### PR TITLE
[GAWB-2056] The status of the last run is showing green when there are errors in them

### DIFF
--- a/core/src/main/resources/swagger/rawls.yaml
+++ b/core/src/main/resources/swagger/rawls.yaml
@@ -5051,11 +5051,11 @@ definitions:
       lastSuccessDate:
         type: string
         format: date-time
-        description: The date of the last successful workflow
+        description: The date of the last successful submission
       lastFailureDate:
         type: string
         format: date-time
-        description: The date of the last failed workflow
+        description: The date of the last failed submission
       runningSubmissionsCount:
         type: integer
         description: Count of all the running submissions

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
@@ -121,9 +121,6 @@ trait DriverComponent {
     name + "_" + getSufficientlyRandomSuffix(recordCount)
   }
 
-  // Note: if we used shapeless we could abstract the following functions further by abstracting over the arity.
-  // But I'm not going to add shapeless just for this. :)
-
   /**
     * Converts a `Seq[(A, B)]` into a `Map[A, B]`, combining the values with a `Monoid[B]` in case of key conflicts.
     *
@@ -145,14 +142,20 @@ trait DriverComponent {
     * {{{
     * scala> case class Foo(i: Int)
     * defined class Foo
+    *
+    * scala> groupPairs(Seq(("a", Foo(1).some), ("b", Foo(2).some), ("c", Foo(3).some)))
+    * << does not compile as there is no Monoid instance for Foo >>
+    *
     * scala> groupPairsK(Seq(("a", Foo(1).some), ("b", Foo(2).some), ("c", Foo(3).some)))
     * res9: Map[String,Option[Foo]] = Map(b -> Some(Foo(2)), a -> Some(Foo(1)), c -> Some(Foo(3)))
     * }}}
-    *
     */
   def groupPairsK[F[_], A, B](pairs: Seq[(A, F[B])])(implicit M: MonoidK[F]): Map[A, F[B]] =
     groupPairs(pairs)(M.algebra[B])
 
+  // Same as above but with triples.
+  // Note: if we used shapeless we could generalize these functions for any arity.
+  // But I'm not going to add shapeless just for this. :)
   def groupTriples[A, B, C: Monoid](trips: Seq[(A, B, C)]): Map[A, Map[B, C]] =
     trips.toList.foldMap { case (a, b, c) => Map(a -> Map(b -> c)) }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
@@ -4,14 +4,15 @@ import java.nio.ByteOrder
 import java.sql.Timestamp
 import java.util.UUID
 
-import akka.util.{ByteString, ByteStringBuilder}
+import akka.util.ByteString
+import cats._
+import cats.implicits._
+import org.apache.commons.codec.binary.Base64
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
-import org.joda.time.DateTime
 import slick.driver.JdbcDriver
 import slick.jdbc.{GetResult, PositionedParameters, SQLActionBuilder, SetParameter}
 import spray.http.StatusCodes
-import org.apache.commons.codec.binary.Base64
 
 import scala.concurrent.ExecutionContext
 
