### PR TITLE
Added new parser for simple expressions ending in an entity reference

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAO.scala
@@ -13,7 +13,7 @@ class GraphEntityDAO extends EntityDAO with GraphDAO {
 
   //NOTE: attributeToProperty and propertyToAttrbute have now moved to WorkspaceModel.AttributeConversions.
 
-  private def loadEntity(entity: Vertex, workspaceNamespace: String, workspaceName: String) = {
+  def loadEntity(entity: Vertex, workspaceNamespace: String, workspaceName: String) = {
     // NB: when starting from an edge, inV() returns the DESTINATION vertices, not the source vertices, and vice versa.
     def edgeOutgoingReferenceFunc(e: Edge) = {
       val kv = e.getLabel -> new GremlinPipeline(e).inV().transform(

--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -33,7 +33,7 @@ object MethodConfigResolver {
       val evaluator = new ExpressionEvaluator(graph, new ExpressionParser)
       methodConfig.inputs.map {
         case (name, expression) => {
-          val evaluated = evaluator.evaluate(entity.workspaceName.namespace, entity.workspaceName.name, entity.entityType, entity.name, expression)
+          val evaluated = evaluator.evalFinalAttribute(entity.workspaceName.namespace, entity.workspaceName.name, entity.entityType, entity.name, expression)
           // now look at expected WDL type to see if we should unpack a single value from the Seq[Any]
           val unpacked = evaluated.flatMap(sequence => wdlInputs.get(name) match {
               // TODO: Cromwell doesn't yet have compound types (e.g. Seq)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -226,8 +226,8 @@ class WorkspaceService(dataSource: DataSource, workspaceDAO: WorkspaceDAO, entit
   def evaluateExpression(workspaceNamespace: String, workspaceName: String, entityType: String, entityName: String, expression: String): PerRequestMessage =
     dataSource inTransaction { txn =>
       txn withGraph { graph =>
-        new ExpressionEvaluator( graph, new ExpressionParser() ).evaluate(workspaceNamespace, workspaceName, entityType, entityName, expression) match {
-          case Success(result) => RequestComplete(http.StatusCodes.OK, result.map(AttributeConversions.propertyToAttribute))
+        new ExpressionEvaluator( graph, new ExpressionParser() ).evalFinalAttribute(workspaceNamespace, workspaceName, entityType, entityName, expression) match {
+          case Success(result) => RequestComplete(http.StatusCodes.OK, result)
           case Failure(regret) => RequestComplete(http.StatusCodes.BadRequest, regret.getMessage)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParser.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParser.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.expressions
 
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
+import org.broadinstitute.dsde.rawls.model.AttributeString
 import org.scalatest.FunSuite
 
 import scala.collection.immutable.HashMap
@@ -13,16 +14,29 @@ import scala.util.Success
 class SimpleExpressionParserTest extends FunSuite with OrientDbTestFixture {
   override val testDbName = "ExpressionParserTest"
 
-  test("simple expression") {
+  test("simple attribute expression") {
     initializeTestGraph()
     val evaluator = new ExpressionEvaluator(graph, new ExpressionParser)
 
-    assertResult( Success(ArrayBuffer("normal", "tumor", "tumor")) ) {
-      evaluator.evaluate("workspaces", "test_workspace", "SampleSet", "sset1", "this.samples.type")
+    assertResult( Success(ArrayBuffer(AttributeString("normal"))) ) {
+      evaluator.evalFinalAttribute("workspaces", "test_workspace", "Sample", "sample1", "this.type")
     }
 
-    assertResult( Success(ArrayBuffer("normal")) ) {
-      evaluator.evaluate("workspaces", "test_workspace", "Sample", "sample1", "this.type")
+    assertResult( Success(ArrayBuffer(AttributeString("normal"), AttributeString("tumor"), AttributeString("tumor"))) ) {
+      evaluator.evalFinalAttribute("workspaces", "test_workspace", "SampleSet", "sset1", "this.samples.type")
+    }
+  }
+
+  test("simple entity expression") {
+    initializeTestGraph()
+    val evaluator = new ExpressionEvaluator(graph, new ExpressionParser)
+
+    assertResult( Success( ArrayBuffer(tg_sample2) ) ) {
+      evaluator.evalFinalEntity("workspaces", "test_workspace", "Pair", "pair1", "this.case")
+    }
+
+    assertResult( Success(ArrayBuffer(tg_sample1, tg_sample2, tg_sample3)) ) {
+      evaluator.evalFinalEntity("workspaces", "test_workspace", "Individual", "indiv1", "this.sset.samples")
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -21,48 +21,50 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
   lazy val entityDAO: GraphEntityDAO = new GraphEntityDAO()
   lazy val configDAO: GraphMethodConfigurationDAO = new GraphMethodConfigurationDAO()
 
-  /**
-   * Creates a small default graph. Note that these variables will be inaccessible from outside tests, so you need to remember the entity names, etc.
-   */
+  val tg_workspace = new Workspace("workspaces", "test_workspace", DateTime.now, "testUser", new HashMap[String, Attribute]() )
+
+  val tg_sample1 = new Entity("sample1", "Sample", Map( "type" -> AttributeString("normal") ), WorkspaceName("workspaces", "test_workspace") )
+  val tg_sample2 = new Entity("sample2", "Sample", Map( "type" -> AttributeString("tumor") ), WorkspaceName("workspaces", "test_workspace") )
+  val tg_sample3 = new Entity("sample3", "Sample", Map( "type" -> AttributeString("tumor") ), WorkspaceName("workspaces", "test_workspace") )
+
+  val tg_pair1 = new Entity("pair1", "Pair",
+    Map( "case" -> AttributeReferenceSingle("Sample", "sample2"),
+      "control" -> AttributeReferenceSingle("Sample", "sample1") ),
+    WorkspaceName("workspaces", "test_workspace") )
+  val tg_pair2 = new Entity("pair2", "Pair",
+    Map( "case" -> AttributeReferenceSingle("Sample", "sample3"),
+      "control" -> AttributeReferenceSingle("Sample", "sample1") ),
+    WorkspaceName("workspaces", "test_workspace") )
+
+  val tg_sset1 = new Entity("sset1", "SampleSet",
+    Map( "samples" -> AttributeReferenceList( List(AttributeReferenceSingle("Sample", "sample1"),
+      AttributeReferenceSingle("Sample", "sample2"),
+      AttributeReferenceSingle("Sample", "sample3"))) ),
+    WorkspaceName("workspaces", "test_workspace") )
+  val tg_sset2 = new Entity("sset2", "SampleSet",
+    Map( "samples" -> AttributeReferenceList( List(AttributeReferenceSingle("Sample", "sample2"))) ),
+    WorkspaceName("workspaces", "test_workspace") )
+
+  val tg_ps1 = new Entity("ps1", "PairSet",
+    Map( "pairs" -> AttributeReferenceList( List(AttributeReferenceSingle("Pair", "pair1"),
+      AttributeReferenceSingle("Pair", "pair2"))) ),
+    WorkspaceName("workspaces", "test_workspace") )
+
+  val tg_indiv1 = new Entity("indiv1", "Individual",
+    Map( "sset" -> AttributeReferenceSingle("SampleSet", "sset1") ),
+    WorkspaceName("workspaces", "test_workspace") )
+
   def initializeTestGraph(tx:RawlsTransaction = txn): Unit = {
-    val workspace = new Workspace("workspaces", "test_workspace", DateTime.now, "testUser", new HashMap[String, Attribute]() )
-
-    val sample1 = new Entity("sample1", "Sample", Map( "type" -> AttributeString("normal") ), WorkspaceName("workspaces", "test_workspace") )
-    val sample2 = new Entity("sample2", "Sample", Map( "type" -> AttributeString("tumor") ), WorkspaceName("workspaces", "test_workspace") )
-    val sample3 = new Entity("sample3", "Sample", Map( "type" -> AttributeString("tumor") ), WorkspaceName("workspaces", "test_workspace") )
-
-    val pair1 = new Entity("pair1", "Pair",
-      Map( "case" -> AttributeReferenceSingle("Sample", "sample2"),
-        "control" -> AttributeReferenceSingle("Sample", "sample1") ),
-      WorkspaceName("workspaces", "test_workspace") )
-    val pair2 = new Entity("pair2", "Pair",
-      Map( "case" -> AttributeReferenceSingle("Sample", "sample3"),
-        "control" -> AttributeReferenceSingle("Sample", "sample1") ),
-      WorkspaceName("workspaces", "test_workspace") )
-
-    val sset1 = new Entity("sset1", "SampleSet",
-      Map( "samples" -> AttributeReferenceList( List(AttributeReferenceSingle("Sample", "sample1"),
-        AttributeReferenceSingle("Sample", "sample2"),
-        AttributeReferenceSingle("Sample", "sample3"))) ),
-      WorkspaceName("workspaces", "test_workspace") )
-    val sset2 = new Entity("sset2", "SampleSet",
-      Map( "samples" -> AttributeReferenceList( List(AttributeReferenceSingle("Sample", "sample2"))) ),
-      WorkspaceName("workspaces", "test_workspace") )
-
-    val ps1 = new Entity("ps1", "PairSet",
-      Map( "pairs" -> AttributeReferenceList( List(AttributeReferenceSingle("Pair", "pair1"),
-        AttributeReferenceSingle("Pair", "pair2"))) ),
-      WorkspaceName("workspaces", "test_workspace") )
-
-    workspaceDAO.save(workspace, tx)
-    entityDAO.save("workspaces", "test_workspace", sample1, tx)
-    entityDAO.save("workspaces", "test_workspace", sample2, tx)
-    entityDAO.save("workspaces", "test_workspace", sample3, tx)
-    entityDAO.save("workspaces", "test_workspace", pair1, tx)
-    entityDAO.save("workspaces", "test_workspace", pair2, tx)
-    entityDAO.save("workspaces", "test_workspace", sset1, tx)
-    entityDAO.save("workspaces", "test_workspace", sset2, tx)
-    entityDAO.save("workspaces", "test_workspace", ps1, tx)
+    workspaceDAO.save(tg_workspace, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_sample1, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_sample2, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_sample3, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_pair1, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_pair2, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_sset1, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_sset2, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_ps1, tx)
+    entityDAO.save("workspaces", "test_workspace", tg_indiv1, tx)
   }
 
   override def beforeAll {


### PR DESCRIPTION
There's a separate entrypoint because there's no sane way to determine whether an entity expression ends in a ref or an attribute just by looking at it.