### PR TITLE
hack to make coveralls work

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,6 @@ lazy val rawls = project.in(file("."))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.testTasks): _*)
   .settings(
-    testOptions in Test := Seq(Tests.Filter(s => !isIntegrationTest(s))),
+    testOptions in Test ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
     testOptions in IntegrationTest := Seq(Tests.Filter(s => isIntegrationTest(s)))
   )


### PR DESCRIPTION
As discussed here: https://github.com/broadinstitute/rawls/pull/61

Note that ```IntegrationTest``` still uses ```:=```.This is necessary because of reasons.