@@ -118,6 +119,45 @@ trait DriverComponent {
 
   def renameForHiding(recordCount: Long, name: String): String = {
     name + "_" + getSufficientlyRandomSuffix(recordCount)
+  }
+
+  // Note: if we used shapeless we could abstract the following functions further by abstracting over the arity.
+  // But I'm not going to add shapeless just for this. :)
+
+  /**
+    * Converts a `Seq[(A, B)]` into a `Map[A, B]`, combining the values with a `Monoid[B]` in case of key conflicts.
+    *
+    * For example:
+    * {{{
+    * scala> groupPairs(Seq(("a", 1), ("b", 2), ("a", 3)))
+    * res0: Map[String,Int] = Map(b -> 2, a -> 4)
+    * }}}
+    * */
+  def groupPairs[A, B: Monoid](pairs: Seq[(A, B)]): Map[A, B] =
+    pairs.toList.foldMap { case (a, b) => Map(a -> b) }
+
+  /**
+    * Converts a `Seq[(A, F[B])]` into a `Map[A, F[B]]`, combining the values with the _universal_ monoid for type F.
+    * This can be useful for when using groupBy with slick aggregate functions such as max, min, avg, etc which return
+    * an Option.
+    *
+    * For example:
+    * {{{
+    * scala> case class Foo(i: Int)
+    * defined class Foo
+    * scala> groupPairsK(Seq(("a", Foo(1).some), ("b", Foo(2).some), ("c", Foo(3).some)))
+    * res9: Map[String,Option[Foo]] = Map(b -> Some(Foo(2)), a -> Some(Foo(1)), c -> Some(Foo(3)))
+    * }}}
+    *
+    */
+  def groupPairsK[F[_], A, B](pairs: Seq[(A, F[B])])(implicit M: MonoidK[F]): Map[A, F[B]] =
+    groupPairs(pairs)(M.algebra[B])
+
+  def groupTriples[A, B, C: Monoid](trips: Seq[(A, B, C)]): Map[A, Map[B, C]] =
+    trips.toList.foldMap { case (a, b, c) => Map(a -> Map(b -> c)) }
+
+  def groupTriplesK[F[_], A, B, C](trips: Seq[(A, B, F[C])])(implicit M: MonoidK[F]): Map[A, Map[B, F[C]]] = {
+    groupTriples(trips)(M.algebra[C])
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -519,7 +519,7 @@ trait WorkspaceComponent {
       //   group by 1, 2, 3) v
       // where (status = 'Failure' or (status = 'Succeeded' and count = 1)
       // group by 1, 2
-      //
+
       val workflowStatusQuery = for {
         submissions <- submissionQuery if submissions.workspaceId.inSetBind(workspaceIds)
         workflows <- workflowQuery if submissions.id === workflows.submissionId

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -770,7 +770,7 @@ trait WorkspaceComponent {
   }
 
   private def groupByWorkspaceId(runningSubmissions: Seq[(UUID, Int)]): Map[UUID, Int] = {
-    CollectionUtils.groupPairs(runningSubmissions.toList)
+    CollectionUtils.groupPairs(runningSubmissions)
   }
 
   private def groupByWorkspaceIdThenStatus(workflowDates: Seq[(UUID, String, Option[Timestamp])]): Map[UUID, Map[String, Option[Timestamp]]] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -507,30 +507,40 @@ trait WorkspaceComponent {
      * @return WorkspaceSubmissionStats keyed by workspace id
      */
     def listSubmissionSummaryStats(workspaceIds: Seq[UUID]): ReadAction[Map[UUID, WorkspaceSubmissionStats]] = {
+
       // submission date query:
       //
       // select workspaceId, status, max(submissionDate)
       // from (
-      //   select submission.id, submission.workspaceId, workflow.status, max(submission.submissionDate)
+      //   select submission.workspaceId, workflow.status, submission.submissionDate, count(1)
       //   from submission
-      //   join workflow on workflow.submissionId = s.id
+      //   join workflow on workflow.submissionId = submission.id
       //   where submission.workspaceId in (:workspaceIds)
-      //   group by submission.id, submission.workspaceId, workflow.status) v
-      // group by v.workspaceId, v.status
+      //   group by 1, 2, 3) v
+      // where (status = 'Failure' or (status = 'Succeeded' and count = 1)
+      // group by 1, 2
       //
-      val submissionDatesQuery = for {
+      val workflowStatusQuery = for {
         submissions <- submissionQuery if submissions.workspaceId.inSetBind(workspaceIds)
         workflows <- workflowQuery if submissions.id === workflows.submissionId
-      } yield (submissions.id, submissions.workspaceId, workflows.status, submissions.submissionDate)
+      } yield (submissions.workspaceId, workflows.status, submissions.submissionDate)
 
-      val submissionDatesGroupedQuery = submissionDatesQuery.groupBy { case (subId, wsId, status, _) =>
-        (subId, wsId, status)
-      }.map { case ((subId, wsId, status), records) =>
-        (subId, wsId, status, records.map(_._4).max)
-      }.groupBy { case (_, wsId, status, _) =>
-        (wsId, status)
-      }.map { case ((wsId, status), records) =>
-        (wsId, status, records.map(_._4).max)
+      val groupedWorkflowStatusQuery = workflowStatusQuery.groupBy { case (wsId, status, submissionDate) =>
+        (wsId, status, submissionDate)
+      }.map { case ((wsId, status, submissionDate), records) =>
+        (wsId, status, submissionDate, records.map(_._3).length)
+      }
+
+      // Note: a submission is successful if it contains _only_ successful workflows.
+      // A submission is a failure if it contains _any_ failed workflows.
+      val filteredWorkflowStatusQuery = groupedWorkflowStatusQuery.filter { case (_, status, _, count) =>
+        status === WorkflowStatuses.Failed.toString || (status === WorkflowStatuses.Succeeded.toString && count === 1)
+      }
+
+      val submissionDateQuery = filteredWorkflowStatusQuery.groupBy { case (workspaceId, status, submissionDate, _) =>
+        (workspaceId, status)
+      }.map { case ((workspaceId, status), recs) =>
+        (workspaceId, status, recs.map(_._3).max)
       }
 
       // running submission query: select workspaceId, count(1) ... where submissions.status === Submitted group by workspaceId
@@ -539,7 +549,7 @@ trait WorkspaceComponent {
       } yield submissions).groupBy(_.workspaceId).map { case (wfId, submissions) => (wfId, submissions.length)}
 
       for {
-        submissionDates <- submissionDatesGroupedQuery.result
+        submissionDates <- submissionDateQuery.result
         runningSubmissions <- runningSubmissionsQuery.result
       } yield {
         val submissionDatesByWorkspaceByStatus = groupTriplesK(submissionDates)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -541,7 +541,7 @@ trait WorkspaceComponent {
       }.groupBy { case (submissionId, workspaceId, _, _) =>
         (submissionId, workspaceId)
       }.map { case ((submissionId, workspaceId), recs) =>
-        (submissionId, workspaceId, recs.map(_._3).count, recs.map(_._4).max)
+        (submissionId, workspaceId, recs.map(_._3).sum, recs.map(_._4).max)
       }
 
       val outerSubmissionDateQuery = innerSubmissionDateQuery.map { case (_, workspaceId, numFailures, maxDate) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -541,7 +541,7 @@ trait WorkspaceComponent {
       }.groupBy { case (submissionId, workspaceId, _, _) =>
         (submissionId, workspaceId)
       }.map { case ((submissionId, workspaceId), recs) =>
-        (submissionId, workspaceId, recs.map(_._3).max, recs.map(_._4).max)
+        (submissionId, workspaceId, recs.map(_._3).count, recs.map(_._4).max)
       }
 
       val outerSubmissionDateQuery = innerSubmissionDateQuery.map { case (_, workspaceId, numFailures, maxDate) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/CollectionUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/CollectionUtils.scala
@@ -25,10 +25,10 @@ object CollectionUtils {
     * res0: Map[String,Int] = Map(b -> 2, a -> 4)
     * }}}
     * */
-  def groupPairs[A, B: Monoid](pairs: List[(A, B)]): Map[A, B] =
-    pairs.foldMap { case (a, b) => Map(a -> b) }
+  def groupPairs[A, B: Monoid](pairs: Seq[(A, B)]): Map[A, B] =
+    pairs.toList.foldMap { case (a, b) => Map(a -> b) }
 
   // Same as above but with triples
-  def groupTriples[A, B, C: Monoid](trips: List[(A, B, C)]): Map[A, Map[B, C]] =
-    trips.foldMap { case (a, b, c) => Map(a -> Map(b -> c)) }
+  def groupTriples[A, B, C: Monoid](trips: Seq[(A, B, C)]): Map[A, Map[B, C]] =
+    trips.toList.foldMap { case (a, b, c) => Map(a -> Map(b -> c)) }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/CollectionUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/CollectionUtils.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsde.rawls.util
 
-import cats._
-import cats.implicits._
+import cats.Monoid
+import cats.instances.list._
+import cats.instances.map._
+import cats.syntax.foldable._
 
 object CollectionUtils {
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/CollectionUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/CollectionUtils.scala
@@ -1,5 +1,8 @@
 package org.broadinstitute.dsde.rawls.util
 
+import cats._
+import cats.implicits._
+
 object CollectionUtils {
 
   //A saner group by than Scala's.
@@ -10,4 +13,20 @@ object CollectionUtils {
   def groupByTuplesFlatten[A, B]( tupleSeq: Seq[(A, Seq[B])] ): Map[A, Seq[B]] = {
     tupleSeq groupBy { case (a,b) => a } map { case (k, v) => k -> v.flatMap(_._2) }
   }
+
+  /**
+    * Converts a `Seq[(A, B)]` into a `Map[A, B]`, combining the values with a `Monoid[B]` in case of key conflicts.
+    *
+    * For example:
+    * {{{
+    * scala> groupPairs(Seq(("a", 1), ("b", 2), ("a", 3)))
+    * res0: Map[String,Int] = Map(b -> 2, a -> 4)
+    * }}}
+    * */
+  def groupPairs[A, B: Monoid](pairs: List[(A, B)]): Map[A, B] =
+    pairs.foldMap { case (a, b) => Map(a -> b) }
+
+  // Same as above but with triples
+  def groupTriples[A, B, C: Monoid](trips: List[(A, B, C)]): Map[A, Map[B, C]] =
+    trips.foldMap { case (a, b, c) => Map(a -> Map(b -> c)) }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
@@ -69,7 +69,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryRecords = runAndWait(query.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(24) { queryRecords.length }
+    assertResult(26) { queryRecords.length }
 
     assertResult(queryRecords) {
       runAndWait(concatSqlActions(select, where1, reduceSqlActionsWithDelim(statuses), where2).as[WorkflowRecord])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -138,6 +138,7 @@ class WorkspaceComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSubmittedSubmission)))
     }
 
+    // Note: a submission with both a successful and failed workflow is a failure
     val wsIdMixedSubmission: UUID = testData.workspaceMixedSubmissions
     assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdMixedSubmission)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -114,4 +114,38 @@ class WorkspaceComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       runAndWait(workspaceQuery.delete(workspace.toWorkspaceName))
     }
   }
+
+  it should "list submission summary stats" in withDefaultTestDatabase {
+    implicit def toWorkspaceId(ws: Workspace): UUID = UUID.fromString(ws.workspaceId)
+
+    val wsIdNoSubmissions: UUID = testData.workspaceNoSubmissions
+    assertResult(Map(wsIdNoSubmissions -> WorkspaceSubmissionStats(None, None, 0))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdNoSubmissions)))
+    }
+
+    val wsIdSuccessfulSubmission: UUID = testData.workspaceSuccessfulSubmission
+    assertResult(Map(wsIdSuccessfulSubmission -> WorkspaceSubmissionStats(Some(testDate), None, 0))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSuccessfulSubmission)))
+    }
+
+    val wsIdFailedSubmission: UUID = testData.workspaceFailedSubmission
+    assertResult(Map(wsIdFailedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 0))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdFailedSubmission)))
+    }
+
+    val wsIdSubmittedSubmission: UUID = testData.workspaceSubmittedSubmission
+    assertResult(Map(wsIdSubmittedSubmission -> WorkspaceSubmissionStats(None, None, 1))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSubmittedSubmission)))
+    }
+
+    val wsIdMixedSubmission: UUID = testData.workspaceMixedSubmissions
+    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 1))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdMixedSubmission)))
+    }
+
+    val wsIdTerminatedSubmission: UUID = testData.workspaceTerminatedSubmissions
+    assertResult(Map(wsIdTerminatedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 0))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdTerminatedSubmission)))
+    }
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -118,32 +118,38 @@ class WorkspaceComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
   it should "list submission summary stats" in withDefaultTestDatabase {
     implicit def toWorkspaceId(ws: Workspace): UUID = UUID.fromString(ws.workspaceId)
 
+    // no submissions
     val wsIdNoSubmissions: UUID = testData.workspaceNoSubmissions
     assertResult(Map(wsIdNoSubmissions -> WorkspaceSubmissionStats(None, None, 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdNoSubmissions)))
     }
 
