### PR TITLE
GAWB-1096 Reworked how attribute lists are stored in the database and exported to JSON

### DIFF
--- a/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -25,4 +25,5 @@
     <include file="changesets/20160909_method_config_deleted_column.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20160914_create_temp_tables_proc.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20160920_attribute_namespace.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20161007_empty_attributevalue_lists.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161007_empty_attributevalue_lists.xml
+++ b/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161007_empty_attributevalue_lists.xml
@@ -1,21 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
-    <changeSet id="add_minusone_to_empty_entityattribute_value_lists" author="hussein" logicalFilePath="dummy">
+    <changeSet id="fixup_empty_entityattribute_value_lists" author="hussein" logicalFilePath="dummy">
         <sql>
             UPDATE ENTITY_ATTRIBUTE eattr
             SET
-            eattr.value_number = -1
+            eattr.value_number = -1, eattr.list_index = NULL
             WHERE
             eattr.list_index = -1 AND eattr.name not in ('participants', 'samples', 'pairs')
         </sql>
     </changeSet>
 
-    <changeSet id="add_minusone_to_empty_wsattribute_value_lists" author="hussein" logicalFilePath="dummy">
+    <changeSet id="fixup_empty_entityattribute_ref_lists" author="hussein" logicalFilePath="dummy">
+        <sql>
+            UPDATE ENTITY_ATTRIBUTE eattr
+            SET
+            eattr.list_index = NULL
+            WHERE
+            eattr.list_index = -1 AND eattr.name in ('participants', 'samples', 'pairs')
+        </sql>
+    </changeSet>
+
+    <changeSet id="fixup_empty_wsattribute_value_lists" author="hussein" logicalFilePath="dummy">
         <sql>
             UPDATE WORKSPACE_ATTRIBUTE wsattr
             SET
-            wsattr.value_number = -1
+            wsattr.value_number = -1, wsattr.list_index = NULL
             WHERE
             wsattr.list_index = -1
         </sql>
@@ -25,7 +35,7 @@
         <sql>
             UPDATE SUBMISSION_ATTRIBUTE subattr
             SET
-            subattr.value_number = -1
+            subattr.value_number = -1, subattr.list_index = NULL
             WHERE
             subattr.list_index = -1
         </sql>

--- a/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161007_empty_attributevalue_lists.xml
+++ b/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161007_empty_attributevalue_lists.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="add_minusone_to_empty_entityattribute_value_lists" author="hussein" logicalFilePath="dummy">
+        <sql>
+            UPDATE ENTITY_ATTRIBUTE eattr
+            SET
+            eattr.value_number = -1
+            WHERE
+            eattr.list_index = -1 AND eattr.name not in ('participants', 'samples', 'pairs')
+        </sql>
+    </changeSet>
+
+    <changeSet id="add_minusone_to_empty_wsattribute_value_lists" author="hussein" logicalFilePath="dummy">
+        <sql>
+            UPDATE WORKSPACE_ATTRIBUTE wsattr
+            SET
+            wsattr.value_number = -1
+            WHERE
+            wsattr.list_index = -1
+        </sql>
+    </changeSet>
+
+    <changeSet id="add_minusone_to_empty_subattribute_value_lists" author="hussein" logicalFilePath="dummy">
+        <sql>
+            UPDATE SUBMISSION_ATTRIBUTE subattr
+            SET
+            subattr.value_number = -1
+            WHERE
+            subattr.list_index = -1
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -3988,6 +3988,10 @@ definitions:
         $ref: '#/definitions/AddListMember'
       Example payload for RemoveListMember:
         $ref: '#/definitions/RemoveListMember'
+      Example payload for CreateAttributeEntityReferenceList:
+        $ref: '#/definitions/CreateAttributeEntityReferenceList'
+      Example payload for CreateAttributeValueList:
+        $ref: '#/definitions/CreateAttributeValueList'
 
   AddUpdateAttribute:
     description: ''
@@ -4052,6 +4056,32 @@ definitions:
       removeMember:
         type: string
         description: The attribute to remove
+
+  CreateAttributeEntityReferenceList:
+      description: ''
+      required:
+        - op
+        - attributeListName
+      properties:
+        op:
+          type: string
+          description: The operation to perform on the attribute
+        attributeListName:
+          type: string
+          description: The name of the empty attribute entity reference list to create. This is a non-destructive operation.
+
+  CreateAttributeValueList:
+      description: ''
+      required:
+        - op
+        - attributeListName
+      properties:
+        op:
+          type: string
+          description: The operation to perform on the attribute
+        attributeListName:
+          type: string
+          description: The name of the empty attribute value list to create. This is a non-destructive operation.
 
   EntityUpdateDefinition:
     description: ''

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -4058,30 +4058,30 @@ definitions:
         description: The attribute to remove
 
   CreateAttributeEntityReferenceList:
-      description: ''
-      required:
-        - op
-        - attributeListName
-      properties:
-        op:
-          type: string
-          description: The operation to perform on the attribute
-        attributeListName:
-          type: string
-          description: The name of the empty attribute entity reference list to create. This is a non-destructive operation.
+    description: ''
+    required:
+      - op
+      - attributeListName
+    properties:
+      op:
+        type: string
+        description: The operation to perform on the attribute
+      attributeListName:
+        type: string
+        description: The name of the empty attribute entity reference list to create. This is a non-destructive operation.
 
   CreateAttributeValueList:
-      description: ''
-      required:
-        - op
-        - attributeListName
-      properties:
-        op:
-          type: string
-          description: The operation to perform on the attribute
-        attributeListName:
-          type: string
-          description: The name of the empty attribute value list to create. This is a non-destructive operation.
+    description: ''
+    required:
+      - op
+      - attributeListName
+    properties:
+      op:
+        type: string
+        description: The operation to perform on the attribute
+      attributeListName:
+        type: string
+        description: The name of the empty attribute value list to create. This is a non-destructive operation.
 
   EntityUpdateDefinition:
     description: ''

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -4032,7 +4032,7 @@ definitions:
     properties:
       op:
         type: string
