### PR TITLE
DSDEEPB-2021 Enable string and numeric literals for method configuration inputs

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
@@ -63,7 +63,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
       MethodRepoMethod(testData.wsName.namespace, "method-a", 1))
 
     val expectedSuccessInputs = Seq("good_in")
-    val expectedFailureInputs = Map("bad_in" -> "Failed at line 1, column 1: `workspace.' expected but `d' found")
+    val expectedFailureInputs = Map("bad_in" -> "Failed at line 1, column 1: string matching regex `^\\\".*\\\"$' expected but `d' found")
     val expectedSuccessOutputs = Seq("good_out")
     val expectedFailureOutputs = Map("bad_out" -> "Failed at line 1, column 1: `workspace.' expected but `a' found")
 
@@ -239,7 +239,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     val modifiedMethodConfig = testData.methodConfig.copy(inputs = newInputs, outputs = newOutputs)
 
     val expectedSuccessInputs = Seq("good_in")
-    val expectedFailureInputs = Map("bad_in" -> "Failed at line 1, column 1: `workspace.' expected but `d' found")
+    val expectedFailureInputs = Map("bad_in" -> "Failed at line 1, column 1: string matching regex `^\\\".*\\\"$' expected but `d' found")
     val expectedSuccessOutputs = Seq("good_out")
     val expectedFailureOutputs = Map("bad_out" -> "Failed at line 1, column 1: `workspace.' expected but `a' found")
 
@@ -271,7 +271,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     val theOutputs = Map("good_out" -> AttributeString("this.bar"), "bad_out" -> AttributeString("also.does.not.parse"))
 
     val expectedSuccessInputs = Seq("good_in")
-    val expectedFailureInputs = Map("bad_in" -> "Failed at line 1, column 1: `workspace.' expected but `d' found")
+    val expectedFailureInputs = Map("bad_in" -> "Failed at line 1, column 1: string matching regex `^\\\".*\\\"$' expected but `d' found")
     val expectedSuccessOutputs = Seq("good_out")
     val expectedFailureOutputs = Map("bad_out" -> "Failed at line 1, column 1: `workspace.' expected but `a' found")
 


### PR DESCRIPTION
_Update:_ I managed to stand up a local Rawls and submit a job with a literal input to Cromwell. It seems to have turned into a real input as expected, though Cromwell doesn't feel like running the job so it's hard to absolutely-definitely verify.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: Verify swagger UI on dev server still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
