### PR TITLE
Nix BigQuery logging

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -71,13 +71,6 @@
         <appender-ref ref="Sentry" />
     </logger>
 
-    <logger name="org.broadinstitute.dsde.workbench.google.HttpGoogleBigQueryDAO" level="debug" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-        <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
-    </logger>
-
     <logger name="org.broadinstitute.dsde.rawls.dataaccess.SubmissionCostService" level="debug" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>


### PR DESCRIPTION
We hypothesised that printing the bigquery queries to syslog was OOMing rawls. This PR nixes them and will thus help with CA-379 (but is merely the dumb fix rather than the smart fix).

(please go ahead and merge if you approve, my availability is extremely sporadic)