+    // 1 successful submission, 0 failed, 0 running
     val wsIdSuccessfulSubmission: UUID = testData.workspaceSuccessfulSubmission
     assertResult(Map(wsIdSuccessfulSubmission -> WorkspaceSubmissionStats(Some(testDate), None, 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSuccessfulSubmission)))
     }
 
+    // 0 successful submissions, 1 failed, 0 running
     val wsIdFailedSubmission: UUID = testData.workspaceFailedSubmission
     assertResult(Map(wsIdFailedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdFailedSubmission)))
     }
 
+    // 0 successful submissions, 0 failed, 1 running
     val wsIdSubmittedSubmission: UUID = testData.workspaceSubmittedSubmission
     assertResult(Map(wsIdSubmittedSubmission -> WorkspaceSubmissionStats(None, None, 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSubmittedSubmission)))
     }
 
-    // Note: a submission with both a successful and failed workflow is a failure
+    // 0 successful submissions, 1 failed, 1 running
+
     val wsIdMixedSubmission: UUID = testData.workspaceMixedSubmissions
-    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 1))) {
+    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdMixedSubmission)))
     }
 
+    // 1 successful submissions, 1 failed, 0 running
     val wsIdTerminatedSubmission: UUID = testData.workspaceTerminatedSubmissions
     assertResult(Map(wsIdTerminatedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdTerminatedSubmission)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -118,41 +118,46 @@ class WorkspaceComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
   it should "list submission summary stats" in withDefaultTestDatabase {
     implicit def toWorkspaceId(ws: Workspace): UUID = UUID.fromString(ws.workspaceId)
 
-    // no submissions
+    // no submissions: 0 successful, 0 failed, 0 running
     val wsIdNoSubmissions: UUID = testData.workspaceNoSubmissions
     assertResult(Map(wsIdNoSubmissions -> WorkspaceSubmissionStats(None, None, 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdNoSubmissions)))
     }
 
-    // 1 successful submission, 0 failed, 0 running
+    // successful submission: 1 successful, 0 failed, 0 running
     val wsIdSuccessfulSubmission: UUID = testData.workspaceSuccessfulSubmission
     assertResult(Map(wsIdSuccessfulSubmission -> WorkspaceSubmissionStats(Some(testDate), None, 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSuccessfulSubmission)))
     }
 
