### PR TITLE
Modified format of method configs to have a sub-document for methods …

### DIFF
--- a/src/it/scala/org/broadinstitute/dsde/rawls/RemoteServicesSpec.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/RemoteServicesSpec.scala
@@ -23,7 +23,7 @@ class RemoteServicesSpec extends IntegrationTestBase with WorkspaceApiService wi
 
     val wsns = "namespace"
     val wsname = UUID.randomUUID().toString
-    val methodConfig = MethodConfiguration("testConfig", "samples", wsns, "method-a", "1", Map("ready" -> "true"), Map("param1" -> "foo"), Map("out" -> "bar"), WorkspaceName(wsns, wsname), "dsde")
+    val methodConfig = MethodConfiguration(wsns, "testConfig", "samples", Map("ready" -> "true"), Map("param1" -> "foo"), Map("out" -> "bar"), WorkspaceName(wsns, wsname), MethodStoreConfiguration("method-a-config", "dsde", "1"), MethodStoreMethod("method-a", "dsde", "1"))
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, methodConfig.workspaceName)
 
     val workspace = WorkspaceRequest(

--- a/src/it/scala/org/broadinstitute/dsde/rawls/WorkspaceGenerator.scala
+++ b/src/it/scala/org/broadinstitute/dsde/rawls/WorkspaceGenerator.scala
@@ -143,12 +143,15 @@ class WorkspaceGenerator(workspaceNamespace: String, workspaceName: String) {
   }
 
   def createMethodConfig(nParamsEachType: Int) = {
-    MethodConfiguration(makeMethodConfigName,
-      "foo", "bar", "baz", "1", // don't care about entity type or method details
+
+    MethodConfiguration(methodConfigNamespace, makeMethodConfigName,
+      "foo", // don't care about entity type
       generateMethodConfigParameters(nParamsEachType),
       generateMethodConfigParameters(nParamsEachType),
       generateMethodConfigParameters(nParamsEachType),
-      wn, methodConfigNamespace)
+      wn,
+      MethodStoreConfiguration("bar", "baz", "1"), // don't care about method details
+      MethodStoreMethod("bar-config", "baz", "1")) // don't care about method config details
   }
 
   def updateParameterSet(params: Map[String, String], nDelete: Int, nModify: Int, nCreate: Int) = {
@@ -165,12 +168,13 @@ class WorkspaceGenerator(workspaceNamespace: String, workspaceName: String) {
    * For now we apply the same operations to prereqs, inputs and outputs, for simplicity.
    */
   def createUpdatedMethodConfig(config: MethodConfiguration, nDelete: Int, nModify: Int, nCreate: Int) = {
-    MethodConfiguration(config.name, config.rootEntityType,
-      config.methodNamespace, config.methodName, config.methodVersion,
+    MethodConfiguration(config.namespace, config.name, config.rootEntityType,
       updateParameterSet(config.prerequisites, nDelete, nModify, nCreate),
       updateParameterSet(config.inputs, nDelete, nModify, nCreate),
       updateParameterSet(config.outputs, nDelete, nModify, nCreate),
-      config.workspaceName, config.namespace
+      config.workspaceName,
+      config.methodStoreConfig,
+      config.methodStoreMethod
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -120,14 +120,8 @@ case class EntityCopyDefinition(
                    entityNames: Seq[String]
                    )
 
-@ApiModel(value = "Method Configuration")
-case class MethodConfiguration(
-                   @(ApiModelProperty@field)(required = true, value = "The name of the method configuration")
-                   @(VertexProperty@field)
-                   name: String,
-                   @(ApiModelProperty@field)(required = true, value = "The root entity type that the method will be running on")
-                   @(VertexProperty@field)
-                   rootEntityType: String,
+@ApiModel(value = "Method Store Method")
+case class MethodStoreMethod(
                    @(ApiModelProperty@field)(required = true, value = "The namespace of method from method store")
                    @(VertexProperty@field)
                    methodNamespace: String,
@@ -136,7 +130,31 @@ case class MethodConfiguration(
                    methodName: String,
                    @(ApiModelProperty@field)(required = true, value = "The version of method from method store")
                    @(VertexProperty@field)
-                   methodVersion: String,
+                   methodVersion: String
+                   )
+@ApiModel(value = "Method Store Configuration")
+case class MethodStoreConfiguration(
+                   @(ApiModelProperty@field)(required = true, value = "The namespace of method config from method store")
+                   @(VertexProperty@field)
+                   methodConfigNamespace: String,
+                   @(ApiModelProperty@field)(required = true, value = "The name of method config from method store")
+                   @(VertexProperty@field)
+                   methodConfigName: String,
+                   @(ApiModelProperty@field)(required = true, value = "The version of method config from method store")
+                   @(VertexProperty@field)
+                   methodConfigVersion: String
+                   )
+@ApiModel(value = "Method Configuration")
+case class MethodConfiguration(
+                   @(ApiModelProperty@field)(required = true, value = "This method configuration's namespace")
+                   @(VertexProperty@field)
+                   namespace: String,
+                   @(ApiModelProperty@field)(required = true, value = "The name of the method configuration")
+                   @(VertexProperty@field)
+                   name: String,
+                   @(ApiModelProperty@field)(required = true, value = "The root entity type that the method will be running on")
+                   @(VertexProperty@field)
+                   rootEntityType: String,
                    @(ApiModelProperty@field)(required = false, value = "PreRequisites for the method")
                    prerequisites: Map[String, String],
                    @(ApiModelProperty@field)(required = true, value = "Inputs for the method")
@@ -145,11 +163,13 @@ case class MethodConfiguration(
                    outputs: Map[String, String],
                    @(ApiModelProperty@field)(required = true, value = "This method configuration's owning workspace")
                    workspaceName:WorkspaceName,
-                   @(ApiModelProperty@field)(required = true, value = "This method configuration's namespace")
-                   @(VertexProperty@field)
-                   namespace: String) extends Identifiable {
+                   @(ApiModelProperty@field)(required = false, value = "The properties of the method configuration from the method store that this derived from")
+                   methodStoreConfig:MethodStoreConfiguration,
+                   @(ApiModelProperty@field)(required = true, value = "The properties of the method from the method store that this config is associated with")
+                   methodStoreMethod:MethodStoreMethod
+                   ) extends Identifiable {
   def path : String = workspaceName.path + "/methodConfigs/" + namespace + "/" + name
-  def toShort : MethodConfigurationShort = MethodConfigurationShort(name, rootEntityType, methodNamespace, methodName, methodVersion, workspaceName, namespace)
+  def toShort : MethodConfigurationShort = MethodConfigurationShort(name, rootEntityType, methodStoreConfig, methodStoreMethod, workspaceName, namespace)
 }
 @ApiModel(value = "Method Configuration without inputs, outputs, or prerequisites")
 case class MethodConfigurationShort(
@@ -159,15 +179,10 @@ case class MethodConfigurationShort(
                                 @(ApiModelProperty@field)(required = true, value = "The root entity type that the method will be running on")
                                 @(VertexProperty@field)
                                 rootEntityType: String,
-                                @(ApiModelProperty@field)(required = true, value = "The namespace of method from method store")
-                                @(VertexProperty@field)
-                                methodNamespace: String,
-                                @(ApiModelProperty@field)(required = true, value = "The name of method from method store")
-                                @(VertexProperty@field)
-                                methodName: String,
-                                @(ApiModelProperty@field)(required = true, value = "The version of method from method store")
-                                @(VertexProperty@field)
-                                methodVersion: String,
+                                @(ApiModelProperty@field)(required = false, value = "The properties of the method configuration from the method store that this derived from")
+                                methodStoreConfig:MethodStoreConfiguration,
+                                @(ApiModelProperty@field)(required = true, value = "The properties of the method from the method store that this config is associated with")
+                                methodStoreMethod:MethodStoreMethod,
                                 @(ApiModelProperty@field)(required = true, value = "This method configuration's owning workspace")
                                 @(VertexProperty@field)
                                 workspaceName:WorkspaceName,
@@ -237,9 +252,13 @@ object WorkspaceJsonSupport extends JsonSupport {
 
   implicit val EntityCopyDefinitionFormat = jsonFormat4(EntityCopyDefinition)
 
-  implicit val MethodConfigurationFormat = jsonFormat10(MethodConfiguration)
+  implicit val MethodStoreMethodFormat = jsonFormat3(MethodStoreMethod)
 
-  implicit val MethodConfigurationShortFormat = jsonFormat7(MethodConfigurationShort)
+  implicit val MethodStoreConfigurationFormat = jsonFormat3(MethodStoreConfiguration)
+
+  implicit val MethodConfigurationFormat = jsonFormat9(MethodConfiguration)
+
+  implicit val MethodConfigurationShortFormat = jsonFormat6(MethodConfigurationShort)
 
   implicit val MethodRepoConfigurationQueryFormat = jsonFormat4(MethodRepoConfigurationQuery)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -548,7 +548,7 @@ class WorkspaceService(dataSource: DataSource, workspaceDAO: WorkspaceDAO, entit
         withWorkspace(workspaceNamespace, workspaceName, txn) { workspace =>
           withMethodConfig(workspace, methodConfigurationNamespace, methodConfigurationName, txn) { methodConfig =>
             withEntity(workspace, entityType, entityName, txn) { entity =>
-              withMethod(workspace, methodConfig.methodNamespace, methodConfig.methodName, methodConfig.methodVersion, authCookie) { method =>
+              withMethod(workspace, methodConfig.methodStoreMethod.methodNamespace, methodConfig.methodStoreMethod.methodName, methodConfig.methodStoreMethod.methodVersion, authCookie) { method =>
                 withWdl(method) { wdl =>
                   // TODO should we return OK even if there are validation errors?
                   RequestComplete(StatusCodes.OK, MethodConfigResolver.getValidationErrors(methodConfig, entity, wdl, txn))
@@ -576,7 +576,7 @@ class WorkspaceService(dataSource: DataSource, workspaceDAO: WorkspaceDAO, entit
       withWorkspace(workspaceName.namespace, workspaceName.name, txn) { workspace =>
         withMethodConfig(workspace, submission.methodConfigurationNamespace, submission.methodConfigurationName, txn) { methodConfig =>
           withEntity(workspace, submission.entityType, submission.entityName, txn) { entity =>
-            withMethod(workspace, methodConfig.methodNamespace, methodConfig.methodName, methodConfig.methodVersion, authCookie) { agoraEntity =>
+            withMethod(workspace, methodConfig.methodStoreMethod.methodNamespace, methodConfig.methodStoreMethod.methodName, methodConfig.methodStoreMethod.methodVersion, authCookie) { agoraEntity =>
               withWdl(agoraEntity) { wdl =>
 
                 //If there's an expression, evaluate it to get the list of entities to run this job on.

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphMethodConfigDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphMethodConfigDAOSpec.scala
@@ -13,16 +13,16 @@ class GraphMethodConfigDAOSpec extends FlatSpec with Matchers with OrientDbTestF
   "GraphMethodConfigDAO" should "save and get a method config" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
       val methodConfig2 = MethodConfiguration(
+        "ns",
         "config2",
         "sample",
-        "ns",
-        "meth2",
-        "2",
+
         Map("input.expression" -> "this..wont.parse"),
         Map("output.expression" -> "output.expr"),
         Map("prereq.expression" -> "prereq.expr"),
         testData.wsName,
-        "ns"
+        MethodStoreConfiguration("ns", "meth2", "2"),
+        MethodStoreMethod("ns-config", "meth2", "2")
       )
 
       new GraphWorkspaceDAO().save(testData.workspace, txn)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -11,6 +11,10 @@ import scala.collection.immutable.HashMap
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import java.util.UUID.randomUUID
 import java.util.UUID
+import spray.json._
+import spray.httpx.SprayJsonSupport
+import SprayJsonSupport._
+import WorkspaceJsonSupport._
 
 
 trait OrientDbTestFixture extends BeforeAndAfterAll {
@@ -101,25 +105,24 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
       WorkspaceName(wsName.namespace, wsName.name) )
 
     val methodConfig = MethodConfiguration(
+      "ns",
       "testConfig1",
       "Sample",
-      "ns",
-      "meth1",
-      "1",
       Map("i1" -> "input expr"),
       Map("o1" -> "output expr"),
       Map("p1" -> "prereq expr"),
       wsName,
-      "ns"
+      MethodStoreConfiguration("ns", "meth1", "1"),
+      MethodStoreMethod("ns-config", "meth1", "1")
     )
 
-    val methodConfig2 = MethodConfiguration("testConfig2", "Sample", wsName.namespace, "method-a", "1", Map("ready"-> "true"), Map("param1"-> "foo"), Map("out" -> "bar"), wsName, "dsde")
-    val methodConfig3 = MethodConfiguration("testConfig", "Sample", wsName.namespace, "method-a", "1", Map("ready"-> "true"), Map("param1"-> "foo", "param2"-> "foo2"), Map("out" -> "bar"), wsName, "dsde")
+    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", "Sample", Map("ready"-> "true"), Map("param1"-> "foo"), Map("out" -> "bar"), wsName, MethodStoreConfiguration(wsName.namespace+"-config", "method-a-config", "1"), MethodStoreMethod(wsName.namespace, "method-a", "1"))
+    val methodConfig3 = MethodConfiguration("dsde", "testConfig", "Sample", Map("ready"-> "true"), Map("param1"-> "foo", "param2"-> "foo2"), Map("out" -> "bar"), wsName, MethodStoreConfiguration("ns", "meth1", "1"), MethodStoreMethod("ns-config", "meth1", "1"))
 
-    val methodConfigValid = MethodConfiguration("GoodMethodConfig", "Sample", "dsde", "three_step", "1", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this.type"), outputs=Map.empty, wsName, "dsde")
-    val methodConfigUnparseable = MethodConfiguration("UnparseableMethodConfig", "Sample", "dsde", "three_step", "1", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this..wont.parse"), outputs=Map.empty, wsName, "dsde")
-    val methodConfigNotAllSamples = MethodConfiguration("NotAllSamplesMethodConfig", "Sample", "dsde", "three_step", "1", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this.tumortype"), outputs=Map.empty, wsName, "dsde")
-    val methodConfigAttrTypeMixup = MethodConfiguration("AttrTypeMixupMethodConfig", "Sample", "dsde", "three_step", "1", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this.confused"), outputs=Map.empty, wsName, "dsde")
+    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", "Sample", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this.type"), outputs=Map.empty, wsName, MethodStoreConfiguration("dsde-config", "three_step", "1"), MethodStoreMethod("dsde", "three_step", "1"))
+    val methodConfigUnparseable = MethodConfiguration("dsde", "UnparseableMethodConfig", "Sample", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this..wont.parse"), outputs=Map.empty, wsName, MethodStoreConfiguration("dsde-config", "three_step", "1"), MethodStoreMethod("dsde", "three_step", "1"))
+    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", "Sample", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this.tumortype"), outputs=Map.empty, wsName, MethodStoreConfiguration("dsde-config", "three_step", "1"), MethodStoreMethod("dsde", "three_step", "1"))
+    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", "Sample", prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> "this.confused"), outputs=Map.empty, wsName, MethodStoreConfiguration("dsde-config", "three_step", "1"), MethodStoreMethod("dsde", "three_step", "1"))
 
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, methodConfig.workspaceName)
     val methodConfigName2 = methodConfigName.copy(name="novelName")

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -27,11 +27,13 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbT
   val sampleGood = new Entity("sampleGood", "Sample", Map("blah" -> AttributeNumber(1)), WorkspaceName("workspaces", "test_workspace"))
   val sampleMissingValue = new Entity("sampleMissingValue", "Sample", Map.empty, WorkspaceName("workspaces", "test_workspace"))
 
-  val configGood = new MethodConfiguration("configGood", "Sample", "method_namespace", "test_method", "1",
-    Map.empty, Map(intArgName -> "this.blah"), Map.empty, WorkspaceName("workspaces", "test_workspace"), "config_namespace")
+  val configGood = new MethodConfiguration("config_namespace", "configGood", "Sample",
+    Map.empty, Map(intArgName -> "this.blah"), Map.empty, WorkspaceName("workspaces", "test_workspace"),
+    MethodStoreConfiguration( "method_config_namespace", "test_method", "1"), MethodStoreMethod( "method_namespace", "test_method", "1"))
 
-  val configMissingExpr = new MethodConfiguration("configMissingExpr", "Sample", "method_namespace", "test_method", "1",
-    Map.empty, Map.empty, Map.empty, WorkspaceName("workspaces", "test_workspace"), "config_namespace")
+  val configMissingExpr = new MethodConfiguration("config_namespace", "configMissingExpr", "Sample",
+    Map.empty, Map.empty, Map.empty, WorkspaceName("workspaces", "test_workspace"),
+    MethodStoreConfiguration( "method_config_namespace", "test_method", "1"), MethodStoreMethod( "method_namespace", "test_method", "1"))
 
   class ConfigData extends TestData {
     override def save(txn: RawlsTransaction): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
@@ -36,7 +36,7 @@ class RemoteServicesMockServer(port:Int) {
     val copyMethodConfigPath = "/configurations"
 
     val goodResult = AgoraEntity(Some("workspace_test"), Some("rawls_test_good"), Some(1), None, None, None, None,
-      Some("{\n  \"name\": \"rawls_test_1\",\n  \"rootEntityType\": \"rawls_test_type_1\",\n  \"methodNamespace\": \"rawls_test_m_namespace_1\",\n  \"methodName\": \"rawls_test_m_name_1\",\n  \"methodVersion\": \"rawls_test_m_version_1\",\n  \"prerequisites\": { },\n  \"inputs\": { },\n  \"outputs\": { },\n  \"workspaceName\": {\n    \"namespace\": \"rawls_test_w_namespace_1\",\n    \"name\": \"rawls_test_w_name_1\"\n  },\n  \"namespace\": \"rawls_test_namespace_1\"\n}"),
+      Some("{\"name\":\"testConfig1\",\"workspaceName\":{\"namespace\":\"myNamespace\",\"name\":\"myWorkspace\"},\"methodStoreMethod\":{\"methodNamespace\":\"ns-config\",\"methodName\":\"meth1\",\"methodVersion\":\"1\"},\"methodStoreConfig\":{\"methodConfigNamespace\":\"ns\",\"methodConfigName\":\"meth1\",\"methodConfigVersion\":\"1\"},\"outputs\":{\"p1\":\"prereq expr\"},\"inputs\":{\"o1\":\"output expr\"},\"rootEntityType\":\"Sample\",\"prerequisites\":{\"i1\":\"input expr\"},\"namespace\":\"ns\"}"),
       None, None)
 
     val emptyPayloadResult = AgoraEntity(Some("workspace_test"), Some("rawls_test_empty_payload"), Some(1), None, None, None, None,

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceApiServiceSpec.scala
@@ -511,7 +511,8 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
   }
 
   it should "return 201 on create method configuration" in withTestDataApiServices { services =>
-    val newMethodConfig = MethodConfiguration("testConfig2", "samples", testData.wsName.namespace, "method-a", "1", Map("ready" -> "true"), Map("param1" -> "foo"), Map("out" -> "bar"), testData.wsName, "dsde")
+    val newMethodConfig = MethodConfiguration("dsde", "testConfig2", "samples", Map("ready" -> "true"), Map("param1" -> "foo"), Map("out" -> "bar"),
+      testData.wsName, MethodStoreConfiguration(testData.wsName.namespace+"_config", "method-a", "1"), MethodStoreMethod(testData.wsName.namespace, "method-a", "1"))
 
     Post(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/methodconfigs", HttpEntity(ContentTypes.`application/json`, newMethodConfig.toJson.toString())) ~>
       addMockOpenAmCookie ~>
@@ -825,7 +826,7 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
 
   it should "return 404 Not Found when creating a submission using an Entity that doesn't exist in the workspace" in withTestDataApiServices { services =>
     val mcName = MethodConfigurationName("three_step_1","dsde",testData.wsName)
-    val methodConf = MethodConfiguration(mcName.name,"Pattern","dsde","three_step","1",Map.empty,Map("pattern"->"String"),Map.empty,mcName.workspaceName,mcName.namespace)
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name,"Pattern",Map.empty,Map("pattern"->"String"),Map.empty,mcName.workspaceName, MethodStoreConfiguration("dsde_config","three_step","1"), MethodStoreMethod("dsde","three_step","1"))
     Post(s"/workspaces/${testData.wsName.namespace}/${testData.wsName.name}/methodconfigs", HttpEntity(ContentTypes.`application/json`,methodConf.toJson.toString)) ~>
       addMockOpenAmCookie ~>
       sealRoute(services.createMethodConfigurationRoute) ~>
@@ -839,7 +840,7 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
   it should "return 201 Created when creating a submission" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("three_step","dsde",wsName)
-    val methodConf = MethodConfiguration(mcName.name,"Pattern","dsde","three_step","1",Map.empty,Map.empty,Map.empty,mcName.workspaceName,mcName.namespace)
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name,"Pattern",Map.empty,Map.empty,Map.empty, wsName, MethodStoreConfiguration("dsde_config","three_step","1"), MethodStoreMethod("dsde","three_step","1"))
     Post(s"/workspaces/${testData.wsName.namespace}/${testData.wsName.name}/methodconfigs", HttpEntity(ContentTypes.`application/json`,methodConf.toJson.toString)) ~>
       addMockOpenAmCookie ~>
       sealRoute(services.createMethodConfigurationRoute) ~>


### PR DESCRIPTION
…so namespace, name

and version of method are grouped together, and added sub-document for method config
from repo info.  These were two requested features from Chet/Silver as defined in
DSDEEPB-829.