### PR TITLE
GAWB-1289: Fixing method config page bugs

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -136,9 +136,9 @@ trait MethodConfigurationComponent {
       workspaceQuery.updateLastModified(workspaceContext.workspaceId) andThen
         hideMethodConfigurationAction(currentMethodConfigRec.id, currentMethodConfigRec.name) andThen
         (methodConfigurationQuery returning methodConfigurationQuery.map(_.id) += marshalMethodConfig(workspaceContext.workspaceId,
-          newMethodConfig.copy(methodConfigVersion=currentMethodConfigRec.methodConfigVersion + 1))) flatMap { configId => {
-        saveMaps(newMethodConfig, configId)}
-      }
+          newMethodConfig.copy(methodConfigVersion=currentMethodConfigRec.methodConfigVersion + 1))) flatMap { configId =>
+            saveMaps(newMethodConfig, configId)
+          }
     }
 
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
-import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickWorkspaceContext
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
@@ -91,7 +90,7 @@ trait MethodConfigurationComponent {
   protected val methodConfigurationOutputQuery = TableQuery[MethodConfigurationOutputTable]
   protected val methodConfigurationPrereqQuery = TableQuery[MethodConfigurationPrereqTable]
 
-  object methodConfigurationQuery extends TableQuery(new MethodConfigurationTable(_)) with LazyLogging {
+  object methodConfigurationQuery extends TableQuery(new MethodConfigurationTable(_)) {
 
     private type MethodConfigurationQueryType = driver.api.Query[MethodConfigurationTable, MethodConfigurationRecord, Seq]
     private type MethodConfigurationInputQueryType = driver.api.Query[MethodConfigurationInputTable, MethodConfigurationInputRecord, Seq]
@@ -112,9 +111,7 @@ trait MethodConfigurationComponent {
         case None =>
           val configInsert = (methodConfigurationQuery returning methodConfigurationQuery.map(_.id) +=  marshalMethodConfig(workspaceContext.workspaceId, newMethodConfig))
           configInsert flatMap { configId =>
-            {logger.info("create CONFIG ID:   " + configId.toString)
-              logger.info("create NEW METHOD CONFIG:  " + newMethodConfig.toString)
-              saveMaps(newMethodConfig, configId)}
+            saveMaps(newMethodConfig, configId)
           }
         case Some(currentMethodConfigRec) =>
          save(workspaceContext, currentMethodConfigRec, newMethodConfig)
@@ -139,10 +136,8 @@ trait MethodConfigurationComponent {
       workspaceQuery.updateLastModified(workspaceContext.workspaceId) andThen
         hideMethodConfigurationAction(currentMethodConfigRec.id, currentMethodConfigRec.name) andThen
         (methodConfigurationQuery returning methodConfigurationQuery.map(_.id) += marshalMethodConfig(workspaceContext.workspaceId,
-          newMethodConfig.copy(methodConfigVersion=currentMethodConfigRec.methodConfigVersion + 1))) flatMap { configId =>
-       { logger.info("CONFIG ID:   " + configId.toString)
-         logger.info("NEW METHOD CONFIG:  " + newMethodConfig.toString)
-         saveMaps(newMethodConfig, configId)}
+          newMethodConfig.copy(methodConfigVersion=currentMethodConfigRec.methodConfigVersion + 1))) flatMap { configId => {
+        saveMaps(newMethodConfig, configId)}
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -1,5 +1,4 @@
 package org.broadinstitute.dsde.rawls.jobexec
-import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickWorkspaceContext
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
@@ -14,7 +13,7 @@ import wdl4s.{FullyQualifiedName, WdlNamespaceWithWorkflow, WorkflowInput}
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
-object MethodConfigResolver extends LazyLogging {
+object MethodConfigResolver {
   val emptyResultError = "Expected single value for workflow input, but evaluated result set was empty"
   val multipleResultError  = "Expected single value for workflow input, but evaluated result set had multiple values"
   val missingMandatoryValueError  = "Mandatory workflow input is not specified in method config"
@@ -53,7 +52,7 @@ object MethodConfigResolver extends LazyLogging {
 
   def gatherInputs(methodConfig: MethodConfiguration, wdl: String): Try[Seq[MethodInput]] = parseWDL(wdl) map { workflow =>
 
-    def emptyAttribute(fqn: FullyQualifiedName): Boolean = {
+    def isAttributeEmpty(fqn: FullyQualifiedName): Boolean = {
       methodConfig.inputs.get(fqn) match {
           // The reason this is specifically an AttributeString rather than any other kind of attribute is because
           //   MethodConfiguration also only uses AttributeString. Unsure if that's okay?
@@ -63,7 +62,7 @@ object MethodConfigResolver extends LazyLogging {
     }
 
     val agoraInputs = workflow.inputs
-    val missingInputs = agoraInputs.filter { case (fqn, workflowInput) => (!methodConfig.inputs.contains(fqn) || emptyAttribute(fqn)) && !workflowInput.optional }.keys
+    val missingInputs = agoraInputs.filter { case (fqn, workflowInput) => (!methodConfig.inputs.contains(fqn) || isAttributeEmpty(fqn)) && !workflowInput.optional }.keys
     val extraInputs = methodConfig.inputs.filter { case (name, expression) => !agoraInputs.contains(name) }.keys
     if (missingInputs.nonEmpty || extraInputs.nonEmpty) {
       val message =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -54,7 +54,7 @@ object MethodConfigResolver {
     def isAttributeEmpty(fqn: FullyQualifiedName): Boolean = {
       methodConfig.inputs.get(fqn) match {
         case Some(AttributeString(value)) => value.isEmpty
-        case _ => throw new AssertionError(s"MethodConfiguration ${methodConfig.namespace}/${methodConfig.name} input ${fqn} value is unavailable")
+        case _ => throw new RawlsException(s"MethodConfiguration ${methodConfig.namespace}/${methodConfig.name} input ${fqn} value is unavailable")
       }
     }
     val agoraInputs = workflow.inputs


### PR DESCRIPTION
There are a bunch of bugs on the method config details page. 

This rawls PR fixes the following bug:

Currently, if you import a method config with any kind of inputs (required or optional), a submission will be created but will immediately fail because there are no values for the inputs. This should not happen. In the case of required inputs, when you hit the launch button, an error message should tell you that you didn't add give your inputs values. It should not let you create a submission. In the case of optional inputs, you should be able to create a submission, but it should not immediately fail because you don't have values assigned for your inputs (since they're optional).

Interestingly, if you edit and then save the imported config (without actually changing anything), and then attempt to launch, the method configs behave correctly: required inputs with no values do not launch and show an error on the launch modal, optional inputs with no values submit and then run correctly.

This means that there was some kind of issue with the inputs upon import, but not after it had been saved the first time. 

I looked at the way the inputs are saved. Upon import, the METHOD_CONFIG_INPUT table saves the inputs and their values (this column is blank initially). If you edit the method config and save it, a new row is created for the saved method config in the METHOD_CONFIG table. However, new rows were only being created in the METHOD_CONFIG_INPUT table if there were actual values associated with them. If no values were present, no rows were added to the input table.

I'm attempting to fix this in tandem with a ui PR: https://github.com/broadinstitute/firecloud-ui/pull/840

This PR extends what a "missing input" is. Previously a missing input was any required input that was null. However, because the input value was being created as an AttributeString("..."), this meant it was never null, or never missing. (an AttributeString("") should be a missing input. an AttributeString("\"\"") is an empty input). I made it so that any AttributeString("") is missing. This causes any empty input fields to prevent the creation of a submission.


- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
