### PR TITLE
GAWB-1059: Endpoints for listing workspaces by attribute

### DIFF
--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1163,6 +1163,34 @@ paths:
             - openid
             - email
             - profile
+  '/api/admin/publishedWorkspaces':
+    get:
+      responses:
+        '200':
+          description: Successful Request
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Workspace'
+        '403':
+          description: You must be an admin to list published workspaces
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        '500':
+          description: Rawls Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      description: List published workspaces
+      tags:
+        - admin
+        - workspaces
+      summary: list published workspaces
+      operationId: listPublishedWorkspaces
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   '/api/admin/workspaces/{workspaceNamespace}/{workspaceName}':
     delete:
           responses:

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1158,40 +1158,27 @@ paths:
         - workspaces
       summary: list all workspaces
       operationId: listAllWorkspaces
-      security:
-        - authorization:
-            - openid
-            - email
-            - profile
-  '/api/admin/workspacesByAttribute':
-    post:
-      responses:
-        '200':
-          description: Successful Request
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Workspace'
-        '403':
-          description: You must be an admin to list published workspaces
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '500':
-          description: Rawls Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
-      description: look up workspaces containing a certain attribute
-      tags:
-        - admin
-        - workspaces
-      summary: workspaces by attribute
-      operationId: workspacesByAttribute
       parameters:
-        - in: body
-          description: Attribute and value map
-          name: attributeMap
-          required: true
-          type: Map
+        - in: query
+          description: Optional workspace attribute to filter on
+          name: attributeName
+          required: false
+          type: string
+        - in: query
+          description: attribute value (for String attributes)
+          name: valueString
+          required: false
+          type: string
+        - in: query
+          description: attribute value (for numerical attributes)
+          name: valueNumber
+          required: false
+          type: number
+        - in: query
+          description: attribute value (for boolean attributes)
+          name: valueBoolean
+          required: false
+          type: boolean
       security:
         - authorization:
             - openid
@@ -4134,11 +4121,11 @@ definitions:
   ValidatedMethodConfiguration:
     description: ''
     required:
-      -methodConfiguration
-      -validInputs
-      -invalidInputs
-      -validOutputs
-      -invalidOutputs
+      - methodConfiguration
+      - validInputs
+      - invalidInputs
+      - validOutputs
+      - invalidOutputs
     properties:
       validInputs:
         type: array

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1163,34 +1163,6 @@ paths:
             - openid
             - email
             - profile
-  '/api/admin/publishedWorkspaces':
-    get:
-      responses:
-        '200':
-          description: Successful Request
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Workspace'
-        '403':
-          description: You must be an admin to list published workspaces
-          schema:
-            $ref: '#/definitions/ErrorReport'
-        '500':
-          description: Rawls Internal Error
-          schema:
-            $ref: '#/definitions/ErrorReport'
-      description: List published workspaces
-      tags:
-        - admin
-        - workspaces
-      summary: list published workspaces
-      operationId: listPublishedWorkspaces
-      security:
-        - authorization:
-            - openid
-            - email
-            - profile
   '/api/admin/workspacesByAttribute':
     post:
       responses:

--- a/src/main/resources/swagger/rawls.yaml
+++ b/src/main/resources/swagger/rawls.yaml
@@ -1191,6 +1191,40 @@ paths:
             - openid
             - email
             - profile
