### PR TITLE
untag SmokeTest tag from test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupApiSpec.scala
@@ -43,7 +43,7 @@ class AuthDomainGroupApiSpec extends FreeSpec with Matchers with WorkspaceFixtur
         }
       }
 
-      "can be cloned and retain the auth domain" taggedAs Tags.SmokeTest in {
+      "can be cloned and retain the auth domain" in {
         val user = UserPool.chooseAuthDomainUser
         implicit val authToken: AuthToken = authTokenDefault
 


### PR DESCRIPTION
a Firecloud-UI test converted to Rawls API test. Tag SmokeTest was in Firecloud_UI test and copied over in new API test. It is decided now by QA team that the tag is not needed anymore in API test.
Untagging SmokeTest tag for "A workspace with one group in its auth domain can be cloned and retain the auth domain". 