### PR TITLE
Workspace now stores ACL group map as EnumType -> GroupRef

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
 
 trait AuthDAO {
@@ -7,5 +8,5 @@ trait AuthDAO {
 
   def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup
 
-  def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[String, RawlsGroupRef]
+  def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef]
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.services.admin.directory.model.Group
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, WorkspacePermissionsPair, UserInfo, WorkspaceACLUpdate, WorkspaceACL, WorkspaceName}
 import spray.http.StatusCodes
 import scala.concurrent.Future

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
 
 class GraphAuthDAO extends AuthDAO with GraphDAO {
@@ -25,21 +26,21 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
     }
   }
 
-  override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[String, RawlsGroupRef] = {
+  override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef] = {
     val user = RawlsUser(userInfo.userSubjectId)
     saveUser(user, txn)
 
     // add user to Owner group only
-    val oGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Owner), Set(user), Set.empty)
-    val wGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Write), Set.empty, Set.empty)
-    val rGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Read), Set.empty, Set.empty)
+    val oGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Owner), Set(user), Set.empty)
+    val wGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Write), Set.empty, Set.empty)
+    val rGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Read), Set.empty, Set.empty)
     createGroup(oGroup, txn)
     createGroup(wGroup, txn)
     createGroup(rGroup, txn)
 
     Map(
-      WorkspaceAccessLevel.Owner.toString -> oGroup,
-      WorkspaceAccessLevel.Write.toString -> wGroup,
-      WorkspaceAccessLevel.Read.toString -> rGroup)
+      WorkspaceAccessLevels.Owner -> oGroup,
+      WorkspaceAccessLevels.Write -> wGroup,
+      WorkspaceAccessLevels.Read -> rGroup)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -26,7 +26,7 @@ import com.google.api.services.storage.model.{Bucket, BucketAccessControl, Objec
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 
 import spray.http.StatusCodes
 
@@ -43,7 +43,7 @@ class HttpGoogleServicesDAO(
 
   val groupMemberRole = "MEMBER" // the Google Group role corresponding to a member (note that this is distinct from the GCS roles defined in WorkspaceAccessLevel)
 
-  val groupAccessLevelsAscending = Seq(WorkspaceAccessLevel.Read, WorkspaceAccessLevel.Write, WorkspaceAccessLevel.Owner)
+  val groupAccessLevelsAscending = Seq(WorkspaceAccessLevels.Read, WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Owner)
 
   // modify these if we need more granular access in the future
   val storageScopes = Seq(StorageScopes.DEVSTORAGE_FULL_CONTROL, ComputeScopes.COMPUTE)
@@ -87,7 +87,7 @@ class HttpGoogleServicesDAO(
     def insertOwnerMember: (Seq[Try[Group]]) => Future[Member] = { _ =>
       retry(when500) {
         () => Future {
-          val ownersGroupId = toGroupId(bucketName, WorkspaceAccessLevel.Owner)
+          val ownersGroupId = toGroupId(bucketName, WorkspaceAccessLevels.Owner)
           val owner = new Member().setEmail(userInfo.userEmail).setRole(groupMemberRole)
           val ownerInserter = directory.members.insert(ownersGroupId, owner)
           blocking {
@@ -103,7 +103,7 @@ class HttpGoogleServicesDAO(
           val bucketAcls = groupAccessLevelsAscending.map(ac => newBucketAccessControl(makeGroupEntityString(toGroupId(bucketName, ac)), ac))
           val defaultObjectAcls = groupAccessLevelsAscending.map(ac => {
             // NB: writers have read access to objects -- there is no write access, objects are immutable
-            newObjectAccessControl(makeGroupEntityString(toGroupId(bucketName, ac)), if (ac == WorkspaceAccessLevel.Owner) WorkspaceAccessLevel.Owner else WorkspaceAccessLevel.Read)
+            newObjectAccessControl(makeGroupEntityString(toGroupId(bucketName, ac)), if (ac == WorkspaceAccessLevels.Owner) WorkspaceAccessLevels.Owner else WorkspaceAccessLevels.Read)
           })
 
           val bucket = new Bucket().setName(bucketName).setAcl(bucketAcls).setDefaultObjectAcl(defaultObjectAcls)
@@ -123,10 +123,10 @@ class HttpGoogleServicesDAO(
     new Group().setEmail(toGroupId(bucketName,accessLevel)).setName(UserAuth.toWorkspaceAccessGroupName(workspaceName,accessLevel))
 
   private def newBucketAccessControl(entity: String, accessLevel: WorkspaceAccessLevel) =
-    new BucketAccessControl().setEntity(entity).setRole(WorkspaceAccessLevel.toCanonicalString(accessLevel))
+    new BucketAccessControl().setEntity(entity).setRole(accessLevel.toString)
 
   private def newObjectAccessControl(entity: String, accessLevel: WorkspaceAccessLevel) =
-    new ObjectAccessControl().setEntity(entity).setRole(WorkspaceAccessLevel.toCanonicalString(accessLevel))
+    new ObjectAccessControl().setEntity(entity).setRole(accessLevel.toString)
 
   override def deleteBucket(userInfo: UserInfo, workspaceId: String): Future[Any] = {
     val bucketName = getBucketName(workspaceId)
@@ -220,7 +220,7 @@ class HttpGoogleServicesDAO(
   override def getOwners(workspaceId: String): Future[Seq[String]] = {
     val members = getGroupDirectory.members
     //a workspace should always have an owner, but just in case for some reason it doesn't...
-    val fetcher = members.list(toGroupId(getBucketName(workspaceId), WorkspaceAccessLevel.Owner))
+    val fetcher = members.list(toGroupId(getBucketName(workspaceId), WorkspaceAccessLevels.Owner))
     val ownersQuery = retry(when500) (() => Future {
       blocking { fetcher.execute }
     })
@@ -241,10 +241,10 @@ class HttpGoogleServicesDAO(
           accessLevel
         }
       } recover {
-        case t => WorkspaceAccessLevel.NoAccess
+        case t => WorkspaceAccessLevels.NoAccess
       }
     } map { userAccessLevels =>
-      userAccessLevels.sorted.last
+      userAccessLevels.sorted[WorkspaceAccessLevel].last
     }
   }
 
@@ -335,13 +335,13 @@ class HttpGoogleServicesDAO(
         val inserter = members.insert(targetGroupId, member)
 
         val deleteFuture: Future[Option[Throwable]] =
-          if (currentAccessLevel < WorkspaceAccessLevel.Read)
+          if (currentAccessLevel < WorkspaceAccessLevels.Read)
             Future.successful(None)
           else
             retryWhen500(()=>deleter.execute()).map(_=>None).recover{case throwable=>Some(throwable)}
 
         val insertFuture: Future[Option[Throwable]] =
-          if (targetAccessLevel < WorkspaceAccessLevel.Read)
+          if (targetAccessLevel < WorkspaceAccessLevels.Read)
             Future.successful(None)
           else
             retryWhen500(()=>inserter.execute()).map(_=>None).recover{case throwable=>Some(throwable)}
@@ -413,12 +413,12 @@ class HttpGoogleServicesDAO(
   def toUserFromProxy(proxy: String) = getGroupDirectory.groups().get(proxy).execute().getName
 
   def adminGroupName = s"${groupsPrefix}-ADMIN@${appsDomain}"
-  def toGroupId(bucketName: String, accessLevel: WorkspaceAccessLevel) = s"${bucketName}-${WorkspaceAccessLevel.toCanonicalString(accessLevel)}@${appsDomain}"
+  def toGroupId(bucketName: String, accessLevel: WorkspaceAccessLevel) = s"${bucketName}-${accessLevel.toString}@${appsDomain}"
   def fromGroupId(groupId: String): Option[WorkspacePermissionsPair] = {
     val pattern = s"rawls-([0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+)-([a-zA-Z]+)@${appsDomain}".r
     Try{
       val pattern(workspaceId,accessLevelString) = groupId
-      WorkspacePermissionsPair(workspaceId,WorkspaceAccessLevel.fromCanonicalString(accessLevelString.toUpperCase))
+      WorkspacePermissionsPair(workspaceId,WorkspaceAccessLevels.withName(accessLevelString.toUpperCase))
     }.toOption
   }
   def makeGroupEntityString(groupId: String) = s"group-$groupId"

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.model
 
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 
 sealed trait UserAuthRef
 case class RawlsUserRef(userSubjectId: String) extends UserAuthRef

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.rawls.model
 
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport._
 import org.joda.time.DateTime
 import spray.http.StatusCode
 import spray.json._
@@ -56,7 +58,7 @@ case class Workspace(
                       lastModified: DateTime,
                       createdBy: String,
                       attributes: Map[String, Attribute],
-                      accessLevels: Map[String, RawlsGroupRef],
+                      accessLevels: Map[WorkspaceAccessLevel, RawlsGroupRef],
                       isLocked: Boolean = false
                       ) extends Attributable with DomainObject {
   def toWorkspaceName = WorkspaceName(namespace,name)
@@ -236,6 +238,8 @@ object WorkspaceJsonSupport extends JsonSupport {
 
   implicit val RawlsGroupRefFormat = UserAuthJsonSupport.RawlsGroupRefFormat
 
+  implicit val WorkspaceAccessLevelFormat = WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
+
   implicit val WorkspaceFormat = jsonFormat10(Workspace)
 
   implicit val EntityNameFormat = jsonFormat1(EntityName)
@@ -259,8 +263,6 @@ object WorkspaceJsonSupport extends JsonSupport {
   implicit val ConflictingEntitiesFormat = jsonFormat1(ConflictingEntities)
 
   implicit val WorkspaceSubmissionStatsFormat = jsonFormat3(WorkspaceSubmissionStats)
-
-  implicit val WorkspaceAccessLevelFormat = WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
 
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
@@ -172,7 +172,7 @@ class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
         txn.withGraph { graph =>
           val mapVertex = authDAO.getVertices(wc.workspaceVertex, Direction.OUT, EdgeSchema.Own, "accessLevels").head
 
-          Seq(WorkspaceAccessLevel.Owner, WorkspaceAccessLevel.Write, WorkspaceAccessLevel.Read) foreach { level =>
+          Seq(WorkspaceAccessLevels.Owner, WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Read) foreach { level =>
             val levelFromWs = authDAO.getVertices(mapVertex, Direction.OUT, EdgeSchema.Ref, level.toString).head
 
             val levelGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(testData.workspace.toWorkspaceName, level), Set.empty, Set.empty)
@@ -202,7 +202,7 @@ class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
       withWorkspaceContext(testData.workspace, txn, bSkipLockCheck = true) { wc =>
         txn.withGraph { graph =>
           val vAccessLevels = authDAO.getVertices(wc.workspaceVertex, Direction.OUT, EdgeSchema.Own, "accessLevels").head
-          val vOwnerGroup = authDAO.getVertices(vAccessLevels, Direction.OUT, EdgeSchema.Ref, WorkspaceAccessLevel.Owner.toString).head
+          val vOwnerGroup = authDAO.getVertices(vAccessLevels, Direction.OUT, EdgeSchema.Ref, WorkspaceAccessLevels.Owner.toString).head
           val vOwnerGroupUsers = authDAO.getVertices(vOwnerGroup, Direction.OUT, EdgeSchema.Own, "users").head
           val vOwnerGroupUser0 = authDAO.getVertices(vOwnerGroupUsers, Direction.OUT, EdgeSchema.Ref, "0").head
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import WorkspaceACLJsonSupport._
 import spray.json._
 import scala.concurrent.Future
@@ -12,12 +12,12 @@ object MockGoogleServicesDAO extends GoogleServicesDAO {
 
 
   val mockPermissions: Map[String, WorkspaceAccessLevel] = Map(
-    "test@broadinstitute.org" -> WorkspaceAccessLevel.Owner,
-    "test_token" -> WorkspaceAccessLevel.Owner,
-    "owner-access" -> WorkspaceAccessLevel.Owner,
-    "write-access" -> WorkspaceAccessLevel.Write,
-    "read-access" -> WorkspaceAccessLevel.Read,
-    "no-access" -> WorkspaceAccessLevel.NoAccess
+    "test@broadinstitute.org" -> WorkspaceAccessLevels.Owner,
+    "test_token" -> WorkspaceAccessLevels.Owner,
+    "owner-access" -> WorkspaceAccessLevels.Owner,
+    "write-access" -> WorkspaceAccessLevels.Write,
+    "read-access" -> WorkspaceAccessLevels.Read,
+    "no-access" -> WorkspaceAccessLevels.NoAccess
   )
 
   private def getAccessLevelOrDieTrying(userId: String) = {
@@ -34,15 +34,15 @@ object MockGoogleServicesDAO extends GoogleServicesDAO {
 
   override def updateACL(userEmail: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]) = Future.successful(None)
 
-  override def getOwners(workspaceId: String) = Future.successful(mockPermissions.filter(_._2 == WorkspaceAccessLevel.Owner).keys.toSeq)
+  override def getOwners(workspaceId: String) = Future.successful(mockPermissions.filter(_._2 == WorkspaceAccessLevels.Owner).keys.toSeq)
 
   override def getMaximumAccessLevel(userId: String, workspaceId: String) = Future.successful(getAccessLevelOrDieTrying(userId))
 
   override def getWorkspaces(userId: String) = Future.successful(
     Seq(
-      WorkspacePermissionsPair("workspaceId1", WorkspaceAccessLevel.Owner),
-      WorkspacePermissionsPair("workspaceId2", WorkspaceAccessLevel.Write),
-      WorkspacePermissionsPair("workspaceId3", WorkspaceAccessLevel.Read)
+      WorkspacePermissionsPair("workspaceId1", WorkspaceAccessLevels.Owner),
+      WorkspacePermissionsPair("workspaceId2", WorkspaceAccessLevels.Write),
+      WorkspacePermissionsPair("workspaceId3", WorkspaceAccessLevels.Read)
     )
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -215,7 +215,7 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
         val dateTime = org.joda.time.DateTime.now
         services.dataSource.inTransaction() { txn =>
           assertResult(
-            WorkspaceListResponse(WorkspaceAccessLevel.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
+            WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
             ){
               val response = responseAs[WorkspaceListResponse]
               WorkspaceListResponse(response.accessLevel, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.owners)
@@ -258,9 +258,9 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
         val dateTime = org.joda.time.DateTime.now
         services.dataSource.inTransaction() { txn =>
           assertResult(Set(
-            WorkspaceListResponse(WorkspaceAccessLevel.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
-            WorkspaceListResponse(WorkspaceAccessLevel.Write, testWorkspaces.workspaceWriter.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
-            WorkspaceListResponse(WorkspaceAccessLevel.Read, testWorkspaces.workspaceReader.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
+            WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
+            WorkspaceListResponse(WorkspaceAccessLevels.Write, testWorkspaces.workspaceWriter.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
+            WorkspaceListResponse(WorkspaceAccessLevels.Read, testWorkspaces.workspaceReader.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(MockGoogleServicesDAO.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
           )) {
             responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
           }


### PR DESCRIPTION
A few changes here:
1. Turned WorkspaceAccessLevel into a RawlsEnumeration rather than a Java Enumeration.
2. Storing ACL groups in the workspace as `Map[WorkspaceAccessLevel, RawlsGroupRef]`
3. GraphDAO can now serialize `Map[RawlsEnumeration, _]` as well as `Map[String, _]`
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: Verify swagger UI on dev server still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
