### PR TITLE
CA-217 Remove prerequisite expressions

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -67,4 +67,5 @@
     <include file="changesets/20181009_drop_extra_perm_fks.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20181018_workflowcollections_on_workspaces.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20190405_cleanup.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20190503_drop_prereqs.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20190503_drop_prereqs.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20190503_drop_prereqs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="hussein" id="drop-prereqs">
+        <sql stripComments="true">
+            drop table METHOD_CONFIG_PREREQ
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4051,8 +4051,6 @@ definitions:
       rootEntityType:
         type: string
         description: The root entity type that the method will be running on. Optional if this method config doesn't run on an entity (i.e. uses only workspace attributes and literal inputs).
-      prerequisites:
-        type: object
       inputs:
         type: object
       outputs:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -36,7 +36,6 @@ trait DataAccess
       TableQuery[SubmissionAttributeTable].delete andThen         // FK to entity, submissionvalidation
       TableQuery[MethodConfigurationInputTable].delete andThen    // FK to MC
       TableQuery[MethodConfigurationOutputTable].delete andThen   // FK to MC
-      TableQuery[MethodConfigurationPrereqTable].delete andThen   // FK to MC
       TableQuery[SubmissionValidationTable].delete andThen        // FK to workflow, workflowfailure
       TableQuery[WorkflowMessageTable].delete andThen             // FK to workflow
       TableQuery[WorkflowTable].delete andThen                    // FK to submission, entity

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -71,28 +71,14 @@ trait MethodConfigurationComponent {
     def configKeyIdx = index("IDX_MC_OUTPUT", (methodConfigId, key), unique = true)
   }
 
-  class MethodConfigurationPrereqTable(tag: Tag) extends Table[MethodConfigurationPrereqRecord](tag, "METHOD_CONFIG_PREREQ") {
-    def methodConfigId = column[Long]("METHOD_CONFIG_ID")
-    def id = column[Long]("ID", O.PrimaryKey, O.AutoInc)
-    def key = column[String]("KEY", O.Length(254))
-    def value = column[String]("VALUE")
-
-    def * = (methodConfigId, id, key, value) <> (MethodConfigurationPrereqRecord.tupled, MethodConfigurationPrereqRecord.unapply)
-
-    def methodConfig = foreignKey("FK_MC_PREREQ", methodConfigId, methodConfigurationQuery)(_.id)
-    def configKeyIdx = index("IDX_MC_PREREQ", (methodConfigId, key), unique = true)
-  }
-
   protected val methodConfigurationInputQuery = TableQuery[MethodConfigurationInputTable]
   protected val methodConfigurationOutputQuery = TableQuery[MethodConfigurationOutputTable]
