### PR TITLE
Fix issues with integration tests. Add it:compile to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
 scala:
   - 2.11.1
-script: sbt clean coverage test -Denv.type=test
+script: sbt clean coverage test -Denv.type=test it:compile
 after_success: sbt coveralls

--- a/src/it/scala/org/broadinstitute/dsde/rawls/WorkspaceGenerator.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/WorkspaceGenerator.scala
@@ -58,11 +58,6 @@ object WorkspaceGenerator {
     // this works equally well for inputs, outputs or prerequisites
     (for (i <- 0 to n) yield (generatePropertyKey, generateMethodConfigValue)).toMap
   }
-
-  def generateMethod = {
-    // don't really care about method content
-    Method("foo", "bar", "baz")
-  }
 }
 
 class WorkspaceGenerator(workspaceNamespace: String, workspaceName: String) {
@@ -148,8 +143,8 @@ class WorkspaceGenerator(workspaceNamespace: String, workspaceName: String) {
   }
 
   def createMethodConfig(nParamsEachType: Int) = {
-    // don't care about entity type, namespace, etc
-    MethodConfiguration(makeMethodConfigName, "foo", generateMethod,
+    MethodConfiguration(makeMethodConfigName,
+      "foo", "bar", "baz", "1", // don't care about entity type or method details
       generateMethodConfigParameters(nParamsEachType),
       generateMethodConfigParameters(nParamsEachType),
       generateMethodConfigParameters(nParamsEachType),
@@ -170,7 +165,8 @@ class WorkspaceGenerator(workspaceNamespace: String, workspaceName: String) {
    * For now we apply the same operations to prereqs, inputs and outputs, for simplicity.
    */
   def createUpdatedMethodConfig(config: MethodConfiguration, nDelete: Int, nModify: Int, nCreate: Int) = {
-    MethodConfiguration(config.name, config.rootEntityType, config.method,
+    MethodConfiguration(config.name, config.rootEntityType,
+      config.methodNamespace, config.methodName, config.methodVersion,
       updateParameterSet(config.prerequisites, nDelete, nModify, nCreate),
       updateParameterSet(config.inputs, nDelete, nModify, nCreate),
       updateParameterSet(config.outputs, nDelete, nModify, nCreate),

--- a/src/it/scala/org/broadinstitute/dsde/rawls/WorkspaceSimulation.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/WorkspaceSimulation.scala
@@ -174,7 +174,7 @@ class WorkspaceSimulation extends FlatSpec with WorkspaceApiService with Scalate
         nCreate = numAnnotationUpdatesSmall
       )
       updateEntityTimer.timedOperation {
-        Post(s"/workspaces/${gen.wn.namespace}/${gen.wn.name}/entities/sample/${name}", httpJson(updateOps)) ~>
+        Patch(s"/workspaces/${gen.wn.namespace}/${gen.wn.name}/entities/sample/${name}", httpJson(updateOps)) ~>
           addCookie ~> sealRoute(updateEntityRoute) ~>
           check { assertResult(StatusCodes.OK) {status} }
       }
@@ -245,7 +245,7 @@ class WorkspaceSimulation extends FlatSpec with WorkspaceApiService with Scalate
     )
 
     updateEntityTimer.timedOperation {
-      Post(s"/workspaces/${gen.wn.namespace}/${gen.wn.name}/entities/${sample.entityType}/${sample.name}", httpJson(sampleUpdates)) ~>
+      Patch(s"/workspaces/${gen.wn.namespace}/${gen.wn.name}/entities/${sample.entityType}/${sample.name}", httpJson(sampleUpdates)) ~>
         addCookie ~> sealRoute(updateEntityRoute) ~>
         check { assertResult(StatusCodes.OK) {status} }
     }


### PR DESCRIPTION
Fix integration test to be consistent with current API. Add ```it:compile``` to Travis so that compile errors in the integration tests will be caught before merging.