### PR TITLE
implicit toString for UserAuthType makes .value unnecessary

### DIFF
--- a/src/main/config/rawls.conf.ctmpl
+++ b/src/main/config/rawls.conf.ctmpl
@@ -29,6 +29,11 @@ userLdap {
   providerUrl = "{{.Data.ldap_provider_url}}"
   user = "{{.Data.ldap_user}}"
   password = "{{.Data.ldap_password}}"
+  groupDn = "{{.Data.ldap_group_dn}}"
+  memberAttribute = "{{.Data.ldap_member_attribute}}"
+  userObjectClasses = [{{.Data.ldap_user_object_classes}}]
+  userAttributes = [{{.Data.ldap_user_attributes}}]
+  userDnFormat =  "{{.Data.ldap_user_dn_format}}"
 }
 {{end}}
 {{end}}

--- a/src/main/config/rawls.conf.ctmpl
+++ b/src/main/config/rawls.conf.ctmpl
@@ -25,5 +25,10 @@ methodrepo {
 executionservice {
   server = "{{.Data.execservice_server}}"
 }
+userLdap {
+  providerUrl = "{{.Data.ldap_provider_url}}"
+  user = "{{.Data.ldap_user}}"
+  password = "{{.Data.ldap_password}}"
+}
 {{end}}
 {{end}}

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1937,10 +1937,82 @@ paths:
        parameters:
        security:
          - authorization:
-             - openid
-             - email
-             - profile
- '/user/refreshToken':
+            - openid
+            - email
+            - profile
+  '/user':
+     get:
+       responses:
+         '200':
+           description: Successful Request
+           schema:
+             $ref: '#/definitions/UserStatus'
+         '500':
+           description: Rawls Internal Error
+           schema:
+             $ref: '#/definitions/ErrorReport'
+       description: "gets the status of a user"
+       tags:
+         - users
+       summary: gets the status of a user
+       operationId: status
+       parameters:
+       security:
+         - authorization:
+            - openid
+            - email
+            - profile
+  '/user/{userSubjectId}/disable':
+     post:
+       responses:
+         '204':
+           description: Successful Request
+         '500':
+           description: Rawls Internal Error
+           schema:
+             $ref: '#/definitions/ErrorReport'
+       description: "creates a user in the Rawls system"
+       tags:
+         - users
+       summary: Disable user
+       operationId: diable
+       parameters:
+        - in: path
+          description: subject id of user
+          name: userSubjectId
+          required: true
+          type: string
+       security:
+         - authorization:
+            - openid
+            - email
+            - profile
+  '/user/{userSubjectId}/enable':
+     post:
+       responses:
+         '204':
+           description: Successful Request
+         '500':
+           description: Rawls Internal Error
+           schema:
+             $ref: '#/definitions/ErrorReport'
+       description: "creates a user in the Rawls system"
+       tags:
+         - users
+       summary: Enable user
+       operationId: enable
+       parameters:
+        - in: path
+          description: subject id of user
+          name: userSubjectId
+          required: true
+          type: string
+       security:
+         - authorization:
+            - openid
+            - email
+            - profile
+  '/user/refreshToken':
     put:
       responses:
         '201':
@@ -1971,6 +2043,8 @@ paths:
       responses:
         '200':
           description: Successful Request
+          schema:
+            $ref: '#/definitions/UserRefreshTokenDate'
         '404':
           description: There is no refresh token for the user
           schema:
@@ -2880,3 +2954,18 @@ definitions:
       refreshTokenUpdatedDate:
         type: string
         format: date-time
+  UserStatus:
+    description: users status
+    properties:
+      userInfo:
+        $ref: '#/definitions/RawlsUser'
+      enabled:
+        type: ''
+        description: Map[String,Boolean]
+  RawlsUser:
+    description: information about a rawls user
+    properties:
+      userSubjectId:
+        type: String
+      userEmail:
+        type: String

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -2670,6 +2670,7 @@ definitions:
       - createdDate
       - createdBy
       - attributes
+      - accessLevels
     properties:
       namespace:
         type: string
@@ -2696,6 +2697,13 @@ definitions:
         description: The user who created the workspace
       attributes:
         $ref: ''
+        description: Map[String, Attribute]
+      accessLevels:
+         $ref: ''
+         description: Map[String, RawlsGroupRef]
+      isLocked:
+        type: boolean
+        description: Can the Workspace currently be modified?
 
   WorkspaceSubmissionStats:
     description: Statistics about submissions in a workspace

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1654,12 +1654,12 @@ paths:
       responses:
         '200':
           description: Successful Request
-        '400':
-          description: 'Can''t set ACL for workspace'
+        '404':
+          description: Workspace, user or group not found
           schema:
             $ref: '#/definitions/ErrorReport'
-        '404':
-          description: Workspace not found
+        '409':
+          description: 'Error altering some ACLs'
           schema:
             $ref: '#/definitions/ErrorReport'
         '500':
@@ -2744,15 +2744,15 @@ definitions:
   WorkspaceACLUpdate:
     description: ''
     required:
-      - userId
+      - email
       - accessLevel
     properties:
-      userId:
+      email:
         type: string
-        description: ID of the user whose permissions will be changed
+        description: email address of the user or group whose permissions will be changed
       accessLevel:
         type: string
-        description: The access level to grant to this user (OWNER, READER, WRITER, NO ACCESS)
+        description: The access level to grant to this user or group (OWNER, READER, WRITER, NO ACCESS)
 
   Workspace:
     description: ''

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1920,7 +1920,27 @@ paths:
             - email
             - profile
             - https://www.googleapis.com/auth/devstorage.full_control
-  '/user/refreshToken':
+  '/user':
+     post:
+       responses:
+         '201':
+           description: Successful Request
+         '500':
+           description: Rawls Internal Error
+           schema:
+             $ref: '#/definitions/ErrorReport'
+       description: "creates a user in the Rawls system"
+       tags:
+         - users
+       summary: Create user
+       operationId: create
+       parameters:
+       security:
+         - authorization:
+             - openid
+             - email
+             - profile
+ '/user/refreshToken':
     put:
       responses:
         '201':

--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -64,6 +64,7 @@ object Boot extends App {
       new GraphEntityDAO(),
       new GraphMethodConfigurationDAO(),
       new GraphAuthDAO(),
+      new GraphBillingDAO(),
       new GraphSubmissionDAO()
     )
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -19,6 +19,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.JavaConversions._
 
 object Boot extends App {
 
@@ -51,7 +52,12 @@ object Boot extends App {
     val userDirDAO = new JndiUserDirectoryDAO(
       ldapConfig.getString("providerUrl"),
       ldapConfig.getString("user"),
-      ldapConfig.getString("password")
+      ldapConfig.getString("password"),
+      ldapConfig.getString("groupDn"),
+      ldapConfig.getString("memberAttribute"),
+      ldapConfig.getStringList("userObjectClasses").toList,
+      ldapConfig.getStringList("userAttributes").toList,
+      ldapConfig.getString("userDnFormat")
     )
 
     system.registerOnTermination {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -47,6 +47,13 @@ object Boot extends App {
       gcsConfig.getString("tokenEncryptionKey")
     )
 
+    val ldapConfig = conf.getConfig("userLdap")
+    val userDirDAO = new JndiUserDirectoryDAO(
+      ldapConfig.getString("providerUrl"),
+      ldapConfig.getString("user"),
+      ldapConfig.getString("password")
+    )
+
     system.registerOnTermination {
       dataSource.shutdown()
     }
@@ -72,7 +79,7 @@ object Boot extends App {
                                                   new HttpMethodRepoDAO(conf.getConfig("methodrepo").getString("server")),
                                                   new HttpExecutionServiceDAO(conf.getConfig("executionservice").getString("server")),
                                                   gcsDAO, submissionSupervisor),
-                    UserService.constructor(dataSource, gcsDAO, containerDAO)),
+                    UserService.constructor(dataSource, gcsDAO, containerDAO, userDirDAO)),
                     "rawls-service")
 
     implicit val timeout = Timeout(5.seconds)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls
 
-
 import java.io.File
 
 import akka.actor.ActorSystem
@@ -17,7 +16,6 @@ import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 import spray.can.Http
 
 import scala.concurrent.duration._
-import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -74,7 +72,7 @@ object Boot extends App {
                                                   new HttpMethodRepoDAO(conf.getConfig("methodrepo").getString("server")),
                                                   new HttpExecutionServiceDAO(conf.getConfig("executionservice").getString("server")),
                                                   gcsDAO, submissionSupervisor),
-                    UserService.constructor(dataSource, gcsDAO)),
+                    UserService.constructor(dataSource, gcsDAO, containerDAO)),
                     "rawls-service")
 
     implicit val timeout = Timeout(5.seconds)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -58,6 +58,7 @@ object Boot extends App {
       new GraphWorkspaceDAO(),
       new GraphEntityDAO(),
       new GraphMethodConfigurationDAO(),
+      new GraphAuthDAO(),
       new GraphSubmissionDAO()
     )
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -8,8 +8,6 @@ trait AuthDAO {
 
   def loadUserByEmail(userEmail: String, txn: RawlsTransaction): Option[RawlsUser]
 
-  def createUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser
-
   def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser
 
   def loadGroup(groupRef: RawlsGroupRef, txn: RawlsTransaction): Option[RawlsGroup]

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -11,4 +11,6 @@ trait AuthDAO {
   def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef]
 
   def getMaximumAccessLevel(userSubjectId: String, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel
+
+  def listWorkspaces(userSubjectId: String, txn: RawlsTransaction): Seq[WorkspacePermissionsPair]
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -18,7 +18,7 @@ trait AuthDAO {
     }
   }
 
-  def getMaximumAccessLevel(userSubjectId: String, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel
+  def getMaximumAccessLevel(user: RawlsUserRef, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel
 
-  def listWorkspaces(userSubjectId: String, txn: RawlsTransaction): Seq[WorkspacePermissionsPair]
+  def listWorkspaces(user: RawlsUserRef, txn: RawlsTransaction): Seq[WorkspacePermissionsPair]
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -8,7 +8,15 @@ trait AuthDAO {
 
   def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup
 
+  def deleteGroup(rawlsGroup: RawlsGroupRef, txn: RawlsTransaction)
+
   def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef]
+
+  def deleteWorkspaceAccessGroups(workspace: Workspace, txn: RawlsTransaction) = {
+    workspace.accessLevels foreach { case (_, group) =>
+      deleteGroup(group, txn)
+    }
+  }
 
   def getMaximumAccessLevel(userSubjectId: String, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -1,15 +1,14 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
-
-import scala.util.{Failure, Try}
 
 trait AuthDAO {
   def loadUser(ref: RawlsUserRef, txn: RawlsTransaction): Option[RawlsUser]
 
   def loadUserByEmail(userEmail: String, txn: RawlsTransaction): Option[RawlsUser]
+
+  def createUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser
 
   def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -1,14 +1,29 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
 
+import scala.util.{Failure, Try}
+
 trait AuthDAO {
+  def loadUser(ref: RawlsUserRef, txn: RawlsTransaction): Option[RawlsUser]
+
+  def loadUserByEmail(userEmail: String, txn: RawlsTransaction): Option[RawlsUser]
+
   def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser
+
+  def loadGroup(groupRef: RawlsGroupRef, txn: RawlsTransaction): Option[RawlsGroup]
+
+  def loadGroupByEmail(groupEmail: String, txn: RawlsTransaction): Option[RawlsGroup]
 
   def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup
 
   def deleteGroup(rawlsGroup: RawlsGroupRef, txn: RawlsTransaction)
+
+  def loadFromEmail(email: String, txn: RawlsTransaction): Option[Either[RawlsUser, RawlsGroup]] = {
+    (loadUserByEmail(email, txn).map(Left(_)) ++ loadGroupByEmail(email, txn).map(Right(_))).headOption
+  }
 
   def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef]
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.model._
+
+trait AuthDAO {
+  def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser
+
+  def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup
+
+  def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[String, RawlsGroupRef]
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -9,4 +9,6 @@ trait AuthDAO {
   def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup
 
   def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef]
+
+  def getMaximumAccessLevel(userSubjectId: String, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/AuthDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
 
 trait AuthDAO {
@@ -7,5 +8,5 @@ trait AuthDAO {
 
   def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup
 
-  def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[String, RawlsGroupRef]
+  def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef]
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/BillingDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/BillingDAO.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.model._
+
+trait BillingDAO {
+  def saveProject(rawlsProject: RawlsBillingProject, txn: RawlsTransaction): RawlsBillingProject
+
+  def loadProject(rawlsProjectName: RawlsBillingProjectName, txn: RawlsTransaction): Option[RawlsBillingProject]
+
+  def deleteProject(rawlsProject: RawlsBillingProject, txn: RawlsTransaction): Boolean
+
+  def addUserToProject(rawlsUser: RawlsUserRef, rawlsProject: RawlsBillingProject, txn: RawlsTransaction): RawlsBillingProject = {
+    saveProject(rawlsProject.copy(users = rawlsProject.users + rawlsUser), txn)
+  }
+
+  def removeUserFromProject(rawlsUser: RawlsUserRef, rawlsProject: RawlsBillingProject, txn: RawlsTransaction): RawlsBillingProject = {
+    saveProject(rawlsProject.copy(users = rawlsProject.users - rawlsUser), txn)
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -24,8 +24,6 @@ trait GoogleServicesDAO {
 
   def getMaximumAccessLevel(userId: String, workspaceId: String): Future[WorkspaceAccessLevel]
 
-  def getWorkspaces(userId: String): Future[Seq[WorkspacePermissionsPair]]
-
   def getBucketName(workspaceId: String): String
 
   def isAdmin(userId: String): Future[Boolean]

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -18,8 +18,6 @@ trait GoogleServicesDAO {
 
   def updateACL(userEmail: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]): Future[Option[Seq[ErrorReport]]]
 
-  def getOwners(workspaceId: String): Future[Seq[String]]
-
   def getMaximumAccessLevel(userId: String, workspaceId: String): Future[WorkspaceAccessLevel]
 
   def getBucketName(workspaceId: String): String

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -1,13 +1,11 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
-import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, WorkspacePermissionsPair, UserInfo, WorkspaceACLUpdate, WorkspaceACL, WorkspaceName}
 import org.joda.time.DateTime
 import spray.http.StatusCodes
 import scala.concurrent.Future
-import scala.util.Try
 
 trait GoogleServicesDAO {
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.services.admin.directory.model.Group
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, WorkspacePermissionsPair, UserInfo, WorkspaceACLUpdate, WorkspaceACL, WorkspaceName}
 import org.joda.time.DateTime
 import spray.http.StatusCodes

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, WorkspacePermissionsPair, UserInfo, WorkspaceACLUpdate, WorkspaceACL, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 import spray.http.StatusCodes
 import scala.concurrent.Future
@@ -32,7 +32,7 @@ trait GoogleServicesDAO {
 
   def listAdmins(): Future[Seq[String]]
 
-  def createProxyGroup(userInfo: UserInfo): Future[Unit]
+  def createProxyGroup(user: RawlsUser): Future[Unit]
 
   def storeToken(userInfo: UserInfo, refreshToken: String): Future[Unit]
   def getToken(userInfo: UserInfo): Future[Option[String]]

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -16,7 +16,7 @@ trait GoogleServicesDAO {
 
   def getACL(workspaceId: String): Future[WorkspaceACL]
 
-  def updateACL(userEmail: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]): Future[Option[Seq[ErrorReport]]]
+  def updateACL(currentUser: UserInfo, workspaceId: String, aclUpdates: Map[Either[RawlsUser, RawlsGroup], WorkspaceAccessLevel]): Future[Option[Seq[ErrorReport]]]
 
   def getMaximumAccessLevel(userId: String, workspaceId: String): Future[WorkspaceAccessLevel]
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -32,6 +32,12 @@ trait GoogleServicesDAO {
 
   def createProxyGroup(user: RawlsUser): Future[Unit]
 
+  def addUserToProxyGroup(user: RawlsUser): Future[Unit]
+
+  def removeUserFromProxyGroup(user: RawlsUser): Future[Unit]
+
+  def isUserInProxyGroup(user: RawlsUser): Future[Boolean]
+
   def storeToken(userInfo: UserInfo, refreshToken: String): Future[Unit]
   def getToken(userInfo: UserInfo): Future[Option[String]]
   def getTokenDate(userInfo: UserInfo): Future[Option[DateTime]]

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -1,8 +1,16 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import java.util
+
+import com.tinkerpop.blueprints.{Direction, Vertex}
+import com.tinkerpop.pipes.PipeFunction
+import com.tinkerpop.pipes.branch.LoopPipe
+
 import org.broadinstitute.dsde.rawls.RawlsException
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
+
+import scala.collection.JavaConversions._
 
 class GraphAuthDAO extends AuthDAO with GraphDAO {
   override def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser = txn withGraph { db =>
@@ -42,5 +50,50 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
       WorkspaceAccessLevels.Owner -> oGroup,
       WorkspaceAccessLevels.Write -> wGroup,
       WorkspaceAccessLevels.Read -> rGroup)
+  }
+
+  //turns a PipeFunction into one that takes a LoopBundle
+  implicit def pipeToLoopBundle[A,B](f: PipeFunction[A,B]) = new PipeFunction[LoopPipe.LoopBundle[A], B] {
+    override def compute(bundle: LoopPipe.LoopBundle[A]) : B = f.compute(bundle.getObject)
+  }
+
+  private def invert[A](f: PipeFunction[A, java.lang.Boolean]) = new PipeFunction[A, java.lang.Boolean] {
+    override def compute(v: A) = !f.compute(v)
+  }
+
+  private def isConnectedToTargetWorkspace(wsId:String) = new PipeFunction[Vertex, java.lang.Boolean] {
+    override def compute(v: Vertex) = v.getVertices(Direction.IN).iterator.exists({ case ws =>
+      isVertexOfClass(VertexSchema.Workspace).compute(ws) &&
+        hasPropertyValue("workspaceId", wsId).compute(ws) })
+  }
+
+  override def getMaximumAccessLevel(userSubjectId: String, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel = {
+    txn withGraph { db =>
+
+      //Returns a list of paths starting with a group the user belongs in and ending with the workspace's access map.
+      // user -> group -> ...some other groups... -> group -> workspace access map
+      //Multiple paths implies that the user belongs to multiple groups associated with the workspace.
+      val accessMapPaths =
+        userPipeline(db, userSubjectId).as("vtx").in()
+          .loop(
+            "vtx", //start point of loop
+            invert(isVertexOfClass(VertexSchema.Workspace)), //loop condition: stop walking the path once we've found a workspace node
+            isConnectedToTargetWorkspace(workspaceId)) //loop body: only emit paths to access maps connected to the target workspace
+          .enablePath.path()
+
+      //The last two elements of each path are the group and then the workspace access map.
+      //The edge label between them corresponds to the access level for the group.
+      //This foldl is equivalent to doing a max() on the list of those access levels.
+      accessMapPaths.iterator.foldLeft(WorkspaceAccessLevels.NoAccess:WorkspaceAccessLevel)({ (maxAccessLevel, path) =>
+        val reversePath = path.reverseIterator
+        val accessMap = reversePath.next().asInstanceOf[Vertex]
+        val group = reversePath.next().asInstanceOf[Vertex]
+
+        val accessLabel = accessMap.getEdges(Direction.OUT).filter( _.getVertex(Direction.IN) == group ).head.getLabel
+        val accessLevel = WorkspaceAccessLevels.withName(EdgeSchema.stripEdgeRelation(accessLabel))
+
+        WorkspaceAccessLevels.max(accessLevel, maxAccessLevel)
+      })
+    }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -19,15 +19,6 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
     getUserVertexByEmail(db, userEmail).map(loadObject[RawlsUser])
   }
 
-  override def createUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser = txn withGraph { db =>
-    getUserVertex(db, rawlsUser) match {
-      case Some(_) => throw new RawlsException("Cannot create user %s in database because it already exists".format(rawlsUser))
-      case None =>
-        saveObject[RawlsUser](rawlsUser, addVertex(db, VertexSchema.User), None, db)
-        rawlsUser
-    }
-  }
-
   override def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser = txn withGraph { db =>
     val vertex = getUserVertex(db, rawlsUser).getOrElse(addVertex(db, VertexSchema.User))
     saveObject[RawlsUser](rawlsUser, vertex, None, db)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -13,26 +13,26 @@ import scala.collection.JavaConversions._
 class GraphAuthDAO extends AuthDAO with GraphDAO {
 
   override def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser = txn withGraph { db =>
-    val vertex = getUserVertex(db, rawlsUser.userSubjectId).getOrElse(addVertex(db, VertexSchema.User))
+    val vertex = getUserVertex(db, rawlsUser).getOrElse(addVertex(db, VertexSchema.User))
     saveObject[RawlsUser](rawlsUser, vertex, None, db)
     rawlsUser
   }
 
   override def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup = txn withGraph { db =>
-    val vertex = getGroupVertex(db, rawlsGroup.groupName).getOrElse(addVertex(db, VertexSchema.Group))
+    val vertex = getGroupVertex(db, rawlsGroup).getOrElse(addVertex(db, VertexSchema.Group))
     saveObject[RawlsGroup](rawlsGroup, vertex, None, db)
     rawlsGroup
   }
 
   override def deleteGroup(rawlsGroup: RawlsGroupRef, txn: RawlsTransaction) = txn withGraph { db =>
-    val vertex = getGroupVertex(db, rawlsGroup.groupName) match {
+    val vertex = getGroupVertex(db, rawlsGroup) match {
       case None => throw new RawlsException("Cannot delete group %s from database because it does not exist".format(rawlsGroup.groupName))
       case Some(vertex) => removeObject(vertex, db)
     }
   }
 
   private def createGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup = txn withGraph { db =>
-    getGroupVertex(db, rawlsGroup.groupName) match {
+    getGroupVertex(db, rawlsGroup) match {
       case Some(_) => throw new RawlsException("Cannot create group %s in database because it already exists".format(rawlsGroup.groupName))
       case None =>
         saveObject[RawlsGroup](rawlsGroup, addVertex(db, VertexSchema.Group), None, db)
@@ -41,13 +41,13 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
   }
 
   override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef] = {
-    val user = RawlsUser(userInfo.userSubjectId)
+    val user = RawlsUser(userInfo)
     saveUser(user, txn)
 
     // add user to Owner group only
-    val oGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Owner), Set(user), Set.empty)
-    val wGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Write), Set.empty, Set.empty)
-    val rGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Read), Set.empty, Set.empty)
+    val oGroup = RawlsGroup(workspaceName, WorkspaceAccessLevels.Owner, Set[RawlsUserRef](user), Set.empty[RawlsGroupRef])
+    val wGroup = RawlsGroup(workspaceName, WorkspaceAccessLevels.Write)
+    val rGroup = RawlsGroup(workspaceName, WorkspaceAccessLevels.Read)
     createGroup(oGroup, txn)
     createGroup(wGroup, txn)
     createGroup(rGroup, txn)
@@ -73,23 +73,23 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
     }
   }
 
-  override def getMaximumAccessLevel(userSubjectId: String, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel = {
-    val workspaces = listWorkspaces(userSubjectId, isTargetWorkspace(workspaceId), txn)
+  override def getMaximumAccessLevel(user: RawlsUserRef, workspaceId: String, txn: RawlsTransaction): WorkspaceAccessLevel = {
+    val workspaces = listWorkspaces(user, isTargetWorkspace(workspaceId), txn)
     workspaces.find(_.workspaceId == workspaceId).map(_.accessLevel).getOrElse(WorkspaceAccessLevels.NoAccess)
   }
 
-  override def listWorkspaces(userSubjectId: String, txn: RawlsTransaction): Seq[WorkspacePermissionsPair] = {
-    listWorkspaces(userSubjectId, isVertexOfClass(VertexSchema.Workspace), txn)
+  override def listWorkspaces(user: RawlsUserRef, txn: RawlsTransaction): Seq[WorkspacePermissionsPair] = {
+    listWorkspaces(user, isVertexOfClass(VertexSchema.Workspace), txn)
   }
 
-  private def listWorkspaces(userSubjectId: String, loopEmitFn: PipeFunction[Vertex, java.lang.Boolean], txn: RawlsTransaction): Seq[WorkspacePermissionsPair] = {
+  private def listWorkspaces(user: RawlsUserRef, loopEmitFn: PipeFunction[Vertex, java.lang.Boolean], txn: RawlsTransaction): Seq[WorkspacePermissionsPair] = {
     txn withGraph { db =>
 
       //Returns a list of paths starting with a group the user belongs in and ending with the workspace's access map.
       // user -> group -> ...some other groups... -> group -> workspace access map
       //Multiple paths implies that the user belongs to multiple groups associated with the workspace.
       val accessMapPaths =
-        userPipeline(db, userSubjectId).as("vtx").in()
+        userPipeline(db, user).as("vtx").in()
           .loop(
             "vtx", //start point of loop
             invert(isVertexOfClass(VertexSchema.Workspace)), //loop condition: stop walking the path once we've found a workspace node

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.model._
+
+class GraphAuthDAO extends AuthDAO with GraphDAO {
+  override def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser = txn withGraph { db =>
+    val vertex = getUserVertex(db, rawlsUser.userSubjectId).getOrElse(addVertex(db, VertexSchema.User))
+    saveObject[RawlsUser](rawlsUser, vertex, None, db)
+    rawlsUser
+  }
+
+  override def saveGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup = txn withGraph { db =>
+    val vertex = getGroupVertex(db, rawlsGroup.groupName).getOrElse(addVertex(db, VertexSchema.Group))
+    saveObject[RawlsGroup](rawlsGroup, vertex, None, db)
+    rawlsGroup
+  }
+
+  private def createGroup(rawlsGroup: RawlsGroup, txn: RawlsTransaction): RawlsGroup = txn withGraph { db =>
+    getGroupVertex(db, rawlsGroup.groupName) match {
+      case Some(_) => throw new RawlsException("Cannot create group %s in database because it already exists".format(rawlsGroup.groupName))
+      case None =>
+        saveObject[RawlsGroup](rawlsGroup, addVertex(db, VertexSchema.Group), None, db)
+        rawlsGroup
+    }
+  }
+
+  override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[String, RawlsGroupRef] = {
+    val user = RawlsUser(userInfo.userSubjectId)
+    saveUser(user, txn)
+
+    // add user to Owner group only
+    val oGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Owner), Set(user), Set.empty)
+    val wGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Write), Set.empty, Set.empty)
+    val rGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Read), Set.empty, Set.empty)
+    createGroup(oGroup, txn)
+    createGroup(wGroup, txn)
+    createGroup(rGroup, txn)
+
+    Map(
+      WorkspaceAccessLevel.Owner.toString -> oGroup,
+      WorkspaceAccessLevel.Write.toString -> wGroup,
+      WorkspaceAccessLevel.Read.toString -> rGroup)
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import java.util
-
 import com.tinkerpop.blueprints.{Direction, Vertex}
 import com.tinkerpop.pipes.PipeFunction
 import com.tinkerpop.pipes.branch.LoopPipe

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
 
 class GraphAuthDAO extends AuthDAO with GraphDAO {
@@ -25,21 +26,21 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
     }
   }
 
-  override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[String, RawlsGroupRef] = {
+  override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef] = {
     val user = RawlsUser(userInfo.userSubjectId)
     saveUser(user, txn)
 
     // add user to Owner group only
-    val oGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Owner), Set(user), Set.empty)
-    val wGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Write), Set.empty, Set.empty)
-    val rGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevel.Read), Set.empty, Set.empty)
+    val oGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Owner), Set(user), Set.empty)
+    val wGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Write), Set.empty, Set.empty)
+    val rGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(workspaceName, WorkspaceAccessLevels.Read), Set.empty, Set.empty)
     createGroup(oGroup, txn)
     createGroup(wGroup, txn)
     createGroup(rGroup, txn)
 
     Map(
-      WorkspaceAccessLevel.Owner.toString -> oGroup,
-      WorkspaceAccessLevel.Write.toString -> wGroup,
-      WorkspaceAccessLevel.Read.toString -> rGroup)
+      WorkspaceAccessLevels.Owner -> oGroup,
+      WorkspaceAccessLevels.Write -> wGroup,
+      WorkspaceAccessLevels.Read -> rGroup)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAO.scala
@@ -11,6 +11,13 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccess
 import scala.collection.JavaConversions._
 
 class GraphAuthDAO extends AuthDAO with GraphDAO {
+  override def loadUser(ref: RawlsUserRef, txn: RawlsTransaction): Option[RawlsUser] = txn withGraph { db =>
+    getUserVertex(db, ref).map(loadObject[RawlsUser])
+  }
+
+  override def loadUserByEmail(userEmail: String, txn: RawlsTransaction): Option[RawlsUser] = txn withGraph { db =>
+    getUserVertexByEmail(db, userEmail).map(loadObject[RawlsUser])
+  }
 
   override def saveUser(rawlsUser: RawlsUser, txn: RawlsTransaction): RawlsUser = txn withGraph { db =>
     val vertex = getUserVertex(db, rawlsUser).getOrElse(addVertex(db, VertexSchema.User))
@@ -38,6 +45,14 @@ class GraphAuthDAO extends AuthDAO with GraphDAO {
         saveObject[RawlsGroup](rawlsGroup, addVertex(db, VertexSchema.Group), None, db)
         rawlsGroup
     }
+  }
+
+  override def loadGroup(groupRef: RawlsGroupRef, txn: RawlsTransaction): Option[RawlsGroup] = txn withGraph { db =>
+    getGroupVertex(db, groupRef).map(loadObject[RawlsGroup])
+  }
+
+  def loadGroupByEmail(groupEmail: String, txn: RawlsTransaction): Option[RawlsGroup] = txn withGraph { db =>
+    getGroupVertexByEmail(db, groupEmail).map(loadObject[RawlsGroup])
   }
 
   override def createWorkspaceAccessGroups(workspaceName: WorkspaceName, userInfo: UserInfo, txn: RawlsTransaction): Map[WorkspaceAccessLevel, RawlsGroupRef] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphBillingDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphBillingDAO.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.model._
+
+class GraphBillingDAO extends BillingDAO with GraphDAO {
+  override def saveProject(rawlsProject: RawlsBillingProject, txn: RawlsTransaction) = txn withGraph { db =>
+    val vertex = getBillingProjectVertex(db, rawlsProject.projectName).getOrElse(addVertex(db, VertexSchema.BillingProject))
+    saveObject[RawlsBillingProject](rawlsProject, vertex, None, db)
+    rawlsProject
+  }
+
+  override def loadProject(rawlsProjectName: RawlsBillingProjectName, txn: RawlsTransaction) = txn withGraph { db =>
+    getBillingProjectVertex(db, rawlsProjectName) map { loadObject[RawlsBillingProject] }
+  }
+
+  override def deleteProject(rawlsProject: RawlsBillingProject, txn: RawlsTransaction) = txn withGraph { db =>
+    getBillingProjectVertex(db, rawlsProject.projectName) match {
+      case Some(v) =>
+        removeObject(v, db)
+        true
+      case None =>
+        false
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphContainerDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphContainerDAO.scala
@@ -3,4 +3,4 @@ package org.broadinstitute.dsde.rawls.dataaccess
 /**
  * Created by mbemis on 8/27/15.
  */
-case class GraphContainerDAO(workflowDAO: GraphWorkflowDAO, workspaceDAO: GraphWorkspaceDAO, entityDAO: GraphEntityDAO, methodConfigurationDAO: GraphMethodConfigurationDAO, submissionDAO: GraphSubmissionDAO)
+case class GraphContainerDAO(workflowDAO: GraphWorkflowDAO, workspaceDAO: GraphWorkspaceDAO, entityDAO: GraphEntityDAO, methodConfigurationDAO: GraphMethodConfigurationDAO, authDAO: GraphAuthDAO, submissionDAO: GraphSubmissionDAO)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphContainerDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphContainerDAO.scala
@@ -3,4 +3,4 @@ package org.broadinstitute.dsde.rawls.dataaccess
 /**
  * Created by mbemis on 8/27/15.
  */
-case class GraphContainerDAO(workflowDAO: GraphWorkflowDAO, workspaceDAO: GraphWorkspaceDAO, entityDAO: GraphEntityDAO, methodConfigurationDAO: GraphMethodConfigurationDAO, submissionDAO: SubmissionDAO)
+case class GraphContainerDAO(workflowDAO: GraphWorkflowDAO, workspaceDAO: GraphWorkspaceDAO, entityDAO: GraphEntityDAO, methodConfigurationDAO: GraphMethodConfigurationDAO, submissionDAO: GraphSubmissionDAO)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphContainerDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphContainerDAO.scala
@@ -3,4 +3,4 @@ package org.broadinstitute.dsde.rawls.dataaccess
 /**
  * Created by mbemis on 8/27/15.
  */
-case class GraphContainerDAO(workflowDAO: GraphWorkflowDAO, workspaceDAO: GraphWorkspaceDAO, entityDAO: GraphEntityDAO, methodConfigurationDAO: GraphMethodConfigurationDAO, authDAO: GraphAuthDAO, submissionDAO: GraphSubmissionDAO)
+case class GraphContainerDAO(workflowDAO: GraphWorkflowDAO, workspaceDAO: GraphWorkspaceDAO, entityDAO: GraphEntityDAO, methodConfigurationDAO: GraphMethodConfigurationDAO, authDAO: GraphAuthDAO, billingDAO: GraphBillingDAO, submissionDAO: GraphSubmissionDAO)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -244,8 +244,16 @@ trait GraphDAO {
     new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.User)).filter(hasPropertyValue("userSubjectId",user.userSubjectId.value))
   }
 
+  def userPipelineByEmail(db: Graph, email: String) = {
+    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.User)).filter(hasPropertyValue("userEmail",email))
+  }
+
   def groupPipeline(db: Graph, group: RawlsGroupRef) = {
     new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.Group)).filter(hasPropertyValue("groupName",group.groupName.value))
