### PR TITLE
GAWB-443: Optimistic Locking for Workspaces

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -5,4 +5,5 @@
     <include file="changesets/20160318.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20160330_refactor_entities_attributes.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20160406.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20160420_workspace_record_version.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20160420_workspace_record_version.xml
+++ b/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20160420_workspace_record_version.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="thibault" id="workspace_record_version">
+        <addColumn tableName="WORKSPACE">
+            <column name="record_version" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsConcurrentModificationException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsConcurrentModificationException.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.RawlsException
+
+/**
+ * Created by dvoet on 3/24/16.
+ */
+class RawlsConcurrentModificationException(message: String = null, cause: Throwable = null) extends RawlsException(message, cause)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -78,7 +78,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
 
   it should "insert entity reference attribute" in withEmptyTestDatabase {
     val workspaceId = UUID.randomUUID()
-    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname1", workspaceId, "bucket", defaultTimeStamp, defaultTimeStamp, "me", false, None))
+    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname1", workspaceId, "bucket", defaultTimeStamp, defaultTimeStamp, "me", false, None, 0))
     val entityId = UUID.randomUUID()
     runAndWait(entityQuery += EntityRecord(entityId, "name", "type", workspaceId))
     val testAttribute = AttributeEntityReference("type", "name")
@@ -92,7 +92,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
 
   it should "insert entity reference attribute list" in withEmptyTestDatabase {
     val workspaceId = UUID.randomUUID()
-    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname2", workspaceId, "bucket", defaultTimeStamp, defaultTimeStamp, "me", false, None))
+    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname2", workspaceId, "bucket", defaultTimeStamp, defaultTimeStamp, "me", false, None, 0))
     val ids = List.fill(4) { UUID.randomUUID() }
     val entityId1 = runAndWait((entityQuery += EntityRecord(ids(0), "name1", "type", workspaceId)).map(_ => ids(0)))
     val entityId2 = runAndWait((entityQuery += EntityRecord(ids(1), "name2", "type", workspaceId)).map(_ => ids(1)))
@@ -117,7 +117,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
 
   it should "throw exception inserting ref to nonexistent entity" in withEmptyTestDatabase {
     val workspaceId = UUID.randomUUID()
-    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname3", workspaceId, "bucket", defaultTimeStamp, defaultTimeStamp, "me", false, None))
+    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname3", workspaceId, "bucket", defaultTimeStamp, defaultTimeStamp, "me", false, None, 0))
     val testAttribute = AttributeEntityReference("type", "name")
     intercept[RawlsException] {
       attributeQuery.insertAttributeRecords("test", testAttribute, workspaceId).map(x => runAndWait(x))


### PR DESCRIPTION
Tests and fixes the Workspace Attribute portion of the corruption in GAWB-443.  The Entity Attribute portion remains.  Pieces inspired by / copied from @dvoet 
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Make sure liquibase is updated if appropriate
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
