### PR TITLE
SubmissionListResponse.workflowIds is now an Option

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4235,11 +4235,6 @@ definitions:
         description: What happens after a task fails. Choose from ContinueWhilePossible and NoNewCalls. Defaults to NoNewCalls if not specified. See Cromwell docs for more information.
         default: NoNewCalls
         enum: ["NoNewCalls", "ContinueWhilePossible"]
-      workflowIds:
-        type: array
-        items:
-          type: string
-        description: Always empty. To be removed.
       cost:
         type: number
         format: float

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -132,7 +132,8 @@ trait SubmissionComponent {
           val user = usersById(RawlsUserSubjectId(submissionRec.submitterId))
           val config = methodConfigurationQuery.unmarshalMethodConfig(methodConfigRec, Map.empty, Map.empty, Map.empty)
           val statusCounts = states.getOrElse(submissionRec.id, Seq.empty).map(x => Map(x.workflowStatus -> x.count)).foldLeft(Map.empty[String, Int])(_|+|_)
-          val workflowIds = states.getOrElse(submissionRec.id, Seq.empty).flatMap(_.workflowId).sorted
+          val maybeWorkflowIds = states.getOrElse(submissionRec.id, Seq.empty).flatMap(_.workflowId).sorted
+          val workflowIds = if (maybeWorkflowIds.nonEmpty) Some(maybeWorkflowIds) else None
           SubmissionListResponse(unmarshalSubmission(submissionRec, config, entityRec.map(_.toReference), Seq.empty), user, workflowIds, statusCounts)
         }
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -163,11 +163,11 @@ case class SubmissionListResponse(
   workflowStatuses: StatusCounts,
   useCallCache: Boolean,
   workflowFailureMode: Option[WorkflowFailureMode] = None,
-  workflowIds: Seq[String],
+  workflowIds: Option[Seq[String]],
   cost: Option[Float] = None
 )
 object SubmissionListResponse {
-  def apply(submission: Submission, rawlsUser: RawlsUser, workflowIds: Seq[String], workflowStatuses: StatusCounts): SubmissionListResponse =
+  def apply(submission: Submission, rawlsUser: RawlsUser, workflowIds: Option[Seq[String]], workflowStatuses: StatusCounts): SubmissionListResponse =
     SubmissionListResponse(
       submissionId = submission.submissionId,
       submissionDate = submission.submissionDate,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -279,10 +279,10 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
     lazy val failedSubmission = getSubmission(submissionResponseWithFailureMode.submissionId)
     lazy val submission = getSubmission(submissionResponseWithoutFailureMode.submissionId)
     val submissionListResponseWithFailureMode =
-      SubmissionListResponse(failedSubmission, testData.userOwner, Seq(), Map("Queued" -> 1)).copy(cost = Some(0f))
+      SubmissionListResponse(failedSubmission, testData.userOwner, None, Map("Queued" -> 1)).copy(cost = None)
     val submissionListResponseWithoutFailureMode =
       SubmissionListResponse(
-        getSubmission(submissionResponseWithoutFailureMode.submissionId), testData.userOwner, Seq(), Map("Queued" -> 1)).copy(cost = Some(0f))
+        getSubmission(submissionResponseWithoutFailureMode.submissionId), testData.userOwner, None, Map("Queued" -> 1)).copy(cost = None)
 
     // Sanity check the workflow failure modes in the expected SubmissionListResponse objects
     submissionListResponseWithFailureMode.workflowFailureMode should equal (Some(WorkflowFailureModes.ContinueWhilePossible))
@@ -418,9 +418,9 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
     def expectedResponse(sub: Submission): SubmissionListResponse = {
       val wfCount = sub.workflows.length
       val statuses: Map[String, Int] = if (wfCount > 0) Map("Submitted" -> wfCount) else Map.empty
-      val runCost = wfCount * 1.23f  // mockSubmissionCostService.fixedCost
+      val runCost = if (wfCount == 0) None else Some(wfCount * 1.23f)  // mockSubmissionCostService.fixedCost
 
-      SubmissionListResponse(sub, testData.userOwner, Seq(), statuses).copy(cost = Option(runCost))
+      SubmissionListResponse(sub, testData.userOwner, None, statuses).copy(cost = runCost)
     }
 
 


### PR DESCRIPTION
In the `SubmissionListResponse`, make `workflowIds` an `Option`. This means that when serializing to json, we can omit this property entirely from the response.

As a side tweak, this PR also sets a `SubmissionListResponse`'s `cost` to `None` when no workflows exist; previously this was set to `Some(0)`.

It's a stretch, but if we can get this merged prior to release, we will have never rendered `workflowIds` in a response, making for less churn in our APIs.

