### PR TITLE
Refactor: use Entity.toReference where possible

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -32,15 +32,15 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
     runAndWait(entityQuery.save(workspaceContext, target2))
 
     val updatedEntity = entity.copy(attributes = Map("string" -> AttributeString("foo"),
-      "ref" -> AttributeEntityReference(target1.entityType, target1.name),
-      "refList" -> AttributeEntityReferenceList(Seq(AttributeEntityReference(target1.entityType, target1.name), AttributeEntityReference(target2.entityType, target2.name)))))
+      "ref" -> target1.toReference,
+      "refList" -> AttributeEntityReferenceList(Seq(target1.toReference, target2.toReference))))
 
     assertResult(updatedEntity) { runAndWait(entityQuery.save(workspaceContext, updatedEntity)) }
     assertResult(Some(updatedEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
 
     val updatedAgainEntity = updatedEntity.copy(attributes = Map("string2" -> AttributeString("foo"),
-      "ref" -> AttributeEntityReference(target2.entityType, target2.name),
-      "refList" -> AttributeEntityReferenceList(Seq(AttributeEntityReference(target2.entityType, target2.name), AttributeEntityReference(target1.entityType, target1.name)))))
+      "ref" -> target2.toReference,
+      "refList" -> AttributeEntityReferenceList(Seq(target2.toReference, target1.toReference))))
     assertResult(updatedAgainEntity) { runAndWait(entityQuery.save(workspaceContext, updatedAgainEntity)) }
     assertResult(Some(updatedAgainEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -69,14 +69,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
 
     val workflows = workflowEntities map { ref =>
       val uuid = if(status == WorkflowStatuses.Queued) None else Option(UUID.randomUUID.toString)
-      Workflow(uuid, status, testDate, AttributeEntityReference(ref.entityType, ref.name), inputResolutions(ref))
+      Workflow(uuid, status, testDate, ref.toReference, inputResolutions(ref))
     }
 
     val failedWorkflows = failedWorkflowEntities map { ref =>
         WorkflowFailure(ref.name, ref.entityType, failedInputResolutions(ref), Seq(AttributeString("errorMessage1"), AttributeString("errorMessage2")))
     }
 
-    Submission(UUID.randomUUID.toString, testDate, rawlsUserRef, methodConfig.namespace, methodConfig.name, AttributeEntityReference(submissionEntity.entityType, submissionEntity.name),
+    Submission(UUID.randomUUID.toString, testDate, rawlsUserRef, methodConfig.namespace, methodConfig.name, submissionEntity.toReference,
       workflows,
       failedWorkflows, SubmissionStatuses.Submitted)
   }
@@ -319,11 +319,11 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
       Seq(indiv1), Map(indiv1 -> inputResolutions),
       Seq(indiv2), Map(indiv2 -> inputResolutions2))
 
-    val submissionTerminateTest = Submission(UUID.randomUUID().toString(),testDate, userOwner,methodConfig.namespace,methodConfig.name,AttributeEntityReference(indiv1.entityType, indiv1.name),
-      Seq(Workflow(Option("workflowA"),WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), inputResolutions),
-        Workflow(Option("workflowB"),WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample2.entityType, sample2.name), inputResolutions),
-        Workflow(Option("workflowC"),WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample3.entityType, sample3.name), inputResolutions),
-        Workflow(Option("workflowD"),WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample4.entityType, sample4.name), inputResolutions)), Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
+    val submissionTerminateTest = Submission(UUID.randomUUID().toString(),testDate, userOwner,methodConfig.namespace,methodConfig.name,indiv1.toReference,
+      Seq(Workflow(Option("workflowA"),WorkflowStatuses.Submitted,testDate,sample1.toReference, inputResolutions),
+        Workflow(Option("workflowB"),WorkflowStatuses.Submitted,testDate,sample2.toReference, inputResolutions),
+        Workflow(Option("workflowC"),WorkflowStatuses.Submitted,testDate,sample3.toReference, inputResolutions),
+        Workflow(Option("workflowD"),WorkflowStatuses.Submitted,testDate,sample4.toReference, inputResolutions)), Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
     override def save() = {
       DBIO.seq(

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -78,32 +78,32 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpe
     
     
     
-    val submissionTestAbortMissingWorkflow = Submission(subMissingWorkflow,testDate, testData.userOwner, "std","someMethod",AttributeEntityReference(sample1.entityType, sample1.name),
-      Seq(Workflow(nonExistingWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), testData.inputResolutions)),
+    val submissionTestAbortMissingWorkflow = Submission(subMissingWorkflow,testDate, testData.userOwner, "std","someMethod",sample1.toReference,
+      Seq(Workflow(nonExistingWorkflowId,WorkflowStatuses.Submitted,testDate,sample1.toReference, testData.inputResolutions)),
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
-    val submissionTestAbortMalformedWorkflow = Submission(subMalformedWorkflow,testDate, testData.userOwner, "std","someMethod",AttributeEntityReference(sample1.entityType, sample1.name),
-      Seq(Workflow(Option("malformed_workflow"),WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), testData.inputResolutions)),
+    val submissionTestAbortMalformedWorkflow = Submission(subMalformedWorkflow,testDate, testData.userOwner, "std","someMethod",sample1.toReference,
+      Seq(Workflow(Option("malformed_workflow"),WorkflowStatuses.Submitted,testDate,sample1.toReference, testData.inputResolutions)),
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
-    val submissionTestAbortGoodWorkflow = Submission(subGoodWorkflow,testDate, testData.userOwner, "std","someMethod",AttributeEntityReference(sample1.entityType, sample1.name),
-      Seq(Workflow(existingWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), testData.inputResolutions)),
+    val submissionTestAbortGoodWorkflow = Submission(subGoodWorkflow,testDate, testData.userOwner, "std","someMethod",sample1.toReference,
+      Seq(Workflow(existingWorkflowId,WorkflowStatuses.Submitted,testDate,sample1.toReference, testData.inputResolutions)),
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
-    val submissionTestAbortTerminalWorkflow = Submission(subTerminalWorkflow,testDate, testData.userOwner, "std","someMethod",AttributeEntityReference(sample1.entityType, sample1.name),
-      Seq(Workflow(alreadyTerminatedWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), testData.inputResolutions)),
+    val submissionTestAbortTerminalWorkflow = Submission(subTerminalWorkflow,testDate, testData.userOwner, "std","someMethod",sample1.toReference,
+      Seq(Workflow(alreadyTerminatedWorkflowId,WorkflowStatuses.Submitted,testDate,sample1.toReference, testData.inputResolutions)),
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
-    val submissionTestAbortOneMissingWorkflow = Submission(subOneMissingWorkflow,testDate, testData.userOwner, "std","someMethod",AttributeEntityReference(sample1.entityType, sample1.name),
+    val submissionTestAbortOneMissingWorkflow = Submission(subOneMissingWorkflow,testDate, testData.userOwner, "std","someMethod",sample1.toReference,
       Seq(
-        Workflow(existingWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), testData.inputResolutions),
-        Workflow(nonExistingWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample2.entityType, sample2.name), testData.inputResolutions)),
+        Workflow(existingWorkflowId,WorkflowStatuses.Submitted,testDate,sample1.toReference, testData.inputResolutions),
+        Workflow(nonExistingWorkflowId,WorkflowStatuses.Submitted,testDate,sample2.toReference, testData.inputResolutions)),
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
-    val submissionTestAbortTwoGoodWorkflows = Submission(subTwoGoodWorkflows,testDate, testData.userOwner, "std","someMethod",AttributeEntityReference(sample1.entityType, sample1.name),
+    val submissionTestAbortTwoGoodWorkflows = Submission(subTwoGoodWorkflows,testDate, testData.userOwner, "std","someMethod",sample1.toReference,
       Seq(
-        Workflow(existingWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample1.entityType, sample1.name), testData.inputResolutions),
-        Workflow(alreadyTerminatedWorkflowId,WorkflowStatuses.Submitted,testDate,AttributeEntityReference(sample2.entityType, sample2.name), testData.inputResolutions)),
+        Workflow(existingWorkflowId,WorkflowStatuses.Submitted,testDate,sample1.toReference, testData.inputResolutions),
+        Workflow(alreadyTerminatedWorkflowId,WorkflowStatuses.Submitted,testDate,sample2.toReference, testData.inputResolutions)),
       Seq.empty[WorkflowFailure], SubmissionStatuses.Submitted)
 
     val extantWorkflowOutputs = WorkflowOutputs( existingWorkflowId.get,

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -127,9 +127,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     val sample5 = Entity("sample5", "sample", Map.empty)
     val sample6 = Entity("sample6", "sample", Map.empty)
     val sampleSet = Entity("sampleset", "sample_set", Map("samples" -> AttributeEntityReferenceList(Seq(
-      AttributeEntityReference(sample1.entityType, sample1.name),
-      AttributeEntityReference(sample2.entityType, sample2.name),
-      AttributeEntityReference(sample3.entityType, sample3.name)
+      sample1.toReference,
+      sample2.toReference,
+      sample3.toReference
     ))))
 
     val methodConfig = MethodConfiguration("dsde", "testConfig", "Sample", Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), MethodRepoMethod(workspaceName.namespace, "method-a", 1))


### PR DESCRIPTION
Just cleaning up some test code
- [ ] **Submitter**: Rebase to develop. DO NOT SQUASH
- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: Make sure documentation for code is complete
- [ ] **Submitter**: Make sure liquibase is updated if appropriate
- [ ] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [ ] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it **(apply requires_doge label)**
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
- [ ] **LR**: Initial review by LR and others.
- [ ] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [ ] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Squash commits, rebase if necessary
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Merge to develop 
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: Check configuration files in Jenkins in case they need changes
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
