### PR TITLE
Clean up some rawls compile warnings

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -18,7 +18,7 @@ import com.readytalk.metrics.{StatsDReporter, WorkbenchStatsD}
 import com.typesafe.config.{ConfigFactory, ConfigObject}
 import com.typesafe.scalalogging.LazyLogging
 import slick.backend.DatabaseConfig
-import slick.driver.JdbcDriver
+import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.jndi.DirectoryConfig
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
@@ -60,7 +60,7 @@ object Boot extends App with LazyLogging {
       conf.getString("directory.baseDn")
     )
 
-    val slickDataSource = DataSource(DatabaseConfig.forConfig[JdbcDriver]("slick", conf), directoryConfig)
+    val slickDataSource = DataSource(DatabaseConfig.forConfig[JdbcProfile]("slick", conf), directoryConfig)
 
     val liquibaseConf = conf.getConfig("liquibase")
     val liquibaseChangeLog = liquibaseConf.getString("changelog")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -17,7 +17,7 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.readytalk.metrics.{StatsDReporter, WorkbenchStatsD}
 import com.typesafe.config.{ConfigFactory, ConfigObject}
 import com.typesafe.scalalogging.LazyLogging
-import slick.backend.DatabaseConfig
+import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.jndi.DirectoryConfig

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 import java.sql.SQLTimeoutException
 import java.util.concurrent.{ExecutorService, Executors}
 
-import _root_.slick.backend.DatabaseConfig
+import _root_.slick.basic.DatabaseConfig
 import _root_.slick.jdbc.{JdbcProfile, TransactionIsolation}
 import _root_.slick.jdbc.meta.MTable
 import com.google.common.base.Throwables

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -4,8 +4,7 @@ import java.sql.SQLTimeoutException
 import java.util.concurrent.{ExecutorService, Executors}
 
 import _root_.slick.backend.DatabaseConfig
-import _root_.slick.driver.JdbcDriver
-import _root_.slick.jdbc.TransactionIsolation
+import _root_.slick.jdbc.{JdbcProfile, TransactionIsolation}
 import _root_.slick.jdbc.meta.MTable
 import com.google.common.base.Throwables
 import com.typesafe.config.ConfigValueFactory
