### PR TITLE
Copy method configuration from method repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies ++= {
     "org.webjars" % "swagger-ui" % "2.0.24",
     "io.spray" %% "spray-testkit" % sprayV % "it, test",
     "org.scalatest" %% "scalatest" % "2.2.4" % "it, test",
+    "org.mock-server" % "mockserver-netty" % "3.9.2" % "test",
     "com.orientechnologies" % "orientdb-core" % "2.0.8",
     "com.orientechnologies" % "orientdb-graphdb" % "2.0.8",
     "com.orientechnologies" % "orientdb-server" % "2.0.8",

--- a/src/it/scala/org/broadinstitute/dsde/rawls/IntegrationTestBase.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/IntegrationTestBase.scala
@@ -1,0 +1,60 @@
+package org.broadinstitute.dsde.rawls
+
+import java.util.concurrent.TimeUnit
+import java.util.logging.{Logger, LogManager}
+
+import akka.testkit.TestActorRef
+import akka.util.Timeout
+import com.orientechnologies.orient.client.remote.OServerAdmin
+import org.broadinstitute.dsde.rawls.dataaccess.{GraphMethodConfigurationDAO, GraphEntityDAO, GraphWorkspaceDAO, DataSource}
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
+import org.scalatest.{FlatSpec, Matchers}
+import spray.http.{ContentTypes, HttpEntity, HttpCookie}
+import spray.http.HttpHeaders.Cookie
+import spray.json.JsonWriter
+import spray.testkit.ScalatestRouteTest
+
+import scala.concurrent.Await
+import scala.concurrent.duration.FiniteDuration
+import scala.org.broadinstitute.dsde.rawls.openam.OpenAmClientService
+import scala.org.broadinstitute.dsde.rawls.openam.OpenAmClientService.{OpenAmAuthRequest, OpenAmResponse}
+import akka.pattern.ask
+
+import spray.json._
+
+trait IntegrationTestBase extends FlatSpec with ScalatestRouteTest with Matchers with IntegrationTestConfig {
+
+  val timeoutDuration = new FiniteDuration(5, TimeUnit.SECONDS)
+  implicit val timeout = Timeout(timeoutDuration)
+  def getOpenAmToken: Option[OpenAmResponse] = {
+    val actor = TestActorRef[OpenAmClientService]
+    val future = actor ? OpenAmAuthRequest(openAmTestUser, openAmTestUserPassword)
+    Some(Await.result(future, timeoutDuration).asInstanceOf[OpenAmResponse])
+  }
+
+  lazy val openAmResponse = getOpenAmToken.get
+  def addOpenAmCookie: RequestTransformer = {
+    Cookie(HttpCookie("iPlanetDirectoryPro", openAmResponse.tokenId))
+  }
+
+  // convenience methods - TODO add these to unit tests too?
+  def addMockOpenAmCookie = addHeader(Cookie(HttpCookie("iPlanetDirectoryPro", "test_token")))
+  def httpJson[T](obj: T)(implicit writer: JsonWriter[T]) = HttpEntity(ContentTypes.`application/json`, obj.toJson.toString())
+  def repeat[T](n: Int)(exp: => T) = (1 to n) map (_ => exp)
+
+  // suppress Java logging (otherwise OrientDB will produce a ton of useless log messages)
+  LogManager.getLogManager().reset()
+  Logger.getLogger(java.util.logging.Logger.GLOBAL_LOGGER_NAME).setLevel(java.util.logging.Level.SEVERE)
+
+  def workspaceServiceWithDbName(dbName: String) = {
+    // setup DB. if it already exists, drop and then re-create it.
+    val dbUrl = s"remote:${orientServer}/${dbName}"
+    val admin = new OServerAdmin(dbUrl).connect(orientRootUser, orientRootPassword)
+    if (admin.existsDatabase()) admin.dropDatabase(dbName)
+    admin.createDatabase("graph", "plocal") // storage type is 'plocal' even though this is a remote server
+    val dataSource = DataSource(dbUrl, orientRootUser, orientRootPassword, 0, 30)
+
+    WorkspaceService.constructor(dataSource, new GraphWorkspaceDAO(), new GraphEntityDAO(), new GraphMethodConfigurationDAO(), methodRepoServer)
+  }
+
+}

--- a/src/it/scala/org/broadinstitute/dsde/rawls/IntegrationTestConfig.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/IntegrationTestConfig.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.rawls
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+
+trait IntegrationTestConfig {
+  // get config defined by Jenkins, which is where integration tests usually run.
+  // as a fallback, get config from the usual rawls.conf
+  val etcConf = ConfigFactory.parseFile(new File("/etc/rawls.conf"))
+  val jenkinsConf = ConfigFactory.parseFile(new File("jenkins.conf"))
+
+  val orientConfig = jenkinsConf.withFallback(etcConf).getConfig("orientdb")
+  val orientServer = orientConfig.getString("server")
+  val orientRootUser = orientConfig.getString("rootUser")
+  val orientRootPassword = orientConfig.getString("rootPassword")
+
+  val methodRepoConfig = jenkinsConf.withFallback(etcConf).getConfig("methodrepo")
+  val methodRepoServer = methodRepoConfig.getString("server")
+
+  val openAmConfig = jenkinsConf.withFallback(etcConf).getConfig("openam")
+  val openAmUrl = openAmConfig.getString("tokenUrl")
+  val openAmTestUser = openAmConfig.getString("testUser")
+  val openAmTestUserPassword = openAmConfig.getString("testPassword")
+}

--- a/src/it/scala/org/broadinstitute/dsde/rawls/RemoteServicesSpec.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/RemoteServicesSpec.scala
@@ -1,0 +1,103 @@
+package org.broadinstitute.dsde.rawls
+
+import java.util.UUID
+
+import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.webservice.{WorkspaceApiService, MethodConfigApiService}
+import org.joda.time.DateTime
+import spray.http.StatusCodes
+import scala.concurrent.duration._
+
+import WorkspaceJsonSupport._
+
+class RemoteServicesSpec extends IntegrationTestBase with WorkspaceApiService with MethodConfigApiService  {
+  def actorRefFactory = system
+
+  // setup workspace service
+  val workspaceServiceConstructor = workspaceServiceWithDbName("remote-services-latest") // TODO move this into config?
+
+  implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
+
+  "RemoteServicesSpec" should "copy a method config from the method repo" in {
+    // TODO make a common test space? copied these from other tests
+
+    val wsns = "namespace"
+    val wsname = UUID.randomUUID().toString
+    val methodConfig = MethodConfiguration("testConfig", "samples", wsns, "method-a", "1", Map("ready" -> "true"), Map("param1" -> "foo"), Map("out" -> "bar"), WorkspaceName(wsns, wsname), "dsde")
+    val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, methodConfig.workspaceName)
+
+    val workspace = Workspace(
+      wsns,
+      wsname,
+      DateTime.now().withMillis(0),
+      "test",
+      Map.empty
+    )
+
+    val uniqueMethodConfigName = UUID.randomUUID.toString
+    val newMethodConfigName = MethodConfigurationName(uniqueMethodConfigName, methodConfig.namespace, methodConfig.workspaceName)
+    val methodRepoGood = MethodRepoConfigurationQuery("workspace_test", "rawls_test_good", "1", newMethodConfigName)
+    val methodRepoMissing = MethodRepoConfigurationQuery("workspace_test", "rawls_test_missing", "1", methodConfigName)
+    val methodRepoEmptyPayload = MethodRepoConfigurationQuery("workspace_test", "rawls_test_empty_payload", "1", methodConfigName)
+    val methodRepoBadPayload = MethodRepoConfigurationQuery("workspace_test", "rawls_test_bad_payload", "1", methodConfigName)
+
+    // need to init workspace
+    Post(s"/workspaces", httpJson(workspace)) ~>
+      addOpenAmCookie ~>
+      sealRoute(postWorkspaceRoute) ~>
+      check {
+        assertResult(StatusCodes.Created) {
+          status
+        }
+      }
+
+    val endpoint = "/methodconfigs/copyFromMethodRepo"
+
+    Post(endpoint, httpJson(methodRepoGood)) ~>
+      addOpenAmCookie ~>
+      sealRoute(copyMethodRepoConfigurationRoute) ~>
+      check {
+        assertResult(StatusCodes.Created) {
+          status
+        }
+      }
+
+    Post(endpoint, httpJson(methodRepoGood)) ~>
+      addOpenAmCookie ~>
+      sealRoute(copyMethodRepoConfigurationRoute) ~>
+      check {
+        assertResult(StatusCodes.Conflict) {
+          status
+        }
+      }
+
+    Post(endpoint, httpJson(methodRepoMissing)) ~>
+      addOpenAmCookie ~>
+      sealRoute(copyMethodRepoConfigurationRoute) ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+
+    Post(endpoint, httpJson(methodRepoEmptyPayload)) ~>
+      addOpenAmCookie ~>
+      sealRoute(copyMethodRepoConfigurationRoute) ~>
+      check {
+        assertResult(StatusCodes.UnprocessableEntity) {
+          status
+        }
+      }
+
+    Post(endpoint, httpJson(methodRepoBadPayload)) ~>
+      addOpenAmCookie ~>
+      sealRoute(copyMethodRepoConfigurationRoute) ~>
+      check {
+        assertResult(StatusCodes.UnprocessableEntity) {
+          status
+        }
+      }
+
+  }
+
+}