-  protected val methodConfigurationPrereqQuery = TableQuery[MethodConfigurationPrereqTable]
 
   object methodConfigurationQuery extends TableQuery(new MethodConfigurationTable(_)) {
 
     private type MethodConfigurationQueryType = driver.api.Query[MethodConfigurationTable, MethodConfigurationRecord, Seq]
     private type MethodConfigurationInputQueryType = driver.api.Query[MethodConfigurationInputTable, MethodConfigurationInputRecord, Seq]
     private type MethodConfigurationOutputQueryType = driver.api.Query[MethodConfigurationOutputTable, MethodConfigurationOutputRecord, Seq]
-    private type MethodConfigurationPrereqQueryType = driver.api.Query[MethodConfigurationPrereqTable, MethodConfigurationPrereqRecord, Seq]
 
     /*
       the core methods
@@ -152,11 +138,9 @@ trait MethodConfigurationComponent {
 
 
     private def saveMaps(methodConfig: MethodConfiguration, configId: Long) = {
-      val prerequisites = methodConfig.prerequisites.map { case (key, value) => marshalConfigPrereq(configId, key, value) }
       val inputs = methodConfig.inputs.map { case (key, value) => marshalConfigInput(configId, key, value) }
       val outputs = methodConfig.outputs.map{ case (key, value) => marshalConfigOutput(configId, key, value) }
 
-      (methodConfigurationPrereqQuery ++= prerequisites) andThen
         (methodConfigurationInputQuery ++= inputs) andThen
         (methodConfigurationOutputQuery ++= outputs)
     }
@@ -193,7 +177,7 @@ trait MethodConfigurationComponent {
       val driver: JdbcProfile = MethodConfigurationComponent.this.driver
 
       def deleteAction(workspaceId: UUID): WriteAction[Seq[Int]] = {
-        val tables: Seq[String] = Seq("METHOD_CONFIG_INPUT", "METHOD_CONFIG_OUTPUT", "METHOD_CONFIG_PREREQ")
+        val tables: Seq[String] = Seq("METHOD_CONFIG_INPUT", "METHOD_CONFIG_OUTPUT")
 
         DBIO.sequence(tables map { table =>
           sqlu"""delete t from #$table as t
@@ -242,8 +226,7 @@ trait MethodConfigurationComponent {
       for {
         inputs <- loadInputs(methodConfigRec.id)
         outputs <- loadOutputs(methodConfigRec.id)
-        prereqs <- loadPrereqs(methodConfigRec.id)
-      } yield unmarshalMethodConfig(methodConfigRec, inputs, outputs, prereqs)
+      } yield unmarshalMethodConfig(methodConfigRec, inputs, outputs)
     }
 
     def loadMethodConfigurationByName(workspaceId: UUID, methodConfigNamespace: String, methodConfigName: String): ReadAction[Option[MethodConfiguration]] = {
@@ -271,10 +254,6 @@ trait MethodConfigurationComponent {
       (methodConfigurationOutputQuery filter (_.methodConfigId === methodConfigId)).result.map(unmarshalConfigOutputs)
     }
 
-    private def loadPrereqs(methodConfigId: Long) = {
-      (methodConfigurationPrereqQuery filter (_.methodConfigId === methodConfigId)).result.map(unmarshalConfigPrereqs)
-    }
-
     /*
       the marshal/unmarshal helper methods
      */
@@ -283,8 +262,8 @@ trait MethodConfigurationComponent {
       MethodConfigurationRecord(0, methodConfig.namespace, methodConfig.name, workspaceId, methodConfig.rootEntityType, methodConfig.methodRepoMethod.methodUri, methodConfig.methodConfigVersion, methodConfig.deleted, methodConfig.deletedDate.map( d => new Timestamp(d.getMillis)))
     }
 
-    def unmarshalMethodConfig(methodConfigRec: MethodConfigurationRecord, inputs: Map[String, AttributeString], outputs: Map[String, AttributeString], prereqs: Map[String, AttributeString]): MethodConfiguration = {
-      MethodConfiguration(methodConfigRec.namespace, methodConfigRec.name, methodConfigRec.rootEntityType, prereqs, inputs, outputs, MethodRepoMethod.fromUri(methodConfigRec.methodUri), methodConfigRec.methodConfigVersion, methodConfigRec.deleted, methodConfigRec.deletedDate.map(ts => new DateTime(ts)))
+    def unmarshalMethodConfig(methodConfigRec: MethodConfigurationRecord, inputs: Map[String, AttributeString], outputs: Map[String, AttributeString]): MethodConfiguration = {
+      MethodConfiguration(methodConfigRec.namespace, methodConfigRec.name, methodConfigRec.rootEntityType, None, inputs, outputs, MethodRepoMethod.fromUri(methodConfigRec.methodUri), methodConfigRec.methodConfigVersion, methodConfigRec.deleted, methodConfigRec.deletedDate.map(ts => new DateTime(ts)))
     }
 
     private def unmarshalMethodConfigToShort(methodConfigRec: MethodConfigurationRecord): MethodConfigurationShort = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponent.scala
@@ -263,7 +263,7 @@ trait MethodConfigurationComponent {
     }
 
     def unmarshalMethodConfig(methodConfigRec: MethodConfigurationRecord, inputs: Map[String, AttributeString], outputs: Map[String, AttributeString]): MethodConfiguration = {
-      MethodConfiguration(methodConfigRec.namespace, methodConfigRec.name, methodConfigRec.rootEntityType, None, inputs, outputs, MethodRepoMethod.fromUri(methodConfigRec.methodUri), methodConfigRec.methodConfigVersion, methodConfigRec.deleted, methodConfigRec.deletedDate.map(ts => new DateTime(ts)))
+      MethodConfiguration(methodConfigRec.namespace, methodConfigRec.name, methodConfigRec.rootEntityType, Some(Map.empty[String, AttributeString]), inputs, outputs, MethodRepoMethod.fromUri(methodConfigRec.methodUri), methodConfigRec.methodConfigVersion, methodConfigRec.deleted, methodConfigRec.deletedDate.map(ts => new DateTime(ts)))
     }
 
     private def unmarshalMethodConfigToShort(methodConfigRec: MethodConfigurationRecord): MethodConfigurationShort = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -125,7 +125,7 @@ trait SubmissionComponent {
         recs <- query.result
       } yield {
         recs.map { case (submissionRec, methodConfigRec, entityRec) =>
-          val config = methodConfigurationQuery.unmarshalMethodConfig(methodConfigRec, Map.empty, Map.empty, Map.empty)
+          val config = methodConfigurationQuery.unmarshalMethodConfig(methodConfigRec, Map.empty, Map.empty)
           val statusCounts = states.getOrElse(submissionRec.id, Seq.empty).map(x => Map(x.workflowStatus -> x.count)).foldLeft(Map.empty[String, Int])(_|+|_)
           val maybeWorkflowIds = states.getOrElse(submissionRec.id, Seq.empty).flatMap(_.workflowId).sorted
           val workflowIds = if (maybeWorkflowIds.nonEmpty) Some(maybeWorkflowIds) else None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -150,7 +150,7 @@ object MethodConfigResolver {
     getMethodInputsOutputs(wdl) map { io =>
       val inputs = io.inputs map { _.name -> empty }
       val outputs = io.outputs map { _.name -> empty }
-      MethodConfiguration("namespace", "name", Some("rootEntityType"), None, inputs.toMap, outputs.toMap, methodRepoMethod)
+      MethodConfiguration("namespace", "name", Some("rootEntityType"), Some(Map.empty[String, AttributeString]), inputs.toMap, outputs.toMap, methodRepoMethod)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolver.scala
@@ -150,7 +150,7 @@ object MethodConfigResolver {
     getMethodInputsOutputs(wdl) map { io =>
       val inputs = io.inputs map { _.name -> empty }
       val outputs = io.outputs map { _.name -> empty }
-      MethodConfiguration("namespace", "name", Some("rootEntityType"), Map(), inputs.toMap, outputs.toMap, methodRepoMethod)
+      MethodConfiguration("namespace", "name", Some("rootEntityType"), None, inputs.toMap, outputs.toMap, methodRepoMethod)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1257,7 +1257,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
   }
 
   private def convertToMethodConfiguration(agoraMethodConfig: AgoraMethodConfiguration): MethodConfiguration = {
-    MethodConfiguration(agoraMethodConfig.namespace, agoraMethodConfig.name, Some(agoraMethodConfig.rootEntityType), agoraMethodConfig.prerequisites, agoraMethodConfig.inputs, agoraMethodConfig.outputs, agoraMethodConfig.methodRepoMethod)
+    MethodConfiguration(agoraMethodConfig.namespace, agoraMethodConfig.name, Some(agoraMethodConfig.rootEntityType), Some(agoraMethodConfig.prerequisites), agoraMethodConfig.inputs, agoraMethodConfig.outputs, agoraMethodConfig.methodRepoMethod)
   }
 
   def copyMethodConfigurationToMethodRepo(methodRepoQuery: MethodRepoConfigurationExport): Future[PerRequestMessage] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1257,7 +1257,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
   }
 
   private def convertToMethodConfiguration(agoraMethodConfig: AgoraMethodConfiguration): MethodConfiguration = {
-    MethodConfiguration(agoraMethodConfig.namespace, agoraMethodConfig.name, Some(agoraMethodConfig.rootEntityType), Some(agoraMethodConfig.prerequisites), agoraMethodConfig.inputs, agoraMethodConfig.outputs, agoraMethodConfig.methodRepoMethod)
+    MethodConfiguration(agoraMethodConfig.namespace, agoraMethodConfig.name, Some(agoraMethodConfig.rootEntityType), Some(Map.empty[String, AttributeString]), agoraMethodConfig.inputs, agoraMethodConfig.outputs, agoraMethodConfig.methodRepoMethod)
   }
 
   def copyMethodConfigurationToMethodRepo(methodRepoQuery: MethodRepoConfigurationExport): Future[PerRequestMessage] = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -18,7 +18,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       "config2",
       Some("sample"),
 
-      Map("input.expression" -> AttributeString("this..wont.parse")),
+      Some(Map("input.expression" -> AttributeString("this..wont.parse"))),
       Map("output.expression" -> AttributeString("output.expr")),
       Map("prereq.expression" -> AttributeString("prereq.expr")),
       AgoraMethod("ns-config", "meth2", 2)
@@ -78,7 +78,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     val oldMethod = runAndWait(uniqueResult[MethodConfigurationRecord](methodConfigurationQuery.findActiveByName(workspaceContext.workspaceId, testData.agoraMethodConfig.namespace, testData.agoraMethodConfig.name))).get
 
     val changed = testData.agoraMethodConfig.copy(rootEntityType = Some("goober"),
-      prerequisites = Map.empty,
+      prerequisites = None,
       inputs = Map("input.expression.new" -> AttributeString("input.expr")),
       outputs = Map("output.expression.new" -> AttributeString("output.expr")),
       methodRepoMethod = testData.agoraMethod.copy(methodVersion = 2)
@@ -107,7 +107,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     val oldMethod = runAndWait(uniqueResult[MethodConfigurationRecord](methodConfigurationQuery.findActiveByName(workspaceContext.workspaceId, testData.agoraMethodConfig.namespace, testData.agoraMethodConfig.name))).get
 
     val changed = testData.agoraMethodConfig.copy(rootEntityType = Some("goober"),
-      prerequisites = Map.empty,
+      prerequisites = None,
       inputs = Map("input.expression.new" -> AttributeString("input.expr")),
       outputs = Map("output.expression.new" -> AttributeString("output.expr")),
       methodRepoMethod = testData.agoraMethod.copy(methodVersion = 2)
@@ -137,7 +137,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       "ns",
       "oldName",
       Some("sample"),
-      Map("input.expression" -> AttributeString("this..wont.parse")),
+      None,
       Map("output.expression" -> AttributeString("output.expr")),
       Map("prereq.expression" -> AttributeString("prereq.expr")),
       AgoraMethod("ns-config", "meth2", 2)
@@ -168,7 +168,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       "ns",
       "oldName",
       Some("sample"),
-      Map("input.expression" -> AttributeString("this..wont.parse")),
+      None,
       Map("output.expression" -> AttributeString("output.expr")),
       Map("prereq.expression" -> AttributeString("prereq.expr")),
       AgoraMethod("ns-config", "meth2", 2)
@@ -178,7 +178,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       "ns",
       "newName",
       Some("sample"),
-      Map("input.expression" -> AttributeString("this..wont.parse")),
+      None,
       Map("output.expression" -> AttributeString("already.there")),
       Map("prereq.expression" -> AttributeString("already.there")),
       AgoraMethod("ns-config", "meth2", 2),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -17,7 +17,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       "ns",
       "config2",
       Some("sample"),
-      None, //
+      None, //nuked prereq expressions
       Map("input.expression" -> AttributeString("this..wont.parse")),
       Map("output.expression" -> AttributeString("output.expr")),
       AgoraMethod("ns-config", "meth2", 2)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -17,10 +17,9 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       "ns",
       "config2",
       Some("sample"),
-
-      Some(Map("input.expression" -> AttributeString("this..wont.parse"))),
+      None, //
+      Map("input.expression" -> AttributeString("this..wont.parse")),
       Map("output.expression" -> AttributeString("output.expr")),
-      Map("prereq.expression" -> AttributeString("prereq.expr")),
       AgoraMethod("ns-config", "meth2", 2)
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/MethodConfigurationComponentSpec.scala
@@ -23,9 +23,11 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
       AgoraMethod("ns-config", "meth2", 2)
     )
 
+    val expectedMC = methodConfig2.copy(prerequisites = Some(Map()))
+
     runAndWait(methodConfigurationQuery.create(workspaceContext, methodConfig2))
 
-    assertResult(Option(methodConfig2)) {
+    assertResult(Option(expectedMC)) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, methodConfig2.namespace, methodConfig2.name))
     }
   }
@@ -85,7 +87,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
 
     runAndWait(methodConfigurationQuery.upsert(workspaceContext, changed))
 
-    assertResult(Option(changed.copy(methodConfigVersion = 2))) {
+    assertResult(Option(changed.copy(methodConfigVersion = 2, prerequisites = Some(Map())))) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, changed.namespace, changed.name))
     }
 
@@ -114,7 +116,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
 
     runAndWait(methodConfigurationQuery.update(workspaceContext, testData.agoraMethodConfig.namespace, testData.agoraMethodConfig.name, changed))
 
-    assertResult(Option(changed.copy(methodConfigVersion = 2))) {
+    assertResult(Option(changed.copy(methodConfigVersion = 2, prerequisites = Some(Map())))) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, changed.namespace, changed.name))
     }
 
