### PR TITLE
use WorkspaceContext

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -47,6 +47,7 @@ object Boot extends App {
     }
 
     val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
+      new GraphWorkspaceDAO(),
       new GraphSubmissionDAO(new GraphWorkflowDAO()),
       new HttpExecutionServiceDAO(conf.getConfig("executionservice").getString("server")),
       new GraphWorkflowDAO(),

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/EntityDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/EntityDAO.scala
@@ -9,32 +9,30 @@ import AttributeUpdateOperations.AttributeUpdateOperation
  */
 trait EntityDAO {
   /** gets the given entity */
-  def get(workspaceNamespace: String, workspaceName: String, entityType: String, entityName: String, txn: RawlsTransaction): Option[Entity]
+  def get(workspaceContext: WorkspaceContext, entityType: String, entityName: String, txn: RawlsTransaction): Option[Entity]
 
   /** creates or replaces an entity */
-  def save(workspaceNamespace: String, workspaceName: String, entity: Entity, txn: RawlsTransaction): Entity
+  def save(workspaceContext: WorkspaceContext, entity: Entity, txn: RawlsTransaction): Entity
 
-  /**
-   * deletes an entity
-   */
-  def delete(workspaceNamespace: String, workspaceName: String, entityType: String, entityName: String, txn: RawlsTransaction)
+  /** deletes an entity */
+  def delete(workspaceContext: WorkspaceContext, entityType: String, entityName: String, txn: RawlsTransaction): Boolean
 
   /** list all entities of the given type in the workspace */
-  def list(workspaceNamespace: String, workspaceName: String, entityType: String, txn: RawlsTransaction): TraversableOnce[Entity]
+  def list(workspaceContext: WorkspaceContext, entityType: String, txn: RawlsTransaction): TraversableOnce[Entity]
 
-  def rename(workspaceNamespace: String, workspaceName: String, entityType: String, entityName: String, newName: String, txn: RawlsTransaction)
+  def rename(workspaceContext: WorkspaceContext, entityType: String, oldName: String, newName: String, txn: RawlsTransaction): Unit
 
-  def getEntityTypes(workspaceNamespace: String, workspaceName: String, txn: RawlsTransaction): Seq[String]
+  def getEntityTypes(workspaceContext: WorkspaceContext, txn: RawlsTransaction): TraversableOnce[String]
 
-  def listEntitiesAllTypes(workspaceNamespace: String, workspaceName: String, txn: RawlsTransaction): TraversableOnce[Entity]
+  def listEntitiesAllTypes(workspaceContext: WorkspaceContext, txn: RawlsTransaction): TraversableOnce[Entity]
 
-  def cloneAllEntities(workspaceNamespace: String, newWorkspaceNamespace: String, workspaceName: String, newWorkspaceName: String, txn: RawlsTransaction): Unit
+  def cloneAllEntities(sourceWorkspaceContext: WorkspaceContext, destWorkspaceContext: WorkspaceContext, txn: RawlsTransaction): Unit
 
-  def cloneTheseEntities( entities: Seq[Entity], newWorkspaceNamespace: String, newWorkspaceName: String, txn: RawlsTransaction ): Unit
+  def cloneEntities(destWorkspaceContext: WorkspaceContext, entities: Seq[Entity], txn: RawlsTransaction): Unit
 
-  def getEntitySubtrees(workspaceNamespace: String, workspaceName: String, entityType: String, entityNames: Seq[String], txn: RawlsTransaction): TraversableOnce[Entity]
+  def getEntitySubtrees(workspaceContext: WorkspaceContext, entityType: String, entityNames: Seq[String], txn: RawlsTransaction): TraversableOnce[Entity]
 
-  def copyEntities(destNamespace: String, destWorkspace: String, sourceNamespace: String, sourceWorkspace: String, entityType: String, entityNames: Seq[String], txn: RawlsTransaction): Seq[Entity]
+  def copyEntities(sourceWorkspaceContext: WorkspaceContext, destWorkspaceContext: WorkspaceContext, entityType: String, entityNames: Seq[String], txn: RawlsTransaction): TraversableOnce[Entity]
 
-  def getCopyConflicts(destNamespace: String, destWorkspace: String, entitiesToCopy: Seq[Entity], txn: RawlsTransaction): Seq[Entity]
+  def getCopyConflicts(destWorkspaceContext: WorkspaceContext, entitiesToCopy: Seq[Entity], txn: RawlsTransaction): TraversableOnce[Entity]
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphSubmissionDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphSubmissionDAO.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.rawls.RawlsException
 import org.joda.time.DateTime
 import org.broadinstitute.dsde.rawls.model.{WorkspaceName, WorkflowFailure, Submission, Workflow}
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 
 /**
@@ -15,79 +16,80 @@ import scala.language.implicitConversions
 class GraphWorkflowDAO extends WorkflowDAO with GraphDAO {
 
   /** get a workflow by workspace and workflowId */
-  override def get(workspaceName: WorkspaceName, workflowId: String, txn: RawlsTransaction): Option[Workflow] =
+  override def get(workspaceContext: WorkspaceContext, workflowId: String, txn: RawlsTransaction): Option[Workflow] =
     txn withGraph { db =>
-      getSinglePipelineResult(getPipeline(db,workspaceName.namespace,workspaceName.name,workflowId)) map { loadFromVertex[Workflow](_, Option(workspaceName)) }
+      getWorkflowVertex(workspaceContext, workflowId) map { loadFromVertex[Workflow](_, Some(workspaceContext.workspaceName)) }
     }
 
   /** update a workflow */
-  override def update(workspaceName: WorkspaceName, workflow: Workflow, txn: RawlsTransaction): Workflow =
+  override def update(workspaceContext: WorkspaceContext, workflow: Workflow, txn: RawlsTransaction): Workflow =
     txn withGraph { db =>
-      val vertex = getSinglePipelineResult(getPipeline(db,workspaceName.namespace,workspaceName.name,workflow.workflowId))
-      if ( vertex.isDefined ) saveToVertex(workflow, vertex.get, db, workspaceName)
-      else throw new RawlsException(s"workflow does not exist: ${workflow}")
+      getWorkflowVertex(workspaceContext, workflow.workflowId) match {
+        case Some(vertex) => saveToVertex[Workflow](db, workspaceContext, workflow, vertex)
+        case None => throw new RawlsException(s"workflow does not exist: ${workflow}")
+      }
       workflow
     }
 
   /** delete a workflow */
-  override def delete(workspaceName: WorkspaceName, workflowId: String, txn: RawlsTransaction): Boolean =
+  override def delete(workspaceContext: WorkspaceContext, workflowId: String, txn: RawlsTransaction): Boolean =
     txn withGraph { db =>
-      val vertex = getSinglePipelineResult(getPipeline(db,workspaceName.namespace,workspaceName.name,workflowId))
-      if ( vertex.isDefined ) vertex.get.remove
-      vertex.isDefined
+      getWorkflowVertex(workspaceContext, workflowId) match {
+        case Some(vertex) => {
+          vertex.remove
+          true
+        }
+        case None => false
+      }
     }
-
-  private def getPipeline(db: Graph, workspaceNamespace: String, workspaceName: String, workflowId: String) =
-    workspacePipeline(db, workspaceNamespace, workspaceName).out(workflowEdge).filter(hasPropertyValue("workflowId",workflowId))
 }
 
 class GraphSubmissionDAO(graphWorkflowDAO: GraphWorkflowDAO) extends SubmissionDAO with GraphDAO {
 
   /** get a submission by workspace and submissionId */
-  override def get(workspaceNamespace: String, workspaceName: String, submissionId: String, txn: RawlsTransaction): Option[Submission] =
+  override def get(workspaceContext: WorkspaceContext, submissionId: String, txn: RawlsTransaction): Option[Submission] =
     txn withGraph { db =>
-      getSinglePipelineResult[Vertex](getPipeline(db,workspaceNamespace,workspaceName,submissionId)) map { fromVertex(workspaceNamespace,workspaceName,_) }
+      getSubmissionVertex(workspaceContext, submissionId) map { fromVertex(workspaceContext, _) }
     }
 
   /** list all submissions in the workspace */
-  override def list(workspaceNamespace: String, workspaceName: String, txn: RawlsTransaction): TraversableOnce[Submission] =
+  override def list(workspaceContext: WorkspaceContext, txn: RawlsTransaction): TraversableOnce[Submission] =
     txn withGraph { db =>
-      workspacePipeline(db, workspaceNamespace, workspaceName).out(submissionEdge).transform[Submission] { vertex: Vertex => fromVertex(workspaceNamespace,workspaceName,vertex) }.iterator
+      workspacePipeline(workspaceContext).out(submissionEdge).transform((v: Vertex) => fromVertex(workspaceContext, v)).toList.asScala
     }
 
   /** create a submission (and its workflows) */
-  override def save(workspaceNamespace: String, workspaceName: String, submission: Submission, txn: RawlsTransaction) =
+  override def save(workspaceContext: WorkspaceContext, submission: Submission, txn: RawlsTransaction) =
     txn withGraph { db =>
-      val workspaceVertex = getWorkspaceVertex(db, workspaceNamespace, workspaceName).getOrElse(throw new IllegalArgumentException(s"workspace ${workspaceNamespace}/${workspaceName} does not exist"))
-      val submissionVertex = saveToVertex(submission, addVertex(db, VertexSchema.Submission), db, WorkspaceName(workspaceNamespace, workspaceName))
-      addEdge(workspaceVertex, submissionEdge, submissionVertex)
+      val submissionVertex = saveToVertex[Submission](db, workspaceContext, submission, addVertex(db, VertexSchema.Submission))
+      addEdge(workspaceContext.workspaceVertex, submissionEdge, submissionVertex)
+      submission
     }
 
-  override def update(submission: Submission, txn: RawlsTransaction): Unit = {
+  override def update(workspaceContext: WorkspaceContext, submission: Submission, txn: RawlsTransaction) = {
     txn withGraph { db =>
-      getSinglePipelineResult[Vertex](getPipeline(db, submission.workspaceName.namespace, submission.workspaceName.name, submission.submissionId)) match {
-        case Some(vertex) => saveToVertex(submission, vertex, db, submission.workspaceName)
+      getSubmissionVertex(workspaceContext, submission.submissionId) match {
+        case Some(vertex) => saveToVertex[Submission](db, workspaceContext, submission, vertex)
         case None => throw new RawlsException("submission does not exist to be updated: " + submission)
       }
+      submission
     }
   }
 
   /** delete a submission (and its workflows) */
-  override def delete(workspaceNamespace: String, workspaceName: String, submissionId: String, txn: RawlsTransaction): Boolean =
+  override def delete(workspaceContext: WorkspaceContext, submissionId: String, txn: RawlsTransaction): Boolean =
     txn withGraph { db =>
-      val vertex = getSinglePipelineResult(getPipeline(db,workspaceNamespace,workspaceName,submissionId))
-      if ( vertex.isDefined ) {
-        new GremlinPipeline(vertex.get).out(workflowEdge, workflowFailureEdge).remove
-        vertex.get.remove
+      getSubmissionVertex(workspaceContext, submissionId) match {
+        case Some(vertex) => {
+          new GremlinPipeline(vertex).out(workflowEdge, workflowFailureEdge).remove
+          vertex.remove
+          true
+        }
+        case None => false
       }
-      vertex.isDefined
     }
 
-  private def getPipeline(db: Graph, workspaceNamespace: String, workspaceName: String, submissionId: String) = {
-    workspacePipeline(db, workspaceNamespace, workspaceName).out(submissionEdge).filter(hasPropertyValue("submissionId",submissionId))
-  }
-
-  private def fromVertex(workspaceNamespace: String, workspaceName: String, vertex: Vertex): Submission = {
-    loadFromVertex[Submission](vertex, Option(WorkspaceName(workspaceNamespace, workspaceName)))
+  private def fromVertex(workspaceContext: WorkspaceContext, vertex: Vertex): Submission = {
+    loadFromVertex[Submission](vertex, Some(workspaceContext.workspaceName))
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/MethodConfigurationDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/MethodConfigurationDAO.scala
@@ -7,17 +7,17 @@ import org.broadinstitute.dsde.rawls.model.{MethodConfigurationShort, MethodConf
  */
 trait MethodConfigurationDAO {
   /** gets by method config name*/
-  def get(workspaceNamespace: String, workspaceName: String, methodConfigurationNamespace: String, methodConfigurationName: String, txn: RawlsTransaction) : Option[MethodConfiguration]
+  def get(workspaceContext: WorkspaceContext, methodConfigurationNamespace: String, methodConfigurationName: String, txn: RawlsTransaction) : Option[MethodConfiguration]
 
   /** creates or replaces a method configuration */
-  def save(workspaceNamespace: String, workspaceName: String, methodConfiguration: MethodConfiguration, txn: RawlsTransaction) : MethodConfiguration
+  def save(workspaceContext: WorkspaceContext, methodConfiguration: MethodConfiguration, txn: RawlsTransaction) : MethodConfiguration
 
   /** delete a method configuration, not sure if we need to delete all or a specific version?*/
-  def delete(workspaceNamespace: String, workspaceName: String, methodConfigurationNamespace: String, methodConfigurationName: String, txn: RawlsTransaction)
+  def delete(workspaceContext: WorkspaceContext, methodConfigurationNamespace: String, methodConfigurationName: String, txn: RawlsTransaction): Boolean
 
   /** list all method configurations in the workspace */
-  def list(workspaceNamespace: String, workspaceName: String, txn: RawlsTransaction): TraversableOnce[MethodConfigurationShort]
+  def list(workspaceContext: WorkspaceContext, txn: RawlsTransaction): TraversableOnce[MethodConfigurationShort]
 
   /** rename method configuration */
-  def rename(workspaceNamespace: String, workspaceName: String, methodConfigurationNamespace: String, methodConfiguration: String, newName: String, txn: RawlsTransaction)
+  def rename(workspaceContext: WorkspaceContext, methodConfigurationNamespace: String, oldName: String, newName: String, txn: RawlsTransaction): Unit
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionDAO.scala
@@ -7,27 +7,27 @@ import org.broadinstitute.dsde.rawls.model.{WorkspaceName, Submission, Workflow}
  */
 trait SubmissionDAO {
   /** get a submission by workspace and submissionId */
-  def get(workspaceNamespace: String, workspaceName: String, submissionId: String, txn: RawlsTransaction): Option[Submission]
+  def get(workspaceContext: WorkspaceContext, submissionId: String, txn: RawlsTransaction): Option[Submission]
 
   /** list all submissions in the workspace */
-  def list(workspaceNamespace: String, workspaceName: String, txn: RawlsTransaction): TraversableOnce[Submission]
+  def list(workspaceContext: WorkspaceContext, txn: RawlsTransaction): TraversableOnce[Submission]
 
   /** create a submission (and its workflows) */
-  def save(workspaceNamespace: String, workspaceName: String, submission: Submission, txn: RawlsTransaction): Unit
+  def save(workspaceContext: WorkspaceContext, submission: Submission, txn: RawlsTransaction): Submission
 
   /** delete a submission (and its workflows) */
-  def delete(workspaceNamespace: String, workspaceName: String, submissionId: String, txn: RawlsTransaction): Boolean
+  def delete(workspaceContext: WorkspaceContext, submissionId: String, txn: RawlsTransaction): Boolean
 
-  def update(submission: Submission, txn: RawlsTransaction): Unit
+  def update(workspaceContext: WorkspaceContext, submission: Submission, txn: RawlsTransaction): Submission
 }
 
 trait WorkflowDAO {
   /** get a workflow by workspace and workflowId */
-  def get(workspaceName: WorkspaceName, workflowId: String, txn: RawlsTransaction): Option[Workflow]
+  def get(workspaceContext: WorkspaceContext, workflowId: String, txn: RawlsTransaction): Option[Workflow]
 
   /** update a workflow */
-  def update(workspaceName: WorkspaceName, workflow: Workflow, txn: RawlsTransaction): Workflow
+  def update(workspaceContext: WorkspaceContext, workflow: Workflow, txn: RawlsTransaction): Workflow
 
   /** delete a workflow */
-  def delete(workspaceName: WorkspaceName, workflowId: String, txn: RawlsTransaction): Boolean
+  def delete(workspaceContext: WorkspaceContext, workflowId: String, txn: RawlsTransaction): Boolean
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceContext.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceContext.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import com.tinkerpop.blueprints.{Graph, Vertex}
+import org.broadinstitute.dsde.rawls.model.{WorkspaceName, Workspace}
+
+/**
+ * Holds information about a workspace inside a DB transaction.
+ *
+ * @param workspaceName
+ * @param bucketName
+ * @param workspaceVertex
+ */
+case class WorkspaceContext(workspaceName: WorkspaceName, bucketName: String, workspaceVertex: Vertex) {
+  override def toString = workspaceName.toString // used in error messages
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceDAO.scala
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import org.broadinstitute.dsde.rawls.model.Workspace
+import org.broadinstitute.dsde.rawls.model.{WorkspaceName, Workspace}
 
 /**
  * Created by dvoet on 4/24/15.
  */
 trait WorkspaceDAO {
   def save(workspace: Workspace, txn: RawlsTransaction): Workspace
-  def load(namespace: String, name: String, txn: RawlsTransaction): Option[Workspace]
-  def list(txn: RawlsTransaction): Seq[Workspace]
+  def load(workspaceName: WorkspaceName, txn: RawlsTransaction): Option[Workspace]
+  def loadContext(workspaceName: WorkspaceName, txn: RawlsTransaction): Option[WorkspaceContext]
+  def list(txn: RawlsTransaction): TraversableOnce[Workspace]
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -26,6 +26,7 @@ case class WorkspaceRequest (
                       attributes: Map[String, Attribute]
                       ) extends Identifiable with Attributable {
   def path = WorkspaceName(namespace,name).path
+  def toWorkspaceName = WorkspaceName(namespace,name)
 }
 
 case class Workspace (
@@ -74,6 +75,7 @@ case class MethodRepoMethod(
                    methodName: String,
                    methodVersion: String
                    )
+
 case class MethodRepoConfiguration(
                    methodConfigNamespace: String,
                    methodConfigName: String,

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAOSpec.scala
@@ -13,26 +13,29 @@ import scala.collection.immutable.HashMap
 class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
   lazy val dao: GraphEntityDAO = new GraphEntityDAO()
 
-
   "GraphEntityDAO" should "get entity types" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Set("PairSet", "Individual", "Sample", "Aliquot", "SampleSet", "Pair")) {
-        dao.getEntityTypes(testData.workspace.namespace, testData.workspace.name, txn).toSet
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Set("PairSet", "Individual", "Sample", "Aliquot", "SampleSet", "Pair")) {
+          dao.getEntityTypes(context, txn).toSet
+        }
       }
     }
   }
 
   it should "list all entities of all entity types" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Set(testData.sample1, testData.sample2, testData.sample3, testData.sample4, testData.sample5, testData.sample6, testData.sample7, testData.sset1, testData.sset2, testData.sset3, testData.sset4, testData.sset_empty, testData.aliquot1, testData.aliquot2, testData.pair1, testData.pair2, testData.ps1, testData.indiv1, testData.aliquot1, testData.aliquot2)) {
-        dao.listEntitiesAllTypes(testData.workspace.namespace, testData.workspace.name, txn).toSet
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Set(testData.sample1, testData.sample2, testData.sample3, testData.sample4, testData.sample5, testData.sample6, testData.sample7, testData.sset1, testData.sset2, testData.sset3, testData.sset4, testData.sset_empty, testData.aliquot1, testData.aliquot2, testData.pair1, testData.pair2, testData.ps1, testData.indiv1, testData.aliquot1, testData.aliquot2)) {
+          dao.listEntitiesAllTypes(context, txn).toSet
+        }
       }
     }
   }
 
   class BugTestData() extends TestData {
     val wsName = WorkspaceName("myNamespace2", "myWorkspace2")
-    val workspace = new Workspace(wsName.namespace, wsName.name, "aBucket", DateTime.now, "testUser", Map.empty )
+    val workspace = new Workspace(wsName.namespace, wsName.name, "aBucket", DateTime.now, "testUser", Map.empty)
 
     val sample1 = new Entity("sample1", "Sample",
       Map(
@@ -41,66 +44,68 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
 
     val aliquot1 = Entity("aliquot1", "Aliquot", Map.empty, wsName)
 
-    override def save(txn:RawlsTransaction): Unit = {
+    override def save(txn: RawlsTransaction): Unit = {
       workspaceDAO.save(workspace, txn)
-      entityDAO.save(workspace.namespace, workspace.name, aliquot1, txn)
-      entityDAO.save(workspace.namespace, workspace.name, sample1, txn)
+      withWorkspaceContext(workspace, txn) { context =>
+        entityDAO.save(context, aliquot1, txn)
+        entityDAO.save(context, sample1, txn)
+      }
     }
   }
   val bugData = new BugTestData
 
   it should "get an entity with attribute ref name same as an entity, but different case" in withCustomTestDatabase(new BugTestData) { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Some(bugData.sample1)) {
-        dao.get(bugData.workspace.namespace, bugData.workspace.name, "Sample", "sample1", txn)
+      withWorkspaceContext(bugData.workspace, txn) { context =>
+        assertResult(Some(bugData.sample1)) {
+          dao.get(context, "Sample", "sample1", txn)
+        }
       }
     }
   }
 
   it should "get an entity" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Some(testData.pair1)) {
-        dao.get(testData.workspace.namespace, testData.workspace.name, "Pair", "pair1", txn)
-      }
-      assertResult(Some(testData.sample1)) {
-        dao.get(testData.workspace.namespace, testData.workspace.name, "Sample", "sample1", txn)
-      }
-      assertResult(Some(testData.sset1)) {
-        dao.get(testData.workspace.namespace, testData.workspace.name, "SampleSet", "sset1", txn)
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Some(testData.pair1)) {
+          dao.get(context, "Pair", "pair1", txn)
+        }
+        assertResult(Some(testData.sample1)) {
+          dao.get(context, "Sample", "sample1", txn)
+        }
+        assertResult(Some(testData.sset1)) {
+          dao.get(context, "SampleSet", "sset1", txn)
+        }
       }
     }
   }
 
   it should "return None when an entity does not exist" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(None) {
-        dao.get(testData.workspace.namespace, testData.workspace.name, "pair", "fnord", txn)
-      }
-      assertResult(None) {
-        dao.get(testData.workspace.namespace, testData.workspace.name, "fnord", "pair1", txn)
-      }
-    }
-  }
-
-  it should "return None when a parent workspace does not exist" in withDefaultTestDatabase { dataSource =>
-    dataSource.inTransaction { txn =>
-      assertResult(None) {
-        dao.get(testData.workspace.namespace, "fnord", "pair", "pair1", txn)
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(None) {
+          dao.get(context, "pair", "fnord", txn)
+        }
+        assertResult(None) {
+          dao.get(context, "fnord", "pair1", txn)
+        }
       }
     }
   }
 
   it should "save a new entity" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      val pair2 = Entity("pair2", "Pair",
-        Map(
-          "case" -> AttributeEntityReference("Sample", "sample3"),
-          "control" -> AttributeEntityReference("Sample", "sample1")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, pair2, txn)
-      assert {
-        txn.withGraph { graph =>
-          graph.getVertices("entityType", "Pair").exists(v => v.getProperty[String]("name") == "pair2")
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        val pair2 = Entity("pair2", "Pair",
+          Map(
+            "case" -> AttributeEntityReference("Sample", "sample3"),
+            "control" -> AttributeEntityReference("Sample", "sample1")),
+          testData.wsName)
+        dao.save(context, pair2, txn)
+        assert {
+          txn.withGraph { graph =>
+            graph.getVertices("entityType", "Pair").exists(v => v.getProperty[String]("name") == "pair2")
+          }
         }
       }
     }
@@ -137,78 +142,79 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
       workspaceDaoOriginal.save(workspaceOriginal, txn)
       workspaceDaoClone.save(workspaceClone, txn)
 
-      daoCycles.save(workspaceOriginal.namespace, workspaceOriginal.name, c3, txn)
-      daoCycles.save(workspaceOriginal.namespace, workspaceOriginal.name, c2, txn)
-      daoCycles.save(workspaceOriginal.namespace, workspaceOriginal.name, c1, txn)
+      withWorkspaceContext(workspaceOriginal, txn) { originalContext =>
+        withWorkspaceContext(workspaceClone, txn) { cloneContext =>
+          daoCycles.save(originalContext, c3, txn)
+          daoCycles.save(originalContext, c2, txn)
+          daoCycles.save(originalContext, c1, txn)
 
-      c3 = Entity("c3", "samples", Map("foo" -> AttributeString("x"), "bar" -> AttributeNumber(3), "cycle3" -> AttributeEntityReference("samples", "c1")), WorkspaceName(testData.workspace.namespace, testData.workspace.name))
+          c3 = Entity("c3", "samples", Map("foo" -> AttributeString("x"), "bar" -> AttributeNumber(3), "cycle3" -> AttributeEntityReference("samples", "c1")), WorkspaceName(testData.workspace.namespace, testData.workspace.name))
 
-      daoCycles.save(workspaceOriginal.namespace, workspaceOriginal.name, c3, txn)
-      daoCycles.cloneAllEntities(workspaceOriginal.namespace, workspaceClone.namespace, workspaceOriginal.name, workspaceClone.name, txn)
+          daoCycles.save(originalContext, c3, txn)
+          daoCycles.cloneAllEntities(originalContext, cloneContext, txn)
 
-      assertResult(dao.listEntitiesAllTypes(workspaceOriginal.namespace, workspaceOriginal.name, txn).map(_.copy(workspaceName = WorkspaceName(workspaceClone.namespace, workspaceClone.name))).toSet) {
-        dao.listEntitiesAllTypes(workspaceClone.namespace, workspaceClone.name, txn).toSet
+          assertResult(dao.listEntitiesAllTypes(originalContext, txn).map(_.copy(workspaceName = WorkspaceName(workspaceClone.namespace, workspaceClone.name))).toSet) {
+            dao.listEntitiesAllTypes(cloneContext, txn).toSet
+          }
+        }
       }
     }
   }
 
   it should "save updates to an existing entity" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      // flip case / control and add property, remove a property
-      val pair1Updated = Entity("pair1", "Pair",
-        Map(
-          "isItAPair" -> AttributeBoolean(true),
-          "case" -> AttributeEntityReference("Sample", "sample2"),
-          "control" -> AttributeEntityReference("Sample", "sample1")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, pair1Updated, txn)
-      txn.withGraph { graph =>
-        val fetched = graph.getVertices("entityType", "Pair").filter(v => v.getProperty[String]("name") == "pair1").head
-        assert {
-          fetched.getVertices(Direction.OUT).head.getPropertyKeys.contains("isItAPair")
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        // flip case / control and add property, remove a property
+        val pair1Updated = Entity("pair1", "Pair",
+          Map(
+            "isItAPair" -> AttributeBoolean(true),
+            "case" -> AttributeEntityReference("Sample", "sample2"),
+            "control" -> AttributeEntityReference("Sample", "sample1")),
+          testData.wsName)
+        dao.save(context, pair1Updated, txn)
+        txn.withGraph { graph =>
+          val fetched = graph.getVertices("entityType", "Pair").filter(v => v.getProperty[String]("name") == "pair1").head
+          assert {
+            fetched.getVertices(Direction.OUT).head.getPropertyKeys.contains("isItAPair")
+          }
+          // TODO check edges?
         }
-        // TODO check edges?
-      }
 
-      val pair1UpdatedAgain = Entity("pair1", "Pair",
-        Map(
-          "case" -> AttributeEntityReference("Sample", "sample2"),
-          "control" -> AttributeEntityReference("Sample", "sample1")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, pair1UpdatedAgain, txn)
-      txn.withGraph { graph =>
-        val fetched = graph.getVertices("entityType", "Pair").filter(v => v.getProperty[String]("name") == "pair1").head
-        assert {
-          !fetched.getPropertyKeys.contains("isItAPair")
+        val pair1UpdatedAgain = Entity("pair1", "Pair",
+          Map(
+            "case" -> AttributeEntityReference("Sample", "sample2"),
+            "control" -> AttributeEntityReference("Sample", "sample1")),
+          testData.wsName)
+        dao.save(context, pair1UpdatedAgain, txn)
+        txn.withGraph { graph =>
+          val fetched = graph.getVertices("entityType", "Pair").filter(v => v.getProperty[String]("name") == "pair1").head
+          assert {
+            !fetched.getPropertyKeys.contains("isItAPair")
+          }
         }
-      }
-    }
-  }
-
-  it should "throw an exception when trying to save an entity to a nonexistent workspace" in withDefaultTestDatabase { dataSource =>
-    dataSource.inTransaction { txn =>
-      val foo = Entity("foo", "bar", Map.empty, testData.wsName)
-      intercept[IllegalArgumentException] {
-        dao.save("fnord", "dronf", foo, txn)
       }
     }
   }
 
   it should "throw an exception if trying to save invalid references" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      val baz = Entity("wig", "wug", Map("edgeToNowhere" -> AttributeEntityReference("sample", "notTheSampleYoureLookingFor")), testData.wsName)
-      intercept[RawlsException] {
-        dao.save(testData.workspace.namespace, testData.workspace.name, baz, txn)
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        val baz = Entity("wig", "wug", Map("edgeToNowhere" -> AttributeEntityReference("sample", "notTheSampleYoureLookingFor")), testData.wsName)
+        intercept[RawlsException] {
+          dao.save(context, baz, txn)
+        }
       }
     }
   }
 
   it should "delete an entity" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      dao.delete(testData.workspace.namespace, testData.workspace.name, "Pair", "pair2", txn)
-      assert {
-        txn.withGraph { graph =>
-          !graph.getVertices("entityType", "Pair").exists(v => v.getProperty[String]("name") == "pair2")
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        dao.delete(context, "Pair", "pair2", txn)
+        assert {
+          txn.withGraph { graph =>
+            !graph.getVertices("entityType", "Pair").exists(v => v.getProperty[String]("name") == "pair2")
+          }
         }
       }
     }
@@ -216,52 +222,56 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
 
   it should "list entities" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Set(testData.sample1, testData.sample2, testData.sample3, testData.sample4, testData.sample5, testData.sample6, testData.sample7)) {
-        dao.list(testData.workspace.namespace, testData.workspace.name, "Sample", txn).toSet
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Set(testData.sample1, testData.sample2, testData.sample3, testData.sample4, testData.sample5, testData.sample6, testData.sample7)) {
+          dao.list(context, "Sample", txn).toSet
+        }
       }
     }
   }
 
   it should "add cycles to entity graph" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      val sample1Copy = Entity("sample1", "Sample",
-        Map(
-          "type" -> AttributeString("normal"),
-          "whatsit" -> AttributeNumber(100),
-          "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
-          "aliquot" -> AttributeEntityReference("Aliquot", "aliquot1"),
-          "cycle" -> AttributeEntityReference("SampleSet", "sset1")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, sample1Copy, txn)
-      val sample5Copy = Entity("sample5", "Sample",
-        Map(
-          "type" -> AttributeString("tumor"),
-          "whatsit" -> AttributeNumber(100),
-          "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
-          "cycle" -> AttributeEntityReference("SampleSet", "sset4")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, sample5Copy, txn)
-      val sample7Copy = Entity("sample7", "Sample",
-        Map(
-          "type" -> AttributeString("tumor"),
-          "whatsit" -> AttributeNumber(100),
-          "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
-          "cycle" -> AttributeEntityReference("Sample", "sample6")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, sample7Copy, txn)
-      val sample6Copy = Entity("sample6", "Sample",
-        Map(
-          "type" -> AttributeString("tumor"),
-          "whatsit" -> AttributeNumber(100),
-          "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
-          "cycle" -> AttributeEntityReference("SampleSet", "sset3")),
-        testData.wsName)
-      dao.save(testData.workspace.namespace, testData.workspace.name, sample6Copy, txn)
-      val entitiesWithCycles = List("sample1", "sample5", "sample7", "sample6")
-      txn.withGraph { graph =>
-        val fetched = graph.getVertices().filter(v => entitiesWithCycles.contains(v.getProperty[String]("name"))).head.getVertices(Direction.OUT).head.getEdges(Direction.OUT, "cycle")
-        assert {
-          fetched.size == 1
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        val sample1Copy = Entity("sample1", "Sample",
+          Map(
+            "type" -> AttributeString("normal"),
+            "whatsit" -> AttributeNumber(100),
+            "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
+            "aliquot" -> AttributeEntityReference("Aliquot", "aliquot1"),
+            "cycle" -> AttributeEntityReference("SampleSet", "sset1")),
+          testData.wsName)
+        dao.save(context, sample1Copy, txn)
+        val sample5Copy = Entity("sample5", "Sample",
+          Map(
+            "type" -> AttributeString("tumor"),
+            "whatsit" -> AttributeNumber(100),
+            "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
+            "cycle" -> AttributeEntityReference("SampleSet", "sset4")),
+          testData.wsName)
+        dao.save(context, sample5Copy, txn)
+        val sample7Copy = Entity("sample7", "Sample",
+          Map(
+            "type" -> AttributeString("tumor"),
+            "whatsit" -> AttributeNumber(100),
+            "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
+            "cycle" -> AttributeEntityReference("Sample", "sample6")),
+          testData.wsName)
+        dao.save(context, sample7Copy, txn)
+        val sample6Copy = Entity("sample6", "Sample",
+          Map(
+            "type" -> AttributeString("tumor"),
+            "whatsit" -> AttributeNumber(100),
+            "thingies" -> AttributeValueList(Seq(AttributeString("a"), AttributeBoolean(true))),
+            "cycle" -> AttributeEntityReference("SampleSet", "sset3")),
+          testData.wsName)
+        dao.save(context, sample6Copy, txn)
+        val entitiesWithCycles = List("sample1", "sample5", "sample7", "sample6")
+        txn.withGraph { graph =>
+          val fetched = graph.getVertices().filter(v => entitiesWithCycles.contains(v.getProperty[String]("name"))).head.getVertices(Direction.OUT).head.getEdges(Direction.OUT, "cycle")
+          assert {
+            fetched.size == 1
+          }
         }
       }
     }
@@ -269,14 +279,16 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
 
   it should "rename an entity" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      dao.rename(testData.workspace.namespace, testData.workspace.name, "Pair", "pair1", "amazingPair", txn)
-      txn.withGraph { graph =>
-        val pairNames = graph.getVertices("entityType", "Pair").map(_.getProperty[String]("name")).toList
-        assert {
-          pairNames.contains("amazingPair")
-        }
-        assert {
-          !pairNames.contains("pair1")
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        dao.rename(context, "Pair", "pair1", "amazingPair", txn)
+        txn.withGraph { graph =>
+          val pairNames = graph.getVertices("entityType", "Pair").map(_.getProperty[String]("name")).toList
+          assert {
+            pairNames.contains("amazingPair")
+          }
+          assert {
+            !pairNames.contains("pair1")
+          }
         }
       }
     }
@@ -287,8 +299,10 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
    */
   it should "get entity subtrees from a list of entities" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Set(testData.sset3, testData.sample1, testData.sset2, testData.aliquot1, testData.sample6, testData.sset1, testData.sample2, testData.sample3, testData.sample5)) {
-        dao.getEntitySubtrees(testData.workspace.namespace, testData.workspace.name, "SampleSet", List("sset1", "sset2", "sset3", "sampleSetDOESNTEXIST"), txn).toSet
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Set(testData.sset3, testData.sample1, testData.sset2, testData.aliquot1, testData.sample6, testData.sset1, testData.sample2, testData.sample3, testData.sample5)) {
+          dao.getEntitySubtrees(context, "SampleSet", List("sset1", "sset2", "sset3", "sampleSetDOESNTEXIST"), txn).toSet
+        }
       }
     }
   }