+  }
+
+  def groupPipelineByEmail(db: Graph, email: String) = {
+    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.Group)).filter(hasPropertyValue("groupEmail",email))
   }
 
   // vertex getters
@@ -282,8 +290,16 @@ trait GraphDAO {
     getSinglePipelineResult(userPipeline(db, user))
   }
 
+  def getUserVertexByEmail(db: Graph, email: String) = {
+    getSinglePipelineResult(userPipelineByEmail(db, email))
+  }
+
   def getGroupVertex(db: Graph, group: RawlsGroupRef) = {
     getSinglePipelineResult(groupPipeline(db, group))
+  }
+
+  def getGroupVertexByEmail(db: Graph, email: String) = {
+    getSinglePipelineResult(groupPipelineByEmail(db, email))
   }
 
   def getCtorProperties(tpe: Type): Iterable[(Type, String)] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -146,7 +146,7 @@ trait GraphDAO {
 
   /**
    * Returns the class of a vertex. */
-  private def getVertexClass(vertex: Vertex): String = vertex.asInstanceOf[OrientVertex].getRecord.getClassName
+  def getVertexClass(vertex: Vertex): String = vertex.asInstanceOf[OrientVertex].getRecord.getClassName
 
   /**
    * Gets the properties of a vertex.

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -242,7 +242,7 @@ trait GraphDAO {
   }
 
   def userPipeline(db: Graph, user: RawlsUserRef) = {
-    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.User)).filter(hasPropertyValue("userSubjectId",user.userSubjectId.value))
+    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.User)).filter(hasPropertyValue[String]("userSubjectId",user.userSubjectId))
   }
 
   def userPipelineByEmail(db: Graph, email: String) = {
@@ -250,7 +250,7 @@ trait GraphDAO {
   }
 
   def groupPipeline(db: Graph, group: RawlsGroupRef) = {
-    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.Group)).filter(hasPropertyValue("groupName",group.groupName.value))
+    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.Group)).filter(hasPropertyValue[String]("groupName",group.groupName))
   }
 
   def groupPipelineByEmail(db: Graph, email: String) = {
@@ -258,7 +258,7 @@ trait GraphDAO {
   }
 
   def billingProjectPipeline(db: Graph, projectName: RawlsBillingProjectName) = {
-    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.BillingProject)).filter(hasPropertyValue("projectName",projectName.value))
+    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.BillingProject)).filter(hasPropertyValue[String]("projectName",projectName))
   }
 
   // vertex getters
@@ -437,7 +437,7 @@ trait GraphDAO {
       case (_, value:DateTime)=> vertex.setProperty(propName, value.toDate)
 
       // RawlsUser and RawlsGroup field types.
-      case (_, value:UserAuthType)  => vertex.setProperty(propName, value.value)
+      case (_, value:UserAuthType)  => vertex.setProperty(propName, value.toString)
 
       //Attributes.
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -613,13 +613,13 @@ trait GraphDAO {
       case tp if isRawlsEnum(tp) => enumWithName(tp, vertex.getProperty(propName))
 
       //Collections. Note that a Seq is treated as a map with the keys as indices.
-      case tp if tp <:< typeOf[Seq[Any]] => loadStringMap(getTypeParams(tp).head, propName, vertex).toSeq.sortBy(_._1.toInt).map(_._2)
-      case tp if tp <:< typeOf[Set[Any]] => loadStringMap(getTypeParams(tp).head, propName, vertex).toSeq.sortBy(_._1.toInt).map(_._2).toSet
-      case tp if tp <:< typeOf[Map[String,Any]] => loadStringMap(getTypeParams(tp).last, propName, vertex)
+      case tp if tp <:< typeOf[Seq[_]] => loadStringMap(getTypeParams(tp).head, propName, vertex).toSeq.sortBy(_._1.toInt).map(_._2)
+      case tp if tp <:< typeOf[Set[_]] => loadStringMap(getTypeParams(tp).head, propName, vertex).toSeq.sortBy(_._1.toInt).map(_._2).toSet
+      case tp if tp <:< typeOf[Map[String,_]] => loadStringMap(getTypeParams(tp).last, propName, vertex)
 
       case tp if tp <:< typeOf[Map[_,_]] && isRawlsEnum(getTypeParams(tp).head) => loadRawlsEnumMap(getTypeParams(tp).head, getTypeParams(tp).last, propName, vertex)
 
-      case tp if tp <:< typeOf[Option[Any]] => loadOpt(tp, propName, vertex)
+      case tp if tp <:< typeOf[Option[_]] => loadOpt(tp, propName, vertex)
 
       //Everything else.
       case tp if tp <:< typeOf[DomainObject] => loadSubObject(tp, propName, vertex)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAO.scala
@@ -31,11 +31,12 @@ object VertexSchema {
   val WorkflowFailure = vertexClassOf[org.broadinstitute.dsde.rawls.model.WorkflowFailure]
   val User = vertexClassOf[org.broadinstitute.dsde.rawls.model.RawlsUser]
   val Group = vertexClassOf[org.broadinstitute.dsde.rawls.model.RawlsGroup]
+  val BillingProject = vertexClassOf[org.broadinstitute.dsde.rawls.model.RawlsBillingProject]
 
   // container types
   val Map = vertexClassOf[scala.collection.Map[String,Attribute]]
 
-  val allClasses = Seq(Workspace, Entity, MethodConfig, MethodRepoMethod, Submission, Workflow, WorkflowFailure, User, Group, Map)
+  val allClasses = Seq(Workspace, Entity, MethodConfig, MethodRepoMethod, Submission, Workflow, WorkflowFailure, User, Group, BillingProject, Map)
 
   def vertexClassOf[T: TypeTag]: String = typeOf[T].typeSymbol.name.decodedName.toString
   def vertexClassOf(tpe: Type): String  = tpe.typeSymbol.name.decodedName.toString
@@ -256,6 +257,10 @@ trait GraphDAO {
     new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.Group)).filter(hasPropertyValue("groupEmail",email))
   }
 
+  def billingProjectPipeline(db: Graph, projectName: RawlsBillingProjectName) = {
+    new GremlinPipeline(db.asInstanceOf[OrientGraph].getVerticesOfClass(VertexSchema.BillingProject)).filter(hasPropertyValue("projectName",projectName.value))
+  }
+
   // vertex getters
 
   def getWorkspaceVertex(db: Graph, workspaceName: WorkspaceName) = {
@@ -300,6 +305,10 @@ trait GraphDAO {
 
   def getGroupVertexByEmail(db: Graph, email: String) = {
     getSinglePipelineResult(groupPipelineByEmail(db, email))
+  }
+
+  def getBillingProjectVertex(db: Graph, projectName: RawlsBillingProjectName) = {
+    getSinglePipelineResult(billingProjectPipeline(db, projectName))
   }
 
   def getCtorProperties(tpe: Type): Iterable[(Type, String)] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAO.scala
@@ -1,12 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import com.tinkerpop.blueprints.impls.orient.OrientVertex
-import com.tinkerpop.blueprints.{Graph, Vertex}
+import com.tinkerpop.blueprints.Vertex
 import com.tinkerpop.gremlin.java.GremlinPipeline
-import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.{WorkspaceName, Workspace}
 
-import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.auth.oauth2.{GoogleCredential, GoogleClientSecrets}
@@ -31,10 +31,8 @@ import com.google.api.services.storage.{StorageScopes, Storage}
 import com.google.api.services.storage.model.{StorageObject, Bucket, BucketAccessControl, ObjectAccessControl}
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 
-import org.broadinstitute.dsde.rawls.RawlsException
-import org.broadinstitute.dsde.rawls.model.{WorkspaceACLUpdate,WorkspaceAccessLevel}
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
 
 import spray.http.StatusCodes
 
@@ -162,7 +160,7 @@ class HttpGoogleServicesDAO(
   }
 
   private def newGroup(bucketName: String, workspaceName: WorkspaceName, accessLevel: WorkspaceAccessLevel) =
-    new Group().setEmail(toGroupId(bucketName,accessLevel)).setName(toGroupName(workspaceName,accessLevel))
+    new Group().setEmail(toGroupId(bucketName,accessLevel)).setName(UserAuth.toWorkspaceAccessGroupName(workspaceName,accessLevel))
 
   private def newBucketAccessControl(entity: String, accessLevel: WorkspaceAccessLevel) =
     new BucketAccessControl().setEntity(entity).setRole(WorkspaceAccessLevel.toCanonicalString(accessLevel))
@@ -507,6 +505,5 @@ class HttpGoogleServicesDAO(
       WorkspacePermissionsPair(workspaceId,WorkspaceAccessLevel.fromCanonicalString(accessLevelString.toUpperCase))
     }.toOption
   }
-  private def toGroupName(workspaceName: WorkspaceName, accessLevel: WorkspaceAccessLevel) = s"rawls ${workspaceName.namespace}/${workspaceName.name} ${accessLevel}"
   def makeGroupEntityString(groupId: String) = s"group-$groupId"
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -234,13 +234,12 @@ class HttpGoogleServicesDAO(
    *
    * @return a map from userId to error message (an empty map means everything was successful)
    */
-  override def updateACL(currentUserId: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]): Future[Option[Seq[ErrorReport]]] = {
+  override def updateACL(currentUser: UserInfo, workspaceId: String, aclUpdates: Map[Either[RawlsUser, RawlsGroup], WorkspaceAccessLevel]): Future[Option[Seq[ErrorReport]]] = {
     val directory = getGroupDirectory
 
-    // make map to eliminate redundant instructions for a single user (last one in the sequence for a given user wins)
-    val updateMap = aclUpdates.map{ workspaceACLUpdate => workspaceACLUpdate.userId -> workspaceACLUpdate.accessLevel }.toMap
-    val futureReports = Future.traverse(updateMap){ case (userId,accessLevel) =>
-        updateUserAccess(currentUserId,userId,accessLevel,workspaceId,directory)
+    val futureReports = Future.traverse(aclUpdates){
+      case (Left(ru:RawlsUser), level) => updateUserAccess(currentUser,toProxyFromUser(ru),ru.userEmail.value,level,workspaceId,directory)
+      case (Right(rg:RawlsGroup), level) => updateUserAccess(currentUser,rg.groupEmail.value,rg.groupEmail.value,level,workspaceId,directory)
     }.map(_.collect{case Some(errorReport)=>errorReport})
     futureReports.map { reports =>
       if (reports.isEmpty) None
@@ -248,14 +247,14 @@ class HttpGoogleServicesDAO(
     }
   }
 
-  override def getMaximumAccessLevel(userId: String, workspaceId: String): Future[WorkspaceAccessLevel] = {
+  override def getMaximumAccessLevel(email: String, workspaceId: String): Future[WorkspaceAccessLevel] = {
     val bucketName = getBucketName(workspaceId)
     val members = getGroupDirectory.members
 
     Future.traverse(groupAccessLevelsAscending) { accessLevel =>
       retry(when500) { () =>
         Future {
-          blocking { members.get(toGroupId(bucketName, accessLevel), userId).execute() }
+          blocking { members.get(toGroupId(bucketName, accessLevel), email).execute() }
           accessLevel
         }
       } recover {
@@ -388,18 +387,23 @@ class HttpGoogleServicesDAO(
     retry(when500)(()=>Future(blocking(op())))
   }
 
-  private def updateUserAccess(currentUserId: String, userId: String, targetAccessLevel: WorkspaceAccessLevel, workspaceId: String, directory: Directory): Future[Option[ErrorReport]] = {
+  //expects the email to be of a google group, i.e. that users have been converted to their proxies first.
+  //userFacingEmail is the pre-proxified email for display to users in errors.
+  private def updateUserAccess(currentUser: UserInfo, groupEmail: String, userFacingEmail: String, targetAccessLevel: WorkspaceAccessLevel, workspaceId: String, directory: Directory): Future[Option[ErrorReport]] = {
     val members = directory.members
-    getMaximumAccessLevel(userId, workspaceId) flatMap { currentAccessLevel =>
+
+    //Ask Google what it thinks this group's current access level is.
+    //It might be wrong, but we still need to delete it from that group and then add it to the new level.
+    getMaximumAccessLevel(groupEmail, workspaceId) flatMap { currentAccessLevel =>
       if ( currentAccessLevel == targetAccessLevel )
         Future.successful(None)
-      else if ( userId.toLowerCase.equals(currentUserId.toLowerCase) && currentAccessLevel != targetAccessLevel )
-        Future.successful(Option(ErrorReport(s"Failed to change permissions for $userId.  You cannot change your own permissions.",Seq.empty)))
+      else if ( groupEmail.toLowerCase.equals(toProxyFromUser(currentUser).toLowerCase) && currentAccessLevel != targetAccessLevel )
+        Future.successful(Option(ErrorReport(s"Failed to change permissions for ${currentUser.userEmail}.  You cannot change your own permissions.",Seq.empty)))
       else {
         val bucketName = getBucketName(workspaceId)
-        val member = new Member().setEmail(userId).setRole(groupMemberRole)
+        val member = new Member().setEmail(groupEmail).setRole(groupMemberRole)
         val currentGroupId = toGroupId(bucketName,currentAccessLevel)
-        val deleter = members.delete(currentGroupId, userId)
+        val deleter = members.delete(currentGroupId, groupEmail)
         val targetGroupId = toGroupId(bucketName, targetAccessLevel)
         val inserter = members.insert(targetGroupId, member)
 
@@ -415,7 +419,7 @@ class HttpGoogleServicesDAO(
           else
             retryWhen500(()=>inserter.execute()).map(_=>None).recover{case throwable=>Some(throwable)}
 
-        val badThing = s"Unable to change permissions for $userId from $currentAccessLevel to $targetAccessLevel access."
+        val badThing = s"Unable to change permissions for $userFacingEmail from $currentAccessLevel to $targetAccessLevel access."
         deleteFuture zip insertFuture flatMap { _ match {
             case (None, None) => Future.successful(None) // delete and insert succeeded
             case (None, Some(throwable)) => // delete ok, but insert failed: try to restore access
@@ -427,10 +431,10 @@ class HttpGoogleServicesDAO(
               }
             case (Some(throwable), None) => // delete failed, but insert succeeded -- user is now on two lists
               val cause = toErrorReport(throwable)
-              val restoreDeleter = members.delete(targetGroupId, userId)
+              val restoreDeleter = members.delete(targetGroupId, groupEmail)
               retryWhen500(()=>restoreDeleter.execute()).map{ _ =>
                 Some(ErrorReport(badThing, cause))}.recover { case _ =>
-                Some(ErrorReport(s"Successfully granted $userId $targetAccessLevel access, but failed to remove $currentAccessLevel access. This may result in inconsistent behavior, please try removing the user (may take more than 1 try) and re-adding.", cause))
+                Some(ErrorReport(s"Successfully granted $userFacingEmail $targetAccessLevel access, but failed to remove $currentAccessLevel access. This may result in inconsistent behavior, please try removing the user (may take more than 1 try) and re-adding.", cause))
               }
             case (Some(throwable1), Some(throwable2)) => // both operations failed
               Future.successful(Some(ErrorReport(badThing,Seq(toErrorReport(throwable1),toErrorReport(throwable2)))))
@@ -478,7 +482,10 @@ class HttpGoogleServicesDAO(
       .build()
   }
 
-  def toProxyFromUser(subjectId: RawlsUserSubjectId) = s"PROXY_${subjectId.value}@${appsDomain}"
+  def toProxyFromUser(rawlsUser: RawlsUser) = toProxyFromUserSubjectId(rawlsUser.userSubjectId.value)
+  def toProxyFromUser(userInfo: UserInfo) = toProxyFromUserSubjectId(userInfo.userSubjectId)
+  def toProxyFromUser(subjectId: RawlsUserSubjectId) = toProxyFromUserSubjectId(subjectId.value)
+  def toProxyFromUserSubjectId(subjectId: String) = s"PROXY_${subjectId}@${appsDomain}"
   def toUserFromProxy(proxy: String) = getGroupDirectory.groups().get(proxy).execute().getName
 
   def adminGroupName = s"${groupsPrefix}-ADMINS@${appsDomain}"

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -53,8 +53,6 @@ class HttpGoogleServicesDAO(
 
   val groupMemberRole = "MEMBER" // the Google Group role corresponding to a member (note that this is distinct from the GCS roles defined in WorkspaceAccessLevel)
 
-  val groupAccessLevelsAscending = Seq(WorkspaceAccessLevels.Read, WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Owner)
-
   // modify these if we need more granular access in the future
   val storageScopes = Seq(StorageScopes.DEVSTORAGE_FULL_CONTROL, ComputeScopes.COMPUTE)
   val directoryScopes = Seq(DirectoryScopes.ADMIN_DIRECTORY_GROUP)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -249,19 +249,6 @@ class HttpGoogleServicesDAO(
     }
   }
 
-  override def getOwners(workspaceId: String): Future[Seq[String]] = {
-    val members = getGroupDirectory.members
-    //a workspace should always have an owner, but just in case for some reason it doesn't...
-    val fetcher = members.list(toGroupId(getBucketName(workspaceId), WorkspaceAccessLevels.Owner))
-    val ownersQuery = retry(when500) (() => Future {
-      blocking { fetcher.execute }
-    })
-
-    ownersQuery map { queryResults =>
-      Option(queryResults.getMembers).getOrElse(List.empty[Member].asJava).map(_.getEmail)
-    }
-  }
-
   override def getMaximumAccessLevel(userId: String, workspaceId: String): Future[WorkspaceAccessLevel] = {
     val bucketName = getBucketName(workspaceId)
     val members = getGroupDirectory.members

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1,18 +1,16 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import java.io.{ByteArrayOutputStream, ByteArrayInputStream, StringReader}
-import java.util.Date
 
-import akka.actor.{ActorSystem, ActorContext}
+import akka.actor.ActorSystem
 import com.google.api.client.http.{HttpResponseException, InputStreamContent}
-import com.google.api.client.util.DateTime
-import com.google.api.services.storage.model.BucketAccessControl.ProjectTeam
 import org.broadinstitute.dsde.rawls.crypto.{EncryptedBytes, Aes256Cbc, SecretKey}
 import org.broadinstitute.dsde.rawls.util.FutureSupport
 import org.joda.time
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
+
 import scala.concurrent.Future
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -35,10 +33,6 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 
 import spray.http.StatusCodes
-
-import JavaConversions._
-
-// Seq[String] -> Collection<String>
 
 class HttpGoogleServicesDAO(
   useServiceAccountForBuckets: Boolean,

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -313,12 +313,12 @@ class HttpGoogleServicesDAO(
     }
   }
 
-  def createProxyGroup(userInfo: UserInfo): Future[Unit] = {
+  def createProxyGroup(user: RawlsUser): Future[Unit] = {
     val directory = getGroupDirectory
     val groups = directory.groups
     retry(when500) {
       () => Future {
-        val inserter = groups.insert(new Group().setEmail(toProxyFromUser(userInfo)).setName(userInfo.userEmail))
+        val inserter = groups.insert(new Group().setEmail(toProxyFromUser(user.userSubjectId)).setName(user.userEmail.value))
         blocking {
           inserter.execute
         }
@@ -472,7 +472,7 @@ class HttpGoogleServicesDAO(
       .build()
   }
 
-  def toProxyFromUser(userInfo: UserInfo) = s"PROXY_${userInfo.userSubjectId}@${appsDomain}"
+  def toProxyFromUser(subjectId: RawlsUserSubjectId) = s"PROXY_${subjectId.value}@${appsDomain}"
   def toUserFromProxy(proxy: String) = getGroupDirectory.groups().get(proxy).execute().getName
 
   def adminGroupName = s"${groupsPrefix}-ADMIN@${appsDomain}"

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -288,19 +288,6 @@ class HttpGoogleServicesDAO(
     }
   }
 
-  override def getWorkspaces(userId: String): Future[Seq[WorkspacePermissionsPair]] = {
-    val directory = getGroupDirectory
-    val fetcher = directory.groups().list().setUserKey(userId)
-    val groupsQuery = retry(when500)(() => Future {
-      blocking { fetcher.execute }
-    })
-
-    groupsQuery map { groupsResult =>
-      val workspaceGroups = Option(groupsResult.getGroups).getOrElse(List.empty[Group].asJava)
-      workspaceGroups.flatMap( group => fromGroupId(group.getEmail) ).toSeq
-    }
-  }
-
   override def getBucketName(workspaceId: String) = s"rawls-${workspaceId}"
 
   override def isAdmin(userId: String): Future[Boolean] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/JndiUserDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/JndiUserDirectoryDAO.scala
@@ -1,0 +1,143 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import java.util
+import javax.naming._
+import javax.naming.directory._
+
+import org.broadinstitute.dsde.rawls.model.RawlsUser
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Success, Try}
+import scala.collection.JavaConversions._
+
+/**
+ * Created by dvoet on 11/5/15.
+ */
+class JndiUserDirectoryDAO(providerUrl: String, user: String, password: String)(implicit executionContext: ExecutionContext) extends UserDirectoryDAO {
+  // TODO make these vals configurable DSDEEPB-1930
+  val groupDn: String = "cn=broad-dsde-dev,ou=groups,dc=dsde-dev,dc=broadinstitute,dc=org"
+  val memberAttribute = "member"
+  val userObjectClasses = Seq("inetOrgPerson", "organizationalPerson", "person", "top")
+  val userAttributes = Seq("mail", "sn", "cn")
+
+  override def createUser(user: RawlsUser): Future[Unit] = withContext { ctx =>
+    val p = new Person(user)
+    ctx.bind(p.name, p)
+  }
+
+  override def disableUser(user: RawlsUser): Future[Unit] = withContext { ctx =>
+    ctx.modifyAttributes(groupDn, DirContext.REMOVE_ATTRIBUTE, new BasicAttributes(memberAttribute, new Person(user).name))
+  }
+
+  override def enableUser(user: RawlsUser): Future[Unit] = withContext { ctx =>
+    ctx.modifyAttributes(groupDn, DirContext.ADD_ATTRIBUTE, new BasicAttributes(memberAttribute, new Person(user).name))
+  }
+
+  override def isEnabled(user: RawlsUser): Future[Boolean] = withContext { ctx =>
+    val members = for (
+      attr <- ctx.getAttributes(groupDn, Array(memberAttribute)).getAll;
+      attrE <- attr.getAll
+    ) yield attrE.asInstanceOf[String]
+
+    members.contains(new Person(user).name)
+  }
+
+  def removeUser(user: RawlsUser): Future[Unit] = withContext { ctx =>
+    ctx.unbind(new Person(user).name)
+  }
+
+  private def getContext(): InitialDirContext = {
+    val env = new util.Hashtable[String, String]()
+    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
+    env.put(Context.PROVIDER_URL, providerUrl)
+    env.put(Context.SECURITY_PRINCIPAL, user)
+    env.put(Context.SECURITY_CREDENTIALS, password)
+
+    new InitialDirContext(env)
+  }
+
+  private def withContext[T](op: InitialDirContext => T): Future[T] = Future {
+    val ctx = getContext()
+    val t = Try(op(ctx))
+    ctx.close()
+    t.get
+  }
+
+  private class Person(rawlsUser: RawlsUser) extends BaseDirContext {
+    override def getAttributes(name: String): Attributes = {
+      val myAttrs = new BasicAttributes(true)  // Case ignore
+
+      val oc = new BasicAttribute("objectclass")
+      userObjectClasses.foreach(oc.add)
+      myAttrs.put(oc)
+
+      userAttributes.foreach(myAttrs.put(_, rawlsUser.userSubjectId.value))
+
+      myAttrs
+    }
+
+    val name = s"mail=${rawlsUser.userSubjectId.value},ou=people,dc=dsde-dev,dc=broadinstitute,dc=org"
+  }
+}
+
+
+/**
+ * this does nothing but throw new OperationNotSupportedException but makes extending classes nice
+ */
+trait BaseDirContext extends DirContext {
+  override def getAttributes(name: Name): Attributes = throw new OperationNotSupportedException
+  override def getAttributes(name: String): Attributes = throw new OperationNotSupportedException
+  override def getAttributes(name: Name, attrIds: Array[String]): Attributes = throw new OperationNotSupportedException
+  override def getAttributes(name: String, attrIds: Array[String]): Attributes = throw new OperationNotSupportedException
+  override def getSchema(name: Name): DirContext = throw new OperationNotSupportedException
+  override def getSchema(name: String): DirContext = throw new OperationNotSupportedException
+  override def createSubcontext(name: Name, attrs: Attributes): DirContext = throw new OperationNotSupportedException
+  override def createSubcontext(name: String, attrs: Attributes): DirContext = throw new OperationNotSupportedException
+  override def modifyAttributes(name: Name, mod_op: Int, attrs: Attributes): Unit = throw new OperationNotSupportedException
+  override def modifyAttributes(name: String, mod_op: Int, attrs: Attributes): Unit = throw new OperationNotSupportedException
+  override def modifyAttributes(name: Name, mods: Array[ModificationItem]): Unit = throw new OperationNotSupportedException
+  override def modifyAttributes(name: String, mods: Array[ModificationItem]): Unit = throw new OperationNotSupportedException
+  override def getSchemaClassDefinition(name: Name): DirContext = throw new OperationNotSupportedException
+  override def getSchemaClassDefinition(name: String): DirContext = throw new OperationNotSupportedException
+  override def rebind(name: Name, obj: scala.Any, attrs: Attributes): Unit = throw new OperationNotSupportedException
+  override def rebind(name: String, obj: scala.Any, attrs: Attributes): Unit = throw new OperationNotSupportedException
+  override def bind(name: Name, obj: scala.Any, attrs: Attributes): Unit = throw new OperationNotSupportedException
+  override def bind(name: String, obj: scala.Any, attrs: Attributes): Unit = throw new OperationNotSupportedException
+  override def search(name: Name, matchingAttributes: Attributes, attributesToReturn: Array[String]): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: String, matchingAttributes: Attributes, attributesToReturn: Array[String]): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: Name, matchingAttributes: Attributes): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: String, matchingAttributes: Attributes): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: Name, filter: String, cons: SearchControls): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: String, filter: String, cons: SearchControls): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: Name, filterExpr: String, filterArgs: Array[AnyRef], cons: SearchControls): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def search(name: String, filterExpr: String, filterArgs: Array[AnyRef], cons: SearchControls): NamingEnumeration[SearchResult] = throw new OperationNotSupportedException
+  override def getNameInNamespace: String = throw new OperationNotSupportedException
+  override def addToEnvironment(propName: String, propVal: scala.Any): AnyRef = throw new OperationNotSupportedException
+  override def rename(oldName: Name, newName: Name): Unit = throw new OperationNotSupportedException
+  override def rename(oldName: String, newName: String): Unit = throw new OperationNotSupportedException
+  override def lookup(name: Name): AnyRef = throw new OperationNotSupportedException
+  override def lookup(name: String): AnyRef = throw new OperationNotSupportedException
+  override def destroySubcontext(name: Name): Unit = throw new OperationNotSupportedException
+  override def destroySubcontext(name: String): Unit = throw new OperationNotSupportedException
+  override def composeName(name: Name, prefix: Name): Name = throw new OperationNotSupportedException
+  override def composeName(name: String, prefix: String): String = throw new OperationNotSupportedException
+  override def createSubcontext(name: Name): Context = throw new OperationNotSupportedException
+  override def createSubcontext(name: String): Context = throw new OperationNotSupportedException
+  override def unbind(name: Name): Unit = throw new OperationNotSupportedException
+  override def unbind(name: String): Unit = throw new OperationNotSupportedException
+  override def removeFromEnvironment(propName: String): AnyRef = throw new OperationNotSupportedException
+  override def rebind(name: Name, obj: scala.Any): Unit = throw new OperationNotSupportedException
+  override def rebind(name: String, obj: scala.Any): Unit = throw new OperationNotSupportedException
+  override def getEnvironment: util.Hashtable[_, _] = throw new OperationNotSupportedException
+  override def list(name: Name): NamingEnumeration[NameClassPair] = throw new OperationNotSupportedException
+  override def list(name: String): NamingEnumeration[NameClassPair] = throw new OperationNotSupportedException
+  override def close(): Unit = throw new OperationNotSupportedException
+  override def lookupLink(name: Name): AnyRef = throw new OperationNotSupportedException
+  override def lookupLink(name: String): AnyRef = throw new OperationNotSupportedException
+  override def getNameParser(name: Name): NameParser = throw new OperationNotSupportedException
+  override def getNameParser(name: String): NameParser = throw new OperationNotSupportedException
+  override def bind(name: Name, obj: scala.Any): Unit = throw new OperationNotSupportedException
+  override def bind(name: String, obj: scala.Any): Unit = throw new OperationNotSupportedException
+  override def listBindings(name: Name): NamingEnumeration[Binding] = throw new OperationNotSupportedException
+  override def listBindings(name: String): NamingEnumeration[Binding] = throw new OperationNotSupportedException
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/JndiUserDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/JndiUserDirectoryDAO.scala
@@ -13,12 +13,7 @@ import scala.collection.JavaConversions._
 /**
  * Created by dvoet on 11/5/15.
  */
-class JndiUserDirectoryDAO(providerUrl: String, user: String, password: String)(implicit executionContext: ExecutionContext) extends UserDirectoryDAO {
-  // TODO make these vals configurable DSDEEPB-1930
-  val groupDn: String = "cn=broad-dsde-dev,ou=groups,dc=dsde-dev,dc=broadinstitute,dc=org"
-  val memberAttribute = "member"
-  val userObjectClasses = Seq("inetOrgPerson", "organizationalPerson", "person", "top")
-  val userAttributes = Seq("mail", "sn", "cn")
+class JndiUserDirectoryDAO(providerUrl: String, user: String, password: String, groupDn: String, memberAttribute: String, userObjectClasses: List[String], userAttributes: List[String], userDnFormat: String)(implicit executionContext: ExecutionContext) extends UserDirectoryDAO {
 
   override def createUser(user: RawlsUser): Future[Unit] = withContext { ctx =>
     val p = new Person(user)
@@ -76,7 +71,7 @@ class JndiUserDirectoryDAO(providerUrl: String, user: String, password: String)(
       myAttrs
     }
 
-    val name = s"mail=${rawlsUser.userSubjectId.value},ou=people,dc=dsde-dev,dc=broadinstitute,dc=org"
+    val name = userDnFormat.format(rawlsUser.userSubjectId.value)
   }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/JndiUserDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/JndiUserDirectoryDAO.scala
@@ -66,12 +66,12 @@ class JndiUserDirectoryDAO(providerUrl: String, user: String, password: String, 
       userObjectClasses.foreach(oc.add)
       myAttrs.put(oc)
 
-      userAttributes.foreach(myAttrs.put(_, rawlsUser.userSubjectId.value))
+      userAttributes.foreach(myAttrs.put(_, rawlsUser.userSubjectId))
 
       myAttrs
     }
 
-    val name = userDnFormat.format(rawlsUser.userSubjectId.value)
+    val name = userDnFormat.format(rawlsUser.userSubjectId)
   }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/UserDirectoryDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/UserDirectoryDAO.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.model.RawlsUser
+
+import scala.concurrent.Future
+
+/**
+ * Created by dvoet on 11/5/15.
+ */
+trait UserDirectoryDAO {
+  def createUser(user: RawlsUser): Future[Unit]
+  def enableUser(user: RawlsUser): Future[Unit]
+  def disableUser(user: RawlsUser): Future[Unit]
+  def isEnabled(user: RawlsUser): Future[Boolean]
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -7,7 +7,12 @@ sealed trait UserAuthRef
 case class RawlsUserRef(userSubjectId: RawlsUserSubjectId) extends UserAuthRef
 case class RawlsGroupRef(groupName: RawlsGroupName) extends UserAuthRef
 
-sealed trait UserAuthType { val value: String }
+sealed trait UserAuthType {
+  val value: String
+  override def toString = UserAuthType.toString(this)
+}
+object UserAuthType { implicit def toString(u:UserAuthType) = u.value }
+
 case class RawlsUserEmail(value: String) extends UserAuthType
 case class RawlsUserSubjectId(value: String) extends UserAuthType
 case class RawlsGroupName(value: String) extends UserAuthType

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -3,23 +3,42 @@ package org.broadinstitute.dsde.rawls.model
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 
 sealed trait UserAuthRef
-case class RawlsUserRef(userSubjectId: String) extends UserAuthRef
-case class RawlsGroupRef(groupName: String) extends UserAuthRef
+case class RawlsUserRef(userSubjectId: RawlsUserSubjectId) extends UserAuthRef
+case class RawlsGroupRef(groupName: RawlsGroupName) extends UserAuthRef
 
-case class RawlsUser(userSubjectId: String) extends DomainObject {
+sealed trait UserAuthType { val value: String }
+case class RawlsUserEmail(value: String) extends UserAuthType
+case class RawlsUserSubjectId(value: String) extends UserAuthType
+case class RawlsGroupName(value: String) extends UserAuthType
+case class RawlsGroupEmail(value: String) extends UserAuthType
+
+case class RawlsUser(userSubjectId: RawlsUserSubjectId, userEmail: RawlsUserEmail) extends DomainObject {
   def idFields = Seq("userSubjectId")
 }
 
 object RawlsUser {
   implicit def toRef(u: RawlsUser) = RawlsUserRef(u.userSubjectId)
+
+  def apply(userInfo: UserInfo): RawlsUser =
+    RawlsUser(RawlsUserSubjectId(userInfo.userSubjectId), RawlsUserEmail(userInfo.userEmail))
 }
 
-case class RawlsGroup(groupName: String, users: Set[RawlsUserRef], subGroups: Set[RawlsGroupRef]) extends DomainObject {
+case class RawlsGroup(groupName: RawlsGroupName, groupEmail: RawlsGroupEmail, users: Set[RawlsUserRef], subGroups: Set[RawlsGroupRef]) extends DomainObject {
   def idFields = Seq("groupName")
 }
 
 object RawlsGroup {
   implicit def toRef(g: RawlsGroup) = RawlsGroupRef(g.groupName)
+
+  // for Workspace Access Groups
+  def apply(workspaceName: WorkspaceName, accessLevel: WorkspaceAccessLevel): RawlsGroup =
+    apply(workspaceName, accessLevel, Set.empty[RawlsUserRef], Set.empty[RawlsGroupRef])
+
+  // for Workspace Access Groups
+  def apply(workspaceName: WorkspaceName, accessLevel: WorkspaceAccessLevel, users: Set[RawlsUserRef], groups: Set[RawlsGroupRef]): RawlsGroup = {
+    val name = RawlsGroupName(UserAuth.toWorkspaceAccessGroupName(workspaceName, accessLevel))
+    RawlsGroup(name, RawlsGroupEmail(""), users, groups)
+  }
 }
 
 
@@ -31,12 +50,20 @@ object UserAuth {
 }
 
 object UserAuthJsonSupport extends JsonSupport {
+  implicit val RawlsUserEmailFormat = jsonFormat1(RawlsUserEmail)
+
+  implicit val RawlsUserSubjectIdFormat = jsonFormat1(RawlsUserSubjectId)
+
+  implicit val RawlsGroupNameFormat = jsonFormat1(RawlsGroupName)
+
+  implicit val RawlsGroupEmailFormat = jsonFormat1(RawlsGroupEmail)
+
   // need "apply" here so it doesn't choose the companion class
-  implicit val RawlsUserFormat = jsonFormat1(RawlsUser.apply)
+  implicit val RawlsUserFormat = jsonFormat2(RawlsUser.apply)
 
   implicit val RawlsUserRefFormat = jsonFormat1(RawlsUserRef)
 
   implicit val RawlsGroupRefFormat = jsonFormat1(RawlsGroupRef)
 
-  implicit val RawlsGroupFormat = jsonFormat3(RawlsGroup.apply)
+  implicit val RawlsGroupFormat = jsonFormat4[RawlsGroupName, RawlsGroupEmail, Set[RawlsUserRef], Set[RawlsGroupRef], RawlsGroup](RawlsGroup.apply)
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -12,6 +12,7 @@ case class RawlsUserEmail(value: String) extends UserAuthType
 case class RawlsUserSubjectId(value: String) extends UserAuthType
 case class RawlsGroupName(value: String) extends UserAuthType
 case class RawlsGroupEmail(value: String) extends UserAuthType
+case class RawlsBillingProjectName(value: String) extends UserAuthType
 
 case class RawlsUser(userSubjectId: RawlsUserSubjectId, userEmail: RawlsUserEmail) extends DomainObject {
   def idFields = Seq("userSubjectId")
@@ -42,6 +43,9 @@ object RawlsGroup {
   }
 }
 
+case class RawlsBillingProject(projectName: RawlsBillingProjectName, users: Set[RawlsUserRef]) extends DomainObject {
+  def idFields = Seq("projectName")
+}
 
 object UserAuth {
 
@@ -51,42 +55,52 @@ object UserAuth {
 }
 
 object UserAuthJsonSupport extends JsonSupport {
-  implicit object RawlsUserEmailFormat extends RootJsonFormat[RawlsUserEmail] {
+  trait UserAuthJsonFormatter[T <: UserAuthType] extends RootJsonFormat[T] {
+    // TODO: a generic read.  May require reflection.
+    override def write(obj: T): JsValue = JsString(obj.value)
+  }
+
+  implicit object RawlsUserEmailFormat extends UserAuthJsonFormatter[RawlsUserEmail] {
     override def read(json: JsValue): RawlsUserEmail = json match {
       case JsString(value) => RawlsUserEmail(value)
       case _ => throw new DeserializationException("could not deserialize user object")
     }
-    override def write(obj: RawlsUserEmail): JsValue = JsString(obj.value)
   }
-  implicit object RawlsUserSubjectIdFormat extends RootJsonFormat[RawlsUserSubjectId] {
+
+  implicit object RawlsUserSubjectIdFormat extends UserAuthJsonFormatter[RawlsUserSubjectId] {
     override def read(json: JsValue): RawlsUserSubjectId = json match {
       case JsString(value) => RawlsUserSubjectId(value)
       case _ => throw new DeserializationException("could not deserialize user object")
     }
-    override def write(obj: RawlsUserSubjectId): JsValue = JsString(obj.value)
   }
 
-  implicit object RawlsGroupNameFormat extends RootJsonFormat[RawlsGroupName] {
+  implicit object RawlsGroupNameFormat extends UserAuthJsonFormatter[RawlsGroupName] {
     override def read(json: JsValue): RawlsGroupName = json match {
       case JsString(value) => RawlsGroupName(value)
       case _ => throw new DeserializationException("could not deserialize user object")
     }
-    override def write(obj: RawlsGroupName): JsValue = JsString(obj.value)
   }
 
-  implicit object RawlsGroupEmailFormat extends RootJsonFormat[RawlsGroupEmail] {
+  implicit object RawlsGroupEmailFormat extends UserAuthJsonFormatter[RawlsGroupEmail] {
     override def read(json: JsValue): RawlsGroupEmail = json match {
       case JsString(value) => RawlsGroupEmail(value)
       case _ => throw new DeserializationException("could not deserialize user object")
     }
-    override def write(obj: RawlsGroupEmail): JsValue = JsString(obj.value)
   }
 
+  implicit object RawlsBillingProjectNameFormat extends UserAuthJsonFormatter[RawlsBillingProjectName] {
+    override def read(json: JsValue): RawlsBillingProjectName = json match {
+      case JsString(value) => RawlsBillingProjectName(value)
+      case _ => throw new DeserializationException("could not deserialize user object")
+    }
+  }
 
   // need "apply" here so it doesn't choose the companion class
   implicit val RawlsUserFormat = jsonFormat2(RawlsUser.apply)
 
   implicit val RawlsUserRefFormat = jsonFormat1(RawlsUserRef)
+
+  implicit val RawlsBillingProjectFormat = jsonFormat2(RawlsBillingProject)
 
   implicit val RawlsGroupRefFormat = jsonFormat1(RawlsGroupRef)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.model
 
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 
 sealed trait UserAuthRef
 case class RawlsUserRef(userSubjectId: String) extends UserAuthRef

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.rawls.model
+
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel._
+
+sealed trait UserAuthRef
+case class RawlsUserRef(userSubjectId: String) extends UserAuthRef
+case class RawlsGroupRef(groupName: String) extends UserAuthRef
+
+case class RawlsUser(userSubjectId: String) extends DomainObject {
+  def idFields = Seq("userSubjectId")
+}
+
+object RawlsUser {
+  implicit def toRef(u: RawlsUser) = RawlsUserRef(u.userSubjectId)
+}
+
+case class RawlsGroup(groupName: String, users: Set[RawlsUserRef], subGroups: Set[RawlsGroupRef]) extends DomainObject {
+  def idFields = Seq("groupName")
+}
+
+object RawlsGroup {
+  implicit def toRef(g: RawlsGroup) = RawlsGroupRef(g.groupName)
+}
+
+
+object UserAuth {
+
+  def toWorkspaceAccessGroupName(workspaceName: WorkspaceName, accessLevel: WorkspaceAccessLevel) =
+    s"rawls ${workspaceName.namespace}/${workspaceName.name} ${accessLevel}"
+
+}
+
+object UserAuthJsonSupport extends JsonSupport {
+  // need "apply" here so it doesn't choose the companion class
+  implicit val RawlsUserFormat = jsonFormat1(RawlsUser.apply)
+
+  implicit val RawlsUserRefFormat = jsonFormat1(RawlsUserRef)
+
+  implicit val RawlsGroupRefFormat = jsonFormat1(RawlsGroupRef)
+
+  implicit val RawlsGroupFormat = jsonFormat3(RawlsGroup.apply)
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.model
 
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
+import spray.json._
 
 sealed trait UserAuthRef
 case class RawlsUserRef(userSubjectId: RawlsUserSubjectId) extends UserAuthRef
@@ -50,13 +51,37 @@ object UserAuth {
 }
 
 object UserAuthJsonSupport extends JsonSupport {
-  implicit val RawlsUserEmailFormat = jsonFormat1(RawlsUserEmail)
+  implicit object RawlsUserEmailFormat extends RootJsonFormat[RawlsUserEmail] {
+    override def read(json: JsValue): RawlsUserEmail = json match {
+      case JsString(value) => RawlsUserEmail(value)
+      case _ => throw new DeserializationException("could not deserialize user object")
+    }
+    override def write(obj: RawlsUserEmail): JsValue = JsString(obj.value)
+  }
+  implicit object RawlsUserSubjectIdFormat extends RootJsonFormat[RawlsUserSubjectId] {
+    override def read(json: JsValue): RawlsUserSubjectId = json match {
+      case JsString(value) => RawlsUserSubjectId(value)
+      case _ => throw new DeserializationException("could not deserialize user object")
+    }
+    override def write(obj: RawlsUserSubjectId): JsValue = JsString(obj.value)
+  }
 
-  implicit val RawlsUserSubjectIdFormat = jsonFormat1(RawlsUserSubjectId)
+  implicit object RawlsGroupNameFormat extends RootJsonFormat[RawlsGroupName] {
+    override def read(json: JsValue): RawlsGroupName = json match {
+      case JsString(value) => RawlsGroupName(value)
+      case _ => throw new DeserializationException("could not deserialize user object")
+    }
+    override def write(obj: RawlsGroupName): JsValue = JsString(obj.value)
+  }
 
-  implicit val RawlsGroupNameFormat = jsonFormat1(RawlsGroupName)
+  implicit object RawlsGroupEmailFormat extends RootJsonFormat[RawlsGroupEmail] {
+    override def read(json: JsValue): RawlsGroupEmail = json match {
+      case JsString(value) => RawlsGroupEmail(value)
+      case _ => throw new DeserializationException("could not deserialize user object")
+    }
+    override def write(obj: RawlsGroupEmail): JsValue = JsString(obj.value)
+  }
 
-  implicit val RawlsGroupEmailFormat = jsonFormat1(RawlsGroupEmail)
 
   // need "apply" here so it doesn't choose the companion class
   implicit val RawlsUserFormat = jsonFormat2(RawlsUser.apply)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserInfo.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.model
 
-import spray.http.{OAuth2BearerToken, HttpCookie}
+import spray.http.OAuth2BearerToken
 
 /**
  * Created by dvoet on 7/21/15.

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/UserModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/UserModel.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.rawls.model
 
 import org.joda.time.DateTime
+import UserAuthJsonSupport._
+import spray.httpx.SprayJsonSupport._
 
 /**
  * Created by dvoet on 10/27/15.
@@ -8,7 +10,11 @@ import org.joda.time.DateTime
 case class UserRefreshToken(refreshToken: String)
 case class UserRefreshTokenDate(refreshTokenUpdatedDate: DateTime)
 
+// there are a couple systems we check for enabled status, google and ldap, the enabled map below has an entry for each
+case class UserStatus(userInfo: RawlsUser, enabled: Map[String, Boolean])
+
 object UserJsonSupport extends JsonSupport {
   implicit val UserRefreshTokenFormat = jsonFormat1(UserRefreshToken)
   implicit val UserRefreshTokenDateFormat = jsonFormat1(UserRefreshTokenDate)
+  implicit val UserStatusFormat = jsonFormat2(UserStatus)
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceACL.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceACL.scala
@@ -6,13 +6,13 @@ import spray.json._
 
 case class WorkspaceACL(acl: Map[String, WorkspaceAccessLevel])
 
-case class WorkspaceACLUpdate(userId: String, accessLevel: WorkspaceAccessLevel)
+case class WorkspaceACLUpdate(email: String, accessLevel: WorkspaceAccessLevel)
 
 object WorkspaceAccessLevels {
   sealed trait WorkspaceAccessLevel extends RawlsEnumeration[WorkspaceAccessLevel] with Ordered[WorkspaceAccessLevel] {
-    private val ordering = Seq(UnknownUser, NoAccess, Read, Write, Owner)
+    val all = Seq(UnknownUser, NoAccess, Read, Write, Owner)
 
-    def compare(that: WorkspaceAccessLevel) = { ordering.indexOf(this).compare(ordering.indexOf(that)) }
+    def compare(that: WorkspaceAccessLevel) = { all.indexOf(this).compare(all.indexOf(that)) }
 
     override def toString = WorkspaceAccessLevels.toString(this)
     override def withName(name: String) = WorkspaceAccessLevels.withName(name)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceACL.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceACL.scala
@@ -24,6 +24,8 @@ object WorkspaceAccessLevels {
   case object Write extends WorkspaceAccessLevel
   case object Owner extends WorkspaceAccessLevel
 
+  val groupAccessLevelsAscending = Seq(Read, Write, Owner)
+
   // note that the canonical string must match the format for GCS ACL roles,
   // because we use it to set the role of entities in the ACL.
   // (see https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceACL.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceACL.scala
@@ -48,6 +48,14 @@ object WorkspaceAccessLevels {
       case _ => throw new RawlsException(s"invalid WorkspaceAccessLevel [${s}]")
     }
   }
+
+  def max(a: WorkspaceAccessLevel, b: WorkspaceAccessLevel): WorkspaceAccessLevel = {
+    if( a <= b ) {
+      b
+    } else {
+      a
+    }
+  }
 }
 
 object WorkspaceACLJsonSupport extends JsonSupport {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -56,6 +56,7 @@ case class Workspace(
                       lastModified: DateTime,
                       createdBy: String,
                       attributes: Map[String, Attribute],
+                      accessLevels: Map[String, RawlsGroupRef],
                       isLocked: Boolean = false
                       ) extends Attributable with DomainObject {
   def toWorkspaceName = WorkspaceName(namespace,name)
@@ -233,7 +234,9 @@ object WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceRequestFormat = jsonFormat3(WorkspaceRequest)
 
-  implicit val WorkspaceFormat = jsonFormat9(Workspace)
+  implicit val RawlsGroupRefFormat = UserAuthJsonSupport.RawlsGroupRefFormat
+
+  implicit val WorkspaceFormat = jsonFormat10(Workspace)
 
   implicit val EntityNameFormat = jsonFormat1(EntityName)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.rawls.model
 
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport._
 import org.joda.time.DateTime
 import spray.http.StatusCode
 import spray.json._
@@ -56,7 +58,7 @@ case class Workspace(
                       lastModified: DateTime,
                       createdBy: String,
                       attributes: Map[String, Attribute],
-                      accessLevels: Map[String, RawlsGroupRef],
+                      accessLevels: Map[WorkspaceAccessLevel, RawlsGroupRef],
                       isLocked: Boolean = false
                       ) extends Attributable with DomainObject {
   def toWorkspaceName = WorkspaceName(namespace,name)
@@ -236,6 +238,8 @@ object WorkspaceJsonSupport extends JsonSupport {
 
   implicit val RawlsGroupRefFormat = UserAuthJsonSupport.RawlsGroupRefFormat
 
+  implicit val WorkspaceAccessLevelFormat = WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
+
   implicit val WorkspaceFormat = jsonFormat10(Workspace)
 
   implicit val EntityNameFormat = jsonFormat1(EntityName)
@@ -259,8 +263,6 @@ object WorkspaceJsonSupport extends JsonSupport {
   implicit val ConflictingEntitiesFormat = jsonFormat1(ConflictingEntities)
 
   implicit val WorkspaceSubmissionStatsFormat = jsonFormat3(WorkspaceSubmissionStats)
-
-  implicit val WorkspaceAccessLevelFormat = WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
 
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/openam/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/openam/StandardUserInfoDirectives.scala
@@ -2,8 +2,7 @@ package org.broadinstitute.dsde.rawls.openam
 
 import org.broadinstitute.dsde.rawls.model.UserInfo
 import org.broadinstitute.dsde.vault.common.util.ImplicitMagnet
-import spray.http.HttpHeaders.Authorization
-import spray.http.{HttpHeader, OAuth2BearerToken, HttpHeaders, HttpCookie}
+import spray.http.{HttpHeader, OAuth2BearerToken}
 import spray.routing.Directive1
 import spray.routing.Directives._
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.rawls.user
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, DataSource}
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, UserRefreshTokenDate, UserInfo, UserRefreshToken}
+import org.broadinstitute.dsde.rawls.dataaccess.{GraphContainerDAO, GoogleServicesDAO, DataSource}
+import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.user.UserService._
 import org.broadinstitute.dsde.rawls.webservice.PerRequest.{RequestComplete, PerRequestMessage}
 import spray.http.StatusCodes
@@ -21,18 +21,20 @@ object UserService {
     Props(userServiceConstructor(userInfo))
   }
 
-  def constructor(dataSource: DataSource, googleServicesDAO: GoogleServicesDAO)(userInfo: UserInfo)(implicit executionContext: ExecutionContext) =
-    new UserService(userInfo, dataSource, googleServicesDAO)
+  def constructor(dataSource: DataSource, googleServicesDAO: GoogleServicesDAO, containerDAO: GraphContainerDAO)(userInfo: UserInfo)(implicit executionContext: ExecutionContext) =
+    new UserService(userInfo, dataSource, googleServicesDAO, containerDAO)
 
   sealed trait UserServiceMessage
   case class SetRefreshToken(token: UserRefreshToken) extends UserServiceMessage
   case object GetRefreshTokenDate extends UserServiceMessage
+  case object CreateUser extends UserServiceMessage
 }
 
-class UserService(userInfo: UserInfo, dataSource: DataSource, googleServicesDAO: GoogleServicesDAO)(implicit executionContext: ExecutionContext) extends Actor {
+class UserService(userInfo: UserInfo, dataSource: DataSource, googleServicesDAO: GoogleServicesDAO, containerDAO: GraphContainerDAO)(implicit executionContext: ExecutionContext) extends Actor {
   override def receive = {
     case SetRefreshToken(token) => setRefreshToken(token) pipeTo context.parent
     case GetRefreshTokenDate => getRefreshTokenDate() pipeTo context.parent
+    case CreateUser => createUser() pipeTo context.parent
   }
 
   def setRefreshToken(userRefreshToken: UserRefreshToken): Future[PerRequestMessage] = {
@@ -44,5 +46,14 @@ class UserService(userInfo: UserInfo, dataSource: DataSource, googleServicesDAO:
       case None => RequestComplete(ErrorReport(StatusCodes.NotFound, s"no refresh token stored for ${userInfo.userEmail}"))
       case Some(date) => RequestComplete(UserRefreshTokenDate(date))
     })
+  }
+
+  def createUser(): Future[PerRequestMessage] = {
+    dataSource.inFutureTransaction() { txn =>
+      val user = RawlsUser(userInfo)
+      googleServicesDAO.createProxyGroup(user) map
+        { _ => containerDAO.authDAO.createUser(user, txn) } map
+        { _ => RequestComplete(StatusCodes.Created) }
+    }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -2,16 +2,19 @@ package org.broadinstitute.dsde.rawls.user
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import org.broadinstitute.dsde.rawls.dataaccess.{GraphContainerDAO, GoogleServicesDAO, DataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{UserDirectoryDAO, GraphContainerDAO, GoogleServicesDAO, DataSource}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.user.UserService._
-import org.broadinstitute.dsde.rawls.webservice.PerRequest.{RequestComplete, PerRequestMessage}
-import spray.http.StatusCodes
+import org.broadinstitute.dsde.rawls.util.{FutureSupport, AdminSupport}
+import org.broadinstitute.dsde.rawls.webservice.PerRequest.{RequestCompleteWithLocation, PerRequestMessage, RequestComplete}
+import spray.http.{StatusCode, StatusCodes}
 import org.broadinstitute.dsde.rawls.model.UserJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import spray.http.StatusCodes.Success
 import spray.httpx.SprayJsonSupport._
 
 import scala.concurrent.{Future, ExecutionContext}
+import scala.util.{Try, Failure}
 
 /**
  * Created by dvoet on 10/27/15.
@@ -21,39 +24,117 @@ object UserService {
     Props(userServiceConstructor(userInfo))
   }
 
-  def constructor(dataSource: DataSource, googleServicesDAO: GoogleServicesDAO, containerDAO: GraphContainerDAO)(userInfo: UserInfo)(implicit executionContext: ExecutionContext) =
-    new UserService(userInfo, dataSource, googleServicesDAO, containerDAO)
+  def constructor(dataSource: DataSource, googleServicesDAO: GoogleServicesDAO, containerDAO: GraphContainerDAO, userDirectoryDAO: UserDirectoryDAO)(userInfo: UserInfo)(implicit executionContext: ExecutionContext) =
+    new UserService(userInfo, dataSource, googleServicesDAO, containerDAO, userDirectoryDAO)
 
   sealed trait UserServiceMessage
   case class SetRefreshToken(token: UserRefreshToken) extends UserServiceMessage
   case object GetRefreshTokenDate extends UserServiceMessage
   case object CreateUser extends UserServiceMessage
+  case class GetUserStatus(userRef: RawlsUserRef) extends UserServiceMessage
+  case class EnableUser(userRef: RawlsUserRef) extends UserServiceMessage
+  case class DisableUser(userRef: RawlsUserRef) extends UserServiceMessage
 }
 
-class UserService(userInfo: UserInfo, dataSource: DataSource, googleServicesDAO: GoogleServicesDAO, containerDAO: GraphContainerDAO)(implicit executionContext: ExecutionContext) extends Actor {
+class UserService(protected val userInfo: UserInfo, dataSource: DataSource, protected val gcsDAO: GoogleServicesDAO, containerDAO: GraphContainerDAO, userDirectoryDAO: UserDirectoryDAO)(implicit protected val executionContext: ExecutionContext) extends Actor with AdminSupport with FutureSupport {
   override def receive = {
     case SetRefreshToken(token) => setRefreshToken(token) pipeTo context.parent
     case GetRefreshTokenDate => getRefreshTokenDate() pipeTo context.parent
     case CreateUser => createUser() pipeTo context.parent
+    case GetUserStatus(userRef) => getUserStatus(userRef) pipeTo context.parent
+    case EnableUser(userRef) => enableUser(userRef) pipeTo context.parent
+    case DisableUser(userRef) => disableUser(userRef) pipeTo context.parent
   }
 
   def setRefreshToken(userRefreshToken: UserRefreshToken): Future[PerRequestMessage] = {
-    googleServicesDAO.storeToken(userInfo, userRefreshToken.refreshToken).map(_ => RequestComplete(StatusCodes.Created))
+    gcsDAO.storeToken(userInfo, userRefreshToken.refreshToken).map(_ => RequestComplete(StatusCodes.Created))
   }
 
   def getRefreshTokenDate(): Future[PerRequestMessage] = {
-    googleServicesDAO.getTokenDate(userInfo).map( _ match {
+    gcsDAO.getTokenDate(userInfo).map( _ match {
       case None => RequestComplete(ErrorReport(StatusCodes.NotFound, s"no refresh token stored for ${userInfo.userEmail}"))
       case Some(date) => RequestComplete(UserRefreshTokenDate(date))
     })
   }
 
   def createUser(): Future[PerRequestMessage] = {
-    dataSource.inFutureTransaction() { txn =>
-      val user = RawlsUser(userInfo)
-      googleServicesDAO.createProxyGroup(user) map
-        { _ => containerDAO.authDAO.createUser(user, txn) } map
-        { _ => RequestComplete(StatusCodes.Created) }
+    val user = RawlsUser(userInfo)
+
+    // if there is any error, may leave user in weird state which can be seen with getUserStatus
+    // retrying this call will retry the failures, failures due to already created groups/entries are ok
+    handleFutures(Future.sequence(Seq(
+      toFutureTry(gcsDAO.createProxyGroup(user)),
+      toFutureTry(Future(dataSource.inTransaction()(txn => containerDAO.authDAO.saveUser(user, txn)))),
+      toFutureTry(userDirectoryDAO.createUser(user))
+
+    )))(_ => RequestCompleteWithLocation(StatusCodes.Created, s"/user/${user.userSubjectId.value}"), handleException("Errors creating user")
+    )
+  }
+
+  def getUserStatus(userRef: RawlsUserRef): Future[PerRequestMessage] = asAdmin {
+    withUser(userRef) { user =>
+      handleFutures(Future.sequence(Seq(
+        toFutureTry(gcsDAO.isUserInProxyGroup(user).map("google" -> _)),
+        toFutureTry(userDirectoryDAO.isEnabled(user).map("ldap" -> _))
+
+      )))(statuses => RequestComplete(UserStatus(user, statuses.toMap)), handleException("Error checking if a user is enabled"))
     }
   }
+
+  def enableUser(userRef: RawlsUserRef): Future[PerRequestMessage] = asAdmin {
+    // if there is any error, may leave user in weird state which can be seen with getUserStatus
+    // retrying this call will retry the failures, failures due to already added entries are ok
+    withUser(userRef) { user =>
+      handleFutures(Future.sequence(Seq(
+        toFutureTry(gcsDAO.addUserToProxyGroup(user)),
+        toFutureTry(userDirectoryDAO.enableUser(user))
+
+      )))(_ => RequestComplete(StatusCodes.NoContent), handleException("Errors enabling user"))
+    }
+  }
+
+  def disableUser(userRef: RawlsUserRef): Future[PerRequestMessage] = asAdmin {
+    // if there is any error, may leave user in weird state which can be seen with getUserStatus
+    // retrying this call will retry the failures, failures due to already removed entries are ok
+    withUser(userRef) { user =>
+      handleFutures(Future.sequence(Seq(
+        toFutureTry(gcsDAO.removeUserFromProxyGroup(user)),
+        toFutureTry(userDirectoryDAO.disableUser(user))
+
+      )))(_ => RequestComplete(StatusCodes.NoContent), handleException("Errors disabling user"))
+    }
+  }
+
+  private def withUser(rawlsUserRef: RawlsUserRef)(op: RawlsUser => Future[PerRequestMessage]): Future[PerRequestMessage] = {
+    dataSource.inTransaction() { txn =>
+      containerDAO.authDAO.loadUser(rawlsUserRef, txn)
+    } match {
+      case None => Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, s"user [${rawlsUserRef.userSubjectId.value}] not found")))
+      case Some(user) => op(user)
+    }
+  }
+
+  /**
+   * handles a Future [ Seq [ Try [ T ] ] ], calling success with the successful result of the tries or failure with any exceptions
+   * @param futures
+   * @param success
+   * @param failure
+   * @tparam T
+   * @return
+   */
+  private def handleFutures[T](futures: Future[Seq[Try[T]]])(success: Seq[T] => PerRequestMessage, failure: Seq[Throwable] => PerRequestMessage): Future[PerRequestMessage] = {
+    futures map { tries =>
+      val exceptions = tries.collect { case Failure(t) => t }
+      if (exceptions.isEmpty) {
+        success(tries.map(_.get))
+      } else {
+        failure(exceptions)
+      }
+    }
+  }
+
+  private def handleException(message: String)(exceptions: Seq[Throwable]): PerRequestMessage = {
+    RequestComplete(ErrorReport(StatusCodes.InternalServerError, message, exceptions.map(ErrorReport(_))))
+  }
 }
+

--- a/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -67,7 +67,7 @@ class UserService(protected val userInfo: UserInfo, dataSource: DataSource, prot
       toFutureTry(Future(dataSource.inTransaction()(txn => containerDAO.authDAO.saveUser(user, txn)))),
       toFutureTry(userDirectoryDAO.createUser(user))
 
-    )))(_ => RequestCompleteWithLocation(StatusCodes.Created, s"/user/${user.userSubjectId.value}"), handleException("Errors creating user")
+    )))(_ => RequestCompleteWithLocation(StatusCodes.Created, s"/user/${user.userSubjectId}"), handleException("Errors creating user")
     )
   }
 
@@ -109,7 +109,7 @@ class UserService(protected val userInfo: UserInfo, dataSource: DataSource, prot
     dataSource.inTransaction() { txn =>
       containerDAO.authDAO.loadUser(rawlsUserRef, txn)
     } match {
-      case None => Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, s"user [${rawlsUserRef.userSubjectId.value}] not found")))
+      case None => Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, s"user [${rawlsUserRef.userSubjectId}] not found")))
       case Some(user) => op(user)
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/util/AdminSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/util/AdminSupport.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.rawls.util
+
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.dataaccess.GoogleServicesDAO
+import org.broadinstitute.dsde.rawls.model.{UserInfo, ErrorReport}
+import org.broadinstitute.dsde.rawls.webservice.PerRequest.{RequestComplete, PerRequestMessage}
+import spray.http.StatusCodes
+import spray.httpx.SprayJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Created by dvoet on 11/5/15.
+ */
+trait AdminSupport {
+  protected val gcsDAO: GoogleServicesDAO
+  protected val userInfo: UserInfo
+  implicit protected val executionContext: ExecutionContext
+
+  def tryIsAdmin(userId: String): Future[Boolean] = {
+    gcsDAO.isAdmin(userId) transform( s => s, t => throw new RawlsException("Unable to query for admin status.", t))
+  }
+
+  def asAdmin(op: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
+    tryIsAdmin(userInfo.userEmail) flatMap { isAdmin =>
+      if (isAdmin) op else Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, "You must be an admin.")))
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
@@ -43,6 +43,27 @@ trait UserApiService extends HttpService with PerRequestCreator with UserInfoDir
           UserService.props(userServiceConstructor, userInfo),
           UserService.GetRefreshTokenDate)
       }
+    } ~
+    path("user" / Segment) { userSubjectId =>
+      get {
+        requestContext => perRequest(requestContext,
+          UserService.props(userServiceConstructor, userInfo),
+          UserService.GetUserStatus(RawlsUserRef(RawlsUserSubjectId(userSubjectId))))
+      }
+    } ~
+    path("user" / Segment / "enable") { userSubjectId =>
+      post {
+        requestContext => perRequest(requestContext,
+          UserService.props(userServiceConstructor, userInfo),
+          UserService.EnableUser(RawlsUserRef(RawlsUserSubjectId(userSubjectId))))
+      }
+    } ~
+    path("user" / Segment / "disable") { userSubjectId =>
+      post {
+        requestContext => perRequest(requestContext,
+          UserService.props(userServiceConstructor, userInfo),
+          UserService.DisableUser(RawlsUserRef(RawlsUserSubjectId(userSubjectId))))
+      }
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
@@ -1,11 +1,8 @@
 package org.broadinstitute.dsde.rawls.webservice
 
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperation
-import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.user.UserService
-import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 import spray.routing.Directive.pimpApply
 import spray.routing._
 
@@ -24,6 +21,13 @@ trait UserApiService extends HttpService with PerRequestCreator with UserInfoDir
   val userServiceConstructor: UserInfo => UserService
 
   val userRoutes = requireUserInfo() { userInfo =>
+    path("user") {
+      post {
+        requestContext => perRequest(requestContext,
+          UserService.props(userServiceConstructor, userInfo),
+          UserService.CreateUser)
+      }
+    } ~
     path("user" / "refreshToken") {
       put {
         entity(as[UserRefreshToken]) { token =>

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.workspace
 
 import java.util.UUID
 
-import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.pattern._
 import org.broadinstitute.dsde.rawls.RawlsException
@@ -10,16 +9,7 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.MethodInput
 import org.broadinstitute.dsde.rawls.jobexec.SubmissionSupervisor.SubmissionStarted
-import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceACLFormat
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ActiveSubmissionFormat
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ExecutionMetadataFormat
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.SubmissionFormat
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.SubmissionReportFormat
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.SubmissionValidationReportFormat
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.WorkflowOutputsFormat
-import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ExecutionServiceValidationFormat
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.expressions._
 import org.broadinstitute.dsde.rawls.util.FutureSupport
@@ -28,16 +18,17 @@ import org.broadinstitute.dsde.rawls.webservice.PerRequest.{RequestCompleteWithL
 import AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService._
 import org.joda.time.DateTime
-import spray.http
 import spray.http.Uri
 import spray.http.StatusCodes
-import spray.httpx.SprayJsonSupport._
 import spray.httpx.UnsuccessfulResponseException
-import spray.json._
-
-import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+
+import spray.json._
+import spray.httpx.SprayJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceACLFormat
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.{ActiveSubmissionFormat, ExecutionMetadataFormat, SubmissionFormat, SubmissionReportFormat, SubmissionValidationReportFormat, WorkflowOutputsFormat, ExecutionServiceValidationFormat}
 
 /**
  * Created by dvoet on 4/27/15.

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -194,6 +194,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
         }
 
         gcsDAO.deleteBucket(userInfo, workspaceContext.workspace.workspaceId).map { _ =>
+          containerDAO.authDAO.deleteWorkspaceAccessGroups(workspaceContext.workspace, txn)
           containerDAO.workspaceDAO.delete(workspaceName, txn)
 
           RequestComplete(StatusCodes.Accepted, s"Your Google bucket ${gcsDAO.getBucketName(workspaceContext.workspace.workspaceId)} will be deleted within 24h.")

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -218,7 +218,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
     // 1 query to gcsDAO to list all the workspaces
     val permissionsPairs = dataSource.inTransaction() { txn =>
-      containerDAO.authDAO.listWorkspaces(userInfo.userSubjectId, txn)
+      containerDAO.authDAO.listWorkspaces(RawlsUser(userInfo), txn)
     }
 
     // Future.sequence will do everything within in parallel per workspace then join them all

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -10,8 +10,8 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.MethodInput
 import org.broadinstitute.dsde.rawls.jobexec.SubmissionSupervisor.SubmissionStarted
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceACLFormat
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ActiveSubmissionFormat
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ExecutionMetadataFormat
@@ -167,7 +167,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
       withWorkspaceContext(workspaceName, txn) { workspaceContext =>
         gcsDAO.getMaximumAccessLevel(userInfo.userEmail,workspaceContext.workspace.workspaceId) flatMap { accessLevel =>
-          if (accessLevel < WorkspaceAccessLevel.Read)
+          if (accessLevel < WorkspaceAccessLevels.Read)
             Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspaceName))))
           else {
             gcsDAO.getOwners(workspaceContext.workspace.workspaceId) map { owners =>
@@ -184,7 +184,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def deleteWorkspace(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Owner, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Owner, txn) { workspaceContext =>
         //Attempt to abort any running workflows so they don't write any more to the bucket.
         //Notice that we're kicking off Futures to do the aborts concurrently, but we never collect their results!
         //This is because there's nothing we can do if Cromwell fails, so we might as well move on and let the
@@ -203,7 +203,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def updateWorkspace(workspaceName: WorkspaceName, operations: Seq[AttributeUpdateOperation]): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         Future {
           try {
             val updatedWorkspace = applyOperationsToWorkspace(workspaceContext.workspace, operations)
@@ -271,7 +271,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def cloneWorkspace(sourceWorkspaceName: WorkspaceName, destWorkspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(sourceWorkspaceName), writeLocks=Set(destWorkspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(sourceWorkspaceName,WorkspaceAccessLevel.Read,txn) { sourceWorkspaceContext =>
+      withWorkspaceContextAndPermissions(sourceWorkspaceName,WorkspaceAccessLevels.Read,txn) { sourceWorkspaceContext =>
         withNewWorkspaceContext(WorkspaceRequest(destWorkspaceName.namespace,destWorkspaceName.name,sourceWorkspaceContext.workspace.attributes),txn) { destWorkspaceContext =>
           containerDAO.entityDAO.cloneAllEntities(sourceWorkspaceContext, destWorkspaceContext, txn)
           // TODO add a method for cloning all method configs, instead of doing this
@@ -340,8 +340,8 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
     dataSource.inFutureTransaction(readLocks=Set(entityCopyDef.sourceWorkspace), writeLocks=Set(entityCopyDef.destinationWorkspace)) { txn =>
       //NOTE: Order here is important. If the src and dest workspaces are the same, we need to get the write lock first, since
       //we can't upgrade a read lock to a write.
-      withWorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace, WorkspaceAccessLevel.Write, txn) { destWorkspaceContext =>
-        withWorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace, WorkspaceAccessLevel.Read, txn) { sourceWorkspaceContext =>
+      withWorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace, WorkspaceAccessLevels.Write, txn) { destWorkspaceContext =>
+        withWorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace, WorkspaceAccessLevels.Read, txn) { sourceWorkspaceContext =>
           Future {
             val entityNames = entityCopyDef.entityNames
             val entityType = entityCopyDef.entityType
@@ -365,7 +365,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         Future {
           containerDAO.entityDAO.get(workspaceContext, entity.entityType, entity.name, txn) match {
             case Some(_) => RequestComplete(ErrorReport(StatusCodes.Conflict, s"${entity.entityType} ${entity.name} already exists in ${workspaceName}"))
@@ -377,7 +377,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def batchUpdateEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition]): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         Future {
           val results = entityUpdates.map { entityUpdate =>
             val entity = containerDAO.entityDAO.get(workspaceContext, entityUpdate.entityType, entityUpdate.name, txn)
@@ -406,7 +406,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def batchUpsertEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition]): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         Future {
           val results = entityUpdates.map { entityUpdate =>
             val entity = containerDAO.entityDAO.get(workspaceContext, entityUpdate.entityType, entityUpdate.name, txn) match {
@@ -434,21 +434,21 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def listEntityTypes(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         Future.successful(RequestComplete(StatusCodes.OK, containerDAO.entityDAO.getEntityTypes(workspaceContext, txn)))
       }
     }
 
   def listEntities(workspaceName: WorkspaceName, entityType: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         Future.successful(RequestComplete(StatusCodes.OK, containerDAO.entityDAO.list(workspaceContext, entityType, txn).toList))
       }
     }
 
   def getEntity(workspaceName: WorkspaceName, entityType: String, entityName: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withEntity(workspaceContext, entityType, entityName, txn) { entity =>
           Future.successful(PerRequest.RequestComplete(StatusCodes.OK, entity))
         }
@@ -457,7 +457,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def updateEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation]): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         withEntity(workspaceContext, entityType, entityName, txn) { entity =>
           Future {
             try {
@@ -476,7 +476,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def deleteEntity(workspaceName: WorkspaceName, entityType: String, entityName: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         withEntity(workspaceContext, entityType, entityName, txn) { entity =>
           Future {
             containerDAO.entityDAO.delete(workspaceContext, entity.entityType, entity.name, txn)
@@ -488,7 +488,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         withEntity(workspaceContext, entityType, entityName, txn) { entity =>
           Future {
             containerDAO.entityDAO.get(workspaceContext, entity.entityType, newName, txn) match {
@@ -504,7 +504,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def evaluateExpression(workspaceName: WorkspaceName, entityType: String, entityName: String, expression: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         Future {
           txn withGraph { graph =>
             new ExpressionEvaluator(new ExpressionParser())
@@ -633,7 +633,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def getAndValidateMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String): Future[PerRequestMessage] = {
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, txn) { methodConfig =>
           Future { PerRequest.RequestComplete(StatusCodes.OK, validateMCExpressions(methodConfig)) }
         }
@@ -643,7 +643,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def createMethodConfiguration(workspaceName: WorkspaceName, methodConfiguration: MethodConfiguration): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         Future {
           containerDAO.methodConfigurationDAO.get(workspaceContext, methodConfiguration.namespace, methodConfiguration.name, txn) match {
             case Some(_) => RequestComplete(ErrorReport(StatusCodes.Conflict, s"${methodConfiguration.name} already exists in ${workspaceName}"))
@@ -657,7 +657,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def deleteMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, txn) { methodConfig =>
           Future {
             containerDAO.methodConfigurationDAO.delete(workspaceContext, methodConfigurationNamespace, methodConfigurationName, txn)
@@ -669,7 +669,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def renameMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String, newName: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, txn) { methodConfiguration =>
           Future {
             containerDAO.methodConfigurationDAO.get(workspaceContext, methodConfigurationNamespace, newName, txn) match {
@@ -685,7 +685,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def updateMethodConfiguration(workspaceName: WorkspaceName, methodConfiguration: MethodConfiguration): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         Future {
           containerDAO.methodConfigurationDAO.get(workspaceContext, methodConfiguration.namespace, methodConfiguration.name, txn) match {
             case Some(_) => RequestComplete(StatusCodes.OK, saveAndValidateMCExpressions(workspaceContext, methodConfiguration, txn))
@@ -697,7 +697,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def getMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, txn) { methodConfig =>
           Future.successful(PerRequest.RequestComplete(StatusCodes.OK, methodConfig))
         }
@@ -706,8 +706,8 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def copyMethodConfiguration(mcnp: MethodConfigurationNamePair): Future[PerRequestMessage] = {
     dataSource.inFutureTransaction(readLocks=Set(mcnp.source.workspaceName), writeLocks=Set(mcnp.destination.workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(mcnp.destination.workspaceName, WorkspaceAccessLevel.Write, txn) { destContext =>
-        withWorkspaceContextAndPermissions(mcnp.source.workspaceName, WorkspaceAccessLevel.Read, txn) { sourceContext =>
+      withWorkspaceContextAndPermissions(mcnp.destination.workspaceName, WorkspaceAccessLevels.Write, txn) { destContext =>
+        withWorkspaceContextAndPermissions(mcnp.source.workspaceName, WorkspaceAccessLevels.Read, txn) { sourceContext =>
           containerDAO.methodConfigurationDAO.get(sourceContext, mcnp.source.namespace, mcnp.source.name, txn) match {
             case None => Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound,s"There is no method configuration named ${mcnp.source.namespace}/${mcnp.source.name} in ${mcnp.source.workspaceName}.")))
             case Some(methodConfig) => saveCopiedMethodConfiguration(methodConfig, mcnp.destination, destContext, txn)
@@ -719,7 +719,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def copyMethodConfigurationFromMethodRepo(methodRepoQuery: MethodRepoConfigurationImport): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(methodRepoQuery.destination.workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions( methodRepoQuery.destination.workspaceName, WorkspaceAccessLevel.Write, txn ) { destContext =>
+      withWorkspaceContextAndPermissions( methodRepoQuery.destination.workspaceName, WorkspaceAccessLevels.Write, txn ) { destContext =>
         methodRepoDAO.getMethodConfig(methodRepoQuery.methodRepoNamespace, methodRepoQuery.methodRepoName, methodRepoQuery.methodRepoSnapshotId, userInfo) flatMap { agoraEntityOption =>
           agoraEntityOption match {
             case None => Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound,s"There is no method configuration named ${methodRepoQuery.methodRepoNamespace}/${methodRepoQuery.methodRepoName}/${methodRepoQuery.methodRepoSnapshotId} in the repository.")))
@@ -743,7 +743,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def copyMethodConfigurationToMethodRepo(methodRepoQuery: MethodRepoConfigurationExport): Future[PerRequestMessage] = {
     dataSource.inFutureTransaction(readLocks=Set(methodRepoQuery.source.workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(methodRepoQuery.source.workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(methodRepoQuery.source.workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withMethodConfig(workspaceContext, methodRepoQuery.source.namespace, methodRepoQuery.source.name, txn) { methodConfig =>
           import org.broadinstitute.dsde.rawls.model.MethodRepoJsonSupport._
           methodRepoDAO.postMethodConfig(
@@ -769,7 +769,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def listMethodConfigurations(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         // use toList below to eagerly iterate through the response from methodConfigurationDAO.list
         // to ensure it is evaluated within the transaction
         Future.successful(RequestComplete(StatusCodes.OK, containerDAO.methodConfigurationDAO.list(workspaceContext, txn).toList))
@@ -791,7 +791,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
     methodConfigurationNamespace: String, methodConfigurationName: String,
     entityType: String, entityName: String, userInfo: UserInfo): Future[PerRequestMessage] = {
       dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-        withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+        withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
           withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, txn) { methodConfig =>
             withMethod(workspaceContext, methodConfig.methodRepoMethod.methodNamespace, methodConfig.methodRepoMethod.methodName, methodConfig.methodRepoMethod.methodVersion, userInfo) { method =>
               withEntity(workspaceContext, entityType, entityName, txn) { entity =>
@@ -814,7 +814,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def listSubmissions(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         Future.successful(RequestComplete(StatusCodes.OK, containerDAO.submissionDAO.list(workspaceContext, txn).toList))
       }
     }
@@ -867,7 +867,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def getSubmissionStatus(workspaceName: WorkspaceName, submissionId: String) = {
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withSubmission(workspaceContext, submissionId, txn) { submission =>
           Future.successful(RequestComplete(StatusCodes.OK, submission))
         }
@@ -877,7 +877,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def abortSubmission(workspaceName: WorkspaceName, submissionId: String): Future[PerRequestMessage] = {
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         abortSubmission(workspaceContext, submissionId, txn)
       }
     }
@@ -931,7 +931,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
    * Get the list of outputs for a given workflow in this submission */
   def workflowOutputs(workspaceName: WorkspaceName, submissionId: String, workflowId: String) = {
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withSubmission(workspaceContext, submissionId, txn) { submission =>
           withWorkflow(workspaceName, submission, workflowId) { workflow =>
             val outputs = executionServiceDAO.outputs(workflowId, userInfo).map(Success(_)).recover{case t=>Failure(t)}
@@ -956,7 +956,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   def workflowMetadata(workspaceName: WorkspaceName, submissionId: String, workflowId: String) = {
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Read, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Read, txn) { workspaceContext =>
         withSubmission(workspaceContext, submissionId, txn) { submission =>
           withWorkflow(workspaceName, submission, workflowId) { workflow =>
             executionServiceDAO.callLevelMetadata(workflowId, userInfo).map(em => RequestComplete(StatusCodes.OK, em))
@@ -1077,17 +1077,17 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   private def requireAccess(workspace: Workspace, requiredLevel: WorkspaceAccessLevel)(codeBlock: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
     gcsDAO.getMaximumAccessLevel(userInfo.userEmail, workspace.workspaceId) flatMap { userLevel =>
       if (userLevel >= requiredLevel) {
-        if ( (requiredLevel > WorkspaceAccessLevel.Read) && workspace.isLocked )
+        if ( (requiredLevel > WorkspaceAccessLevels.Read) && workspace.isLocked )
           Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, s"The workspace ${workspace.toWorkspaceName} is locked.")))
         else codeBlock
       }
-      else if (userLevel >= WorkspaceAccessLevel.Read) Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, accessDeniedMessage(workspace.toWorkspaceName))))
+      else if (userLevel >= WorkspaceAccessLevels.Read) Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, accessDeniedMessage(workspace.toWorkspaceName))))
       else Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspace.toWorkspaceName))))
     }
   }
 
   private def requireOwnerIgnoreLock(workspace: Workspace)(op: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
-    requireAccess(workspace.copy(isLocked = false),WorkspaceAccessLevel.Owner)(op)
+    requireAccess(workspace.copy(isLocked = false),WorkspaceAccessLevels.Owner)(op)
   }
 
   private def tryIsAdmin(userId: String): Future[Boolean] = {
@@ -1208,7 +1208,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   private def withSubmissionParameters(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest)
    ( op: (RawlsTransaction, WorkspaceContext, String, SubmissionValidationHeader, Seq[SubmissionValidationEntityInputs], Seq[SubmissionValidationEntityInputs]) => Future[PerRequestMessage]): Future[PerRequestMessage] = {
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
-      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevel.Write, txn) { workspaceContext =>
+      withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, txn) { workspaceContext =>
         withMethodConfig(workspaceContext, submissionRequest.methodConfigurationNamespace, submissionRequest.methodConfigurationName, txn) { methodConfig =>
           withMethodInputs(methodConfig) { (wdl,methodInputs) =>
             withSubmissionEntities(submissionRequest, workspaceContext, methodConfig.rootEntityType, txn) { jobEntities =>

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -161,16 +161,23 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
         if (accessLevel < WorkspaceAccessLevels.Read)
           Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspaceName))))
         else {
-          gcsDAO.getOwners(workspaceContext.workspace.workspaceId) map { owners =>
-            val response = WorkspaceListResponse(accessLevel,
-              workspaceContext.workspace,
-              getWorkspaceSubmissionStats(workspaceContext, txn),
-              owners)
-            RequestComplete(StatusCodes.OK, response)
-          }
+          val response = WorkspaceListResponse(accessLevel,
+            workspaceContext.workspace,
+            getWorkspaceSubmissionStats(workspaceContext, txn),
+            getWorkspaceOwners(workspaceName, txn))
+          Future.successful(RequestComplete(StatusCodes.OK, response))
         }
       }
     }
+
+  def getWorkspaceOwners(workspaceName: WorkspaceName, txn: RawlsTransaction): Seq[String] = {
+    val ownerGroup = containerDAO.authDAO.loadGroup(RawlsGroup(workspaceName, WorkspaceAccessLevels.Owner), txn).getOrElse(
+      throw new RawlsException(s"Unable to load owners for workspace ${workspaceName}"))
+    val users = ownerGroup.users.map(u => containerDAO.authDAO.loadUser(u, txn).get.userEmail.value)
+    val subGroups = ownerGroup.subGroups.map(g => containerDAO.authDAO.loadGroup(g, txn).get.groupEmail.value)
+
+    (users++subGroups).toSeq
+  }
 
   def deleteWorkspace(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
@@ -215,17 +222,13 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
     // then for each result in parallel 1 query to get the owners and 1 query to get details out of the db
     // last, join those parallel operations to a single result
 
-    // 1 query to gcsDAO to list all the workspaces
     val permissionsPairs = dataSource.inTransaction() { txn =>
       containerDAO.authDAO.listWorkspaces(RawlsUser(userInfo), txn)
     }
 
     // Future.sequence will do everything within in parallel per workspace then join them all
     val eventualResponses = Future.sequence(permissionsPairs map { permissionsPair =>
-      // query to get owners
-      gcsDAO.getOwners(permissionsPair.workspaceId).zip(Future.successful(permissionsPair))
-    } map { ownersAndPermissionsPairs =>
-      for ((owners, permissionsPair) <- ownersAndPermissionsPairs) yield {
+      Future {
         // database query to get details
         dataSource.inTransaction() { txn =>
           containerDAO.workspaceDAO.findById(permissionsPair.workspaceId, txn) match {
@@ -233,7 +236,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
               Option(WorkspaceListResponse(permissionsPair.accessLevel,
                 workspaceContext.workspace,
                 getWorkspaceSubmissionStats(workspaceContext, txn),
-                owners)
+                getWorkspaceOwners(workspaceContext.workspace.toWorkspaceName, txn))
               )
             case None =>
               // this case will happen when permissions exist for workspaces that don't, use None here and ignore later

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -174,8 +174,8 @@ class WorkspaceService(protected val userInfo: UserInfo, dataSource: DataSource,
   def getWorkspaceOwners(workspaceName: WorkspaceName, txn: RawlsTransaction): Seq[String] = {
     val ownerGroup = containerDAO.authDAO.loadGroup(RawlsGroup(workspaceName, WorkspaceAccessLevels.Owner), txn).getOrElse(
       throw new RawlsException(s"Unable to load owners for workspace ${workspaceName}"))
-    val users = ownerGroup.users.map(u => containerDAO.authDAO.loadUser(u, txn).get.userEmail.value)
-    val subGroups = ownerGroup.subGroups.map(g => containerDAO.authDAO.loadGroup(g, txn).get.groupEmail.value)
+    val users = ownerGroup.users.map(u => containerDAO.authDAO.loadUser(u, txn).get.userEmail.toString)
+    val subGroups = ownerGroup.subGroups.map(g => containerDAO.authDAO.loadGroup(g, txn).get.groupEmail.toString)
 
     (users++subGroups).toSeq
   }
@@ -308,14 +308,14 @@ class WorkspaceService(protected val userInfo: UserInfo, dataSource: DataSource,
               //pairs of user emails -> this access level
               val userLevels = accessGroup.users.map {
                 withRawlsUser(_, txn) { user =>
-                  (user.userEmail.value, level)
+                  (user.userEmail.toString, level)
                 }
               }
 
               //pairs of group emails -> this access level
               val subgroupLevels = accessGroup.subGroups.map {
                 withRawlsGroup(_, txn) { subGroup =>
-                  (subGroup.groupEmail.value, level)
+                  (subGroup.groupEmail.toString, level)
                 }
               }
 
@@ -360,9 +360,9 @@ class WorkspaceService(protected val userInfo: UserInfo, dataSource: DataSource,
             }
           }
 
-          val emailNotFoundReports = (aclUpdates.map( wau => wau.email ) diff updateMap.keys.map({
-              case Left(rawlsUser:RawlsUser) => rawlsUser.userEmail.value
-              case Right(rawlsGroup:RawlsGroup) => rawlsGroup.groupEmail.value
+          val emailNotFoundReports = (aclUpdates.map( wau => wau.email.toString ) diff updateMap.keys.map({
+              case Left(rawlsUser:RawlsUser) => rawlsUser.userEmail.toString
+              case Right(rawlsGroup:RawlsGroup) => rawlsGroup.groupEmail.toString
             }).toSeq)
             .map( email => ErrorReport( StatusCodes.NotFound, email ) )
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -157,17 +157,16 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   def getWorkspace(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
       withWorkspaceContext(workspaceName, txn) { workspaceContext =>
-        gcsDAO.getMaximumAccessLevel(userInfo.userEmail,workspaceContext.workspace.workspaceId) flatMap { accessLevel =>
-          if (accessLevel < WorkspaceAccessLevels.Read)
-            Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspaceName))))
-          else {
-            gcsDAO.getOwners(workspaceContext.workspace.workspaceId) map { owners =>
-              val response = WorkspaceListResponse(accessLevel,
-                workspaceContext.workspace,
-                getWorkspaceSubmissionStats(workspaceContext, txn),
-                owners)
-              RequestComplete(StatusCodes.OK, response)
-            }
+        val accessLevel = containerDAO.authDAO.getMaximumAccessLevel(RawlsUserRef(RawlsUserSubjectId(userInfo.userSubjectId)), workspaceContext.workspace.workspaceId, txn)
+        if (accessLevel < WorkspaceAccessLevels.Read)
+          Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspaceName))))
+        else {
+          gcsDAO.getOwners(workspaceContext.workspace.workspaceId) map { owners =>
+            val response = WorkspaceListResponse(accessLevel,
+              workspaceContext.workspace,
+              getWorkspaceSubmissionStats(workspaceContext, txn),
+              owners)
+            RequestComplete(StatusCodes.OK, response)
           }
         }
       }
@@ -280,7 +279,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   def getACL(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(readLocks=Set(workspaceName)) { txn =>
       withWorkspaceContext(workspaceName, txn) { workspaceContext =>
-        requireOwnerIgnoreLock(workspaceContext.workspace) {
+        requireOwnerIgnoreLock(workspaceContext.workspace, txn) {
           gcsDAO.getACL(workspaceContext.workspace.workspaceId) map { RequestComplete(StatusCodes.OK,_) }
         }
       }
@@ -289,7 +288,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   def updateACL(workspaceName: WorkspaceName, aclUpdates: Seq[WorkspaceACLUpdate]): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
       withWorkspaceContext(workspaceName, txn) { workspaceContext =>
-        requireOwnerIgnoreLock(workspaceContext.workspace) {
+        requireOwnerIgnoreLock(workspaceContext.workspace, txn) {
           gcsDAO.updateACL(userInfo.userEmail, workspaceContext.workspace.workspaceId, aclUpdates).map( _ match {
             case None => RequestComplete(StatusCodes.OK)
             case Some(reports) => RequestComplete(ErrorReport(StatusCodes.Conflict,"Unable to alter some ACLs in $workspaceName",reports))
@@ -301,7 +300,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   def lockWorkspace(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
       withWorkspaceContext(workspaceName, txn) { workspaceContext =>
-        requireOwnerIgnoreLock(workspaceContext.workspace) {
+        requireOwnerIgnoreLock(workspaceContext.workspace, txn) {
           Future {
             if ( !containerDAO.submissionDAO.list(workspaceContext,txn).forall(_.status.isDone) )
               RequestComplete(ErrorReport(StatusCodes.Conflict,s"There are running submissions in workspace $workspaceName, so it cannot be locked."))
@@ -318,7 +317,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
   def unlockWorkspace(workspaceName: WorkspaceName): Future[PerRequestMessage] =
     dataSource.inFutureTransaction(writeLocks=Set(workspaceName)) { txn =>
       withWorkspaceContext(workspaceName, txn) { workspaceContext =>
-        requireOwnerIgnoreLock(workspaceContext.workspace) {
+        requireOwnerIgnoreLock(workspaceContext.workspace, txn) {
           Future {
             if ( workspaceContext.workspace.isLocked ) {
               containerDAO.workspaceDAO.save(workspaceContext.workspace.copy(isLocked = false), txn)
@@ -1054,7 +1053,7 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
 
   private def withWorkspaceContextAndPermissions(workspaceName: WorkspaceName, accessLevel: WorkspaceAccessLevel, txn: RawlsTransaction)(op: (WorkspaceContext) => Future[PerRequestMessage]): Future[PerRequestMessage] = {
     withWorkspaceContext(workspaceName, txn) { workspaceContext =>
-      requireAccess(workspaceContext.workspace, accessLevel) { op(workspaceContext) }
+      requireAccess(workspaceContext.workspace, accessLevel, txn) { op(workspaceContext) }
     }
   }
 
@@ -1067,20 +1066,19 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
     }
   }
 
-  private def requireAccess(workspace: Workspace, requiredLevel: WorkspaceAccessLevel)(codeBlock: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
-    gcsDAO.getMaximumAccessLevel(userInfo.userEmail, workspace.workspaceId) flatMap { userLevel =>
-      if (userLevel >= requiredLevel) {
-        if ( (requiredLevel > WorkspaceAccessLevels.Read) && workspace.isLocked )
-          Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, s"The workspace ${workspace.toWorkspaceName} is locked.")))
-        else codeBlock
-      }
-      else if (userLevel >= WorkspaceAccessLevels.Read) Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, accessDeniedMessage(workspace.toWorkspaceName))))
-      else Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspace.toWorkspaceName))))
+  private def requireAccess(workspace: Workspace, requiredLevel: WorkspaceAccessLevel, txn: RawlsTransaction)(codeBlock: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
+    val userLevel = containerDAO.authDAO.getMaximumAccessLevel(RawlsUserRef(RawlsUserSubjectId(userInfo.userSubjectId)), workspace.workspaceId, txn)
+    if (userLevel >= requiredLevel) {
+      if ( (requiredLevel > WorkspaceAccessLevels.Read) && workspace.isLocked )
+        Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, s"The workspace ${workspace.toWorkspaceName} is locked.")))
+      else codeBlock
     }
+    else if (userLevel >= WorkspaceAccessLevels.Read) Future.successful(RequestComplete(ErrorReport(StatusCodes.Forbidden, accessDeniedMessage(workspace.toWorkspaceName))))
+    else Future.successful(RequestComplete(ErrorReport(StatusCodes.NotFound, noSuchWorkspaceMessage(workspace.toWorkspaceName))))
   }
 
-  private def requireOwnerIgnoreLock(workspace: Workspace)(op: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
-    requireAccess(workspace.copy(isLocked = false),WorkspaceAccessLevels.Owner)(op)
+  private def requireOwnerIgnoreLock(workspace: Workspace, txn: RawlsTransaction)(op: => Future[PerRequestMessage]): Future[PerRequestMessage] = {
+    requireAccess(workspace.copy(isLocked = false),WorkspaceAccessLevels.Owner, txn)(op)
   }
 
   private def tryIsAdmin(userId: String): Future[Boolean] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1048,7 +1048,9 @@ class WorkspaceService(userInfo: UserInfo, dataSource: DataSource, containerDAO:
         val workspaceId = UUID.randomUUID.toString
         gcsDAO.createBucket(userInfo, workspaceRequest.namespace, workspaceId, workspaceName) map { _ =>
           val currentDate = DateTime.now
-          val workspace = Workspace(workspaceRequest.namespace, workspaceRequest.name, workspaceId, gcsDAO.getBucketName(workspaceId), currentDate, currentDate, userInfo.userEmail, workspaceRequest.attributes)
+          val accessLevels = containerDAO.authDAO.createWorkspaceAccessGroups(workspaceName, userInfo, txn)
+
+          val workspace = Workspace(workspaceRequest.namespace, workspaceRequest.name, workspaceId, gcsDAO.getBucketName(workspaceId), currentDate, currentDate, userInfo.userEmail, workspaceRequest.attributes, accessLevels)
           op(containerDAO.workspaceDAO.save(workspace, txn))
         }
     }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
@@ -172,7 +172,7 @@ class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
         txn.withGraph { graph =>
           val mapVertex = authDAO.getVertices(wc.workspaceVertex, Direction.OUT, EdgeSchema.Own, "accessLevels").head
 
-          Seq(WorkspaceAccessLevel.Owner, WorkspaceAccessLevel.Write, WorkspaceAccessLevel.Read) foreach { level =>
+          Seq(WorkspaceAccessLevels.Owner, WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Read) foreach { level =>
             val levelFromWs = authDAO.getVertices(mapVertex, Direction.OUT, EdgeSchema.Ref, level.toString).head
 
             val levelGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(testData.workspace.toWorkspaceName, level), Set.empty, Set.empty)
@@ -202,7 +202,7 @@ class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
       withWorkspaceContext(testData.workspace, txn, bSkipLockCheck = true) { wc =>
         txn.withGraph { graph =>
           val vAccessLevels = authDAO.getVertices(wc.workspaceVertex, Direction.OUT, EdgeSchema.Own, "accessLevels").head
-          val vOwnerGroup = authDAO.getVertices(vAccessLevels, Direction.OUT, EdgeSchema.Ref, WorkspaceAccessLevel.Owner.toString).head
+          val vOwnerGroup = authDAO.getVertices(vAccessLevels, Direction.OUT, EdgeSchema.Ref, WorkspaceAccessLevels.Owner.toString).head
           val vOwnerGroupUsers = authDAO.getVertices(vOwnerGroup, Direction.OUT, EdgeSchema.Own, "users").head
           val vOwnerGroupUser0 = authDAO.getVertices(vOwnerGroupUsers, Direction.OUT, EdgeSchema.Ref, "0").head
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
@@ -309,4 +309,34 @@ class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
       }
     }
   }
+
+  it should "find workspaces for users in subgroups" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val user = RawlsUser("obama@whitehouse.gov")
+      val group2 = RawlsGroup("TotallySuperSecret", Set(user), Set.empty)
+      val group = RawlsGroup("TopSecret", Set.empty, Set(group2))
+
+      authDAO.saveUser(user, txn)
+      authDAO.saveGroup(group2, txn)
+      authDAO.saveGroup(group, txn)
+
+      val levels = authDAO.createWorkspaceAccessGroups(testData.workspace.toWorkspaceName, testUserInfo, txn)
+      val workspace1 = testData.workspace.copy(name = "1", workspaceId = "1", accessLevels = levels ++ Map[WorkspaceAccessLevel, RawlsGroupRef](WorkspaceAccessLevels.Owner -> group))
+      val workspace2 = testData.workspace.copy(name = "2", workspaceId = "2", accessLevels = levels ++ Map[WorkspaceAccessLevel, RawlsGroupRef](WorkspaceAccessLevels.Write -> group))
+      val workspace3 = testData.workspace.copy(name = "3", workspaceId = "3", accessLevels = levels ++ Map[WorkspaceAccessLevel, RawlsGroupRef](WorkspaceAccessLevels.Read -> group))
+      val workspace4 = testData.workspace.copy(name = "4", workspaceId = "4", accessLevels = levels)
+      workspaceDAO.save(workspace1, txn)
+      workspaceDAO.save(workspace2, txn)
+      workspaceDAO.save(workspace3, txn)
+      workspaceDAO.save(workspace4, txn)
+
+      val result = authDAO.listWorkspaces(user.userSubjectId, txn)
+      assertResult( Set(WorkspacePermissionsPair(workspace1.workspaceId, WorkspaceAccessLevels.Owner), WorkspacePermissionsPair(workspace2.workspaceId, WorkspaceAccessLevels.Write), WorkspacePermissionsPair(workspace3.workspaceId, WorkspaceAccessLevels.Read)) ) {
+        result.toSet
+      }
+      assertResult( 3 ) {
+        result.size
+      }
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
@@ -1,0 +1,232 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import com.tinkerpop.blueprints.{Vertex, Graph, Direction}
+import com.tinkerpop.blueprints.impls.orient.OrientVertex
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
+import org.broadinstitute.dsde.rawls.model._
+import org.scalatest.{FlatSpec, Matchers}
+import spray.http.OAuth2BearerToken
+
+import scala.collection.JavaConversions._
+
+class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
+
+  def getMatchingUserVertices(graph: Graph, user: RawlsUser): Iterable[Vertex] =
+    graph.getVertices.filter(v => {
+      v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.User) &&
+        v.getProperty[String]("userSubjectId") == user.userSubjectId
+    })
+
+  def getMatchingGroupVertices(graph: Graph, group: RawlsGroup): Iterable[Vertex] =
+    graph.getVertices.filter(v => {
+      v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.Group) &&
+        v.getProperty[String]("groupName") == group.groupName
+    })
+
+  val testUserInfo = UserInfo("dummy-emal@example.com", OAuth2BearerToken("dummy-token"), 0, "dummy-ID")
+  val testUser = RawlsUser(testUserInfo.userSubjectId)
+
+  "GraphAuthDAO" should "save a new User" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      authDAO.saveUser(testUser, txn)
+
+      txn.withGraph { graph =>
+        assert {
+          getMatchingUserVertices(graph, testUser).nonEmpty
+        }
+      }
+    }
+  }
+
+  it should "save a new Group" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val group = RawlsGroup("Empty Group", Set.empty, Set.empty)
+      authDAO.saveGroup(group, txn)
+
+      txn.withGraph { graph =>
+        assert {
+          getMatchingGroupVertices(graph, group).nonEmpty
+        }
+      }
+    }
+  }
+
+  it should "not save two copies of the same User" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      authDAO.saveUser(testUser, txn)
+      authDAO.saveUser(testUser, txn)
+
+      txn.withGraph { graph =>
+        assertResult(1) {
+          getMatchingUserVertices(graph, testUser).size
+        }
+      }
+    }
+  }
+
+  it should "not save two copies of the same Group" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val group = RawlsGroup("Empty Group", Set.empty, Set.empty)
+      authDAO.saveGroup(group, txn)
+      authDAO.saveGroup(group, txn)
+
+      txn.withGraph { graph =>
+        assertResult(1) {
+          getMatchingGroupVertices(graph, group).size
+        }
+      }
+    }
+  }
+
+  it should "save a User to multiple Groups but not save two copies of the same User" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      authDAO.saveUser(testUser, txn)
+
+      val group1 = RawlsGroup("Group 1 For User", Set(testUser), Set.empty)
+      val group2 = RawlsGroup("Group 2 For User", Set(testUser), Set.empty)
+      authDAO.saveGroup(group1, txn)
+      authDAO.saveGroup(group2, txn)
+
+      txn.withGraph { graph =>
+        assertResult(1) {
+          getMatchingUserVertices(graph, testUser).size
+        }
+        assertResult(1) {
+          getMatchingGroupVertices(graph, group1).size
+        }
+        assertResult(1) {
+          getMatchingGroupVertices(graph, group2).size
+        }
+      }
+    }
+  }
+
+  it should "not save a new Group with missing users" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val user1 = RawlsUser("subjectId1")
+      val user2 = RawlsUser("subjectId2")
+      val group = RawlsGroup("Two User Group", Set(user1, user2), Set.empty)
+
+      intercept[RawlsException] {
+        // note that the users have not first been saved
+        authDAO.saveGroup(group, txn)
+      }
+
+      txn.withGraph { graph =>
+        assert {
+          getMatchingGroupVertices(graph, group).isEmpty
+        }
+      }
+    }
+  }
+
+  it should "not save a new Group with missing groups" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val group1 = RawlsGroup("Group One", Set.empty, Set.empty)
+      val group2 = RawlsGroup("Group Two", Set.empty, Set(group1))
+
+      intercept[RawlsException] {
+        // note that the first group has not first been saved
+        authDAO.saveGroup(group2, txn)
+      }
+
+      txn.withGraph { graph =>
+        assert {
+          getMatchingGroupVertices(graph, group2).isEmpty
+        }
+      }
+    }
+  }
+
+  it should "save a subgroup hierarchy" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val group1 = RawlsGroup("Group One", Set.empty, Set.empty)
+      val group2 = RawlsGroup("Group Two", Set.empty, Set(group1))
+      val group3 = RawlsGroup("Group Three", Set.empty, Set(group1, group2))
+
+      authDAO.saveGroup(group1, txn)
+      authDAO.saveGroup(group2, txn)
+      authDAO.saveGroup(group3, txn)
+
+      txn.withGraph { graph =>
+        Seq(group1, group2, group3) foreach { group =>
+          assert {
+            getMatchingGroupVertices(graph, group).nonEmpty
+          }
+        }
+      }
+    }
+  }
+
+  it should "save Workspace Access Groups as map properties on a Workspace" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val levels = authDAO.createWorkspaceAccessGroups(testData.workspace.toWorkspaceName, testUserInfo, txn)
+      val workspace = testData.workspace.copy(accessLevels = levels)
+      workspaceDAO.save(workspace, txn)
+    }
+
+    // separate transaction so we aren't checking un-saved vertices
+    dataSource.inTransaction() { txn =>
+      withWorkspaceContext(testData.workspace, txn, bSkipLockCheck = true) { wc =>
+        txn.withGraph { graph =>
+          val mapVertex = authDAO.getVertices(wc.workspaceVertex, Direction.OUT, EdgeSchema.Own, "accessLevels").head
+
+          Seq(WorkspaceAccessLevel.Owner, WorkspaceAccessLevel.Write, WorkspaceAccessLevel.Read) foreach { level =>
+            val levelFromWs = authDAO.getVertices(mapVertex, Direction.OUT, EdgeSchema.Ref, level.toString).head
+
+            val levelGroup = RawlsGroup(UserAuth.toWorkspaceAccessGroupName(testData.workspace.toWorkspaceName, level), Set.empty, Set.empty)
+            val levelVertices = getMatchingGroupVertices(graph, levelGroup)
+
+            assertResult(1) {
+              levelVertices.size
+            }
+            assert {
+              levelVertices.head == levelFromWs
+            }
+          }
+        }
+      }
+    }
+  }
+
+  it should "save the user to the Owner Workspace Access Group on a Workspace" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      val levels = authDAO.createWorkspaceAccessGroups(testData.workspace.toWorkspaceName, testUserInfo, txn)
+      val workspace = testData.workspace.copy(accessLevels = levels)
+      workspaceDAO.save(workspace, txn)
+    }
+
+    // separate transaction so we aren't checking un-saved vertices
+    dataSource.inTransaction() { txn =>
+      withWorkspaceContext(testData.workspace, txn, bSkipLockCheck = true) { wc =>
+        txn.withGraph { graph =>
+          val vAccessLevels = authDAO.getVertices(wc.workspaceVertex, Direction.OUT, EdgeSchema.Own, "accessLevels").head
+          val vOwnerGroup = authDAO.getVertices(vAccessLevels, Direction.OUT, EdgeSchema.Ref, WorkspaceAccessLevel.Owner.toString).head
+          val vOwnerGroupUsers = authDAO.getVertices(vOwnerGroup, Direction.OUT, EdgeSchema.Own, "users").head
+          val vOwnerGroupUser0 = authDAO.getVertices(vOwnerGroupUsers, Direction.OUT, EdgeSchema.Ref, "0").head
+
+          val userVertices = getMatchingUserVertices(graph, testUser)
+
+          assertResult(1) {
+            userVertices.size
+          }
+          assert {
+            userVertices.head == vOwnerGroupUser0
+          }
+
+        }
+      }
+    }
+  }
+
+  it should "not allow Workspace Access Groups to be created twice" in withDefaultTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      intercept[RawlsException] {
+        authDAO.createWorkspaceAccessGroups(testData.workspace.toWorkspaceName, testUserInfo, txn)
+        authDAO.createWorkspaceAccessGroups(testData.workspace.toWorkspaceName, testUserInfo, txn)
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphAuthDAOSpec.scala
@@ -16,13 +16,13 @@ class GraphAuthDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
   def getMatchingUserVertices(graph: Graph, user: RawlsUser): Iterable[Vertex] =
     graph.getVertices.filter(v => {
       v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.User) &&
-        v.getProperty[String]("userSubjectId") == user.userSubjectId.value
+        v.getProperty[String]("userSubjectId") == user.userSubjectId.toString
     })
 
   def getMatchingGroupVertices(graph: Graph, group: RawlsGroup): Iterable[Vertex] =
     graph.getVertices.filter(v => {
       v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.Group) &&
-        v.getProperty[String]("groupName") == group.groupName.value
+        v.getProperty[String]("groupName") == group.groupName.toString
     })
 
   val testUserInfo = UserInfo("dummy-emal@example.com", OAuth2BearerToken("dummy-token"), 0, "dummy-ID")

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphBillingDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphBillingDAOSpec.scala
@@ -1,0 +1,205 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import com.tinkerpop.blueprints.impls.orient.OrientVertex
+import com.tinkerpop.blueprints.{Direction, Graph, Vertex}
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model._
+import org.scalatest.{FlatSpec, Matchers}
+import spray.http.OAuth2BearerToken
+
+import scala.collection.JavaConversions._
+
+class GraphBillingDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
+
+  def getMatchingUserVertices(graph: Graph, user: RawlsUser): Iterable[Vertex] =
+    graph.getVertices.filter(v => {
+      v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.User) &&
+        v.getProperty[String]("userSubjectId") == user.userSubjectId.value
+    })
+
+  def getMatchingBillingProjectVertices(graph: Graph, project: RawlsBillingProject): Iterable[Vertex] =
+    graph.getVertices.filter(v => {
+      v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.BillingProject) &&
+        v.getProperty[String]("projectName") == project.projectName.value
+    })
+
+  val testUserInfo = UserInfo("dummy-email@example.com", OAuth2BearerToken("dummy-token"), 0, "dummy-ID")
+  val testUser = RawlsUser(testUserInfo)
+  val testUserRef: RawlsUserRef = testUser
+
+  def userFromId(subjectId: String) =
+    RawlsUser(RawlsUserSubjectId(subjectId), RawlsUserEmail("dummy@example.com"))
+
+  def projectFromName(name: String) =
+    RawlsBillingProject(RawlsBillingProjectName(name), Set.empty)
+
+  val testProject = projectFromName("Test Billing Project")
+
+  "GraphBillingDAO" should "save a new billing project" in withEmptyTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      billingDAO.saveProject(testProject, txn)
+
+      txn.withGraph { graph =>
+        assert {
+          getMatchingBillingProjectVertices(graph, testProject).nonEmpty
+        }
+      }
+    }
+  }
+
+  it should "load a billing project" in withEmptyTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      assert {
+        billingDAO.loadProject(testProject.projectName, txn).isEmpty
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      billingDAO.saveProject(testProject, txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      assertResult(testProject) {
+        billingDAO.loadProject(testProject.projectName, txn).get
+      }
+    }
+  }
+
+  it should "delete a billing project" in withEmptyTestDatabase { dataSource =>
+    val p1 = projectFromName("Project One")
+    val p2 = projectFromName("Project Two")
+
+    dataSource.inTransaction() { txn =>
+      billingDAO.saveProject(p1, txn)
+      billingDAO.saveProject(p2, txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      txn.withGraph { graph =>
+        assert {
+          getMatchingBillingProjectVertices(graph, p1).nonEmpty
+        }
+        assert {
+          getMatchingBillingProjectVertices(graph, p2).nonEmpty
+        }
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      txn.withGraph { graph =>
+        assert {
+          billingDAO.deleteProject(p1, txn)
+        }
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      txn.withGraph { graph =>
+        assert {
+          getMatchingBillingProjectVertices(graph, p1).isEmpty
+        }
+        assert {
+          getMatchingBillingProjectVertices(graph, p2).nonEmpty
+        }
+      }
+    }
+  }
+
+  it should "not delete a non-existent billing project" in withEmptyTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      assert {
+        ! billingDAO.deleteProject(projectFromName("404 Group Not Found LOL"), txn)
+      }
+    }
+  }
+
+  it should "not delete a billing project twice" in withEmptyTestDatabase { dataSource =>
+    val project = projectFromName("Group To Delete")
+
+    dataSource.inTransaction() { txn =>
+      billingDAO.saveProject(project, txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      txn.withGraph { graph =>
+        assert {
+          getMatchingBillingProjectVertices(graph, project).nonEmpty
+        }
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      txn.withGraph { graph =>
+        assert {
+          billingDAO.deleteProject(project, txn)
+        }
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      txn.withGraph { graph =>
+        assert {
+          getMatchingBillingProjectVertices(graph, project).isEmpty
+        }
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      assert {
+        ! billingDAO.deleteProject(project, txn)
+      }
+    }
+  }
+
+  it should "add a User to a billing project" in withEmptyTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      billingDAO.saveProject(testProject, txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      val noUserProject = billingDAO.loadProject(testProject.projectName, txn).get
+      assert {
+        noUserProject.users.isEmpty
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      authDAO.saveUser(testUser, txn)
+      billingDAO.addUserToProject(testUser, testProject, txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      val userProject = billingDAO.loadProject(testProject.projectName, txn).get
+      assertResult(Set(testUserRef)) {
+        userProject.users
+      }
+    }
+  }
+
+  it should "remove a User from a billing project" in withEmptyTestDatabase { dataSource =>
+    dataSource.inTransaction() { txn =>
+      authDAO.saveUser(testUser, txn)
+      billingDAO.saveProject(testProject.copy(users = Set(testUser)), txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      val userProject = billingDAO.loadProject(testProject.projectName, txn).get
+      assertResult(Set(testUserRef)) {
+        userProject.users
+      }
+    }
+
+    dataSource.inTransaction() { txn =>
+      billingDAO.removeUserFromProject(testUser, testProject, txn)
+    }
+
+    dataSource.inTransaction() { txn =>
+      val noUserProject = billingDAO.loadProject(testProject.projectName, txn).get
+      assert {
+        noUserProject.users.isEmpty
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphBillingDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphBillingDAOSpec.scala
@@ -16,13 +16,13 @@ class GraphBillingDAOSpec extends FlatSpec with Matchers with OrientDbTestFixtur
   def getMatchingUserVertices(graph: Graph, user: RawlsUser): Iterable[Vertex] =
     graph.getVertices.filter(v => {
       v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.User) &&
-        v.getProperty[String]("userSubjectId") == user.userSubjectId.value
+        v.getProperty[String]("userSubjectId") == user.userSubjectId.toString
     })
 
   def getMatchingBillingProjectVertices(graph: Graph, project: RawlsBillingProject): Iterable[Vertex] =
     graph.getVertices.filter(v => {
       v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.BillingProject) &&
-        v.getProperty[String]("projectName") == project.projectName.value
+        v.getProperty[String]("projectName") == project.projectName.toString
     })
 
   val testUserInfo = UserInfo("dummy-email@example.com", OAuth2BearerToken("dummy-token"), 0, "dummy-ID")

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAODeleteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphDAODeleteSpec.scala
@@ -16,11 +16,11 @@ import org.broadinstitute.dsde.rawls.model._
  */
 class GraphDAODeleteSpec extends FreeSpec with Matchers with OrientDbTestFixture {
   val wsName = WorkspaceName("myNamespace", "myWorkspace")
-  val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty[String, Attribute] )
+  val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
   val wsWithAttributeVals = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser",
     Map(
       "str" -> AttributeString("str"), "num" -> AttributeNumber(4), "bool" -> AttributeBoolean(true),
-      "empty" -> AttributeEmptyList, "valueList" -> AttributeValueList(Seq(AttributeNumber(4), AttributeNumber(5))) ))
+      "empty" -> AttributeEmptyList, "valueList" -> AttributeValueList(Seq(AttributeNumber(4), AttributeNumber(5))) ), Map.empty)
 
   "Graph objects shouldn't leave stray vertices behind when they're deleted:" - {
     "Empty workspace" in withEmptyTestDatabase { dataSource =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAOSpec.scala
@@ -34,7 +34,7 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
 
   class BugTestData() extends TestData {
     val wsName = WorkspaceName("myNamespace2", "myWorkspace2")
-    val workspace = new Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty)
+    val workspace = new Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
 
     val sample1 = new Entity("sample1", "Sample",
       Map("aliquot" -> AttributeEntityReference("Aliquot", "aliquot1")))
@@ -120,6 +120,7 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
       createdDate = DateTime.now,
       lastModified = DateTime.now,
       createdBy = "Joe Biden",
+      Map.empty,
       Map.empty
     )
 
@@ -131,6 +132,7 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
       createdDate = DateTime.now,
       lastModified = DateTime.now,
       createdBy = "Joe Biden",
+      Map.empty,
       Map.empty
     )
 
@@ -333,6 +335,7 @@ class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture
     createdDate = DateTime.now,
     lastModified = DateTime.now,
     createdBy = "Joe Biden",
+    Map.empty,
     Map.empty
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphEntityDAOSpec.scala
@@ -8,7 +8,6 @@ import org.joda.time.DateTime
 import org.scalatest.{Matchers, FlatSpec}
 
 import scala.collection.JavaConversions._
-import scala.collection.immutable.HashMap
 
 class GraphEntityDAOSpec extends FlatSpec with Matchers with OrientDbTestFixture {
   lazy val dao: GraphEntityDAO = new GraphEntityDAO()

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphSubmissionDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphSubmissionDAOSpec.scala
@@ -1,13 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import java.util.UUID
-
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 import org.scalatest.{Matchers, FlatSpec}
-import scala.collection.immutable.HashMap
-import scala.util.Try
 
 /**
  * @author tsharpe

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/GraphWorkspaceDAOSpec.scala
@@ -21,7 +21,8 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
         createdDate = testDate,
         lastModified = testDate,
         createdBy = "Barack Obama",
-        attributes = Map("workspace_attrib" -> AttributeString("foo"))
+        attributes = Map("workspace_attrib" -> AttributeString("foo")),
+        accessLevels = Map.empty
       )
 
       workspaceDAO.save(workspace2, txn)
@@ -92,7 +93,8 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
         createdDate = testDate,
         lastModified = testDate,
         createdBy = "Mitt Romney",
-        attributes = Map("dots.dots.more.dots" -> AttributeString("foo"))
+        attributes = Map("dots.dots.more.dots" -> AttributeString("foo")),
+        accessLevels = Map.empty
       )
 
       intercept[RawlsException] {
@@ -124,7 +126,8 @@ class GraphWorkspaceDAOSpec extends FlatSpec with Matchers with OrientDbTestFixt
         createdDate = testDate,
         lastModified = testDate,
         createdBy = "Mitt Romney",
-        attributes = Map(reserved -> AttributeString("foo"))
+        attributes = Map(reserved -> AttributeString("foo")),
+        accessLevels = Map.empty
       )
       dataSource.inTransaction(writeLocks=Set(testData.workspace.toWorkspaceName)) { txn =>
         withWorkspaceContext(testData.workspace, txn) { context =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -1,13 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
-import WorkspaceACLJsonSupport._
 import org.joda.time.DateTime
-import spray.json._
 import scala.concurrent.Future
-import scala.util.Try
 
 class MockGoogleServicesDAO extends GoogleServicesDAO {
 
@@ -49,6 +45,8 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
     }
   }
 
+  var mockProxyGroups: Set[RawlsUser] = Set.empty
+
   override def createBucket(userInfo: UserInfo, projectId: String, workspaceId: String, workspaceName: WorkspaceName): Future[Unit] = Future.successful(Unit)
 
   override def deleteBucket(userInfo: UserInfo, workspaceId: String) = Future.successful(Unit)
@@ -73,5 +71,10 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
 
   override def listAdmins(): Future[Seq[String]] = Future.successful(adminList.toSeq)
 
-  override def createProxyGroup(userInfo: UserInfo): Future[Unit] = Future.successful(Unit)
+  override def createProxyGroup(user: RawlsUser): Future[Unit] = {
+    mockProxyGroups += user
+    Future.successful(Unit)
+  }
+
+  def containsProxyGroup(user: RawlsUser) = mockProxyGroups contains user
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevel.WorkspaceAccessLevel
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import WorkspaceACLJsonSupport._
 import org.joda.time.DateTime
 import spray.json._
@@ -35,12 +35,12 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   }
 
   val mockPermissions: Map[String, WorkspaceAccessLevel] = Map(
-    "test@broadinstitute.org" -> WorkspaceAccessLevel.Owner,
-    "test_token" -> WorkspaceAccessLevel.Owner,
-    "owner-access" -> WorkspaceAccessLevel.Owner,
-    "write-access" -> WorkspaceAccessLevel.Write,
-    "read-access" -> WorkspaceAccessLevel.Read,
-    "no-access" -> WorkspaceAccessLevel.NoAccess
+    "test@broadinstitute.org" -> WorkspaceAccessLevels.Owner,
+    "test_token" -> WorkspaceAccessLevels.Owner,
+    "owner-access" -> WorkspaceAccessLevels.Owner,
+    "write-access" -> WorkspaceAccessLevels.Write,
+    "read-access" -> WorkspaceAccessLevels.Read,
+    "no-access" -> WorkspaceAccessLevels.NoAccess
   )
 
   private def getAccessLevelOrDieTrying(userId: String) = {
@@ -57,15 +57,15 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
 
   override def updateACL(userEmail: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]) = Future.successful(None)
 
-  override def getOwners(workspaceId: String) = Future.successful(mockPermissions.filter(_._2 == WorkspaceAccessLevel.Owner).keys.toSeq)
+  override def getOwners(workspaceId: String) = Future.successful(mockPermissions.filter(_._2 == WorkspaceAccessLevels.Owner).keys.toSeq)
 
   override def getMaximumAccessLevel(userId: String, workspaceId: String) = Future.successful(getAccessLevelOrDieTrying(userId))
 
   override def getWorkspaces(userId: String) = Future.successful(
     Seq(
-      WorkspacePermissionsPair("workspaceId1", WorkspaceAccessLevel.Owner),
-      WorkspacePermissionsPair("workspaceId2", WorkspaceAccessLevel.Write),
-      WorkspacePermissionsPair("workspaceId3", WorkspaceAccessLevel.Read)
+      WorkspacePermissionsPair("workspaceId1", WorkspaceAccessLevels.Owner),
+      WorkspacePermissionsPair("workspaceId2", WorkspaceAccessLevels.Write),
+      WorkspacePermissionsPair("workspaceId3", WorkspaceAccessLevels.Read)
     )
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -54,7 +54,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
 
   override def getACL(workspaceId: String) = Future.successful(WorkspaceACL(mockPermissions))
 
-  override def updateACL(userEmail: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]) = Future.successful(None)
+  override def updateACL(currentUser: UserInfo, workspaceId: String, aclUpdates: Map[Either[RawlsUser, RawlsGroup], WorkspaceAccessLevel]): Future[Option[Seq[ErrorReport]]] = Future.successful(None)
 
   override def getMaximumAccessLevel(userId: String, workspaceId: String) = Future.successful(getAccessLevelOrDieTrying(userId))
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.joda.time.DateTime
+import scala.collection.mutable
 import scala.concurrent.Future
 
 class MockGoogleServicesDAO extends GoogleServicesDAO {
@@ -45,7 +46,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
     }
   }
 
-  var mockProxyGroups: Set[RawlsUser] = Set.empty
+  var mockProxyGroups = mutable.Map[RawlsUser, Boolean]()
 
   override def createBucket(userInfo: UserInfo, projectId: String, workspaceId: String, workspaceName: WorkspaceName): Future[Unit] = Future.successful(Unit)
 
@@ -70,9 +71,15 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def listAdmins(): Future[Seq[String]] = Future.successful(adminList.toSeq)
 
   override def createProxyGroup(user: RawlsUser): Future[Unit] = {
-    mockProxyGroups += user
+    mockProxyGroups += (user -> false)
     Future.successful(Unit)
   }
 
-  def containsProxyGroup(user: RawlsUser) = mockProxyGroups contains user
+  def containsProxyGroup(user: RawlsUser) = mockProxyGroups.keySet.contains(user)
+
+  override def addUserToProxyGroup(user: RawlsUser): Future[Unit] = Future.successful(mockProxyGroups += (user -> true))
+
+  override def removeUserFromProxyGroup(user: RawlsUser): Future[Unit] = Future.successful(mockProxyGroups += (user -> false))
+
+  override def isUserInProxyGroup(user: RawlsUser): Future[Boolean] = Future.successful(mockProxyGroups.getOrElse(user, false))
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -55,8 +55,6 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
 
   override def updateACL(userEmail: String, workspaceId: String, aclUpdates: Seq[WorkspaceACLUpdate]) = Future.successful(None)
 
-  override def getOwners(workspaceId: String) = Future.successful(mockPermissions.filter(_._2 == WorkspaceAccessLevels.Owner).keys.toSeq)
-
   override def getMaximumAccessLevel(userId: String, workspaceId: String) = Future.successful(getAccessLevelOrDieTrying(userId))
 
   override def getBucketName(workspaceId: String) = s"rawls-${workspaceId}"

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -61,14 +61,6 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
 
   override def getMaximumAccessLevel(userId: String, workspaceId: String) = Future.successful(getAccessLevelOrDieTrying(userId))
 
-  override def getWorkspaces(userId: String) = Future.successful(
-    Seq(
-      WorkspacePermissionsPair("workspaceId1", WorkspaceAccessLevels.Owner),
-      WorkspacePermissionsPair("workspaceId2", WorkspaceAccessLevels.Write),
-      WorkspacePermissionsPair("workspaceId3", WorkspaceAccessLevels.Read)
-    )
-  )
-
   override def getBucketName(workspaceId: String) = s"rawls-${workspaceId}"
 
   val adminList = scala.collection.mutable.Set("test_token")

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockUserDirectoryDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockUserDirectoryDAO.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.model.RawlsUser
+
+import scala.collection.mutable
+import scala.concurrent.Future
+
+/**
+ * Created by dvoet on 11/6/15.
+ */
+class MockUserDirectoryDAO extends UserDirectoryDAO{
+  val users = mutable.Map[RawlsUser, Boolean]()
+
+  override def createUser(user: RawlsUser): Future[Unit] = Future.successful(users += (user -> false))
+
+  override def isEnabled(user: RawlsUser): Future[Boolean] = Future.successful(users.getOrElse(user, false))
+
+  override def disableUser(user: RawlsUser): Future[Unit] = Future.successful(users += (user -> false))
+
+  override def enableUser(user: RawlsUser): Future[Unit] = Future.successful(users += (user -> true))
+
+  def exists(user: RawlsUser) = users.keys.exists(_ == user)
+}

--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParserTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SimpleExpressionParserTest.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.expressions
 
-import com.tinkerpop.blueprints.Graph
 import org.broadinstitute.dsde.rawls.dataaccess.{RawlsTransaction, WorkspaceContext}
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
 import org.broadinstitute.dsde.rawls.model._

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -56,6 +56,9 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
   }
 
+  def makeRawlsGroup(name: String, users: Set[RawlsUserRef], groups: Set[RawlsGroupRef]) =
+    RawlsGroup(RawlsGroupName(name), RawlsGroupEmail("dummy@example.com"), users, groups)
+
   class EmptyWorkspace() extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
@@ -76,8 +79,8 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
 
   class DefaultTestData() extends TestData {
     // setup workspace objects
-    val owner = RawlsUser(userInfo.userSubjectId)
-    val ownerGroup = RawlsGroup("testwsOwners", Set(owner), Set.empty)
+    val owner = RawlsUser(userInfo)
+    val ownerGroup = makeRawlsGroup("testwsOwners", Set(owner), Set.empty)
 
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val wsAttrs = Map(

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -80,7 +80,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
 
   class LockedWorkspace() extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
-    val owner = RawlsUser(UserInfo("owner_access", OAuth2BearerToken("token"), 123, "123456789876543212345"))
+    val owner = RawlsUser(userInfo)
     val ownerGroup = makeRawlsGroup("testwsOwners", Set(owner), Set.empty)
     val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map(
       WorkspaceAccessLevels.Owner -> ownerGroup), isLocked = true )

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -118,7 +118,6 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
     val ownerGroup = makeRawlsGroup(s"rawls ${wsName} OWNER", Set(userOwner), Set.empty)
     val writerGroup = makeRawlsGroup(s"rawls ${wsName} WRITER", Set(userWriter), Set.empty)
     val readerGroup = makeRawlsGroup(s"rawls ${wsName} READER", Set(userReader), Set.empty)
-
     val wsAttrs = Map(
       "string" -> AttributeString("yep, it's a string"),
       "number" -> AttributeNumber(10),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -11,10 +11,6 @@ import spray.http.OAuth2BearerToken
 import scala.collection.immutable.HashMap
 import org.scalatest.BeforeAndAfterAll
 import java.util.UUID
-import spray.json._
-import spray.httpx.SprayJsonSupport
-import SprayJsonSupport._
-import WorkspaceJsonSupport._
 
 import org.broadinstitute.dsde.rawls.TestExecutionContext.testExecutionContext
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -31,6 +31,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
   lazy val workspaceDAO = new GraphWorkspaceDAO()
   lazy val methodConfigDAO = new GraphMethodConfigurationDAO()
   lazy val authDAO = new GraphAuthDAO()
+  lazy val billingDAO = new GraphBillingDAO()
   lazy val submissionDAO = new GraphSubmissionDAO()
 
   val containerDAO = GraphContainerDAO(
@@ -39,6 +40,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
     entityDAO,
     methodConfigDAO,
     authDAO,
+    billingDAO,
     submissionDAO
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/graph/OrientDbTestFixture.scala
@@ -8,7 +8,6 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.joda.time.DateTime
 import spray.http.OAuth2BearerToken
-import scala.collection.immutable.HashMap
 import org.scalatest.BeforeAndAfterAll
 import java.util.UUID
 
@@ -31,6 +30,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
   lazy val entityDAO: GraphEntityDAO = new GraphEntityDAO()
   lazy val workspaceDAO = new GraphWorkspaceDAO()
   lazy val methodConfigDAO = new GraphMethodConfigurationDAO()
+  lazy val authDAO = new GraphAuthDAO()
   lazy val submissionDAO = new GraphSubmissionDAO()
 
   val containerDAO = GraphContainerDAO(
@@ -38,6 +38,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
     workspaceDAO,
     entityDAO,
     methodConfigDAO,
+    authDAO,
     submissionDAO
   )
 
@@ -57,7 +58,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
 
   class EmptyWorkspace() extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
-    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", new HashMap[String, Attribute]() )
+    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
 
     override def save(txn:RawlsTransaction): Unit = {
       workspaceDAO.save(workspace, txn)
@@ -66,7 +67,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
 
   class LockedWorkspace() extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
-    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", new HashMap[String, Attribute](), isLocked = true )
+    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty, isLocked = true )
 
     override def save(txn:RawlsTransaction): Unit = {
       workspaceDAO.save(workspace, txn)
@@ -82,7 +83,7 @@ trait OrientDbTestFixture extends BeforeAndAfterAll {
       "empty" -> AttributeEmptyList,
       "values" -> AttributeValueList(Seq(AttributeString("another string"), AttributeBoolean(true)))
     )
-    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", wsAttrs)
+    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", wsAttrs, Map.empty)
 
     val sample1 = Entity("sample1", "Sample",
       Map(

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGoogleServicesDAOSpec.scala
@@ -73,11 +73,11 @@ class HttpGoogleServicesDAOSpec extends FlatSpec with Matchers with IntegrationT
     Await.result(gcsDAO.getACL(testWorkspaceId), Duration.Inf).acl should be (Map(testCreator.userEmail -> WorkspaceAccessLevels.Owner))
 
     // try adding a user, changing their access, then revoking it
-    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevels.Read))), Duration.Inf)
+    Await.result(gcsDAO.updateACL(testCreator, testWorkspaceId, Map(Left(RawlsUser(testCollaborator)) -> WorkspaceAccessLevels.Read)), Duration.Inf)
     Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.Read)
-    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevels.Write))), Duration.Inf)
+    Await.result(gcsDAO.updateACL(testCreator, testWorkspaceId, Map(Left(RawlsUser(testCollaborator)) -> WorkspaceAccessLevels.Write)), Duration.Inf)
     Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.Write)
-    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevels.NoAccess))), Duration.Inf)
+    Await.result(gcsDAO.updateACL(testCreator, testWorkspaceId, Map(Left(RawlsUser(testCollaborator)) -> WorkspaceAccessLevels.NoAccess)), Duration.Inf)
     Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.NoAccess)
 
     // check that we can properly deconstruct group names

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGoogleServicesDAOSpec.scala
@@ -110,6 +110,18 @@ class HttpGoogleServicesDAOSpec extends FlatSpec with Matchers with IntegrationT
     assertResult(None) { Await.result(gcsDAO.getTokenDate(userInfo), Duration.Inf) }
   }
 
