### PR TITLE
fix race condition on simultaneous calls to create project

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/CreatingBillingProjectMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/CreatingBillingProjectMonitor.scala
@@ -90,8 +90,8 @@ trait CreatingBillingProjectMonitor extends LazyLogging {
         // see GoogleServicesDAO.createProject for more details
         val nextStepFuture = operationsByProject(project.projectName) match {
           case Seq() =>
-            // for some reason there are no operations, mark it as an error
-            Future.successful(project.copy(status = CreationStatuses.Error, message = Option("Internal error: no operations created")))
+            // there are no operations, there is a small window when this can happen but it should resolve itself so let it pass
+            Future.successful(project)
 
           case Seq(RawlsBillingProjectOperationRecord(_, gcsDAO.CREATE_PROJECT_OPERATION, _, true, None, _)) =>
             // create project operation finished successfully


### PR DESCRIPTION
This fixes a race condition when 2 create project calls come in concurrently for the same project name. The problem is that both make the google call to create the project, both calls would succeed producing separate operations. Both would try to insert into the rawls db and only 1 would succeed. One of the google operations is orphaned. Only one of the google operations will succeed. If the successful google operation is the one that made it to our db, everything is fine, but if not we fail to create the project. The fix is to attempt the rawls db insert first so that one request fails fast and never calls google.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell your tech lead (TL) that the PR exists if they want to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