@@ -306,34 +320,42 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
 
   it should "copy entities without a conflict" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      new GraphWorkspaceDAO().save(workspace2, txn)
-      dao.save(workspace2.namespace, workspace2.name, x1, txn)
+      workspaceDAO.save(workspace2, txn)
+      withWorkspaceContext(testData.workspace, txn) { context1 =>
+        withWorkspaceContext(workspace2, txn) { context2 =>
+          dao.save(context2, x1, txn)
 
-      assertResult(Seq.empty) {
-        dao.getCopyConflicts(testData.workspace.namespace, testData.workspace.name, Seq(x1), txn)
+          // note: we're copying FROM workspace2 INTO workspace
+          assertResult(Seq.empty) {
+            dao.getCopyConflicts(context1, Seq(x1), txn)
+          }
+
+          assertResult(Seq.empty) {
+            dao.copyEntities(context2, context1, "SampleSet", Seq("x1"), txn)
+          }
+
+          //verify it was actually copied into the workspace
+          assert(dao.list(context1, "SampleSet", txn).toList.contains(x1))
+        }
       }
-
-      assertResult(Seq.empty) {
-        dao.copyEntities(testData.workspace.namespace, testData.workspace.name, workspace2.namespace, workspace2.name, "SampleSet", Seq("x1"), txn)
-      }
-
-      //verify it was actually copied into the workspace
-      assert(dao.list(testData.workspace.namespace, testData.workspace.name, "SampleSet", txn).toList.contains(x1))
     }
   }
 
