### PR TITLE
GAWB-487: when loading workflow, don't load the entire submission

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -112,6 +112,10 @@ trait WorkflowComponent {
       }
     }
 
+    def getByExternalId(externalId: String, submissionId: String): ReadAction[Option[Workflow]] = {
+      loadWorkflow(findWorkflowByExternalIdAndSubmissionId(externalId, UUID.fromString(submissionId)))
+    }
+
     def delete(id: Long): ReadWriteAction[Boolean] = {
       deleteWorkflowAction(id).map(_ > 0)
     }
@@ -221,6 +225,10 @@ trait WorkflowComponent {
 
     def findWorkflowById(id: Long): WorkflowQueryType = {
       filter(_.id === id)
+    }
+
+    def findWorkflowByExternalIdAndSubmissionId(externalId: String, submissionId: UUID): WorkflowQueryType = {
+      filter(wf => wf.externalid === externalId && wf.submissionId === submissionId)
     }
 
     def findWorkflowByEntityId(submissionId: UUID, entityId: UUID): WorkflowQueryType = {


### PR DESCRIPTION
Previously, when navigating through the UI to the details of a single workflow, we would load the entire submission. If that submission contained a lot of other workflows, this was a very heavyweight operation just to get a single workflow.

Note to reviewer: a lot of the diff below is whitespace; try with ?w=1 in the github url to ignore whitespace.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Make sure liquibase is updated if appropriate
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [ ] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
