### PR TITLE
API to get workflow outputs from Cromwell

### DIFF
--- a/src/main/resources/swagger/listings/submissions
+++ b/src/main/resources/swagger/listings/submissions
@@ -127,7 +127,56 @@
 				"message": "Rawls Internal Error"
 			}]
 		}]
-	}],
+	}, {
+        "path": "/workspaces/{workspaceNamespace}/{workspaceName}/submissions/{submissionId}/workflows/{workflowId}/outputs",
+        "operations": [{
+            "method": "GET",
+            "summary": "Get workflow outputs.",
+            "notes": "",
+            "type": "WorkflowOutputs",
+            "nickname": "getWorkflowOutputs",
+            "produces": ["application/json"],
+            "parameters": [{
+                "name": "workspaceNamespace",
+                "description": "Workspace Namespace",
+                "required": true,
+                "type": "string",
+                "paramType": "path",
+                "allowMultiple": false
+            }, {
+                "name": "workspaceName",
+                "description": "Workspace Name",
+                "required": true,
+                "type": "string",
+                "paramType": "path",
+                "allowMultiple": false
+            }, {
+                "name": "submissionId",
+                "description": "Submission Id",
+                "required": true,
+                "type": "string",
+                "paramType": "path",
+                "allowMultiple": false
+            }, {
+                 "name": "workflowId",
+                 "description": "Workflow Id",
+                 "required": true,
+                 "type": "string",
+                 "paramType": "path",
+                 "allowMultiple": false
+             }],
+            "responseMessages": [{
+                "code": 200,
+                "message": "Successful Request"
+            }, {
+                "code": 404,
+                "message": "Submission or Workflow Not Found"
+            }, {
+                "code": 500,
+                "message": "Rawls Internal Error"
+            }]
+        }]
+    }],
 	"models": {
 		"Submission": {
 			"id": "Submission",
@@ -284,6 +333,40 @@
 					"description": "Expression that resolves to one or more entities matching the entity type in the method configuration."
 				}
 			}
