### PR TITLE
GAWB-1206: MethodConfiguration Provenance

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -38,4 +38,5 @@
     <include file="changesets/20170127_drop_old_project_tables.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20170130_realms_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20170125_project_operations.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20170219_method_config_versions.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170219_method_config_versions.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170219_method_config_versions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="method_config_version_column" author="ansingh" logicalFilePath="dummy">
+        <addColumn tableName="METHOD_CONFIG">
+            <column name="METHOD_CONFIG_VERSION" type="INT(11)" defaultValue="1" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170219_method_config_versions.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170219_method_config_versions.xml
@@ -3,7 +3,7 @@
 
     <changeSet id="method_config_version_column" author="ansingh" logicalFilePath="dummy">
         <addColumn tableName="METHOD_CONFIG">
-            <column name="METHOD_CONFIG_VERSION" type="INT(11)" defaultValue="1" />
+            <column name="METHOD_CONFIG_VERSION" type="INT" defaultValue="1" />
         </addColumn>
     </changeSet>
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -145,12 +145,12 @@ trait MethodConfigurationComponent {
 
     // To rename a method config, we "delete" (or rather hide) the old version of the method config and create a new row for the new method config, with the
     //  config version # incremented
-    def rename(workspaceContext: SlickWorkspaceContext, methodConfigurationNamespace: String, methodConfigurationName: String, newName: String) = {
+    def rename(workspaceContext: SlickWorkspaceContext, methodConfigurationNamespace: String, methodConfigurationName: String, newMethodConfig: MethodConfiguration) = {
       // get the current method configuration record
       uniqueResult[MethodConfigurationRecord](findByName(workspaceContext.workspaceId, methodConfigurationNamespace, methodConfigurationName)) flatMap {
         case None => DBIO.successful(false)
         case Some(methodConfigRec) =>
-          saveNewVersion(workspaceContext, methodConfigRec, )
+          saveNewVersion(workspaceContext, methodConfigRec, newMethodConfig)
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -207,7 +207,7 @@ trait MethodConfigurationComponent {
     }
 
     private def findActiveByWorkspace(workspaceId: UUID): MethodConfigurationQueryType = {
-      findByWorkspace(workspaceId).filter(rec => !rec.deleted)
+      findByWorkspace(workspaceId).filterNot(_.deleted)
     }
 
     private def findInputsByConfigId(configId: Long): MethodConfigurationInputQueryType = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -108,8 +108,8 @@ trait MethodConfigurationComponent {
           configInsert flatMap { configId =>
             saveMaps(newMethodConfig, configId)
           }
-        case Some(methodConfigRec) =>
-          saveNewVersion(workspaceContext, methodConfigRec, newMethodConfig)
+        case Some(currentMethodConfigRec) =>
+          saveNewVersion(workspaceContext, currentMethodConfigRec, newMethodConfig)
       }
     } map { _ => newMethodConfig }
 
@@ -123,10 +123,10 @@ trait MethodConfigurationComponent {
         (methodConfigurationOutputQuery ++= outputs)
     }
 
-    private def saveNewVersion(workspaceContext: SlickWorkspaceContext, methodConfigRec: MethodConfigurationRecord, newMethodConfig: MethodConfiguration) = {
+    private def saveNewVersion(workspaceContext: SlickWorkspaceContext, currentMethodConfigRec: MethodConfigurationRecord, newMethodConfig: MethodConfiguration) = {
       workspaceQuery.updateLastModified(workspaceContext.workspaceId) andThen
-        hideMethodConfigurationAction(methodConfigRec.id, methodConfigRec.name) andThen
-        (methodConfigurationQuery returning methodConfigurationQuery.map(_.id) += marshalMethodConfig(workspaceContext.workspaceId, newMethodConfig.copy(methodConfigVersion=methodConfigRec.methodConfigVersion + 1))) flatMap { configId =>
+        hideMethodConfigurationAction(currentMethodConfigRec.id, currentMethodConfigRec.name) andThen
+        (methodConfigurationQuery returning methodConfigurationQuery.map(_.id) += marshalMethodConfig(workspaceContext.workspaceId, newMethodConfig.copy(methodConfigVersion=currentMethodConfigRec.methodConfigVersion + 1))) flatMap { configId =>
         saveMaps(newMethodConfig, configId)
       }
     }
@@ -149,8 +149,8 @@ trait MethodConfigurationComponent {
       // get the current method configuration record
       uniqueResult[MethodConfigurationRecord](findByName(workspaceContext.workspaceId, methodConfigurationNamespace, methodConfigurationName)) flatMap {
         case None => DBIO.successful(false)
-        case Some(methodConfigRec) =>
-          saveNewVersion(workspaceContext, methodConfigRec, newMethodConfig)
+        case Some(currentMethodConfigRec) =>
+          saveNewVersion(workspaceContext, currentMethodConfigRec, newMethodConfig)
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.rawls.util
 
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.MethodInput
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.webservice.PerRequest.PerRequestMessage
 import spray.http.StatusCodes
 
-import scala.concurrent.{Future, ExecutionContext}
-import scala.util.{Try, Failure, Success}
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
 
 //Well, this is a joke.
 trait MethodWiths {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.rawls.util
 
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
+import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.MethodInput
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.webservice.PerRequest.PerRequestMessage
 import spray.http.StatusCodes
 
-import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import scala.concurrent.{Future, ExecutionContext}
+import scala.util.{Try, Failure, Success}
 
 //Well, this is a joke.
 trait MethodWiths {
@@ -45,7 +45,7 @@ trait MethodWiths {
     // TODO add Method to model instead of exposing AgoraEntity?
     val methodRepoMethod = methodConfig.methodRepoMethod
     withMethod(methodRepoMethod.methodNamespace, methodRepoMethod.methodName, methodRepoMethod.methodVersion, userInfo) { method =>
-      withWdl(method) { wdl => MethodConfigResolver.gatherInputs(methodConfig, wdl) match {
+      withWdl(method) { wdl => Try(MethodConfigResolver.gatherInputs(methodConfig,wdl)) match {
         case Failure(exception) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(exception,StatusCodes.BadRequest)))
         case Success(methodInputs) => op(wdl,methodInputs)
       }}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.rawls.util
 
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.MethodInput
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.webservice.PerRequest.PerRequestMessage
 import spray.http.StatusCodes
 
-import scala.concurrent.{Future, ExecutionContext}
-import scala.util.{Try, Failure, Success}
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
 
 //Well, this is a joke.
 trait MethodWiths {
@@ -24,6 +24,10 @@ trait MethodWiths {
       case None => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"${methodConfigurationNamespace}/${methodConfigurationName} does not exist in ${workspaceContext}")))
       case Some(methodConfiguration) => op(methodConfiguration)
     }
+  }
+
+  def withMethodConfigRec(workspaceContext: SlickWorkspaceContext, dataAccess: DataAccess) (op: (MethodConfiguration) => ReadWriteAction[PerRequestMessage])(implicit executionContext: ExecutionContext): ReadWriteAction[PerRequestMessage] = {
+    uniqueResult[MethodConfigurationRecord](findByName(workspaceContext.workspaceId, methodConfigurationNamespace, methodConfigurationName))
   }
 
   def withMethod[T](methodNamespace: String, methodName: String, methodVersion: Int, userInfo: UserInfo)(op: (AgoraEntity) => ReadWriteAction[T])(implicit executionContext: ExecutionContext): ReadWriteAction[T] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSupport.scala
@@ -26,10 +26,6 @@ trait MethodWiths {
     }
   }
 
-  def withMethodConfigRec(workspaceContext: SlickWorkspaceContext, dataAccess: DataAccess) (op: (MethodConfiguration) => ReadWriteAction[PerRequestMessage])(implicit executionContext: ExecutionContext): ReadWriteAction[PerRequestMessage] = {
-    uniqueResult[MethodConfigurationRecord](findByName(workspaceContext.workspaceId, methodConfigurationNamespace, methodConfigurationName))
-  }
-
   def withMethod[T](methodNamespace: String, methodName: String, methodVersion: Int, userInfo: UserInfo)(op: (AgoraEntity) => ReadWriteAction[T])(implicit executionContext: ExecutionContext): ReadWriteAction[T] = {
     DBIO.from(methodRepoDAO.getMethod(methodNamespace, methodName, methodVersion, userInfo)).asTry.flatMap { agoraEntityOption => agoraEntityOption match {
       case Success(None) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"Cannot get ${methodNamespace}/${methodName}/${methodVersion} from method repo.")))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1081,9 +1081,10 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     dataSource.inTransaction { dataAccess =>
       withWorkspaceContextAndPermissions(workspaceName, WorkspaceAccessLevels.Write, dataAccess) { workspaceContext =>
         withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { methodConfiguration =>
+          //Check if there are any other method configs that already
           dataAccess.methodConfigurationQuery.get(workspaceContext, methodConfigurationNamespace, newName) flatMap {
             case None =>
-              dataAccess.methodConfigurationQuery.rename(workspaceContext, methodConfigurationNamespace, methodConfigurationName,  methodConfiguration.copy(name = newName))
+              dataAccess.methodConfigurationQuery.rename(workspaceContext, methodConfigurationNamespace, methodConfigurationName, newName)
             case Some(_) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"Destination ${newName} already exists")))
           } map(_ => RequestComplete(StatusCodes.NoContent))
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1084,7 +1084,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
           //Check if there are any other method configs that already
           dataAccess.methodConfigurationQuery.get(workspaceContext, methodConfigurationNamespace, newName) flatMap {
             case None =>
-              dataAccess.methodConfigurationQuery.rename(workspaceContext, methodConfigurationNamespace, methodConfigurationName, newName)
+              dataAccess.methodConfigurationQuery.rename(workspaceContext, methodConfigurationNamespace, methodConfigurationName, methodConfiguration.copy(name = newName))
             case Some(_) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"Destination ${newName} already exists")))
           } map(_ => RequestComplete(StatusCodes.NoContent))
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1083,7 +1083,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
         withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { methodConfiguration =>
           dataAccess.methodConfigurationQuery.get(workspaceContext, methodConfigurationNamespace, newName) flatMap {
             case None =>
-              dataAccess.methodConfigurationQuery.rename(workspaceContext, methodConfigurationNamespace, methodConfigurationName, newName)
+              dataAccess.methodConfigurationQuery.rename(workspaceContext, methodConfigurationNamespace, methodConfigurationName,  methodConfiguration.copy(name = newName))
             case Some(_) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"Destination ${newName} already exists")))
           } map(_ => RequestComplete(StatusCodes.NoContent))
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -48,6 +48,12 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     assertResult(Option(newVersion)) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, changed.namespace, changed.name))
     }