--- a/src/it/scala/org/broadinstitute/dsde/rawls/openam/OpenAmClientService.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/openam/OpenAmClientService.scala
@@ -1,0 +1,49 @@
+package scala.org.broadinstitute.dsde.rawls.openam
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.Actor
+import akka.event.Logging
+import org.broadinstitute.dsde.rawls.IntegrationTestConfig
+import spray.client.pipelining._
+import spray.http.{HttpEntity, MediaTypes}
+import spray.json._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+import OpenAmClientService.{OpenAmAuthRequest,OpenAmResponse}
+
+object OpenAmClientService {
+  case class OpenAmAuthRequest(username: String, password: String)
+  case class OpenAmResponse(tokenId: String, successUrl: String)
+}
+
+object OpenAmResponseJsonProtocol extends DefaultJsonProtocol {
+  implicit val impOpenAmResponse = jsonFormat2(OpenAmResponse)
+}
+
+class OpenAmClientService extends Actor with IntegrationTestConfig {
+
+  implicit val system = context.system
+  import system.dispatcher
+  val log = Logging(system, getClass)
+  val duration: Duration = new FiniteDuration(5, TimeUnit.SECONDS)
+
+  override def receive: Receive = {
+    case OpenAmAuthRequest(username, password) =>
+      log.debug("Querying the OpenAM Server for access token for username: " + username)
+      sender ! {
+        import OpenAmResponseJsonProtocol._
+        import spray.httpx.SprayJsonSupport._
+
+        val pipeline = sendReceive ~> unmarshal[OpenAmResponse]
+        val responseFuture = pipeline {
+          Post(openAmUrl, HttpEntity(MediaTypes.`application/json`, """{}""")) ~>
+            addHeader("X-OpenAM-Username", username) ~>
+            addHeader("X-OpenAM-Password", password)
+        }
+        Await.result(responseFuture, duration)
+      }
+  }
+}

