### PR TITLE
WorkspaceResponse uses Options [risk: no; ticket: no]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -171,7 +171,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
               (canCatalog, canShare, canCompute, owners, authDomain, bucketDetails) <- DBIO.from(futuresInParallel)
               stats <- getWorkspaceSubmissionStats(workspaceContext, dataAccess)
             } yield {
-              RequestComplete(StatusCodes.OK, WorkspaceResponse(Some(accessLevel), Some(canShare), Some(canCompute), Some(canCatalog), WorkspaceDetails(workspaceContext.workspace, authDomain.toSet), Some(stats), Some(bucketDetails), Some(owners), Map()))
+              RequestComplete(StatusCodes.OK, WorkspaceResponse(Some(accessLevel), Some(canShare), Some(canCompute), Some(canCatalog), WorkspaceDetails(workspaceContext.workspace, authDomain.toSet), Some(stats), Some(bucketDetails), Some(owners)))
             }
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -171,7 +171,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
               (canCatalog, canShare, canCompute, owners, authDomain, bucketDetails) <- DBIO.from(futuresInParallel)
               stats <- getWorkspaceSubmissionStats(workspaceContext, dataAccess)
             } yield {
-              RequestComplete(StatusCodes.OK, WorkspaceResponse(Some(accessLevel), Some(canShare), Some(canCompute), Some(canCatalog), WorkspaceDetails(workspaceContext.workspace, authDomain.toSet), Some(stats), Some(bucketDetails), Some(owners)))
+              RequestComplete(StatusCodes.OK, WorkspaceResponse(Option(accessLevel), Option(canShare), Option(canCompute), Option(canCatalog), WorkspaceDetails(workspaceContext.workspace, authDomain.toSet), Option(stats), Option(bucketDetails), Option(owners)))
             }
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -171,7 +171,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
               (canCatalog, canShare, canCompute, owners, authDomain, bucketDetails) <- DBIO.from(futuresInParallel)
               stats <- getWorkspaceSubmissionStats(workspaceContext, dataAccess)
             } yield {
-              RequestComplete(StatusCodes.OK, WorkspaceResponse(accessLevel, canShare, canCompute, canCatalog, WorkspaceDetails(workspaceContext.workspace, authDomain.toSet), stats, bucketDetails, owners))
+              RequestComplete(StatusCodes.OK, WorkspaceResponse(Some(accessLevel), Some(canShare), Some(canCompute), Some(canCatalog), WorkspaceDetails(workspaceContext.workspace, authDomain.toSet), Some(stats), Some(bucketDetails), Some(owners), Map()))
             }
           }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -60,7 +60,7 @@ class PetSASpec extends ApiServiceSpec {
         }
         assertResult(newWorkspace) {
           val ws = responseAs[WorkspaceDetails]
-          WorkspaceRequest(ws.namespace, ws.name, ws.attributes, Option(Set.empty))
+          WorkspaceRequest(ws.namespace, ws.name, ws.attributes.getOrElse(Map()), Option(Set.empty))
         }
       }
   }
@@ -78,7 +78,7 @@ class PetSASpec extends ApiServiceSpec {
           WorkspaceResponse(WorkspaceAccessLevels.Owner, true, true, true, WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), WorkspaceSubmissionStats(None, None, 0), WorkspaceBucketOptions(false), Set.empty)
         ){
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, Map())
         }
       }
   }
@@ -98,7 +98,7 @@ class PetSASpec extends ApiServiceSpec {
           WorkspaceResponse(WorkspaceAccessLevels.Owner, true, true, true, WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), WorkspaceSubmissionStats(None, None, 0), WorkspaceBucketOptions(false), Set.empty)
         ){
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, Map())
         }
       }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -75,7 +75,7 @@ class PetSASpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), Some(true), Some(true), Some(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Some(WorkspaceSubmissionStats(None, None, 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
+          WorkspaceResponse(Option(WorkspaceAccessLevels.Owner), Option(true), Option(true), Option(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(None, None, 0)), Option(WorkspaceBucketOptions(false)), Option(Set.empty))
         ){
           val response = responseAs[WorkspaceResponse]
           WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
@@ -95,7 +95,7 @@ class PetSASpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), Some(true), Some(true), Some(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Some(WorkspaceSubmissionStats(None, None, 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
+          WorkspaceResponse(Option(WorkspaceAccessLevels.Owner), Option(true), Option(true), Option(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(None, None, 0)), Option(WorkspaceBucketOptions(false)), Option(Set.empty))
         ){
           val response = responseAs[WorkspaceResponse]
           WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -75,10 +75,10 @@ class PetSASpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(WorkspaceAccessLevels.Owner, true, true, true, WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), WorkspaceSubmissionStats(None, None, 0), WorkspaceBucketOptions(false), Set.empty)
+          WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), Some(true), Some(true), Some(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Some(WorkspaceSubmissionStats(None, None, 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
         ){
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, Map())
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
         }
       }
   }
@@ -95,10 +95,10 @@ class PetSASpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(WorkspaceAccessLevels.Owner, true, true, true, WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), WorkspaceSubmissionStats(None, None, 0), WorkspaceBucketOptions(false), Set.empty)
+          WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), Some(true), Some(true), Some(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Some(WorkspaceSubmissionStats(None, None, 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
         ){
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, Map())
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
         }
       }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -349,10 +349,10 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(WorkspaceAccessLevels.Owner, true, true, true, WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), WorkspaceBucketOptions(false), Set.empty)
