### PR TITLE
Refactored expression parser for foldier goodness

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParser.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParser.scala
@@ -20,5 +20,9 @@ class SimpleExpressionParserTest extends FunSuite with OrientDbTestFixture {
     assertResult( Success(ArrayBuffer("normal", "tumor", "tumor")) ) {
       evaluator.evaluate("workspaces", "test_workspace", "SampleSet", "sset1", "this.samples.type")
     }
+
+    assertResult( Success(ArrayBuffer("normal")) ) {
+      evaluator.evaluate("workspaces", "test_workspace", "Sample", "sample1", "this.type")
+    }
   }
 }


### PR DESCRIPTION
Changes:

- Moved workspace + entity crud into ExpressionContext case class
- All pipeline functions take an ExpressionContext as the root entity
- Turned [first, middle, last] parsing into [everything_but_the, last]
- Freaked out quite a lot about handling entities vs. attributes as the last token (but it'll all be okay, I have a plan now)
- `runPipe` is now a delicious `foldLeft`