### PR TITLE
GAWB-480: create submissionsCount endpoint

### DIFF
--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -822,6 +822,43 @@ paths:
             - openid
             - email
             - profile
+  '/api/workspaces/{workspaceNamespace}/{workspaceName}/submissionsCount':
+    get:
+      responses:
+        '200':
+          description: Successful Request
+          schema:
+            type: object
+            description: Map[String,Int]
+        '404':
+          description: Workspace not found
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        '500':
+          description: Rawls Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      description: Counts all submissions run in this workspace, grouped by status. Returns a map of status:count.
+      tags:
+        - submissions
+      summary: Count submissions by status
+      operationId: countSubmissions
+      parameters:
+        - in: path
+          description: Workspace Namespace
+          name: workspaceNamespace
+          required: true
+          type: string
+        - in: path
+          description: Workspace Name
+          name: workspaceName
+          required: true
+          type: string
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   '/api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/validate':
     post:
       responses:

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -107,6 +107,14 @@ trait SubmissionComponent {
       }))
     }
 
+    def countByStatus(workspaceContext: SlickWorkspaceContext): ReadAction[Map[String, Int]] = {
+      filter(_.workspaceId === workspaceContext.workspaceId).groupBy(s => s.status).map { case (status, submissions) =>
+        (status, submissions.length)
+      }.result map { result =>
+        result.toMap
+      }
+    }
+
     /* creates a submission and associated workflows in a workspace */
     def create(workspaceContext: SlickWorkspaceContext, submission: Submission): ReadWriteAction[Submission] = {
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -24,6 +24,12 @@ trait SubmissionApiService extends HttpService with PerRequestCreator with UserI
           WorkspaceService.ListSubmissions(WorkspaceName(workspaceNamespace, workspaceName)))
       }
     } ~
+    path("workspaces" / Segment / Segment / "submissionsCount" ) { (workspaceNamespace, workspaceName) =>
+      get {
+        requestContext => perRequest(requestContext, WorkspaceService.props(workspaceServiceConstructor, userInfo),
+          WorkspaceService.CountSubmissions(WorkspaceName(workspaceNamespace, workspaceName)))
+      }
+    } ~
     path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
       post {
         entity(as[SubmissionRequest]) { submission =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -155,4 +155,15 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
         }
       }
   }
+
+  it should "return 200 when counting submissions" in withTestDataApiServices { services =>
+    Get(s"/workspaces/${testData.wsName.namespace}/${testData.wsName.name}/submissionsCount") ~>
+      sealRoute(services.submissionRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) {status}
+        assertResult(Map("Submitted" -> 5)) {
+          responseAs[Map[String, Int]]
+        }
+      }
+  }
 }


### PR DESCRIPTION
Creates a new endpoint to count a workspace's submissions by their statuses. Will be used on the workspace summary tab. I will create a new PR in firecloud-ui to take advantage of this.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Make sure liquibase is updated if appropriate
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
