### PR TITLE
Retry buckets and groups after being rate limited

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,7 +5,8 @@ akka {
 
 spray.can {
   server {
-    request-timeout = 30s
+    request-timeout = 180s
+    idle-timeout = 210s
     parsing {
       max-content-length = 50m
     }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/Retry.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/Retry.scala
@@ -19,7 +19,11 @@ trait Retry {
     retry(allBackoffIntervals)(op,pred)
   }
 
-  private def retry[T](remainingBackoffIntervals: Seq[FiniteDuration])(op: => () => Future[T], pred: (Throwable) => Boolean )(implicit executionContext: ExecutionContext): Future[T] = {
+  def retryExponentially[T](pred: (Throwable) => Boolean = always)(op: () => Future[T])(implicit executionContext: ExecutionContext): Future[T] = {
+    retry(exponentialBackOffIntervals)(op,pred)
+  }
+
+  private def retry[T](remainingBackoffIntervals: Seq[FiniteDuration])(op: => () => Future[T], pred: (Throwable) => Boolean)(implicit executionContext: ExecutionContext): Future[T] = {
     op().recoverWith {
       case t if pred(t) && !remainingBackoffIntervals.isEmpty => after(remainingBackoffIntervals.head, system.scheduler) {
         retry(remainingBackoffIntervals.tail)(op, pred)
@@ -30,4 +34,10 @@ trait Retry {
   private def always( throwable: Throwable ) = { true }
 
   private val allBackoffIntervals = Seq(100 milliseconds, 1 second, 3 seconds)
+
+  private def exponentialBackOffIntervals: Seq[FiniteDuration] = {
+    val plainIntervals = Seq(1000 milliseconds, 2000 milliseconds, 4000 milliseconds, 8000 milliseconds, 16000 milliseconds, 32000 milliseconds)
+    plainIntervals.map(i => i.+(scala.util.Random.nextInt(1000) milliseconds))
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/PerRequest.scala
@@ -154,7 +154,7 @@ object PerRequest {
 trait PerRequestCreator {
   implicit def actorRefFactory: ActorRefFactory
 
-  def perRequest(r: RequestContext, props: Props, message: AnyRef, timeout: Duration = 1 minutes) =
+  def perRequest(r: RequestContext, props: Props, message: AnyRef, timeout: Duration = 3 minutes) =
     actorRefFactory.actorOf(Props(new WithProps(r, props, message, timeout)))
 }
 


### PR DESCRIPTION
This seems to work, although response times are pretty bad (can be ~2 minutes or so). 

Google returns a 403: usageLimits when we create too many groups too quickly, and they return a 429 when we create 2+ buckets within 2 seconds of one another. After talking with Miguel, Red team had some 429 problems where Google was putting a cooldown time once hitting the rate limit. We should probably investigate if that's happening for us too and causing additional retries.
