### PR TITLE
Refactoring for easier testing

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AllComponents.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AllComponents.scala
@@ -1,0 +1,18 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+trait AllComponents
+  extends PendingBucketDeletionComponent
+  // with OtherComponent
+  // with OtherComponent
+  {
+
+  this: DriverComponent =>
+
+  import driver.api._
+
+  lazy val allSchemas =
+    pendingBucketDeletionQuery.schema
+    // ++ otherQuery.schema
+    // ++ otherQuery.schema
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -5,11 +5,4 @@ import slick.driver.JdbcProfile
 import scala.concurrent.ExecutionContext
 
 class DataAccessComponent(val driver: JdbcProfile)(implicit val executionContext: ExecutionContext)
-  extends DriverComponent
-  with PendingBucketDeletionComponent {
-
-  import driver.api._
-
-  lazy val schema =
-    pendingBucketDeletionQuery.schema
-}
+extends DriverComponent with AllComponents

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/PendingBucketDeletionComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/PendingBucketDeletionComponentSpec.scala
@@ -1,16 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import org.scalatest.{BeforeAndAfterAll, Matchers, FlatSpec}
-
 /**
  * Created by dvoet on 2/3/16.
  */
-class PendingBucketDeletionComponentSpec extends FlatSpec with Matchers with TestDriverComponent with PendingBucketDeletionComponent with BeforeAndAfterAll {
-  import driver.api._
-
-  override def beforeAll: Unit = {
-    runAndWait(pendingBucketDeletionQuery.schema.create)
-  }
+class PendingBucketDeletionComponentSpec extends TestDriverComponent {
 
   "PendingBucketDeletionComponent" should "create, list and delete" in {
     val deletion = PendingBucketDeletion("foo")

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.scalatest.{FlatSpec, BeforeAndAfterAll, Matchers}
 import slick.backend.DatabaseConfig
 import slick.driver.JdbcProfile
 import slick.driver.H2Driver.api._
@@ -11,7 +12,8 @@ import scala.concurrent.Await
 /**
  * Created by dvoet on 2/3/16.
  */
-trait TestDriverComponent extends DriverComponent {
+trait TestDriverComponent extends FlatSpec with DriverComponent with Matchers with BeforeAndAfterAll with AllComponents {
+
   override implicit val executionContext = TestExecutionContext.testExecutionContext
 
   val databaseConfig: DatabaseConfig[JdbcProfile] = DatabaseConfig.forConfig[JdbcProfile]("h2mem1")
@@ -21,4 +23,15 @@ trait TestDriverComponent extends DriverComponent {
   protected def runAndWait[R](action: DBIOAction[R, _ <: NoStream, _ <: Effect], duration: Duration = 1 minutes): R = {
     Await.result(database.run(action.transactionally), duration)
   }
+
+  import driver.api._
+
+  override def beforeAll: Unit = {
+    runAndWait(allSchemas.create)
+  }
+
+  override def afterAll: Unit = {
+    runAndWait(allSchemas.drop)
+  }
+
 }


### PR DESCRIPTION
On other branches, I found it challenging to keep track of component dependencies and table creation order.  Following this pattern solved these problems.