-    // 0 successful submissions, 1 failed, 0 running
+    // failed submission: 0 successful, 1 failed, 0 running
     val wsIdFailedSubmission: UUID = testData.workspaceFailedSubmission
     assertResult(Map(wsIdFailedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdFailedSubmission)))
     }
 
-    // 0 successful submissions, 0 failed, 1 running
+    // submitted submissions: 0 successful, 0 failed, 1 running
     val wsIdSubmittedSubmission: UUID = testData.workspaceSubmittedSubmission
     assertResult(Map(wsIdSubmittedSubmission -> WorkspaceSubmissionStats(None, None, 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdSubmittedSubmission)))
     }
 
-    // 0 successful submissions, 1 failed, 1 running
-
+    // mixed submissions: 0 successful, 1 failed, 1 running
     val wsIdMixedSubmission: UUID = testData.workspaceMixedSubmissions
     assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdMixedSubmission)))
     }
 
-    // 1 successful submissions, 1 failed, 0 running
+    // terminated submissions: 1 successful, 1 failed, 0 running
     val wsIdTerminatedSubmission: UUID = testData.workspaceTerminatedSubmissions
     assertResult(Map(wsIdTerminatedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 0))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdTerminatedSubmission)))
+    }
+
+    // interleaved submissions: 1 successful, 1 failed, 0 running
+    val wsIdInterleavedSubmissions: UUID = testData.workspaceInterleavedSubmissions
+    assertResult(Map(wsIdInterleavedSubmissions -> WorkspaceSubmissionStats(Option(testData.t4), Option(testData.t3), 0))) {
+      runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdInterleavedSubmissions)))
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -140,7 +140,7 @@ class WorkspaceComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
 
     // Note: a submission with both a successful and failed workflow is a failure
     val wsIdMixedSubmission: UUID = testData.workspaceMixedSubmissions