--- a/src/it/scala/org/broadinstitute/dsde/rawls/openam/OpenAmClientSpec.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/openam/OpenAmClientSpec.scala
@@ -1,0 +1,32 @@
+package scala.org.broadinstitute.dsde.rawls.openam
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import akka.pattern.ask
+import akka.testkit.{TestActorRef, TestKit}
+import akka.util.Timeout
+import org.broadinstitute.dsde.rawls.IntegrationTestConfig
+import OpenAmClientService.{OpenAmResponse, OpenAmAuthRequest}
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+class OpenAmClientSpec extends TestKit(ActorSystem()) with WordSpecLike with Matchers with IntegrationTestConfig {
+
+  implicit val timeout = Timeout(5, TimeUnit.SECONDS) // Required for actor sendReceive
+  val duration: Duration = new FiniteDuration(5, TimeUnit.SECONDS)
+
+  "The OpenAmClientService Actor" should {
+    "return a valid token id" in {
+      val actor = TestActorRef[OpenAmClientService]
+      val future = actor ? OpenAmAuthRequest(openAmTestUser, openAmTestUserPassword)
+      val result = Await.result(future, duration)
+      result shouldNot be (None)
+      result.asInstanceOf[OpenAmResponse].tokenId shouldNot be (null)
+      result.asInstanceOf[OpenAmResponse].successUrl shouldNot be (null)
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls
 
+
 import java.io.File
 
 import akka.actor.ActorSystem
@@ -49,7 +50,8 @@ object Boot extends App {
       dataSource.shutdown()
     }
 
-    val service = system.actorOf(RawlsApiServiceActor.props(swaggerService, WorkspaceService.constructor(dataSource, new GraphWorkspaceDAO(), new GraphEntityDAO(), new GraphMethodConfigurationDAO())), "rawls-service")
+    val methodRepoConfig = conf.getConfig("methodrepo")
+    val service = system.actorOf(RawlsApiServiceActor.props(swaggerService, WorkspaceService.constructor(dataSource, new GraphWorkspaceDAO(), new GraphEntityDAO(), new GraphMethodConfigurationDAO(), methodRepoConfig.getString("server"))), "rawls-service")
 
     implicit val timeout = Timeout(5.seconds)
     // start a new HTTP server on port 8080 with our service actor as the handler

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/MethodRepoModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/MethodRepoModel.scala
@@ -1,0 +1,36 @@
+package org.broadinstitute.dsde.rawls.model
+
+import com.wordnik.swagger.annotations.{ApiModelProperty, ApiModel}
+import org.joda.time.DateTime
+
+import scala.annotation.meta.field
+
+object AgoraEntityType extends Enumeration {
+  type EntityType = Value
+  val Task = Value("Task")
+  val Workflow = Value("Workflow")
+  val Configuration = Value("Configuration")
+}
+
+@ApiModel(value = "AgoraEntity")
+case class AgoraEntity(
+                        @(ApiModelProperty@field)(required = false, value = "The namespace to which the entity belongs")
+                        namespace: Option[String] = None,
+                        @(ApiModelProperty@field)(required = false, value = "The entity name ")
+                        name: Option[String] = None,
+                        @(ApiModelProperty@field)(required = false, value = "The entity snapshot id")
+                        snapshotId: Option[Int] = None,
+                        @(ApiModelProperty@field)(required = false, value = "A short description of the entity")
+                        synopsis: Option[String] = None,
+                        @(ApiModelProperty@field)(required = false, value = "Entity documentation")
+                        documentation: Option[String] = None,
+                        @(ApiModelProperty@field)(required = false, value = "User who owns this entity in the methods repo")
+                        owner: Option[String] = None,
+                        @(ApiModelProperty@field)(required = false, value = "The date the entity was inserted in the methods repo")
+                        createDate: Option[DateTime] = None,
+                        @(ApiModelProperty@field)(required = false, value = "The entity payload")
+                        payload: Option[String] = None,
+                        @(ApiModelProperty@field)(required = false, value = "URI for entity details")
+                        url: Option[String] = None,
+                        @(ApiModelProperty@field)(required = true, value = "Which agora entity type is this: Task, Workflow, or Configuration")
+                        entityType: Option[AgoraEntityType.EntityType] = None)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -142,7 +142,19 @@ case class MethodConfigurationShort(
                                 @(ApiModelProperty@field)(required = true, value = "This method configuration's namespace")
                                 @(VertexProperty@field)
                                 namespace: String)
-  
+
+@ApiModel(value = "Method repository configuration query")
+case class MethodRepoConfigurationQuery(
+                                         @(ApiModelProperty@field)(required = true, value = "Method Repository Namespace")
+                                         methodRepoNamespace: String,
+                                         @(ApiModelProperty@field)(required = true, value = "Method Repository Name")
+                                         methodRepoName: String,
+                                         @(ApiModelProperty@field)(required = true, value = "Method Repository Snapshot ID")
+                                         methodRepoSnapshotId: String,
+                                         @(ApiModelProperty@field)(required = true, value = "The destination for a copied method configuration")
+                                         destination: MethodConfigurationName
+                                         )
+
 trait Attribute
 trait AttributeValue extends Attribute
 trait AttributeReference extends Attribute
@@ -213,4 +225,18 @@ object WorkspaceJsonSupport extends DefaultJsonProtocol {
   implicit val MethodConfigurationFormat = jsonFormat10(MethodConfiguration)
 
   implicit val MethodConfigurationShortFormat = jsonFormat7(MethodConfigurationShort)
+
+  implicit val MethodRepoConfigurationQueryFormat = jsonFormat4(MethodRepoConfigurationQuery)
+
+  implicit object AgoraEntityTypeFormat extends RootJsonFormat[AgoraEntityType.EntityType] {
+    override def write(obj: AgoraEntityType.EntityType): JsValue = JsString(obj.toString)
+
+    override def read(value: JsValue): AgoraEntityType.EntityType = value match {
+      case JsString(name) => AgoraEntityType.withName(name)
+      case _ => throw new DeserializationException("only string supported")
+    }
+  }
+
+  implicit val AgoraEntityFormat = jsonFormat10(AgoraEntity)
+
 }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <!-- netty (mock server) produces a huge amount of DEBUG output during tests without this line -->
+    <logger name="io.netty" level="WARN"/>
+</configuration>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/mock/MethodRepoMockServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/mock/MethodRepoMockServer.scala
@@ -1,0 +1,85 @@
+package org.broadinstitute.dsde.rawls.mock
+
+import java.io.File
+
+import com.typesafe.config.ConfigFactory
+import org.broadinstitute.dsde.rawls.model.AgoraEntity
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.mockserver.integration.ClientAndServer._
+import org.mockserver.model.Header
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse._
+import spray.http.StatusCodes
+import spray.json._
+
+object MethodRepoMockServer {
+  val port = 8987
+  val mockServerBaseUrl = "http://localhost:" + port
+
+  val jsonHeader = new Header("Content-Type", "application/json")
+  val mockServer = startClientAndServer(port)
+
+  def startServer = {
+
+    // copy method config endpoint
+
+    val copyMethodConfigPath = "/configurations"
+
+    val goodResult = AgoraEntity(Some("workspace_test"), Some("rawls_test_good"), Some(1), None, None, None, None,
+      Some("{\n  \"name\": \"rawls_test_1\",\n  \"rootEntityType\": \"rawls_test_type_1\",\n  \"methodNamespace\": \"rawls_test_m_namespace_1\",\n  \"methodName\": \"rawls_test_m_name_1\",\n  \"methodVersion\": \"rawls_test_m_version_1\",\n  \"prerequisites\": { },\n  \"inputs\": { },\n  \"outputs\": { },\n  \"workspaceName\": {\n    \"namespace\": \"rawls_test_w_namespace_1\",\n    \"name\": \"rawls_test_w_name_1\"\n  },\n  \"namespace\": \"rawls_test_namespace_1\"\n}"),
+      None, None)
+
+    val emptyPayloadResult = AgoraEntity(Some("workspace_test"), Some("rawls_test_empty_payload"), Some(1), None, None, None, None,
+      Some(""),
+      None, None)
+
+    val badPayloadResult = AgoraEntity(Some("workspace_test"), Some("rawls_test_bad_payload"), Some(1), None, None, None, None,
+      Some("{\n  \"name\": \"invalid\",\n}"),
+      None, None)
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath(copyMethodConfigPath + "/workspace_test/rawls_test_good/1")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(goodResult.toJson.prettyPrint)
+          .withStatusCode(StatusCodes.OK.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath(copyMethodConfigPath + "/workspace_test/rawls_test_missing/1")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withStatusCode(StatusCodes.NotFound.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath(copyMethodConfigPath + "/workspace_test/rawls_test_empty_payload/1")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(emptyPayloadResult.toJson.prettyPrint)
+          .withStatusCode(StatusCodes.OK.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath(copyMethodConfigPath + "/workspace_test/rawls_test_bad_payload/1")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(badPayloadResult.toJson.prettyPrint)
+          .withStatusCode(StatusCodes.OK.intValue)
+      )
+  }
+
+  def stopServer = mockServer.stop()
+}

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import akka.testkit.TestActorRef
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.mock.MethodRepoMockServer
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.workspace.AttributeUpdateOperations._
 import org.joda.time.DateTime
@@ -28,7 +29,8 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
   )
 
   val dataSource = DataSource("memory:rawls", "admin", "admin")
-  val workspaceServiceConstructor = WorkspaceService.constructor(dataSource, MockWorkspaceDAO, MockEntityDAO, MockMethodConfigurationDAO)
+
+  val workspaceServiceConstructor = WorkspaceService.constructor(dataSource, MockWorkspaceDAO, MockEntityDAO, MockMethodConfigurationDAO, MethodRepoMockServer.mockServerBaseUrl)
 
   lazy val workspaceService: WorkspaceService = TestActorRef(WorkspaceService.props(workspaceServiceConstructor)).underlyingActor
 


### PR DESCRIPTION
**NOTE: All users must update their rawls.conf from Jenkins after this is merged if they want to run integration tests.**

Resolves DSDEEPB-12

Includes (copied/adapted from Vault):
* OpenAM test client for integration test 
* Mock Method Repo server for unit test

Whitepace changes by IntelliJ.  I can revert if people have strong opinions.

Questions:
* Is `/methodconfigs/copyFromMethodRepo` the best endpoint for this?
* What's a better name for the `MockOpenAmCookie`?  It's not really a Mock, but I want to distinguish it from a cookie that can be used to access remote servers.
* Adding `test/resources/logback.xml` was necessary due to extremely verbose mock-server output, but I don't have much experience configuring logback.  Are there problematic implications to adding this file?
* Is there a good way to share code between `test` and `it`? 