@@ -151,7 +153,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     runAndWait(methodConfigurationQuery.update(workspaceContext, methodConfigOldName.namespace, methodConfigOldName.name, changed))
 
     //there was no config at that location, so the version should be 1
-    assertResult(Option(changed.copy(methodConfigVersion = 1))) {
+    assertResult(Option(changed.copy(methodConfigVersion = 1, prerequisites = Some(Map())))) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, changed.namespace, changed.name))
     }
 
@@ -198,7 +200,7 @@ class MethodConfigurationComponentSpec extends TestDriverComponentWithFlatSpecAn
     runAndWait(methodConfigurationQuery.update(workspaceContext, methodConfigToMove.namespace, methodConfigToMove.name, changed))
 
     //the version number should be incremented relative to the one that was already there
-    assertResult(Option(changed.copy(methodConfigVersion = 4))) {
+    assertResult(Option(changed.copy(methodConfigVersion = 4, prerequisites = Some(Map())))) {
       runAndWait(methodConfigurationQuery.get(workspaceContext, changed.namespace, changed.name))
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -308,7 +308,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "ns",
       "testConfig1",
       Some("Sample"),
-      Map("p1" -> AttributeString("prereq")),
+      None,
       Map("i1" -> AttributeString("input")),
       Map("o1" -> AttributeString("output")),
       agoraMethod
@@ -320,7 +320,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "dsde",
       "good_and_bad",
       Some("samples"),
-      Map(),
+      None,
       Map("goodAndBad.goodAndBadTask.good_in" -> AttributeString("this.foo"), "goodAndBad.goodAndBadTask.bad_in" -> AttributeString("does.not.parse")),
       Map("goodAndBad.goodAndBadTask.good_out" -> AttributeString("this.bar"), "goodAndBad.goodAndBadTask.bad_out" -> AttributeString("also.does.not.parse"), "empty_out" -> AttributeString("")),
       goodAndBadMethod)
@@ -331,35 +331,35 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "dockstore-config-namespace",
       "dockstore-config-name",
       Some("Sample"),
-      Map("p1" -> AttributeString("prereq")),
+      None,
       Map("i1" -> AttributeString("input")),
       Map("o1" -> AttributeString("output")),
       dockstoreMethod
     )
 
