### PR TITLE
implemented api to get method input and output metadata

### DIFF
--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1950,6 +1950,38 @@ paths:
             - openid
             - email
             - profile
+  /methodconfigs/inputsOutputs:
+    post:
+      responses:
+        '200':
+          description: Successful Request
+          schema:
+            $ref: '#/definitions/MethodInputsOutputs'
+        '400':
+          description: Method WDL can't be parsed
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        '404':
+          description: No such method
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      description: ''
+      tags:
+        - methodconfigs
+      summary: Get information about a method's inputs and outputs
+      operationId: method_inputs_outputs
+      parameters:
+        - in: body
+          description: name of method to use for template
+          name: methodName
+          required: true
+          schema:
+            $ref: '#/definitions/MethodRepoMethod'
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   '/api/workspaces/{workspaceNamespace}/{workspaceName}/lock':
     put:
       responses:
@@ -3557,9 +3589,9 @@ definitions:
     description: information about a rawls user
     properties:
       userSubjectId:
-        type: String
+        type: string
       userEmail:
-        type: String
+        type: string
   RawlsUserInfo:
     description: information about a rawls user
     properties:
@@ -3576,3 +3608,30 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/RawlsUserInfo'
+  MethodInput:
+    description: description of a method input
+    properties:
+      name:
+        type: string
+      inputType:
+        type: string
+      optional:
+        type: boolean
+  MethodOutput:
+    description: description of a method output
+    properties:
+      name:
+        type: string
+      outputType:
+        type: string
+  MethodInputsOutputs:
+    description: description of a method's inputs and outputs
+    properties:
+      inputs:
+        type: array
+        items:
+          $ref: '#/definitions/MethodInput'
+      outputs:
+        type: array
+        items:
+          $ref: '#/definitions/MethodOutput'

--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -4,7 +4,7 @@ import cromwell.binding.types.{WdlType, WdlArrayType}
 import cromwell.binding.{WorkflowInput, NamespaceWithWorkflow, WdlNamespace}
 import cromwell.engine.backend.Backend
 import cromwell.parser.BackendType
-import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.{model, RawlsException}
 import org.broadinstitute.dsde.rawls.dataaccess.{WorkspaceContext, RawlsTransaction}
 import org.broadinstitute.dsde.rawls.expressions.{ExpressionParser, ExpressionEvaluator}
 import org.broadinstitute.dsde.rawls.model._
@@ -122,5 +122,12 @@ object MethodConfigResolver {
     val inputs = for ( input <- workflow.inputs ) yield input.fqn.toString -> nothing
     val outputs = for ( output <- workflow.outputs ) yield output._1.toString -> nothing
     MethodConfiguration("namespace","name","rootEntityType",Map(),inputs.toMap,outputs,methodRepoMethod)
+  }
+
+  def getMethodInputsOutputs(wdl: String) = {
+    val workflow = NamespaceWithWorkflow.load(wdl, BackendType.LOCAL).workflow
+    MethodInputsOutputs(
+      workflow.inputs.map(i => model.MethodInput(i.fqn, i.wdlType.toWdlString, i.optional)),
+      workflow.outputs.map(o => MethodOutput(o._1, o._2.toWdlString)).toSeq)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -110,6 +110,10 @@ case class MethodRepoMethod(
   def idFields = Seq("methodName")
 }
 
+case class MethodInput(name: String, inputType: String, optional: Boolean)
+case class MethodOutput(name: String, outputType: String)
+case class MethodInputsOutputs(intputs: Seq[MethodInput], outputs: Seq[MethodOutput])
+
 case class MethodConfiguration(
                    namespace: String,
                    name: String,
@@ -267,6 +271,12 @@ object WorkspaceJsonSupport extends JsonSupport {
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 
   implicit val ValidatedMethodConfigurationFormat = jsonFormat5(ValidatedMethodConfiguration)
+
+  implicit val MethodInputFormat = jsonFormat3(MethodInput)
+
+  implicit val MethodOutputFormat = jsonFormat2(MethodOutput)
+
+  implicit val MethodInputsOutputsFormat = jsonFormat2(MethodInputsOutputs)
 
   implicit object StatusCodeFormat extends JsonFormat[StatusCode] {
     override def write(code: StatusCode): JsValue = JsNumber(code.intValue)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiService.scala
@@ -101,6 +101,15 @@ trait MethodConfigApiService extends HttpService with PerRequestCreator with Use
                                         WorkspaceService.CreateMethodConfigurationTemplate(methodRepoMethod))
         }
       }
+    } ~
+    path("methodconfigs" / "inputsOutputs") {
+      post {
+        entity(as[MethodRepoMethod]) { methodRepoMethod =>
+          requestContext => perRequest(requestContext,
+            WorkspaceService.props(workspaceServiceConstructor, userInfo),
+            WorkspaceService.GetMethodInputsOutputs(methodRepoMethod))
+        }
+      }
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
@@ -437,7 +437,27 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "return 200 getting method inputs and outputs" in withTestDataApiServices { services =>
+    val method = MethodRepoMethod("dsde","three_step",1)
+    Post("/methodconfigs/inputsOutputs", httpJson(method)) ~>
+      sealRoute(services.methodConfigRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) { status }
+        assertResult(MethodInputsOutputs(Seq(MethodInput("three_step.cgrep.pattern","String",false)),Seq(MethodOutput("three_step.ps.procs","File"), MethodOutput("three_step.cgrep.count","Int"), MethodOutput("three_step.wc.count","Int")))) {
+          responseAs[MethodInputsOutputs]
+        }
+      }
+  }
+
   it should "return 404 when generating a method config template from a bogus method" in withTestDataApiServices { services =>
+    Post("/methodconfigs/template", httpJson(MethodRepoMethod("dsde","three_step",2))) ~>
+      sealRoute(services.methodConfigRoutes) ~>
+      check {
+        assertResult(StatusCodes.NotFound) { status }
+      }
+  }
+
+  it should "return 404 getting method inputs and outputs from a bogus method" in withTestDataApiServices { services =>
     Post("/methodconfigs/template", httpJson(MethodRepoMethod("dsde","three_step",2))) ~>
       sealRoute(services.methodConfigRoutes) ~>
       check {


### PR DESCRIPTION
This new end point parses the wdl to get input/output info. This carries type and optional status which is not present in the method config. It is also the master list; the method config is allowed to have missing entries for inputs and/or outputs.

https://broadinstitute.atlassian.net/browse/DSDEEPB-2266
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [ ] **Submitter**: Check configuration files in Jenkins in case they need changes
- [ ] **Submitter**: Verify swagger UI on dev server still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
