### PR TITLE
use rawls group email stored in db

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -34,10 +34,10 @@ abstract class GoogleServicesDAO(groupsPrefix: String) {
 
   /**
    *
-   * @param groupRef
+   * @param group
    * @return None if the google group does not exist, Some(Seq.empty) if there are no members
    */
-  def listGroupMembers(groupRef: RawlsGroupRef): Future[Option[Set[Either[RawlsUserRef, RawlsGroupRef]]]]
+  def listGroupMembers(group: RawlsGroup): Future[Option[Set[Either[RawlsUserRef, RawlsGroupRef]]]]
 
   def createProxyGroup(user: RawlsUser): Future[Unit]
 
@@ -47,13 +47,13 @@ abstract class GoogleServicesDAO(groupsPrefix: String) {
 
   def isUserInProxyGroup(user: RawlsUser): Future[Boolean]
 
-  def createGoogleGroup(groupRef: RawlsGroupRef): Future[Unit]
+  def createGoogleGroup(groupRef: RawlsGroupRef): Future[RawlsGroup]
 
-  def addMemberToGoogleGroup(groupRef: RawlsGroupRef, member: Either[RawlsUser, RawlsGroup]): Future[Unit]
+  def addMemberToGoogleGroup(group: RawlsGroup, member: Either[RawlsUser, RawlsGroup]): Future[Unit]
 
-  def removeMemberFromGoogleGroup(groupRef: RawlsGroupRef, memberToAdd: Either[RawlsUser, RawlsGroup]): Future[Unit]
+  def removeMemberFromGoogleGroup(group: RawlsGroup, memberToAdd: Either[RawlsUser, RawlsGroup]): Future[Unit]
 
-  def deleteGoogleGroup(groupRef: RawlsGroupRef): Future[Unit]
+  def deleteGoogleGroup(group: RawlsGroup): Future[Unit]
 
   def storeToken(userInfo: UserInfo, refreshToken: String): Future[Unit]
   def getToken(rawlsUserRef: RawlsUserRef): Future[Option[String]]
@@ -62,7 +62,6 @@ abstract class GoogleServicesDAO(groupsPrefix: String) {
 
   def toProxyFromUser(userSubjectId: RawlsUserSubjectId): String
   def toUserFromProxy(proxy: String): String
-  def toGoogleGroupName(groupName: RawlsGroupName): String
 
   def toErrorReport(throwable: Throwable) = {
     val SOURCE = "google"

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -306,7 +306,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     Post(s"/admin/groups", httpJson(group)) ~>
       sealRoute(services.adminRoutes) ~>
       check {
-        assertResult(StatusCodes.Created) { status }
+        assertResult(StatusCodes.Created, response.entity.asString) { status }
       }
   }
 


### PR DESCRIPTION
Change to use rawls group email as it is store in db instead of calling toGoogleGroup all the time. This allows us to change how we name groups without breaking all existing groups. This is actually going to happen I realize as part of https://github.com/broadinstitute/rawls/pull/266
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Merge to develop 
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: Check configuration files in Jenkins in case they need changes
- [ ] **Submitter**: Verify swagger UI on dev server still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
