### PR TITLE
discardEntityBytes when you don't read the response

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -52,7 +52,9 @@ class HttpSamDAO(baseSamServiceURL: String, serviceAccountCreds: Credential)(imp
     retry(when401or500) { () =>
       httpClientUtils.executeRequest(http, httpClientUtils.addHeader(request, authHeader(userInfo))).flatMap { response =>
         response.status match {
-          case s if s.isSuccess => Future(())
+          case s if s.isSuccess =>
+            response.discardEntityBytes()
+            Future(())
           case f =>
             // attempt to propagate an ErrorReport from Sam. If we can't understand Sam's response as an ErrorReport,
             // create our own error message.


### PR DESCRIPTION
I spotted this weird error in Rawls logs while debugging a performance thing:

```

Sep 17 16:32:04 gce-rawls-perf402 rawls-app[3293]: [WARN] [09/17/2019 20:32:04.506] [rawls-akka.actor.default-dispatcher-2] [rawls/Pool(shared->https://sam.dsde-perf.broadinstitute.org:443)] [1 (WaitingForResponseEntitySubscription)] Response entity was not subscribed after 1 second. Make sure to read the response entity body or call `discardBytes()` on it. PUT /api/resources/v1/billing-project/aou-rw-perf-9b38863c/policies/workspace-creator Strict(62 bytes) -> 201 Created Default(76 bytes)
```

Did a little digging around and found [this](https://doc.akka.io/docs/akka-http/current/implications-of-streaming-http-entity.html#discarding-the-http-response-entity-client-), which says basically the same thing: when you make an akka request, make sure you either read the entity or call `discardEntityBytes`, else it'll start applying backpressure and slow things down.

I tried this on perf but it doesn't make any difference. It's good housekeeping anyway.