### PR TITLE
Longer eventually in BillingApiSpec

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val serviceTestV = "0.16-6d74a31"
+  val serviceTestV = "0.16-c44b1d3"
   val workbenchGoogleV = "0.18-85787ba"
   val workbenchModelV  = "0.10-52d614b"
   val workbenchMetricsV  = "0.3-7ad0aa8"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
@@ -6,11 +6,13 @@ import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes}
 import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.service.BillingProject.{BillingProjectRole}
+import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service.util.Retry.retry
 import org.broadinstitute.dsde.workbench.service.{Google, Orchestration, Rawls, RestException}
+
 import scala.concurrent.duration.DurationLong
 import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
@@ -19,6 +21,7 @@ import scala.util.Try
 class BillingApiSpec extends FreeSpec with BillingFixtures with MethodFixtures with Matchers with Eventually
   with TestReporterFixture with LazyLogging {
 
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(20, Seconds)))
   /**
     * This test does
     *


### PR DESCRIPTION
tests are failing in alpha as noted in [QA-542](https://broadworkbench.atlassian.net/browse/QA-542). `BillingApiSpec`, `AuthDomainMultiGroupApiSpec` and `AuthDomainGroupApiSpec` all need a longer timespan in `eventually` block.