### PR TITLE
Possible fix for service perimeter automation test failures

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
@@ -177,9 +177,9 @@ class BillingApiSpec extends FreeSpec with BillingFixtures with MethodFixtures w
         withClue(s"Checking status in billing project $billingProjectName") {
           status shouldEqual "Ready"
         }
+        billingProjectName
     }
 
-    billingProjectName
   }
 
   private def deleteBillingProject(billingProjectName: String)(implicit token: AuthToken): Unit = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
@@ -39,7 +39,6 @@ class BillingApiSpec extends FreeSpec with BillingFixtures with MethodFixtures w
     * and)   the project owner can run an analysis and wait for complete successfully
     * and)   the project owner can delete method config
     * and)   the project owner can delete workspace
-    * and)   the project owner can delete Google billing project
     *
     */
 
@@ -119,9 +118,8 @@ class BillingApiSpec extends FreeSpec with BillingFixtures with MethodFixtures w
         }
       }
 
-      // clean up
+      // owner should be able to delete the workspace
       Rawls.workspaces.delete(billingProjectName, workspaceName)
-      deleteBillingProject(billingProjectName)
     }
 
     "can create a new billing project with a service perimeter" in {
@@ -142,9 +140,6 @@ class BillingApiSpec extends FreeSpec with BillingFixtures with MethodFixtures w
 
       // try to create a project with a perimeter. retry up to 3 times for project to reach 'Ready' status
       val billingProjectName = createNewBillingProject(owner, servicePerimeterOpt = Option(fullyQualifiedServicePerimeterId))
-
-      // cleanup
-      deleteBillingProject(billingProjectName)
     }
   }
 


### PR DESCRIPTION
There have been a handful of test failures in the Rawls Fiab Test Runner recently. See [#13455](https://fc-jenkins.dsp-techops.broadinstitute.org/job/rawls-fiab-test-runner/13455/), [#13462](https://fc-jenkins.dsp-techops.broadinstitute.org/job/rawls-fiab-test-runner/13462/), [#13475](https://fc-jenkins.dsp-techops.broadinstitute.org/job/rawls-fiab-test-runner/13475/), and [#13476](https://fc-jenkins.dsp-techops.broadinstitute.org/job/rawls-fiab-test-runner/13476/) for examples. The test that has been failing has been `A user with a billing account can create a new billing project with a service perimeter` in Rawls's BillingApiSpec. The error message that shows up in Jenkins is: `{"causes":[],"message":"http error calling uri https://sam-fiab.dsde-qa.broadinstitute.org/api/resources/v1/billing-project/rawls-billingapispec-pcpra88/allUsers","source":"rawls","stackTrace":[],"statusCode":404}`. 

In each occurrence, the first project the test tries to create ends up in an error state. Even though the test retries the project creation and succeeds the second time around, the test fails when trying to delete the errored project. Google returns a 403 Forbidden response to the request from Rawls to delete the errored project, possibly because project creation didn’t succeed and permissions are a bit messed up. I believe that this error is related to a change I made that is causing part of the test infrastructure to return the wrong billing project name (the name of the errored project instead of the successful one). This PR reverts the change that I made so that hopefully the successfully created project will be deleted and we won't run into permission issues.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
