### PR TITLE
method config validation

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import org.broadinstitute.dsde.rawls.model.{ExecutionServiceLogs, ExecutionServiceOutputs, ExecutionServiceStatus}
+import org.broadinstitute.dsde.rawls.model._
 import spray.http.HttpCookie
 
 /**
@@ -8,6 +8,7 @@ import spray.http.HttpCookie
  */
 trait ExecutionServiceDAO {
   def submitWorkflow( wdl: String, inputs: String, authCookie: HttpCookie ): ExecutionServiceStatus
+  def validateWorkflow( wdl: String, inputs: String, authCookie: HttpCookie ): ExecutionServiceValidation
   def status(id: String, authCookie: HttpCookie): ExecutionServiceStatus
   def outputs(id: String, authCookie: HttpCookie): ExecutionServiceOutputs
   def logs(id: String, authCookie: HttpCookie): ExecutionServiceLogs

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import org.broadinstitute.dsde.rawls.model.{ExecutionServiceLogs, ExecutionServiceOutputs, ExecutionServiceStatus}
+import org.broadinstitute.dsde.rawls.model.{ExecutionServiceValidation, ExecutionServiceLogs, ExecutionServiceOutputs, ExecutionServiceStatus}
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -23,6 +23,14 @@ class HttpExecutionServiceDAO( executionServiceURL: String )( implicit system: A
     val url = executionServiceURL+"/workflows/v1"
     import system.dispatcher
     val pipeline = addHeader(Cookie(authCookie)) ~> sendReceive ~> unmarshal[ExecutionServiceStatus]
+    val formData = FormData(Seq("wdlSource" -> wdl, "workflowInputs" -> inputs))
+    Await.result(pipeline(Post(url,formData)),Duration.Inf)
+  }
+
+  override def validateWorkflow(wdl: String, inputs: String, authCookie: HttpCookie): ExecutionServiceValidation = {
+    val url = executionServiceURL + "/workflows/v1/validate"
+    import system.dispatcher
+    val pipeline = addHeader(Cookie(authCookie)) ~> sendReceive ~> unmarshal[ExecutionServiceValidation]
     val formData = FormData(Seq("wdlSource" -> wdl, "workflowInputs" -> inputs))
     Await.result(pipeline(Post(url,formData)),Duration.Inf)
   }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -22,10 +22,16 @@ case class SubmissionRequest(
   expression: Option[String]
 )
 
-// Cromwell's response to workflow submission (not decorated with annotations because it's not part of our API)
+// Cromwell's response to workflow submission
 case class ExecutionServiceStatus(
   id: String,
   status: String
+)
+
+// Cromwell's response to workflow validation
+case class ExecutionServiceValidation(
+  valid: Boolean,
+  error: String
 )
 
 case class ExecutionServiceOutputs(
@@ -100,6 +106,8 @@ object ExecutionJsonSupport extends JsonSupport {
   implicit val SubmissionRequestFormat = jsonFormat5(SubmissionRequest)
 
   implicit val ExecutionServiceStatusFormat = jsonFormat2(ExecutionServiceStatus)
+
+  implicit val ExecutionServiceValidationFormat = jsonFormat2(ExecutionServiceValidation)
 
   implicit val ExecutionServiceOutputsFormat = jsonFormat2(ExecutionServiceOutputs)
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -6,8 +6,26 @@ import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 import org.scalatest.{WordSpecLike, Matchers, FlatSpec}
 
+import scala.util.{Failure, Success}
+
 class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbTestFixture {
   val littleWdl =
+    """
+      |task t1 {
+      |  Int int_arg
+      |  Int? int_opt
+      |  command {
+      |    echo ${int_arg}
+      |    echo ${int_opt}
+      |  }
+      |}
+      |
+      |workflow w1 {
+      |  call t1
+      |}
+    """.stripMargin
+
+  val arrayWdl =
     """
       |task t1 {
       |  Int int_arg
@@ -17,24 +35,44 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbT
       |}
       |
       |workflow w1 {
-      |  call t1
+      |  Array[Int] int_array
+      |  scatter(i in int_array) {
+      |    call t1 { input: int_arg = i }
+      |  }
       |}
     """.stripMargin
 
   val intArgName = "w1.t1.int_arg"
+  val intOptName = "w1.t1.int_opt"
+  val intArrayName = "w1.int_array"
 
   val workspace = new Workspace("workspaces", "test_workspace", "aBucket", DateTime.now, "testUser", Map.empty)
 
   val sampleGood = new Entity("sampleGood", "Sample", Map("blah" -> AttributeNumber(1)))
   val sampleMissingValue = new Entity("sampleMissingValue", "Sample", Map.empty)
 
+  val sampleSet = new Entity("daSampleSet", "SampleSet",
+    Map("samples" -> AttributeEntityReferenceList(Seq(
+      AttributeEntityReference("Sample", "sampleGood"),
+      AttributeEntityReference("Sample", "sampleMissingValue")
+    )))
+  )
+
   val configGood = new MethodConfiguration("config_namespace", "configGood", "Sample",
     Map.empty, Map(intArgName -> AttributeString("this.blah")), Map.empty,
+    MethodRepoConfiguration( "method_config_namespace", "test_method", "1"), MethodRepoMethod( "method_namespace", "test_method", "1"))
+
+  val configEvenBetter = new MethodConfiguration("config_namespace", "configGood", "Sample",
+    Map.empty, Map(intArgName -> AttributeString("this.blah"), intOptName -> AttributeString("this.blah")), Map.empty,
     MethodRepoConfiguration( "method_config_namespace", "test_method", "1"), MethodRepoMethod( "method_namespace", "test_method", "1"))
 
   val configMissingExpr = new MethodConfiguration("config_namespace", "configMissingExpr", "Sample",
     Map.empty, Map.empty, Map.empty,
     MethodRepoConfiguration( "method_config_namespace", "test_method", "1"), MethodRepoMethod( "method_namespace", "test_method", "1"))
+
+  val configSampleSet = new MethodConfiguration("config_namespace", "configSampleSet", "SampleSet",
+    Map.empty, Map(intArrayName -> AttributeString("this.samples.blah")), Map.empty,
+    MethodRepoConfiguration("method_config_namespace", "test_method", "1"), MethodRepoMethod( "method_namespace", "test_method", "1"))
 
   class ConfigData extends TestData {
     override def save(txn: RawlsTransaction): Unit = {
@@ -42,8 +80,10 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbT
       withWorkspaceContext(workspace, txn) { context =>
         entityDAO.save(context, sampleGood, txn)
         entityDAO.save(context, sampleMissingValue, txn)
+        entityDAO.save(context, sampleSet, txn)
         methodConfigDAO.save(context, configGood, txn)
         methodConfigDAO.save(context, configMissingExpr, txn)
+        methodConfigDAO.save(context, configSampleSet, txn)
       }
     }
   }
@@ -56,12 +96,18 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbT
   }
 
   "MethodConfigResolver" should {
-    "get validation errors" in withConfigData { dataSource =>
+    "resolve method config inputs" in withConfigData { dataSource =>
       dataSource.inTransaction { txn =>
         withWorkspaceContext(workspace, txn) { context =>
-          MethodConfigResolver.getValidationErrors(context, configGood, sampleGood, littleWdl, txn).get(intArgName) should be(None) // Valid input
-          MethodConfigResolver.getValidationErrors(context, configGood, sampleMissingValue, littleWdl, txn).get(intArgName) shouldNot be(None) // Entity missing value
-          MethodConfigResolver.getValidationErrors(context, configMissingExpr, sampleGood, littleWdl, txn).get(intArgName) shouldNot be(None) // Config missing expr
+          // success cases
+          MethodConfigResolver.resolveInputs(context, configGood, sampleGood, littleWdl, txn).get(intArgName) shouldBe Some(Success(AttributeNumber(1)))
+          MethodConfigResolver.resolveInputs(context, configGood, sampleGood, littleWdl, txn).get(intOptName) shouldBe Some(Success(AttributeNull))
+          MethodConfigResolver.resolveInputs(context, configEvenBetter, sampleGood, littleWdl, txn).get(intOptName) shouldBe Some(Success(AttributeNumber(1)))
+          MethodConfigResolver.resolveInputs(context, configSampleSet, sampleSet, arrayWdl, txn).get(intArrayName) shouldBe Some(Success(AttributeValueList(Seq(AttributeNumber(1)))))
+
+          // failure cases
+          MethodConfigResolver.resolveInputs(context, configGood, sampleMissingValue, littleWdl, txn).get(intArgName) should matchPattern { case Some(Failure(_)) => }
+          MethodConfigResolver.resolveInputs(context, configMissingExpr, sampleGood, littleWdl, txn).get(intArgName) should matchPattern { case Some(Failure(_)) => }
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowMonitorSpec.scala
@@ -99,6 +99,7 @@ class WorkflowMonitorSpec(_system: ActorSystem) extends TestKit(_system) with Fl
 
 class WorkflowTestExecutionServiceDAO(workflowStatus: String) extends ExecutionServiceDAO {
   override def submitWorkflow(wdl: String, inputs: String, authCookie: HttpCookie): ExecutionServiceStatus = ExecutionServiceStatus("test_id", workflowStatus)
+  override def validateWorkflow(wdl: String, inputs: String, authCookie: HttpCookie): ExecutionServiceValidation = ExecutionServiceValidation(true, "No errors")
 
   override def outputs(id: String, authCookie: HttpCookie): ExecutionServiceOutputs = ExecutionServiceOutputs(id, Map("o1" -> AttributeString("foo")))
   override def logs(id: String, authCookie: HttpCookie): ExecutionServiceLogs = ExecutionServiceLogs(id, Map("task1" -> Map("wf.t1.foo" -> "foo", "wf.t1.bar" -> "bar")))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
@@ -336,8 +336,8 @@ class MethodConfigApiServiceSpec extends FlatSpec with HttpService with Scalates
       addMockOpenAmCookie ~>
       sealRoute(services.methodConfigRoutes) ~>
       check {
-        val methodConfiguration = MethodConfiguration("namespace","name","rootEntityType",Map(),Map(),
-          Map("three_step.ps.procs"->AttributeString("expression"),"three_step.cgrep.count"->AttributeString("expression"),"three_step.wc.count"->AttributeString("expression")),
+        val methodConfiguration = MethodConfiguration("namespace","name","rootEntityType",Map(), Map("three_step.cgrep.pattern" -> AttributeString("expression")),
+          Map("three_step.ps.procs"->AttributeString("expression"),"three_step.cgrep.count"->AttributeString("expression"), "three_step.wc.count"->AttributeString("expression")),
           MethodRepoConfiguration("none","none","none"),MethodRepoMethod("dsde","three_step","1"))
         assertResult(methodConfiguration) { responseAs[MethodConfiguration] }
         assertResult(StatusCodes.OK) { status }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -84,8 +84,8 @@ class SubmissionApiServiceSpec extends FlatSpec with HttpService with ScalatestR
   }
 
   it should "return 404 Not Found when creating a submission using an Entity that doesn't exist in the workspace" in withTestDataApiServices { services =>
-    val mcName = MethodConfigurationName("three_step_1","dsde", testData.wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name,"Pattern", Map.empty, Map("pattern"->AttributeString("String")), Map.empty, MethodRepoConfiguration("dsde_config","three_step","1"), MethodRepoMethod("dsde","three_step","1"))
+    val mcName = MethodConfigurationName("three_step","dsde", testData.wsName)
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name,"Pattern", Map.empty, Map("pattern"->AttributeString("String")), Map.empty, MethodRepoConfiguration("dsde-config","three_step","1"), MethodRepoMethod("dsde","three_step","1"))
     Post(s"/workspaces/${testData.wsName.namespace}/${testData.wsName.name}/methodconfigs", HttpEntity(ContentTypes.`application/json`, methodConf.toJson.toString)) ~>
       addMockOpenAmCookie ~>
       sealRoute(services.methodConfigRoutes) ~>
@@ -133,8 +133,8 @@ class SubmissionApiServiceSpec extends FlatSpec with HttpService with ScalatestR
 
   it should "return 201 Created when creating and monitoring a submission with no expression" in withTestDataApiServices { services =>
   val wsName = testData.wsName
-    val mcName = MethodConfigurationName("three_step", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, "Sample", Map.empty, Map.empty, Map.empty, MethodRepoConfiguration("dsde_config", "three_step", "1"), MethodRepoMethod("dsde", "three_step", "1"))
+    val mcName = MethodConfigurationName("no_input", "dsde", wsName)
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, "Sample", Map.empty, Map.empty, Map.empty, MethodRepoConfiguration("dsde-config", "no_input", "1"), MethodRepoMethod("dsde", "no_input", "1"))
 
     val submission = createAndMonitorSubmission(wsName, methodConf, testData.sample1, None, services)
 
@@ -144,8 +144,8 @@ class SubmissionApiServiceSpec extends FlatSpec with HttpService with ScalatestR
   }
   it should "return 201 Created when creating and monitoring a submission with valid expression" in withTestDataApiServices { services =>
     val wsName = testData.wsName
-    val mcName = MethodConfigurationName("three_step", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, "Sample", Map.empty, Map.empty, Map.empty, MethodRepoConfiguration("dsde_config", "three_step", "1"), MethodRepoMethod("dsde", "three_step", "1"))
+    val mcName = MethodConfigurationName("no_input", "dsde", wsName)
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, "Sample", Map.empty, Map.empty, Map.empty, MethodRepoConfiguration("dsde-config", "no_input", "1"), MethodRepoMethod("dsde", "no_input", "1"))
 
     val submission = createAndMonitorSubmission(wsName, methodConf, testData.sset1, Option("this.samples"), services)
 


### PR DESCRIPTION
Stuff for https://broadinstitute.atlassian.net/browse/DSDEEPB-661.

* expression evaluation is separate from "unpacking" into WDL, which covers things like array vs single types and optional values
* missing / bad expressions are OK as long as the corresponding WDL input is optional (currently I'm representing this by replacing the eval errors with AttributeNull to represent a null value, which is then ignored when sending to Cromwell. Maybe there's a better way to do it)
* fixed the three-step WDL being used by some unit tests, which had deprecated syntax.
* actual full type-checking is not part of the unpacking. That's done by Cromwell when actually submitting a workflow. And the (still unused) validation function now calls Cromwell's validation endpoint.