-		}
+		},
+        "TaskOutput": {
+            "id": "TaskOutput",
+            "description": "Outputs from a single task in a workflow",
+            "properties": {
+                "logs": {
+                    "type": "object",
+                    "description": "Log messages from this task",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "outputs": {
+                    "type": "object",
+                    "description": "Outputs from this task"
+                }
+            }
+        },
+        "WorkflowOutputs": {
+            "id": "WorkflowOutputs",
+            "description": "Outputs and logs from all tasks in a workflow",
+            "properties": {
+                "tasks": {
+                    "type": "object",
+                    "description": "Map from tasks to output/log pairs",
+                    "properties": {
+                        "$ref": "TaskOutput"
+                    }
+                },
+                "workflowId": {
+                    "type": "string",
+                    "description": "The id of this workflow"
+                }
+            }
+        }
 	}
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import org.broadinstitute.dsde.rawls.model.{ExecutionServiceOutputs, ExecutionServiceStatus}
+import org.broadinstitute.dsde.rawls.model.{ExecutionServiceLogs, ExecutionServiceOutputs, ExecutionServiceStatus}
 import spray.http.HttpCookie
 
 /**
@@ -10,5 +10,6 @@ trait ExecutionServiceDAO {
   def submitWorkflow( wdl: String, inputs: String, authCookie: HttpCookie ): ExecutionServiceStatus
   def status(id: String, authCookie: HttpCookie): ExecutionServiceStatus
   def outputs(id: String, authCookie: HttpCookie): ExecutionServiceOutputs
+  def logs(id: String, authCookie: HttpCookie): ExecutionServiceLogs
   def abort(id: String, authCookie: HttpCookie): ExecutionServiceStatus
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import org.broadinstitute.dsde.rawls.model.{ExecutionServiceOutputs, ExecutionServiceStatus}
+import org.broadinstitute.dsde.rawls.model.{ExecutionServiceLogs, ExecutionServiceOutputs, ExecutionServiceStatus}
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -38,6 +38,13 @@ class HttpExecutionServiceDAO( executionServiceURL: String )( implicit system: A
     val url = executionServiceURL + s"/workflows/v1/${id}/outputs"
     import system.dispatcher
     val pipeline = addHeader(Cookie(authCookie)) ~> sendReceive ~> unmarshal[ExecutionServiceOutputs]
+    Await.result(pipeline(Get(url)), Duration.Inf)
+  }
+
+  override def logs(id: String, authCookie: HttpCookie): ExecutionServiceLogs = {
+    val url = executionServiceURL + s"/workflows/v1/${id}/logs"
+    import system.dispatcher
+    val pipeline = addHeader(Cookie(authCookie)) ~> sendReceive ~> unmarshal[ExecutionServiceLogs]
     Await.result(pipeline(Get(url)), Duration.Inf)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -33,6 +33,11 @@ case class ExecutionServiceOutputs(
   outputs: Map[String, Attribute]
 )
 
+case class ExecutionServiceLogs(
+ id: String,
+ logs: Map[String, Map[String,String]]
+)
+
 // Status of a successfully started workflow
 case class Workflow(
   workspaceName: WorkspaceName,
@@ -49,6 +54,16 @@ case class WorkflowFailure(
   entityName: String,
   entityType: String,
   errors: Seq[AttributeString]
+)
+
+case class TaskOutput(
+  logs: Option[Map[String, String]],
+  outputs: Option[Map[String, Attribute]]
+)
+
+case class WorkflowOutputs(
+  workflowId: String,
+  tasks: Map[String, TaskOutput]
 )
 
 // Status of a submission
@@ -90,6 +105,12 @@ object ExecutionJsonSupport extends JsonSupport {
   implicit val ExecutionServiceStatusFormat = jsonFormat2(ExecutionServiceStatus)
 
   implicit val ExecutionServiceOutputsFormat = jsonFormat2(ExecutionServiceOutputs)
+
+  implicit val ExecutionServiceLogsFormat = jsonFormat2(ExecutionServiceLogs)
+
+  implicit val TaskOutputFormat = jsonFormat2(TaskOutput)
+
+  implicit val WorkflowOutputsFormat = jsonFormat2(WorkflowOutputs)
 
   implicit val WorkflowFormat = jsonFormat6(Workflow)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -45,6 +45,12 @@ trait SubmissionApiService extends HttpService with PerRequestCreator with OpenA
         requestContext => perRequest(requestContext, WorkspaceService.props(workspaceServiceConstructor, userInfo),
           WorkspaceService.AbortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId))
       }
+    } ~
+    path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "outputs") { (workspaceNamespace, workspaceName, submissionId, workflowId) =>
+      get {
+        requestContext => perRequest(requestContext, WorkspaceService.props(workspaceServiceConstructor, userInfo),
+          WorkspaceService.GetWorkflowOutputs(WorkspaceName(workspaceNamespace, workspaceName), submissionId, workflowId))
+      }
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
@@ -101,6 +101,7 @@ class WorkflowTestExecutionServiceDAO(workflowStatus: String) extends ExecutionS
   override def submitWorkflow(wdl: String, inputs: String, authCookie: HttpCookie): ExecutionServiceStatus = ExecutionServiceStatus("test_id", workflowStatus)
 
   override def outputs(id: String, authCookie: HttpCookie): ExecutionServiceOutputs = ExecutionServiceOutputs(id, Map("o1" -> AttributeString("foo")))
+  override def logs(id: String, authCookie: HttpCookie): ExecutionServiceLogs = ExecutionServiceLogs(id, Map("task1" -> Map("wf.t1.foo" -> "foo", "wf.t1.bar" -> "bar")))
 
   override def status(id: String, authCookie: HttpCookie): ExecutionServiceStatus = ExecutionServiceStatus(id, workflowStatus)
   override def abort(id: String, authCookie: HttpCookie): ExecutionServiceStatus = ExecutionServiceStatus(id, workflowStatus)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
@@ -236,6 +236,53 @@ class RemoteServicesMockServer(port:Int) {
           .withHeaders(jsonHeader)
           .withStatusCode(StatusCodes.BadRequest.intValue)
       )
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath("/workflows/v1/69d1d92f-3895-4a7b-880a-82535e9a096e/logs")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(
+            """
+              |{
+              |  "id": "69d1d92f-3895-4a7b-880a-82535e9a096e",
+              |  "logs": {
+              |    "wf.x": {
+              |      "stdout": "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-x/job.stdout.txt",
+              |      "stderr": "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-x/job.stderr.txt"
+              |    },
+              |    "wf.y": {
+              |      "stdout": "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stdout.txt",
+              |      "stderr": "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stderr.txt"
+              |    }
+              |  }
+              |}
+              """.stripMargin)
+          .withStatusCode(StatusCodes.Created.intValue)
+      )
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath("/workflows/v1/69d1d92f-3895-4a7b-880a-82535e9a096e/outputs")
+    ).respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(
+            """
+              |{
+              |  "id": "this_workflow_exists",
+              |  "outputs": {
+              |    "wf.x.four": 4,
+              |    "wf.x.five": 4,
+              |    "wf.y.six": 4
+              |  }
+              |}
+            """.stripMargin)
+          .withStatusCode(StatusCodes.Created.intValue)
+      )
   }
 
   def stopServer = mockServer.stop()


### PR DESCRIPTION
Hits `/outputs` and `/logs` and munges them together.

I tried so hard to Swagger this, but there's no way to say a variable is Map[String, SomeOtherType].