### PR TITLE
NOMERGEY Very early WIP stray vertex cleanup

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -212,7 +212,7 @@ trait GraphDAO {
     ) yield {
       val fieldMirror = mirror.reflect(obj).reflectField(member.asTerm)
       member.name.decodedName.toString.trim -> (fieldMirror.get match {
-        case v: Option[Any] => v
+        case v: Option[Any] => v //FIXME: also return member.typeSignature ?
         case v => Option(v)
       })
     }
@@ -288,7 +288,10 @@ trait GraphDAO {
         // no value for the key so remove anything that is there
         // can't tell if this is a value or a map anymore so just remove both (there should only be one)
         vertex.removeProperty(key)
-        vertex.getVertices(Direction.OUT, key).foreach(removeMapVertex) //FIXME: I think this is insufficient and doesn't cover the case where you overwrite a map with an empty map
+        vertex.getVertices(Direction.OUT, key).foreach(removeMapVertex)
+        //FIXME: ^^^ I think this is insufficient and doesn't cover the case where you overwrite a Some(foo:FooClass) with None, for a FooClass that requires sub-sub-vertices
+        //FIXME: See FIXME in getProperties - I think we can do this if we have the type too?
+        //Needs some shenanigans to figure out the type of an Option if it's None, see http://bit.ly/1htTZJk
       case (key, Some(value: DateTime)) => vertex.setProperty(key, value.toDate)
       case (key, Some(value: Map[_,_])) => serializeAttributeMap(graph, workspaceContext, vertex, key, value.asInstanceOf[Map[String, Attribute]])
       case (key, Some(value: AttributeEntityReference)) => serializeReference(graph, workspaceContext, vertex, key, value)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -296,6 +296,7 @@ trait GraphDAO {
       case (key, Some(value: Map[_,_])) => serializeAttributeMap(graph, workspaceContext, vertex, key, value.asInstanceOf[Map[String, Attribute]])
       case (key, Some(value: AttributeEntityReference)) => serializeReference(graph, workspaceContext, vertex, key, value)
       case (key, Some(seq: Seq[_])) => seq.headOption match {
+        //FIXME: Again, I don't think this isn't sufficient to clear up vertices left behind if we're overwriting a full list with an empty one.
         case None => // empty, do nothing
         case Some(x: Workflow) =>
           serializeDomainObjects(vertex, seq.asInstanceOf[Seq[Workflow]], workflowEdge, (w: Workflow) => w.workflowId, graph, workspaceContext)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -205,6 +205,67 @@ trait GraphDAO {
     getSinglePipelineResult(workflowPipeline(workspaceContext, workflowId))
   }
 
+  def getProperties[T: TypeTag: ClassTag](obj: T): Iterable[(String, Option[Any])] = {
+    val mirror = ru.runtimeMirror(obj.getClass.getClassLoader)
+
+    for (member <- ru.typeTag[T].tpe.members if (member.asTerm.isVal || member.asTerm.isVar)
+    ) yield {
+      val fieldMirror = mirror.reflect(obj).reflectField(member.asTerm)
+      member.name.decodedName.toString.trim -> (fieldMirror.get match {
+        case v: Option[Any] => v
+        case v => Option(v)
+      })
+    }
+  }
+
+  private def deleteSeq(vertex: Vertex, key: String, values: Seq[Attribute]): Unit = {
+    deleteAttributeMap(vertex, key, values.zipWithIndex.map { case (value, index) => index.toString -> value }.toMap)
+  }
+
+  private def deleteAttributeMap(vertex: Vertex, propName: String, map: Map[String, Attribute]): Unit = {
+    vertex.getVertices(Direction.OUT, propName).headOption match {
+      case Some(mapVertex) =>
+        map.foreach { case (key, attribute) =>
+          attribute match {
+            case AttributeValueList(values) => deleteSeq(mapVertex, key, values)
+            case AttributeEntityReferenceList(references) => deleteSeq(mapVertex, key, references)
+            case AttributeEmptyList => deleteAttributeMap(mapVertex, key, Map.empty)
+            case _ => //the other cases simply set properties on the mapVertex, so no other vertices to delete
+          }
+        }
+        removeMapVertex(mapVertex)
+      case None => //nothing to do
+    }
+  }
+
+  private def deleteDomainObjects[T: TypeTag: ClassTag](vertex: Vertex, objs: Seq[T], edgeLabel: String, workspaceContext: WorkspaceContext): Unit = {
+    vertex.getVertices(Direction.OUT, edgeLabel).map { objVertex =>
+      val obj = loadFromVertex[T](objVertex, Some(workspaceContext.workspaceName))
+      deleteVertex(obj, objVertex, workspaceContext)
+      objVertex.remove()
+    }
+  }
+
+  def deleteVertex[T: TypeTag: ClassTag](obj: T, vertex: Vertex, workspaceContext: WorkspaceContext): Unit = {
+    getProperties(obj).foreach(_ match {
+      case (key, None) => vertex.getVertices(Direction.OUT, key).foreach(removeMapVertex)
+      case (key, Some(value: Map[_,_])) => deleteAttributeMap(vertex, key, value.asInstanceOf[Map[String, Attribute]])
+
+      case (key, Some(seq: Seq[_])) => seq.headOption match {
+        case Some(x: Workflow) => deleteDomainObjects(vertex, seq.asInstanceOf[Seq[Workflow]], workflowEdge, workspaceContext)
+        case Some(x: WorkflowFailure) => deleteDomainObjects(vertex, seq.asInstanceOf[Seq[WorkflowFailure]], workflowEdge, workspaceContext)
+        case Some(a: Attribute) => deleteSeq(vertex, key, seq.asInstanceOf[Seq[Attribute]])
+        case x => throw new RawlsException(s"Unexpected object of type [${x.getClass}] in Seq for attribute [${key}]: [${x}]")
+      }
+
+      case (key, Some(mrConfig: MethodRepoConfiguration)) => deleteDomainObjects(vertex, Seq(mrConfig), methodRepoConfigEdge, workspaceContext)
+      case (key, Some(mrMethod: MethodRepoMethod)) => deleteDomainObjects(vertex, Seq(mrMethod), methodRepoMethodEdge, workspaceContext)
+      case (key, _) => //nothing to do
+    })
+
+    vertex.remove()
+  }
+
   /**
    * Serializes an object to a vertex. This supports all properties extending AnyVal, String, joda DateTime
    * Map[String, Attribute], AttributeReference, Seq[Workflow], Seq[WorkflowFailure], MethodRepoConfiguration,
@@ -220,19 +281,6 @@ trait GraphDAO {
    */
   def saveToVertex[T: TypeTag: ClassTag](graph: Graph, workspaceContext: WorkspaceContext, obj: T, vertex: Vertex): Vertex = {
 
-    def getProperties(obj: T): Iterable[(String, Option[Any])] = {
-      val mirror = ru.runtimeMirror(obj.getClass.getClassLoader)
-
-      for (member <- ru.typeTag[T].tpe.members if (member.asTerm.isVal || member.asTerm.isVar)
-      ) yield {
-        val fieldMirror = mirror.reflect(obj).reflectField(member.asTerm)
-        member.name.decodedName.toString.trim -> (fieldMirror.get match {
-          case v: Option[Any] => v
-          case v => Option(v)
-        })
-      }
-    }
-
     getProperties(obj).foreach(_ match {
       // each entry we are iterating over has a key and an Option(value). Match on the type of values we
       // support and serialize to the vertex appropriately
@@ -240,7 +288,7 @@ trait GraphDAO {
         // no value for the key so remove anything that is there
         // can't tell if this is a value or a map anymore so just remove both (there should only be one)
         vertex.removeProperty(key)
-        vertex.getVertices(Direction.OUT, key).foreach(removeMapVertex)
+        vertex.getVertices(Direction.OUT, key).foreach(removeMapVertex) //FIXME: I think this is insufficient and doesn't cover the case where you overwrite a map with an empty map
       case (key, Some(value: DateTime)) => vertex.setProperty(key, value.toDate)
       case (key, Some(value: Map[_,_])) => serializeAttributeMap(graph, workspaceContext, vertex, key, value.asInstanceOf[Map[String, Attribute]])
       case (key, Some(value: AttributeEntityReference)) => serializeReference(graph, workspaceContext, vertex, key, value)
@@ -309,7 +357,7 @@ trait GraphDAO {
 
   private def serializeAttributeMap(graph: Graph, workspaceContext: WorkspaceContext, vertex: Vertex, propName: String, map: Map[String, Attribute]): Unit = {
     // remove existing map then repopulate
-    vertex.getVertices(Direction.OUT, propName).headOption.foreach(removeMapVertex)
+    deleteAttributeMap(vertex, propName, map)
 
     val mapVertex = addVertex(graph, VertexSchema.Map)
     addEdge(vertex, propName, mapVertex)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAO.scala
@@ -46,7 +46,8 @@ class GraphWorkspaceDAO extends WorkspaceDAO with GraphDAO {
   override def delete(workspaceName: WorkspaceName, txn: RawlsTransaction) : Boolean = txn withGraph { db =>
     getWorkspaceVertex(db, workspaceName) match {
       case Some(v) => {
-        v.remove
+        val ws = loadFromVertex[Workspace](v, Some(workspaceName))
+        deleteVertex(ws, v, WorkspaceContext(ws.toWorkspaceName, ws.bucketName, v))
         true
       }
       case None => false

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAO.scala
@@ -42,4 +42,14 @@ class GraphWorkspaceDAO extends WorkspaceDAO with GraphDAO {
   override def list(txn: RawlsTransaction): Seq[Workspace] = txn withGraph { db =>
     new GremlinPipeline(db).V().filter(isWorkspace).transform((v: Vertex) => loadFromVertex[Workspace](v, None)).toList.asScala
   }
+
+  override def delete(workspaceName: WorkspaceName, txn: RawlsTransaction) : Boolean = txn withGraph { db =>
+    getWorkspaceVertex(db, workspaceName) match {
+      case Some(v) => {
+        v.remove
+        true
+      }
+      case None => false
+    }
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceDAO.scala
@@ -10,4 +10,5 @@ trait WorkspaceDAO {
   def load(workspaceName: WorkspaceName, txn: RawlsTransaction): Option[Workspace]
   def loadContext(workspaceName: WorkspaceName, txn: RawlsTransaction): Option[WorkspaceContext]
   def list(txn: RawlsTransaction): TraversableOnce[Workspace]
+  def delete(workspaceName: WorkspaceName, txn: RawlsTransaction): Boolean
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAODeleteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAODeleteSpec.scala
@@ -1,0 +1,54 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import scala.collection.JavaConversions._
+import scala.collection.immutable.HashMap
+
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers, FlatSpec}
+
+import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
+import org.broadinstitute.dsde.rawls.model._
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: hussein
+ * Date: 08/18/2015
+ * Time: 15:05
+ */
+class GraphDAODeleteSpec extends FreeSpec with Matchers with OrientDbTestFixture {
+  val wsName = WorkspaceName("myNamespace", "myWorkspace")
+  val workspace = Workspace(wsName.namespace, wsName.name, "aBucket", DateTime.now, "testUser", new HashMap[String, Attribute]() )
+  val wsWithAttributeVals = Workspace(wsName.namespace, wsName.name, "aBucket", DateTime.now, "testUser",
+    Map(
+      "str" -> AttributeString("str"), "num" -> AttributeNumber(4), "bool" -> AttributeBoolean(true),
+      "empty" -> AttributeEmptyList, "valueList" -> AttributeValueList(Seq(AttributeNumber(4), AttributeNumber(5))) ))
+
+  "Graph objects shouldn't leave stray vertices behind when they're deleted:" - {
+    "Empty workspace" in withEmptyTestDatabase { dataSource =>
+      dataSource.inTransaction { txn =>
+        txn.withGraph { graph =>
+          workspaceDAO.save(workspace, txn)
+          workspaceDAO.delete(wsName, txn)
+          assertResult(0) {
+            graph.getVertices.toList.size
+          }
+        }
+      }
+    }
+
+    "Workspace with value attributes and lists" in withEmptyTestDatabase { dataSource =>
+      dataSource.inTransaction { txn =>
+        txn.withGraph { graph =>
+          workspaceDAO.save(wsWithAttributeVals, txn)
+          workspaceDAO.delete(wsName, txn)
+          assertResult(0) {
+            graph.getVertices.toList.size
+          }
+        }
+      }
+    }
+
+
+  }
+
+}


### PR DESCRIPTION
I'd like to do a presentation-style review of this as I'd like feedback with the direction I'm going (I'm not super thrilled with any of this).

The general overview: Write a parallel implementation of `saveToVertex` called `deleteVertex` that handles deletes. This entails matching all cases where `saveToVertex` creates additional vertices and deleting them.

[Here](https://github.com/broadinstitute/rawls/pull/90/files#diff-e295baee74fdedfd2e5dbfd08f2e7265R249) is the entry point you should probably be starting at.

Some things to think about:

- Is any of this even necessary? I'm doing this whole mess of inspecting the class properties and recursively deleting, but the `removeMapVertex` method that recursively follows edges of type VertexSchema.Map and deletes them. If all containers are (or can be) represented like this then I'm very probably overengineering this solution.

- [This line](https://github.com/broadinstitute/rawls/pull/90/files#diff-e295baee74fdedfd2e5dbfd08f2e7265R291) really bugs me; see the FIXME comment. I think if you have an `Option[Seq[SomeDomainObject]]` and try to update its field from a `Some` to `None`, a recursive call to `removeMapVertex` won't be sufficient to remove the member vertices because they won't be of type `VertexSchema.Map`.

- The serialization code makes me really sad. I really think that our collection types should be recursively serialized; looking inside a `Seq` to determine how to serialize it horrifies me and I don't see why we should do it. I am really tempted to rewrite it all...