### PR TITLE
GAWB-953 We really don't handle empty arrays well.

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -139,6 +139,9 @@ trait AttributeComponent {
         case AttributeEntityReferenceList(refs) =>
           assertConsistentReferenceListMembers(refs)
           refs.zipWithIndex.map { case (ref, index) => insertAttributeRef(ownerId, name, workspaceId, ref, Option(index), Option(refs.length))}
+        //convert empty AttributeValueList to AttributeEmptyList
+        //TODO: Do the same with EntityReferenceLists?
+        case AttributeValueList(values) if values.isEmpty => Seq(insertAttributeValue(ownerId, name, AttributeNull, Option(-1), Option(0))) // storing empty list as an element with index -1
         case AttributeValueList(values) =>
           assertConsistentValueListMembers(values)
           values.zipWithIndex.map { case (value, index) => insertAttributeValue(ownerId, name, value, Option(index), Option(values.length))}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -137,7 +137,7 @@ trait AttributeComponent {
     def insertAttributeRecords(ownerId: OWNER_ID, name: String, attribute: Attribute, workspaceId: UUID): Seq[ReadWriteAction[Int]] = {
 
       def insertEmpty : Seq[ReadWriteAction[Int]] = {
-        // storing empty list as an element with index -1
+        //NOTE: listIndex of -1 is the magic number for "empty list". see unmarshalList
         Seq(insertAttributeValue(ownerId, name, AttributeNull, Option(-1), Option(0)))
       }
 
@@ -173,7 +173,7 @@ trait AttributeComponent {
     def marshalAttribute(ownerId: OWNER_ID, name: String, attribute: Attribute, entityIdsByRef: Map[AttributeEntityReference, Long]): Seq[T#TableElementType] = {
 
       def marshalEmpty : Seq[T#TableElementType] = {
-        // storing empty list as an element with index -1
+        //NOTE: listIndex of -1 is the magic number for "empty list". see unmarshalList
         Seq(marshalAttributeValue(ownerId, name, AttributeNull, Option(-1), Option(0)))
       }
       attribute match {
@@ -325,6 +325,7 @@ trait AttributeComponent {
 
     private def unmarshalList(attributeRecsWithRef: Set[(RECORD, Option[EntityRecord])]) = {
       val sortedRecs = attributeRecsWithRef.toSeq.sortBy(_._1.listIndex.get)
+      //NOTE: listIndex of -1 means "empty list"
       if (sortedRecs.head._1.listIndex.get == -1) {
         AttributeEmptyList
       } else if (sortedRecs.head._2.isDefined) {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -33,7 +33,12 @@ object MethodConfigResolver {
   }
 
   private def getArrayResult(inputName: String, seq: Iterable[AttributeValue]): SubmissionValidationValue = {
-    SubmissionValidationValue(Some(AttributeValueList(seq.filter(v => v != null && v != AttributeNull).toSeq)), None, inputName)
+    val filterSeq = seq.filter(v => v != null && v != AttributeNull).toSeq
+    if(filterSeq.isEmpty) {
+      SubmissionValidationValue(Some(AttributeEmptyList), None, inputName)
+    } else {
+      SubmissionValidationValue(Some(AttributeValueList(filterSeq)), None, inputName)
+    }
   }
 
   private def unpackResult(mcSequence: Iterable[AttributeValue], wfInput: WorkflowInput): SubmissionValidationValue = wfInput.wdlType match {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -68,6 +68,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, "test", testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
+    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
     assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, "test", None, None, None, None, Option(-1), Option(0)))
   }
 
@@ -77,6 +78,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, "test", testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
+    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
     assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, "test", None, None, None, None, Option(-1), Option(0)))
   }
 
@@ -86,6 +88,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, "test", testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
+    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
     assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, "test", None, None, None, None, Option(-1), Option(0)))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -71,6 +71,24 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, "test", None, None, None, None, Option(-1), Option(0)))
   }
 
