### PR TITLE
prevent intersection google group names from going over the char limit

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -203,7 +203,7 @@ class HttpGoogleServicesDAO(
 
   def intersectionGroupName(workspaceId: String, realmGroupRef: RawlsGroupRef, accessLevel: WorkspaceAccessLevel) = {
     val realm = realmGroupRef.groupName.value
-    s"${realm}-${workspaceId}-${accessLevel.toString}"
+    s"I_${workspaceId}-${accessLevel.toString}"
   }
 
   def createCromwellAuthBucket(billingProject: RawlsBillingProjectName): Future[String] = {


### PR DESCRIPTION
Realm name is user-specified and of arbitrary length, so it can push us over the character limit when creating the google groups for intersection groups. This made it impossible to create workspaces with dbGapAuthorizedUsers realm

bad: GROUP_dbGapAuthorizedUsers-bff417af-f795-42a5-ab9a-903a0ded918e-WRITER@dev.test.firecloud.org 
good: GROUP_I_bff417af-f795-42a5-ab9a-903a0ded918e-WRITER@dev.test.firecloud.org