-    val methodConfigDockstore = MethodConfiguration("dsde", "DockstoreConfig", Some("Sample"), Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), DockstoreMethod("dockstore-path", "dockstore-version"))
-    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", Some("Sample"), Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(wsName.namespace, "method-a", 1))
-    val methodConfig3 = MethodConfiguration("dsde", "testConfig", Some("Sample"), Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigDockstore = MethodConfiguration("dsde", "DockstoreConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), DockstoreMethod("dockstore-path", "dockstore-version"))
+    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(wsName.namespace, "method-a", 1))
+    val methodConfig3 = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), AgoraMethod("ns-config", "meth1", 1))
 
-    val methodConfigEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Sample"), Map(), Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), Map(), Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigWorkspaceLibraryUpdate = MethodConfiguration("ns", "testConfigLib", Some("Sample"), Map(), Map(), Map("o1" -> AttributeString("workspace.library:foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigMissingOutputs = MethodConfiguration("ns", "testConfigMissingOutputs", Some("Sample"), Map(), Map(), Map("some.workflow.output" -> AttributeString("this.might_not_be_here")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Sample"), None, Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), None, Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigWorkspaceLibraryUpdate = MethodConfiguration("ns", "testConfigLib", Some("Sample"), None, Map(), Map("o1" -> AttributeString("workspace.library:foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigMissingOutputs = MethodConfiguration("ns", "testConfigMissingOutputs", Some("Sample"), None, Map(), Map("some.workflow.output" -> AttributeString("this.might_not_be_here")), AgoraMethod("ns-config", "meth1", 1))
 
-    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseableInputs = MethodConfiguration("dsde", "UnparseableInputsMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseableOutputs = MethodConfiguration("dsde", "UnparseableOutputsMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")), AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseableBoth = MethodConfiguration("dsde", "UnparseableBothMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..is...bad")), outputs=Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")), AgoraMethod("dsde", "three_step", 1))
-    val methodConfigEmptyOutputs = MethodConfiguration("dsde", "EmptyOutputsMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map("three_step.cgrep.count" -> AttributeString("")), AgoraMethod("dsde", "three_step", 1))
-    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.confused")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigUnparseableInputs = MethodConfiguration("dsde", "UnparseableInputsMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigUnparseableOutputs = MethodConfiguration("dsde", "UnparseableOutputsMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")), AgoraMethod("dsde", "three_step", 1))
+    val methodConfigUnparseableBoth = MethodConfiguration("dsde", "UnparseableBothMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..is...bad")), outputs=Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")), AgoraMethod("dsde", "three_step", 1))
+    val methodConfigEmptyOutputs = MethodConfiguration("dsde", "EmptyOutputsMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map("three_step.cgrep.count" -> AttributeString("")), AgoraMethod("dsde", "three_step", 1))
+    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.confused")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
 
-    val methodConfigArrayType = MethodConfiguration("dsde", "ArrayMethodConfig", Some("SampleSet"), prerequisites=Map.empty,
+    val methodConfigArrayType = MethodConfiguration("dsde", "ArrayMethodConfig", Some("SampleSet"), prerequisites=None,
       inputs=Map("aggregate_data_workflow.aggregate_data.input_array" -> AttributeString("this.samples.type")),
       outputs=Map("aggregate_data_workflow.aggregate_data.output_array" -> AttributeString("this.output_array")),
       AgoraMethod("dsde", "array_task", 1))
 
-    val methodConfigEntityless = MethodConfiguration("ns", "Entityless", None, Map(), inputs=Map("three_step.cgrep.pattern" -> AttributeString("\"bees\"")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigEntityless = MethodConfiguration("ns", "Entityless", None, None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("\"bees\"")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
 
     val agoraMethodConfigName = MethodConfigurationName(agoraMethodConfig.name, agoraMethodConfig.namespace, wsName)
     val dockstoreMethodConfigName = MethodConfigurationName(dockstoreMethodConfig.name, dockstoreMethodConfig.namespace, wsName)
@@ -733,22 +733,22 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "ns",
       "testConfig1",
       Some("Sample"),
-      Map("p1" -> AttributeString("prereq")),
+      None,
       Map("i1" -> AttributeString("input")),
       Map("o1" -> AttributeString("output")),
       AgoraMethod("ns-config", "meth1", 1)
     )
 
-    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", Some("Sample"), Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(wsName.namespace, "method-a", 1))
-    val methodConfig3 = MethodConfiguration("dsde", "testConfig", Some("Sample"), Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(wsName.namespace, "method-a", 1))
+    val methodConfig3 = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), AgoraMethod("ns-config", "meth1", 1))
 
-    val methodConfigEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Spample"), Map(), Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), Map(), Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Spample"), None, Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), None, Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
 
-    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseable = MethodConfiguration("dsde", "UnparseableMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", Some("Sample"), prerequisites=Map.empty, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.confused")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigUnparseable = MethodConfiguration("dsde", "UnparseableMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.confused")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
 
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, wsName)
     val methodConfigName2 = methodConfigName.copy(name="novelName")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/ExpressionValidatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/expressions/ExpressionValidatorSpec.scala
@@ -26,14 +26,14 @@ class ExpressionValidatorSpec extends FlatSpec with TestDriverComponent with Exp
     GatherInputsResult(methodInputs.toSet, Set(), Set(), Set())
   }
 