+  '/api/admin/workspacesByAttribute':
+    post:
+      responses:
+        '200':
+          description: Successful Request
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Workspace'
+        '403':
+          description: You must be an admin to list published workspaces
+          schema:
+            $ref: '#/definitions/ErrorReport'
+        '500':
+          description: Rawls Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      description: look up workspaces containing a certain attribute
+      tags:
+        - admin
+        - workspaces
+      summary: workspaces by attribute
+      operationId: workspacesByAttribute
+      parameters:
+        - in: body
+          description: Attribute and value map
+          name: attributeMap
+          required: true
+          type: Map
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   '/api/admin/workspaces/{workspaceNamespace}/{workspaceName}':
     delete:
           responses:

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -165,7 +165,7 @@ trait AttributeComponent {
       findByNameQuery(attrName).filter { rec =>
         attrValue match {
           case AttributeString(s) => rec.valueString === s
-          case AttributeNumber(n) => rec.valueNumber === n
+          case AttributeNumber(n) => rec.valueNumber === n.doubleValue
           case AttributeBoolean(b) => rec.valueBoolean === b
           case _ => throw new RawlsException("Unsupported attribute type")
         }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -161,12 +161,13 @@ trait AttributeComponent {
       filter(rec => rec.namespace === attrName.namespace && rec.name === attrName.name)
     }
 
-    def queryByAttribute(attrName: AttributeName, attrValue: Attribute): WorkspaceAttributeQueryType = {
+    def queryByAttribute(attrName: AttributeName, attrValue: AttributeValue): WorkspaceAttributeQueryType = {
       findByNameQuery(attrName).filter { rec =>
         attrValue match {
-          case s:AttributeString => rec.valueString === s.value
-          case n:AttributeNumber => rec.valueNumber === n.value.toDouble
-          case b:AttributeBoolean => rec.valueBoolean === b.value
+          case AttributeString(s) => rec.valueString === s
+          case AttributeNumber(n) => rec.valueNumber === n
+          case AttributeBoolean(b) => rec.valueBoolean === b
+          case _ => throw new RawlsException("Unsupported attribute type")
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -154,24 +154,7 @@ trait AttributeComponent {
 
   protected object entityAttributeQuery extends AttributeQuery[Long, EntityAttributeRecord, EntityAttributeTable](new EntityAttributeTable(_), EntityAttributeRecord)
 
-  protected object workspaceAttributeQuery extends AttributeQuery[UUID, WorkspaceAttributeRecord, WorkspaceAttributeTable](new WorkspaceAttributeTable(_), WorkspaceAttributeRecord) {
-    private type WorkspaceAttributeQueryType = driver.api.Query[WorkspaceAttributeTable, WorkspaceAttributeRecord, Seq]
-
-    def findByNameQuery(attrName: AttributeName): WorkspaceAttributeQueryType = {
-      filter(rec => rec.namespace === attrName.namespace && rec.name === attrName.name)
-    }
-
-    def queryByAttribute(attrName: AttributeName, attrValue: AttributeValue): WorkspaceAttributeQueryType = {
-      findByNameQuery(attrName).filter { rec =>
-        attrValue match {
-          case AttributeString(s) => rec.valueString === s
-          case AttributeNumber(n) => rec.valueNumber === n.doubleValue
-          case AttributeBoolean(b) => rec.valueBoolean === b
-          case _ => throw new RawlsException("Unsupported attribute type")
-        }
-      }
-    }
-  }
+  protected object workspaceAttributeQuery extends AttributeQuery[UUID, WorkspaceAttributeRecord, WorkspaceAttributeTable](new WorkspaceAttributeTable(_), WorkspaceAttributeRecord)
 
   protected object submissionAttributeQuery extends AttributeQuery[Long, SubmissionAttributeRecord, SubmissionAttributeTable](new SubmissionAttributeTable(_), SubmissionAttributeRecord)
 
@@ -288,6 +271,21 @@ trait AttributeComponent {
       }
 
       createRecord(0, ownerId, attributeName.namespace, attributeName.name, valueString, valueNumber, valueBoolean, None, listIndex, listLength)
+    }
+
+    def findByNameQuery(attrName: AttributeName) = {
+      filter(rec => rec.namespace === attrName.namespace && rec.name === attrName.name)
+    }
+
+    def queryByAttribute(attrName: AttributeName, attrValue: AttributeValue) = {
+      findByNameQuery(attrName).filter { rec =>
+        attrValue match {
+          case AttributeString(s) => rec.valueString === s
+          case AttributeNumber(n) => rec.valueNumber === n.doubleValue
+          case AttributeBoolean(b) => rec.valueBoolean === b
+          case _ => throw new RawlsException("Unsupported attribute type")
+        }
+      }
     }
 
     def deleteAttributeRecords(attributeRecords: Seq[RECORD]): DBIOAction[Int, NoStream, Write] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -154,7 +154,23 @@ trait AttributeComponent {
 
   protected object entityAttributeQuery extends AttributeQuery[Long, EntityAttributeRecord, EntityAttributeTable](new EntityAttributeTable(_), EntityAttributeRecord)
 
-  protected object workspaceAttributeQuery extends AttributeQuery[UUID, WorkspaceAttributeRecord, WorkspaceAttributeTable](new WorkspaceAttributeTable(_), WorkspaceAttributeRecord)
+  protected object workspaceAttributeQuery extends AttributeQuery[UUID, WorkspaceAttributeRecord, WorkspaceAttributeTable](new WorkspaceAttributeTable(_), WorkspaceAttributeRecord) {
+    private type WorkspaceAttributeQueryType = driver.api.Query[WorkspaceAttributeTable, WorkspaceAttributeRecord, Seq]
+
+    def findByNameQuery(attrName: AttributeName): WorkspaceAttributeQueryType = {
+      filter(rec => rec.namespace === attrName.namespace && rec.name === attrName.name)
+    }
+
+    def queryByAttribute(attrName: AttributeName, attrValue: Attribute): WorkspaceAttributeQueryType = {
+      findByNameQuery(attrName).filter { rec =>
+        attrValue match {
+          case s:AttributeString => rec.valueString === s.value
+          case n:AttributeNumber => rec.valueNumber === n.value.toDouble
+          case b:AttributeBoolean => rec.valueBoolean === b.value
+        }
+      }
+    }
+  }
 
   protected object submissionAttributeQuery extends AttributeQuery[Long, SubmissionAttributeRecord, SubmissionAttributeTable](new SubmissionAttributeTable(_), SubmissionAttributeRecord)
 

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -231,6 +231,16 @@ trait WorkspaceComponent {
       }
     }
 
+    /**
+      * Lists all workspaces with a particular attribute name/value pair.
+      *
+      * ** Note: This is an inefficient query.  It performs a full scan of the attribute table since
+      *    there is no index on attribute name and/or value.  This method is only being used in one
+      *    place; if you find yourself needing this for other things, consider adding such an index.
+      * @param attrName
+      * @param attrValue
+      * @return
+      */
     def getWorkspacesWithAttribute(attrName: AttributeName, attrValue: AttributeValue) = {
       for {
         attribute <- workspaceAttributeQuery.queryByAttribute(attrName, attrValue)

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -85,6 +85,10 @@ trait WorkspaceComponent {
       loadWorkspaces(getPublishedWorkspaces)
     }
 
+    def listWithAttribute(attributeMap: AttributeMap): ReadAction[Seq[Workspace]] = {
+      loadWorkspaces(getWorkspacesWithAttribute(attributeMap))
+    }
+
     def save(workspace: Workspace): ReadWriteAction[Workspace] = {
       validateUserDefinedString(workspace.namespace)
       validateUserDefinedString(workspace.name)
@@ -232,8 +236,13 @@ trait WorkspaceComponent {
     }
 
     def getPublishedWorkspaces = {
+      getWorkspacesWithAttribute(Map(AttributeName.libraryAttribute("published") -> AttributeBoolean(true)))
+    }
+
+    def getWorkspacesWithAttribute(attributeMap: AttributeMap) = {
+      val (attrName, attrValue) = attributeMap.head
       for {
-        attribute <- workspaceAttributeQuery if attribute.namespace === "library" && attribute.name === "published" && attribute.valueBoolean.getOrElse(false)
+        attribute <- workspaceAttributeQuery.queryByAttribute(attrName, attrValue)
         workspace <- workspaceQuery if workspace.id === attribute.ownerId
       } yield workspace
     }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -81,8 +81,8 @@ trait WorkspaceComponent {
       loadWorkspaces(workspaceQuery)
     }
 
-    def listWithAttribute(attributeMap: AttributeMap): ReadAction[Seq[Workspace]] = {
-      loadWorkspaces(getWorkspacesWithAttribute(attributeMap))
+    def listWithAttribute(attrName: AttributeName, attrValue: AttributeValue): ReadAction[Seq[Workspace]] = {
+      loadWorkspaces(getWorkspacesWithAttribute(attrName, attrValue))
     }
 
     def save(workspace: Workspace): ReadWriteAction[Workspace] = {
@@ -231,8 +231,7 @@ trait WorkspaceComponent {
       }
     }
 
-    def getWorkspacesWithAttribute(attributeMap: AttributeMap) = {
-      val (attrName, attrValue) = attributeMap.head
+    def getWorkspacesWithAttribute(attrName: AttributeName, attrValue: AttributeValue) = {
       for {
         attribute <- workspaceAttributeQuery.queryByAttribute(attrName, attrValue)
         workspace <- workspaceQuery if workspace.id === attribute.ownerId

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -81,10 +81,6 @@ trait WorkspaceComponent {
       loadWorkspaces(workspaceQuery)
     }
 
-    def listPublished(): ReadAction[Seq[Workspace]] = {
-      loadWorkspaces(getPublishedWorkspaces)
-    }
-
     def listWithAttribute(attributeMap: AttributeMap): ReadAction[Seq[Workspace]] = {
       loadWorkspaces(getWorkspacesWithAttribute(attributeMap))
     }
@@ -233,10 +229,6 @@ trait WorkspaceComponent {
           }
         })
       }
-    }
-
-    def getPublishedWorkspaces = {
-      getWorkspacesWithAttribute(Map(AttributeName.libraryAttribute("published") -> AttributeBoolean(true)))
     }
 
     def getWorkspacesWithAttribute(attributeMap: AttributeMap) = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -81,6 +81,10 @@ trait WorkspaceComponent {
       loadWorkspaces(workspaceQuery)
     }
 
+    def listPublished(): ReadAction[Seq[Workspace]] = {
+      loadWorkspaces(getPublishedWorkspaces)
+    }
+
     def save(workspace: Workspace): ReadWriteAction[Workspace] = {
       validateUserDefinedString(workspace.namespace)
       validateUserDefinedString(workspace.name)
@@ -225,6 +229,13 @@ trait WorkspaceComponent {
           }
         })
       }
+    }
+
+    def getPublishedWorkspaces = {
+      for {
+        attribute <- workspaceAttributeQuery if attribute.namespace === "library" && attribute.name === "published" && attribute.valueBoolean.getOrElse(false)
+        workspace <- workspaceQuery if workspace.id === attribute.ownerId
+      } yield workspace
     }
 
     def listAccessGroupMemberEmails(workspaceIds: Seq[UUID], accessLevel: WorkspaceAccessLevel): ReadAction[Map[UUID, Seq[String]]] = {

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -46,6 +46,8 @@ object AttributeName {
 
   def withDefaultNS(name: String) = AttributeName(defaultNamespace, name)
 
+  def libraryAttribute(name: String) = AttributeName(libraryNamespace, name)
+
   def toDelimitedName(aName: AttributeName): String = {
     if (aName.namespace == defaultNamespace) aName.name
     else aName.namespace + delimiter + aName.name

--- a/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -46,7 +46,7 @@ object AttributeName {
 
   def withDefaultNS(name: String) = AttributeName(defaultNamespace, name)
 
-  def libraryAttribute(name: String) = AttributeName(libraryNamespace, name)
+  def withLibraryNS(name: String) = AttributeName(libraryNamespace, name)
 
   def toDelimitedName(aName: AttributeName): String = {
     if (aName.namespace == defaultNamespace) aName.name

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -244,7 +244,7 @@ trait AdminApiService extends HttpService with PerRequestCreator with UserInfoDi
         entity(as[AttributeMap]) { attributeMap =>
           requestContext => perRequest(requestContext,
             WorkspaceService.props(workspaceServiceConstructor, userInfo),
-            WorkspaceService.ListWorkspacesWithAttribute(attributeMap))
+            WorkspaceService.AdminListWorkspacesWithAttribute(attributeMap))
         }
       }
     } ~

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -236,19 +236,19 @@ trait AdminApiService extends HttpService with PerRequestCreator with UserInfoDi
     path("admin" / "workspaces") {
       get {
         parameters('attributeName.?, 'valueString.?, 'valueNumber.?, 'valueBoolean.?) { (nameOption, stringOption, numberOption, booleanOption) =>
-          requestContext => perRequest(requestContext,
-            WorkspaceService.props(workspaceServiceConstructor, userInfo),
-            nameOption match {
+          requestContext =>
+            val msg = nameOption match {
               case None => WorkspaceService.ListAllWorkspaces
               case Some(attributeName) =>
                 val name = AttributeName.fromDelimitedName(attributeName)
                 (stringOption, numberOption, booleanOption) match {
                   case (Some(string), None, None) => WorkspaceService.AdminListWorkspacesWithAttribute(name, AttributeString(string))
-                  case (None, Some(number), None) => WorkspaceService.AdminListWorkspacesWithAttribute(name, AttributeNumber(number.toInt))
+                  case (None, Some(number), None) => WorkspaceService.AdminListWorkspacesWithAttribute(name, AttributeNumber(number.toDouble))
                   case (None, None, Some(boolean)) => WorkspaceService.AdminListWorkspacesWithAttribute(name, AttributeBoolean(boolean.toBoolean))
                   case _ => throw new RawlsException("Specify exactly one of valueString, valueNumber, or valueBoolean")
                 }
-            })
+            }
+            perRequest(requestContext, WorkspaceService.props(workspaceServiceConstructor, userInfo), msg)
         }
       }
     } ~

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -239,13 +239,6 @@ trait AdminApiService extends HttpService with PerRequestCreator with UserInfoDi
             WorkspaceService.ListAllWorkspaces)
       }
     } ~
-    path("admin" / "publishedWorkspaces") {
-      get {
-        requestContext => perRequest(requestContext,
-          WorkspaceService.props(workspaceServiceConstructor, userInfo),
-          WorkspaceService.ListPublishedWorkspaces)
-      }
-    } ~
     path("admin" / "workspacesByAttribute") {
       post {
         entity(as[AttributeMap]) { attributeMap =>

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -240,7 +240,7 @@ trait AdminApiService extends HttpService with PerRequestCreator with UserInfoDi
       }
     } ~
     path("admin" / "workspacesByAttribute") {
-      post {
+      get {
         entity(as[AttributeMap]) { attributeMap =>
           requestContext => perRequest(requestContext,
             WorkspaceService.props(workspaceServiceConstructor, userInfo),

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -237,6 +237,13 @@ trait AdminApiService extends HttpService with PerRequestCreator with UserInfoDi
             WorkspaceService.ListAllWorkspaces)
       }
     } ~
+    path("admin" / "publishedWorkspaces") {
+      get {
+        requestContext => perRequest(requestContext,
+          WorkspaceService.props(workspaceServiceConstructor, userInfo),
+          WorkspaceService.ListPublishedWorkspaces)
+      }
+    } ~
     path("admin" / "workspaces" / Segment / Segment ) { (workspaceNamespace, workspaceName) =>
       delete {
         requestContext => perRequest(requestContext,

--- a/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -8,6 +8,8 @@ import java.net.URLDecoder
 
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.statistics.StatisticsService
 import org.broadinstitute.dsde.rawls.user.UserService
@@ -242,6 +244,15 @@ trait AdminApiService extends HttpService with PerRequestCreator with UserInfoDi
         requestContext => perRequest(requestContext,
           WorkspaceService.props(workspaceServiceConstructor, userInfo),
           WorkspaceService.ListPublishedWorkspaces)
+      }
+    } ~
+    path("admin" / "workspacesByAttribute") {
+      post {
+        entity(as[AttributeMap]) { attributeMap =>
+          requestContext => perRequest(requestContext,
+            WorkspaceService.props(workspaceServiceConstructor, userInfo),
+            WorkspaceService.ListWorkspacesWithAttribute(attributeMap))
+        }
       }
     } ~
     path("admin" / "workspaces" / Segment / Segment ) { (workspaceNamespace, workspaceName) =>

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -50,7 +50,6 @@ object WorkspaceService {
   case class UpdateWorkspace(workspaceName: WorkspaceName, operations: Seq[AttributeUpdateOperation]) extends WorkspaceServiceMessage
   case object ListWorkspaces extends WorkspaceServiceMessage
   case object ListAllWorkspaces extends WorkspaceServiceMessage
-  case object ListPublishedWorkspaces extends WorkspaceServiceMessage
   case class ListWorkspacesWithAttribute(attributeMap: AttributeMap) extends WorkspaceServiceMessage
   case class CloneWorkspace(sourceWorkspace: WorkspaceName, destWorkspace: WorkspaceRequest) extends WorkspaceServiceMessage
   case class GetACL(workspaceName: WorkspaceName) extends WorkspaceServiceMessage
@@ -124,7 +123,6 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     case UpdateWorkspace(workspaceName, operations) => pipe(updateWorkspace(workspaceName, operations)) to sender
     case ListWorkspaces => pipe(listWorkspaces()) to sender
     case ListAllWorkspaces => pipe(listAllWorkspaces()) to sender
-    case ListPublishedWorkspaces => pipe(listPublishedWorkspaces()) to sender
     case ListWorkspacesWithAttribute(attributeMap) => pipe(listWorkspacesWithAttribute(attributeMap)) to sender
     case CloneWorkspace(sourceWorkspace, destWorkspaceRequest) => pipe(cloneWorkspace(sourceWorkspace, destWorkspaceRequest)) to sender
     case GetACL(workspaceName) => pipe(getACL(workspaceName)) to sender
@@ -1306,14 +1304,6 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         dataAccess.workspaceQuery.listAll.map(RequestComplete(StatusCodes.OK, _))
-      }
-    }
-  }
-
-  def listPublishedWorkspaces() = {
-    asFCAdmin {
-      dataSource.inTransaction { dataAccess =>
-        dataAccess.workspaceQuery.listPublished.map(RequestComplete(StatusCodes.OK, _))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -50,6 +50,7 @@ object WorkspaceService {
   case class UpdateWorkspace(workspaceName: WorkspaceName, operations: Seq[AttributeUpdateOperation]) extends WorkspaceServiceMessage
   case object ListWorkspaces extends WorkspaceServiceMessage
   case object ListAllWorkspaces extends WorkspaceServiceMessage
+  case object ListPublishedWorkspaces extends WorkspaceServiceMessage
   case class CloneWorkspace(sourceWorkspace: WorkspaceName, destWorkspace: WorkspaceRequest) extends WorkspaceServiceMessage
   case class GetACL(workspaceName: WorkspaceName) extends WorkspaceServiceMessage
   case class UpdateACL(workspaceName: WorkspaceName, aclUpdates: Seq[WorkspaceACLUpdate]) extends WorkspaceServiceMessage
@@ -122,6 +123,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     case UpdateWorkspace(workspaceName, operations) => pipe(updateWorkspace(workspaceName, operations)) to sender
     case ListWorkspaces => pipe(listWorkspaces()) to sender
     case ListAllWorkspaces => pipe(listAllWorkspaces()) to sender
+    case ListPublishedWorkspaces => pipe(listPublishedWorkspaces()) to sender
     case CloneWorkspace(sourceWorkspace, destWorkspaceRequest) => pipe(cloneWorkspace(sourceWorkspace, destWorkspaceRequest)) to sender
     case GetACL(workspaceName) => pipe(getACL(workspaceName)) to sender
     case UpdateACL(workspaceName, aclUpdates) => pipe(updateACL(workspaceName, aclUpdates)) to sender
@@ -1302,6 +1304,14 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         dataAccess.workspaceQuery.listAll.map(RequestComplete(StatusCodes.OK, _))
+      }
+    }
+  }
+
+  def listPublishedWorkspaces() = {
+    asFCAdmin {
+      dataSource.inTransaction { dataAccess =>
+        dataAccess.workspaceQuery.listPublished.map(RequestComplete(StatusCodes.OK, _))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -51,6 +51,7 @@ object WorkspaceService {
   case object ListWorkspaces extends WorkspaceServiceMessage
   case object ListAllWorkspaces extends WorkspaceServiceMessage
   case object ListPublishedWorkspaces extends WorkspaceServiceMessage
+  case class ListWorkspacesWithAttribute(attributeMap: AttributeMap) extends WorkspaceServiceMessage
   case class CloneWorkspace(sourceWorkspace: WorkspaceName, destWorkspace: WorkspaceRequest) extends WorkspaceServiceMessage
   case class GetACL(workspaceName: WorkspaceName) extends WorkspaceServiceMessage
   case class UpdateACL(workspaceName: WorkspaceName, aclUpdates: Seq[WorkspaceACLUpdate]) extends WorkspaceServiceMessage
@@ -124,6 +125,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     case ListWorkspaces => pipe(listWorkspaces()) to sender
     case ListAllWorkspaces => pipe(listAllWorkspaces()) to sender
     case ListPublishedWorkspaces => pipe(listPublishedWorkspaces()) to sender
+    case ListWorkspacesWithAttribute(attributeMap) => pipe(listWorkspacesWithAttribute(attributeMap)) to sender
     case CloneWorkspace(sourceWorkspace, destWorkspaceRequest) => pipe(cloneWorkspace(sourceWorkspace, destWorkspaceRequest)) to sender
     case GetACL(workspaceName) => pipe(getACL(workspaceName)) to sender
     case UpdateACL(workspaceName, aclUpdates) => pipe(updateACL(workspaceName, aclUpdates)) to sender
@@ -1312,6 +1314,14 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         dataAccess.workspaceQuery.listPublished.map(RequestComplete(StatusCodes.OK, _))
+      }
+    }
+  }
+
+  def listWorkspacesWithAttribute(attributeMap: AttributeMap): Future[PerRequestMessage] = {
+    asFCAdmin {
+      dataSource.inTransaction { dataAccess =>
+        dataAccess.workspaceQuery.listWithAttribute(attributeMap).map(RequestComplete(StatusCodes.OK, _))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -50,7 +50,7 @@ object WorkspaceService {
   case class UpdateWorkspace(workspaceName: WorkspaceName, operations: Seq[AttributeUpdateOperation]) extends WorkspaceServiceMessage
   case object ListWorkspaces extends WorkspaceServiceMessage
   case object ListAllWorkspaces extends WorkspaceServiceMessage
-  case class AdminListWorkspacesWithAttribute(attributeMap: AttributeMap) extends WorkspaceServiceMessage
+  case class AdminListWorkspacesWithAttribute(attributeName: AttributeName, attributeValue: AttributeValue) extends WorkspaceServiceMessage
   case class CloneWorkspace(sourceWorkspace: WorkspaceName, destWorkspace: WorkspaceRequest) extends WorkspaceServiceMessage
   case class GetACL(workspaceName: WorkspaceName) extends WorkspaceServiceMessage
   case class UpdateACL(workspaceName: WorkspaceName, aclUpdates: Seq[WorkspaceACLUpdate]) extends WorkspaceServiceMessage
@@ -123,7 +123,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     case UpdateWorkspace(workspaceName, operations) => pipe(updateWorkspace(workspaceName, operations)) to sender
     case ListWorkspaces => pipe(listWorkspaces()) to sender
     case ListAllWorkspaces => pipe(listAllWorkspaces()) to sender
-    case AdminListWorkspacesWithAttribute(attributeMap) => asFCAdmin { listWorkspacesWithAttribute(attributeMap) } pipeTo sender
+    case AdminListWorkspacesWithAttribute(attributeName, attributeValue) => asFCAdmin { listWorkspacesWithAttribute(attributeName, attributeValue) } pipeTo sender
     case CloneWorkspace(sourceWorkspace, destWorkspaceRequest) => pipe(cloneWorkspace(sourceWorkspace, destWorkspaceRequest)) to sender
     case GetACL(workspaceName) => pipe(getACL(workspaceName)) to sender
     case UpdateACL(workspaceName, aclUpdates) => pipe(updateACL(workspaceName, aclUpdates)) to sender
@@ -1308,16 +1308,9 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     }
   }
 
-  def listWorkspacesWithAttribute(attributeMap: AttributeMap): Future[PerRequestMessage] = {
+  def listWorkspacesWithAttribute(attributeName: AttributeName, attributeValue: AttributeValue): Future[PerRequestMessage] = {
     dataSource.inTransaction { dataAccess =>
-      if (attributeMap.size != 1)
-        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "specify one attribute only"))
-
-      val (attrName, attr) = attributeMap.head
-      attr match {
-        case attrValue:AttributeValue => dataAccess.workspaceQuery.listWithAttribute(attrName, attrValue).map(RequestComplete(StatusCodes.OK, _))
-        case _ => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "unsupported attribute type"))
-      }
+      dataAccess.workspaceQuery.listWithAttribute(attributeName, attributeValue).map(RequestComplete(StatusCodes.OK, _))
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -174,7 +174,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
       Map(WorkspaceAccessLevels.Owner -> ownerGroup, WorkspaceAccessLevels.Write -> writerGroup, WorkspaceAccessLevels.Read -> readerGroup))
 
     val workspacePublished = Workspace(wsName.namespace, wsName.name + "_published", None, UUID.randomUUID().toString, "aBucket3", currentTime(), currentTime(), "testUser",
-      wsAttrs + (AttributeName.libraryAttribute("published") -> AttributeBoolean(true)), Map.empty, Map.empty)
+      wsAttrs + (AttributeName.withLibraryNS("published") -> AttributeBoolean(true)), Map.empty, Map.empty)
     val workspaceNoAttrs = Workspace(wsName.namespace, wsName.name + "_noattrs", None, UUID.randomUUID().toString, "aBucket4", currentTime(), currentTime(), "testUser", Map.empty, Map.empty, Map.empty)
 
     val realm = makeRawlsGroup(s"Test-Realm", Set.empty)

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -174,7 +174,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
       Map(WorkspaceAccessLevels.Owner -> ownerGroup, WorkspaceAccessLevels.Write -> writerGroup, WorkspaceAccessLevels.Read -> readerGroup))
 
     val workspacePublished = Workspace(wsName.namespace, wsName.name + "_published", None, UUID.randomUUID().toString, "aBucket3", currentTime(), currentTime(), "testUser",
-      wsAttrs + (AttributeName(AttributeName.libraryNamespace, "published") -> AttributeBoolean(true)), Map.empty, Map.empty)
+      wsAttrs + (AttributeName.libraryAttribute("published") -> AttributeBoolean(true)), Map.empty, Map.empty)
+    val workspaceNoAttrs = Workspace(wsName.namespace, wsName.name + "_noattrs", None, UUID.randomUUID().toString, "aBucket4", currentTime(), currentTime(), "testUser", Map.empty, Map.empty, Map.empty)
 
     val realm = makeRawlsGroup(s"Test-Realm", Set.empty)
     val realmWsName = wsName.name + "withRealm"
@@ -526,6 +527,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
         rawlsGroupQuery.save(realmReaderGroup7),
         workspaceQuery.save(workspace),
         workspaceQuery.save(workspacePublished),
+        workspaceQuery.save(workspaceNoAttrs),
         workspaceQuery.save(workspaceNoGroups),
         workspaceQuery.save(workspaceWithRealm),
         workspaceQuery.save(otherWorkspaceWithRealm),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -173,6 +173,9 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
       Map(WorkspaceAccessLevels.Owner -> ownerGroup, WorkspaceAccessLevels.Write -> writerGroup, WorkspaceAccessLevels.Read -> readerGroup),
       Map(WorkspaceAccessLevels.Owner -> ownerGroup, WorkspaceAccessLevels.Write -> writerGroup, WorkspaceAccessLevels.Read -> readerGroup))
 
+    val workspacePublished = Workspace(wsName.namespace, wsName.name + "_published", None, UUID.randomUUID().toString, "aBucket3", currentTime(), currentTime(), "testUser",
+      wsAttrs + (AttributeName(AttributeName.libraryNamespace, "published") -> AttributeBoolean(true)), Map.empty, Map.empty)
+
     val realm = makeRawlsGroup(s"Test-Realm", Set.empty)
     val realmWsName = wsName.name + "withRealm"
     val realmOwnerIntersectionGroup = makeRawlsGroup(s"${realmWsName} IG OWNER", Set(userOwner))
@@ -522,6 +525,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess {
         rawlsGroupQuery.save(realmWriterGroup7),
         rawlsGroupQuery.save(realmReaderGroup7),
         workspaceQuery.save(workspace),
+        workspaceQuery.save(workspacePublished),
         workspaceQuery.save(workspaceNoGroups),
         workspaceQuery.save(workspaceWithRealm),
         workspaceQuery.save(otherWorkspaceWithRealm),

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -1100,7 +1100,16 @@ AdminApiServiceSpec extends ApiServiceSpec {
         responseAs[Array[Workspace]] should contain
         theSameElementsAs(Array(testData.workspacePublished))
       }
+  }
 
+  it should "return 200 when getting workspaces by attribute" in withTestDataApiServices { services =>
+    Post(s"/admin/workspacesByAttribute", httpJson(Map("number" -> 10))) ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) { status }
+        responseAs[Array[Workspace]] should contain
+        theSameElementsAs(Array(testData.workspace, testData.workspaceNoGroups, testData.workspacePublished))
+      }
   }
 
   it should "delete a workspace" in withTestDataApiServices { services =>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -1092,16 +1092,6 @@ AdminApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 200 when listing all published workspaces" in withTestDataApiServices { services =>
-    Get(s"/admin/publishedWorkspaces") ~>
-      sealRoute(services.adminRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-        responseAs[Array[Workspace]] should contain
-        theSameElementsAs(Array(testData.workspacePublished))
-      }
-  }
-
   it should "return 200 when getting workspaces by attribute" in withTestDataApiServices { services =>
     Post(s"/admin/workspacesByAttribute", httpJson(Map("number" -> 10))) ~>
       sealRoute(services.adminRoutes) ~>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -1088,12 +1088,12 @@ AdminApiServiceSpec extends ApiServiceSpec {
       check {
         assertResult(StatusCodes.OK) { status }
         responseAs[Array[Workspace]] should contain
-        theSameElementsAs(Array(testData.workspace, testData.workspaceNoGroups))
+        theSameElementsAs(Array(testData.workspace, testData.workspaceNoGroups, testData.workspacePublished, testData.workspaceNoAttrs))
       }
   }
 
   it should "return 200 when getting workspaces by attribute" in withTestDataApiServices { services =>
-    Get(s"/admin/workspacesByAttribute", httpJson(Map("number" -> 10))) ~>
+    Get(s"/admin/workspaces?attributeName=number&valueNumber=10", httpJson(Map("number" -> 10))) ~>
       sealRoute(services.adminRoutes) ~>
       check {
         assertResult(StatusCodes.OK) { status }

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -1092,13 +1092,33 @@ AdminApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 200 when getting workspaces by attribute" in withTestDataApiServices { services =>
-    Get(s"/admin/workspaces?attributeName=number&valueNumber=10", httpJson(Map("number" -> 10))) ~>
+  it should "return 200 when getting workspaces by a string attribute" in withTestDataApiServices { services =>
+    Get(s"/admin/workspaces?attributeName=string&valueString=yep%2C%20it's%20a%20string") ~>
       sealRoute(services.adminRoutes) ~>
       check {
         assertResult(StatusCodes.OK) { status }
         responseAs[Array[Workspace]] should contain
         theSameElementsAs(Array(testData.workspace, testData.workspaceNoGroups, testData.workspacePublished))
+      }
+  }
+
+  it should "return 200 when getting workspaces by a numeric attribute" in withTestDataApiServices { services =>
+    Get(s"/admin/workspaces?attributeName=number&valueNumber=10") ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) { status }
+        responseAs[Array[Workspace]] should contain
+        theSameElementsAs(Array(testData.workspace, testData.workspaceNoGroups, testData.workspacePublished))
+      }
+  }
+
+  it should "return 200 when getting workspaces by a boolean attribute" in withTestDataApiServices { services =>
+    Get(s"/admin/workspaces?attributeName=library%3Apublished&valueBoolean=true") ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) { status }
+        responseAs[Array[Workspace]] should contain
+        theSameElementsAs(Array(testData.workspacePublished))
       }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -1092,6 +1092,17 @@ AdminApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "return 200 when listing all published workspaces" in withTestDataApiServices { services =>
+    Get(s"/admin/publishedWorkspaces") ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) { status }
+        responseAs[Array[Workspace]] should contain
+        theSameElementsAs(Array(testData.workspacePublished))
+      }
+
+  }
+
   it should "delete a workspace" in withTestDataApiServices { services =>
     Delete(s"/admin/workspaces/${testData.workspace.namespace}/${testData.workspace.name}") ~>
       sealRoute(services.adminRoutes) ~>

--- a/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -1093,7 +1093,7 @@ AdminApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 200 when getting workspaces by attribute" in withTestDataApiServices { services =>
-    Post(s"/admin/workspacesByAttribute", httpJson(Map("number" -> 10))) ~>
+    Get(s"/admin/workspacesByAttribute", httpJson(Map("number" -> 10))) ~>
       sealRoute(services.adminRoutes) ~>
       check {
         assertResult(StatusCodes.OK) { status }


### PR DESCRIPTION
The query is doing a full scan of the Workspace Attribute table, which seems unavoidable without adding an index on attribute name at least.

To find the desired attributes:

```
select x2.`namespace`, x2.`name`, x2.`id`, x2.`bucket_name`, x2.`created_date`, x2.`last_modified`, x2.`created_by`, x2.`is_locked`, x2.`realm_group_name`, x2.`record_version` from `WORKSPACE` x2, (select `namespace` as x3, `name` as x4, `value_boolean` as x5, `owner_id` as x6 from `WORKSPACE_ATTRIBUTE` where ((`namespace` = 'library') and (`name` = 'published')) and (`value_boolean` = true)) x7 where x2.`id` = x7.x6
```

Explain:

| id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | PRIMARY | <derived2> | ALL | NULL | NULL | NULL | NULL | 600 | NULL |
| 1 | PRIMARY | x2 | eq_ref | PRIMARY | PRIMARY | 16 | x7.x6 | 1 | NULL |
| 2 | DERIVED | WORKSPACE_ATTRIBUTE | ALL | NULL | NULL | NULL | NULL | 600 | "Using where" |

Then to get the workspaces:

```
select x2.x3, x2.x4, x2.x5, x2.x6, x2.x7, x2.x8, x2.x9, x2.x10, x2.x11, x2.x12, x13.`id`, x13.`name`, x13.`entity_type`, x13.`workspace_id`, x13.`record_version`, x13.`all_attribute_values` from (select `owner_id` as x3, `namespace` as x5, `value_entity_ref` as x10, `list_index` as x11, `list_length` as x12, `value_boolean` as x9, `id` as x4, `value_string` as x7, `name` as x6, `value_number` as x8 from `WORKSPACE_ATTRIBUTE` where `owner_id` in (select x14.`id` from `WORKSPACE_ATTRIBUTE` x15, `WORKSPACE` x14 where (((x15.`namespace` = 'library') and (x15.`name` = 'published')) and (x15.`value_boolean` = true)) and (x14.`id` = x15.`owner_id`))) x2 left outer join `ENTITY` x13 on x2.x10 = x13.`id`
```

Explain:

| id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | PRIMARY | <derived2> | ALL | NULL | NULL | NULL | NULL | 450 | NULL |
| 1 | PRIMARY | x13 | eq_ref | PRIMARY | PRIMARY | 8 | x2.x10 | 1 | NULL |
| 2 | DERIVED | x15 | ALL | UNQ_WORKSPACE_ATTRIBUTE | NULL | NULL | NULL | 600 | "Using where; Start temporary" |
| 2 | DERIVED | WORKSPACE_ATTRIBUTE | ref | UNQ_WORKSPACE_ATTRIBUTE | UNQ_WORKSPACE_ATTRIBUTE | 16 | rawls.x15.owner_id | 1 | NULL |
| 2 | DERIVED | x14 | eq_ref | PRIMARY | PRIMARY | 16 | rawls.x15.owner_id | 1 | "Using index; End temporary" |
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  - Acceptance criteria exists and is met
  - Note any changes to implementation from the description
  - Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  - If PR includes new or changed db queries, include the explain plans in the description
  - Make sure liquibase is updated if appropriate
  - If doing a migration, take a backup of the
    [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
    and
    [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
    DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  - Authentication
  - Authorization
  - Encryption
  - Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell ![](http://i.imgur.com/9dLzbPd.png) that the PR exists if he wants to look at it **(apply requires_doge label)**
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- Review cycle:
  - LR reviews
  - Rest of team may comment on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH
  - Submitter updates documentation as needed
  - Submitter **reassigns to LR** for further feedback
- [ ] ![](http://i.imgur.com/9dLzbPd.png) sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Squash commits and merge to develop
- [x] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
