### PR TITLE
return entity type counts only within a single workspace

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -150,7 +150,7 @@ trait EntityComponent {
     }
 
     def getEntityTypesWithCounts(workspaceContext: SlickWorkspaceContext): ReadAction[Map[String, Int]] = {
-      groupBy(e => e.entityType).map { case (entityType, entities) =>
+      filter(_.workspaceId === workspaceContext.workspaceId).groupBy(e => e.entityType).map { case (entityType, entities) =>
         (entityType, entities.countDistinct)
       }.result map { result =>
         result.toMap

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -179,6 +179,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
     val sample6 = Entity("sample6", "Sample", Map("type" -> AttributeString("tumor")))
     val sample7 = Entity("sample7", "Sample", Map("type" -> AttributeString("tumor"), "cycle" -> AttributeEntityReference("Sample", "sample6")))
     val sample8 = Entity("sample8", "Sample", Map("type" -> AttributeString("tumor")))
+    val extraSample = Entity("extraSample", "Sample", Map.empty)
 
     val aliquot1 = Entity("aliquot1", "Aliquot", Map.empty)
     val aliquot2 = Entity("aliquot2", "Aliquot", Map.empty)
@@ -336,6 +337,11 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
                 submissionQuery.create(context, submission2),
                 submissionQuery.create(context, submissionUpdateEntity),
                 submissionQuery.create(context, submissionUpdateWorkspace)
+          )
+        }),
+        withWorkspaceContext(workspaceWithRealm)({ context =>
+          DBIO.seq(
+            entityQuery.save(context, extraSample)
           )
         })
       )


### PR DESCRIPTION
Entity type counts were being returned for the whole database, not just for a single workspace. This fixes that.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Make sure liquibase is updated if appropriate
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Merge to develop 
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: Check configuration files in Jenkins in case they need changes
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