-  val allValid = MethodConfiguration("dsde", "methodConfigValidExprs", Some("Sample"), prerequisites=Map.empty,
+  val allValid = MethodConfiguration("dsde", "methodConfigValidExprs", Some("Sample"), prerequisites=None,
     inputs = toExpressionMap(parseableInputExpressions),
     outputs = toExpressionMap(parseableOutputExpressions),
     AgoraMethod("dsde", "three_step", 1))
 
   val allValidNoRootMC = allValid.copy(inputs = toExpressionMap(parseableInputExpressionsWithNoRoot), outputs = toExpressionMap(parseableOutputExpressionsWithNoRoot), rootEntityType = None)
 
-  val allInvalid = MethodConfiguration("dsde", "methodConfigInvalidExprs", Some("Sample"), prerequisites=Map.empty,
+  val allInvalid = MethodConfiguration("dsde", "methodConfigInvalidExprs", Some("Sample"), prerequisites=None,
     inputs = toExpressionMap(unparseableInputExpressions),
     outputs = toExpressionMap(unparseableOutputExpressions),
     AgoraMethod("dsde", "three_step", 1))
@@ -42,7 +42,7 @@ class ExpressionValidatorSpec extends FlatSpec with TestDriverComponent with Exp
 
   val emptyExpr = "this.empty" -> AttributeString("")
 
-  val oneEmpty = MethodConfiguration("dsde", "methodConfigEmptyExpr", Some("Sample"), prerequisites=Map.empty,
+  val oneEmpty = MethodConfiguration("dsde", "methodConfigEmptyExpr", Some("Sample"), prerequisites=None,
     inputs = toExpressionMap(parseableInputExpressions) + emptyExpr,
     outputs = toExpressionMap(parseableOutputExpressions),
     AgoraMethod("dsde", "three_step", 1))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -146,26 +146,26 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
   val dummyMethod = AgoraMethod("method_namespace", "test_method", 1)
 
   val configGood = MethodConfiguration("config_namespace", "configGood", Some("Sample"),
-    Map.empty, Map(intArgName -> AttributeString("this.blah")), Map.empty, dummyMethod)
+    None, Map(intArgName -> AttributeString("this.blah")), Map.empty, dummyMethod)
 
   val configEvenBetter = MethodConfiguration("config_namespace", "configGood", Some("Sample"),
-    Map.empty, Map(intArgName -> AttributeString("this.blah"), intOptName -> AttributeString("this.blah")),
+    None, Map(intArgName -> AttributeString("this.blah"), intOptName -> AttributeString("this.blah")),
     Map.empty, dummyMethod)
 
   val configMissingExpr = MethodConfiguration("config_namespace", "configMissingExpr", Some("Sample"),
-    Map.empty, Map.empty, Map.empty, dummyMethod)
+    None, Map.empty, Map.empty, dummyMethod)
 
   val configSampleSet = MethodConfiguration("config_namespace", "configSampleSet", Some("SampleSet"),
-    Map.empty, Map(intArrayName -> AttributeString("this.samples.blah")), Map.empty, dummyMethod)
+    None, Map(intArrayName -> AttributeString("this.samples.blah")), Map.empty, dummyMethod)
 
   val configEmptyArray = MethodConfiguration("config_namespace", "configSampleSet", Some("SampleSet"),
-    Map.empty, Map(intArrayName -> AttributeString("this.nonexistent")), Map.empty, dummyMethod)
+    None, Map(intArrayName -> AttributeString("this.nonexistent")), Map.empty, dummyMethod)
 
   val configRawJsonDoubleArray = MethodConfiguration("config_namespace", "configSampleSet", Some("SampleSet"),
-      Map.empty, Map(doubleIntArrayName -> AttributeString("this.rawJsonDoubleArray")), Map.empty, dummyMethod)
+    None, Map(doubleIntArrayName -> AttributeString("this.rawJsonDoubleArray")), Map.empty, dummyMethod)
 
   val configRawJsonTripleArray = MethodConfiguration("config_namespace", "configSample", Some("Sample"),
-    Map.empty, Map(tripleIntArrayName -> AttributeString("this.samples.rawJsonDoubleArray")), Map.empty, dummyMethod)
+    None, Map(tripleIntArrayName -> AttributeString("this.samples.rawJsonDoubleArray")), Map.empty, dummyMethod)
 
   class ConfigData extends TestData {
     override def save() = {
@@ -367,12 +367,12 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
 
     "create a Method Config from a template" in withConfigData {
       val expectedLittleInputs = Map(intArgName -> AttributeString(""), intOptName -> AttributeString(""))
-      val expectedLittleTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), Map(), expectedLittleInputs, Map(), dummyMethod)
+      val expectedLittleTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), None, expectedLittleInputs, Map(), dummyMethod)
 
       assertResult(expectedLittleTemplate) { MethodConfigResolver.toMethodConfiguration(littleWdl, dummyMethod).get }
 
       val expectedArrayInputs = Map(intArrayName -> AttributeString(""))
-      val expectedArrayTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), Map(), expectedArrayInputs, Map(), dummyMethod)
+      val expectedArrayTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), None, expectedArrayInputs, Map(), dummyMethod)
 
       assertResult(expectedArrayTemplate) { MethodConfigResolver.toMethodConfiguration(arrayWdl, dummyMethod).get }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/MethodConfigResolverSpec.scala
@@ -367,12 +367,12 @@ class MethodConfigResolverSpec extends WordSpecLike with Matchers with TestDrive
 
     "create a Method Config from a template" in withConfigData {
       val expectedLittleInputs = Map(intArgName -> AttributeString(""), intOptName -> AttributeString(""))
-      val expectedLittleTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), None, expectedLittleInputs, Map(), dummyMethod)
+      val expectedLittleTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), Some(Map()), expectedLittleInputs, Map(), dummyMethod)
 
       assertResult(expectedLittleTemplate) { MethodConfigResolver.toMethodConfiguration(littleWdl, dummyMethod).get }
 
       val expectedArrayInputs = Map(intArrayName -> AttributeString(""))
-      val expectedArrayTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), None, expectedArrayInputs, Map(), dummyMethod)
+      val expectedArrayTemplate = MethodConfiguration("namespace", "name", Some("rootEntityType"), Some(Map()), expectedArrayInputs, Map(), dummyMethod)
 
       assertResult(expectedArrayTemplate) { MethodConfigResolver.toMethodConfiguration(arrayWdl, dummyMethod).get }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/ShardedHttpExecutionServiceClusterTest.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/ShardedHttpExecutionServiceClusterTest.scala
@@ -70,7 +70,7 @@ class ShardedHttpExecutionServiceClusterTest(_system: ActorSystem) extends TestK
         withWorkspaceContext(workspace) { context =>
           DBIO.seq(
             entityQuery.save(context, sample1),
-            methodConfigurationQuery.create(context, MethodConfiguration("std", "someMethod", Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("std", "someMethod", 1))),
+            methodConfigurationQuery.create(context, MethodConfiguration("std", "someMethod", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("std", "someMethod", 1))),
             submissionQuery.create(context, submissionWithExecutionKeys)
           )
         },

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -357,7 +357,7 @@ class SubmissionMonitorSpec(_system: ActorSystem) extends TestKit(_system) with 
 
   it should "handle inputs and outputs with library attributes" in withDefaultTestDatabase { dataSource: SlickDataSource =>
 
-    val mcUpdateEntityLibraryOutputs = MethodConfiguration("ns", "testConfig12", Some("Sample"), Map(), Map(), Map("o1_lib" -> AttributeString("this.library:foo")), AgoraMethod("ns-config", "meth1", 1))
+    val mcUpdateEntityLibraryOutputs = MethodConfiguration("ns", "testConfig12", Some("Sample"), None, Map(), Map("o1_lib" -> AttributeString("this.library:foo")), AgoraMethod("ns-config", "meth1", 1))
 
     val subUpdateEntityLibraryOutputs = createTestSubmission(testData.workspace, mcUpdateEntityLibraryOutputs, testData.indiv1, WorkbenchEmail(testData.userOwner.userEmail.value),
       Seq(testData.indiv1), Map(testData.indiv1 -> testData.inputResolutions),
@@ -380,7 +380,7 @@ class SubmissionMonitorSpec(_system: ActorSystem) extends TestKit(_system) with 
       }
     }
 