+
+    val list = runAndWait(methodConfigurationQuery.list(workspaceContext))
+
+    assertResult(1) {
+      list.filter(_.name.contains(testData.methodConfig.name + "_")).size
+    }
   }
 
   it should "list method configs" in withConstantTestDatabase {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -43,7 +43,9 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
 
     runAndWait(methodConfigurationQuery.save(workspaceContext, changed))
 
-    assertResult(Option(changed)) {
+    val newVersion = changed.copy(methodConfigVersion = 2)
+
+    assertResult(Option(newVersion)) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, changed.namespace, changed.name))
     }
   }
@@ -92,7 +94,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     val deletedMethod = runAndWait(methodConfigurationQuery.loadMethodConfigurationById(method.head.id))
 
     //Check that the deleted method has an updated name
-    assert(deletedMethod.map(_.name).get.contains(testData.methodConfig3.name + "-deleted-"))
+    assert(deletedMethod.map(_.name).get.contains(testData.methodConfig3.name + "-"))
 
     //Check that the deleted method has the deleted field set to true
     assertResult(Some(true)) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -94,7 +94,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     val deletedMethod = runAndWait(methodConfigurationQuery.loadMethodConfigurationById(method.head.id))
 
     //Check that the deleted method has an updated name
-    assert(deletedMethod.map(_.name).get.contains(testData.methodConfig3.name + "-"))
+    assert(deletedMethod.map(_.name).get.contains(testData.methodConfig3.name + "_"))
 
     //Check that the deleted method has the deleted field set to true
     assertResult(Some(true)) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -31,7 +31,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     }
   }
 
