### PR TITLE
Put cleanupSupervisor in a try/finally block so it gets called even when tests throw exceptions

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/GoogleAuthApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/GoogleAuthApiServiceSpec.scala
@@ -52,8 +52,11 @@ class GoogleAuthApiServiceSpec extends FlatSpec with HttpService with ScalatestR
 
   def withApiServices(dataSource: DataSource)(testCode: TestApiService => Any): Unit = {
     val apiService = new TestApiService(dataSource)
-    testCode(apiService)
-    apiService.cleanupSupervisor
+    try {
+      testCode(apiService)
+    } finally {
+      apiService.cleanupSupervisor
+    }
   }
 
   def withTestDataApiServices(testCode: TestApiService => Any): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceApiServiceSpec.scala
@@ -69,8 +69,11 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
 
   def withApiServices(dataSource: DataSource)(testCode: TestApiService => Any): Unit = {
     val apiService = new TestApiService(dataSource)
-    testCode(apiService)
-    apiService.cleanupSupervisor
+    try {
+      testCode(apiService)
+    } finally {
+      apiService.cleanupSupervisor
+    }
   }
 
   def withTestDataApiServices(testCode: TestApiService => Any): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -50,8 +50,11 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
   def withTestDataServices(testCode: TestApiService => Any): Unit = {
     withDefaultTestDatabase { dataSource =>
       val apiService = new TestApiService(dataSource)
-      testCode(apiService)
-      apiService.cleanupSupervisor
+      try {
+        testCode(apiService)
+      } finally {
+        apiService.cleanupSupervisor
+      }
     }
   }
 


### PR DESCRIPTION
I still think it'd be much better if none of this horrible boilerplate (constructing a workspace service, passing it the dataSource, constructing a submissionSupervisor) existed.