### PR TITLE
GAWB-1112 Fix akka-http rejections lying about content-type

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -68,9 +68,9 @@ trait RawlsApiService //(val workspaceServiceConstructor: UserInfo => WorkspaceS
 
   implicit def rejectionHandler = RejectionHandler.newBuilder().handle {
     case mfrqc: MalformedRequestContentRejection => complete((BadRequest, HttpEntity(ContentTypes.`application/json`, s"""{"malformed request": "${mfrqc.message}"}""")))
-  }
+  }.result()
 
-  def route: server.Route = (logRequestResult & handleExceptions(RawlsApiService.exceptionHandler)) {
+  def route: server.Route = (logRequestResult & handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(rejectionHandler)) {
     swaggerRoutes ~
     versionRoutes ~
     statusRoute ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -66,9 +66,13 @@ trait RawlsApiService //(val workspaceServiceConstructor: UserInfo => WorkspaceS
 
   def apiRoutes = options { complete(OK) } ~ workspaceRoutes ~ entityRoutes ~ methodConfigRoutes ~ submissionRoutes ~ adminRoutes ~ userRoutes ~ billingRoutes ~ notificationsRoutes ~ servicePerimeterRoutes
 
-  implicit def rejectionHandler = RejectionHandler.newBuilder().handle {
-    case mfrqc: MalformedRequestContentRejection => complete((BadRequest, HttpEntity(ContentTypes.`application/json`, s"""{"malformed request": "${mfrqc.message}"}""")))
-  }.result()
+  implicit def rejectionHandler = {
+    import spray.json._
+    import DefaultJsonProtocol._
+    RejectionHandler.newBuilder().handle {
+      case mfrqc: MalformedRequestContentRejection => complete((BadRequest, HttpEntity(ContentTypes.`application/json`, Map("malformed request" -> mfrqc.message).toJson.toString)))
+    }.result()
+  }
 
   def route: server.Route = (logRequestResult & handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(rejectionHandler)) {
     swaggerRoutes ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -16,6 +16,7 @@ import akka.http.scaladsl.model.headers.{Location, OAuth2BearerToken}
 import spray.json.DefaultJsonProtocol._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
+import spray.json.{JsObject, JsValue}
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -1358,6 +1359,17 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.BadRequest) {
           status
         }
+      }
+  }
+
+  it should "return an error in real json when patching entity with badly shaped request body" in withTestDataApiServices { services =>
+    Patch(testData.sample1.path(testData.workspace), httpJson(AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")):AttributeUpdateOperation)) ~>
+      sealRoute(services.entityRoutes)(rejectionHandler=RawlsApiService.rejectionHandler) ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+        responseAs[JsObject]
       }
   }
 


### PR DESCRIPTION
Akka-http will reject requests for being malformed, e.g. the request body doesn't unmarshall to the right shape, or is too long. But its behaviour is... pretty bad. Here's a PATCH entity in Rawls with valid JSON that's the wrong shape:

```
$ curl -X PATCH -vv --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'Authorization: Bearer ya29.blah' -d '{"addUpdateAttribute":"test_value","attributeName":"test_name","op":"AddUpdateAttribute"}' 'https://firecloud-fiab.dsde-dev.broadinstitute.org:23443/api/workspaces/swaggerforward/feep/entities/participant/test1'

> PATCH /api/workspaces/swaggerforward/feep/entities/participant/test1 HTTP/1.1
> Content-Type: application/json
> Accept: application/json

* upload completely sent off: 89 out of 89 bytes
< HTTP/1.1 400 Bad Request
< Date: Fri, 06 Sep 2019 18:18:43 GMT
< Server: spray-can/1.3.4
< X-Frame-Options: SAMEORIGIN
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Headers: authorization,content-type,accept,origin,x-app-id
< Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD
< Access-Control-Max-Age: 1728000

< Content-Type: application/json; charset=UTF-8
< Content-Length: 159
< Connection: close

The request content was malformed:
Expected Array as JsArray, but got {"addUpdateAttribute":"test_value","attributeName":"test_name","op":"AddUpdateAttribute"}
```

Note that:

* The request headers ask for `application/json`
* The response is 400 (which is expected)
* The response headers say the response is in `application/json`
* The response is just some text, and not JSON at all!

This is apparently [standards-compliant](https://doc.akka.io/docs/akka-http/current/routing-dsl/rejections.html?language=scala#customising-rejection-http-responses), and they're pretty open about it:

> Please note that since those are not 200 responses, a different content type than the one that was sent in a client’s Accept header is legal. Thus the default handler renders such rejections as `text/plain`.

This is fine in curl, but Swagger _really_ doesn't like it -- it interprets the response code as `0` and returns no content.

This PR adds a new rejection handler that converts [all akka-http rejections](https://github.com/akka/akka-http/blob/master/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala) to JSON, which makes Swagger happy.

I did a little digging around on the swagger-ui GitHub issues page. [This thread](https://github.com/swagger-api/swagger-ui/issues/4673) outlines the problem, and the response was "try the latest Swagger". I don't know if we'd rather do that instead.