### PR TITLE
Create submission now calls SubmissionSupervisor

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -52,7 +52,7 @@ class SubmissionSupervisor(submissionDAO: SubmissionDAO,
   }
 
   private def startSubmissionMonitor(submission: Submission, authCookie: HttpCookie): Unit = {
-    system.actorOf(SubmissionMonitor.props(submission, submissionDAO, workflowDAO, datasource, workflowPollInterval, submissionPollInterval,
+    actorOf(SubmissionMonitor.props(submission, submissionDAO, workflowDAO, datasource, workflowPollInterval, submissionPollInterval,
       WorkflowMonitor.props(workflowPollInterval, executionServiceDAO, workflowDAO, datasource, authCookie)), submission.id)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/GoogleAuthApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/GoogleAuthApiServiceSpec.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsde.rawls.workspace
 
+import akka.actor.PoisonPill
 import akka.testkit.TestKit
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
+import org.broadinstitute.dsde.rawls.jobexec.SubmissionSupervisor
 import org.broadinstitute.dsde.rawls.webservice._
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.openam._
@@ -35,11 +37,23 @@ class GoogleAuthApiServiceSpec extends FlatSpec with HttpService with ScalatestR
 
   case class TestApiService(dataSource: DataSource) extends GoogleAuthApiService with MockOpenAmDirectives {
     def actorRefFactory = system
-    val workspaceServiceConstructor = WorkspaceService.constructor(dataSource, workspaceDAO, entityDAO, methodConfigDAO, new HttpMethodRepoDAO(mockServer.mockServerBaseUrl), new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl), MockGoogleCloudStorageDAO)
+    val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
+      new GraphSubmissionDAO(new GraphWorkflowDAO()),
+      new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl),
+      new GraphWorkflowDAO(),
+      dataSource
+    ).withDispatcher("submission-monitor-dispatcher"), "test-gauth-submission-supervisor")
+    val workspaceServiceConstructor = WorkspaceService.constructor(dataSource, workspaceDAO, entityDAO, methodConfigDAO, new HttpMethodRepoDAO(mockServer.mockServerBaseUrl), new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl), MockGoogleCloudStorageDAO, submissionSupervisor)
+
+    def cleanupSupervisor = {
+      submissionSupervisor ! PoisonPill
+    }
   }
 
   def withApiServices(dataSource: DataSource)(testCode: TestApiService => Any): Unit = {
-    testCode(new TestApiService(dataSource))
+    val apiService = new TestApiService(dataSource)
+    testCode(apiService)
+    apiService.cleanupSupervisor
   }
 
   def withTestDataApiServices(testCode: TestApiService => Any): Unit = {


### PR DESCRIPTION
1. Added call to SubmissionSupervisor when creating a new submission
2. Made SubmissionSupervisor create submission monitor actors as children
3. Horrible updates to tests to spawn SubmissionSupervisors (to go in the workspace service) and PoisonPill them to avoid name clashes