### PR TITLE
Of course there are multiple spray classes named UnsuccessfulResponseException

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceApiServiceSpec.scala
@@ -629,7 +629,7 @@ class WorkspaceApiServiceSpec extends FlatSpec with WorkspaceApiService with Ent
       addMockOpenAmCookie ~>
       sealRoute(copyMethodRepoConfigurationRoute) ~>
       check {
-        assertResult(StatusCodes.InternalServerError) {
+        assertResult(StatusCodes.NotFound) {
           status
         }
       }


### PR DESCRIPTION
Unfortunate mismatch caused a failing test!

Also simplified the logic slightly and restored a 404 check 