### PR TITLE
GAWB-298 prevent copying entities outside of a Realm

### DIFF
--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1410,6 +1410,10 @@ paths:
           description: One or more entities of that name/type already exist
           schema:
             $ref: '#/definitions/ErrorReport'
+        '422':
+          description: Destination workspace must match source's realm, if the source has a realm
+          schema:
+            $ref: '#/definitions/ErrorReport'
         '500':
           description: Rawls Internal Error
           schema:
@@ -2401,7 +2405,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorReport'
         '422':
-          description: Destination workspace realm must match source's realm if it exists
+          description: Destination workspace must match source's realm, if the dest has a realm
           schema:
             $ref: '#/definitions/ErrorReport'
         '500':

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -345,7 +345,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 Not Found on copy if the source workspace cannot be found" in withTestDataApiServices { services =>
+  it should "return 404 Not Found on clone if the source workspace cannot be found" in withTestDataApiServices { services =>
     Post(s"/workspaces/${testData.workspace.namespace}/nonexistent/clone", httpJson(testData.workspace)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -576,7 +576,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 409 Conflict on copy if the destination already exists" in withTestDataApiServices { services =>
+  it should "return 409 Conflict on clone if the destination already exists" in withTestDataApiServices { services =>
     Post(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/clone", httpJson(testData.workspace)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -721,7 +721,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     }
     import WorkspaceACLJsonSupport._
     WorkspaceAccessLevels.all.foreach { accessLevel =>
-      Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/acl", HttpEntity(ContentTypes.`application/json`, Seq(WorkspaceACLUpdate(allUsersEmail.value, accessLevel)).toJson.toString)) ~>
+      Patch(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/acl", httpJson(Seq(WorkspaceACLUpdate(allUsersEmail.value, accessLevel)))) ~>
         sealRoute(services.workspaceRoutes) ~>
         check {
           assertResult(StatusCodes.BadRequest) { status }


### PR DESCRIPTION
GAWB-298 prevent copying entities outside of a Realm
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