-    val mcUpdateEntityLibraryInputs = MethodConfiguration("ns", "testConfig11", Some("Sample"), Map(), Map("i_lib" -> AttributeString("this.library:foo")), Map("o2_lib" -> AttributeString("this.library:bar")), AgoraMethod("ns-config", "meth1", 1))
+    val mcUpdateEntityLibraryInputs = MethodConfiguration("ns", "testConfig11", Some("Sample"), None, Map("i_lib" -> AttributeString("this.library:foo")), Map("o2_lib" -> AttributeString("this.library:bar")), AgoraMethod("ns-config", "meth1", 1))
 
     val subUpdateEntityLibraryInputs = createTestSubmission(testData.workspace, mcUpdateEntityLibraryInputs, testData.indiv1, WorkbenchEmail(testData.userOwner.userEmail.value),
       Seq(testData.indiv1), Map(testData.indiv1 -> testData.inputResolutions),
@@ -478,7 +478,7 @@ class SubmissionMonitorSpec(_system: ActorSystem) extends TestKit(_system) with 
       case _ => fail
     }
 
-    val mcUnboundExpr = MethodConfiguration("ns", "testConfig12", Some("Sample"), Map(), Map(), outputExpressions, AgoraMethod("ns-config", "meth1", 1))
+    val mcUnboundExpr = MethodConfiguration("ns", "testConfig12", Some("Sample"), None, Map(), outputExpressions, AgoraMethod("ns-config", "meth1", 1))
 
     val subUnboundExpr = createTestSubmission(testData.workspace, mcUnboundExpr, testData.indiv1, WorkbenchEmail(testData.userOwner.userEmail.value),
       Seq(testData.indiv1), Map(testData.indiv1 -> testData.inputResolutions),
@@ -531,7 +531,7 @@ class SubmissionMonitorSpec(_system: ActorSystem) extends TestKit(_system) with 
       "*")
 
     badExprs foreach { badExpr =>
-      val mcBadExprs = MethodConfiguration("ns", "testConfig12", Some("Sample"), Map(), Map(), Map("bad1" -> AttributeString(badExpr)), AgoraMethod("ns-config", "meth1", 1))
+      val mcBadExprs = MethodConfiguration("ns", "testConfig12", Some("Sample"), None, Map(), Map("bad1" -> AttributeString(badExpr)), AgoraMethod("ns-config", "meth1", 1))
 
       val subBadExprs = createTestSubmission(testData.workspace, mcBadExprs, testData.indiv1, WorkbenchEmail(testData.userOwner.userEmail.value),
         Seq(testData.indiv1), Map(testData.indiv1 -> testData.inputResolutions),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -148,7 +148,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system) with FlatSpe
           DBIO.seq(
             entityQuery.save(context, sample1),
             entityQuery.save(context, sample2),
-            methodConfigurationQuery.create(context, MethodConfiguration("std", "someMethod", Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("std", "someMethod", 1))),
+            methodConfigurationQuery.create(context, MethodConfiguration("std", "someMethod", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("std", "someMethod", 1))),
             submissionQuery.create(context, submissionTestAbortMissingWorkflow),
             submissionQuery.create(context, submissionTestAbortMalformedWorkflow),
             submissionQuery.create(context, submissionTestAbortGoodWorkflow),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
@@ -44,7 +44,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
 
   def testCreateMethodConfiguration(method: MethodRepoMethod, wdlName: String, services: TestApiService) = {
     val newMethodConfig =
-      MethodConfiguration("dsde", s"testConfigNew-${method.repo.scheme}", Some("samples"), Map(), Map(s"$wdlName.cgrep.pattern" -> AttributeString("this.foo")), Map(s"$wdlName.cgrep.count" -> AttributeString("this.bar")), method)
+      MethodConfiguration("dsde", s"testConfigNew-${method.repo.scheme}", Some("samples"), None, Map(s"$wdlName.cgrep.pattern" -> AttributeString("this.foo")), Map(s"$wdlName.cgrep.count" -> AttributeString("this.bar")), method)
     withStatsD {
       Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
         services.sealedInstrumentedRoutes ~>
@@ -76,7 +76,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "update the workspace last modified date on create method configuration" in withTestDataApiServices { services =>
-    val newMethodConfig = MethodConfiguration("dsde", "testConfigNew", Some("samples"), Map(), Map("three_step.cgrep.pattern" -> AttributeString("this.foo")), Map("three_step.cgrep.count" -> AttributeString("this.bar")),
+    val newMethodConfig = MethodConfiguration("dsde", "testConfigNew", Some("samples"), None, Map("three_step.cgrep.pattern" -> AttributeString("this.foo")), Map("three_step.cgrep.count" -> AttributeString("this.bar")),
       AgoraMethod("dsde", "three_step", 1))
     Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
       sealRoute(services.methodConfigRoutes) ~>
@@ -102,7 +102,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     //This tests that invalid MC expressions still return 201 and a ValidatedMethodConfiguration with validation results in it
     val inputs = Map("goodAndBad.goodAndBadTask.good_in" -> AttributeString("this.foo"), "goodAndBad.goodAndBadTask.bad_in" -> AttributeString("does.not.parse"))
     val outputs = Map("goodAndBad.goodAndBadTask.good_out" -> AttributeString("this.bar"), "goodAndBad.goodAndBadTask.bad_out" -> AttributeString("also.does.not.parse"), "empty_out" -> AttributeString(""))
-    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", Some("samples"), Map(), inputs, outputs,
+    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", Some("samples"), None, inputs, outputs,
       AgoraMethod("dsde", "good_and_bad", 1))
 
     val expectedSuccessInputs = Seq("goodAndBad.goodAndBadTask.good_in")
@@ -137,7 +137,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     //This tests that invalid MC expressions still return 201 and a ValidatedMethodConfiguration with validation results in it
     val inputs = Map("goodAndBad.goodAndBadTask.good_in" -> AttributeString("workspace.foo"), "goodAndBad.goodAndBadTask.bad_in" -> AttributeString("blah"))
     val outputs = Map("goodAndBad.goodAndBadTask.good_out" -> AttributeString("workspace.bar"), "goodAndBad.goodAndBadTask.bad_out" -> AttributeString("this.nomodel"), "empty_out" -> AttributeString(""))
-    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", None, Map(), inputs, outputs,
+    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", None, None, inputs, outputs,
       AgoraMethod("dsde", "good_and_bad", 1))
 
     val expectedSuccessInputs = Seq("goodAndBad.goodAndBadTask.good_in")
@@ -169,7 +169,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 if you try to create a method configuration that points to an unknown method" in withTestDataApiServices { services =>
-    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", Some("samples"), Map(), Map(), Map(),
+    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", Some("samples"), None, Map(), Map(),
       AgoraMethod("dsde", "method_doesnt_exist", 1))
 
     Post(s"${testData.workspace.path}/methodconfigs", httpJson(newMethodConfig)) ~>
@@ -184,7 +184,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
   it should "not allow library attributes in outputs for create method configuration by curator" in withTestDataApiServices { services =>
     val inputs = Map("lib_ent_in" -> AttributeString("this.library:foo"), "lib_ws_in" -> AttributeString("workspace.library:foo"))
     val outputs = Map("lib_ent_out" -> AttributeString("this.library:bar"),"lib_ws_out" -> AttributeString("workspace.library:bar"))
-    val newMethodConfig = MethodConfiguration("dsde", "testConfigNew", Some("samples"), Map("ready" -> AttributeString("true")), inputs, outputs,
+    val newMethodConfig = MethodConfiguration("dsde", "testConfigNew", Some("samples"), None, inputs, outputs,
       AgoraMethod(testData.wsName.namespace, "method-a", 1))
 
     val expectedSuccessInputs = Seq("lib_ent_in", "lib_ws_in")
@@ -203,7 +203,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     val inputs = Map("goodAndBad.goodAndBadTask.good_in" -> AttributeString("this.library:foo"), "goodAndBad.goodAndBadTask.bad_in" -> AttributeString("workspace.library:foo"))
     val outputs = Map("goodAndBad.goodAndBadTask.good_out" -> AttributeString("this.bar"),"goodAndBad.goodAndBadTask.bad_out" -> AttributeString("workspace.bar"))
 
-    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", Some("samples"), Map(), inputs, outputs,
+    val newMethodConfig = MethodConfiguration("dsde", "good_and_bad2", Some("samples"), None, inputs, outputs,
       AgoraMethod("dsde", "good_and_bad", 1))
 
     val expectedSuccessInputs = Set("goodAndBad.goodAndBadTask.good_in", "goodAndBad.goodAndBadTask.bad_in")
@@ -233,7 +233,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
   it should "not allow library attributes in outputs for create method configuration by non-curator" in withTestDataApiServices { services =>
     val inputs = Map("lib_ent_in" -> AttributeString("this.library:foo"), "lib_ws_in" -> AttributeString("workspace.library:foo"))
     val outputs = Map("lib_ent_out" -> AttributeString("this.library:bar"),"lib_ws_out" -> AttributeString("workspace.library:bar"))
-    val newMethodConfig = MethodConfiguration("dsde", "testConfigNew", Some("samples"), Map("ready" -> AttributeString("true")), inputs, outputs,
+    val newMethodConfig = MethodConfiguration("dsde", "testConfigNew", Some("samples"), None, inputs, outputs,
       AgoraMethod(testData.wsName.namespace, "method-a", 1))
 
     revokeCuratorRole(services)
@@ -252,8 +252,8 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
 
   // DSDEEPB-1433
   it should "successfully create two method configs with the same name but different namespaces" in withTestDataApiServices { services =>
-    val mc1 = MethodConfiguration("ws1", "testConfig", Some("samples"), Map(), Map(), Map(), AgoraMethod("dsde", "good_and_bad", 1))
-    val mc2 = MethodConfiguration("ws2", "testConfig", Some("samples"), Map(), Map(), Map(), AgoraMethod("dsde", "good_and_bad", 1))
+    val mc1 = MethodConfiguration("ws1", "testConfig", Some("samples"), None, Map(), Map(), AgoraMethod("dsde", "good_and_bad", 1))
+    val mc2 = MethodConfiguration("ws2", "testConfig", Some("samples"), None, Map(), Map(), AgoraMethod("dsde", "good_and_bad", 1))
 
     create(mc1)
     create(mc2)
@@ -886,7 +886,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     Post("/methodconfigs/template", httpJson(method)) ~>
       sealRoute(services.methodConfigRoutes) ~>
       check {
-        val methodConfiguration = MethodConfiguration("namespace", "name", Some("rootEntityType"), Map(), Map("three_step.cgrep.pattern" -> AttributeString("")),
+        val methodConfiguration = MethodConfiguration("namespace", "name", Some("rootEntityType"), None, Map("three_step.cgrep.pattern" -> AttributeString("")),
           Map("three_step.ps.procs"->AttributeString(""),"three_step.cgrep.count"->AttributeString(""), "three_step.wc.count"->AttributeString("")),
           AgoraMethod("dsde","three_step",1))
         assertResult(methodConfiguration) { responseAs[MethodConfiguration] }
@@ -899,7 +899,7 @@ class MethodConfigApiServiceSpec extends ApiServiceSpec {
     Post("/methodconfigs/template", httpJson(method)) ~>
       sealRoute(services.methodConfigRoutes) ~>
       check {
-        val methodConfiguration = MethodConfiguration("namespace", "name", Some("rootEntityType"), Map(), Map("three_step_dockstore.cgrep.pattern" -> AttributeString("")),
+        val methodConfiguration = MethodConfiguration("namespace", "name", Some("rootEntityType"), None, Map("three_step_dockstore.cgrep.pattern" -> AttributeString("")),
           Map("three_step_dockstore.ps.procs"->AttributeString(""),"three_step_dockstore.cgrep.count"->AttributeString(""), "three_step_dockstore.wc.count"->AttributeString("")),
           method)
         assertResult(methodConfiguration) { responseAs[MethodConfiguration] }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -117,7 +117,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
 
   it should "return 404 Not Found when creating a submission using an Entity that doesn't exist in the workspace" in withTestDataApiServices { services =>
     val mcName = MethodConfigurationName("three_step","dsde", testData.wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name,Some("Pattern"), Map.empty, Map("three_step.cgrep.pattern"->AttributeString("this.input_expression")), Map.empty, AgoraMethod("dsde","three_step",1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name,Some("Pattern"), None, Map("three_step.cgrep.pattern"->AttributeString("this.input_expression")), Map.empty, AgoraMethod("dsde","three_step",1))
     Post(s"${testData.wsName.path}/methodconfigs", httpJson(methodConf)) ~>
       sealRoute(services.methodConfigRoutes) ~>
       check { assertResult(StatusCodes.Created) {status} }
@@ -211,9 +211,9 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
 
   it should "return 201 Created when creating and monitoring a submission with no expression" in withTestDataApiServices { services =>
     val wsName = testData.wsName
-    val agoraMethodConf = MethodConfiguration("no_input", "dsde", Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val agoraMethodConf = MethodConfiguration("no_input", "dsde", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
     val dockstoreMethodConf =
-      MethodConfiguration("no_input_dockstore", "dsde", Some("Sample"), Map.empty, Map.empty, Map.empty, DockstoreMethod("dockstore-no-input-path", "dockstore-no-input-version"))
+      MethodConfiguration("no_input_dockstore", "dsde", Some("Sample"), None, Map.empty, Map.empty, DockstoreMethod("dockstore-no-input-path", "dockstore-no-input-version"))
 
     List(agoraMethodConf, dockstoreMethodConf) foreach { conf =>
       val submission = createAndMonitorSubmission(wsName, conf, testData.sample1, None, services)
@@ -226,7 +226,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "return 201 Created when creating and monitoring a submission with valid expression" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     val submission = createAndMonitorSubmission(wsName, methodConf, testData.sset1, Option("this.samples"), services)
 
@@ -238,7 +238,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "update the last modified date on a workspace for submission entries" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     val submission = createAndMonitorSubmission(wsName, methodConf, testData.sset1, Option("this.samples"), services)
 
@@ -253,7 +253,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "return 201 Created when creating submission with a workflow_failure_mode" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     val submission = createAndMonitorSubmission(wsName, methodConf, testData.sample1, None, services, Some(WorkflowFailureModes.ContinueWhilePossible.toString))
 
@@ -265,7 +265,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "return workflow_failure_mode in submission GET calls" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     // calls GET ../submissions/<sub-id> and returns the SubmissionStatusResponse
     val submissionResponseWithFailureMode = createAndMonitorSubmission(wsName, methodConf, testData.sample1, None, services, Some(WorkflowFailureModes.ContinueWhilePossible.toString))
@@ -311,7 +311,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "abort a submission" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     // create a submission
     val submission = createAndMonitorSubmission(wsName, methodConf, testData.sample1, None, services, Some(WorkflowFailureModes.ContinueWhilePossible.toString))
@@ -328,7 +328,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "create and abort a large submission" in withLargeSubmissionApiServices { services =>
     val wsName = largeSampleTestData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     // create a submission
     val submission = createAndMonitorSubmission(wsName, methodConf, largeSampleTestData.sampleSet, Option("this.hasSamples"), services)
@@ -349,7 +349,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
     withWorkflowSubmissionActor(services) { _ =>
       val wsName = largeSampleTestData.wsName
       val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-      val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+      val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
       val numIterations = 20
 
       (1 to numIterations).map { i =>
@@ -368,7 +368,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec {
   it should "return 400 Bad Request when passing an unknown workflow_failure_mode" in withTestDataApiServices { services =>
     val wsName = testData.wsName
     val mcName = MethodConfigurationName("no_input", "dsde", wsName)
-    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+    val methodConf = MethodConfiguration(mcName.namespace, mcName.name, Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
 
     val submissionRq = SubmissionRequest(methodConf.namespace, methodConf.name, Some(testData.sample1.entityType), Some(testData.sample1.name), None, false, Some(WorkflowFailureModes.ContinueWhilePossible.toString))
     val jsonStr = submissionRq.toJson.toString.replace("ContinueWhilePossible", "Bogus")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -166,7 +166,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       sample3.toReference
     ))))
 
-    val methodConfig = MethodConfiguration("dsde", "testConfig", Some("Sample"), Map("ready"-> AttributeString("true")), Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(workspaceName.namespace, "method-a", 1))
+    val methodConfig = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(workspaceName.namespace, "method-a", 1))
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, workspaceName)
     val submissionTemplate = createTestSubmission(workspace, methodConfig, sampleSet, WorkbenchEmail(userOwner.userEmail.value),
       Seq(sample1, sample2, sample3), Map(sample1 -> testData.inputResolutions, sample2 -> testData.inputResolutions, sample3 -> testData.inputResolutions),
@@ -1344,9 +1344,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   private def testCreateSubmission(dataSource: SlickDataSource, userEmail: RawlsUserEmail, exectedStatus: StatusCode) = {
     withApiServicesSecure(dataSource, userEmail.value) { services =>
       val wsName = testData.wsName
-      val agoraMethodConf = MethodConfiguration("no_input", "dsde", Some("Sample"), Map.empty, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+      val agoraMethodConf = MethodConfiguration("no_input", "dsde", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
       val dockstoreMethodConf =
-        MethodConfiguration("no_input_dockstore", "dsde", Some("Sample"), Map.empty, Map.empty, Map.empty, DockstoreMethod("dockstore-no-input-path", "dockstore-no-input-version"))
+        MethodConfiguration("no_input_dockstore", "dsde", Some("Sample"), None, Map.empty, Map.empty, DockstoreMethod("dockstore-no-input-path", "dockstore-no-input-version"))
 
       List(agoraMethodConf, dockstoreMethodConf).foreach(createSubmission(wsName, _, testData.sample1, None, services, exectedStatus))
     }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -342,7 +342,9 @@ case class MethodConfiguration(
                    namespace: String,
                    name: String,
                    rootEntityType: Option[String],
-                   prerequisites: Map[String, AttributeString],
+                   //we used to have prereqs but did nothing with them. so we removed them.
+                   //leaving it as an option means users who are still sending an empty object don't suddenly have their code break.
+                   prerequisites: Option[Map[String, AttributeString]],
                    inputs: Map[String, AttributeString],
                    outputs: Map[String, AttributeString],
                    methodRepoMethod: MethodRepoMethod,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -343,7 +343,8 @@ case class MethodConfiguration(
                    name: String,
                    rootEntityType: Option[String],
                    //we used to have prereqs but did nothing with them. so we removed them.
-                   //leaving it as an option means users who are still sending an empty object don't suddenly have their code break.
+                   //leaving it as an option means we can accept it being there or not; when we return this object,
+                   //we'll always put Some(Map.empty) here so that clients who might be expecting this key still get it.
                    prerequisites: Option[Map[String, AttributeString]],
                    inputs: Map[String, AttributeString],
                    outputs: Map[String, AttributeString],


### PR DESCRIPTION
We never used prerequisites for anything, and their documentation in Swagger is wrong. Goodbye.

(there will be a firecloud-orch PR that will update rawls-model, but I need to wait until this branch is merged before i can make that.)