+          WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), Some(true), Some(true), Some(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Some(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
         ){
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, Map())
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
         }
       }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -349,7 +349,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), Some(true), Some(true), Some(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Some(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
+          WorkspaceResponse(Option(WorkspaceAccessLevels.Owner), Option(true), Option(true), Option(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), Option(WorkspaceBucketOptions(false)), Option(Set.empty))
         ){
           val response = responseAs[WorkspaceResponse]
           WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
@@ -815,7 +815,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.Created) {
           status
         }
-        assertResult(Some(testData.workspace.attributes)) {
+        assertResult(Option(testData.workspace.attributes)) {
           responseAs[WorkspaceDetails].attributes
         }
       }
@@ -832,7 +832,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.Created) {
             status
           }
-          assertResult(Some(testData.workspace.attributes ++ newAtts)) {
+          assertResult(Option(testData.workspace.attributes ++ newAtts)) {
             responseAs[WorkspaceDetails].attributes
           }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -250,7 +250,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         assertResult(newWorkspace) {
           val ws = responseAs[WorkspaceDetails]
-          WorkspaceRequest(ws.namespace, ws.name, ws.attributes, Option(Set.empty))
+          WorkspaceRequest(ws.namespace, ws.name, ws.attributes.getOrElse(Map()), Option(Set.empty))
         }
         // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
         assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(newWorkspace.path))))) {
@@ -352,7 +352,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           WorkspaceResponse(WorkspaceAccessLevels.Owner, true, true, true, WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2), WorkspaceBucketOptions(false), Set.empty)
         ){
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, Map())
         }
       }
   }
@@ -815,7 +815,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.Created) {
           status
         }
-        assertResult(testData.workspace.attributes) {
+        assertResult(Some(testData.workspace.attributes)) {
           responseAs[WorkspaceDetails].attributes
         }
       }
@@ -832,7 +832,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.Created) {
             status
           }
-          assertResult(testData.workspace.attributes ++ newAtts) {
+          assertResult(Some(testData.workspace.attributes ++ newAtts)) {
             responseAs[WorkspaceDetails].attributes
           }
         }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -416,8 +416,7 @@ case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
                              workspace: WorkspaceDetails,
                              workspaceSubmissionStats: Option[WorkspaceSubmissionStats],
                              bucketOptions: Option[WorkspaceBucketOptions],