+
   it should "copy entities with a conflict" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Set(testData.sample1)) {
-        dao.getCopyConflicts(testData.workspace.namespace, testData.workspace.name, Seq(testData.sample1), txn).toSet
-      }
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Set(testData.sample1)) {
+          dao.getCopyConflicts(context, Seq(testData.sample1), txn).toSet
+        }
 
-      assertResult(Set(testData.sample1, testData.aliquot1)) {
-        dao.copyEntities(testData.workspace.namespace, testData.workspace.name, testData.workspace.namespace, testData.workspace.name, "Sample", Seq("sample1"), txn).toSet
-      }
+        assertResult(Set(testData.sample1, testData.aliquot1)) {
+          dao.copyEntities(context, context, "Sample", Seq("sample1"), txn).toSet
+        }
 
-      //verify that it wasn't copied into the workspace again
-      assert(dao.list(testData.workspace.namespace, testData.workspace.name, "Sample", txn).toList.filter(entity => entity == testData.sample1).size == 1)
+        //verify that it wasn't copied into the workspace again
+        assert(dao.list(context, "Sample", txn).toList.filter(entity => entity == testData.sample1).size == 1)
+      }
     }
   }
 
@@ -342,9 +364,11 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
     val dottyType = Entity("dottyType", "Sam.ple", Map.empty, testData.wsName)
     val dottyAttr = Entity("dottyAttr", "Sample", Map("foo.bar" -> AttributeBoolean(true)), testData.wsName)
     dataSource inTransaction { txn =>
-      intercept[RawlsException] { dao.save(testData.workspace.namespace, testData.workspace.name, dottyName, txn) }
-      intercept[RawlsException] { dao.save(testData.workspace.namespace, testData.workspace.name, dottyType, txn) }
-      intercept[RawlsException] { dao.save(testData.workspace.namespace, testData.workspace.name, dottyAttr, txn) }
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        intercept[RawlsException] { dao.save(context, dottyName, txn) }
+        intercept[RawlsException] { dao.save(context, dottyType, txn) }
+        intercept[RawlsException] { dao.save(context, dottyAttr, txn) }
+      }
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphMethodConfigDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphMethodConfigDAOSpec.scala
@@ -12,70 +12,77 @@ class GraphMethodConfigDAOSpec extends FlatSpec with Matchers with OrientDbTestF
 
   "GraphMethodConfigDAO" should "save and get a method config" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      val methodConfig2 = MethodConfiguration(
-        "ns",
-        "config2",
-        "sample",
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        val methodConfig2 = MethodConfiguration(
+          "ns",
+          "config2",
+          "sample",
 
-        Map("input.expression" -> AttributeString("this..wont.parse")),
-        Map("output.expression" -> AttributeString("output.expr")),
-        Map("prereq.expression" -> AttributeString("prereq.expr")),
-        testData.wsName,
-        MethodRepoConfiguration("ns", "meth2", "2"),
-        MethodRepoMethod("ns-config", "meth2", "2")
-      )
+          Map("input.expression" -> AttributeString("this..wont.parse")),
+          Map("output.expression" -> AttributeString("output.expr")),
+          Map("prereq.expression" -> AttributeString("prereq.expr")),
+          testData.wsName,
+          MethodRepoConfiguration("ns", "meth2", "2"),
+          MethodRepoMethod("ns-config", "meth2", "2")
+        )
 