-    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 1))) {
+    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdMixedSubmission)))
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -139,7 +139,7 @@ class WorkspaceComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     }
 
     val wsIdMixedSubmission: UUID = testData.workspaceMixedSubmissions
-    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(Some(testDate), Some(testDate), 1))) {
+    assertResult(Map(wsIdMixedSubmission -> WorkspaceSubmissionStats(None, Some(testDate), 1))) {
       runAndWait(workspaceQuery.listSubmissionSummaryStats(Seq(wsIdMixedSubmission)))
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -384,7 +384,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, Option(testDate), 2), Seq(testData.userOwner.userEmail.value))
+          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Seq(testData.userOwner.userEmail.value))
         ){
           val response = responseAs[WorkspaceListResponse]
           WorkspaceListResponse(response.accessLevel, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.owners)
@@ -520,7 +520,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
         val dateTime = currentTime()
         assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, Option(testDate), 2), Seq(testData.userOwner.userEmail.value)),
+          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Seq(testData.userOwner.userEmail.value)),
           WorkspaceListResponse(WorkspaceAccessLevels.Write, testWorkspaces.workspace2.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Seq.empty),
           WorkspaceListResponse(WorkspaceAccessLevels.NoAccess, testWorkspaces.workspace3.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Seq.empty)
         )) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -384,7 +384,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Seq(testData.userOwner.userEmail.value))
