### PR TITLE
Abort submissions

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
@@ -10,4 +10,5 @@ trait ExecutionServiceDAO {
   def submitWorkflow( wdl: String, inputs: String, authCookie: HttpCookie ): ExecutionServiceStatus
   def status(id: String, authCookie: HttpCookie): ExecutionServiceStatus
   def outputs(id: String, authCookie: HttpCookie): ExecutionServiceOutputs
+  def abort(id: String, authCookie: HttpCookie): ExecutionServiceStatus
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
@@ -35,6 +35,13 @@ class HttpExecutionServiceDAO( executionServiceURL: String )( implicit system: A
     val url = executionServiceURL + s"/workflow/${id}/outputs"
     import system.dispatcher
     val pipeline = addHeader(Cookie(authCookie)) ~> sendReceive ~> unmarshal[ExecutionServiceOutputs]
-    Await.result(pipeline(Get(url)),Duration.Inf)
+    Await.result(pipeline(Get(url)), Duration.Inf)
+  }
+
+  override def abort(id: String, authCookie: HttpCookie): ExecutionServiceStatus = {
+    val url = executionServiceURL + s"/workflow/${id}"
+    import system.dispatcher
+    val pipeline = addHeader(Cookie(authCookie)) ~> sendReceive ~> unmarshal[ExecutionServiceStatus]
+    Await.result(pipeline(Delete(url)),Duration.Inf)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -98,7 +98,7 @@ object ExecutionJsonSupport extends JsonSupport {
 }
 
 object WorkflowStatuses {
-  val terminalStatuses: Seq[WorkflowStatus] = Seq(Failed, Succeeded, Unknown)
+  val terminalStatuses: Seq[WorkflowStatus] = Seq(Failed, Succeeded, Aborted, Unknown)
 
   sealed trait WorkflowStatus {
     def isDone = {
@@ -113,6 +113,7 @@ object WorkflowStatuses {
       case "Running" => Running
       case "Failed" => Failed
       case "Succeeded" => Succeeded
+      case "Aborted" => Aborted
       case "Unknown" => Unknown
       case _ => throw new RawlsException(s"invalid WorkflowStatus [${name}]")
     }
@@ -122,6 +123,7 @@ object WorkflowStatuses {
   case object Running extends WorkflowStatus
   case object Failed extends WorkflowStatus
   case object Succeeded extends WorkflowStatus
+  case object Aborted extends WorkflowStatus
   case object Unknown extends WorkflowStatus
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -33,6 +33,12 @@ trait SubmissionApiService extends HttpService with PerRequestCreator with OpenA
         requestContext => perRequest(requestContext, WorkspaceService.props(workspaceServiceConstructor, userInfo),
           WorkspaceService.GetSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName), submissionId))
       }
+    } ~
+    path("workspaces" / Segment / Segment / "submissions" / Segment) { (workspaceNamespace, workspaceName, submissionId) =>
+      delete {
+        requestContext => perRequest(requestContext, WorkspaceService.props(workspaceServiceConstructor, userInfo),
+          WorkspaceService.AbortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId))
+      }
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -85,15 +85,15 @@ class SubmissionMonitorSpec(_system: ActorSystem) extends TestKit(_system) with 
   }
 
   it should "terminate when all workflows are done" in withDefaultTestDatabase { dataSource =>
-    val monitorRef = TestActorRef[SubmissionMonitor](SubmissionMonitor.props(testData.submission1, submissionDAO, new GraphWorkflowDAO, new GraphEntityDAO(), dataSource, 10 milliseconds, 1 second, TestActor.props()))
+    val monitorRef = TestActorRef[SubmissionMonitor](SubmissionMonitor.props(testData.submissionTerminateTest, submissionDAO, new GraphWorkflowDAO, new GraphEntityDAO(), dataSource, 10 milliseconds, 1 second, TestActor.props()))
     watch(monitorRef)
 
-    // set each workflow to one of the terminal statuses, there should be 3 of each
+    // set each workflow to one of the terminal statuses, there should be 4 of each
     assertResult(WorkflowStatuses.terminalStatuses.size) {
-      testData.submission1.workflows.size
+      testData.submissionTerminateTest.workflows.size
     }
 
-    testData.submission1.workflows.zip(WorkflowStatuses.terminalStatuses).foreach { case (workflow, status) =>
+    testData.submissionTerminateTest.workflows.zip(WorkflowStatuses.terminalStatuses).foreach { case (workflow, status) =>
       system.actorSelection(monitorRef.path / workflow.workflowId).tell(SubmissionMonitor.WorkflowStatusChange(workflow.copy(status = status), None), testActor)
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
@@ -54,6 +54,7 @@ class WorkflowMonitorSpec(_system: ActorSystem) extends TestKit(_system) with Fl
       status match {
         case WorkflowStatuses.Failed => expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = status, messages = testData.submission1.workflows.head.messages :+ AttributeString("Workflow execution failed, check outputs for details")), None))
         case WorkflowStatuses.Unknown => expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = status), None))
+        case WorkflowStatuses.Aborted => expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = status), None))
         case WorkflowStatuses.Succeeded => expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = status), Some(Map("output" -> AttributeString("foo")))))
       }
       fishForMessage(1 second) {
@@ -102,4 +103,5 @@ class WorkflowTestExecutionServiceDAO(workflowStatus: String) extends ExecutionS
   override def outputs(id: String, authCookie: HttpCookie): ExecutionServiceOutputs = ExecutionServiceOutputs(id, Map("o1" -> AttributeString("foo")))
 
   override def status(id: String, authCookie: HttpCookie): ExecutionServiceStatus = ExecutionServiceStatus(id, workflowStatus)
+  override def abort(id: String, authCookie: HttpCookie): ExecutionServiceStatus = ExecutionServiceStatus(id, workflowStatus)
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
@@ -189,6 +189,56 @@ class RemoteServicesMockServer(port:Int) {
 }""")
           .withStatusCode(StatusCodes.Created.intValue)
       )
+
+    mockServer.when(
+      request()
+        .withMethod("DELETE")
+        .withPath("/workflow/this_workflow_exists")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(
+            """{
+    "id": "this_workflow_exists",
+    "status": "Aborted"
+}""")
+          .withStatusCode(StatusCodes.OK.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("DELETE")
+        .withPath("/workflow/already_terminal_workflow")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(
+            """{
+    "id": "this_workflow_also_exists",
+    "status": "Aborted"
+}""")
+          .withStatusCode(StatusCodes.Forbidden.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("DELETE")
+        .withPath("/workflow/nonexistent_workflow")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withStatusCode(StatusCodes.NotFound.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("DELETE")
+        .withPath("/workflow/malformed_workflow")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withStatusCode(StatusCodes.NotFound.intValue)
+      )
   }
 
   def stopServer = mockServer.stop()


### PR DESCRIPTION
- Added Aborted status to Workflows (Cromwell now returns this)
- New DELETE verb added to submission/id
- Some nasty futzing in SubmissionMonitorSpec and SubmissionGraphDAOSpec because they both use the same list of submissions defined in the test fixture