-      new GraphWorkspaceDAO().save(testData.workspace, txn)
+        new GraphMethodConfigurationDAO().save(context, methodConfig2, txn)
 
-      new GraphMethodConfigurationDAO().save(testData.wsName.namespace, testData.wsName.name, methodConfig2, txn)
-
-      assertResult(Option(methodConfig2)) {
-        new GraphMethodConfigurationDAO().get(testData.wsName.namespace, testData.wsName.name, methodConfig2.namespace, methodConfig2.name, txn)
+        assertResult(Option(methodConfig2)) {
+          new GraphMethodConfigurationDAO().get(context, methodConfig2.namespace, methodConfig2.name, txn)
+        }
       }
     }
   }
 
   it should "overwrite method configs" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      val changed = testData.methodConfig.copy(rootEntityType = "goober")
-      new GraphMethodConfigurationDAO().save(testData.wsName.namespace, testData.wsName.name, changed, txn)
-
-      assertResult(Option(changed)) {
-        new GraphMethodConfigurationDAO().get(testData.wsName.namespace, testData.wsName.name, changed.namespace, changed.name, txn)
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        val changed = testData.methodConfig.copy(rootEntityType = "goober")
+        new GraphMethodConfigurationDAO().save(context, changed, txn)
+        assertResult(Option(changed)) {
+          new GraphMethodConfigurationDAO().get(context, changed.namespace, changed.name, txn)
+        }
       }
     }
   }
 
   it should "list method configs" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(List(testData.methodConfig, testData.methodConfig2, testData.methodConfigValid, testData.methodConfigUnparseable, testData.methodConfigNotAllSamples, testData.methodConfigAttrTypeMixup).map(_.toShort)) {
-        new GraphMethodConfigurationDAO().list(testData.wsName.namespace, testData.wsName.name, txn).toList
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(List(testData.methodConfig, testData.methodConfig2, testData.methodConfigValid, testData.methodConfigUnparseable, testData.methodConfigNotAllSamples, testData.methodConfigAttrTypeMixup).map(_.toShort)) {
+          new GraphMethodConfigurationDAO().list(context, txn).toList
+        }
       }
     }
   }
 
   it should "rename method configs" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      val changed = testData.methodConfig.copy(name = "sample", rootEntityType = "Sample")
