### PR TITLE
GAWB-2189: fixing launch of method config where input is optional

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2137,14 +2137,14 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
           withMethodInputs(methodConfig, userInfo) { (wdl, methodInputs) =>
             withSubmissionEntityRecs(submissionRequest, workspaceContext, methodConfig.rootEntityType, dataAccess) { jobEntityRecs =>
               withWorkflowFailureMode(submissionRequest) { workflowFailureMode =>
-                val requiredMethodInputs = methodInputs.filter(input => !input.workflowInput.optional || !input.expression.isEmpty)
+                val nonEmptyMethodInputs = methodInputs.filter(input => !input.workflowInput.optional || !input.expression.isEmpty)
                 //Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
-                MethodConfigResolver.resolveInputsForEntities(workspaceContext, requiredMethodInputs, jobEntityRecs, dataAccess) flatMap { valuesByEntity =>
+                MethodConfigResolver.resolveInputsForEntities(workspaceContext, nonEmptyMethodInputs, jobEntityRecs, dataAccess) flatMap { valuesByEntity =>
                   valuesByEntity
                     .map({ case (entityName, values) => SubmissionValidationEntityInputs(entityName, values) })
                     .partition({ entityInputs => entityInputs.inputResolutions.forall(_.error.isEmpty) }) match {
                     case (succeeded, failed) =>
-                      val methodConfigInputs = requiredMethodInputs.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.fqn, methodInput.expression) }
+                      val methodConfigInputs = nonEmptyMethodInputs.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.fqn, methodInput.expression) }
                       val header = SubmissionValidationHeader(methodConfig.rootEntityType, methodConfigInputs)
                       op(dataAccess, workspaceContext, wdl, header, succeeded.toSeq, failed.toSeq, workflowFailureMode)
                   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2137,14 +2137,15 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
           withMethodInputs(methodConfig, userInfo) { (wdl, methodInputs) =>
             withSubmissionEntityRecs(submissionRequest, workspaceContext, methodConfig.rootEntityType, dataAccess) { jobEntityRecs =>
               withWorkflowFailureMode(submissionRequest) { workflowFailureMode =>
-                val nonEmptyMethodInputs = methodInputs.filter(input => !input.workflowInput.optional || !input.expression.isEmpty)
+                //Remove inputs that are both empty and optional
+                val inputsToEvaluate = methodInputs.filter(input => !(input.workflowInput.optional && input.expression.isEmpty))
                 //Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
-                MethodConfigResolver.resolveInputsForEntities(workspaceContext, nonEmptyMethodInputs, jobEntityRecs, dataAccess) flatMap { valuesByEntity =>
+                MethodConfigResolver.resolveInputsForEntities(workspaceContext, inputsToEvaluate, jobEntityRecs, dataAccess) flatMap { valuesByEntity =>
                   valuesByEntity
                     .map({ case (entityName, values) => SubmissionValidationEntityInputs(entityName, values) })
                     .partition({ entityInputs => entityInputs.inputResolutions.forall(_.error.isEmpty) }) match {
                     case (succeeded, failed) =>
-                      val methodConfigInputs = nonEmptyMethodInputs.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.fqn, methodInput.expression) }
+                      val methodConfigInputs = inputsToEvaluate.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.fqn, methodInput.expression) }
                       val header = SubmissionValidationHeader(methodConfig.rootEntityType, methodConfigInputs)
                       op(dataAccess, workspaceContext, wdl, header, succeeded.toSeq, failed.toSeq, workflowFailureMode)
                   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2137,13 +2137,14 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
           withMethodInputs(methodConfig, userInfo) { (wdl, methodInputs) =>
             withSubmissionEntityRecs(submissionRequest, workspaceContext, methodConfig.rootEntityType, dataAccess) { jobEntityRecs =>
               withWorkflowFailureMode(submissionRequest) { workflowFailureMode =>
+                val requiredMethodInputs = methodInputs.filter(input => !input.workflowInput.optional || !input.expression.isEmpty)
                 //Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
-                MethodConfigResolver.resolveInputsForEntities(workspaceContext, methodInputs, jobEntityRecs, dataAccess) flatMap { valuesByEntity =>
+                MethodConfigResolver.resolveInputsForEntities(workspaceContext, requiredMethodInputs, jobEntityRecs, dataAccess) flatMap { valuesByEntity =>
                   valuesByEntity
                     .map({ case (entityName, values) => SubmissionValidationEntityInputs(entityName, values) })
                     .partition({ entityInputs => entityInputs.inputResolutions.forall(_.error.isEmpty) }) match {
                     case (succeeded, failed) =>
-                      val methodConfigInputs = methodInputs.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.fqn, methodInput.expression) }
+                      val methodConfigInputs = requiredMethodInputs.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.fqn, methodInput.expression) }
                       val header = SubmissionValidationHeader(methodConfig.rootEntityType, methodConfigInputs)
                       op(dataAccess, workspaceContext, wdl, header, succeeded.toSeq, failed.toSeq, workflowFailureMode)
                   }


### PR DESCRIPTION
This bug happened because of a recent UI change. 

Before, the UI was removing inputs with empty expressions before passing inputs/outputs to rawls when launching a submission.

Since we are now passing all mc inputs to rawls, regardless of whether they are empty or not, at launch, rawls attempts to parse empty expressions, which causes the submission to fail. This code removes the empty inputs before parsing. (Previously, empty optional inputs were not reaching this stage because they were removed by the UI)

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
