### PR TITLE
Reduce statsd timer metrics

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -12,7 +12,7 @@ import akka.util.Timeout
 import com.codahale.metrics.SharedMetricRegistries
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.readytalk.metrics.StatsDReporter
+import com.readytalk.metrics.{StatsD, StatsDReporter}
 import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigRenderOptions}
 import com.typesafe.scalalogging.LazyLogging
 import slick.backend.DatabaseConfig
@@ -21,6 +21,7 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.google.HttpGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionSupervisor, WorkflowSubmissionActor}
+import org.broadinstitute.dsde.rawls.metrics.RawlsStatsD
 import org.broadinstitute.dsde.rawls.model.{ApplicationVersion, UserInfo}
 import org.broadinstitute.dsde.rawls.monitor._
 import org.broadinstitute.dsde.rawls.statistics.StatisticsService
@@ -290,7 +291,7 @@ object Boot extends App with LazyLogging {
       .prefixedWith(apiKey.orNull)
       .convertRatesTo(TimeUnit.SECONDS)
       .convertDurationsTo(TimeUnit.MILLISECONDS)
-      .build(host, port)
+      .build(RawlsStatsD(host, port))
     reporter.start(period.toMillis, period.toMillis, TimeUnit.MILLISECONDS)
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -12,7 +12,7 @@ import akka.util.Timeout
 import com.codahale.metrics.SharedMetricRegistries
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.readytalk.metrics.{StatsD, StatsDReporter}
+import com.readytalk.metrics.{WorkbenchStatsD, StatsDReporter}
 import com.typesafe.config.{ConfigFactory, ConfigObject, ConfigRenderOptions}
 import com.typesafe.scalalogging.LazyLogging
 import slick.backend.DatabaseConfig
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.google.HttpGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionSupervisor, WorkflowSubmissionActor}
-import org.broadinstitute.dsde.rawls.metrics.RawlsStatsD
 import org.broadinstitute.dsde.rawls.model.{ApplicationVersion, UserInfo}
 import org.broadinstitute.dsde.rawls.monitor._
 import org.broadinstitute.dsde.rawls.statistics.StatisticsService
@@ -291,7 +290,7 @@ object Boot extends App with LazyLogging {
       .prefixedWith(apiKey.orNull)
       .convertRatesTo(TimeUnit.SECONDS)
       .convertDurationsTo(TimeUnit.MILLISECONDS)
-      .build(RawlsStatsD(host, port))
+      .build(WorkbenchStatsD(host, port))
     reporter.start(period.toMillis, period.toMillis, TimeUnit.MILLISECONDS)
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsStatsD.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsStatsD.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.rawls.metrics
+
+import com.readytalk.metrics.StatsD
+import com.typesafe.scalalogging.LazyLogging
+
+/**
+  * Created by rtitle on 8/21/17.
+  */
+class RawlsStatsD(host: String, port: Int) extends StatsD(host, port) with LazyLogging {
+  // Filter out detailed timer metrics to prevent hitting Hosted Graphite quotas.
+  // Keep: mean, p95, stddev
+  val MetricSuffixesToFilter = Set("max", "min", "p50", "p75", "p98", "p99", "p999", "samples", "m1_rate", "m5_rate", "m15_rate", "mean_rate")
+
+  override def send(name: String, value: String): Unit = {
+    if (MetricSuffixesToFilter.exists(suffix => name.endsWith(suffix))) {
+      logger.debug(s"Filtering metric with name [$name] and value [$value]")
+    } else {
+      super.send(name, value)
+    }
+  }
+}
+
+object RawlsStatsD {
+  def apply(host: String, port: Int): RawlsStatsD = new RawlsStatsD(host, port)
+}

--- a/metrics/src/main/scala/com/readytalk/metrics/WorkbenchStatsD.scala
+++ b/metrics/src/main/scala/com/readytalk/metrics/WorkbenchStatsD.scala
@@ -1,12 +1,11 @@
-package org.broadinstitute.dsde.rawls.metrics
+package com.readytalk.metrics
 
-import com.readytalk.metrics.StatsD
 import com.typesafe.scalalogging.LazyLogging
 
 /**
   * Created by rtitle on 8/21/17.
   */
-class RawlsStatsD(host: String, port: Int) extends StatsD(host, port) with LazyLogging {
+class WorkbenchStatsD(host: String, port: Int) extends StatsD(host, port) with LazyLogging {
   // Filter out detailed timer metrics to prevent hitting Hosted Graphite quotas.
   // Keep: mean, p95, stddev
   val MetricSuffixesToFilter = Set("max", "min", "p50", "p75", "p98", "p99", "p999", "samples", "m1_rate", "m5_rate", "m15_rate", "mean_rate")
@@ -20,6 +19,6 @@ class RawlsStatsD(host: String, port: Int) extends StatsD(host, port) with LazyL
   }
 }
 
-object RawlsStatsD {
-  def apply(host: String, port: Int): RawlsStatsD = new RawlsStatsD(host, port)
+object WorkbenchStatsD {
+  def apply(host: String, port: Int): WorkbenchStatsD = new WorkbenchStatsD(host, port)
 }


### PR DESCRIPTION
No JIRA.

For the record, I don't love having to make this change, but I think it should be fine.

Metrics has been enabled on Rawls dev for 1 day. It's working great, but I'm concerned about hitting metric limits. We're currently using 4600 metrics out of 10000. If we enable it on all environments (dev, alpha, staging, prod) we could well exceed our 10k limit.

This change will eliminate 2590 of the metrics currently on dev, meaning dev Rawls will only use about 2k metrics. This should give us some more breathing room. These detailed timer metrics don't seem all that useful anyway.

If we _still_ bump up against quotas after deploying to all environments, my preferred next steps would be (in order):
1) only enable metrics in prod
2) upgrade our graphite plan
3) look at more metrics to filter


- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] Tell your tech lead (TL) that the PR exists if they want to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