-                             owners: Option[Set[String]]
-                            )
+                             owners: Option[Set[String]])
 
 case class WorkspaceDetails(namespace: String,
                             name: String,
@@ -652,7 +651,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 
-  implicit val WorkspaceResponseFormat = jsonFormat8(WorkspaceResponse.apply)
+  implicit val WorkspaceResponseFormat = jsonFormat8(WorkspaceResponse)
 
   implicit val WorkspaceAccessInstructionsFormat = jsonFormat2(ManagedGroupAccessInstructions)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -409,14 +409,30 @@ case class WorkspaceListResponse(accessLevel: WorkspaceAccessLevel,
                                  workspaceSubmissionStats: WorkspaceSubmissionStats,
                                  public: Boolean)
 
-case class WorkspaceResponse(accessLevel: WorkspaceAccessLevel,
-                             canShare: Boolean,
-                             canCompute: Boolean,
-                             catalog: Boolean,
+case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
+                             canShare: Option[Boolean],
+                             canCompute: Option[Boolean],
+                             catalog: Option[Boolean],
                              workspace: WorkspaceDetails,
-                             workspaceSubmissionStats: WorkspaceSubmissionStats,
-                             bucketOptions: WorkspaceBucketOptions,
-                             owners: Set[String])
+                             workspaceSubmissionStats: Option[WorkspaceSubmissionStats],
+                             bucketOptions: Option[WorkspaceBucketOptions],
+                             owners: Option[Set[String]],
+                             requestOptions: Map[String, Boolean] // TODO: strongly type this
+                            )
+
+object WorkspaceResponse {
+  def apply(accessLevel: WorkspaceAccessLevel,
+            canShare: Boolean,
+            canCompute: Boolean,
+            catalog: Boolean,
+            workspace: WorkspaceDetails,
+            workspaceSubmissionStats: WorkspaceSubmissionStats,
+            bucketOptions: WorkspaceBucketOptions,
+            owners: Set[String]): WorkspaceResponse = {
+    WorkspaceResponse(Some(accessLevel), Some(canShare), Some(canCompute), Some(catalog), workspace,
+      Some(workspaceSubmissionStats), Some(bucketOptions), Some(owners), Map())
+  }
+}
 
 case class WorkspaceDetails(namespace: String,
                             name: String,
@@ -426,10 +442,10 @@ case class WorkspaceDetails(namespace: String,
                             createdDate: DateTime,
                             lastModified: DateTime,
                             createdBy: String,
-                            attributes: AttributeMap,
+                            attributes: Option[AttributeMap],
                             isLocked: Boolean = false,
-                            authorizationDomain: Set[ManagedGroupRef]) {
-  def toWorkspace: Workspace = Workspace(namespace, name, workspaceId, bucketName, workflowCollectionName, createdDate, lastModified, createdBy, attributes, isLocked)
+                            authorizationDomain: Option[Set[ManagedGroupRef]]) {
+  def toWorkspace: Workspace = Workspace(namespace, name, workspaceId, bucketName, workflowCollectionName, createdDate, lastModified, createdBy, attributes.getOrElse(Map()), isLocked)
 }
 
 object WorkspaceDetails {
@@ -443,9 +459,9 @@ object WorkspaceDetails {
       workspace.createdDate,
       workspace.lastModified,
       workspace.createdBy,
-      workspace.attributes,
+      Some(workspace.attributes),
       workspace.isLocked,
-      authorizationDomain
+      Some(authorizationDomain)
     )
   }
 }
@@ -651,7 +667,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 
-  implicit val WorkspaceResponseFormat = jsonFormat8(WorkspaceResponse)
+  implicit val WorkspaceResponseFormat = jsonFormat9(WorkspaceResponse.apply)
 
   implicit val WorkspaceAccessInstructionsFormat = jsonFormat2(ManagedGroupAccessInstructions)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -416,23 +416,8 @@ case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
                              workspace: WorkspaceDetails,
                              workspaceSubmissionStats: Option[WorkspaceSubmissionStats],
                              bucketOptions: Option[WorkspaceBucketOptions],
-                             owners: Option[Set[String]],
-                             requestOptions: Map[String, Boolean] // TODO: strongly type this
+                             owners: Option[Set[String]]
                             )
-
-object WorkspaceResponse {
-  def apply(accessLevel: WorkspaceAccessLevel,
-            canShare: Boolean,
-            canCompute: Boolean,
-            catalog: Boolean,
-            workspace: WorkspaceDetails,
-            workspaceSubmissionStats: WorkspaceSubmissionStats,
-            bucketOptions: WorkspaceBucketOptions,
-            owners: Set[String]): WorkspaceResponse = {
-    WorkspaceResponse(Some(accessLevel), Some(canShare), Some(canCompute), Some(catalog), workspace,
-      Some(workspaceSubmissionStats), Some(bucketOptions), Some(owners), Map())
-  }
-}
 
 case class WorkspaceDetails(namespace: String,
                             name: String,
@@ -667,7 +652,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 
-  implicit val WorkspaceResponseFormat = jsonFormat9(WorkspaceResponse.apply)
+  implicit val WorkspaceResponseFormat = jsonFormat8(WorkspaceResponse.apply)
 
   implicit val WorkspaceAccessInstructionsFormat = jsonFormat2(ManagedGroupAccessInstructions)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -443,9 +443,9 @@ object WorkspaceDetails {
       workspace.createdDate,
       workspace.lastModified,
       workspace.createdBy,
-      Some(workspace.attributes),
+      Option(workspace.attributes),
       workspace.isLocked,
-      Some(authorizationDomain)
+      Option(authorizationDomain)
     )
   }
 }


### PR DESCRIPTION
This PR should have *zero* impact on functionality or end user behavior.

It modifies the `WorkspaceResponse` model object - and the `WorkspaceDetails` model object which is a component of `WorkspaceResponse` - to use `Option`s for many of its properties.

This PR is prep for a future PR, in which to assist with scale and performance I plan to allow the end user to specify which parts of the `WorkspaceResponse` should be calculated and returned as part of the get-workspace API. My thinking is to get this PR in to make that future one cleaner and easier to review; I would totally accept PR feedback of "please make one big PR so I can see it all together" if that's your opinion.

I considered an alternate implementation of making a `WorkspaceResponse` companion object and overloaded `apply` method. In practice that didn't offer much benefit  and imho was more confusing.

-----


- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