+  it should "save empty AttributeValueLists as AttributeEmptyList" in withEmptyTestDatabase {
+    val testAttribute = AttributeValueList(Seq())
+    runAndWait(workspaceQuery.save(workspace))
+    val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, "test", testAttribute, workspaceId).map(x => runAndWait(x))
+    assertResult(1) { numRows.head }
+
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, "test", None, None, None, None, Option(-1), Option(0)))
+  }
+
+  it should "save empty AttributeEntityReferenceLists as AttributeEmptyList" in withEmptyTestDatabase {
+    val testAttribute = AttributeEntityReferenceList(Seq())
+    runAndWait(workspaceQuery.save(workspace))
+    val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, "test", testAttribute, workspaceId).map(x => runAndWait(x))
+    assertResult(1) { numRows.head }
+
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, "test", None, None, None, None, Option(-1), Option(0)))
+  }
+
   it should "insert null attribute" in withEmptyTestDatabase {
     val testAttribute = AttributeNull
     runAndWait(workspaceQuery.save(workspace))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -51,6 +51,16 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
     runAndWait(entityQuery.save(workspaceContext, emptyListAttributeEntity))
     assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyListy")) }
 
+    //convert AttributeValueList(Seq()) -> AttributeEmptyList
+    val emptyValListEntity = entity.copy(name = "emptyValList", attributes = Map("emptyList" -> AttributeValueList(Seq())))
+    runAndWait(entityQuery.save(workspaceContext, emptyValListEntity))
+    assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList")) }
+
+    //convert AttributeEntityReferenceList(Seq()) -> AttributeEmptyList
+    val emptyRefListEntity = entity.copy(name = "emptyRefList", attributes = Map("emptyList" -> AttributeEntityReferenceList(Seq())))
+    runAndWait(entityQuery.save(workspaceContext, emptyRefListEntity))
+    assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList")) }
+
     assertResult(true) { runAndWait(entityQuery.delete(workspaceContext, "type", "name")) }
     assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
     assertResult(false) { runAndWait(entityQuery.delete(workspaceContext, "type", "name")) }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -47,6 +47,10 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
     assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
     assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
 
+    val emptyListAttributeEntity = entity.copy(name = "emptyListy", attributes = Map("emptyList" -> AttributeEmptyList))
+    runAndWait(entityQuery.save(workspaceContext, emptyListAttributeEntity))
+    assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyListy")) }
+
     assertResult(true) { runAndWait(entityQuery.delete(workspaceContext, "type", "name")) }
     assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
     assertResult(false) { runAndWait(entityQuery.delete(workspaceContext, "type", "name")) }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -54,12 +54,12 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
     //convert AttributeValueList(Seq()) -> AttributeEmptyList
     val emptyValListEntity = entity.copy(name = "emptyValList", attributes = Map("emptyList" -> AttributeValueList(Seq())))
     runAndWait(entityQuery.save(workspaceContext, emptyValListEntity))
-    assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList")) }
+    assertResult(Some(emptyListAttributeEntity.copy(name="emptyValList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList")) }
 
     //convert AttributeEntityReferenceList(Seq()) -> AttributeEmptyList
     val emptyRefListEntity = entity.copy(name = "emptyRefList", attributes = Map("emptyList" -> AttributeEntityReferenceList(Seq())))
     runAndWait(entityQuery.save(workspaceContext, emptyRefListEntity))
-    assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList")) }
+    assertResult(Some(emptyListAttributeEntity.copy(name="emptyRefList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList")) }
 
     assertResult(true) { runAndWait(entityQuery.delete(workspaceContext, "type", "name")) }
     assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -36,6 +36,17 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
     Seq(testData.sset1), Map(testData.sset1 -> inputResolutionsList),
     Seq.empty, Map.empty)
 