-      new GraphMethodConfigurationDAO().rename(testData.wsName.namespace, testData.wsName.name, testData.methodConfig.namespace, testData.methodConfig.name, changed.name, txn)
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        val changed = testData.methodConfig.copy(name = "sample", rootEntityType = "Sample")
+        new GraphMethodConfigurationDAO().rename(context, testData.methodConfig.namespace, testData.methodConfig.name, changed.name, txn)
 
-      assertResult(Option(changed)) {
-        new GraphMethodConfigurationDAO().get(testData.wsName.namespace, testData.wsName.name, changed.namespace, changed.name, txn)
-      }
-      assertResult(None) {
-        new GraphMethodConfigurationDAO().get(testData.wsName.namespace, testData.wsName.name, testData.methodConfig.namespace, testData.methodConfig.name, txn)
+        assertResult(Option(changed)) {
+          new GraphMethodConfigurationDAO().get(context, changed.namespace, changed.name, txn)
+        }
+        assertResult(None) {
+          new GraphMethodConfigurationDAO().get(context, testData.methodConfig.namespace, testData.methodConfig.name, txn)
+        }
       }
     }
   }
 
   it should "delete method configs" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      assertResult(Option("testConfig1")) {
-        new GraphMethodConfigurationDAO().get(testData.wsName.namespace, testData.wsName.name, testData.methodConfig.namespace, "testConfig1", txn).map(_.name)
-      }
-      new GraphMethodConfigurationDAO().delete(testData.wsName.namespace, testData.wsName.name, testData.methodConfig.namespace, "testConfig1", txn)
-      assertResult(None) {
-        new GraphMethodConfigurationDAO().get(testData.wsName.namespace, testData.wsName.name, testData.methodConfig.namespace, "testConfig1", txn)
+      withWorkspaceContext(testData.workspace, txn) { context =>
+        assertResult(Option("testConfig1")) {
+          new GraphMethodConfigurationDAO().get(context, testData.methodConfig.namespace, "testConfig1", txn).map(_.name)
+        }
+        new GraphMethodConfigurationDAO().delete(context, testData.methodConfig.namespace, "testConfig1", txn)
+        assertResult(None) {
+          new GraphMethodConfigurationDAO().get(context, testData.methodConfig.namespace, "testConfig1", txn)
+        }
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphSubmissionDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphSubmissionDAOSpec.scala
@@ -18,10 +18,12 @@ class GraphSubmissionDAOSpec extends FlatSpec with Matchers with OrientDbTestFix
   val workflowDAO = new GraphWorkflowDAO
   val dao: SubmissionDAO = new GraphSubmissionDAO(workflowDAO)
   
-  def withSubmissionData(testCode:RawlsTransaction => Any):Unit = {
+  def withSubmissionData(testCode: (WorkspaceContext, RawlsTransaction) => Any):Unit = {
     withDefaultTestDatabase { dataSource =>
       dataSource.inTransaction { txn =>
-        testCode(txn)
+        withWorkspaceContext(testData.workspace, txn) { context =>
+          testCode(context, txn)
+        }
       }
     }
   }
@@ -29,82 +31,78 @@ class GraphSubmissionDAOSpec extends FlatSpec with Matchers with OrientDbTestFix
   private val submission3 = createTestSubmission(testData.workspace, testData.methodConfig2, testData.indiv1, Seq(testData.sample1, testData.sample2, testData.sample3))
   private val submission4 = createTestSubmission(testData.workspace, testData.methodConfig2, testData.indiv1, Seq(testData.sample1, testData.sample2, testData.sample3))
 
-
-  "GraphSubmissionDAO" should "save, get, list, and delete a submission status" in withSubmissionData { txn =>
-    dao.save(workspace.namespace,workspace.name,submission3,txn)
+  "GraphSubmissionDAO" should "save, get, list, and delete a submission status" in withSubmissionData { (context, txn) =>
+    dao.save(context, submission3, txn)
     assertResult(Some(submission3)) {
-      dao.get(workspace.namespace,workspace.name,submission3.submissionId,txn)
+      dao.get(context, submission3.submissionId, txn)
     }
-    assert(dao.list(workspace.namespace,workspace.name,txn).toSet.contains(submission3))
+    assert(dao.list(context, txn).toSet.contains(submission3))
 
-    assert(dao.delete(workspace.namespace,workspace.name,submission3.submissionId,txn))
+    assert(dao.delete(context, submission3.submissionId, txn))
     assertResult(None) {
-      dao.get(workspace.namespace,workspace.name,submission3.submissionId,txn)
+      dao.get(context, submission3.submissionId, txn)
     }
-    assert(!dao.list(workspace.namespace,workspace.name,txn).toSet.contains(submission3))
+    assert(!dao.list(context, txn).toSet.contains(submission3))
   }
 
-  it should "save, get, list, and delete two submission statuses" in withSubmissionData { txn =>
-    dao.save(workspace.namespace,workspace.name,submission3,txn)
-    dao.save(workspace.namespace,workspace.name,submission4,txn)
+  it should "save, get, list, and delete two submission statuses" in withSubmissionData { (context, txn) =>
+    dao.save(context, submission3, txn)
+    dao.save(context, submission4, txn)
     assertResult(Some(submission3)) {
-      dao.get(workspace.namespace,workspace.name,submission3.submissionId,txn) }
+      dao.get(context, submission3.submissionId, txn) }
     assertResult(Some(submission4)) {
-      dao.get(workspace.namespace,workspace.name,submission4.submissionId,txn) }
+      dao.get(context, submission4.submissionId, txn) }
 
-    assert(dao.list(workspace.namespace,workspace.name,txn).toSet.contains(submission3))
-    assert(dao.list(workspace.namespace,workspace.name,txn).toSet.contains(submission4))
+    assert(dao.list(context, txn).toSet.contains(submission3))
+    assert(dao.list(context, txn).toSet.contains(submission4))
 
-    assert(dao.delete(workspace.namespace,workspace.name,submission3.submissionId,txn))
-    assert(dao.delete(workspace.namespace,workspace.name,submission4.submissionId,txn))
+    assert(dao.delete(context, submission3.submissionId, txn))
+    assert(dao.delete(context, submission4.submissionId, txn))
 
-    assert(!dao.list(workspace.namespace,workspace.name,txn).toSet.contains(submission3))
-    assert(!dao.list(workspace.namespace,workspace.name,txn).toSet.contains(submission4))
+    assert(!dao.list(context, txn).toSet.contains(submission3))
+    assert(!dao.list(context, txn).toSet.contains(submission4))
   }
 
+  // TODO make this work
+//  it should "fail to save into workspaces that don't exist" in withSubmissionData { (context, txn) =>
+//    intercept[IllegalArgumentException]{
+//      dao.save(workspace.namespace,"noSuchThing", testData.submission1, txn)
+//    }
+//  }
 
-  it should "fail to save into workspaces that don't exist" in withSubmissionData { txn =>
-    intercept[IllegalArgumentException]{
-      dao.save(workspace.namespace,"noSuchThing",testData.submission1,txn)
-    }
+  it should "fail to delete submissions that don't exist" in withSubmissionData { (context, txn) =>
+    assert(!dao.delete(context,"doesn't exist", txn))
   }
 
-  it should "fail to delete submissions that don't exist" in withSubmissionData { txn =>
-    assert(!dao.delete(workspace.namespace,workspace.name,"doesn't exist",txn))
-  }
-
-  it should "update submissions" in withSubmissionData { txn =>
-//      dao.save(workspace.namespace,workspace.name,testData.submission1,txn)
-    dao.update(testData.submission1.copy(status = SubmissionStatuses.Done), txn)
+  it should "update submissions" in withSubmissionData { (context, txn) =>
+    dao.update(context, testData.submission1.copy(status = SubmissionStatuses.Done), txn)
     assertResult(Option(testData.submission1.copy(status = SubmissionStatuses.Done))) {
-      dao.get(workspace.namespace,workspace.name,testData.submission1.submissionId,txn)
+      dao.get(context, testData.submission1.submissionId, txn)
     }
   }
 
-  "GraphWorkflowDAO" should "let you modify Workflows within a submission" in withSubmissionData { txn =>
-//      dao.save(workspace.namespace,workspace.name,testData.submission1,txn)
+  "GraphWorkflowDAO" should "let you modify Workflows within a submission" in withSubmissionData { (context, txn) =>
       val workflow0 = testData.submission1.workflows(0)
       assertResult(Some(workflow0)) {
-        workflowDAO.get(workspace.toWorkspaceName,workflow0.workflowId,txn)
+        workflowDAO.get(context, workflow0.workflowId, txn)
       }
       val workflow1 = testData.submission1.workflows(1)
       assertResult(Some(workflow1)) {
-        workflowDAO.get(workspace.toWorkspaceName,workflow1.workflowId,txn)
+        workflowDAO.get(context, workflow1.workflowId, txn)
       }
       val workflow2 = testData.submission1.workflows(2)
       assertResult(Some(workflow2)) {
-        workflowDAO.get(workspace.toWorkspaceName,workflow2.workflowId,txn)
+        workflowDAO.get(context, workflow2.workflowId, txn)
       }
-      val workflow3 = Workflow(workspace.toWorkspaceName,workflow1.workflowId,WorkflowStatuses.Failed,DateTime.now,workflow1.workflowEntity)
-      workflowDAO.update(workspace.toWorkspaceName,workflow3,txn)
+      val workflow3 = Workflow(workspace.toWorkspaceName, workflow1.workflowId, WorkflowStatuses.Failed, DateTime.now, workflow1.workflowEntity)
+      workflowDAO.update(context, workflow3, txn)
       assertResult(Some(workflow3)) {
-        workflowDAO.get(workspace.toWorkspaceName,workflow3.workflowId,txn)
+        workflowDAO.get(context, workflow3.workflowId, txn)
       }
-      assert(workflowDAO.delete(workspace.toWorkspaceName,workflow3.workflowId,txn))
-      val submission = testData.submission1.copy(workflows=Seq(workflow0,workflow2))
+      assert(workflowDAO.delete(context, workflow3.workflowId, txn))
+      val submission = testData.submission1.copy(workflows=Seq(workflow0, workflow2))
       assertResult(Some(submission)) {
-        dao.get(workspace.namespace,workspace.name,submission.submissionId,txn)
+        dao.get(context, submission.submissionId, txn)
       }
     }
-
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAOSpec.scala
@@ -37,7 +37,6 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
 
   it should "save updates to an existing workspace" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
-      // TODO since workspaces don't currently have mutable properties, is this redundant with EntityDAO?
       // for now, just save the workspace again (making sure it doesn't crash)
       workspaceDAO.save(testData.workspace, txn)
     }
@@ -46,7 +45,7 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
   it should "load a workspace" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
       assertResult(Some(testData.workspace)) {
-        workspaceDAO.load(testData.workspace.namespace, testData.workspace.name, txn)
+        workspaceDAO.load(testData.workspace.toWorkspaceName, txn)
       }
     }
   }
@@ -54,10 +53,10 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
   it should "return None when a workspace does not exist" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
       assertResult(None) {
-        new GraphWorkspaceDAO().load(testData.workspace.namespace, "fnord", txn)
+        new GraphWorkspaceDAO().load(WorkspaceName(testData.workspace.namespace, "fnord"), txn)
       }
       assertResult(None) {
-        new GraphWorkspaceDAO().load("fnord", testData.workspace.name, txn)
+        new GraphWorkspaceDAO().load(WorkspaceName("fnord", testData.workspace.name), txn)
       }
     }
   }
@@ -65,7 +64,7 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
   it should "load the short version of a workspace" in withDefaultTestDatabase { dataSource =>
     dataSource.inTransaction { txn =>
       assertResult(Some(testData.workspace)) {
-        workspaceDAO.load(testData.workspace.namespace, testData.workspace.name, txn)
+        workspaceDAO.load(testData.workspace.toWorkspaceName, txn)
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParserTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParserTest.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.expressions
 
 import com.tinkerpop.blueprints.Graph
+import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceContext
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
 import org.broadinstitute.dsde.rawls.model.AttributeString
 import org.scalatest.FunSuite
@@ -23,29 +24,39 @@ class SimpleExpressionParserTest extends FunSuite with OrientDbTestFixture {
     }
   }
 
+  def withTestWorkspace(testCode: WorkspaceContext => Any): Unit = {
+    withDefaultTestDatabase { dataSource =>
+      dataSource inTransaction { txn =>
+        withWorkspaceContext(testData.workspace, txn) { workspaceContext =>
+          testCode(workspaceContext)
+        }
+      }
+    }
+  }
+
   test("simple attribute expression") {
-    withTestData { graph =>
-      val evaluator = new ExpressionEvaluator(graph, new ExpressionParser)
+    withTestWorkspace { workspaceContext =>
+      val evaluator = new ExpressionEvaluator(new ExpressionParser)
       assertResult(Success(ArrayBuffer(AttributeString("normal")))) {
-        evaluator.evalFinalAttribute(testData.wsName.namespace, testData.wsName.name, "Sample", "sample1", "this.type")
+        evaluator.evalFinalAttribute(workspaceContext, "Sample", "sample1", "this.type")
       }
 
       assertResult(Success(ArrayBuffer(AttributeString("normal"), AttributeString("tumor"), AttributeString("tumor")))) {
-        evaluator.evalFinalAttribute(testData.wsName.namespace, testData.wsName.name, "SampleSet", "sset1", "this.samples.type")
+        evaluator.evalFinalAttribute(workspaceContext, "SampleSet", "sset1", "this.samples.type")
       }
     }
   }
 
   test("simple entity expression") {
-    withTestData { graph =>
-      val evaluator = new ExpressionEvaluator(graph, new ExpressionParser)
+    withTestWorkspace { workspaceContext =>
+      val evaluator = new ExpressionEvaluator(new ExpressionParser)
 
       assertResult(Success(ArrayBuffer(testData.sample2))) {
-        evaluator.evalFinalEntity(testData.wsName.namespace, testData.wsName.name, "Pair", "pair1", "this.case")
+        evaluator.evalFinalEntity(workspaceContext, "Pair", "pair1", "this.case")
       }
 
       assertResult(Success(ArrayBuffer(testData.sample1, testData.sample2, testData.sample3))) {
-        evaluator.evalFinalEntity(testData.wsName.namespace, testData.wsName.name, "Individual", "indiv1", "this.sset.samples")
+        evaluator.evalFinalEntity(workspaceContext, "Individual", "indiv1", "this.sset.samples")
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestBase.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestBase.scala
@@ -60,6 +60,7 @@ trait IntegrationTestBase extends FlatSpec with ScalatestRouteTest with Matchers
     val gcsDAO = MockGoogleCloudStorageDAO
 
     val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
+      new GraphWorkspaceDAO(),
       new GraphSubmissionDAO(new GraphWorkflowDAO()),
       new HttpExecutionServiceDAO(executionServiceServer),
       new GraphWorkflowDAO(),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -82,19 +82,22 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpe
 
     override def save(txn:RawlsTransaction): Unit = {
       workspaceDAO.save(workspace, txn)
-      entityDAO.save(workspace.namespace, workspace.name, sample1, txn)
-      submissionDAO.save(workspace.namespace, workspace.name, submissionTestAbortMissingWorkflow, txn)
-      submissionDAO.save(workspace.namespace, workspace.name, submissionTestAbortMalformedWorkflow, txn)
-      submissionDAO.save(workspace.namespace, workspace.name, submissionTestAbortGoodWorkflow, txn)
-      submissionDAO.save(workspace.namespace, workspace.name, submissionTestAbortTerminalWorkflow, txn)
-      submissionDAO.save(workspace.namespace, workspace.name, submissionTestAbortOneMissingWorkflow, txn)
-      submissionDAO.save(workspace.namespace, workspace.name, submissionTestAbortTwoGoodWorkflows, txn)
+      withWorkspaceContext(workspace, txn) { context =>
+        entityDAO.save(context, sample1, txn)
+        submissionDAO.save(context, submissionTestAbortMissingWorkflow, txn)
+        submissionDAO.save(context, submissionTestAbortMalformedWorkflow, txn)
+        submissionDAO.save(context, submissionTestAbortGoodWorkflow, txn)
+        submissionDAO.save(context, submissionTestAbortTerminalWorkflow, txn)
+        submissionDAO.save(context, submissionTestAbortOneMissingWorkflow, txn)
+        submissionDAO.save(context, submissionTestAbortTwoGoodWorkflows, txn)
+      }
     }
   }
 
   def withDataAndService(testCode: WorkspaceService => Any, withDataOp: (DataSource => Any) => Unit): Unit = {
     withDataOp { dataSource =>
       val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
+        new GraphWorkspaceDAO(),
         new GraphSubmissionDAO(new GraphWorkflowDAO()),
         new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl),
         new GraphWorkflowDAO(),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
@@ -28,7 +28,7 @@ class WorkflowMonitorSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   "WorkflowMonitor" should "throw exception for non-existent workflow" in withDefaultTestDatabase { dataSource =>
     val workflow = Workflow(WorkspaceName("wns", "wn"), "id-string", WorkflowStatuses.Running, new DateTime(0), AttributeEntityReference("entityType", "entity"))
-    val monitorRef = TestActorRef[WorkflowMonitor](WorkflowMonitor.props(1 millisecond, new WorkflowTestExecutionServiceDAO(WorkflowStatuses.Running.toString), workflowDAO, new GraphMethodConfigurationDAO(), dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, workflow))
+    val monitorRef = TestActorRef[WorkflowMonitor](WorkflowMonitor.props(1 millisecond, workspaceDAO, new WorkflowTestExecutionServiceDAO(WorkflowStatuses.Running.toString), workflowDAO, new GraphMethodConfigurationDAO(), entityDAO, dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, workflow))
     intercept[RawlsException] {
       monitorRef.underlyingActor.checkWorkflowStatus()
     }
@@ -36,20 +36,20 @@ class WorkflowMonitorSpec(_system: ActorSystem) extends TestKit(_system) with Fl
   }
 
   it should "do nothing for unchanged state" in withDefaultTestDatabase { dataSource =>
-    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, new WorkflowTestExecutionServiceDAO(testData.submission1.workflows.head.status.toString), workflowDAO, new GraphMethodConfigurationDAO(), dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, testData.submission1.workflows.head))
+    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, workspaceDAO, new WorkflowTestExecutionServiceDAO(testData.submission1.workflows.head.status.toString), workflowDAO, new GraphMethodConfigurationDAO(), entityDAO, dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, testData.submission1.workflows.head))
     expectNoMsg(1 seconds)
     system.stop(monitorRef)
   }
 
   it should "emit update message for changed state" in withDefaultTestDatabase { dataSource =>
-    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, new WorkflowTestExecutionServiceDAO(WorkflowStatuses.Running.toString), workflowDAO, new GraphMethodConfigurationDAO(), dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, testData.submission1.workflows.head))
+    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, workspaceDAO, new WorkflowTestExecutionServiceDAO(WorkflowStatuses.Running.toString), workflowDAO, new GraphMethodConfigurationDAO(), entityDAO, dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, testData.submission1.workflows.head))
     expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = WorkflowStatuses.Running), None))
     system.stop(monitorRef)
   }
 
   WorkflowStatuses.terminalStatuses.foreach { status =>
     it should s"terminate when ${status}" in withDefaultTestDatabase { dataSource =>
-      val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, new WorkflowTestExecutionServiceDAO(status.toString), workflowDAO, new GraphMethodConfigurationDAO(), dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, testData.submission1.workflows.head))
+      val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, workspaceDAO, new WorkflowTestExecutionServiceDAO(status.toString), workflowDAO, new GraphMethodConfigurationDAO(), entityDAO, dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1, testData.submission1.workflows.head))
       watch(monitorRef)
       status match {
         case WorkflowStatuses.Failed => expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = status, messages = testData.submission1.workflows.head.messages :+ AttributeString("Workflow execution failed, check outputs for details")), None))