-  it should "overwrite method configs" in withDefaultTestDatabase {
+  it should "hide old method config and save new method config with incremented version" in withDefaultTestDatabase {
     val workspaceContext = SlickWorkspaceContext(testData.workspace)
 
     val changed = testData.methodConfig.copy(rootEntityType = "goober",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -282,7 +282,7 @@ class SubmissionMonitorSpec(_system: ActorSystem) extends TestKit(_system) with 
 
   it should "handle inputs and outputs with library attributes" in withDefaultTestDatabase { dataSource: SlickDataSource =>
 
-    val mcUpdateEntityLibraryOutputs = MethodConfiguration("ns", "testConfig11", "Sample", Map(), Map(), Map("o1_lib" -> AttributeString("this.library:foo")), MethodRepoMethod("ns-config", "meth1", 1))
+    val mcUpdateEntityLibraryOutputs = MethodConfiguration("ns", "testConfig12", "Sample", Map(), Map(), Map("o1_lib" -> AttributeString("this.library:foo")), MethodRepoMethod("ns-config", "meth1", 1))
 
     val subUpdateEntityLibraryOutputs = createTestSubmission(testData.workspace, mcUpdateEntityLibraryOutputs, testData.indiv1, testData.userOwner,
       Seq(testData.indiv1), Map(testData.indiv1 -> testData.inputResolutions),

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -7,7 +7,6 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccess
 import org.joda.time.DateTime
 import spray.http.StatusCode
 import spray.json._
-import spray.json.DefaultJsonProtocol._
 
 object Attributable {
   // if updating these, also update their use in SlickExpressionParsing
@@ -184,7 +183,8 @@ case class MethodConfiguration(
                    prerequisites: Map[String, AttributeString],
                    inputs: Map[String, AttributeString],
                    outputs: Map[String, AttributeString],
-                   methodRepoMethod:MethodRepoMethod,
+                   methodRepoMethod: MethodRepoMethod,
+                   methodConfigVersion: Int = 1,
                    deleted: Boolean = false
                    ) {
   def toShort : MethodConfigurationShort = MethodConfigurationShort(name, rootEntityType, methodRepoMethod, namespace)
@@ -371,7 +371,7 @@ object WorkspaceJsonSupport extends JsonSupport {
 
   implicit val MethodStoreMethodFormat = jsonFormat3(MethodRepoMethod)
 
-  implicit val MethodConfigurationFormat = jsonFormat8(MethodConfiguration)
+  implicit val MethodConfigurationFormat = jsonFormat9(MethodConfiguration)
 
   implicit val AgoraMethodConfigurationFormat = jsonFormat7(AgoraMethodConfiguration)
 


### PR DESCRIPTION
# Method Configuration Provenance

**Why are we doing this?**
Currently, method configs in FireCloud are overwritten anytime they are edited, making it impossible to track changes. For example, if we have submission on a particular method config and the method config is edited, the submission is now pointing to a method config that is different from the one it actually ran on. **(1)** The use case we want to support is one where the user can look at a submission run on an method config that was edited and can click method config from the submission page and see all the relevant information about the method config. **(2)** The second use case that we may (or may not) support in the future will allow users to go to a submission page and revert it's method config so that more submissions may be run on it.


**What's the implementation?**
- Liquibase change: Adding a METHOD_CONFIG_VERSION column, which defaults as 1 for new method configs.
- Changes to case classes MethodConfiguration and MethodConfigurationRecord to add a methodConfigVersion field
- Change to save(...) method in MethodConfigurationComponent so that, instead of overwriting a method config on edit, we flip the old config to deleted and append the date and time to the name. Then we add a new row for the new method config (with the version incremented) and add the inputs and outputs. 
- Change to the rename process for method Configs was changed so that it too creates a new row in the db for renamed method configs and deletes/hides the old method config. The overlapping parts of the save and rename processes were broken out into their own methods


**Why is this the implementation?**
It took some time to decide on this implementation because others were more attractive in their thoroughness. In the end, more complicated implementations were cast aside because the 2 use cases did not require this added complexity. If we are only considered the 2 uses cases described above, this implementation is sufficient. There is no reason to differentiate a user deleted vs. archived method config. 


- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell your tech lead (TL) that the PR exists if they want to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
