### PR TITLE
fixed batch acl update bug

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -216,7 +216,11 @@ class HttpGoogleServicesDAO(
     val updates = Future.traverse(updateMap) {
       case (userId,accessLevel) => {
         if(userId.toLowerCase.equals(userEmail.toLowerCase)) {
-          Future.successful(Option((userId, s"Failed to change permissions for $userId. You cannot change your own permissions.")))
+          getMaximumAccessLevel(userId, workspaceId) flatMap { currentAccessLevel =>
+            if (currentAccessLevel != accessLevel)
+              Future.successful(Option((userId, s"Failed to change permissions for $userId. You cannot change your own permissions.")))
+            else updateUserAccess(userId, accessLevel, workspaceId, directory)
+          }
         }
         else updateUserAccess(userId, accessLevel, workspaceId, directory)
       }


### PR DESCRIPTION
Previous implementation didn't allow you to perform an acl update operation on yourself, even if you weren't actually changing the permission (i.e. I should still be able to update my access level from OWNER -> OWNER). The UI relies on this behavior.