### PR TITLE
GAWB-1697: unmarshal numeric attributes as ints vs. doubles

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -433,7 +433,8 @@ trait AttributeComponent {
       if (attributeRec.valueBoolean.isDefined) {
         AttributeBoolean(attributeRec.valueBoolean.get)
       } else if (attributeRec.valueNumber.isDefined) {
-        AttributeNumber(attributeRec.valueNumber.get)
+        val n = attributeRec.valueNumber.get
+        if (n.isValidInt) AttributeNumber(n.toInt) else AttributeNumber(n)
       } else if (attributeRec.valueString.isDefined) {
         AttributeString(attributeRec.valueString.get)
       } else if (attributeRec.valueJson.isDefined) {


### PR DESCRIPTION
When we retrieve a numeric attribute from the database, we represent it as a `Double`. Then, when we create an `AttributeNumber` object, we construct the attribute's `BigDecimal` from that `Double` ... which tell the `BigDecimal` that it has a mantissa, even if the mantissa is `.0`. 

Finally, when we serialize the attribute to a json string in the APIs, spray's `JsNumber` is sensitive to the scale of that `BigDecimal`, and will output the `.0`. Thus, if the user supplies an integer for an attribute (say, 12), we'll round-trip and serialize it as a double ("12.0").

This has been a quirk of the API for a while, but hasn't caused any problems. Now, as part of GAWB-1697, this *is* causing problems. We're trying to validate an `AttributeMap` against the Library schema ... and the Library schema defines certain attributes as integers. When we serialize a workspace's pre-existing Library attributes, then validate them, we fail validation because we are supplying doubles instead of integers.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