+  val inputResolutionsListEmpty = Seq(SubmissionValidationValue(Option(
+    AttributeValueList(Seq())), Option("message4"), "test_input_name4"))
+  private val submissionListEmpty = createTestSubmission(testData.workspace, testData.methodConfigArrayType, testData.sset1, testData.userOwner,
+    Seq(testData.sset1), Map(testData.sset1 -> inputResolutionsListEmpty),
+    Seq.empty, Map.empty)
+
+  val inputResolutionsAttrEmptyList = Seq(SubmissionValidationValue(Option(AttributeEmptyList), Option("message4"), "test_input_name4"))
+  private val submissionAttrEmptyList = createTestSubmission(testData.workspace, testData.methodConfigArrayType, testData.sset1, testData.userOwner,
+    Seq(testData.sset1), Map(testData.sset1 -> inputResolutionsAttrEmptyList),
+    Seq.empty, Map.empty)
+
   "SubmissionComponent" should "save, get, list, and delete a submission status" in withDefaultTestDatabase {
     val workspaceContext = SlickWorkspaceContext(testData.workspace)
 
@@ -89,6 +100,26 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
 
     assertResult(Some(submissionList)) {
       runAndWait(submissionQuery.get(workspaceContext, submissionList.submissionId))
+    }
+  }
+
+  it should "save and unmarshal empty list input resolutions correctly"  in withDefaultTestDatabase {
+    //This test fails because saving AttributeList(Seq()) gives us None back
+    val workspaceContext = SlickWorkspaceContext(testData.workspace)
+
+    runAndWait(submissionQuery.create(workspaceContext, submissionListEmpty))
+    assertResult(Some(submissionListEmpty)) {
+      runAndWait(submissionQuery.get(workspaceContext, submissionListEmpty.submissionId))
+    }
+  }
+
+  it should "save and unmarshal attribute empty list input resolutions correctly"  in withDefaultTestDatabase {
+    //This test passes because saving AttributeEmptyList gives us AttributeEmptyList back
+    val workspaceContext = SlickWorkspaceContext(testData.workspace)
+
+      runAndWait(submissionQuery.create(workspaceContext, submissionAttrEmptyList))
+    assertResult(Some(submissionAttrEmptyList)) {
+      runAndWait(submissionQuery.get(workspaceContext, submissionAttrEmptyList.submissionId))
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -103,17 +103,19 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
     }
   }
 
-  it should "save and unmarshal empty list input resolutions correctly"  in withDefaultTestDatabase {
-    //This test fails because saving AttributeList(Seq()) gives us None back
+  it should "quietly marshal AttributeList(Seq()) input resolutions into AttributeEmptyList"  in withDefaultTestDatabase {
     val workspaceContext = SlickWorkspaceContext(testData.workspace)
 
+    val turnedIntoAttrEmptyList = submissionListEmpty.copy(
+      workflows = Seq(submissionListEmpty.workflows.head.copy(inputResolutions = inputResolutionsAttrEmptyList)))
+
     runAndWait(submissionQuery.create(workspaceContext, submissionListEmpty))
-    assertResult(Some(submissionListEmpty)) {
+    assertResult(Some(turnedIntoAttrEmptyList)) {
       runAndWait(submissionQuery.get(workspaceContext, submissionListEmpty.submissionId))
     }
   }
 
-  it should "save and unmarshal attribute empty list input resolutions correctly"  in withDefaultTestDatabase {
+  it should "save and unmarshal AttributeEmptyList input resolutions correctly"  in withDefaultTestDatabase {
     //This test passes because saving AttributeEmptyList gives us AttributeEmptyList back
     val workspaceContext = SlickWorkspaceContext(testData.workspace)
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -87,6 +87,10 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
     Map.empty, Map(intArrayName -> AttributeString("this.samples.blah")), Map.empty,
     MethodRepoMethod( "method_namespace", "test_method", 1))
 
+  val configEmptyArray = new MethodConfiguration("config_namespace", "configSampleSet", "SampleSet",
+    Map.empty, Map(intArrayName -> AttributeString("this.nonexistent")), Map.empty,
+    MethodRepoMethod( "method_namespace", "test_method", 1))
+
   class ConfigData extends TestData {
     override def save() = {
       DBIO.seq(
@@ -152,6 +156,17 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
       intercept[RawlsException] {
         runAndWait(testResolveInputs(context, configMissingExpr, sampleGood, littleWdl, this))
       }
+    }
+
+    "resolve empty lists into AttributeLists" in withConfigData {
+      val context = new SlickWorkspaceContext(workspace)
+
+      runAndWait(testResolveInputs(context, configEmptyArray, sampleSet2, arrayWdl, this)) shouldBe
+        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq())), None, intArrayName)))
+    }
+
+    "translate empty AttributeLists into empty array WDL" in withConfigData {
+      //check methodConfigResolver.propertiesToWdlInputs too
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -164,9 +164,5 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
       runAndWait(testResolveInputs(context, configEmptyArray, sampleSet2, arrayWdl, this)) shouldBe
         Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq())), None, intArrayName)))
     }