@@ -22,12 +21,12 @@ import liquibase.resource.{ClassLoaderResourceAccessor, ResourceAccessor}
 import org.broadinstitute.dsde.rawls.dataaccess.jndi.DirectoryConfig
 
 object DataSource {
-  def apply(databaseConfig: DatabaseConfig[JdbcDriver], directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext): SlickDataSource = {
+  def apply(databaseConfig: DatabaseConfig[JdbcProfile], directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext): SlickDataSource = {
     new SlickDataSource(databaseConfig, directoryConfig)
   }
 }
 
-class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcDriver], directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext) extends LazyLogging {
+class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile], directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext) extends LazyLogging {
   val dataAccess = new DataAccessComponent(databaseConfig.driver, databaseConfig.config.getInt("batchSize"), directoryConfig)
 
   val database = databaseConfig.db

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -27,7 +27,7 @@ object DataSource {
 }
 
 class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile], directoryConfig: DirectoryConfig)(implicit executionContext: ExecutionContext) extends LazyLogging {
-  val dataAccess = new DataAccessComponent(databaseConfig.driver, databaseConfig.config.getInt("batchSize"), directoryConfig)
+  val dataAccess = new DataAccessComponent(databaseConfig.profile, databaseConfig.config.getInt("batchSize"), directoryConfig)
 
   val database = databaseConfig.db
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model._
 import slick.ast.{BaseTypedType, TypedType}
 import slick.dbio.Effect.Write
-import slick.driver.JdbcDriver
+import slick.jdbc.JdbcProfile
 import akka.http.scaladsl.model.StatusCodes
 
 import reflect.runtime.universe._
@@ -347,7 +347,7 @@ trait AttributeComponent {
     }
 
     object AlterAttributesUsingScratchTableQueries extends RawSqlQuery {
-      val driver: JdbcDriver = AttributeComponent.this.driver
+      val driver: JdbcProfile = AttributeComponent.this.driver
 
       //MySQL seems to handle null safe operators inefficiently. the solution to this
       //is to use ifnull and default to -2 if the list_index is null. list_index of -2

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -6,7 +6,7 @@ import javax.naming.directory.DirContext
 import org.broadinstitute.dsde.rawls.dataaccess.jndi.JndiDirectoryDAO
 import org.broadinstitute.dsde.rawls.expressions.SlickExpressionParser
 import org.broadinstitute.dsde.rawls.model.{RawlsGroupName, RawlsGroupRef}
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 import scala.concurrent.Future
 import scala.util.Try

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import org.broadinstitute.dsde.rawls.dataaccess.jndi.DirectoryConfig
-import slick.driver.JdbcDriver
+import slick.jdbc.JdbcProfile
 
 import scala.concurrent.ExecutionContext
 
-class DataAccessComponent(val driver: JdbcDriver, val batchSize: Int, override val directoryConfig: DirectoryConfig)(implicit val executionContext: ExecutionContext)
+class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int, override val directoryConfig: DirectoryConfig)(implicit val executionContext: ExecutionContext)
 extends DriverComponent with DataAccess

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
@@ -8,14 +8,13 @@ import akka.util.ByteString
 import org.apache.commons.codec.binary.Base64
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, StringValidationUtils}
-import slick.driver.JdbcDriver
-import slick.jdbc.{GetResult, PositionedParameters, SQLActionBuilder, SetParameter}
+import slick.jdbc.{GetResult, JdbcProfile, PositionedParameters, SQLActionBuilder, SetParameter}
 import akka.http.scaladsl.model.StatusCodes
 
 import scala.concurrent.ExecutionContext
 
 trait DriverComponent extends StringValidationUtils {
-  val driver: JdbcDriver
+  val driver: JdbcProfile
   val batchSize: Int
   implicit val executionContext: ExecutionContext
   override implicit val errorReportSource = ErrorReportSource("rawls")
@@ -113,7 +112,7 @@ trait DriverComponent extends StringValidationUtils {
  * that encloses all the GetResult, SetParameter and raw sql into a nice package.
  */
 trait RawSqlQuery {
-  val driver: JdbcDriver
+  val driver: JdbcProfile
 
   import driver.api._
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -10,8 +10,7 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model._
 import slick.dbio.DBIOAction
 import slick.dbio.Effect.{Read, Write}
-import slick.driver.JdbcDriver
-import slick.jdbc.GetResult
+import slick.jdbc.{GetResult, JdbcProfile}
 import akka.http.scaladsl.model.StatusCodes
 
 /**
@@ -99,7 +98,7 @@ trait EntityComponent {
     // Raw queries - used when querying for multiple AttributeEntityReferences
 
     private object EntityRecordRawSqlQuery extends RawSqlQuery {
-      val driver: JdbcDriver = EntityComponent.this.driver
+      val driver: JdbcProfile = EntityComponent.this.driver
       implicit val getEntityRecord = GetResult { r => EntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, None, r.<<, r.<<) }
 
       def action(workspaceId: UUID, entities: Set[AttributeEntityReference]): ReadAction[Seq[EntityRecord]] = {
@@ -114,7 +113,7 @@ trait EntityComponent {
     }
 
     private object EntityAndAttributesRawSqlQuery extends RawSqlQuery {
-      val driver: JdbcDriver = EntityComponent.this.driver
+      val driver: JdbcProfile = EntityComponent.this.driver
 
       // result structure from entity and attribute list raw sql
       case class EntityAndAttributesResult(entityRecord: EntityRecord, attributeRecord: Option[EntityAttributeRecord], refEntityRecord: Option[EntityRecord])
@@ -257,7 +256,7 @@ trait EntityComponent {
     // Raw query for performing actual deletion (not hiding) of everything that depends on an entity
 
     private object EntityDependenciesDeletionQuery extends RawSqlQuery {
-      val driver: JdbcDriver = EntityComponent.this.driver
+      val driver: JdbcProfile = EntityComponent.this.driver
 
       def deleteAction(workspaceId: UUID): WriteAction[Int] =
         sqlu"""delete ea from ENTITY_ATTRIBUTE ea
@@ -780,7 +779,7 @@ trait EntityComponent {
     }
 
     object EntityStatisticsQueries extends RawSqlQuery {
-      val driver: JdbcDriver = EntityComponent.this.driver
+      val driver: JdbcProfile = EntityComponent.this.driver
       def countEntitiesofTypeInNamespace(workspaceNamespace: Option[String], workspaceName: Option[String]): ReadAction[Seq[NamedStatistic]] = {
         val baseSelect = sql"""select entity_type, count(1) as entityCount
                 from ENTITY e, WORKSPACE w

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess.SlickWorkspaceContext
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver
+import slick.jdbc.JdbcProfile
 
 case class MethodConfigurationRecord(id: Long,
                                      namespace: String,
@@ -190,7 +190,7 @@ trait MethodConfigurationComponent {
 
     // performs actual deletion (not hiding) of everything that depends on a method configuration
     object MethodConfigurationDependenciesDeletionQuery extends RawSqlQuery {
-      val driver: JdbcDriver = MethodConfigurationComponent.this.driver
+      val driver: JdbcProfile = MethodConfigurationComponent.this.driver
 
       def deleteAction(workspaceId: UUID): WriteAction[Seq[Int]] = {
         val tables: Seq[String] = Seq("METHOD_CONFIG_INPUT", "METHOD_CONFIG_OUTPUT", "METHOD_CONFIG_PREREQ")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -12,8 +12,7 @@ import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
-import slick.driver.JdbcDriver
-import slick.jdbc.GetResult
+import slick.jdbc.{GetResult, JdbcProfile}
 
 /**
  * Created by mbemis on 2/18/16.
@@ -411,7 +410,7 @@ trait SubmissionComponent {
     private def unmarshalEntity(entityRec: EntityRecord): AttributeEntityReference = entityRec.toReference
 
     private object WorkflowAndMessagesRawSqlQuery extends RawSqlQuery {
-      val driver: JdbcDriver = SubmissionComponent.this.driver
+      val driver: JdbcProfile = SubmissionComponent.this.driver
       case class WorkflowMessagesListResult(workflowRecord: WorkflowRecord, entityRecord: EntityRecord, messageRecord: Option[WorkflowMessageRecord])
 
       implicit val getWorkflowMessagesListResult = GetResult { r =>
@@ -435,7 +434,7 @@ trait SubmissionComponent {
     }
 
     private object WorkflowAndInputResolutionRawSqlQuery extends RawSqlQuery {
-      val driver: JdbcDriver = SubmissionComponent.this.driver
+      val driver: JdbcProfile = SubmissionComponent.this.driver
       case class WorkflowInputResolutionListResult(workflowRecord: WorkflowRecord, submissionValidationRec: Option[SubmissionValidationRecord], submissionAttributeRec: Option[SubmissionAttributeRecord])
 
       implicit val getWorkflowInputResolutionListResult = GetResult { r =>
@@ -462,7 +461,7 @@ trait SubmissionComponent {
 
     // performs actual deletion (not hiding) of everything that depends on a submission
     object SubmissionDependenciesDeletionQuery extends RawSqlQuery {
-      val driver: JdbcDriver = SubmissionComponent.this.driver
+      val driver: JdbcProfile = SubmissionComponent.this.driver
 
       def deleteAction(workspaceId: UUID): WriteAction[Seq[Int]] = {
 
@@ -506,7 +505,7 @@ trait SubmissionComponent {
     }
 
     object SubmissionStatisticsQueries extends RawSqlQuery {
-      val driver: JdbcDriver = SubmissionComponent.this.driver
+      val driver: JdbcProfile = SubmissionComponent.this.driver
 
       def countSubmissionsPerUserQuery(startDate: String, endDate: String) = {
         sql"""select min(count), max(count), avg(count), stddev(count)
@@ -537,7 +536,7 @@ trait SubmissionComponent {
     }
 
     object GatherStatusesForWorkspaceSubmissionsQuery extends RawSqlQuery {
-      val driver: JdbcDriver = SubmissionComponent.this.driver
+      val driver: JdbcProfile = SubmissionComponent.this.driver
 
       implicit val getSubmissionWorkflowStatusResponse = GetResult { r =>
         SubmissionWorkflowStatusResponse(r.<<, r.<<, r.<<)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.{Aborting, Running, 
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 import slick.dbio.Effect.Write
-import slick.driver.JdbcDriver
+import slick.jdbc.JdbcProfile
 
 /**
  * Created by mbemis on 2/18/16.
@@ -593,7 +593,7 @@ trait WorkflowComponent {
     }
 
     object WorkflowStatisticsQueries extends RawSqlQuery {
-      val driver: JdbcDriver = WorkflowComponent.this.driver
+      val driver: JdbcProfile = WorkflowComponent.this.driver
 
       def countWorkflowsPerUserQuery(startDate: String, endDate: String) = {
         sql"""select min(count), max(count), avg(count), stddev(count)
@@ -634,7 +634,7 @@ trait WorkflowComponent {
   }
 
   private object UpdateWorkflowStatusRawSql extends RawSqlQuery {
-    val driver: JdbcDriver = WorkflowComponent.this.driver
+    val driver: JdbcProfile = WorkflowComponent.this.driver
 
     private def update(newStatus: WorkflowStatus) = sql"update WORKFLOW set status = ${newStatus.toString}, status_last_changed = ${new Timestamp(System.currentTimeMillis())}, record_version = record_version + 1, rawls_hostname = ${hostname} "
 
@@ -654,7 +654,7 @@ trait WorkflowComponent {
   }
 
   private object UpdateWorkflowStatusAndExecutionIdRawSql extends RawSqlQuery {
-    val driver: JdbcDriver = WorkflowComponent.this.driver
+    val driver: JdbcProfile = WorkflowComponent.this.driver
 
     private def update(newStatus: WorkflowStatus, executionServiceId: ExecutionServiceId) = sql"update WORKFLOW set status = ${newStatus.toString}, exec_service_key = ${executionServiceId.id}, status_last_changed = ${new Timestamp(System.currentTimeMillis())}, record_version = record_version + 1, rawls_hostname = ${hostname} "
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -368,11 +368,11 @@ trait WorkspaceComponent {
     }
 
     def getUserSharePermissions(subjectId: RawlsUserSubjectId, workspaceContext: SlickWorkspaceContext): ReadWriteAction[Boolean] = {
-      workspaceUserShareQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).countDistinct.result.map(rows => rows > 0) flatMap { hasSharePermission =>
+      workspaceUserShareQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).distinct.length.result.map(rows => rows > 0) flatMap { hasSharePermission =>
         if(hasSharePermission) DBIO.successful(hasSharePermission)
         else rawlsGroupQuery.listGroupsForUser(RawlsUserRef(subjectId)).flatMap { userGroups =>
           val groupNames = userGroups.map(_.groupName.value)
-          workspaceGroupShareQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).countDistinct.result.map(rows => rows > 0)
+          workspaceGroupShareQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).distinct.length.result.map(rows => rows > 0)
         }
       }
     }
@@ -403,11 +403,11 @@ trait WorkspaceComponent {
     }
 
     def getUserComputePermissions(subjectId: RawlsUserSubjectId, workspaceContext: SlickWorkspaceContext): ReadWriteAction[Boolean] = {
-      workspaceUserComputeQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).countDistinct.result.map(rows => rows > 0) flatMap { hasComputePermission =>
+      workspaceUserComputeQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).distinct.length.result.map(rows => rows > 0) flatMap { hasComputePermission =>
         if(hasComputePermission) DBIO.successful(hasComputePermission)
         else rawlsGroupQuery.listGroupsForUser(RawlsUserRef(subjectId)).flatMap { userGroups =>
           val groupNames = userGroups.map(_.groupName.value)
-          workspaceGroupComputeQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).countDistinct.result.map(rows => rows > 0)
+          workspaceGroupComputeQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).distinct.length.result.map(rows => rows > 0)
         }
       }
     }
@@ -438,12 +438,12 @@ trait WorkspaceComponent {
     }
 
     def getUserCatalogPermissions(subjectId: RawlsUserSubjectId, workspaceContext: SlickWorkspaceContext): ReadWriteAction[Boolean] = {
-      workspaceUserCatalogQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).countDistinct.result.map(
+      workspaceUserCatalogQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).distinct.length.result.map(
         rows => rows > 0) flatMap { hasCatalogPermission =>
         if(hasCatalogPermission) DBIO.successful(hasCatalogPermission)
         else rawlsGroupQuery.listGroupsForUser(RawlsUserRef(subjectId)).flatMap { userGroups =>
           val groupNames = userGroups.map(_.groupName.value)
-          workspaceGroupCatalogQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).countDistinct.result.map(rows => rows > 0)
+          workspaceGroupCatalogQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).distinct.length.result.map(rows => rows > 0)
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -368,11 +368,11 @@ trait WorkspaceComponent {
     }
 
     def getUserSharePermissions(subjectId: RawlsUserSubjectId, workspaceContext: SlickWorkspaceContext): ReadWriteAction[Boolean] = {
-      workspaceUserShareQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).distinct.length.result.map(rows => rows > 0) flatMap { hasSharePermission =>
+      workspaceUserShareQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).countDistinct.result.map(rows => rows > 0) flatMap { hasSharePermission =>
         if(hasSharePermission) DBIO.successful(hasSharePermission)
         else rawlsGroupQuery.listGroupsForUser(RawlsUserRef(subjectId)).flatMap { userGroups =>
           val groupNames = userGroups.map(_.groupName.value)
-          workspaceGroupShareQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).distinct.length.result.map(rows => rows > 0)
+          workspaceGroupShareQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).countDistinct.result.map(rows => rows > 0)
         }
       }
     }
@@ -403,11 +403,11 @@ trait WorkspaceComponent {
     }
 
     def getUserComputePermissions(subjectId: RawlsUserSubjectId, workspaceContext: SlickWorkspaceContext): ReadWriteAction[Boolean] = {
-      workspaceUserComputeQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).distinct.length.result.map(rows => rows > 0) flatMap { hasComputePermission =>
+      workspaceUserComputeQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).countDistinct.result.map(rows => rows > 0) flatMap { hasComputePermission =>
         if(hasComputePermission) DBIO.successful(hasComputePermission)
         else rawlsGroupQuery.listGroupsForUser(RawlsUserRef(subjectId)).flatMap { userGroups =>
           val groupNames = userGroups.map(_.groupName.value)
-          workspaceGroupComputeQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).distinct.length.result.map(rows => rows > 0)
+          workspaceGroupComputeQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).countDistinct.result.map(rows => rows > 0)
         }
       }
     }
@@ -438,12 +438,12 @@ trait WorkspaceComponent {
     }
 
     def getUserCatalogPermissions(subjectId: RawlsUserSubjectId, workspaceContext: SlickWorkspaceContext): ReadWriteAction[Boolean] = {
-      workspaceUserCatalogQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).distinct.length.result.map(
+      workspaceUserCatalogQuery.filter(rec => rec.userSubjectId === subjectId.value && rec.workspaceId === workspaceContext.workspaceId).countDistinct.result.map(
         rows => rows > 0) flatMap { hasCatalogPermission =>
         if(hasCatalogPermission) DBIO.successful(hasCatalogPermission)
         else rawlsGroupQuery.listGroupsForUser(RawlsUserRef(subjectId)).flatMap { userGroups =>
           val groupNames = userGroups.map(_.groupName.value)
-          workspaceGroupCatalogQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).distinct.length.result.map(rows => rows > 0)
+          workspaceGroupCatalogQuery.filter(rec => (rec.workspaceId === workspaceContext.workspaceId) && rec.groupName.inSetBind(groupNames)).countDistinct.result.map(rows => rows > 0)
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/HttpClientUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/HttpClientUtils.scala
@@ -46,9 +46,9 @@ trait HttpClientUtils extends LazyLogging {
   }
 }
 
-case class HttpClientUtilsStandard(implicit val materializer: Materializer, val executionContext: ExecutionContext) extends HttpClientUtils
+case class HttpClientUtilsStandard()(implicit val materializer: Materializer, val executionContext: ExecutionContext) extends HttpClientUtils
 
-case class HttpClientUtilsGzip(implicit val materializer: Materializer, val executionContext: ExecutionContext) extends HttpClientUtils {
+case class HttpClientUtilsGzip()(implicit val materializer: Materializer, val executionContext: ExecutionContext) extends HttpClientUtils {
   override def executeRequest(http: HttpExt, httpRequest: HttpRequest): Future[HttpResponse] = {
     http.singleRequest(addHeader(httpRequest, `Accept-Encoding`(HttpEncodings.gzip))).map { response =>
       Gzip.decodeMessage(response)
@@ -56,7 +56,7 @@ case class HttpClientUtilsGzip(implicit val materializer: Materializer, val exec
   }
 }
 
-case class HttpClientUtilsInstrumented(implicit val materializer: Materializer, requestCounter: (HttpRequest, HttpResponse) => Counter, requestTimer: (HttpRequest, HttpResponse) => Timer, actorRefFactory: ActorRefFactory, val executionContext: ExecutionContext) extends HttpClientUtils {
+case class HttpClientUtilsInstrumented()(implicit val materializer: Materializer, requestCounter: (HttpRequest, HttpResponse) => Counter, requestTimer: (HttpRequest, HttpResponse) => Timer, actorRefFactory: ActorRefFactory, val executionContext: ExecutionContext) extends HttpClientUtils {
   override def executeRequest(http: HttpExt, httpRequest: HttpRequest): Future[HttpResponse] = {
     val start = System.currentTimeMillis()
     http.singleRequest(httpRequest) andThen {
@@ -67,7 +67,7 @@ case class HttpClientUtilsInstrumented(implicit val materializer: Materializer, 
   }
 }
 
-case class HttpClientUtilsGzipInstrumented(implicit val materializer: Materializer, requestCounter: (HttpRequest, HttpResponse) => Counter, requestTimer: (HttpRequest, HttpResponse) => Timer, actorRefFactory: ActorRefFactory, val executionContext: ExecutionContext) extends HttpClientUtils {
+case class HttpClientUtilsGzipInstrumented()(implicit val materializer: Materializer, requestCounter: (HttpRequest, HttpResponse) => Counter, requestTimer: (HttpRequest, HttpResponse) => Timer, actorRefFactory: ActorRefFactory, val executionContext: ExecutionContext) extends HttpClientUtils {
   override def executeRequest(http: HttpExt, httpRequest: HttpRequest): Future[HttpResponse] = {
     val start = System.currentTimeMillis()
     http.singleRequest(addHeader(httpRequest, `Accept-Encoding`(HttpEncodings.gzip))) andThen {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -7,8 +7,8 @@ import com.typesafe.config.ConfigFactory
 import nl.grons.metrics.scala.{Counter, DefaultInstrumented, MetricName}
 import org.broadinstitute.dsde.rawls.{SamDataSaver, TestExecutionContext, model}
 import slick.backend.DatabaseConfig
-import slick.driver.JdbcDriver
-import slick.driver.MySQLDriver.api._
+import slick.jdbc.MySQLProfile.api._
+import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.jndi.{DirectoryConfig, DirectorySubjectNameSupport}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
@@ -34,7 +34,7 @@ object DbResource {
   private val testdb = ConfigFactory.load.getStringOr("testdb", "mysql")
   private val conf = ConfigFactory.parseResources("version.conf").withFallback(ConfigFactory.load())
 
-  val dataConfig = DatabaseConfig.forConfig[JdbcDriver](testdb)
+  val dataConfig = DatabaseConfig.forConfig[JdbcProfile](testdb)
   val dirConfig = DirectoryConfig(
     conf.getString("directory.url"),
     conf.getString("directory.user"),
@@ -72,7 +72,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   implicit def wfStatusCounter(wfStatus: WorkflowStatus): Counter = metrics.counter(s"${wfStatus.toString}")
   implicit def subStatusCounter(subStatus: SubmissionStatus): Counter = metrics.counter(s"${subStatus.toString}")
 
-  override val driver: JdbcDriver = DbResource.dataConfig.driver
+  override val driver: JdbcProfile = DbResource.dataConfig.driver
   override val batchSize: Int = DbResource.dataConfig.config.getInt("batchSize")
   val slickDataSource = DbResource.dataSource
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -6,7 +6,7 @@ import com.mysql.jdbc.exceptions.jdbc4.MySQLTransactionRollbackException
 import com.typesafe.config.ConfigFactory
 import nl.grons.metrics.scala.{Counter, DefaultInstrumented, MetricName}
 import org.broadinstitute.dsde.rawls.{SamDataSaver, TestExecutionContext, model}
-import slick.backend.DatabaseConfig
+import slick.basic.DatabaseConfig
 import slick.jdbc.MySQLProfile.api._
 import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/MockGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/MockGooglePubSubDAO.scala
@@ -10,7 +10,7 @@ import com.google.api.services.pubsub.model.Topic
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 
-import scala.collection.convert.decorateAsScala._
+import scala.collection.JavaConverters._
 import scala.collection.{mutable, _}
 import scala.concurrent.{ExecutionContext, Future}
 


### PR DESCRIPTION
no ticket.

Code cleanup - primarily migration from `JdbcDriver` to `JdbcProfile` - to get rid of *some* of the compile warnings. This doesn't come close to getting rid of all of them nor does this PR intend to do so ... incremental progress!

I thought about tackling the remainder of the `JavaConverters` deprecation warnings, but that would have made this PR much larger; I'd rather make a separate PR for that.

Read individual commits if desired to review smaller chunks.