### PR TITLE
clean up slick table definitions to match hotfix

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -33,8 +33,8 @@ trait MethodConfigurationComponent {
     def name = column[String]("NAME", O.Length(254))
     def workspaceId = column[UUID]("WORKSPACE_ID")
     def rootEntityType = column[String]("ROOT_ENTITY_TYPE", O.Length(254))
-    def methodNamespace = column[String]("METHOD_NAMESPACE", O.Length(254))
-    def methodName = column[String]("METHOD_NAME", O.Length(254))
+    def methodNamespace = column[String]("METHOD_NAMESPACE")
+    def methodName = column[String]("METHOD_NAME")
     def methodVersion = column[Int]("METHOD_VERSION")
 
     def * = (id, namespace, name, workspaceId, rootEntityType, methodNamespace, methodName, methodVersion) <> (MethodConfigurationRecord.tupled, MethodConfigurationRecord.unapply)
@@ -47,7 +47,7 @@ trait MethodConfigurationComponent {
     def methodConfigId = column[Long]("METHOD_CONFIG_ID")
     def id = column[Long]("ID", O.PrimaryKey, O.AutoInc)
     def key = column[String]("KEY", O.Length(254))
-    def value = column[String]("VALUE", O.Length(254))
+    def value = column[String]("VALUE")
 
     def * = (methodConfigId, id, key, value) <> (MethodConfigurationInputRecord.tupled, MethodConfigurationInputRecord.unapply)
 
@@ -59,7 +59,7 @@ trait MethodConfigurationComponent {
     def methodConfigId = column[Long]("METHOD_CONFIG_ID")
     def id = column[Long]("ID", O.PrimaryKey, O.AutoInc)
     def key = column[String]("KEY", O.Length(254))
-    def value = column[String]("VALUE", O.Length(254))
+    def value = column[String]("VALUE")
 
     def * = (methodConfigId, id, key, value) <> (MethodConfigurationOutputRecord.tupled, MethodConfigurationOutputRecord.unapply)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -63,14 +63,10 @@ trait SubmissionComponent {
   }
 
   class SubmissionValidationTable(tag: Tag) extends Table[SubmissionValidationRecord](tag, "SUBMISSION_VALIDATION") {
-    /*
-      TODO: add a constraint to ensure that one of workflowId / workflowFailureId are present
-      See GAWB-288
-     */
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def workflowId = column[Long]("WORKFLOW_ID")
     def errorText = column[Option[String]]("ERROR_TEXT")
-    def inputName = column[String]("INPUT_NAME", O.Length(254))
+    def inputName = column[String]("INPUT_NAME")
 
     def * = (id, workflowId, errorText, inputName) <> (SubmissionValidationRecord.tupled, SubmissionValidationRecord.unapply)
 


### PR DESCRIPTION
This doesn't appear to actually be important (i.e. slick doesn't prevent you from saving a field with > 254 characters if the actual column type is TEXT). This is just some cleanup to be consistent.