-        description: The operation to perform on the attribute
+        description: The operation to perform on the attribute. The attribute type must match the list type, reference or value
       attributeListName:
         type: string
         description: The name of the attribute list

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -912,6 +912,7 @@ class HttpGoogleServicesDAO(
 private case class GoogleRequest(method: String, url: String, payload: Option[JsValue], time_ms: Long, statusCode: Option[Int], errorReport: Option[ErrorReport])
 private object GoogleRequestJsonSupport extends JsonSupport {
   import WorkspaceJsonSupport.ErrorReportFormat
+
   val GoogleRequestFormat = jsonFormat6(GoogleRequest)
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -912,7 +912,6 @@ class HttpGoogleServicesDAO(
 private case class GoogleRequest(method: String, url: String, payload: Option[JsValue], time_ms: Long, statusCode: Option[Int], errorReport: Option[ErrorReport])
 private object GoogleRequestJsonSupport extends JsonSupport {
   import WorkspaceJsonSupport.ErrorReportFormat
-
   val GoogleRequestFormat = jsonFormat6(GoogleRequest)
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WDLJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WDLJsonSupport.scala
@@ -1,0 +1,27 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import org.broadinstitute.dsde.rawls.model._
+import spray.json.{DeserializationException, JsArray, JsObject, JsString, JsValue}
+
+object WDLJsonSupport extends JsonSupport {
+
+  override def writeListType(obj: Attribute): JsValue = obj match {
+    //lists
+    case AttributeValueEmptyList => JsArray()
+    case AttributeValueList(l) => JsArray(l.map(AttributeFormat.write(_)):_*)
+    case AttributeEntityReferenceEmptyList => JsArray()
+    case AttributeEntityReferenceList(l) => JsArray(l.map(AttributeFormat.write(_)):_*)
+  }
+
+  override def readListType(json: JsValue): Attribute = json match {
+    case JsArray(a) =>
+      val attrList: Seq[Attribute] = a.map(AttributeFormat.read(_))
+      attrList match {
+        case e: Seq[_] if e.isEmpty => AttributeValueEmptyList
+        case v: Seq[AttributeValue @unchecked] if attrList.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(v)
+        case r: Seq[AttributeEntityReference @unchecked] if attrList.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(r)
+        case _ => throw new DeserializationException("illegal array type")
+      }
+    case _ => throw new DeserializationException("unexpected json type")
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -358,10 +358,10 @@ trait AttributeComponent {
       allAttributeRecsWithRef.groupBy { case ((id, attrRec), entOp) => id }.map { case (id, workspaceAttributeRecsWithRef) =>
         id -> workspaceAttributeRecsWithRef.groupBy { case ((id, attrRec), entOp) => AttributeName(attrRec.namespace, attrRec.name) }.map { case (attrName, attributeRecsWithRefForNameWithDupes) =>
           val attributeRecsWithRefForName = attributeRecsWithRefForNameWithDupes.map { case ((wsId, attributeRec), entityRec) => (attributeRec, entityRec) }.toSet
-          val unmarshalled = if (attributeRecsWithRefForName.forall(_._1.listIndex.isDefined) && attributeRecsWithRefForName.forall(_._1.listLength.isDefined) ) {
+          val unmarshalled = if (attributeRecsWithRefForName.forall(_._1.listLength.isDefined)) {
             unmarshalList(attributeRecsWithRefForName)
           } else if (attributeRecsWithRefForName.size > 1) {
-            throw new RawlsException(s"more than one value exists for attribute but list length and index not defined for all, records: $attributeRecsWithRefForName")
+            throw new RawlsException(s"more than one value exists for attribute but list length not defined for all, records: $attributeRecsWithRefForName")
           } else if (attributeRecsWithRefForName.head._2.isDefined) {
             unmarshalReference(attributeRecsWithRefForName.head._2.get)
           } else {
@@ -373,8 +373,15 @@ trait AttributeComponent {
     }
 
     private def unmarshalList(attributeRecsWithRef: Set[(RECORD, Option[EntityRecord])]) = {
-      val sortedRecs = attributeRecsWithRef.toSeq.sortBy(_._1.listIndex.get)
-      if (sortedRecs.head._1.listLength.getOrElse(-1) == 0) {
+      val isEmptyList = attributeRecsWithRef.size == 1 && attributeRecsWithRef.head._1.listLength.getOrElse(-1) == 0
+
+      val sortedRecs = try {
+        attributeRecsWithRef.toSeq.sortBy(_._1.listIndex.get)
+      } catch {
+        case e: NoSuchElementException => throw new RawlsException(s"more than one value exists for attribute but list index not defined for all, records: $attributeRecsWithRef")
+      }
+
+      if (isEmptyList) {
         if( isEntityRefRecord(sortedRecs.head._1) ) {
           AttributeEntityReferenceEmptyList
         } else {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -358,10 +358,10 @@ trait AttributeComponent {
       allAttributeRecsWithRef.groupBy { case ((id, attrRec), entOp) => id }.map { case (id, workspaceAttributeRecsWithRef) =>
         id -> workspaceAttributeRecsWithRef.groupBy { case ((id, attrRec), entOp) => AttributeName(attrRec.namespace, attrRec.name) }.map { case (attrName, attributeRecsWithRefForNameWithDupes) =>
           val attributeRecsWithRefForName = attributeRecsWithRefForNameWithDupes.map { case ((wsId, attributeRec), entityRec) => (attributeRec, entityRec) }.toSet
-          val unmarshalled = if (attributeRecsWithRefForName.forall(_._1.listLength.isDefined)) {
+          val unmarshalled = if (attributeRecsWithRefForName.forall(_._1.listIndex.isDefined) && attributeRecsWithRefForName.forall(_._1.listLength.isDefined) ) {
             unmarshalList(attributeRecsWithRefForName)
           } else if (attributeRecsWithRefForName.size > 1) {
-            throw new RawlsException(s"more than one value exists for attribute but list index is not defined for all, records: $attributeRecsWithRefForName")
+            throw new RawlsException(s"more than one value exists for attribute but list length and index not defined for all, records: $attributeRecsWithRefForName")
           } else if (attributeRecsWithRefForName.head._2.isDefined) {
             unmarshalReference(attributeRecsWithRefForName.head._2.get)
           } else {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -358,7 +358,7 @@ trait AttributeComponent {
       allAttributeRecsWithRef.groupBy { case ((id, attrRec), entOp) => id }.map { case (id, workspaceAttributeRecsWithRef) =>
         id -> workspaceAttributeRecsWithRef.groupBy { case ((id, attrRec), entOp) => AttributeName(attrRec.namespace, attrRec.name) }.map { case (attrName, attributeRecsWithRefForNameWithDupes) =>
           val attributeRecsWithRefForName = attributeRecsWithRefForNameWithDupes.map { case ((wsId, attributeRec), entityRec) => (attributeRec, entityRec) }.toSet
-          val unmarshalled = if (attributeRecsWithRefForName.forall(_._1.listIndex.isDefined)) {
+          val unmarshalled = if (attributeRecsWithRefForName.forall(_._1.listLength.isDefined)) {
             unmarshalList(attributeRecsWithRefForName)
           } else if (attributeRecsWithRefForName.size > 1) {
             throw new RawlsException(s"more than one value exists for attribute but list index is not defined for all, records: $attributeRecsWithRefForName")

--- a/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParsing.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParsing.scala
@@ -248,8 +248,7 @@ trait SlickExpressionParser extends JavaTokenParsers {
         // but we didn't do the extra JOIN in the SQL query to find out _which_ entity it is.
 
         // The upshot of all this is we have to handle these dangling and unwanted entity references separately. So first we filter out the well-behaved value attributes.
-        def isEntityRefAttr( rootEntityName: String, lastEntityName: String, attrRec: EntityAttributeRecord ): Boolean = { attrRec.valueEntityRef.isDefined }
-        val (refAttrRecs, valueAttrRecs) = attrs.partition { case (root, attrEnt, attrRec) => isEntityRefAttr(root, attrEnt, attrRec) }
+        val (refAttrRecs, valueAttrRecs) = attrs.partition { case (root, attrEnt, attrRec) => isEntityRefRecord(attrRec) }
 
         //Unmarshal the good ones. This is what the user actually meant.
         val attributesByEntityId: Map[String, AttributeMap] = entityAttributeQuery.unmarshalAttributes(valueAttrRecs.map { case (root, attrEnt, attrRec) => ((attrEnt, attrRec), None) })

--- a/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParsing.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParsing.scala
@@ -394,7 +394,7 @@ class SlickExpressionEvaluator protected (val parser: DataAccess, val rootEntiti
           val results = exprResults map { case (key, attrVals) =>
             key -> Try(attrVals.collect {
               case AttributeNull => Seq.empty
-              case AttributeEmptyList => Seq.empty
+              case AttributeValueEmptyList => Seq.empty
               case av: AttributeValue => Seq(av)
               case avl: AttributeValueList => avl.list
               case badType => throw new RawlsException(s"unsupported type resulting from attribute expression: $badType: ${badType.getClass}")

--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -106,7 +106,7 @@ object MethodConfigResolver {
   def propertiesToWdlInputs(inputs: Map[String, Attribute]): String = JsObject(
     inputs flatMap {
       case (key, AttributeNull) => None
-      case (key, notNullValue) => Some(key, notNullValue.toJson(WDLJsonSupport.AttributeFormat))
+      case (key, notNullValue) => Some(key, notNullValue.toJson(WDLJsonSupport.attributeFormat))
     }
   ) toString
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -36,7 +36,7 @@ object MethodConfigResolver {
 
   private def getArrayResult(inputName: String, seq: Iterable[AttributeValue]): SubmissionValidationValue = {
     val notNull = seq.filter(v => v != null && v != AttributeNull)
-    val attr = if (notNull.isEmpty) Option(AttributeEmptyList) else Option(AttributeValueList(notNull.toSeq))
+    val attr = if (notNull.isEmpty) Option(AttributeValueEmptyList) else Option(AttributeValueList(notNull.toSeq))
     SubmissionValidationValue(attr, None, inputName)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -8,7 +8,7 @@ import wdl4s.{FullyQualifiedName, NamespaceWithWorkflow, WorkflowInput}
 import wdl4s.types.WdlArrayType
 import org.broadinstitute.dsde.rawls.{RawlsException, model}
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WDLJsonSupport._
 import spray.json._
 
 import scala.util.{Failure, Success, Try}
@@ -106,7 +106,7 @@ object MethodConfigResolver {
   def propertiesToWdlInputs(inputs: Map[String, Attribute]): String = JsObject(
     inputs flatMap {
       case (key, AttributeNull) => None
-      case (key, notNullValue) => Some(key, notNullValue.toJson)
+      case (key, notNullValue) => Some(key, notNullValue.toJson(WDLJsonSupport.AttributeFormat))
     }
   ) toString
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/AttributeUpdateOperations.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/AttributeUpdateOperations.scala
@@ -13,6 +13,8 @@ object AttributeUpdateOperations {
       case RemoveAttribute(attributeName) => attributeName
       case AddListMember(attributeListName, _) => attributeListName
       case RemoveListMember(attributeListName, _) => attributeListName
+      case CreateAttributeEntityReferenceList(attributeListName) => attributeListName
+      case CreateAttributeValueList(attributeListName) => attributeListName
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/AttributeUpdateOperations.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/AttributeUpdateOperations.scala
@@ -18,11 +18,15 @@ object AttributeUpdateOperations {
 
   case class AddUpdateAttribute(attributeName: AttributeName, addUpdateAttribute: Attribute) extends AttributeUpdateOperation
   case class RemoveAttribute(attributeName: AttributeName) extends AttributeUpdateOperation
+  case class CreateAttributeEntityReferenceList(attributeName: AttributeName) extends AttributeUpdateOperation
+  case class CreateAttributeValueList(attributeName: AttributeName) extends AttributeUpdateOperation
   case class AddListMember(attributeListName: AttributeName, newMember: Attribute) extends AttributeUpdateOperation
   case class RemoveListMember(attributeListName: AttributeName, removeMember: Attribute) extends AttributeUpdateOperation
 
   private val AddUpdateAttributeFormat = jsonFormat2(AddUpdateAttribute)
   private val RemoveAttributeFormat = jsonFormat1(RemoveAttribute)
+  private val CreateAttributeEntityReferenceListFormat = jsonFormat1(CreateAttributeEntityReferenceList)
+  private val CreateAttributeValueListFormat = jsonFormat1(CreateAttributeValueList)
   private val AddListMemberFormat = jsonFormat2(AddListMember)
   private val RemoveListMemberFormat = jsonFormat2(RemoveListMember)
 
@@ -32,6 +36,8 @@ object AttributeUpdateOperations {
       val json = obj match {
         case x: AddUpdateAttribute => AddUpdateAttributeFormat.write(x)
         case x: RemoveAttribute => RemoveAttributeFormat.write(x)
+        case x: CreateAttributeEntityReferenceList => CreateAttributeEntityReferenceListFormat.write(x)
+        case x: CreateAttributeValueList => CreateAttributeValueListFormat.write(x)
         case x: AddListMember => AddListMemberFormat.write(x)
         case x: RemoveListMember => RemoveListMemberFormat.write(x)
       }
@@ -45,6 +51,8 @@ object AttributeUpdateOperations {
         op match {
           case JsString("AddUpdateAttribute") => AddUpdateAttributeFormat.read(json)
           case JsString("RemoveAttribute") => RemoveAttributeFormat.read(json)
+          case JsString("CreateAttributeEntityReferenceList") => CreateAttributeEntityReferenceListFormat.read(json)
+          case JsString("CreateAttributeValueList") => CreateAttributeValueListFormat.read(json)
           case JsString("AddListMember") => AddListMemberFormat.read(json)
           case JsString("RemoveListMember") => RemoveListMemberFormat.read(json)
           case x => throw new DeserializationException("unrecognized op: " + x)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -222,6 +222,7 @@ case class SubmissionWorkflowStatusResponse(
 
 object ExecutionJsonSupport extends JsonSupport {
   type OutputType = Either[Attribute, UnsupportedOutputType]
+  implicit override val attributeFormat = new AttributeFormat with PlainArrayAttributeListSerializer
 
   implicit object WorkflowStatusFormat extends RootJsonFormat[WorkflowStatus] {
     override def write(obj: WorkflowStatus): JsValue = JsString(obj.toString)
@@ -241,12 +242,12 @@ object ExecutionJsonSupport extends JsonSupport {
 
   implicit object ExecutionOutputFormat extends RootJsonFormat[OutputType] {
     override def write(obj: OutputType): JsValue = obj match {
-      case Left(attribute) => AttributeFormat.write(attribute)
+      case Left(attribute) => attributeFormat.write(attribute)
       case Right(UnsupportedOutputType(json)) => json
     }
 
     override def read(json: JsValue): OutputType = {
-      Try { AttributeFormat.read(json) } match {
+      Try { attributeFormat.read(json) } match {
         case Success(attribute) => Left(attribute)
         case Failure(e: DeserializationException) => Right(UnsupportedOutputType(json))
         case Failure(t) => throw t

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -174,12 +174,12 @@ case class SubmissionReport(
 )
 
 case class CallMetadata(
-  inputs: Map[String, Attribute],
+  inputs: JsObject,
   executionStatus: String,
   backend: Option[String],
   backendStatus: Option[String],
-  backendLogs: Option[Map[String, Attribute]],
-  outputs: Option[Map[String, OutputType]],
+  backendLogs: Option[JsObject],
+  outputs: Option[JsObject],
   start: Option[DateTime],
   end: Option[DateTime],
   jobId: Option[String],
@@ -196,8 +196,8 @@ case class ExecutionMetadata
   submission: DateTime,
   start: Option[DateTime],
   end: Option[DateTime],
-  inputs: Map[String, Attribute],
-  outputs: Option[Map[String, OutputType]],
+  inputs: JsObject,
+  outputs: Option[JsObject],
   calls: Map[String, Seq[CallMetadata]]
 )
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -122,7 +122,7 @@ class JsonSupport extends DefaultJsonProtocol {
 
       case JsObject(members) if ENTITY_OBJECT_KEYS subsetOf members.keySet => (members(ENTITY_TYPE_KEY), members(ENTITY_NAME_KEY)) match {
         case (JsString(typeKey), JsString(nameKey)) => AttributeEntityReference(typeKey, nameKey)
-        case _ => throw new RawlsException()
+        case _ => throw new RawlsException("somehow JsObject keys have ceased being strings, which is terrifying")
       }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -125,7 +125,7 @@ class JsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  implicit val attributeFormat = new AttributeFormat with TypedAttributeListSerializer
+  implicit val attributeFormat: AttributeFormat = new AttributeFormat with TypedAttributeListSerializer
 
   implicit object AttributeStringFormat extends RootJsonFormat[AttributeString] {
     override def write(obj: AttributeString): JsValue = attributeFormat.write(obj)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -48,6 +48,7 @@ trait TypedAttributeListSerializer extends AttributeListSerializer {
 
   val VALUE_LIST_TYPE = "AttributeValue"
   val REF_LIST_TYPE = "EntityReference"
+  val ALLOWED_LIST_TYPES = Seq(VALUE_LIST_TYPE, REF_LIST_TYPE)
 
   def writeListType(obj: Attribute): JsValue = obj match {
     //lists
@@ -75,13 +76,14 @@ trait TypedAttributeListSerializer extends AttributeListSerializer {
     }
 
     (jsMap(LIST_ITEMS_TYPE_KEY), attrList) match {
-      case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if vals.isEmpty => AttributeValueEmptyList
-      case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if vals.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(vals)
+      case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if attrList.isEmpty => AttributeValueEmptyList
+      case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if attrList.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(vals)
 
-      case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if refs.isEmpty => AttributeEntityReferenceEmptyList
-      case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if refs.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(refs)
+      case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if attrList.isEmpty => AttributeEntityReferenceEmptyList
+      case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if attrList.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(refs)
 
-      case _ => throw new DeserializationException("illegal array type")
+      case (JsString(s), _) if !ALLOWED_LIST_TYPES.contains(s) => throw new DeserializationException(s"illegal array type: $LIST_ITEMS_TYPE_KEY must be one of ${ALLOWED_LIST_TYPES.mkString(", ")}")
+      case _ => throw new DeserializationException("illegal array type: array elements don't match array type")
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -15,6 +15,7 @@ sealed trait AttributeListSerializer {
 }
 
 //Serializes attribute lists to e.g. [1,2,3]
+//When reading in JSON, assumes that [] is an empty value list, not an empty ref list
 trait PlainArrayAttributeListSerializer extends AttributeListSerializer {
   override def writeListType(obj: Attribute): JsValue = obj match {
     //lists

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -34,8 +34,7 @@ trait JsonSupport extends DefaultJsonProtocol {
     }
 
     def getAttributeList(s: Seq[Attribute]) = s match {
-      case e: Seq[_] if e.isEmpty => AttributeValueEmptyList
-        //TODO: What to do about AttributeEntityReferenceEmptyList?
+      case e: Seq[_] if e.isEmpty => throw new DeserializationException("can't infer type from empty array")
       case v: Seq[AttributeValue @unchecked] if (s.map(_.isInstanceOf[AttributeValue]).reduce(_&&_)) => AttributeValueList(v)
       case r: Seq[AttributeEntityReference @unchecked] if (s.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_)) => AttributeEntityReferenceList(r)
       case _ => throw new DeserializationException("illegal array type")

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -24,6 +24,7 @@ trait PlainArrayAttributeListSerializer extends AttributeListSerializer {
     case AttributeValueList(l) => JsArray(l.map(writeAttribute):_*)
     case AttributeEntityReferenceEmptyList => JsArray()
     case AttributeEntityReferenceList(l) => JsArray(l.map(writeAttribute):_*)
+    case _ => throw new RawlsException("you can't pass a non-list to writeListType")
   }
 
   override def readListType(json: JsValue): Attribute = json match {
@@ -54,6 +55,7 @@ trait TypedAttributeListSerializer extends AttributeListSerializer {
     case AttributeValueList(l) => writeAttributeList(VALUE_LIST_TYPE, l)
     case AttributeEntityReferenceEmptyList => writeAttributeList(REF_LIST_TYPE, Seq.empty[AttributeEntityReference])
     case AttributeEntityReferenceList(l) => writeAttributeList(REF_LIST_TYPE, l)
+    case _ => throw new RawlsException("you can't pass a non-list to writeListType")
   }
 
   def readListType(json: JsValue): Attribute = json match {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -1,15 +1,44 @@
 package org.broadinstitute.dsde.rawls.model
 
-import spray.json._
+import spray.json.{JsArray, _}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
 
-/**
- * @author tsharpe
- */
-trait JsonSupport extends DefaultJsonProtocol {
-  //Magic strings we use in JSON serialization
-  //Lists get serialized to e.g. { "itemsType" : "AttributeValue", "items" : [1,2,3] }
+//Mix in one of these with your AttributeFormat so you can serialize lists
+//This also needs mixing in with an AttributeFormat because they're symbiotic
+sealed trait AttributeListSerializer {
+  def writeListType(obj: Attribute): JsValue
+  def readListType(json: JsValue): Attribute
+
+  def writeAttribute(obj: Attribute): JsValue
+  def readAttribute(json: JsValue): Attribute
+}
+
+//Serializes attribute lists to e.g. [1,2,3]
+trait PlainArrayAttributeListSerializer extends AttributeListSerializer {
+  override def writeListType(obj: Attribute): JsValue = obj match {
+    //lists
+    case AttributeValueEmptyList => JsArray()
+    case AttributeValueList(l) => JsArray(l.map(writeAttribute):_*)
+    case AttributeEntityReferenceEmptyList => JsArray()
+    case AttributeEntityReferenceList(l) => JsArray(l.map(writeAttribute):_*)
+  }
+
+  override def readListType(json: JsValue): Attribute = json match {
+    case JsArray(a) =>
+      val attrList: Seq[Attribute] = a.map(readAttribute)
+      attrList match {
+        case e: Seq[_] if e.isEmpty => AttributeValueEmptyList
+        case v: Seq[AttributeValue @unchecked] if attrList.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(v)
+        case r: Seq[AttributeEntityReference @unchecked] if attrList.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(r)
+        case _ => throw new DeserializationException("illegal array type")
+      }
+    case _ => throw new DeserializationException("unexpected json type")
+  }
+}
+
+//Serializes attribute lists to e.g. { "itemsType" : "AttributeValue", "items" : [1,2,3] }
+trait TypedAttributeListSerializer extends AttributeListSerializer {
   val LIST_ITEMS_TYPE_KEY = "itemsType"
   val LIST_ITEMS_KEY = "items"
   val LIST_OBJECT_KEYS = Set(LIST_ITEMS_TYPE_KEY, LIST_ITEMS_KEY)
@@ -17,28 +46,58 @@ trait JsonSupport extends DefaultJsonProtocol {
   val VALUE_LIST_TYPE = "AttributeValue"
   val REF_LIST_TYPE = "EntityReference"
 
+  def writeListType(obj: Attribute): JsValue = obj match {
+    //lists
+    case AttributeValueEmptyList => writeAttributeList(VALUE_LIST_TYPE, Seq.empty[AttributeValue])
+    case AttributeValueList(l) => writeAttributeList(VALUE_LIST_TYPE, l)
+    case AttributeEntityReferenceEmptyList => writeAttributeList(REF_LIST_TYPE, Seq.empty[AttributeEntityReference])
+    case AttributeEntityReferenceList(l) => writeAttributeList(REF_LIST_TYPE, l)
+  }
+
+  def readListType(json: JsValue): Attribute = json match {
+    case JsObject(members) if LIST_OBJECT_KEYS subsetOf members.keySet => readAttributeList(members)
+
+    case _ => throw new DeserializationException("unexpected json type")
+  }
+
+  def writeAttributeList[T <: Attribute](listType: String, list: Seq[T]): JsValue = {
+    JsObject( Map(LIST_ITEMS_TYPE_KEY -> JsString(listType), LIST_ITEMS_KEY -> JsArray(list.map( writeAttribute ).toSeq:_*)) )
+  }
+
+  def readAttributeList(jsMap: Map[String, JsValue]) = {
+    val attrList: Seq[Attribute] = jsMap(LIST_ITEMS_KEY) match {
+      case JsArray(elems) => elems.map(readAttribute)
+      case _ => throw new DeserializationException(s"the value of %s should be an array".format(LIST_ITEMS_KEY))
+    }
+
+    (jsMap(LIST_ITEMS_TYPE_KEY), attrList) match {
+      case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if vals.isEmpty => AttributeValueEmptyList
+      case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if vals.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(vals)
+
+      case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if refs.isEmpty => AttributeEntityReferenceEmptyList
+      case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if refs.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(refs)
+
+      case _ => throw new DeserializationException("illegal array type")
+    }
+  }
+}
+
+/**
+ * NOTE: When subclassing this, you may want to define your own implicit val attributeFormat with an AttributeListSerializer mixin
+ * if you want e.g. the plain old JSON array attribute list serialization strategy
+ */
+class JsonSupport extends DefaultJsonProtocol {
+  //Magic strings we use in JSON serialization
+
   //Entity refs get serialized to e.g. { "entityType" : "sample", "entityName" : "theBestSample" }
   val ENTITY_TYPE_KEY = "entityType"
   val ENTITY_NAME_KEY = "entityName"
   val ENTITY_OBJECT_KEYS = Set(ENTITY_TYPE_KEY, ENTITY_NAME_KEY)
 
-  def writeListType(obj: Attribute): JsValue = obj match {
-    //lists
-    case AttributeValueEmptyList => AttributeFormat.writeAttributeList(VALUE_LIST_TYPE, Seq.empty[AttributeValue])
-    case AttributeValueList(l) => AttributeFormat.writeAttributeList(VALUE_LIST_TYPE, l)
-    case AttributeEntityReferenceEmptyList => AttributeFormat.writeAttributeList(REF_LIST_TYPE, Seq.empty[AttributeEntityReference])
-    case AttributeEntityReferenceList(l) => AttributeFormat.writeAttributeList(REF_LIST_TYPE, l)
-  }
+  trait AttributeFormat extends RootJsonFormat[Attribute] with AttributeListSerializer {
 
-  def readListType(json: JsValue): Attribute = json match {
-    case JsObject(members) if LIST_OBJECT_KEYS subsetOf members.keySet => AttributeFormat.readAttributeList(members)
-
-    case _ => throw new DeserializationException("unexpected json type")
-  }
-
-  implicit object AttributeFormat extends RootJsonFormat[Attribute] {
-
-    def write(obj: Attribute): JsValue = obj match {
+    override def write(obj: Attribute): JsValue = writeAttribute(obj)
+    def writeAttribute(obj: Attribute): JsValue = obj match {
       //vals
       case AttributeNull => JsNull
       case AttributeBoolean(b) => JsBoolean(b)
@@ -52,7 +111,8 @@ trait JsonSupport extends DefaultJsonProtocol {
       case _ => throw new SerializationException("AttributeFormat doesn't know how to write JSON for type " + obj.getClass.getSimpleName)
     }
 
-    override def read(json: JsValue): Attribute = json match {
+    override def read(json: JsValue): Attribute = readAttribute(json)
+    def readAttribute(json: JsValue): Attribute = json match {
       case JsNull => AttributeNull
       case JsString(s) => AttributeString(s)
       case JsBoolean(b) => AttributeBoolean(b)
@@ -63,31 +123,12 @@ trait JsonSupport extends DefaultJsonProtocol {
 
       case _ => readListType(json)
     }
-
-    def writeAttributeList[T <: Attribute](listType: String, list: Seq[T]): JsValue = {
-      JsObject( Map(LIST_ITEMS_TYPE_KEY -> JsString(listType), LIST_ITEMS_KEY -> JsArray(list.map( AttributeFormat.write(_) ).toSeq:_*)) )
-    }
-
-    def readAttributeList(jsMap: Map[String, JsValue]) = {
-      val attrList: Seq[Attribute] = jsMap(LIST_ITEMS_KEY) match {
-        case JsArray(elems) => elems.map(AttributeFormat.read(_))
-        case _ => throw new DeserializationException(s"the value of %s should be an array".format(LIST_ITEMS_KEY))
-      }
-
-      (jsMap(LIST_ITEMS_TYPE_KEY), attrList) match {
-        case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if vals.isEmpty => AttributeValueEmptyList
-        case (JsString(VALUE_LIST_TYPE), vals: Seq[AttributeValue @unchecked]) if vals.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(vals)
-
-        case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if refs.isEmpty => AttributeEntityReferenceEmptyList
-        case (JsString(REF_LIST_TYPE), refs: Seq[AttributeEntityReference @unchecked]) if refs.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(refs)
-
-        case _ => throw new DeserializationException("illegal array type")
-      }
-    }
   }
 
+  implicit val attributeFormat = new AttributeFormat with TypedAttributeListSerializer
+
   implicit object AttributeStringFormat extends RootJsonFormat[AttributeString] {
-    override def write(obj: AttributeString): JsValue = AttributeFormat.write(obj)
+    override def write(obj: AttributeString): JsValue = attributeFormat.write(obj)
     override def read(json: JsValue): AttributeString = json match {
       case JsString(s) => AttributeString(s)
       case _ => throw new DeserializationException("unexpected json type")
@@ -95,7 +136,7 @@ trait JsonSupport extends DefaultJsonProtocol {
   }
 
   implicit object AttributeReferenceFormat extends RootJsonFormat[AttributeEntityReference] {
-    override def write(obj: AttributeEntityReference): JsValue = AttributeFormat.write(obj)
+    override def write(obj: AttributeEntityReference): JsValue = attributeFormat.write(obj)
     override def read(json: JsValue): AttributeEntityReference = json match {
       case JsObject(members) => AttributeEntityReference(members(ENTITY_TYPE_KEY).asInstanceOf[JsString].value, members(ENTITY_NAME_KEY).asInstanceOf[JsString].value)
       case _ => throw new DeserializationException("unexpected json type")
@@ -119,11 +160,11 @@ trait JsonSupport extends DefaultJsonProtocol {
 
   implicit object SeqAttributeFormat extends RootJsonFormat[Seq[AttributeValue]] {
     override def write(obj: Seq[AttributeValue]) = {
-      JsArray(obj.map( AttributeFormat.write ).toVector)
+      JsArray(obj.map( attributeFormat.write ).toVector)
     }
 
     override def read(json: JsValue): Seq[AttributeValue] = {
-      AttributeFormat.read(json) match {
+      attributeFormat.read(json) match {
         case AttributeValueEmptyList => Seq.empty
         case AttributeValueList(l) => l
         case _ => throw new DeserializationException("unexpected json type")

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.model
 
+import org.broadinstitute.dsde.rawls.RawlsException
 import spray.json.{JsArray, _}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
@@ -119,8 +120,11 @@ class JsonSupport extends DefaultJsonProtocol {
       case JsBoolean(b) => AttributeBoolean(b)
       case JsNumber(n) => AttributeNumber(n)
 
-      case JsObject(members) if ENTITY_OBJECT_KEYS subsetOf members.keySet =>
-        AttributeEntityReference(members(ENTITY_TYPE_KEY).asInstanceOf[JsString].value, members(ENTITY_NAME_KEY).asInstanceOf[JsString].value)
+      case JsObject(members) if ENTITY_OBJECT_KEYS subsetOf members.keySet => (members(ENTITY_TYPE_KEY), members(ENTITY_NAME_KEY)) match {
+        case (JsString(typeKey), JsString(nameKey)) => AttributeEntityReference(typeKey, nameKey)
+        case _ => throw new RawlsException()
+      }
+
 
       case _ => readListType(json)
     }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/JsonSupport.scala
@@ -19,7 +19,8 @@ trait JsonSupport extends DefaultJsonProtocol {
       case AttributeValueList(l) => JsArray(l.map(write(_)):_*)
       case AttributeEntityReferenceList(l) => JsArray(l.map(write(_)).toSeq:_*)
       case AttributeEntityReference(entityType, entityName) => JsObject(Map("entityType" -> JsString(entityType), "entityName" -> JsString(entityName)))
-      case AttributeEmptyList => JsArray()
+      case AttributeValueEmptyList => JsArray()
+      case AttributeEntityReferenceEmptyList => JsArray()
     }
 
     override def read(json: JsValue): Attribute = json match {
@@ -33,7 +34,8 @@ trait JsonSupport extends DefaultJsonProtocol {
     }
 
     def getAttributeList(s: Seq[Attribute]) = s match {
-      case e: Seq[_] if e.isEmpty => AttributeEmptyList
+      case e: Seq[_] if e.isEmpty => AttributeValueEmptyList
+        //TODO: What to do about AttributeEntityReferenceEmptyList?
       case v: Seq[AttributeValue @unchecked] if (s.map(_.isInstanceOf[AttributeValue]).reduce(_&&_)) => AttributeValueList(v)
       case r: Seq[AttributeEntityReference @unchecked] if (s.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_)) => AttributeEntityReferenceList(r)
       case _ => throw new DeserializationException("illegal array type")

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WDLJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WDLJsonSupport.scala
@@ -3,24 +3,5 @@ package org.broadinstitute.dsde.rawls.model
 import spray.json.{DeserializationException, JsArray, JsValue}
 
 object WDLJsonSupport extends JsonSupport {
-
-  override def writeListType(obj: Attribute): JsValue = obj match {
-    //lists
-    case AttributeValueEmptyList => JsArray()
-    case AttributeValueList(l) => JsArray(l.map(AttributeFormat.write(_)):_*)
-    case AttributeEntityReferenceEmptyList => JsArray()
-    case AttributeEntityReferenceList(l) => JsArray(l.map(AttributeFormat.write(_)):_*)
-  }
-
-  override def readListType(json: JsValue): Attribute = json match {
-    case JsArray(a) =>
-      val attrList: Seq[Attribute] = a.map(AttributeFormat.read(_))
-      attrList match {
-        case e: Seq[_] if e.isEmpty => AttributeValueEmptyList
-        case v: Seq[AttributeValue @unchecked] if attrList.map(_.isInstanceOf[AttributeValue]).reduce(_&&_) => AttributeValueList(v)
-        case r: Seq[AttributeEntityReference @unchecked] if attrList.map(_.isInstanceOf[AttributeEntityReference]).reduce(_&&_) => AttributeEntityReferenceList(r)
-        case _ => throw new DeserializationException("illegal array type")
-      }
-    case _ => throw new DeserializationException("unexpected json type")
-  }
+  implicit override val attributeFormat = new AttributeFormat with PlainArrayAttributeListSerializer
 }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WDLJsonSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WDLJsonSupport.scala
@@ -1,7 +1,6 @@
-package org.broadinstitute.dsde.rawls.dataaccess
+package org.broadinstitute.dsde.rawls.model
 
-import org.broadinstitute.dsde.rawls.model._
-import spray.json.{DeserializationException, JsArray, JsObject, JsString, JsValue}
+import spray.json.{DeserializationException, JsArray, JsValue}
 
 object WDLJsonSupport extends JsonSupport {
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -271,7 +271,8 @@ case object AttributeNull extends AttributeValue
 case class AttributeString(val value: String) extends AttributeValue
 case class AttributeNumber(val value: BigDecimal) extends AttributeValue
 case class AttributeBoolean(val value: Boolean) extends AttributeValue
-case object AttributeEmptyList extends AttributeList[Attribute] { val list = Seq.empty }
+case object AttributeValueEmptyList extends AttributeList[AttributeValue] { val list = Seq.empty }
+case object AttributeEntityReferenceEmptyList extends AttributeList[AttributeEntityReference] { val list = Seq.empty }
 case class AttributeValueList(val list: Seq[AttributeValue]) extends AttributeList[AttributeValue]
 case class AttributeEntityReferenceList(val list: Seq[AttributeEntityReference]) extends AttributeList[AttributeEntityReference]
 case class AttributeEntityReference(val entityType: String, val entityName: String) extends Attribute

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -265,8 +265,9 @@ object ErrorReport extends ((String,String,Option[StatusCode],Seq[ErrorReport],S
 case class ApplicationVersion(gitHash: String, buildNumber: String, version: String)
 
 sealed trait Attribute
-sealed trait AttributeValue extends Attribute
-sealed trait AttributeList[T <: Attribute] extends Attribute { val list: Seq[T] }
+sealed trait AttributeListElementable extends Attribute //terrible name for "this type can legally go in an attribute list"
+sealed trait AttributeValue extends AttributeListElementable
+sealed trait AttributeList[T <: AttributeListElementable] extends Attribute { val list: Seq[T] }
 case object AttributeNull extends AttributeValue
 case class AttributeString(val value: String) extends AttributeValue
 case class AttributeNumber(val value: BigDecimal) extends AttributeValue
@@ -275,7 +276,7 @@ case object AttributeValueEmptyList extends AttributeList[AttributeValue] { val 
 case object AttributeEntityReferenceEmptyList extends AttributeList[AttributeEntityReference] { val list = Seq.empty }
 case class AttributeValueList(val list: Seq[AttributeValue]) extends AttributeList[AttributeValue]
 case class AttributeEntityReferenceList(val list: Seq[AttributeEntityReference]) extends AttributeList[AttributeEntityReference]
-case class AttributeEntityReference(val entityType: String, val entityName: String) extends Attribute
+case class AttributeEntityReference(val entityType: String, val entityName: String) extends AttributeListElementable
 
 object AttributeStringifier {
   def apply(attribute: Attribute): String = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -794,8 +794,19 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
         case RemoveAttribute(attributeName) => startingAttributes - attributeName
 
-        case CreateAttributeEntityReferenceList(attributeName) => startingAttributes + (attributeName -> AttributeEntityReferenceEmptyList)
-        case CreateAttributeValueList(attributeName) => startingAttributes + (attributeName -> AttributeValueEmptyList)
+        case CreateAttributeEntityReferenceList(attributeName) =>
+          if( startingAttributes.contains(attributeName) ) { //non-destructive
+            startingAttributes
+          } else {
+            startingAttributes + (attributeName -> AttributeEntityReferenceEmptyList)
+          }
+
+        case CreateAttributeValueList(attributeName) =>
+          if( startingAttributes.contains(attributeName) ) { //non-destructive
+            startingAttributes
+          } else {
+            startingAttributes + (attributeName -> AttributeValueEmptyList)
+          }
 
         case AddListMember(attributeListName, newMember) =>
           startingAttributes.get(attributeListName) match {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -794,6 +794,9 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
         case RemoveAttribute(attributeName) => startingAttributes - attributeName
 
+        case CreateAttributeEntityReferenceList(attributeName) => startingAttributes + (attributeName -> AttributeEntityReferenceEmptyList)
+        case CreateAttributeValueList(attributeName) => startingAttributes + (attributeName -> AttributeValueEmptyList)
+
         case AddListMember(attributeListName, newMember) =>
           startingAttributes.get(attributeListName) match {
             case Some(AttributeValueEmptyList) =>
@@ -839,8 +842,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             case None =>
               newMember match {
                 case AttributeNull =>
-                  startingAttributes + (attributeListName -> AttributeValueEmptyList)
-                //TODO: How do we load in an empty reflist?
+                  throw new AttributeUpdateOperationException("Cannot use AttributeNull to create empty list. Use CreateEmpty[Ref|Val]List instead.")
                 case newMember: AttributeValue =>
                   startingAttributes + (attributeListName -> AttributeValueList(Seq(newMember)))
                 case newMember: AttributeEntityReference =>

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -796,14 +796,25 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
         case AddListMember(attributeListName, newMember) =>
           startingAttributes.get(attributeListName) match {
-            case Some(AttributeEmptyList) =>
+            case Some(AttributeValueEmptyList) =>
               newMember match {
                 case AttributeNull =>
                   startingAttributes
                 case newMember: AttributeValue =>
                   startingAttributes + (attributeListName -> AttributeValueList(Seq(newMember)))
                 case newMember: AttributeEntityReference =>
+                  throw new AttributeUpdateOperationException("Cannot add non-value to list of values.")
+                case _ => throw new AttributeUpdateOperationException("Cannot create list with that type.")
+              }
+
+            case Some(AttributeEntityReferenceEmptyList) =>
+              newMember match {
+                case AttributeNull =>
+                  startingAttributes
+                case newMember: AttributeEntityReference =>
                   startingAttributes + (attributeListName -> AttributeEntityReferenceList(Seq(newMember)))
+                case newMember: AttributeValue =>
+                  throw new AttributeUpdateOperationException("Cannot add non-reference to list of references.")
                 case _ => throw new AttributeUpdateOperationException("Cannot create list with that type.")
               }
 
@@ -828,7 +839,8 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             case None =>
               newMember match {
                 case AttributeNull =>
-                  startingAttributes + (attributeListName -> AttributeEmptyList)
+                  startingAttributes + (attributeListName -> AttributeValueEmptyList)
+                //TODO: How do we load in an empty reflist?
                 case newMember: AttributeValue =>
                   startingAttributes + (attributeListName -> AttributeValueList(Seq(newMember)))
                 case newMember: AttributeEntityReference =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -76,7 +76,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
   }
 
   it should "insert empty list" in withEmptyTestDatabase {
-    val testAttribute = AttributeEmptyList
+    val testAttribute = AttributeValueEmptyList
     runAndWait(workspaceQuery.save(workspace))
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
@@ -208,7 +208,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
           AttributeName.withDefaultNS("bool") -> AttributeBoolean(true),
           AttributeName.withDefaultNS("ref") -> AttributeEntityReference("type", "name"),
           AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(Seq(AttributeEntityReference("type", "name3"), AttributeEntityReference("type", "name2"), AttributeEntityReference("type", "name1"))),
-          AttributeName.withDefaultNS("emptyList") -> AttributeEmptyList,
+          AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList,
           AttributeName.withDefaultNS("null") -> AttributeNull),
         2 -> Map(AttributeName.withDefaultNS("valList") -> AttributeValueList(Seq(AttributeNumber(3), AttributeNumber(2), AttributeNumber(1))))
       )) {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -223,6 +223,18 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     }
   }
 
+  it should "throw exception unmarshalling a list without listLength set for all" in withEmptyTestDatabase {
+    val attributeRecs = Seq(
+      ((1 -> WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "valList", None, Some(1), None, None, Some(2), Some(3))), None),
+      ((1 -> WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "valList", None, Some(2), None, None, Some(1), None)), None),
+      ((1 -> WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "valList", None, Some(3), None, None, Some(0), Some(3))), None)
+    )
+
+    intercept[RawlsException] {
+      workspaceAttributeQuery.unmarshalAttributes(attributeRecs)
+    }
+  }
+
   it should "throw exception unmarshalling a list without listIndex set for all" in withEmptyTestDatabase {
     val attributeRecs = Seq(
       ((1 -> WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "valList", None, Some(1), None, None, Some(2), Some(3))), None),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -75,18 +75,18 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Option(6), None, None, Option(3), Option(4)))
   }
 
-  it should "insert empty list" in withEmptyTestDatabase {
+  it should "insert empty value list" in withEmptyTestDatabase {
     val testAttribute = AttributeValueEmptyList
     runAndWait(workspaceQuery.save(workspace))
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
     //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
-    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, None, None, None, Option(-1), Option(0)))
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Some(-1.0), None, None, Option(-1), Option(0)))
   }
 
-  it should "save empty AttributeValueLists as AttributeEmptyList" in withEmptyTestDatabase {
-    val testAttribute = AttributeValueList(Seq())
+  it should "insert empty ref list" in withEmptyTestDatabase {
+    val testAttribute = AttributeEntityReferenceEmptyList
     runAndWait(workspaceQuery.save(workspace))
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
@@ -95,7 +95,17 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, None, None, None, Option(-1), Option(0)))
   }
 
-  it should "save empty AttributeEntityReferenceLists as AttributeEmptyList" in withEmptyTestDatabase {
+  it should "save empty AttributeValueLists as AttributeValueEmptyList" in withEmptyTestDatabase {
+    val testAttribute = AttributeValueList(Seq())
+    runAndWait(workspaceQuery.save(workspace))
+    val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
+    assertResult(1) { numRows.head }
+
+    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Some(-1.0), None, None, Option(-1), Option(0)))
+  }
+
+  it should "save empty AttributeEntityReferenceLists as AttributeEntityReferenceEmptyList" in withEmptyTestDatabase {
     val testAttribute = AttributeEntityReferenceList(Seq())
     runAndWait(workspaceQuery.save(workspace))
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -81,8 +81,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
-    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
-    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Some(-1.0), None, None, Option(-1), Option(0)))
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Some(-1.0), None, None, None, Option(0)))
   }
 
   it should "insert empty ref list" in withEmptyTestDatabase {
@@ -91,8 +90,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
-    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
-    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, None, None, None, Option(-1), Option(0)))
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, None, None, None, None, Option(0)))
   }
 
   it should "save empty AttributeValueLists as AttributeValueEmptyList" in withEmptyTestDatabase {
@@ -101,8 +99,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
-    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
-    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Some(-1.0), None, None, Option(-1), Option(0)))
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, Some(-1.0), None, None, None, Option(0)))
   }
 
   it should "save empty AttributeEntityReferenceLists as AttributeEntityReferenceEmptyList" in withEmptyTestDatabase {
@@ -111,8 +108,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val numRows = workspaceAttributeQuery.insertAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute, workspaceId).map(x => runAndWait(x))
     assertResult(1) { numRows.head }
 
-    //NOTE: listIndex of -1 is the magic number for "empty list". see AttributeComponent.unmarshalList
-    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, None, None, None, Option(-1), Option(0)))
+    assertExpectedRecords(WorkspaceAttributeRecord(dummyId2, workspaceId, AttributeName.defaultNamespace, "test", None, None, None, None, None, Option(0)))
   }
 
   it should "insert null attribute" in withEmptyTestDatabase {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -49,7 +49,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
     assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
     assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
 
-    val emptyListAttributeEntity = entity.copy(name = "emptyListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEmptyList))
+    val emptyListAttributeEntity = entity.copy(name = "emptyListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList))
     runAndWait(entityQuery.save(workspaceContext, emptyListAttributeEntity))
     assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyListy")) }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -49,19 +49,25 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers {
     assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
     assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
 
-    val emptyListAttributeEntity = entity.copy(name = "emptyListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList))
-    runAndWait(entityQuery.save(workspaceContext, emptyListAttributeEntity))
-    assertResult(Some(emptyListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyListy")) }
+    //save AttributeValueEmptyList
+    val emptyValListAttributeEntity = entity.copy(name = "emptyValListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList))
+    runAndWait(entityQuery.save(workspaceContext, emptyValListAttributeEntity))
+    assertResult(Some(emptyValListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValListy")) }
 
     //convert AttributeValueList(Seq()) -> AttributeEmptyList
     val emptyValListEntity = entity.copy(name = "emptyValList", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueList(Seq())))
     runAndWait(entityQuery.save(workspaceContext, emptyValListEntity))
-    assertResult(Some(emptyListAttributeEntity.copy(name="emptyValList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList")) }
+    assertResult(Some(emptyValListAttributeEntity.copy(name="emptyValList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList")) }
 
-    //convert AttributeEntityReferenceList(Seq()) -> AttributeEmptyList
+    //save AttributeEntityReferenceEmptyList
+    val emptyRefListAttributeEntity = entity.copy(name = "emptyRefListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEntityReferenceEmptyList))
+    runAndWait(entityQuery.save(workspaceContext, emptyRefListAttributeEntity))
+    assertResult(Some(emptyRefListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefListy")) }
+
+    //convert AttributeEntityReferenceList(Seq()) -> AttributeEntityReferenceEmptyList
     val emptyRefListEntity = entity.copy(name = "emptyRefList", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEntityReferenceList(Seq())))
     runAndWait(entityQuery.save(workspaceContext, emptyRefListEntity))
-    assertResult(Some(emptyListAttributeEntity.copy(name="emptyRefList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList")) }
+    assertResult(Some(emptyRefListAttributeEntity.copy(name="emptyRefList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList")) }
 
     assertResult(true) { runAndWait(entityQuery.delete(workspaceContext, "type", "name")) }
     assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -51,7 +51,7 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
     Seq(testData.sset1), Map(testData.sset1 -> inputResolutionsListEmpty),
     Seq.empty, Map.empty)
 
-  val inputResolutionsAttrEmptyList = Seq(SubmissionValidationValue(Option(AttributeEmptyList), Option("message4"), "test_input_name4"))
+  val inputResolutionsAttrEmptyList = Seq(SubmissionValidationValue(Option(AttributeValueEmptyList), Option("message4"), "test_input_name4"))
   private val submissionAttrEmptyList = createTestSubmission(testData.workspace, testData.methodConfigArrayType, testData.sset1, testData.userOwner,
     Seq(testData.sset1), Map(testData.sset1 -> inputResolutionsAttrEmptyList),
     Seq.empty, Map.empty)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -163,7 +163,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
     val wsAttrs = Map(
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),
       AttributeName.withDefaultNS("number") -> AttributeNumber(10),
-      AttributeName.withDefaultNS("empty") -> AttributeEmptyList,
+      AttributeName.withDefaultNS("empty") -> AttributeValueEmptyList,
       AttributeName.withDefaultNS("values") -> AttributeValueList(Seq(AttributeString("another string"), AttributeString("true")))
     )
 
@@ -352,7 +352,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
         AttributeEntityReference("Sample", "sample7")))))
 
     val sset_empty = Entity("sset_empty", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEmptyList ))
+      Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList ))
 
     val ps1 = Entity("ps1", "PairSet",
       Map(AttributeName.withDefaultNS("pairs") -> AttributeEntityReferenceList( Seq(AttributeEntityReference("Pair", "pair1"),
@@ -631,7 +631,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
     val wsAttrs = Map(
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),
       AttributeName.withDefaultNS("number") -> AttributeNumber(10),
-      AttributeName.withDefaultNS("empty") -> AttributeEmptyList,
+      AttributeName.withDefaultNS("empty") -> AttributeValueEmptyList,
       AttributeName.withDefaultNS("values") -> AttributeValueList(Seq(AttributeString("another string"), AttributeString("true")))
     )
 
@@ -684,7 +684,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
         AttributeEntityReference("Sample", "sample7")))))
 
     val sset_empty = Entity("sset_empty", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEmptyList ))
+      Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList ))
 
     val ps1 = Entity("ps1", "PairSet",
       Map(AttributeName.withDefaultNS("pairs") -> AttributeEntityReferenceList( Seq(AttributeEntityReference("Pair", "pair1"),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SlickSimpleExpressionParserTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SlickSimpleExpressionParserTest.scala
@@ -106,9 +106,8 @@ class SlickSimpleExpressionParserTest extends FunSuite with TestDriverComponent 
 
   test("attribute expression that refers to an entity should except") {
     withTestWorkspace { workspaceContext =>
-      intercept[RawlsException] {
-        runAndWait(evalFinalAttribute(workspaceContext, "Pair", "pair1", "this.case"))
-      }
+      val exprResult = runAndWait(evalFinalAttribute(workspaceContext, "Pair", "pair1", "this.case"))
+      assert(exprResult("pair1").isFailure)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SlickSimpleExpressionParserTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SlickSimpleExpressionParserTest.scala
@@ -104,6 +104,14 @@ class SlickSimpleExpressionParserTest extends FunSuite with TestDriverComponent 
     }
   }
 
+  test("attribute expression that refers to an entity should except") {
+    withTestWorkspace { workspaceContext =>
+      intercept[RawlsException] {
+        runAndWait(evalFinalAttribute(workspaceContext, "Pair", "pair1", "this.case"))
+      }
+    }
+  }
+
   test("library entity attribute expression") {
     withTestWorkspace { workspaceContext =>
       val libraryAttribute = Map(AttributeName("library", "book") -> AttributeString("arbitrary"))

--- a/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SlickSimpleExpressionParserTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/expressions/SlickSimpleExpressionParserTest.scala
@@ -400,7 +400,7 @@ class SlickSimpleExpressionParserTest extends FunSuite with TestDriverComponent 
 
       val libraryAttributes = Map(
         AttributeName("library", "author") -> AttributeString("L. Ron Hubbard"),
-        AttributeName("library", "nothing") -> AttributeEmptyList,
+        AttributeName("library", "nothing") -> AttributeValueEmptyList,
         AttributeName("library", "series") -> AttributeValueList(series)
       )
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -162,7 +162,7 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
       val context = SlickWorkspaceContext(workspace)
 
       runAndWait(testResolveInputs(context, configEmptyArray, sampleSet2, arrayWdl, this)) shouldBe
-        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeEmptyList), None, intArrayName)))
+        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueEmptyList), None, intArrayName)))
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
@@ -460,7 +460,7 @@ class AttributeSpec extends FreeSpec with Assertions {
           |    {"entityType":"pair","entityName":"MyPairName"}
           |  ]}
           |}
-        """.stripMargin.trim.replace(" ", "").replace("\n","")
+        """.stripMargin.trim.replace(" ", "").replace("\n","").replace("\r","")
 
         val actual = testData.toJson.compactPrint
         // we can't test the two strings directly, because AttributeMap doesn't preserve order,

--- a/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
@@ -1,0 +1,480 @@
+package org.broadinstitute.dsde.rawls.model
+
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{attributeFormat, AttributeNameFormat}
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.scalatest.{Assertions, FreeSpec}
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+class AttributeSpec extends FreeSpec with Assertions {
+
+  "AttributeName model" - {
+    "when unmarshalling from json" - {
+      "should handle namespaces" in {
+        val testData = """ "namespace:name" """
+        val an = testData.parseJson.convertTo[AttributeName]
+        assertResult("namespace") {an.namespace}
+        assertResult("name") {an.name}
+      }
+      "should handle missing namespace" in {
+        val testData = """ "name" """
+        val an = testData.parseJson.convertTo[AttributeName]
+        assertResult(AttributeName.defaultNamespace) {an.namespace}
+        assertResult("name") {an.name}
+      }
+      "should fail with multiple delimiters" in {
+        val testData = """ "one:two:three" """
+        intercept[RawlsException] {
+          testData.parseJson.convertTo[AttributeName]
+        }
+      }
+    }
+    "when marshalling to json" - {
+      "should handle arbitrary namespace" in {
+        val testData = AttributeName("namespace", "name")
+        assertResult(JsString("namespace:name")) {testData.toJson}
+      }
+      "should handle library namespace" in {
+        val testData = AttributeName(AttributeName.libraryNamespace, "name")
+        assertResult(JsString("library:name")) {testData.toJson}
+      }
+      "should omit default namespace" in {
+        val testData = AttributeName.withDefaultNS("name")
+        assertResult(JsString("name")) {testData.toJson}
+      }
+    }
+  }
+
+  "AttributeMap model" - {
+    "when unmarshalling from json" - {
+      "should handle string value" in {
+        val testData =
+          """
+            | {"testKey" : "helloWorld"}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeString("helloWorld")) { attr }
+      }
+      "should handle numeric value" in {
+        val testData =
+          """
+            | {"testKey" : 123}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeNumber(123)) { attr }
+      }
+      "should handle boolean value" in {
+        val testData =
+          """
+            | {"testKey" : true}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeBoolean(true)) { attr }
+      }
+      "should handle null value" in {
+        val testData =
+          """
+            | {"testKey" : null}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeNull) { attr }
+      }
+      "should handle entity reference value" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "entityType" : "sample",
+            |   "entityName" : "My Sample Name"
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeEntityReference("sample", "My Sample Name")) { attr }
+      }
+      "should handle empty value list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : []
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeValueEmptyList) { attr }
+      }
+      "should handle empty entity reference list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "EntityReference",
+            |   "items" : []
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        assertResult(AttributeEntityReferenceEmptyList) { attr }
+      }
+      "should handle populated entity reference list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "EntityReference",
+            |   "items" : [
+            |     {"entityType" : "sample", "entityName" : "My Sample Name"},
+            |     {"entityType" : "participant", "entityName" : "My Participant Name"},
+            |     {"entityType" : "pair", "entityName" : "My Pair Name"}
+            |   ]
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        val expected = AttributeEntityReferenceList( Seq(
+          AttributeEntityReference("sample", "My Sample Name"),
+          AttributeEntityReference("participant", "My Participant Name"),
+          AttributeEntityReference("pair", "My Pair Name")
+        ) )
+        assertResult(expected) { attr }
+      }
+      "should handle populated string list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : [ "foo", "bar", "baz" ]
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        val expected = AttributeValueList(Seq(
+          AttributeString("foo"),
+          AttributeString("bar"),
+          AttributeString("baz")
+        ))
+        assertResult(expected) { attr }
+      }
+      "should handle populated numeric list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : [ 123, 456, 789 ]
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        val expected = AttributeValueList(Seq(
+          AttributeNumber(123),
+          AttributeNumber(456),
+          AttributeNumber(789)
+        ))
+        assertResult(expected) { attr }
+      }
+      "should handle populated boolean list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : [ true, false, true ]
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        val expected = AttributeValueList(Seq(
+          AttributeBoolean(true),
+          AttributeBoolean(false),
+          AttributeBoolean(true)
+        ))
+        assertResult(expected) { attr }
+      }
+      "should fail if entity reference list contains values" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "EntityReference",
+            |   "items" : [ 123, 456, 789 ]
+            | }}
+          """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[AttributeMap]
+        }
+      }
+      "should fail if value list contains entities" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : [
+            |     {"entityType" : "sample", "entityName" : "My Sample Name"},
+            |     {"entityType" : "participant", "entityName" : "My Participant Name"},
+            |     {"entityType" : "pair", "entityName" : "My Pair Name"}
+            |   ]
+            | }}
+          """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[AttributeMap]
+        }
+      }
+      "should work even if value list contains mixed types" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : ["hello world", 123, false]
+            | }}
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+        val attr = obj.getOrElse(AttributeName.withDefaultNS("testKey"), fail("attr doesn't exist"))
+        val expected = AttributeValueList(Seq(
+          AttributeString("hello world"),
+          AttributeNumber(123),
+          AttributeBoolean(false)
+        ))
+        assertResult(expected) { attr }
+      }
+      "should fail if list specifies unknown type" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "SomeValueNotExpected",
+            |   "items" : ["foo", "bar", "baz"]
+            | }}
+          """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[AttributeMap]
+        }
+      }
+      "should fail if list omits type" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "items" : ["foo", "bar", "baz"]
+            | }}
+          """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[AttributeMap]
+        }
+      }
+      "should fail if entity reference list contains list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "EntityReference",
+            |   "items" : [
+            |     {"anotherList" :
+            |       {
+            |         "itemsType" : "AttributeValue",
+            |         "items" : ["foo", "bar", "baz"]
+            |       }
+            |     }
+            |   ]
+            | }}
+          """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[AttributeMap]
+        }
+      }
+      "should fail if value list contains list" in {
+        val testData =
+          """
+            | {"testKey" : {
+            |   "itemsType" : "AttributeValue",
+            |   "items" : [
+            |     {"anotherList" :
+            |       {
+            |         "itemsType" : "AttributeValue",
+            |         "items" : ["foo", "bar", "baz"]
+            |       }
+            |     }
+            |   ]
+            | }}
+          """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[AttributeMap]
+        }
+      }
+      "should handle a json with every possible type" in {
+        val testData =
+          """
+            | {
+            |   "stringKey" : "stringValue",
+            |   "numberKey" : 123,
+            |   "booleanKey" : true,
+            |   "nullKey" : null,
+            |   "entityReferenceKey" : {"entityType" : "sample", "entityName" : "Top-level reference"},
+            |   "emptyValueListKey" : { "itemsType" : "AttributeValue", "items" : []},
+            |   "emptyEntityReferenceListKey" : { "itemsType" : "EntityReference", "items" : []},
+            |   "valueListKey" : { "itemsType" : "AttributeValue", "items" : ["foo", 456, false]},
+            |   "entityReferenceListKey" : {
+            |     "itemsType" : "EntityReference",
+            |     "items" : [
+            |       {"entityType" : "sample", "entityName" : "My Sample Name"},
+            |       {"entityType" : "participant", "entityName" : "My Participant Name"},
+            |       {"entityType" : "pair", "entityName" : "My Pair Name"}
+            |     ]
+            |   }
+            | }
+          """.stripMargin
+        val obj = testData.parseJson.convertTo[AttributeMap]
+
+        val expected = Map[AttributeName,Attribute](
+          AttributeName.withDefaultNS("stringKey") -> AttributeString("stringValue"),
+          AttributeName.withDefaultNS("numberKey") -> AttributeNumber(123),
+          AttributeName.withDefaultNS("booleanKey") -> AttributeBoolean(true),
+          AttributeName.withDefaultNS("nullKey") -> AttributeNull,
+          AttributeName.withDefaultNS("entityReferenceKey") -> AttributeEntityReference("sample", "Top-level reference"),
+          AttributeName.withDefaultNS("emptyValueListKey") -> AttributeValueEmptyList,
+          AttributeName.withDefaultNS("emptyEntityReferenceListKey") -> AttributeEntityReferenceEmptyList,
+          AttributeName.withDefaultNS("valueListKey") -> AttributeValueList(Seq(
+            AttributeString("foo"), AttributeNumber(456), AttributeBoolean(false)
+          )),
+          AttributeName.withDefaultNS("entityReferenceListKey") -> AttributeEntityReferenceList(Seq(
+            AttributeEntityReference("sample", "My Sample Name"),
+            AttributeEntityReference("participant", "My Participant Name"),
+            AttributeEntityReference("pair", "My Pair Name")
+          ))
+        )
+        assertResult(expected) { obj }
+      }
+    }
+    "when marshalling to json" - {
+      "should handle string value" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeString("abc"))
+        val expected =
+          """
+            |{"ns:name":"abc"}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle numeric value" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeNumber(777))
+        val expected =
+          """
+            |{"ns:name":777}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle boolean value" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeBoolean(true))
+        val expected =
+          """
+            |{"ns:name":true}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle null value" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeNull)
+        val expected =
+          """
+            |{"ns:name":null}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle entity reference value" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->
+          AttributeEntityReference("sample", "some sample name"))
+        val expected =
+          """
+            |{"ns:name":{"entityType":"sample","entityName":"some sample name"}}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle empty value list" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeValueEmptyList)
+        val expected =
+          """
+            |{"ns:name":{"itemsType":"AttributeValue","items":[]}}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle empty entity reference list" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeEntityReferenceEmptyList)
+        val expected =
+          """
+            |{"ns:name":{"itemsType":"EntityReference","items":[]}}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle populated entity reference list" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeEntityReferenceList(Seq(
+          AttributeEntityReference("sample", "some sample name"),
+          AttributeEntityReference("participant", "some participant name")
+        )))
+        val expected =
+          """
+            |{"ns:name":{"itemsType":"EntityReference","items":[{"entityType":"sample","entityName":"some sample name"},{"entityType":"participant","entityName":"some participant name"}]}}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle populated mixed value list" in {
+        val testData:AttributeMap = Map(AttributeName("ns","name")->AttributeValueList(Seq(
+          AttributeString("def"),
+          AttributeNumber(999),
+          AttributeBoolean(true),
+          AttributeNull
+        )))
+        val expected =
+          """
+            |{"ns:name":{"itemsType":"AttributeValue","items":["def",999,true,null]}}
+          """.stripMargin.trim
+        assertResult(expected) { testData.toJson.compactPrint }
+      }
+      "should handle a json with every possible type" in {
+        val testData:AttributeMap = Map[AttributeName,Attribute](
+          AttributeName.withDefaultNS("stringKey") -> AttributeString("stringValue"),
+          AttributeName.withDefaultNS("numberKey") -> AttributeNumber(123),
+          AttributeName.withDefaultNS("booleanKey") -> AttributeBoolean(true),
+          AttributeName.withDefaultNS("nullKey") -> AttributeNull,
+          AttributeName.withDefaultNS("entityReferenceKey") -> AttributeEntityReference("sample", "TopLevelReference"),
+          AttributeName.withDefaultNS("emptyValueListKey") -> AttributeValueEmptyList,
+          AttributeName.withDefaultNS("emptyEntityReferenceListKey") -> AttributeEntityReferenceEmptyList,
+          AttributeName.withDefaultNS("valueListKey") -> AttributeValueList(Seq(
+            AttributeString("foo"), AttributeNumber(456), AttributeBoolean(false)
+          )),
+          AttributeName.withDefaultNS("entityReferenceListKey") -> AttributeEntityReferenceList(Seq(
+            AttributeEntityReference("sample", "MySampleName"),
+            AttributeEntityReference("participant", "MyParticipantName"),
+            AttributeEntityReference("pair", "MyPairName")
+          ))
+        )
+        // use replace to make the test code easier to read
+        val expected =
+        """
+          |{
+          |  "stringKey" : "stringValue",
+          |  "numberKey" : 123,
+          |  "booleanKey" : true,
+          |  "nullKey" : null,
+          |  "entityReferenceKey" : {"entityType":"sample","entityName":"TopLevelReference"},
+          |  "emptyValueListKey" : {"itemsType" : "AttributeValue", "items" : []},
+          |  "emptyEntityReferenceListKey" : {"itemsType" : "EntityReference", "items" : []},
+          |  "valueListKey" : {"itemsType" : "AttributeValue", "items" : [ "foo", 456, false ]},
+          |  "entityReferenceListKey" : {"itemsType" : "EntityReference", "items" : [
+          |    {"entityType":"sample","entityName":"MySampleName"},
+          |    {"entityType":"participant","entityName":"MyParticipantName"},
+          |    {"entityType":"pair","entityName":"MyPairName"}
+          |  ]}
+          |}
+        """.stripMargin.trim.replace(" ", "").replace("\n","")
+
+        val actual = testData.toJson.compactPrint
+        // we can't test the two strings directly, because AttributeMap doesn't preserve order,
+        // and therefore we don't know in which order the keys will appear. So, jump through a
+        // few hoops to validate.
+        assertResult(expected.length) { actual.length }
+        // strip off the first and last { and }, which gives us each individual key/value pair,
+        // sort, and compare the sorted results
+        val expectedSubStrings = expected.substring(1,expected.length-1).split(",").sorted
+        val actualSubStrings = actual.substring(1,actual.length-1).split(",").sorted
+        assertResult(expectedSubStrings) { actualSubStrings }
+
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -192,6 +192,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val referenceList = AttributeEntityReferenceList(Seq(testData.sample2.toReference, newEntity.toReference))
     val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), referenceList)))
     val update2 = EntityUpdateDefinition(newEntity.name, newEntity.entityType, Seq.empty)
+    val blep = httpJson(Seq(update1, update2))
     Post(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
       sealRoute(services.entityRoutes) ~>
       check {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1338,7 +1338,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 409 Conflict on clone if the destination already exists" in withTestDataApiServices { services =>
-    Post(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/clone", httpJson(testData.workspace)) ~>
+    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = testData.workspaceNoGroups.name, None, Map.empty)
+    Post(s"/workspaces/${testData.workspace.namespace}/${testData.workspace.name}/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Conflict) {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -693,12 +693,6 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.BadRequest) {
           status
         }
-        // TODO: test currently fails, response is as follows. What should this respond with?
-        /*
-        HttpResponse(400 Bad Request,HttpEntity(text/plain; charset=UTF-8,The request content was malformed:illegal array type),List(),HTTP/1.1)
-         */
-        val errorText = responseAs[ErrorReport].message
-        assert(errorText.contains(name.namespace))
       }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -521,7 +521,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 Not Found on clone if the source workspace cannot be found" in withTestDataApiServices { services =>
-    Post(s"/workspaces/${testData.workspace.namespace}/nonexistent/clone", httpJson(testData.workspace)) ~>
+    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_nonexistent", None, Map.empty)
+    Post(s"/workspaces/${testData.workspace.namespace}/nonexistent/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -29,7 +29,11 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
   import driver.api._
 
   val attributeList = AttributeValueList(Seq(AttributeString("a"), AttributeString("b"), AttributeBoolean(true)))
-  val s1 = Entity("s1", "samples", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3), AttributeName.withDefaultNS("splat") -> attributeList))
+  val s1 = Entity("s1", "samples", Map(
+    AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+    AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+    AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(Seq(AttributeEntityReference("participant", "p1"))),
+    AttributeName.withDefaultNS("splat") -> attributeList))
   val workspace = Workspace(
     testData.wsName.namespace,
     testData.wsName.name,
@@ -138,9 +142,21 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     }
   }
 
+  it should "not wipe existing AttributeEntityReferenceList when calling CreateAttributeEntityReferenceList" in withTestDataServices { services =>
+    assertResult(Some(s1.attributes(AttributeName.withDefaultNS("refs")))) {
+      services.workspaceService.applyOperationsToEntity(s1, Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("refs")))).attributes.get(AttributeName.withDefaultNS("refs"))
+    }
+  }
+
   it should "create empty AttributeValueList" in withTestDataServices { services =>
     assertResult(Some(AttributeValueEmptyList)) {
       services.workspaceService.applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("emptyValList")))).attributes.get(AttributeName.withDefaultNS("emptyValList"))
+    }
+  }
+
+  it should "not wipe existing AttributeValueList when calling CreateAttributeValueList" in withTestDataServices { services =>
+    assertResult(Some(s1.attributes(AttributeName.withDefaultNS("splat")))) {
+      services.workspaceService.applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("splat")))).attributes.get(AttributeName.withDefaultNS("splat"))
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -126,9 +126,21 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     }
   }
 
-  it should "create an empty list when inserting null via AddListMember" in withTestDataServices { services =>
-    assertResult(Some(AttributeValueEmptyList)) {
+  it should "throw AttributeUpdateOperationException when trying to create a new empty list by inserting AttributeNull" in withTestDataServices { services =>
+    intercept[AttributeUpdateOperationException] {
       services.workspaceService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("nolisthere"), AttributeNull))).attributes.get(AttributeName.withDefaultNS("nolisthere"))
+    }
+  }
+
+  it should "create empty AttributeEntityReferenceList" in withTestDataServices { services =>
+    assertResult(Some(AttributeEntityReferenceEmptyList)) {
+      services.workspaceService.applyOperationsToEntity(s1, Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("emptyRefList")))).attributes.get(AttributeName.withDefaultNS("emptyRefList"))
+    }
+  }
+
+  it should "create empty AttributeValueList" in withTestDataServices { services =>
+    assertResult(Some(AttributeValueEmptyList)) {
+      services.workspaceService.applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("emptyValList")))).attributes.get(AttributeName.withDefaultNS("emptyValList"))
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -127,7 +127,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
   }
 
   it should "create an empty list when inserting null via AddListMember" in withTestDataServices { services =>
-    assertResult(Some(AttributeEmptyList)) {
+    assertResult(Some(AttributeValueEmptyList)) {
       services.workspaceService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("nolisthere"), AttributeNull))).attributes.get(AttributeName.withDefaultNS("nolisthere"))
     }
   }


### PR DESCRIPTION
This PR covers GAWB-1114 as well. It has a few moving parts, so here's a walkthrough. The links dotted through the doc will jump you around the diff.

Sibling PR in orch: https://github.com/broadinstitute/firecloud-orchestration/pull/271
Sibling PR in UI: <as yet unwritten>
# The Context

https://broadinstitute.atlassian.net/browse/GAWB-1096

TL;DR: Put this.participant into a method config input and you don't get an error. You should.
# The Bugs
## Bug One: We don't throw an error when an attribute expression returns an entity

Here's [the bug](https://github.com/broadinstitute/rawls/pull/547/files#diff-5311caed81a6a46128e4132cfeeedac8L243): "Since we know we are not dealing with a reference here as this is the attribute final func, we can pass in None."

Turns out that's wrong: we've pulled the attribute with the matching name (in this case, "participant"), but because we pass in None for the referenced entity, we end up skipping past [the branch we wanted to go into](https://github.com/broadinstitute/rawls/blob/8114dfef312fe18d555710f774dcb03820a968ab/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala#L348) and end up treating it as a value instead, ultimately [returning AttributeNull](https://github.com/broadinstitute/rawls/blob/8114dfef312fe18d555710f774dcb03820a968ab/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala#L397).

The fix is to [distinguish between reference and value attributes](https://github.com/broadinstitute/rawls/pull/547/files#diff-5311caed81a6a46128e4132cfeeedac8R251) ahead of time, parse the value attributes nicely, and then [handle the entity references](https://github.com/broadinstitute/rawls/pull/547/files#diff-5311caed81a6a46128e4132cfeeedac8R257) by turning them into fake `AttributeEntityReference` objects that we can [catch and throw an exception in later](https://github.com/broadinstitute/rawls/pull/547/files#diff-5311caed81a6a46128e4132cfeeedac8R399).
### Detour: Distinguishing between reference and value attributes

Well, this is easy, right? Here are the fields of an AttributeRecord:

```
trait AttributeRecord[OWNER_ID] {
  val id: Long
  val ownerId: OWNER_ID
  val namespace: String
  val name: String
  val valueString: Option[String]
  val valueNumber: Option[Double]
  val valueBoolean: Option[Boolean]
  val valueEntityRef: Option[Long]
  val listIndex: Option[Int]
  val listLength: Option[Int]
}
```

It's an entity reference if `valueEntityRef` is defined and a value otherwise. For lists, we populate the `listIndex` field to indicate which element of the list the record refers to, pull 'em all, and reassemble the list afterwards.

For empty lists, we just save a dummy record with `listIndex = -1` to indicate that the list is empty, and leave all the `valueFoo` fields blank.

Ah.

Now we can't tell the difference between an empty reference list and an empty value list, because [they're saved to the database in the same way.](https://github.com/broadinstitute/rawls/pull/547/files#diff-37c2cc14b84b1a0ed1d99ba2adb74b18L234)

Guess we have to fix that now.
## Bug Two: Can't tell the difference between an empty value list and an empty reference list

This doesn't _seem_ to be a huge problem: the list is empty, who cares?

Well, maybe you're a user who accidentally writes `this.samples` in your method config expression when you really mean `this.samples.name` (I've seen this happen), and it doesn't error the first time because your sample set was empty. Then you reuse the method config a second time and it suddenly stops working because we fixed Bug One and now throw errors when you end up with a ref at the end of a value expression.

So let's fix that. New rule! For empty value lists, [we jam a -1 in the `valueNumber` field](https://github.com/broadinstitute/rawls/pull/547/files#diff-37c2cc14b84b1a0ed1d99ba2adb74b18R199). For empty ref lists, we leave them all blank (because `valueEntityRef` is enforced with a foreign key constraint, so we can't put a dummy value in there). This also means we get rid of `AttributeEmptyList` in favour of [two new types](https://github.com/broadinstitute/rawls/pull/547/files#diff-37c2cc14b84b1a0ed1d99ba2adb74b18R248), `AttributeEntityReferenceEmptyList` and `AttributeValueEmptyList`.

Then when we go to unmarshal the list from the database, if the `listIndex` is -1 we can [look at the `valueNumber` field and distinguish whether it's an empty ref or value list](https://github.com/broadinstitute/rawls/pull/547/files#diff-37c2cc14b84b1a0ed1d99ba2adb74b18R381).

This is great - we've now added types to empty lists (something even Scala can't do!) and we can distinguish between them.

Unfortunately we're still not done yet.
## Bug Three: JSON representation is still ambiguous

`AttributeEmptyList` was serialized out to JSON as `[]`. Now we've ditched that in favour of two separate empty list types, how do we distinguish between them in JSON? Unless we do something about this, we can't roundtrip our data through JSON, as we'll have no idea how to interpret `[]` and _must_ error.

Welp, there's only one thing we can do. Here's [how lists are represented now](https://github.com/broadinstitute/rawls/pull/547/files#diff-6242a09492d6dabd946ed5cadd93113aR68):

```
{
    "itemsType" : "AttributeValue", //or "EntityReference"
    "items" : [1,2,3]
}
```

Eww.

That's what the changes around [AttributeFormat](https://github.com/broadinstitute/rawls/pull/547/files#diff-6242a09492d6dabd946ed5cadd93113aR39) are about.

But we only want to use this representation when talking to the outside world. Cromwell expects the old behaviour of lists being plain old JSON arrays, so we encapsulate that behaviour [in a new different WDLJsonSupport class](https://github.com/broadinstitute/rawls/pull/547/files#diff-527aaa28a026d49549dfda679d66e494R5).
### Tweaking JsonSupport

The first version of this PR had an icky implementation of providing different AttributeList serialization strategies (object-y version vs. plain old lists). This has since been reworked thanks to a suggestion from Doge.

`JsonSupport.AttributeFormat` now [has a mixin](https://github.com/broadinstitute/rawls/pull/547/files#diff-6242a09492d6dabd946ed5cadd93113aR97) called `AttributeListSerializer`. There are two versions of this mixin: `TypedAttributeListSerializer` and `PlainArrayAttributeListSerializer`, representing the object-y version and the plain old list version. [The default version of the implicit](https://github.com/broadinstitute/rawls/pull/547/files#diff-6242a09492d6dabd946ed5cadd93113aR128) uses the `TypedAttributeListSerializer`, but things that interact with Cromwell provide [their own JsonSupport implicit](https://github.com/broadinstitute/rawls/pull/547/files#diff-527aaa28a026d49549dfda679d66e494R6) that overrides the mixin.
## Bonus time: deserialize fewer things from Cromwell

A bunch of our endpoints just pass through to Cromwell. We were deserializing them to Attributes and then back to JSON again in the HTTP response. [I made that go away, because why?](https://github.com/broadinstitute/rawls/pull/547/files#diff-4c7743f07a412bba7e50f81369371f28R200)
# Checklist time!
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  - Acceptance criteria exists and is met
  - Note any changes to implementation from the description
  - Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  - If PR includes new or changed db queries, include the explain plans in the description
  - Make sure liquibase is updated if appropriate
  - If doing a migration, take a backup of the
    [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
    and
    [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
    DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  - Authentication
  - Authorization
  - Encryption
  - Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it **(apply requires_doge label)**
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- Review cycle:
  - LR reviews
  - Rest of team may comment on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH
  - Submitter updates documentation as needed
  - Submitter **reassigns to LR** for further feedback
- [ ] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
