### PR TITLE
Optimize entity queries

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -45,7 +45,7 @@ object EntityRecordBuilder {
   def toEntityRecord(tuple: (Long, String, String, UUID, Long, Boolean, Option[Timestamp])): EntityRecord = {
     tuple match {
       case (id, name, entityType, workspaceId, recordVersion, deleted, deletedDate) =>
-        new EntityRecord(id, name, entityType, workspaceId, recordVersion, None, deleted, deletedDate)
+        new EntityRecord(id, name, entityType, workspaceId, recordVersion, allAttributeValues = None, deleted, deletedDate)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -83,12 +83,15 @@ trait EntityComponent {
     type EntityQuery = Query[EntityTable, EntityRecord, Seq]
     type EntityAttributeQuery = Query[EntityAttributeTable, EntityAttributeRecord, Seq]
 
+    // understands how to translate EntityRecordLiteLifted into EntityRecord
     implicit object EntityRecordLightShape
       extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
 
-    def withoutAllAttributeValues = {
+    // use as a replacement for entityQuery. This query never selects the all_attribute_values column and therefore
+    // will always return an EntityRecord where .allAttributeValues is None.
+    // anywhere this query is used, Slick needs the the EntityRecordLightShape object in implicit scope.
+    def withoutAllAttributeValues =
       map(e => EntityRecordLiteLifted(e.id, e.name, e.entityType, e.workspaceId, e.version, e.deleted, e.deletedDate))
-    }
 
     // Raw queries - used when querying for multiple AttributeEntityReferences
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -28,6 +28,9 @@ case class EntityRecord(id: Long,
   def toReference = AttributeEntityReference(entityType, name)
 }
 
+// used in conjunction with entityQuery.withoutAllAttributes and EntityRecordLightShape.
+// Slick usually magically creates these shapes but this one is necessary because withoutAllAttributes
+// omits a column, and the magically-created shapes want that column.
 case class EntityRecordLiteLifted(id: slick.lifted.Rep[Long],
                                   name: slick.lifted.Rep[String],
                                   entityType: slick.lifted.Rep[String],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -117,9 +117,12 @@ trait WorkflowComponent {
         val entityRecsMap = entityRecs.map(e => e.toReference -> e.id).toMap
         val recsToInsert = workflows.map(workflow => marshalNewWorkflow(submissionId, workflow, entityRecsMap(workflow.workflowEntity)))
 
+        implicit object EntityRecordLightShape
+          extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
+
         val insertedRecQuery = for {
           workflowRec <- findWorkflowsBySubmissionId(submissionId)
-          workflowEntityRec <- entityQuery if workflowEntityRec.id === workflowRec.workflowEntityId
+          workflowEntityRec <- entityQuery.withoutAllAttributeValues if workflowEntityRec.id === workflowRec.workflowEntityId
         } yield (workflowRec, workflowEntityRec)
 
         insertInBatches(workflowQuery, recsToInsert).map { rows =>
@@ -139,9 +142,12 @@ trait WorkflowComponent {
           marshalInputResolution(inputResolution, workflowRecsByEntity(workflow.workflowEntity).id)
         }
 
+        implicit object EntityRecordLightShape
+          extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
+
         val insertedRecQuery = for {
           workflowRec <- findWorkflowsBySubmissionId(submissionId)
-          workflowEntityRec <- entityQuery if workflowEntityRec.id === workflowRec.workflowEntityId
+          workflowEntityRec <- entityQuery.withoutAllAttributeValues if workflowEntityRec.id === workflowRec.workflowEntityId
           insertedInputResolutionRec <- submissionValidationQuery if insertedInputResolutionRec.workflowId === workflowRec.id
         } yield (workflowEntityRec, insertedInputResolutionRec)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -47,6 +47,7 @@ trait WorkflowComponent {
     with JndiDirectoryDAO =>
 
   import driver.api._
+  import entityQuery.EntityRecordLightShape
 
   class WorkflowTable(tag: Tag) extends Table[WorkflowRecord](tag, "WORKFLOW") {
     def id = column[Long]("ID", O.PrimaryKey, O.AutoInc)
@@ -117,9 +118,6 @@ trait WorkflowComponent {
         val entityRecsMap = entityRecs.map(e => e.toReference -> e.id).toMap
         val recsToInsert = workflows.map(workflow => marshalNewWorkflow(submissionId, workflow, entityRecsMap(workflow.workflowEntity)))
 
-        implicit object EntityRecordLightShape
-          extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
-
         val insertedRecQuery = for {
           workflowRec <- findWorkflowsBySubmissionId(submissionId)
           workflowEntityRec <- entityQuery.withoutAllAttributeValues if workflowEntityRec.id === workflowRec.workflowEntityId
@@ -141,9 +139,6 @@ trait WorkflowComponent {
         } yield {
           marshalInputResolution(inputResolution, workflowRecsByEntity(workflow.workflowEntity).id)
         }
-
-        implicit object EntityRecordLightShape
-          extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
 
         val insertedRecQuery = for {
           workflowRec <- findWorkflowsBySubmissionId(submissionId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParser.scala
@@ -20,6 +20,7 @@ trait SlickExpressionParser extends JavaTokenParsers {
     with WorkspaceComponent
     with AttributeComponent =>
   import driver.api._
+  import entityQuery.EntityRecordLightShape
 
   // A parsed expression will result in a PipelineQuery. Each step in a query traverses from entity to
   // entity following references. The final step takes the last entity, producing a result dependent on the query
@@ -166,9 +167,6 @@ trait SlickExpressionParser extends JavaTokenParsers {
 
   // the root function starts the pipeline at some root entity type in the workspace
   private def entityRootFunc(context: SlickExpressionContext): PipeType = {
-    implicit object EntityRecordLightShape
-      extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
-
     for {
       rootEntities <- exprEvalQuery if rootEntities.transactionId === context.transactionId
       entity <- entityQuery.withoutAllAttributeValues if rootEntities.id === entity.id
@@ -199,10 +197,6 @@ trait SlickExpressionParser extends JavaTokenParsers {
 
   // root func that gets an entity reference off a workspace
   private def workspaceEntityRefRootFunc(attrName: AttributeName)(context: SlickExpressionContext): PipeType = {
-
-    implicit object EntityRecordLightShape
-      extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
-
     for {
       rootEntity <- exprEvalQuery if rootEntity.transactionId === context.transactionId
       workspace <- workspaceQuery.findByIdQuery(context.workspaceContext.workspaceId)
@@ -213,10 +207,6 @@ trait SlickExpressionParser extends JavaTokenParsers {
 
   // add pipe to an entity referenced by the current entity
   private def entityNameAttributePipeFunc(attrName: AttributeName)(context: SlickExpressionContext, queryPipeline: PipeType): PipeType = {
-
-    implicit object EntityRecordLightShape
-      extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
-
     (for {
       (rootEntityName, entity) <- queryPipeline
       attribute <- entityAttributeQuery if entity.id === attribute.ownerId && attribute.name === attrName.name && attribute.namespace === attrName.namespace

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/expressions/SlickExpressionParser.scala
@@ -328,9 +328,6 @@ trait SlickExpressionParser extends JavaTokenParsers {
   private def workspaceEntityFinalFunc(attrName: AttributeName)(context: SlickExpressionContext, shouldBeNone: Option[PipeType]): ReadAction[Map[String,Iterable[EntityRecord]]] = {
     assert(shouldBeNone.isEmpty)
 
-    implicit object EntityRecordLightShape
-      extends CaseClassShape(EntityRecordLiteLifted.tupled, EntityRecordBuilder.toEntityRecord)
-
     val query = for {
       workspace <- workspaceQuery.findByIdQuery(context.workspaceContext.workspaceId)
       attribute <- workspaceAttributeQuery if attribute.ownerId === workspace.id && attribute.name === attrName.name && attribute.namespace === attrName.namespace

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -936,12 +936,12 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
         .result.headOption)
 
-      assert(recWithoutAttrs.isDefined, "entityQueryLight should find the record")
+      assert(recWithoutAttrs.isDefined, "entityQuery.withoutAllAttributeValues should find the record")
       assertResult(Some(None), "entityQueryLight should not return allAttributeValues") {
         recWithoutAttrs.map(_.allAttributeValues)
       }
 
-      assertResult(recWithoutAttrs, "entityQuery and entityQueryLight should return the same record otherwise") {
+      assertResult(recWithoutAttrs, "entityQuery and entityQuery.withoutAllAttributeValues should return the same record otherwise") {
         recWithAttrs.map(_.copy(allAttributeValues = None))
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -910,4 +910,41 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
+  it should "not select the all_attribute_values column when using entityQuery.withoutAllAttributes" in withDefaultTestDatabase {
+    withWorkspaceContext(testData.workspace) { context =>
+
+      val hasAttrs = Entity("entityWithAttrs", "Pair", Map(
+        AttributeName.withDefaultNS("attrOne") -> AttributeString("one"),
+        AttributeName.withDefaultNS("attrTwo") -> AttributeString("two"),
+        AttributeName.withDefaultNS("attrThree") -> AttributeString("three"),
+        AttributeName.withDefaultNS("attrFour") -> AttributeString("four")
+      ))
+
+      runAndWait(entityQuery.save(context, hasAttrs))
+
+      val recWithAttrs = runAndWait(entityQuery
+        .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
+          .result.headOption)
+
+      assert(recWithAttrs.isDefined, "entityQuery should find the record")
+      assertResult(Some(Some("entitywithattrs one two three four")), "entityQuery should return allAttributeValues") {
+        recWithAttrs.map(_.allAttributeValues)
+      }
+      import entityQuery.EntityRecordLightShape
+
+      val recWithoutAttrs = runAndWait(entityQuery.withoutAllAttributeValues
+        .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
+        .result.headOption)
+
+      assert(recWithoutAttrs.isDefined, "entityQueryLight should find the record")
+      assertResult(Some(None), "entityQueryLight should not return allAttributeValues") {
+        recWithoutAttrs.map(_.allAttributeValues)
+      }
+
+      assertResult(recWithoutAttrs, "entityQuery and entityQueryLight should return the same record otherwise") {
+        recWithAttrs.map(_.copy(allAttributeValues = None))
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
This PR creates a variant of `entityQuery` that does not return the `all_attribute_values` column from the DB, which is a big time/payload savings for certain rows.

The new `entityQuery.withoutAllAttributes` query should be usable anywhere `entityQuery` was, returning `EntityRecords` and requiring just one implicit import (`import entityQuery.EntityRecordLightShape`).

The code in `SlickExpressionParser.scala` required a slightly larger update, because that code was strongly-typed to `entityQuery`.

The changes in this PR optimize - significantly - the create-submission code path, which is where we've seen database locks. I hope that by cutting down query time and size, we alleviate locks.

With information from a previous PR (#894), we know that the changes in WorkflowComponent reduce result set size by ~480MB on our test use case. The changes in SlickExpressionParser save another ~12.5MB.


- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