+  it should "crud proxy groups" in {
+    val user = RawlsUser(UserInfo("foo@bar.com", null, 0, UUID.randomUUID().toString))
+    Await.result(gcsDAO.createProxyGroup(user), Duration.Inf)
+    assert(! Await.result(gcsDAO.isUserInProxyGroup(user), Duration.Inf))
+    Await.result(gcsDAO.addUserToProxyGroup(user), Duration.Inf)
+    assert(Await.result(gcsDAO.isUserInProxyGroup(user), Duration.Inf))
+    Await.result(gcsDAO.removeUserFromProxyGroup(user), Duration.Inf)
+    assert(! Await.result(gcsDAO.isUserInProxyGroup(user), Duration.Inf))
+
+    gcsDAO.getGroupDirectory.groups().delete(gcsDAO.toProxyFromUser(user.userSubjectId)).execute()
+  }
+
   private def when500( throwable: Throwable ): Boolean = {
     throwable match {
       case gjre: GoogleJsonResponseException => gjre.getStatusCode/100 == 5

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGoogleServicesDAOSpec.scala
@@ -49,18 +49,18 @@ class HttpGoogleServicesDAOSpec extends FlatSpec with Matchers with IntegrationT
     // if this does not throw an exception, then the bucket exists
     val bucketResource = Await.result(retry(when500)(() => Future { storage.buckets.get(testBucket).execute() }), Duration.Inf)
 
-    val readerGroup = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevel.Read)
-    val writerGroup = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevel.Write)
-    val ownerGroup = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevel.Owner)
+    val readerGroup = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevels.Read)
+    val writerGroup = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevels.Write)
+    val ownerGroup = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevels.Owner)
 
     // check that the access level for each group is what we expect
     val readerBAC = Await.result(retry(when500)(() => Future { storage.bucketAccessControls.get(testBucket, gcsDAO.makeGroupEntityString(readerGroup)).execute() }), Duration.Inf)
     val writerBAC = Await.result(retry(when500)(() => Future { storage.bucketAccessControls.get(testBucket, gcsDAO.makeGroupEntityString(writerGroup)).execute() }), Duration.Inf)
     val ownerBAC = Await.result(retry(when500)(() => Future { storage.bucketAccessControls.get(testBucket, gcsDAO.makeGroupEntityString(ownerGroup)).execute() }), Duration.Inf)
 
