### PR TITLE
update serviceTest version to 0.16-56c9393

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaV = "2.5.7"
   val akkaHttpV = "10.0.10"
 
-  val serviceTestV = "0.16-f63a6eb"
+  val serviceTestV = "0.16-56c9393"
   val workbenchGoogleV = "0.18-5941525"
   val workbenchModelV  = "0.13-4c7acd5"
   val workbenchMetricsV  = "0.3-7ad0aa8"


### PR DESCRIPTION
https://github.com/broadinstitute/workbench-libs/commit/56c939315e83bd45dc501cd99e8d3e1ab4c37a25

new workbench-service-test version contains a test fix that increases AuthDomainMatcher eventually timeout to 150 seconds from 60 seconds. Checks in AuthDomainMatcher sometimes fails in Alpha env. It probably related to IAM cache in Sam.