### PR TITLE
DSDEEPB-1139 Fixes for graph serializer

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -16,17 +16,17 @@ object DataSource {
     new DataSource(factory)
   }
 
-  def apply(url: String, user: String, password: String) = {
-    val factory: OrientGraphFactory = createFactory(url, user, password)
+  def apply(url: String, user: String, password: String, lwEdges:Boolean=true) = {
+    val factory: OrientGraphFactory = createFactory(url, user, password, lwEdges)
     new DataSource(factory)
   }
 
-  def createFactory(url: String, user: String, password: String): OrientGraphFactory = {
+  def createFactory(url: String, user: String, password: String, lwEdges:Boolean=true): OrientGraphFactory = {
     val factory = new OrientGraphFactory(url, user, password)
     factory.setThreadMode(THREAD_MODE.MANUAL)
     factory.setAutoStartTx(false)
     factory.setUseClassForEdgeLabel(false)
-    factory.setUseLightweightEdges(true)
+    factory.setUseLightweightEdges(lwEdges)
     factory
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -277,10 +277,14 @@ trait GraphDAO {
     })
   }
 
-  private def removeDomainObjectFilterFn(tpe: Type, obj: DomainObject)(vertex: Vertex): Boolean = {
+  private def getDomainObjectIdField(tpe: Type, obj: DomainObject): String = {
     val mirror = ru.runtimeMirror(obj.getClass.getClassLoader)
     val idFieldSym = tpe.decl(ru.TermName(obj.idField)).asMethod
-    vertex.getProperty(obj.idField) == mirror.reflect(obj).reflectField(idFieldSym).get
+    mirror.reflect(obj).reflectField(idFieldSym).get.asInstanceOf[String]
+  }
+
+  private def domainObjectFilterFn(tpe: Type, obj: DomainObject)(vertex: Vertex): Boolean = {
+    vertex.getProperty(obj.idField) == getDomainObjectIdField(tpe, obj)
   }
 
   def saveSubObject[T <: DomainObject :TypeTag :ClassTag](propName: String, obj: T, vertex: Vertex, wsc: WorkspaceContext, graph: Graph): Vertex = {
@@ -288,8 +292,23 @@ trait GraphDAO {
   }
 
   def saveSubObject(tpe: Type, propName: String, obj: DomainObject, vertex: Vertex, wsc: WorkspaceContext, graph: Graph): Vertex = {
-    removeProperty(propName, vertex, graph, removeDomainObjectFilterFn(tpe, obj))
+    //Preserve references into this vertex. List of (vertex, edgeLabel).
+    val referencers = getVertices(vertex, Direction.OUT, EdgeSchema.Own, propName)
+      .filter( subV => domainObjectFilterFn(tpe, obj)(subV) ) //only our actual object
+      .map({ subObj =>
+        subObj.getEdges(Direction.IN)
+          .filter( e => EdgeSchema.getEdgeRelation(e.getLabel) == EdgeSchema.Ref )
+          .map( e => ( e.getVertex(Direction.OUT), EdgeSchema.stripEdgeRelation(e.getLabel) ) ).toList
+    }).flatten
+
+    removeProperty(propName, vertex, graph, domainObjectFilterFn(tpe, obj))
     val objVert = addVertex(graph, VertexSchema.vertexClassOf(tpe))
+
+    //Restore vertex references.
+    referencers.map { case (refVtx, label) =>
+      addEdge(refVtx, EdgeSchema.Ref, label, objVert )
+    }
+
     addEdge(vertex, EdgeSchema.Own, propName, objVert)
     saveObject(tpe, obj, objVert, wsc, graph)
     objVert

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -271,6 +271,10 @@ trait GraphDAO {
   }
 
   def saveObject(tpe: Type, obj: DomainObject, vertex: Vertex, wsc: WorkspaceContext, graph: Graph): Unit = {
+    //Bit of a hack: always make sure that the idField is the first thing to be serialized.
+    //This makes sure that half-serialized objects are always findable even if they didn't save successfully.
+    saveProperty(tpe, obj.idField, getDomainObjectIdField(tpe, obj), vertex, wsc, graph)
+
     //Serialize out each of the case class properties.
     getPropertiesAndValues(tpe, obj).foreach({
       case (tp, prop, value) => saveProperty(tp, prop, value, vertex, wsc, graph)
@@ -284,7 +288,7 @@ trait GraphDAO {
   }
 
   private def domainObjectFilterFn(tpe: Type, obj: DomainObject)(vertex: Vertex): Boolean = {
-    vertex.getProperty(obj.idField) == getDomainObjectIdField(tpe, obj)
+    getDomainObjectIdField(tpe, obj) == vertex.getProperty(obj.idField)
   }
 
   def saveSubObject[T <: DomainObject :TypeTag :ClassTag](propName: String, obj: T, vertex: Vertex, wsc: WorkspaceContext, graph: Graph): Vertex = {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -188,7 +188,7 @@ class SubmissionApiServiceSpec extends FlatSpec with HttpService with ScalatestR
       sealRoute(services.submissionRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {status}
-        assertResult(List(testData.submissionTerminateTest, testData.submission1, testData.submission2)) {
+        assertResult(List(testData.submissionTerminateTest, testData.submission1, testData.submission2, testData.submission3)) {
           responseAs[List[Submission]]
         }
       }


### PR DESCRIPTION
This PR fixes:
1. DSDEEPB-1139: the unit test that always times out. References weren't being preserved during `saveSubObject`.
2. I broke cloneEntities with cycles, but the test was broken so I didn't realise.

Much thanks to @dvoet for catching my stupids and providing a fixed test for no.2.

I'll squash commits once this gets a :+1: .
