### PR TITLE
Redundant creation of bucketName

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -166,7 +166,6 @@ class UserService(protected val userInfo: UserInfo, dataSource: DataSource, prot
         case None =>
           // note: executes in a Future
           gcsDAO.createCromwellAuthBucket(projectName) map { bucketName =>
-            val bucketName = gcsDAO.getCromwellAuthBucketName(projectName)
             val bucketUrl = "gs://" + bucketName
             containerDAO.billingDAO.saveProject(RawlsBillingProject(projectName, Set.empty, bucketUrl), txn)
             RequestComplete(StatusCodes.Created)


### PR DESCRIPTION
Not needed, and masks the other bucketName.  Could conflict in the future.