-
-    "translate empty AttributeLists into empty array WDL" in withConfigData {
-      //check methodConfigResolver.propertiesToWdlInputs too
-    }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -158,11 +158,11 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
       }
     }
 
-    "resolve empty lists into AttributeLists" in withConfigData {
+    "resolve empty lists into AttributeEmptyLists" in withConfigData {
       val context = new SlickWorkspaceContext(workspace)
 
       runAndWait(testResolveInputs(context, configEmptyArray, sampleSet2, arrayWdl, this)) shouldBe
-        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq())), None, intArrayName)))
+        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeEmptyList), None, intArrayName)))
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -132,7 +132,7 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
 
   "MethodConfigResolver" should {
     "resolve method config inputs" in withConfigData {
-      val context = new SlickWorkspaceContext(workspace)
+      val context = SlickWorkspaceContext(workspace)
       runAndWait(testResolveInputs(context, configGood, sampleGood, littleWdl, this)) shouldBe
         Map(sampleGood.name -> Seq(SubmissionValidationValue(Some(AttributeNumber(1)), None, intArgName)))
 
@@ -159,7 +159,7 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
     }
 
     "resolve empty lists into AttributeEmptyLists" in withConfigData {
-      val context = new SlickWorkspaceContext(workspace)
+      val context = SlickWorkspaceContext(workspace)
 
       runAndWait(testResolveInputs(context, configEmptyArray, sampleSet2, arrayWdl, this)) shouldBe
         Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeEmptyList), None, intArrayName)))


### PR DESCRIPTION
Input resolutions of empty arrays were saving as `AttributeValueList(Seq())`, which translates in the database to a list of zero records - i.e. it vanishes entirely.

The fix is to quietly convert `AttributeValueList(Seq())` and `AttributeEntityReferenceList(Seq())` to `AttributeEmptyList` on save. I've also made a similar change to `MethodConfigResolver.getArrayResult` which isn't technically necessary given this but returns more predictable results earlier.

The upshot of this is that saving an entity with an attribute `AttributeValueList(Seq())` and then reloading it will **not** return the same thing you gave it. It will return an `AttributeEmptyList` instead. This may be surprising in some cases.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Make sure liquibase is updated if appropriate. 
  - If doing a migration, take a backup of the dev and alpha DBs in Google Cloud Console
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] **Submitter**: If PR includes new or changed db queries, include the explain plans in the description
- [x] **Submitter**: Update FISMA documentation if changes to:
  - Authentication
  - Authorization
  - Encryption
  - Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it **(apply requires_doge label)**
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- Review cycle:
  - LR reviews
  - Rest of team may comment on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH
  - Submitter updates documentation as needed
  - Submitter **reassigns to LR** for further feedback
- [x] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
