### PR TITLE
GAWB-2486 When workflows complete, only update attributes that have changed

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -322,7 +322,7 @@ trait AttributeComponent {
     def toPrimaryKeyMap(recs: Traversable[RECORD]) =
       recs.map { rec => (AttributeRecordPrimaryKey(rec.ownerId, rec.namespace, rec.name, rec.listIndex), rec) }.toMap
 
-    def upsertAction(attributesToSave: Traversable[RECORD], existingAttributes: Traversable[RECORD], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
+    def rewriteAttrsAction(attributesToSave: Traversable[RECORD], existingAttributes: Traversable[RECORD], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
       val toSaveAttrMap = toPrimaryKeyMap(attributesToSave)
       val existingAttrMap = toPrimaryKeyMap(existingAttributes)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -183,6 +183,10 @@ trait AttributeComponent {
   protected object submissionAttributeQuery extends AttributeQuery[Long, SubmissionAttributeRecord, SubmissionAttributeTable](new SubmissionAttributeTable(_), SubmissionAttributeRecord)
 
   protected abstract class AttributeScratchQuery[OWNER_ID: TypeTag, RECORD <: AttributeRecord[OWNER_ID], TEMP_RECORD <: AttributeScratchRecord[OWNER_ID], T <: AttributeScratchTable[OWNER_ID, TEMP_RECORD]](cons: Tag => T, createRecord: (Long, OWNER_ID, String, String, Option[String], Option[Double], Option[Boolean], Option[String], Option[Long], Option[Int], Option[Int], Boolean, Option[Timestamp], String) => TEMP_RECORD) extends TableQuery[T](cons) {
+    def insertScratchAttributes(attributeRecs: Seq[RECORD])(transactionId: String): WriteAction[Int] = {
+      batchInsertAttributes(attributeRecs, transactionId)
+    }
+
     def batchInsertAttributes(attributes: Seq[RECORD], transactionId: String) = {
       insertInBatches(this, attributes.map { case rec =>
         createRecord(rec.id, rec.ownerId, rec.namespace, rec.name, rec.valueString, rec.valueNumber, rec.valueBoolean, rec.valueJson, rec.valueEntityRef, rec.listIndex, rec.listLength, rec.deleted, rec.deletedDate, transactionId)
@@ -300,8 +304,8 @@ trait AttributeComponent {
       res.sortBy(r => (r._2.desc, r._1)).map(x => (x._1.get, x._2))
     }
 
-    def deleteAttributeRecords(attributeRecords: Seq[RECORD]): DBIOAction[Int, NoStream, Write] = {
-      filter(_.id inSetBind attributeRecords.map(_.id)).delete
+    def deleteAttributeRecordsById(attributeRecordIds: Seq[Long]): DBIOAction[Int, NoStream, Write] = {
+      filter(_.id inSetBind attributeRecordIds).delete
     }
 
     // for DB performance reasons, it's necessary to split "save attributes" into 3 steps:
@@ -322,6 +326,12 @@ trait AttributeComponent {
     def toPrimaryKeyMap(recs: Traversable[RECORD]) =
       recs.map { rec => (AttributeRecordPrimaryKey(rec.ownerId, rec.namespace, rec.name, rec.listIndex), rec) }.toMap
 
+    def deltaAttrsAction(inserts: Traversable[RECORD], updates: Traversable[RECORD], deleteIds: Traversable[Long], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
+      deleteAttributeRecordsById(deleteIds.toSeq) andThen
+        batchInsertAttributes(inserts.toSeq) andThen
+        AlterAttributesUsingScratchTableQueries.updateAction(insertFunction(updates.toSeq))
+    }
+
     def rewriteAttrsAction(attributesToSave: Traversable[RECORD], existingAttributes: Traversable[RECORD], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
       val toSaveAttrMap = toPrimaryKeyMap(attributesToSave)
       val existingAttrMap = toPrimaryKeyMap(existingAttributes)
@@ -331,7 +341,7 @@ trait AttributeComponent {
       // delete attributes which currently exist but are not in the attributes to save
       val attributesToDelete = existingAttrMap.filterKeys(! attrsToUpdateMap.keySet.contains(_)).values
 
-      deleteAttributeRecords(attributesToDelete.toSeq) andThen
+      deleteAttributeRecordsById(attributesToDelete.map(_.id).toSeq) andThen
         batchInsertAttributes(attrsToInsertMap.values.toSeq) andThen
         AlterAttributesUsingScratchTableQueries.updateAction(insertFunction(attrsToUpdateMap.values.toSeq))
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -326,7 +326,7 @@ trait AttributeComponent {
     def toPrimaryKeyMap(recs: Traversable[RECORD]) =
       recs.map { rec => (AttributeRecordPrimaryKey(rec.ownerId, rec.namespace, rec.name, rec.listIndex), rec) }.toMap
 
-    def deltaAttrsAction(inserts: Traversable[RECORD], updates: Traversable[RECORD], deleteIds: Traversable[Long], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
+    def patchAttributesAction(inserts: Traversable[RECORD], updates: Traversable[RECORD], deleteIds: Traversable[Long], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
       deleteAttributeRecordsById(deleteIds.toSeq) andThen
         batchInsertAttributes(inserts.toSeq) andThen
         AlterAttributesUsingScratchTableQueries.updateAction(insertFunction(updates.toSeq))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -14,8 +14,6 @@ import slick.driver.JdbcDriver
 import slick.jdbc.GetResult
 import spray.http.StatusCodes
 
-import scala.collection.immutable.Iterable
-
 /**
  * Created by dvoet on 2/4/16.
  */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -401,21 +401,20 @@ trait EntityComponent {
       } else if (deleteIntersectUpsert.nonEmpty) {
         DBIO.failed(new RawlsException(s"Can't saveEntityDeltas on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"))
       } else {
-        getEntityRecords(workspaceContext.workspaceId, Set(entityRef)) flatMap { eRecs =>
-          if (eRecs.length != 1) {
-            throw new RawlsException(s"saveEntityDeltas looked up $entityRef expecting 1 record, got ${eRecs.length} instead")
+        getEntityRecords(workspaceContext.workspaceId, Set(entityRef)) flatMap { entityRecs =>
+          if (entityRecs.length != 1) {
+            throw new RawlsException(s"saveEntityDeltas looked up $entityRef expecting 1 record, got ${entityRecs.length} instead")
           }
 
-          val eRec = eRecs.head
-
+          val entityRecord = entityRecs.head
           upserts.keys.foreach { attrName =>
             validateUserDefinedString(attrName.name)
-            validateAttributeName(attrName, eRec.entityType)
+            validateAttributeName(attrName, entityRecord.entityType)
           }
 
           for {
-            _ <- applyAttributeDeltas(workspaceContext, eRec, upserts, deletes)
-            _ <- optimisticLockUpdate(eRec)
+            _ <- applyAttributeDeltas(workspaceContext, entityRecord, upserts, deletes)
+            _ <- optimisticLockUpdate(entityRecord)
           } yield {}
         }
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -14,6 +14,8 @@ import slick.driver.JdbcDriver
 import slick.jdbc.GetResult
 import spray.http.StatusCodes
 
+import scala.collection.immutable.Iterable
+
 /**
  * Created by dvoet on 2/4/16.
  */
@@ -374,7 +376,7 @@ trait EntityComponent {
           val (updateAttrs, insertAttrs) = upserts.partition( attr => existingAttributes.contains(attr._1) )
 
           //function that marshals attribute maps to list of attribute records for saving
-          def attributeMapToRecs(attrMap: AttributeMap) = {
+          def attributeMapToRecs(attrMap: AttributeMap): Iterable[EntityAttributeRecord] = {
             for {
               (attributeName, attribute) <- attrMap
               attributeRec <- entityAttributeQuery.marshalAttribute(refsToIds(entityRecord.toReference), attributeName, attribute, refsToIds)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -417,7 +417,9 @@ trait EntityComponent {
     //save the deltas for some attributes on an existing entity. a little more database efficient than a "full" save, but requires the entity already exist.
     def saveEntityDeltas(workspaceContext: SlickWorkspaceContext, entityRef: AttributeEntityReference, upserts: AttributeMap, deletes: Traversable[AttributeName]) = {
       val deleteIntersectUpsert = deletes.toSet intersect upserts.keySet
-      if (deleteIntersectUpsert.nonEmpty) {
+      if (upserts.isEmpty && deletes.isEmpty) {
+        DBIO.successful(()) //no-op
+      } else if (deleteIntersectUpsert.nonEmpty) {
         DBIO.failed(new RawlsException(s"Can't saveEntityDeltas on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"))
       } else {
         getEntityRecords(workspaceContext.workspaceId, Set(entityRef)) flatMap { eRecs =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -357,6 +357,8 @@ trait EntityComponent {
       } yield entities
     }
 
+    def saveEntityDeltas(workspaceContext: SlickWorkspaceContext, )
+
     private def lookupNotYetLoadedReferences(workspaceContext: SlickWorkspaceContext, entities: Traversable[Entity], alreadyLoadedEntityRecs: Seq[EntityRecord]): ReadAction[Seq[EntityRecord]] = {
       val notYetLoadedEntityRecs = (for {
         entity <- entities

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -230,7 +230,7 @@ trait WorkspaceComponent {
         val attributesToSave = workspace.attributes flatMap { attr => workspaceAttributeQuery.marshalAttribute(workspaceId, attr._1, attr._2, entityIdsByRef) }
 
         workspaceAttributeQuery.findByOwnerQuery(Seq(workspaceId)).result flatMap { existingAttributes =>
-          workspaceAttributeQuery.upsertAction(attributesToSave, existingAttributes, insertScratchAttributes)
+          workspaceAttributeQuery.rewriteAttrsAction(attributesToSave, existingAttributes, insertScratchAttributes)
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -197,11 +197,11 @@ trait WorkspaceComponent {
           (workspaceQuery += marshalNewWorkspace(workspace)) andThen
             insertAuthDomainRecords(workspace) andThen
             insertOrUpdateAccessRecords(workspace) andThen
-            upsertAttributes(workspace) andThen
+            rewriteAttributes(workspace) andThen
             updateLastModified(UUID.fromString(workspace.workspaceId))
         case Some(workspaceRecord) =>
           insertOrUpdateAccessRecords(workspace) andThen
-            upsertAttributes(workspace) andThen
+            rewriteAttributes(workspace) andThen
             optimisticLockUpdate(workspaceRecord) andThen
             updateLastModified(UUID.fromString(workspace.workspaceId))
       } map { _ => workspace }
@@ -214,23 +214,19 @@ trait WorkspaceComponent {
       DBIO.sequence((accessRecords ++ authDomainAclRecords).map { workspaceAccessQuery insertOrUpdate }).map(_.sum)
     }
 
-    private def upsertAttributes(workspace: Workspace) = {
+    private def rewriteAttributes(workspace: Workspace) = {
       val workspaceId = UUID.fromString(workspace.workspaceId)
 
       val entityRefs = workspace.attributes.collect { case (_, ref: AttributeEntityReference) => ref }
       val entityRefListMembers = workspace.attributes.collect { case (_, refList: AttributeEntityReferenceList) => refList.list }.flatten
       val entitiesToLookup = (entityRefs ++ entityRefListMembers).toSet
 
-      def insertScratchAttributes(attributeRecs: Seq[WorkspaceAttributeRecord])(transactionId: String): WriteAction[Int] = {
-        workspaceAttributeScratchQuery.batchInsertAttributes(attributeRecs, transactionId)
-      }
-
       entityQuery.getEntityRecords(workspaceId, entitiesToLookup) flatMap { entityRecords =>
         val entityIdsByRef = entityRecords.map(e => e.toReference -> e.id).toMap
         val attributesToSave = workspace.attributes flatMap { attr => workspaceAttributeQuery.marshalAttribute(workspaceId, attr._1, attr._2, entityIdsByRef) }
 
         workspaceAttributeQuery.findByOwnerQuery(Seq(workspaceId)).result flatMap { existingAttributes =>
-          workspaceAttributeQuery.rewriteAttrsAction(attributesToSave, existingAttributes, insertScratchAttributes)
+          workspaceAttributeQuery.rewriteAttrsAction(attributesToSave, existingAttributes, workspaceAttributeScratchQuery.insertScratchAttributes)
         }
       }
     }
@@ -626,7 +622,7 @@ trait WorkspaceComponent {
     }
 
     private def deleteWorkspaceAttributes(attributeRecords: Seq[WorkspaceAttributeRecord]) = {
-      workspaceAttributeQuery.deleteAttributeRecords(attributeRecords)
+      workspaceAttributeQuery.deleteAttributeRecordsById(attributeRecords.map(_.id))
     }
 
     private def findByNameQuery(workspaceName: WorkspaceName): WorkspaceQueryType = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -112,6 +112,7 @@ class SubmissionMonitorActor(val workspaceName: WorkspaceName,
 
 }
 
+//A map of writebacks to apply to the given entity reference
 case class WorkflowEntityUpdate(entityRef: AttributeEntityReference, upserts: AttributeMap)
 
 trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrumented {
@@ -354,7 +355,8 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     }
   }
 
-  def attachOutputs(workspace: Workspace, workflowsWithOutputs: Seq[(WorkflowRecord, ExecutionServiceOutputs)], entitiesById: scala.collection.Map[Long, Entity], outputExpressionMap: Map[String, String]): Seq[Either[(WorkflowEntityUpdate, Option[Workspace]), (WorkflowRecord, Seq[AttributeString])]] = {    workflowsWithOutputs.map { case (workflowRecord, outputsResponse) =>
+  def attachOutputs(workspace: Workspace, workflowsWithOutputs: Seq[(WorkflowRecord, ExecutionServiceOutputs)], entitiesById: scala.collection.Map[Long, Entity], outputExpressionMap: Map[String, String]): Seq[Either[(WorkflowEntityUpdate, Option[Workspace]), (WorkflowRecord, Seq[AttributeString])]] = {
+    workflowsWithOutputs.map { case (workflowRecord, outputsResponse) =>
       val outputs = outputsResponse.outputs
       logger.debug(s"attaching outputs for ${submissionId.toString}/${workflowRecord.externalId.getOrElse("MISSING_WORKFLOW")}: ${outputs}")
       logger.debug(s"output expressions for ${submissionId.toString}/${workflowRecord.externalId.getOrElse("MISSING_WORKFLOW")}: ${outputExpressionMap}")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -112,6 +112,8 @@ class SubmissionMonitorActor(val workspaceName: WorkspaceName,
 
 }
 
+case class WorkflowEntityUpdate(entityRef: AttributeEntityReference, upserts: AttributeMap)
+
 trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrumented {
   val workspaceName: WorkspaceName
   val submissionId: UUID
@@ -133,8 +135,6 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
 
   private implicit val subStatusCounter: SubmissionStatus => Counter =
     submissionStatusCounter(workspaceMetricBuilder)
-
-  case class EntityUpdate(entityRef: AttributeEntityReference, upserts: AttributeMap)
 
   import datasource.dataAccess.driver.api._
 
@@ -312,8 +312,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
         outputExpressionMap <-  listMethodConfigOutputsForSubmission(dataAccess)
         workspace <-            getWorkspace(dataAccess).map(_.getOrElse(throw new RawlsException(s"workspace for submission $submissionId not found")))
 
-        // update the appropriate entities and workspace (in memory)
-      //TODO too: decide if workspace attributes need a delta sync too
+        // figure out the updates that need to occur to entities and workspaces
         updatedEntitiesAndWorkspace = attachOutputs(workspace, workflowsWithOutputs, entitiesById, outputExpressionMap)
 
         // save everything to the db
@@ -336,14 +335,14 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     dataAccess.entityQuery.getEntities(workflowsWithOutputs.map { case (workflowRec, outputs) => workflowRec.workflowEntityId }).map(_.toMap)
   }
 
-  def saveWorkspace(dataAccess: DataAccess, updatedEntitiesAndWorkspace: Seq[Either[(EntityUpdate, Option[Workspace]), (WorkflowRecord, scala.Seq[AttributeString])]]) = {
+  def saveWorkspace(dataAccess: DataAccess, updatedEntitiesAndWorkspace: Seq[Either[(WorkflowEntityUpdate, Option[Workspace]), (WorkflowRecord, scala.Seq[AttributeString])]]) = {
     //note there is only 1 workspace (may be None if it is not updated) even though it may be updated multiple times so reduce it into 1 update
     val workspaces = updatedEntitiesAndWorkspace.collect { case Left((_, Some(workspace))) => workspace }
     if (workspaces.isEmpty) DBIO.successful(0)
     else dataAccess.workspaceQuery.save(workspaces.reduce((a, b) => a.copy(attributes = a.attributes ++ b.attributes)))
   }
 
-  def saveEntities(dataAccess: DataAccess, workspace: Workspace, updatedEntitiesAndWorkspace: Seq[Either[(EntityUpdate, Option[Workspace]), (WorkflowRecord, scala.Seq[AttributeString])]])(implicit executionContext: ExecutionContext) = {
+  def saveEntities(dataAccess: DataAccess, workspace: Workspace, updatedEntitiesAndWorkspace: Seq[Either[(WorkflowEntityUpdate, Option[Workspace]), (WorkflowRecord, scala.Seq[AttributeString])]])(implicit executionContext: ExecutionContext) = {
     val entityUpdates = updatedEntitiesAndWorkspace.collect { case Left((entityUpdate, _)) if entityUpdate.upserts.nonEmpty => entityUpdate }
     if(entityUpdates.isEmpty) {
        DBIO.successful(())
@@ -355,7 +354,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     }
   }
 
-  def attachOutputs(workspace: Workspace, workflowsWithOutputs: Seq[(WorkflowRecord, ExecutionServiceOutputs)], entitiesById: scala.collection.Map[Long, Entity], outputExpressionMap: Map[String, String]): Seq[Either[(EntityUpdate, Option[Workspace]), (WorkflowRecord, Seq[AttributeString])]] = {    workflowsWithOutputs.map { case (workflowRecord, outputsResponse) =>
+  def attachOutputs(workspace: Workspace, workflowsWithOutputs: Seq[(WorkflowRecord, ExecutionServiceOutputs)], entitiesById: scala.collection.Map[Long, Entity], outputExpressionMap: Map[String, String]): Seq[Either[(WorkflowEntityUpdate, Option[Workspace]), (WorkflowRecord, Seq[AttributeString])]] = {    workflowsWithOutputs.map { case (workflowRecord, outputsResponse) =>
       val outputs = outputsResponse.outputs
       logger.debug(s"attaching outputs for ${submissionId.toString}/${workflowRecord.externalId.getOrElse("MISSING_WORKFLOW")}: ${outputs}")
       logger.debug(s"output expressions for ${submissionId.toString}/${workflowRecord.externalId.getOrElse("MISSING_WORKFLOW")}: ${outputExpressionMap}")
@@ -381,11 +380,11 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     }
   }
 
-  def updateEntityAndWorkspace(entity: Entity, workspace: Workspace, workflowOutputs: Iterable[BoundOutputExpression]): (EntityUpdate, Option[Workspace]) = {
+  def updateEntityAndWorkspace(entity: Entity, workspace: Workspace, workflowOutputs: Iterable[BoundOutputExpression]): (WorkflowEntityUpdate, Option[Workspace]) = {
     val entityUpsert = workflowOutputs.collect({ case BoundOutputExpression(ThisEntityTarget, attrName, attr) => (attrName, attr) })
     val workspaceAttributes = workflowOutputs.collect({ case BoundOutputExpression(WorkspaceTarget, attrName, attr) => (attrName, attr) })
 
-    val entityAndUpsert = EntityUpdate(entity.toReference, entityUpsert.toMap)
+    val entityAndUpsert = WorkflowEntityUpdate(entity.toReference, entityUpsert.toMap)
     val updatedWorkspace = if (workspaceAttributes.isEmpty) None else Option(workspace.copy(attributes = workspace.attributes ++ workspaceAttributes))
     
     (entityAndUpsert, updatedWorkspace)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -350,7 +350,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     }
     else {
       DBIO.sequence(entityUpdates map { entityUpd =>
-        dataAccess.entityQuery.saveEntityDeltas(SlickWorkspaceContext(workspace), entityUpd.entityRef, entityUpd.upserts, Seq())
+        dataAccess.entityQuery.saveEntityPatch(SlickWorkspaceContext(workspace), entityUpd.entityRef, entityUpd.upserts, Seq())
       })
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -446,7 +446,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     assertExpectedRecords(toSave:_*)
   }
 
-  it should "apply attribute deltas" in withEmptyTestDatabase {
+  it should "apply attribute patch" in withEmptyTestDatabase {
     def insertAndUpdateID(rec: WorkspaceAttributeRecord): WorkspaceAttributeRecord = {
       rec.copy(id = runAndWait((workspaceAttributeQuery returning workspaceAttributeQuery.map(_.id)) += rec))
     }
@@ -464,11 +464,11 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val insert = WorkspaceAttributeRecord(3, workspaceId, AttributeName.defaultNamespace, "test3", None, None, Option(false), None, None, None, None, deleted = false, None)
 
     //test insert and update
-    runAndWait(workspaceAttributeQuery.deltaAttrsAction(Seq(insert), Seq(update), Seq(), workspaceAttributeScratchQuery.insertScratchAttributes))
+    runAndWait(workspaceAttributeQuery.patchAttributesAction(Seq(insert), Seq(update), Seq(), workspaceAttributeScratchQuery.insertScratchAttributes))
     assertExpectedRecords(Seq(existing.head, update, insert):_*)
 
     //test delete
-    runAndWait(workspaceAttributeQuery.deltaAttrsAction(Seq(), Seq(), existing.map(_.id), workspaceAttributeScratchQuery.insertScratchAttributes))
+    runAndWait(workspaceAttributeQuery.patchAttributesAction(Seq(), Seq(), existing.map(_.id), workspaceAttributeScratchQuery.insertScratchAttributes))
     assertExpectedRecords(Seq(insert):_*)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -463,12 +463,12 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val update = WorkspaceAttributeRecord(2, workspaceId, AttributeName.defaultNamespace, "test2", Option("test2"), None, None, None, None, None, None, deleted = false, None)
     val insert = WorkspaceAttributeRecord(3, workspaceId, AttributeName.defaultNamespace, "test3", None, None, Option(false), None, None, None, None, deleted = false, None)
 
+    //test insert and update
     runAndWait(workspaceAttributeQuery.deltaAttrsAction(Seq(insert), Seq(update), Seq(), workspaceAttributeScratchQuery.insertScratchAttributes))
-
     assertExpectedRecords(Seq(existing.head, update, insert):_*)
 
+    //test delete
     runAndWait(workspaceAttributeQuery.deltaAttrsAction(Seq(), Seq(), existing.map(_.id), workspaceAttributeScratchQuery.insertScratchAttributes))
-
     assertExpectedRecords(Seq(insert):_*)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -423,7 +423,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     }
   }
 
-  it should "upsert" in withEmptyTestDatabase {
+  it should "rewrite" in withEmptyTestDatabase {
     // copied from WorkspaceComponent
     def insertScratchAttributes(attributeRecs: Seq[WorkspaceAttributeRecord])(transactionId: String): WriteAction[Int] = {
       workspaceAttributeScratchQuery.batchInsertAttributes(attributeRecs, transactionId)
@@ -446,7 +446,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val insert = WorkspaceAttributeRecord(3, workspaceId, AttributeName.defaultNamespace, "test3", None, None, Option(false), None, None, None, None, deleted = false, None)
     val toSave = Seq(update, insert)
 
-    runAndWait(workspaceAttributeQuery.upsertAction(toSave, existing, insertScratchAttributes))
+    runAndWait(workspaceAttributeQuery.rewriteAttrsAction(toSave, existing, insertScratchAttributes))
 
     assertExpectedRecords(toSave:_*)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -127,37 +127,37 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     assertResult(0)(activeAttributeCount4)
   }
 
-  it should "fail to saveEntityDeltas for a nonexistent entity" in withConstantTestDatabase {
+  it should "fail to saveEntityPatch for a nonexistent entity" in withConstantTestDatabase {
     withWorkspaceContext(constantData.workspace) { context =>
       val caught = intercept[RawlsException] {
         runAndWait(
-          entityQuery.saveEntityDeltas(context, AttributeEntityReference("Sample", "nonexistent"),
+          entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "nonexistent"),
             Map(AttributeName.withDefaultNS("newAttribute") -> AttributeNumber(2)),
             Seq(AttributeName.withDefaultNS("type"))
           ))
       }
       //make sure we get the _right_ RawlsException:
-      //"saveEntityDeltas looked up $entityRef expecting 1 record, got 0 instead"
+      //"saveEntityPatch looked up $entityRef expecting 1 record, got 0 instead"
       caught.getMessage should include("expecting")
     }
   }
 
-  it should "fail to saveEntityDeltas if you try to delete and upsert the same attribute" in withConstantTestDatabase {
+  it should "fail to saveEntityPatch if you try to delete and upsert the same attribute" in withConstantTestDatabase {
     withWorkspaceContext(constantData.workspace) { context =>
       val caught = intercept[RawlsException] {
         runAndWait(
-          entityQuery.saveEntityDeltas(context, AttributeEntityReference("Sample", "sample1"),
+          entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"),
             Map(AttributeName.withDefaultNS("type") -> AttributeNumber(2)),
             Seq(AttributeName.withDefaultNS("type"))
           ))
       }
       //make sure we get the _right_ RawlsException:
-      //"Can't saveEntityDeltas on $entityRef because upserts and deletes share attributes <blah>"
+      //"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes <blah>"
       caught.getMessage should include("share")
     }
   }
 
-  it should "saveEntityDeltas" in withDefaultTestDatabase {
+  it should "saveEntityPatch" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       val inserts = Map(
         AttributeName.withDefaultNS("totallyNew") -> AttributeNumber(2),
@@ -173,7 +173,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       val expected = testData.sample1.attributes ++ inserts ++ updates -- deletes
 
       runAndWait {
-        entityQuery.saveEntityDeltas(context, AttributeEntityReference("Sample", "sample1"), inserts ++ updates, deletes)
+        entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), inserts ++ updates, deletes)
       }
 
       assertSameElements(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -136,6 +136,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
             Seq(AttributeName.withDefaultNS("type"))
           ))
       }
+      //make sure we get the _right_ RawlsException:
+      //"saveEntityDeltas looked up $entityRef expecting 1 record, got 0 instead"
       caught.getMessage should include("expecting")
     }
   }
@@ -149,6 +151,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
             Seq(AttributeName.withDefaultNS("type"))
           ))
       }
+      //make sure we get the _right_ RawlsException:
+      //"Can't saveEntityDeltas on $entityRef because upserts and deletes share attributes <blah>"
       caught.getMessage should include("share")
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -127,6 +127,52 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     assertResult(0)(activeAttributeCount4)
   }
 
+  it should "fail to saveEntityDeltas for a nonexistent entity" in withDefaultTestDatabase {
+    withWorkspaceContext(constantData.workspace) { context =>
+      intercept[RawlsException] {
+        runAndWait(
+          entityQuery.saveEntityDeltas(context, AttributeEntityReference("Sample", "nonexistent"),
+            Map(AttributeName.withDefaultNS("newAttribute") -> AttributeNumber(2)),
+            Seq(AttributeName.withDefaultNS("type"))
+          ))
+      }
+    }
+  }
+
+  it should "fail to saveEntityDeltas if you try to delete and upsert the same attribute" in withDefaultTestDatabase {
+    withWorkspaceContext(constantData.workspace) { context =>
+      intercept[RawlsException] {
+        runAndWait(
+          entityQuery.saveEntityDeltas(context, AttributeEntityReference("Sample", "sample1"),
+            Map(AttributeName.withDefaultNS("type") -> AttributeNumber(2)),
+            Seq(AttributeName.withDefaultNS("type"))
+          ))
+      }
+    }
+  }
+
+  it should "saveEntityDeltas" in withDefaultTestDatabase {
+    withWorkspaceContext(testData.workspace) { context =>
+      val insert = Map(AttributeName.withDefaultNS("totallyNew") -> AttributeNumber(2))
+      val updates = Map(
+        AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+        AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("c"), AttributeString("d")))
+      )
+      val delete = Seq(AttributeName.withDefaultNS("whatsit"))
+
+      val expected = testData.sample1.attributes ++ insert ++ updates -- delete
+
+      runAndWait {
+        entityQuery.saveEntityDeltas(context, AttributeEntityReference("Sample", "sample1"), insert ++ updates, delete)
+      }
+
+      assertSameElements(
+        expected,
+        runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes
+      )
+    }
+  }
+
   it should "list all entities of all entity types" in withConstantTestDatabase {
     withWorkspaceContext(constantData.workspace) { context =>
       assertSameElements(constantData.allEntities, runAndWait(entityQuery.listActiveEntities(context)))


### PR DESCRIPTION
Old behaviour: SubmissionMonitorActor would calculate the new state of all entities in this `attachOutputs` batch and save them all to the database in one big bundle. If there are 5 entities with 200 attributes each and one writeback to each entity, it'd still save all 1000 attributes.

New behaviour: for every entity, figure out which attributes have changed and write those, once per entity.

This is therefore a tradeoff of "resave all the attributes at once in one SQL statement" vs "save only changed attributes in one SQL statement per entity". Unless the SMA is picking up many completed workflows in one pass I suspect this is a better approach.

I haven't provided a delta-update for workspaces because we haven't been seeing deadlocks on the workspace attribute scratch table. We could lift the pattern over to `WorkspaceComponent` though.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
