### PR TITLE
get individual workspace status and owners list

### DIFF
--- a/src/main/resources/swagger/listings/workspaces
+++ b/src/main/resources/swagger/listings/workspaces
@@ -175,7 +175,7 @@
 			"method": "GET",
 			"summary": "Get workspace",
 			"notes": "",
-			"type": "Workspace",
+			"type": "WorkspaceListResponse",
 			"nickname": "list",
 			"produces": ["application/json"],
 			"parameters": [{

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleCloudStorageDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleCloudStorageDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
-import org.broadinstitute.dsde.rawls.model.{UserInfo, WorkspaceACLUpdate, WorkspaceACL, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{WorkspacePermissionsPair, UserInfo, WorkspaceACLUpdate, WorkspaceACL, WorkspaceName}
 
 trait GoogleCloudStorageDAO {
   def createBucket(userInfo: UserInfo, projectId: String, bucketName: String): Unit
@@ -20,6 +20,8 @@ trait GoogleCloudStorageDAO {
 
   def getMaximumAccessLevel(userId: String, workspaceName: WorkspaceName): WorkspaceAccessLevel
 
-  def getWorkspaces(userId: String): Seq[(WorkspaceName, WorkspaceAccessLevel)]
+  def getWorkspaces(userId: String): Seq[WorkspacePermissionsPair]
+
+  def getWorkspace(userId: String, workspaceName: WorkspaceName): Seq[WorkspacePermissionsPair]
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -134,6 +134,9 @@ case class WorkspaceListResponse(accessLevel: WorkspaceAccessLevel,
                                  workspaceSubmissionStats: WorkspaceSubmissionStats,
                                  owners: Seq[String])
 
+case class WorkspacePermissionsPair(workspaceName: WorkspaceName,
+                                    accessLevel: WorkspaceAccessLevel)
+
 sealed trait Attribute
 sealed trait AttributeValue extends Attribute
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleCloudStorageDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleCloudStorageDAO.scala
@@ -40,12 +40,16 @@ object MockGoogleCloudStorageDAO extends GoogleCloudStorageDAO {
     getAccessLevelOrDieTrying(userId)
   }
 
-  override def getWorkspaces(userId: String): Seq[(WorkspaceName, WorkspaceAccessLevel)] = {
+  override def getWorkspaces(userId: String): Seq[WorkspacePermissionsPair] = {
     Seq(
-      (WorkspaceName("ns", "owner"), WorkspaceAccessLevel.Owner),
-      (WorkspaceName("ns", "writer"), WorkspaceAccessLevel.Write),
-      (WorkspaceName("ns", "reader"), WorkspaceAccessLevel.Read)
+      WorkspacePermissionsPair(WorkspaceName("ns", "owner"), WorkspaceAccessLevel.Owner),
+      WorkspacePermissionsPair(WorkspaceName("ns", "writer"), WorkspaceAccessLevel.Write),
+      WorkspacePermissionsPair(WorkspaceName("ns", "reader"), WorkspaceAccessLevel.Read)
     )
+  }
+
+  override def getWorkspace(userId: String, workspaceName: WorkspaceName): Seq[WorkspacePermissionsPair] = {
+    Seq(WorkspacePermissionsPair(WorkspaceName("ns", "owner"), WorkspaceAccessLevel.Owner))
   }
 
   override def getOwners(workspaceName: WorkspaceName): Seq[String] = mockPermissions.filter(_._2 == WorkspaceAccessLevel.Owner).keys.toSeq


### PR DESCRIPTION
- [x] rebased
- [x] swagger updated
- [x] tests pass
- [x] squashed
- [x] signed-off on by LR