### PR TITLE
use submission id in bigquery cost lookup

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -62,8 +62,9 @@ class SubmissionCostService(tableName: String, serviceProject: String, bigQueryD
 
   private def partitionDateClause(submissionDate: Option[DateTime]): String = {
     (submissionDate map { d: DateTime =>
-      val date = d.toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
-      s"AND _PARTITIONDATE >= $date"
+      //subtract a day so we never have to deal with timezones
+      val date = d.minusDays(1).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
+      s"""AND _PARTITIONDATE >= "$date""""
     }).getOrElse("")
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -3,9 +3,10 @@ package org.broadinstitute.dsde.rawls.dataaccess
 import java.util
 
 import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
-import com.google.api.services.bigquery.model.{QueryParameter, QueryParameterType, QueryParameterValue, TableRow}
+import com.google.api.services.bigquery.model.{GetQueryResultsResponse, QueryParameter, QueryParameterType, QueryParameterValue, TableRow}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,26 +18,70 @@ object SubmissionCostService {
 
 class SubmissionCostService(tableName: String, serviceProject: String, bigQueryDAO: GoogleBigQueryDAO)(implicit val executionContext: ExecutionContext) extends LazyLogging {
 
+  val stringParamType = new QueryParameterType().setType("STRING")
 
-  def getWorkflowCosts(workflowIds: Seq[String],
+  def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String): Future[Map[String, Float]] = {
+    if( workflowIds.isEmpty ) {
+      Future.successful(Map.empty[String, Float])
+    } else {
+      for {
+        //try looking up the workflows via the submission ID.
+        //this makes for a smaller query string (though no faster).
+        submissionCosts <- executeSubmissionCostsQuery(submissionId, workspaceNamespace)
+        //if that doesn't return anything, fall back to
+        fallbackCosts <- if (submissionCosts.size() == 0)
+          executeWorkflowCostsQuery(workflowIds, workspaceNamespace)
+        else
+          Future.successful(submissionCosts)
+      } yield {
+        extractCostResults(fallbackCosts)
+      }
+    }
+  }
+
+
+  def getWorkflowCost(workflowId: String,
                        workspaceNamespace: String): Future[Map[String, Float]] = {
-
-    extractWorkflowCostResults(executeWorkflowCostsQuery(workflowIds, workspaceNamespace))
+    executeWorkflowCostsQuery(Seq(workflowId), workspaceNamespace) map extractCostResults
   }
 
   /*
    * Manipulates and massages a BigQuery result.
    */
-  def extractWorkflowCostResults(rowsFuture: Future[util.List[TableRow]]): Future[Map[String, Float]] = {
+  def extractCostResults(rows: util.List[TableRow]): Map[String, Float] = {
+    Option(rows) match {
+      case Some(rows) => rows.asScala.map { row =>
+        // workflow ID is contained in the 2nd cell, cost is contained in the 3rd cell
+        row.getF.get(1).getV.toString -> row.getF.get(2).getV.toString.toFloat
+      }.toMap
+      case None => Map.empty[String, Float]
+    }
+  }
 
-    rowsFuture map { rowsOrNull =>
-      Option(rowsOrNull) match {
-        case Some(rows) => rows.asScala.map { row =>
-          // workflow ID is contained in the 2nd cell, cost is contained in the 3rd cell
-          row.getF.get(1).getV.toString -> row.getF.get(2).getV.toString.toFloat
-        }.toMap
-        case None => Map.empty[String, Float]
-      }
+  //TODO: add optional _PARTITIONDATE to save $$$. pass in submissionDate: Option[DateTime] = None
+  private def executeSubmissionCostsQuery(submissionId: String, workspaceNamespace: String): Future[util.List[TableRow]] = {
+
+    val querySql: String =
+      s"""SELECT wflabels.key, REPLACE(wflabels.value, "cromwell-", "") as `workflowId`, SUM(billing.cost)
+      |FROM `$tableName` as billing, UNNEST(labels) as wflabels
+      |CROSS JOIN UNNEST(billing.labels) as blabels
+      |WHERE blabels.value = "terra-$submissionId"
+      |AND wflabels.key = "cromwell-workflow-id"
+      |AND project.id = ?
+      |GROUP BY wflabels.key, workflowId""".stripMargin
+
+    val namespaceParam =
+      new QueryParameter()
+        .setParameterType(stringParamType)
+        .setParameterValue(new QueryParameterValue().setValue(workspaceNamespace))
+
+    val queryParameters: List[QueryParameter] = List(namespaceParam)
+
+    executeBigQuery(querySql, queryParameters) map { result =>
+      val rowsReturned = result.getTotalRows
+      val bytesProcessed = result.getTotalBytesProcessed
+      logger.debug(s"Queried for costs of submission $submissionId: $rowsReturned Rows Returned and $bytesProcessed Bytes Processed.")
+      result.getRows
     }
   }
 
@@ -56,7 +101,7 @@ class SubmissionCostService(tableName: String, serviceProject: String, bigQueryD
               |AND labels.key LIKE "cromwell-workflow-id"
               |GROUP BY labels.key, workflowId
               |HAVING $subquery""".stripMargin
-        val stringParamType = new QueryParameterType().setType("STRING")
+
         val namespaceParam =
           new QueryParameter()
             .setParameterType(stringParamType)
@@ -68,18 +113,23 @@ class SubmissionCostService(tableName: String, serviceProject: String, bigQueryD
         }
         val queryParameters: List[QueryParameter] = namespaceParam :: subqueryParams
 
-        for {
-          jobRef <- bigQueryDAO.startParameterizedQuery(GoogleProject(serviceProject), querySql, queryParameters, "POSITIONAL")
-          job <- bigQueryDAO.getQueryStatus(jobRef)
-          result <- bigQueryDAO.getQueryResult(job)
-        } yield {
+        executeBigQuery(querySql, queryParameters) map { result =>
           val idCount = ids.length
           val rowsReturned = result.getTotalRows
           val bytesProcessed = result.getTotalBytesProcessed
           logger.debug(s"Queried for costs of $idCount Workflow IDs: $rowsReturned Rows Returned and $bytesProcessed Bytes Processed.")
-
           result.getRows
         }
+    }
+  }
+
+  private def executeBigQuery(querySql: String, queryParams: List[QueryParameter]): Future[GetQueryResultsResponse] = {
+    for {
+      jobRef <- bigQueryDAO.startParameterizedQuery(GoogleProject(serviceProject), querySql, queryParams, "POSITIONAL")
+      job <- bigQueryDAO.getQueryStatus(jobRef)
+      result <- bigQueryDAO.getQueryResult(job)
+    } yield {
+      result
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1472,7 +1472,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     submissionWithoutCosts flatMap {
       case (submission) => {
         val allWorkflowIds: Seq[String] = submission.workflows.flatMap(_.workflowId)
-        toFutureTry(submissionCostService.getWorkflowCosts(allWorkflowIds, workspaceName.namespace)) map {
+        toFutureTry(submissionCostService.getSubmissionCosts(submissionId, allWorkflowIds, workspaceName.namespace)) map {
           case Failure(ex) =>
             logger.error("Unable to get workflow costs for this submission. ", ex)
             RequestComplete((StatusCodes.OK, SubmissionStatusResponse(submission)))
@@ -1569,7 +1569,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       // we don't need the Execution Service ID, but we do need to confirm the Workflow is in one for this Submission
       // if we weren't able to do so above
       _ <- executionServiceCluster.findExecService(submissionId, workflowId, userInfo, optExecId)
-      costs <- submissionCostService.getWorkflowCosts(Seq(workflowId), workspaceName.namespace)
+      costs <- submissionCostService.getWorkflowCost(workflowId, workspaceName.namespace)
     } yield RequestComplete(StatusCodes.OK, WorkflowCost(workflowId, costs.get(workflowId)))
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1472,7 +1472,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     submissionWithoutCosts flatMap {
       case (submission) => {
         val allWorkflowIds: Seq[String] = submission.workflows.flatMap(_.workflowId)
-        toFutureTry(submissionCostService.getSubmissionCosts(submissionId, allWorkflowIds, workspaceName.namespace)) map {
+        toFutureTry(submissionCostService.getSubmissionCosts(submissionId, allWorkflowIds, workspaceName.namespace, Option(submission.submissionDate))) map {
           case Failure(ex) =>
             logger.error("Unable to get workflow costs for this submission. ", ex)
             RequestComplete((StatusCodes.OK, SubmissionStatusResponse(submission)))
@@ -1559,17 +1559,19 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     val execIdFutOpt = dataSource.inTransaction { dataAccess =>
       withWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, dataAccess) { workspaceContext =>
         withSubmissionAndWorkflowExecutionServiceKey(workspaceContext, submissionId, workflowId, dataAccess) { optExecKey =>
-          DBIO.successful(optExecKey)
+          withSubmission(workspaceContext, submissionId, dataAccess) { submission =>
+            DBIO.successful((optExecKey, submission))
+          }
         }
       }
     }
 
     for {
-      optExecId <- execIdFutOpt
+      (optExecId, submission) <- execIdFutOpt
       // we don't need the Execution Service ID, but we do need to confirm the Workflow is in one for this Submission
       // if we weren't able to do so above
       _ <- executionServiceCluster.findExecService(submissionId, workflowId, userInfo, optExecId)
-      costs <- submissionCostService.getWorkflowCost(workflowId, workspaceName.namespace)
+      costs <- submissionCostService.getWorkflowCost(workflowId, workspaceName.namespace, Option(submission.submissionDate))
     } yield RequestComplete(StatusCodes.OK, WorkflowCost(workflowId, costs.get(workflowId)))
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
@@ -6,7 +6,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MockSubmissionCostService(tableName: String, serviceProject: String, bigQueryDAO: GoogleBigQueryDAO)(implicit executionContext: ExecutionContext) extends SubmissionCostService(tableName, serviceProject, bigQueryDAO) {
   val fixedCost = 1.23f
-  override def getWorkflowCosts(workflowIds: Seq[String], workspaceNamespace: String): Future[Map[String, Float]] = {
+  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String): Future[Map[String, Float]] = {
     Future(workflowIds.map(_ -> fixedCost).toMap)
+  }
+
+  override def getWorkflowCost(workflowId: String, workspaceNamespace: String): Future[Map[String, Float]] = {
+    Future(Map(workflowId -> fixedCost))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
@@ -1,16 +1,17 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
+import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class MockSubmissionCostService(tableName: String, serviceProject: String, bigQueryDAO: GoogleBigQueryDAO)(implicit executionContext: ExecutionContext) extends SubmissionCostService(tableName, serviceProject, bigQueryDAO) {
   val fixedCost = 1.23f
-  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String): Future[Map[String, Float]] = {
+  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String, submissionDate: Option[DateTime]): Future[Map[String, Float]] = {
     Future(workflowIds.map(_ -> fixedCost).toMap)
   }
 
-  override def getWorkflowCost(workflowId: String, workspaceNamespace: String): Future[Map[String, Float]] = {
+  override def getWorkflowCost(workflowId: String, workspaceNamespace: String, submissionDate: Option[DateTime]): Future[Map[String, Float]] = {
     Future(Map(workflowId -> fixedCost))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -15,16 +15,16 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
   val mockBigQueryDAO = new MockGoogleBigQueryDAO
   val submissionCostService = SubmissionCostService.constructor("test", "test", mockBigQueryDAO)
 
-  val rows = Future(List(
+  val rows = List(
     new TableRow().setF(List(new TableCell().setV("wfKey"), new TableCell().setV("wf1"), new TableCell().setV(1.32f)).asJava),
     new TableRow().setF(List(new TableCell().setV("wfKey"), new TableCell().setV("wf2"), new TableCell().setV(3f)).asJava),
     new TableRow().setF(List(new TableCell().setV("wfKey"), new TableCell().setV("wf3"), new TableCell().setV(101.00f)).asJava)
-  ).asJava)
+  ).asJava
 
   "SubmissionCostService" should "extract a map of workflow ID to cost" in {
     val expected = Map("wf1" -> 1.32f, "wf2" -> 3.00f, "wf3" -> 101.00f)
     assertResult(expected) {
-      Await.result(submissionCostService.extractWorkflowCostResults(rows), 1 minute)
+      submissionCostService.extractCostResults(rows)
     }
   }
 
@@ -36,7 +36,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
    */
   it should "bypass BigQuery with no workflow IDs" in {
     assertResult(Map.empty) {
-      Await.result(submissionCostService.getWorkflowCosts(Seq.empty, "test"), 1 minute)
+      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test"), 1 minute)
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -36,7 +36,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
    */
   it should "bypass BigQuery with no workflow IDs" in {
     assertResult(Map.empty) {
-      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test"), 1 minute)
+      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", None), 1 minute)
     }
   }
 }


### PR DESCRIPTION
Follow-on from the previous PR.

I still need to check that the query works; I've done a big submission in a fiab and am waiting for the export to bigquery.

I broke out the original function of "get me costs for this list of workflows" into "get me costs for this submission" and "get me costs for this one workflow", which more closely matches our usage. In the first case, we start by looking up the submission ID, and if that doesn't work, we fall back to executing the monster query. Over time this means we'll run more of the former than the latter, which won't make the results any smaller but the queries will be a lot more manageable.

I also passed through `_PARTITIONDATE` as that's an easy way to limit the amount of data BQ scans, thus making queries cheaper.