+          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, Option(testDate), 2), Seq(testData.userOwner.userEmail.value))
         ){
           val response = responseAs[WorkspaceListResponse]
           WorkspaceListResponse(response.accessLevel, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.owners)
@@ -520,7 +520,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
         val dateTime = currentTime()
         assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), Seq(testData.userOwner.userEmail.value)),
+          WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspaces.workspace.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, Option(testDate), 2), Seq(testData.userOwner.userEmail.value)),
           WorkspaceListResponse(WorkspaceAccessLevels.Write, testWorkspaces.workspace2.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Seq.empty),
           WorkspaceListResponse(WorkspaceAccessLevels.NoAccess, testWorkspaces.workspace3.copy(lastModified = dateTime), WorkspaceSubmissionStats(None, None, 0), Seq.empty)
         )) {


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/GAWB-2056 (see latest comments)

### Problem: 
In "get workspace" calls, Rawls was returning the timestamps of the most recent successful and failed workflows. This is used in the UI to display either green or red in the workspace summary and list pages (red if latest failed workflow timestamp > latest successful workflow timestamp; green otherwise).

However, these workflows might be in the same submission. In the UI, a submission is red if _any_ of its workflows failed. This led to confusing behavior: a workspace might be green in the Summary tab, but have only failed submissions in the Monitor tab.

### Solution:
Change semantics of `WorkspaceSubmissionStats` to return the timestamps of the most recent successful and failed _submission_, taking into account the logic that a submission is a failure if any of its workflows are a failure.

Tested via unit tests and manually using a UI. Also confirmed the generated slick query matches the query in the [comments](https://github.com/broadinstitute/rawls/compare/rt-gawb-2056?expand=1#diff-ce257bad14de3e732d04d31146839b87R511).

Also, query explain plan: 
![image](https://user-images.githubusercontent.com/5368863/26995875-2914d2fe-4d3d-11e7-8c1a-6048635934d2.png)





- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] Tell your tech lead (TL) that the PR exists if they want to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
