### PR TITLE
Move getUserStatus endpoint out from under proxy

### DIFF
--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1910,7 +1910,7 @@ paths:
             - openid
             - email
             - profile
-  /workspaces:
+  '/api/workspaces':
     post:
       responses:
         '200':
@@ -2163,13 +2163,14 @@ paths:
             - openid
             - email
             - profile
-  '/api/user':
      get:
        responses:
          '200':
            description: Successful Request
            schema:
              $ref: '#/definitions/UserStatus'
+         '404':
+           description: User Not Found
          '500':
            description: Rawls Internal Error
            schema:
@@ -2185,6 +2186,7 @@ paths:
             - openid
             - email
             - profile
+            
   '/api/user/{userSubjectId}/disable':
      post:
        responses:

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -28,7 +28,7 @@ class RawlsApiServiceActor(val workspaceServiceConstructor: UserInfo => Workspac
 
   def actorRefFactory = context
   def apiRoutes = options{ complete(OK) } ~ baseRoute ~ workspaceRoutes ~ entityRoutes ~ methodConfigRoutes ~ submissionRoutes ~ adminRoutes ~ userRoutes
-  def registerRoutes = options{ complete(OK) } ~ createUserRoute
+  def registerRoutes = options{ complete(OK) } ~ createUserRoute ~ getUserStatusRoute
 
   val swaggerRoute = {
     get {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
@@ -31,6 +31,16 @@ trait UserApiService extends HttpService with PerRequestCreator with UserInfoDir
     }
   }
 
+  val getUserStatusRoute = requireUserInfo() { userInfo =>
+    path("user") {
+      get {
+        requestContext => perRequest(requestContext,
+          UserService.props(userServiceConstructor, userInfo),
+          UserService.UserGetUserStatus)
+      }
+    }
+  }
+
   val userRoutes = requireUserInfo() { userInfo =>
     path("user" / "refreshToken") {
       put {
@@ -60,13 +70,6 @@ trait UserApiService extends HttpService with PerRequestCreator with UserInfoDir
         requestContext => perRequest(requestContext,
           UserService.props(userServiceConstructor, userInfo),
           UserService.AdminGetUserStatus(RawlsUserRef(RawlsUserSubjectId(userSubjectId))))
-      }
-    } ~
-    path("user") {
-      get {
-        requestContext => perRequest(requestContext,
-          UserService.props(userServiceConstructor, userInfo),
-          UserService.UserGetUserStatus)
       }
     } ~
     path("user" / Segment / "enable") { userSubjectId =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
@@ -177,7 +177,7 @@ class UserApiServiceSpec extends ApiServiceSpec {
     }
 
     Get("/user") ~>
-      sealRoute(services.userRoutes) ~>
+      sealRoute(services.getUserStatusRoute) ~>
       check {
         assertResult(StatusCodes.OK) {
           status


### PR DESCRIPTION
Moves the getUserStatus endpoint out from under the proxy so that it can be accessed by users that don't exist. Now silver can determine if a user is already registered before trying to register them again. No associated ticket.
