### PR TITLE
streamline SQL query for input resolution records

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -139,10 +139,8 @@ trait WorkflowComponent {
           marshalInputResolution(inputResolution, workflowRecsByEntity(workflow.workflowEntity).id)
         }
 
-        val insertedRecQuery = submissionQuery.loadSubmissionValidationsAndReferences(submissionId)
-
         insertInBatches(submissionValidationQuery, inputResolutionRecs) andThen
-        insertedRecQuery.map(_.map { case (ref, insertedInputResolutionRec) =>
+        submissionQuery.loadSubmissionValidationsAndReferences(submissionId).map(_.map { case (ref, insertedInputResolutionRec) =>
           val name = insertedInputResolutionRec.inputName
           (ref, name) -> insertedInputResolutionRec
         }.toMap)


### PR DESCRIPTION
The SQL query in question uses `entityQuery`, which is a `select *` on the ENTITY table. By using `select *`, we are retrieving the `all_attribute_values` column from the database - which we immediately discard when we turn the EntityRecord into an AttributeEntityReference.

Against the reproduction data we identified from prod, retrieving the all_attribute_values column adds **_480MB_** to the size of the result set - none of which is used - and all of which needs to move over the wire. Changing the SQL query to ignore this column makes the result set much smaller.

In informal testing from my laptop, ignoring this column reduces the query time (including network transfer time) from 8-10 seconds to ~0.2 seconds.

Old SQL query:
```
select x2.`id`, x2.`name`, x2.`entity_type`, x2.`workspace_id`, x2.`record_version`, x2.`all_attribute_values`, x2.`deleted`, x2.`deleted_date`, x3.`id`, x3.`WORKFLOW_ID`, x3.`ERROR_TEXT`, x3.`INPUT_NAME`
from `WORKFLOW` x4, `ENTITY` x2, `SUBMISSION_VALIDATION` x3
where ((x4.`SUBMISSION_ID` = x'my-submission-id') and (x2.`id` = x4.`ENTITY_ID`)) and (x3.`WORKFLOW_ID` = x4.`ID`);
```

New SQL query:
```
select e.entity_type, e.name,
              sv.id, sv.WORKFLOW_ID, sv.ERROR_TEXT, sv.INPUT_NAME
        from ENTITY e, SUBMISSION_VALIDATION sv, WORKFLOW w
        where w.SUBMISSION_ID = x'my-submission-id'
          and e.id = w.ENTITY_ID
          and sv.WORKFLOW_ID = w.ID
```
where clauses and target tables haven't changed, so the explain plan hasn't either.

I don't know if this is **THE** cause of lock issues we've had in prod. However, this query is in the codepath identified to be troublesome, and it is a worthwhile fix even if this isn't the only cause.

We do need to audit everywhere else `entityQuery` is used. I didn't want to hold this PR waiting on that.

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] Tell your tech lead (TL) that the PR exists if they want to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