-    readerBAC.getRole should be (WorkspaceAccessLevel.toCanonicalString(WorkspaceAccessLevel.Read))
-    writerBAC.getRole should be (WorkspaceAccessLevel.toCanonicalString(WorkspaceAccessLevel.Write))
-    ownerBAC.getRole should be (WorkspaceAccessLevel.toCanonicalString(WorkspaceAccessLevel.Owner))
+    readerBAC.getRole should be (WorkspaceAccessLevels.Read.toString)
+    writerBAC.getRole should be (WorkspaceAccessLevels.Write.toString)
+    ownerBAC.getRole should be (WorkspaceAccessLevels.Owner.toString)
 
     // check that the groups exist (i.e. that this doesn't throw exceptions)
     val directory = gcsDAO.getGroupDirectory
@@ -69,20 +69,20 @@ class HttpGoogleServicesDAOSpec extends FlatSpec with Matchers with IntegrationT
     val ownerResource = Await.result(retry(when500)(() => Future { directory.groups.get(ownerGroup).execute() }), Duration.Inf)
 
     // check that the creator is an owner, and that getACL is consistent
-    Await.result(gcsDAO.getMaximumAccessLevel(testCreator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevel.Owner)
-    Await.result(gcsDAO.getACL(testWorkspaceId), Duration.Inf).acl should be (Map(testCreator.userEmail -> WorkspaceAccessLevel.Owner))
+    Await.result(gcsDAO.getMaximumAccessLevel(testCreator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.Owner)
+    Await.result(gcsDAO.getACL(testWorkspaceId), Duration.Inf).acl should be (Map(testCreator.userEmail -> WorkspaceAccessLevels.Owner))
 
     // try adding a user, changing their access, then revoking it
-    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevel.Read))), Duration.Inf)
-    Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevel.Read)
-    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevel.Write))), Duration.Inf)
-    Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevel.Write)
-    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevel.NoAccess))), Duration.Inf)
-    Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevel.NoAccess)
+    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevels.Read))), Duration.Inf)
+    Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.Read)
+    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevels.Write))), Duration.Inf)
+    Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.Write)
+    Await.result(gcsDAO.updateACL(testCreator.userEmail, testWorkspaceId, Seq(WorkspaceACLUpdate(testCollaborator.userEmail, WorkspaceAccessLevels.NoAccess))), Duration.Inf)
+    Await.result(gcsDAO.getMaximumAccessLevel(testCollaborator.userEmail, testWorkspaceId), Duration.Inf) should be (WorkspaceAccessLevels.NoAccess)
 
     // check that we can properly deconstruct group names
