### PR TITLE
disable costs for submission list

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1396,9 +1396,11 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
     }
 
-    val costMapFuture = costlessSubmissionsFuture flatMap { submissions =>
-      submissionCostService.getWorkflowCosts(submissions.flatMap(_.workflowIds).flatten, workspaceName.namespace)
-    }
+    // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
+    // val costMapFuture = costlessSubmissionsFuture flatMap { submissions =>
+    //   submissionCostService.getWorkflowCosts(submissions.flatMap(_.workflowIds).flatten, workspaceName.namespace)
+    // }
+    val costMapFuture = Future.successful(Map.empty[String,Float])
 
     toFutureTry(costMapFuture) flatMap { costMapTry =>
       val costMap: Map[String,Float] = costMapTry match {
@@ -1410,7 +1412,9 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
       costlessSubmissionsFuture map { costlessSubmissions =>
         val costedSubmissions = costlessSubmissions map { costlessSubmission =>
-          val summedCost = costlessSubmission.workflowIds.map { workflowIds => workflowIds.flatMap(costMap.get).sum }
+          // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
+          // val summedCost = costlessSubmission.workflowIds.map { workflowIds => workflowIds.flatMap(costMap.get).sum }
+          val summedCost = None
           // Clearing workflowIds is a quick fix to prevent SubmissionListResponse from having too much data. Will address in the near future.
           costlessSubmission.copy(cost = summedCost, workflowIds = None)
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -418,7 +418,9 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
     def expectedResponse(sub: Submission): SubmissionListResponse = {
       val wfCount = sub.workflows.length
       val statuses: Map[String, Int] = if (wfCount > 0) Map("Submitted" -> wfCount) else Map.empty
-      val runCost = if (wfCount == 0) None else Some(wfCount * 1.23f)  // mockSubmissionCostService.fixedCost
+      // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
+      // val runCost = if (wfCount == 0) None else Some(wfCount * 1.23f)  // mockSubmissionCostService.fixedCost
+      val runCost = None
 
       SubmissionListResponse(sub, testData.userOwner, None, statuses).copy(cost = runCost)
     }


### PR DESCRIPTION
we are seeing perf problem; let's disable this until we can quantify.

This was committed over a few PRs so it's not a simple revert; this PR disables the relevant BigQuery call but makes it easy to re-enable.