@@ -67,7 +67,7 @@ class WorkflowMonitorSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "fail a workflow if the method config can't be found" in withDefaultTestDatabase { dataSource =>
     val status = WorkflowStatuses.Succeeded
-    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, new WorkflowTestExecutionServiceDAO(status.toString), workflowDAO, new GraphMethodConfigurationDAO(), dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1.copy(methodConfigurationName = "DNE"), testData.submission1.workflows.head))
+    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, workspaceDAO, new WorkflowTestExecutionServiceDAO(status.toString), workflowDAO, new GraphMethodConfigurationDAO(), entityDAO, dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission1.copy(methodConfigurationName = "DNE"), testData.submission1.workflows.head))
     watch(monitorRef)
     expectMsg(SubmissionMonitor.WorkflowStatusChange(testData.submission1.workflows.head.copy(status = WorkflowStatuses.Failed, messages = Seq(AttributeString(s"Could not find method config ${testData.submission1.methodConfigurationNamespace}/DNE, was it deleted?"))), None))
     fishForMessage(1 second) {
@@ -79,7 +79,7 @@ class WorkflowMonitorSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
   it should "fail a workflow if outputs can't be found" in withDefaultTestDatabase { dataSource =>
     val status = WorkflowStatuses.Succeeded
-    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, new WorkflowTestExecutionServiceDAO(status.toString), workflowDAO, new GraphMethodConfigurationDAO(), dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission2, testData.submission2.workflows.head))
+    val monitorRef = system.actorOf(WorkflowMonitor.props(1 millisecond, workspaceDAO, new WorkflowTestExecutionServiceDAO(status.toString), workflowDAO, new GraphMethodConfigurationDAO(), entityDAO, dataSource, HttpCookie("iPlanetDirectoryPro", "test_token"))(testActor, testData.submission2, testData.submission2.workflows.head))
     watch(monitorRef)
     fishForMessage(1 second) {
       case m: SubmissionMonitor.WorkflowStatusChange =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/GoogleAuthApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/GoogleAuthApiServiceSpec.scala
@@ -38,6 +38,7 @@ class GoogleAuthApiServiceSpec extends FlatSpec with HttpService with ScalatestR
   case class TestApiService(dataSource: DataSource) extends GoogleAuthApiService with MockOpenAmDirectives {
     def actorRefFactory = system
     val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
+      new GraphWorkspaceDAO(),
       new GraphSubmissionDAO(new GraphWorkflowDAO()),
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl),
       new GraphWorkflowDAO(),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -36,6 +36,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     val mockServer = RemoteServicesMockServer()
 
     val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
+      new GraphWorkspaceDAO(),
       new GraphSubmissionDAO(new GraphWorkflowDAO()),
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl),
       new GraphWorkflowDAO(),


### PR DESCRIPTION
The main goals of this PR: 

* Make DAOs take a ```WorkspaceContext``` object instead of workspace name and namespace. The context contains the ```WorkspaceName```, bucket name (for checking ACLs), and workspace vertex (so we can start pipelines directly from there instead of looking it up every time).
* Add a ```WorkspaceDAO.loadContext``` method so we can just get the context without pulling in the entire workspace (specifically, without needing to pull in the attributes map). Switch most of the ```WorkspaceDAO.load``` calls in ```WorkspaceService``` to use this instead.

Other things:
* Make DAO interfaces more consistent. All ```save``` / ```update``` methods return the thing that was saved/updated. All ```delete``` methods return a ```Boolean``` specifying whether the delete was successful. All ```list``` methods return ```TraversableOnce``` instead of ```Seq```, due to the possibility of Gremlin iterators (previously it was a mix of both). All return types have been made explicit, including ```Unit```.
* Changed the argument order of some functions to be more consistent (e.g. if something takes a ```WorkspaceContext```, that always comes first; if cloning, source always comes before dest).
* General cleanup / moving functions around to make classes more readable.

There is more stuff I might add, but this is ready to start being reviewed.
