### PR TITLE
checkBucketReadAccess / oauth scopes

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -174,6 +174,10 @@ class HttpSamDAO(baseSamServiceURL: String, serviceAccountCreds: Credential)(imp
     retry(when401or500) { () => asRawlsSAPipeline[String] apply RequestBuilding.Get(url) }
   }
 
+  override def getDefaultPetServiceAccountKeyForUser(userInfo: UserInfo): Future[String] = {
+    val url = samServiceURL + "/api/google/v1/user/petServiceAccount/key"
+    retry(when401or500) { () => pipeline[String](userInfo) apply RequestBuilding.Get(url) }
+  }
 
   //managed group apis
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -53,6 +53,7 @@ trait SamDAO extends ErrorReportable {
     * @return a json blob
     */
   def getPetServiceAccountKeyForUser(googleProject: String, userEmail: RawlsUserEmail): Future[String]
+  def getDefaultPetServiceAccountKeyForUser(userInfo: UserInfo): Future[String]
 
   def getStatus(): Future[SubsystemStatus]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1684,14 +1684,20 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       resultsForPet <- if (maxAccessLevel >= WorkspaceAccessLevels.Write) {
         gcsDAO.diagnosticBucketRead(UserInfo(userInfo.userEmail, OAuth2BearerToken(accessToken), 60, userInfo.userSubjectId), workspace.bucketName)
       } else Future.successful(None)
-      resultsForUser <- gcsDAO.diagnosticBucketRead(userInfo, workspace.bucketName)
     } yield {
-      (resultsForUser, resultsForPet) match {
-        case (None, None) => RequestComplete(StatusCodes.OK)
-        case (Some(report), _) => RequestComplete(report) // report actual user does not have access first
-        case (_, Some(report)) => RequestComplete(report)
+      resultsForPet match {
+        case None => RequestComplete(StatusCodes.OK)
+        case Some(report) => RequestComplete(report)
       }
     }
+//      resultsForUser <- gcsDAO.diagnosticBucketRead(userInfo, workspace.bucketName)
+//    } yield {
+//      (resultsForUser, resultsForPet) match {
+//        case (None, None) => RequestComplete(StatusCodes.OK)
+//        case (Some(report), _) => RequestComplete(report) // report actual user does not have access first
+//        case (_, Some(report)) => RequestComplete(report)
+//      }
+//    }
   }
 
   def listAllActiveSubmissions() = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1680,7 +1680,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
       accessToken <- gcsDAO.getAccessTokenUsingJson(petKey)
 
-      //if the user only has read access, it doesn't matter if their pet doesn't have access because it will never be used. so we skip over it.
+      // we access GCS as the user's pet, so check access as the pet.
       resultsForPet <- if (maxAccessLevel >= WorkspaceAccessLevels.Write) {
         gcsDAO.diagnosticBucketRead(UserInfo(userInfo.userEmail, OAuth2BearerToken(accessToken), 60, userInfo.userSubjectId), workspace.bucketName)
       } else Future.successful(None)
@@ -1690,14 +1690,6 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
         case Some(report) => RequestComplete(report)
       }
     }
-//      resultsForUser <- gcsDAO.diagnosticBucketRead(userInfo, workspace.bucketName)
-//    } yield {
-//      (resultsForUser, resultsForPet) match {
-//        case (None, None) => RequestComplete(StatusCodes.OK)
-//        case (Some(report), _) => RequestComplete(report) // report actual user does not have access first
-//        case (_, Some(report)) => RequestComplete(report)
-//      }
-//    }
   }
 
   def listAllActiveSubmissions() = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/RemoteServicesMockServer.scala
@@ -981,6 +981,19 @@ class RemoteServicesMockServer(port:Int) extends RawlsTestUtils {
     mockServer.when(
       request()
         .withMethod("GET")
+        .withPath("/api/google/v1/user/petServiceAccount/key")
+    ).respond(
+      response()
+        .withHeaders(jsonHeader)
+        .withBody(
+          """{"client_email": "pet-110347448408766049948@broad-dsde-dev.iam.gserviceaccount.com"}""".stripMargin
+        )
+        .withStatusCode(StatusCodes.OK.intValue)
+    )
+
+    mockServer.when(
+      request()
+        .withMethod("GET")
         .withPath("/api/groups")
     ).respond(
       response()


### PR DESCRIPTION
before this PR:
`checkBucketReadAccess` attempted to read the target workspace's bucket using both a pet token and the current user's token. When called from the UI, this succeeded, because the UI asks for oauth storage scopes when logging in the user. However, I don't believe this ever worked when calling rawls directly from rawls swagger, because rawls swagger does NOT request oauth storage scope.

I am removing the UI's request for storage scope in broadinstitute/firecloud-ui#1336, which suddenly makes the UI's requests to `checkBucketReadAccess` fail.

after this PR:
`checkBucketReadAccess` only attempts to read the target workspace's bucket as a pet.


- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
