### PR TITLE
fixed swagger authorization for entityQuery endpoint

### DIFF
--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1170,8 +1170,7 @@ paths:
         500:
           description: Internal Server Error
       security:
-        - bearer:
-        - googleoauth:
+        - authorization:
             - openid
             - email
             - profile


### PR DESCRIPTION
I wanted to try out the new SSP endpoint for entities using swagger and couldn't 😭😭
- [x] no checklist