-    val groupName = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevel.Owner)
-    gcsDAO.fromGroupId(groupName) should be (Some(WorkspacePermissionsPair(testWorkspaceId, WorkspaceAccessLevel.Owner)))
+    val groupName = gcsDAO.toGroupId(testBucket, WorkspaceAccessLevels.Owner)
+    gcsDAO.fromGroupId(groupName) should be (Some(WorkspacePermissionsPair(testWorkspaceId, WorkspaceAccessLevels.Owner)))
 
     // delete the bucket. confirm that the corresponding groups are deleted
     Await.result(gcsDAO.deleteBucket(testCreator, testWorkspaceId), Duration.Inf)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestBase.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestBase.scala
@@ -38,6 +38,7 @@ trait IntegrationTestBase extends FlatSpec with ScalatestRouteTest with Matchers
     new GraphEntityDAO(),
     new GraphMethodConfigurationDAO(),
     new GraphAuthDAO(),
+    new GraphBillingDAO(),
     new GraphSubmissionDAO()
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestBase.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestBase.scala
@@ -37,6 +37,7 @@ trait IntegrationTestBase extends FlatSpec with ScalatestRouteTest with Matchers
     new GraphWorkspaceDAO(),
     new GraphEntityDAO(),
     new GraphMethodConfigurationDAO(),
