### PR TITLE
BillingApiSpec: handles RestException

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
@@ -134,7 +134,8 @@ class BillingApiSpec extends FreeSpec with BillingFixtures with MethodFixtures w
     // waiting for creationStatus becomes Error or Ready but not Creating
     val statusOption: Option[String] = retry(30.seconds, 20.minutes)({
       val creationStatusOption: Option[String] = for {
-        status <- Rawls.billing.getBillingProjectStatus(billingProjectName)(token).get("creationStatus")
+        statusMap <- Try(Rawls.billing.getBillingProjectStatus(billingProjectName)(token)).toOption
+        status <- statusMap.get("creationStatus")
       } yield status
       creationStatusOption.filterNot(_ equals "Creating")
     })


### PR DESCRIPTION
Rawls.billing.getBillingProjectStatus throws RestException (sometimes) that caused test to end prematurely.

https://fc-jenkins.dsp-techops.broadinstitute.org/job/rawls-real-test-runner/624/

Stacktrace
`
      org.broadinstitute.dsde.workbench.service.RestException: The requested resource could not be found but may be available again in the future.
      at org.broadinstitute.dsde.workbench.service.RestClient.throwRestException(RestClient.scala:85)
      at org.broadinstitute.dsde.workbench.service.RestClient.parseResponse(RestClient.scala:80)
      at org.broadinstitute.dsde.workbench.service.RestClient.parseResponse$(RestClient.scala:74)
      at org.broadinstitute.dsde.workbench.service.Rawls$.parseResponse(Rawls.scala:268)
      at org.broadinstitute.dsde.workbench.service.RestClient.parseResponseAs(RestClient.scala:92)
      at org.broadinstitute.dsde.workbench.service.RestClient.parseResponseAs$(RestClient.scala:89)
      at org.broadinstitute.dsde.workbench.service.Rawls$.parseResponseAs(Rawls.scala:268)
      at org.broadinstitute.dsde.workbench.service.Rawls$billing$.getBillingProjectStatus(Rawls.scala:32)
      at org.broadinstitute.dsde.test.api.BillingApiSpec.$anonfun$createNewBillingProject$3(BillingApiSpec.scala:135)`

