### PR TITLE
add ws creators proxy group to google group instead of email

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -121,7 +121,7 @@ class HttpGoogleServicesDAO(
       retry(when500) {
         () => Future {
           val ownersGroupId = toGroupId(bucketName, WorkspaceAccessLevels.Owner)
-          val owner = new Member().setEmail(userInfo.userEmail).setRole(groupMemberRole)
+          val owner = new Member().setEmail(toProxyFromUser(userInfo)).setRole(groupMemberRole)
           val ownerInserter = directory.members.insert(ownersGroupId, owner)
           blocking {
             ownerInserter.execute


### PR DESCRIPTION
Related to the bug brought up in HipChat on nov 14/15.

When a workspace was created, the creators real email was being added to the OWNER google group. Their proxy group is what needed to be added. This resulted in several ACL problems.

I've checked other areas where this could happen and didn't find any.
