### PR TITLE
Save errors when writing workflow outputs instead of restarting forever [WA-60]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -492,11 +492,11 @@ trait EntityComponent {
       if (upserts.isEmpty && deletes.isEmpty) {
         DBIO.successful(()) //no-op
       } else if (deleteIntersectUpsert.nonEmpty) {
-        DBIO.failed(new RawlsException(s"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"))
+        DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(message = s"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert", statusCode = StatusCodes.BadRequest)))
       } else {
         getEntityRecords(workspaceContext.workspaceId, Set(entityRef)) flatMap { entityRecs =>
           if (entityRecs.length != 1) {
-            throw new RawlsException(s"saveEntityPatch looked up $entityRef expecting 1 record, got ${entityRecs.length} instead")
+            throw new RawlsExceptionWithErrorReport(ErrorReport(message = s"saveEntityPatch looked up $entityRef expecting 1 record, got ${entityRecs.length} instead", statusCode = StatusCodes.BadRequest))
           }
 
           val entityRecord = entityRecs.head


### PR DESCRIPTION
Buckle up, this is gonna be a ride.

I was in the Rawls logs today investigating a user liaison issue and noticed a lot of spam looking like this:

```
[rawls-akka.actor.default-dispatcher-95] o.b.d.r.jobexec.SubmissionSupervisor - error monitoring submission [[redacted]] in workspace [[redacted]] after 2209 times
    October 30th 2019, 12:05:52.000    Oct 30 12:05:52 gce-rawls-prod601 rawls-app[1580]: org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport: ErrorReport(rawls,Attribute name participant_id is reserved,Some(400 Bad Request),List(),List(),None)
    October 30th 2019, 12:05:51.000    Oct 30 12:05:51 gce-rawls-prod601 rawls-app[1580]: [ERROR] [10/30/2019 16:05:51.962] [rawls-akka.actor.default-dispatcher-18] [akka://rawls/user/rawls-submission-supervisor/[[redacted]]] org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport: ErrorReport(rawls,Attribute name participant_id is reserved,Some(400 Bad Request),List(),List(),None)
```

What's happening here:
* A workflow has succeeded in Cromwell.
* The Rawls submission monitor is picking it up, and is writing back its outputs to the entity model.
* The method config associated with the workflow is attempting to write one of the outputs back to the attribute `participant_id`.
* `participant_id` is a reserved attribute name and cannot be overwritten.
* Rawls throws an exception which is caught and triggers a restart of the submission monitor.
* Repeatedly, forever (2209 times and counting).

This PR is an untested, uncompiled, best-guess stab at a fix for this. The rationale:

`SubmissionMonitorActor.saveEntities` calls `EntityComponent.saveEntityPatch`. The triggering behaviour is in `saveEntityPatch`'s call to `validateAttributeName`, which throws a `RawlsExceptionWithErrorReport` if you're attempting to write to a reserved attribute name. The current behaviour is for this exception to be caught, fail the `DBIOAction` in `SubmissionMonitorActor.handleOutputs`, and ultimately trigger the actor to be restarted (repeatedly, forever). The goal with this PR is to take the call to `saveEntityPatch`, wrap it in a `Try`, and only trigger an actor-level failure if the exception type is *not* `RawlsExceptionWithErrorReport`. In other cases, we can treat this failure the same as other kinds of failure when writing outputs and simply fail the workflow. This is the rationale behind the code I've written in the `yield` block of `handleOutputs`, though my implementation is horrific.

Whichever unfortunate soul picks up this ticket should probably:
a) make it compile
b) write some tests confirming the new behaviour is correct

Note also that method configs should probably turn you away if you're trying to write to a reserved attribute name. We apparently don't check for this and should; this deserves a ticket.