### PR TITLE
GAWB-1905: rawls submits to only cromwell1

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -108,7 +108,11 @@ object Boot extends App with LazyLogging {
         case (strName, strHostname) => (ExecutionServiceId(strName)->new HttpExecutionServiceDAO(strHostname.unwrapped.toString, submissionTimeout))
       }.toMap
 
-    val shardedExecutionServiceCluster:ExecutionServiceCluster = new ShardedHttpExecutionServiceCluster(executionServiceServers, slickDataSource)
+    val executionServiceSubmitServers: Map[ExecutionServiceId, ExecutionServiceDAO] = executionServiceConfig.getObject("submitServers").map {
+      case (strName, strHostname) => (ExecutionServiceId(strName)->new HttpExecutionServiceDAO(strHostname.unwrapped.toString, submissionTimeout))
+    }.toMap
+
+    val shardedExecutionServiceCluster:ExecutionServiceCluster = new ShardedHttpExecutionServiceCluster(executionServiceServers, executionServiceSubmitServers, slickDataSource)
 
     val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
       shardedExecutionServiceCluster,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -104,7 +104,7 @@ object Boot extends App with LazyLogging {
     val executionServiceConfig = conf.getConfig("executionservice")
     val submissionTimeout = util.toScalaDuration(executionServiceConfig.getDuration("workflowSubmissionTimeout"))
 
-    val executionServiceServers: Map[ExecutionServiceId, ExecutionServiceDAO] = executionServiceConfig.getObject("servers").map {
+    val executionServiceServers: Map[ExecutionServiceId, ExecutionServiceDAO] = executionServiceConfig.getObject("readServers").map {
         case (strName, strHostname) => (ExecutionServiceId(strName)->new HttpExecutionServiceDAO(strHostname.unwrapped.toString, submissionTimeout))
       }.toMap
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ShardedHttpExecutionServiceCluster.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ShardedHttpExecutionServiceCluster.scala
@@ -10,11 +10,11 @@ import scala.concurrent.Future
 import scala.util.{Random, Try}
 
 
-class ShardedHttpExecutionServiceCluster (members: Map[ExecutionServiceId,ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource) extends ExecutionServiceCluster {
+class ShardedHttpExecutionServiceCluster (readMembers: Map[ExecutionServiceId,ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource) extends ExecutionServiceCluster {
 
   // make a copy of the members map as an array for easy reads; routing algorithm will return an index in this array.
   // ensure we sort the array by key for determinism/easy understanding
-  private val memberArray:Array[ClusterMember] = (members map {case (id, dao) => ClusterMember(id, dao)})
+  private val readMemberArray:Array[ClusterMember] = (readMembers map {case (id, dao) => ClusterMember(id, dao)})
       .toList.sortBy(_.key.id).toArray
   private val submitMemberArray:Array[ClusterMember] = (submitMembers map {case (id, dao) => ClusterMember(id, dao)})
       .toList.sortBy(_.key.id).toArray
@@ -52,7 +52,7 @@ class ShardedHttpExecutionServiceCluster (members: Map[ExecutionServiceId,Execut
     getMember(workflowRec).abort(workflowRec.externalId.get, userInfo)
 
   def version(userInfo: UserInfo): Future[ExecutionServiceVersion] =
-    getRandomMember.version(userInfo)
+    getRandomReadMember.version(userInfo)
 
   // ====================
   // facade-to-cluster entry points
@@ -61,7 +61,7 @@ class ShardedHttpExecutionServiceCluster (members: Map[ExecutionServiceId,Execut
   private def getMember(workflowRec: WorkflowRecord): ExecutionServiceDAO = {
     (workflowRec.externalId, workflowRec.executionServiceKey) match {
       case (Some(extId), Some(execKey)) => {
-        members.get(ExecutionServiceId(execKey)) match {
+        readMembers.get(ExecutionServiceId(execKey)) match {
           case Some(dao) => dao
           case None => throw new RawlsException(s"member with key $execKey does not exist")
         }
@@ -70,8 +70,8 @@ class ShardedHttpExecutionServiceCluster (members: Map[ExecutionServiceId,Execut
     }
   }
 
-  private def getRandomMember: ExecutionServiceDAO = {
-    memberArray(Random.nextInt(memberArray.length)).dao
+  private def getRandomReadMember: ExecutionServiceDAO = {
+    readMemberArray(Random.nextInt(readMemberArray.length)).dao
   }
 
   // for unsubmitted workflows, get the best instance to which we should submit

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockShardedExecutionServiceCluster.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockShardedExecutionServiceCluster.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.rawls.dataaccess
 /**
   * Created by davidan on 6/16/16.
   */
-class MockShardedExecutionServiceCluster(members: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource)
-  extends ShardedHttpExecutionServiceCluster(members: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource) {
+class MockShardedExecutionServiceCluster(members: Map[ExecutionServiceId, ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource)
+  extends ShardedHttpExecutionServiceCluster(members: Map[ExecutionServiceId, ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource) {
 
   // for unit tests
   def getDefaultMember: ExecutionServiceDAO = members.values.head
@@ -12,5 +12,5 @@ class MockShardedExecutionServiceCluster(members: Map[ExecutionServiceId, Execut
 }
 
 object MockShardedExecutionServiceCluster {
-  def fromDAO(dao: ExecutionServiceDAO, dataSource: SlickDataSource) = new MockShardedExecutionServiceCluster( Map(ExecutionServiceId("unittestdefault")->dao), dataSource)
+  def fromDAO(dao: ExecutionServiceDAO, dataSource: SlickDataSource) = new MockShardedExecutionServiceCluster( Map(ExecutionServiceId("unittestdefault")->dao), Map(ExecutionServiceId("unittestdefault")->dao), dataSource)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockShardedExecutionServiceCluster.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockShardedExecutionServiceCluster.scala
@@ -3,11 +3,11 @@ package org.broadinstitute.dsde.rawls.dataaccess
 /**
   * Created by davidan on 6/16/16.
   */
-class MockShardedExecutionServiceCluster(members: Map[ExecutionServiceId, ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource)
-  extends ShardedHttpExecutionServiceCluster(members: Map[ExecutionServiceId, ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource) {
+class MockShardedExecutionServiceCluster(readMembers: Map[ExecutionServiceId, ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource)
+  extends ShardedHttpExecutionServiceCluster(readMembers: Map[ExecutionServiceId, ExecutionServiceDAO], submitMembers: Map[ExecutionServiceId, ExecutionServiceDAO], dataSource: SlickDataSource) {
 
   // for unit tests
-  def getDefaultMember: ExecutionServiceDAO = members.values.head
+  def getDefaultSubmitMember: ExecutionServiceDAO = submitMembers.values.head
 
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/ShardedHttpExecutionServiceClusterTest.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/ShardedHttpExecutionServiceClusterTest.scala
@@ -28,7 +28,7 @@ class ShardedHttpExecutionServiceClusterTest(_system: ActorSystem) extends TestK
 
   // arbitrary choice for the instance we'll use for tests; neither first nor last instances
   val instanceKeyForTests = "instance3"
-  val cluster = new ShardedHttpExecutionServiceCluster(instanceMap, slickDataSource)
+  val cluster = new ShardedHttpExecutionServiceCluster(instanceMap, instanceMap, slickDataSource)
 
   // private method wrapper for testing
   val getMember = PrivateMethod[ExecutionServiceDAO]('getMember)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -195,7 +195,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem) extends TestKit(_system) with
       Await.result(workflowSubmission.submitWorkflowBatch(workflowIds), Duration.Inf)
 
       assertResult(workflowIds.map(_ => s"""{"${testData.inputResolutions.head.inputName}":"${testData.inputResolutions.head.value.get.asInstanceOf[AttributeString].value}"}""")) {
-        mockExecCluster.getDefaultMember.asInstanceOf[MockExecutionServiceDAO].submitInput
+        mockExecCluster.getDefaultSubmitMember.asInstanceOf[MockExecutionServiceDAO].submitInput
       }
 
       import spray.json._
@@ -213,7 +213,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem) extends TestKit(_system) with
             Some(JsObject(Map("zones" -> JsString("us-central-someother")))),
             false
           ))) {
-        mockExecCluster.getDefaultMember.asInstanceOf[MockExecutionServiceDAO].submitOptions.map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
+        mockExecCluster.getDefaultSubmitMember.asInstanceOf[MockExecutionServiceDAO].submitOptions.map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
       }
     }
   }


### PR DESCRIPTION
Because we have 2 Cromwells per environment, this means that we also have 2 caches. This is interfering with call caching. 

ShardedHttpExecutionServiceCluster.scala is changed to take in 'submitMembers', which contains the Cromwells we want to submit to (in this case, it should only have cromwell1). The 'members' field and 'memberArray' is kept intact because we still want to be able to read from both cromwells.

Boot.scala is changed to pass the submitMembers to the serviceCluster. 

Testing - I submitted lots of workflows to a dev db clone and they all submitted to the right Cromwell. Nothing seemed broken.

**Question** -  Is any other testing needed? 

**Question** - Am I using the best names for things? Should we change "members" to be something like "readMembers"? 

**Question** - I changed MockShardedExecutionServiceCluster.scala and ShardedHttpExecutionServiceClusterTest.scala so they simply use whatever's being for 'members' for 'submitMembers' as well. Is this the right thing to do?

Future step: Before this PR and the related config changes on the 3 firecloud-develop branches are merged, talk about testing using 1 Cromwell with the QA team, possibly putting this on staging so that it doesn't hold up the next release (?) 


- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