+    new GraphAuthDAO(),
     new GraphSubmissionDAO()
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestConfig.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestConfig.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.integrationtest
 
 import java.io.File
+import scala.collection.JavaConversions._
 
 import com.typesafe.config.ConfigFactory
 
@@ -29,4 +30,9 @@ trait IntegrationTestConfig {
   val ldapProviderUrl = ldapConfig.getString("providerUrl")
   val ldapUser = ldapConfig.getString("user")
   val ldapPassword = ldapConfig.getString("password")
+  val ldapGroupDn = ldapConfig.getString("groupDn")
+  val ldapMemberAttribute = ldapConfig.getString("memberAttribute")
+  val ldapUserObjectClasses = ldapConfig.getStringList("userObjectClasses").toList
+  val ldapUserAttributes = ldapConfig.getStringList("userAttributes").toList
+  val ldapUserDnFormat = ldapConfig.getString("userDnFormat")
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestConfig.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/IntegrationTestConfig.scala
@@ -24,4 +24,9 @@ trait IntegrationTestConfig {
 
   val integrationConfig = jenkinsConf.withFallback(etcConf).getConfig("integration")
   val integrationRunFullLoadTest = integrationConfig.getBoolean("runFullLoadTest")
+
+  val ldapConfig = jenkinsConf.withFallback(etcConf).getConfig("userLdap")
+  val ldapProviderUrl = ldapConfig.getString("providerUrl")
+  val ldapUser = ldapConfig.getString("user")
+  val ldapPassword = ldapConfig.getString("password")
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/JndiUserDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/JndiUserDirectoryDAOSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class JndiUserDirectoryDAOSpec extends FlatSpec with Matchers with IntegrationTestConfig {
 
   "JndiUserDirectoryDAO" should "create/enable/disable users" in {
-    val dao = new JndiUserDirectoryDAO(ldapProviderUrl, ldapUser, ldapPassword)
+    val dao = new JndiUserDirectoryDAO(ldapProviderUrl, ldapUser, ldapPassword, ldapGroupDn, ldapMemberAttribute, ldapUserObjectClasses, ldapUserAttributes, ldapUserDnFormat)
     val user = RawlsUser(RawlsUserSubjectId(UUID.randomUUID().toString), RawlsUserEmail("foo@bar.com"))
 
     assert(!Await.result(dao.isEnabled(user), Duration.Inf))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/JndiUserDirectoryDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/JndiUserDirectoryDAOSpec.scala
@@ -1,0 +1,32 @@
+package org.broadinstitute.dsde.rawls.integrationtest
+
+import java.util.UUID
+
+import org.broadinstitute.dsde.rawls.dataaccess.JndiUserDirectoryDAO
+import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, RawlsUserSubjectId, RawlsUser}
+import org.scalatest.{Matchers, FlatSpec}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+ * Created by dvoet on 11/5/15.
+ */
+class JndiUserDirectoryDAOSpec extends FlatSpec with Matchers with IntegrationTestConfig {
+
+  "JndiUserDirectoryDAO" should "create/enable/disable users" in {
+    val dao = new JndiUserDirectoryDAO(ldapProviderUrl, ldapUser, ldapPassword)
+    val user = RawlsUser(RawlsUserSubjectId(UUID.randomUUID().toString), RawlsUserEmail("foo@bar.com"))
+
+    assert(!Await.result(dao.isEnabled(user), Duration.Inf))
+    Await.result(dao.createUser(user), Duration.Inf)
+    assert(!Await.result(dao.isEnabled(user), Duration.Inf))
+    Await.result(dao.enableUser(user), Duration.Inf)
+    assert(Await.result(dao.isEnabled(user), Duration.Inf))
+    Await.result(dao.disableUser(user), Duration.Inf)
+    assert(!Await.result(dao.isEnabled(user), Duration.Inf))
+    Await.result(dao.removeUser(user), Duration.Inf)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -44,7 +44,7 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbT
   val intOptName = "w1.t1.int_opt"
   val intArrayName = "w1.int_array"
 
-  val workspace = new Workspace("workspaces", "test_workspace", "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty)
+  val workspace = new Workspace("workspaces", "test_workspace", "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
 
   val sampleGood = new Entity("sampleGood", "Sample", Map("blah" -> AttributeNumber(1)))
   val sampleMissingValue = new Entity("sampleMissingValue", "Sample", Map.empty)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -4,9 +4,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{DataSource, RawlsTransaction}
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
-import org.scalatest.{WordSpecLike, Matchers, FlatSpec}
-
-import scala.util.{Failure, Success}
+import org.scalatest.{WordSpecLike, Matchers}
 
 class MethodConfigResolverSpec extends WordSpecLike with Matchers with OrientDbTestFixture {
   val littleWdl =

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -48,7 +48,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpe
 
   class SubmissionTestData() extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
-    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", new HashMap[String, Attribute]() )
+    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
 
     val sample1 = Entity("sample1", "Sample",
       Map("type" -> AttributeString("normal")))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -48,7 +48,9 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpe
 
   class SubmissionTestData() extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
-    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map.empty)
+    val user = RawlsUser(userInfo)
+    val ownerGroup = makeRawlsGroup("workspaceOwnerGroup", Set(user), Set.empty)
+    val workspace = Workspace(wsName.namespace, wsName.name, "aWorkspaceId", "aBucket", DateTime.now, DateTime.now, "testUser", Map.empty, Map(WorkspaceAccessLevels.Owner -> ownerGroup))
 
     val sample1 = Entity("sample1", "Sample",
       Map("type" -> AttributeString("normal")))
@@ -105,6 +107,8 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpe
             "wf.x.five" -> AttributeNumber(4))))))
 
     override def save(txn:RawlsTransaction): Unit = {
+      authDAO.saveUser(user, txn)
+      authDAO.saveGroup(ownerGroup, txn)
       workspaceDAO.save(workspace, txn)
       withWorkspaceContext(workspace, txn, bSkipLockCheck=true) { context =>
         entityDAO.save(context, sample1, txn)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/openam/MockUserInfoDirectives.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/openam/MockUserInfoDirectives.scala
@@ -6,7 +6,7 @@ import spray.http.OAuth2BearerToken
 import spray.routing.Directive1
 import spray.routing.Directives._
 
-import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext
 
 trait MockUserInfoDirectives extends UserInfoDirectives {
   def requireUserInfo(magnet: ImplicitMagnet[ExecutionContext]): Directive1[UserInfo] = {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
@@ -87,7 +87,7 @@ class UserApiServiceSpec extends FlatSpec with HttpService with ScalatestRouteTe
   def getMatchingUserVertices(graph: Graph, user: RawlsUser): Iterable[Vertex] =
     graph.getVertices.filter(v => {
       v.asInstanceOf[OrientVertex].getRecord.getClassName.equalsIgnoreCase(VertexSchema.User) &&
-        v.getProperty[String]("userSubjectId") == user.userSubjectId.value
+        v.getProperty[String]("userSubjectId") == user.userSubjectId.toString
     })
 
 
@@ -166,7 +166,7 @@ class UserApiServiceSpec extends FlatSpec with HttpService with ScalatestRouteTe
             status
           }
         }
-      Get(s"/user/${user.userSubjectId.value}") ~>
+      Get(s"/user/${user.userSubjectId}") ~>
         sealRoute(services.userRoutes) ~>
         check {
           assertResult(StatusCodes.OK) {
@@ -176,14 +176,14 @@ class UserApiServiceSpec extends FlatSpec with HttpService with ScalatestRouteTe
             responseAs[UserStatus]
           }
         }
-      Post(s"/user/${user.userSubjectId.value}/enable") ~>
+      Post(s"/user/${user.userSubjectId}/enable") ~>
         sealRoute(services.userRoutes) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
           }
         }
-      Get(s"/user/${user.userSubjectId.value}") ~>
+      Get(s"/user/${user.userSubjectId}") ~>
         sealRoute(services.userRoutes) ~>
         check {
           assertResult(StatusCodes.OK) {
@@ -193,14 +193,14 @@ class UserApiServiceSpec extends FlatSpec with HttpService with ScalatestRouteTe
             responseAs[UserStatus]
           }
         }
-      Post(s"/user/${user.userSubjectId.value}/disable") ~>
+      Post(s"/user/${user.userSubjectId}/disable") ~>
         sealRoute(services.userRoutes) ~>
         check {
           assertResult(StatusCodes.NoContent) {
             status
           }
         }
-      Get(s"/user/${user.userSubjectId.value}") ~>
+      Get(s"/user/${user.userSubjectId}") ~>
         sealRoute(services.userRoutes) ~>
         check {
           assertResult(StatusCodes.OK) {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -216,7 +216,7 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
         val dateTime = org.joda.time.DateTime.now
         services.dataSource.inTransaction() { txn =>
           assertResult(
-            WorkspaceListResponse(WorkspaceAccessLevel.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
+            WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
             ){
               val response = responseAs[WorkspaceListResponse]
               WorkspaceListResponse(response.accessLevel, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.owners)
@@ -259,9 +259,9 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
         val dateTime = org.joda.time.DateTime.now
         services.dataSource.inTransaction() { txn =>
           assertResult(Set(
-            WorkspaceListResponse(WorkspaceAccessLevel.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
-            WorkspaceListResponse(WorkspaceAccessLevel.Write, testWorkspaces.workspaceWriter.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
-            WorkspaceListResponse(WorkspaceAccessLevel.Read, testWorkspaces.workspaceReader.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
+            WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspaceOwner.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
+            WorkspaceListResponse(WorkspaceAccessLevels.Write, testWorkspaces.workspaceWriter.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf)),
+            WorkspaceListResponse(WorkspaceAccessLevels.Read, testWorkspaces.workspaceReader.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Await.result(services.gcsDao.getOwners(testWorkspaces.workspaceOwner.workspaceId), Duration.Inf))
           )) {
             responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
           }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -103,10 +103,10 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
 
   class TestWorkspaces() extends TestData {
     val writerWorkspaceName = WorkspaceName("ns", "writer")
-    val workspaceOwner = Workspace("ns", "owner", "workspaceId1", "bucket1", testDate, testDate, "testUser", Map("a" -> AttributeString("x")) )
-    val workspaceWriter = Workspace(writerWorkspaceName.namespace, writerWorkspaceName.name, "workspaceId2", "bucket2", testDate, testDate, "testUser", Map("b" -> AttributeString("y")) )
-    val workspaceReader = Workspace("ns", "reader", "workspaceId3", "bucket3", testDate, testDate, "testUser", Map("c" -> AttributeString("z")) )
-    val workspaceNoAccess = Workspace("ns", "noaccess", "workspaceId4", "bucket4", testDate, testDate, "testUser", Map("d" -> AttributeString("afterz")) )
+    val workspaceOwner = Workspace("ns", "owner", "workspaceId1", "bucket1", testDate, testDate, "testUser", Map("a" -> AttributeString("x")), Map.empty)
+    val workspaceWriter = Workspace(writerWorkspaceName.namespace, writerWorkspaceName.name, "workspaceId2", "bucket2", testDate, testDate, "testUser", Map("b" -> AttributeString("y")), Map.empty)
+    val workspaceReader = Workspace("ns", "reader", "workspaceId3", "bucket3", testDate, testDate, "testUser", Map("c" -> AttributeString("z")), Map.empty)
+    val workspaceNoAccess = Workspace("ns", "noaccess", "workspaceId4", "bucket4", testDate, testDate, "testUser", Map("d" -> AttributeString("afterz")), Map.empty)
 
     val sample1 = Entity("sample1", "sample", Map.empty)
     val sample2 = Entity("sample2", "sample", Map.empty)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -260,7 +260,8 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
       }
   }
 
-  it should "list workspaces" in withTestWorkspacesApiServices { services =>     Get("/workspaces") ~>
+  it should "list workspaces" in withTestWorkspacesApiServices { services =>
+    Get("/workspaces") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -102,10 +102,10 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
   }
 
   class TestWorkspaces() extends TestData {
-    val user = RawlsUser(userInfo.userSubjectId)
-    val workspaceOwnerGroup = RawlsGroup("workspaceOwnerGroup", Set(user), Set.empty)
-    val workspaceWriterGroup = RawlsGroup("workspaceWriterGroup", Set(user), Set.empty)
-    val workspaceReaderGroup = RawlsGroup("workspaceReaderGroup", Set(user), Set.empty)
+    val user = RawlsUser(userInfo)
+    val workspaceOwnerGroup = makeRawlsGroup("workspaceOwnerGroup", Set(user), Set.empty)
+    val workspaceWriterGroup = makeRawlsGroup("workspaceWriterGroup", Set(user), Set.empty)
+    val workspaceReaderGroup = makeRawlsGroup("workspaceReaderGroup", Set(user), Set.empty)
 
     val writerWorkspaceName = WorkspaceName("ns", "writer")
     val workspaceOwner = Workspace("ns", "owner", "workspaceId1", "bucket1", testDate, testDate, "testUser", Map("a" -> AttributeString("x")), Map(WorkspaceAccessLevels.Owner -> workspaceOwnerGroup))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -3,25 +3,22 @@ package org.broadinstitute.dsde.rawls.webservice
 import java.util.UUID
 
 import akka.actor.PoisonPill
-import org.broadinstitute.dsde.rawls.dataaccess.{DataSource, GraphEntityDAO, GraphMethodConfigurationDAO, GraphWorkspaceDAO, HttpExecutionServiceDAO, HttpMethodRepoDAO, _}
+import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.graph.OrientDbTestFixture
 import org.broadinstitute.dsde.rawls.jobexec.SubmissionSupervisor
 import org.broadinstitute.dsde.rawls.mock.RemoteServicesMockServer
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.openam.{UserInfoDirectives, MockUserInfoDirectives}
+import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 import org.broadinstitute.dsde.vault.common.util.ImplicitMagnet
 import org.scalatest.{FlatSpec, Matchers}
-import spray.http.HttpHeaders.Cookie
 import spray.http._
 import spray.httpx.SprayJsonSupport._
 import spray.json._
-import spray.routing.Directives._
 import spray.routing._
 import spray.testkit.ScalatestRouteTest
-import scala.collection.immutable.HashMap
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -102,10 +102,15 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
   }
 
   class TestWorkspaces() extends TestData {
+    val user = RawlsUser(userInfo.userSubjectId)
+    val workspaceOwnerGroup = RawlsGroup("workspaceOwnerGroup", Set(user), Set.empty)
+    val workspaceWriterGroup = RawlsGroup("workspaceWriterGroup", Set(user), Set.empty)
+    val workspaceReaderGroup = RawlsGroup("workspaceReaderGroup", Set(user), Set.empty)
+
     val writerWorkspaceName = WorkspaceName("ns", "writer")
-    val workspaceOwner = Workspace("ns", "owner", "workspaceId1", "bucket1", testDate, testDate, "testUser", Map("a" -> AttributeString("x")), Map.empty)
-    val workspaceWriter = Workspace(writerWorkspaceName.namespace, writerWorkspaceName.name, "workspaceId2", "bucket2", testDate, testDate, "testUser", Map("b" -> AttributeString("y")), Map.empty)
-    val workspaceReader = Workspace("ns", "reader", "workspaceId3", "bucket3", testDate, testDate, "testUser", Map("c" -> AttributeString("z")), Map.empty)
+    val workspaceOwner = Workspace("ns", "owner", "workspaceId1", "bucket1", testDate, testDate, "testUser", Map("a" -> AttributeString("x")), Map(WorkspaceAccessLevels.Owner -> workspaceOwnerGroup))
+    val workspaceWriter = Workspace(writerWorkspaceName.namespace, writerWorkspaceName.name, "workspaceId2", "bucket2", testDate, testDate, "testUser", Map("b" -> AttributeString("y")), Map(WorkspaceAccessLevels.Write -> workspaceWriterGroup))
+    val workspaceReader = Workspace("ns", "reader", "workspaceId3", "bucket3", testDate, testDate, "testUser", Map("c" -> AttributeString("z")), Map(WorkspaceAccessLevels.Read -> workspaceReaderGroup))
     val workspaceNoAccess = Workspace("ns", "noaccess", "workspaceId4", "bucket4", testDate, testDate, "testUser", Map("d" -> AttributeString("afterz")), Map.empty)
 
     val sample1 = Entity("sample1", "sample", Map.empty)
@@ -142,6 +147,11 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
     )
 
     override def save(txn: RawlsTransaction): Unit = {
+      authDAO.saveUser(user, txn)
+      authDAO.saveGroup(workspaceOwnerGroup, txn)
+      authDAO.saveGroup(workspaceWriterGroup, txn)
+      authDAO.saveGroup(workspaceReaderGroup, txn)
+
       workspaceDAO.save(workspaceOwner, txn)
       workspaceDAO.save(workspaceWriter, txn)
       workspaceDAO.save(workspaceReader, txn)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -460,8 +460,8 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
 
   // Update Workspace requires WRITE access.  Accept if OWNER or WRITE; Reject if READ or NO ACCESS
 
-  it should "allow an owner-access user to update a workspace" in withTestDataApiServicesAndUser("owner-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("boo"): AttributeUpdateOperation).toJson.toString())) ~>
+  it should "allow an owner-access user to update a workspace" in withTestWorkspacesApiServicesAndUser("owner-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceOwner.namespace}/${testWorkspaces.workspaceOwner.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("a"): AttributeUpdateOperation).toJson.toString())) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -470,8 +470,8 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
       }
   }
 
-  it should "allow a write-access user to update a workspace" in withTestDataApiServicesAndUser("write-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("boo"): AttributeUpdateOperation).toJson.toString())) ~>
+  it should "allow a write-access user to update a workspace" in withTestWorkspacesApiServicesAndUser("write-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceWriter.namespace}/${testWorkspaces.workspaceWriter.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("b"): AttributeUpdateOperation).toJson.toString())) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -480,8 +480,8 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
       }
   }
 
-  it should "not allow a read-access user to update a workspace" in withTestDataApiServicesAndUser("read-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("boo"): AttributeUpdateOperation).toJson.toString())) ~>
+  it should "not allow a read-access user to update a workspace" in withTestWorkspacesApiServicesAndUser("read-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceReader.namespace}/${testWorkspaces.workspaceReader.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("c"): AttributeUpdateOperation).toJson.toString())) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
@@ -490,8 +490,8 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
       }
   }
 
-  it should "not allow a no-access user to update a workspace" in withTestDataApiServicesAndUser("no-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("boo"): AttributeUpdateOperation).toJson.toString())) ~>
+  it should "not allow a no-access user to update a workspace" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceNoAccess.namespace}/${testWorkspaces.workspaceNoAccess.name}", HttpEntity(ContentTypes.`application/json`, Seq(RemoveAttribute("d"): AttributeUpdateOperation).toJson.toString())) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -502,32 +502,32 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
 
   // Put ACL requires OWNER access.  Accept if OWNER; Reject if WRITE, READ, NO ACCESS
 
-  it should "allow an owner-access user to update an ACL" in withTestDataApiServicesAndUser("owner-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
+  it should "allow an owner-access user to update an ACL" in withTestWorkspacesApiServicesAndUser("owner-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceOwner.namespace}/${testWorkspaces.workspaceOwner.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) { status }
       }
   }
 
-  it should "not allow a write-access user to update an ACL" in withTestDataApiServicesAndUser("write-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
+  it should "not allow a write-access user to update an ACL" in withTestWorkspacesApiServicesAndUser("write-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceWriter.namespace}/${testWorkspaces.workspaceWriter.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) { status }
       }
   }
 
-  it should "not allow a read-access user to update an ACL" in withTestDataApiServicesAndUser("read-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
+  it should "not allow a read-access user to update an ACL" in withTestWorkspacesApiServicesAndUser("read-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceReader.namespace}/${testWorkspaces.workspaceReader.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) { status }
       }
   }
 
-  it should "not allow a no-access user to update an ACL" in withTestDataApiServicesAndUser("no-access") { services =>
-    Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
+  it should "not allow a no-access user to update an ACL" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
+    Patch(s"/workspaces/${testWorkspaces.workspaceNoAccess.namespace}/${testWorkspaces.workspaceNoAccess.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq.empty.toJson.toString)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) { status }
@@ -608,25 +608,25 @@ class WorkspaceApiServiceSpec extends FlatSpec with HttpService with ScalatestRo
   }
 
   it should "not allow a non-owner to lock or unlock the workspace" in withEmptyWorkspaceApiServices("write-access") { services =>
-    Put(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/lock") ~>
+    Put(s"/workspaces/${testData.workspaceWriter.namespace}/${testData.workspaceWriter.name}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) { status }
       }
-    Put(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/unlock") ~>
+    Put(s"/workspaces/${testData.workspaceWriter.namespace}/${testData.workspaceWriter.name}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) { status }
       }
   }
 
-  it should "not allow a no-access user to infer the existence the workspace by locking or unlocking" in withLockedWorkspaceApiServices("no-access") { services =>
-    Put(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/lock") ~>
+  it should "not allow a no-access user to infer the existence of the workspace by locking or unlocking" in withLockedWorkspaceApiServices("no-access") { services =>
+    Put(s"/workspaces/${testData.workspaceNoAccess.namespace}/${testData.workspaceNoAccess.name}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) { status }
       }
-    Put(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/unlock") ~>
+    Put(s"/workspaces/${testData.workspaceNoAccess.namespace}/${testData.workspaceNoAccess.name}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) { status }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -12,7 +12,6 @@ import org.broadinstitute.dsde.rawls.webservice._
 import AttributeUpdateOperations._
 import org.joda.time.DateTime
 import org.scalatest.{FlatSpec, Matchers}
-import spray.http.{StatusCodes, ContentTypes, HttpEntity, HttpCookie}
 import spray.testkit.ScalatestRouteTest
 
 import scala.concurrent.ExecutionContext

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -16,7 +16,6 @@ import spray.testkit.ScalatestRouteTest
 
 import scala.concurrent.ExecutionContext
 
-
 class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matchers with OrientDbTestFixture {
   val attributeList = AttributeValueList(Seq(AttributeString("a"), AttributeString("b"), AttributeBoolean(true)))
   val s1 = Entity("s1", "samples", Map("foo" -> AttributeString("x"), "bar" -> AttributeNumber(3), "splat" -> attributeList))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -28,6 +28,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     DateTime.now().withMillis(0),
     DateTime.now().withMillis(0),
     "test",
+    Map.empty,
     Map.empty
   )
 


### PR DESCRIPTION
Looking for feedback on this PR. Adding an implicit `toString` to `UserAuthType` makes doing `rawlsGroupEmail.value` unnecessary, which is nice.

The tradeoff is having to be more careful in type comparisons (using `toString` where necessary) and explicitly specifying e.g. `hasPropertyValue[String]` instead of `hasPropertyValue`.

I would like the team's +1/+0/-1 for this change.
