### PR TITLE
Add comment about billing scope

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -615,6 +615,9 @@ class HttpGoogleServicesDAO(
       case gjre: GoogleJsonResponseException
         if gjre.getStatusCode == StatusCodes.Forbidden.intValue &&
           gjre.getDetails.getMessage == "Request had insufficient authentication scopes." =>
+        // This error message is purely informational. A client can determine which scopes it has
+        // been granted, so an insufficiently-scoped request would generally point to a programming
+        // error.
         throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, BillingAccountScopes(billingScopes).toJson.toString))
     }
   }


### PR DESCRIPTION
Someone could mistakenly believe that changing this would automatically cause a client to request the correct scopes.