### PR TITLE
AS-68: retrieve attributes/authorizationDomain if top-level workspace is requested [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -212,6 +212,9 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
               Future.successful(WorkspaceAccessLevels.NoAccess)
             }
 
+          // determine whether or not to retrieve attributes
+          val useAttributes = options.contains("workspace") || attrSpecs.all || attrSpecs.attrsToSelect.nonEmpty
+
           traceDBIOWithParent("accessLevelFuture", s2)(s3 => DBIO.from(accessLevelFuture())) flatMap { accessLevel =>
             // we may have calculated accessLevel because canShare/canCompute needs it;
             // but if the user didn't ask for it, don't return it
@@ -246,7 +249,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
               noFuture
             }
 
-            def workspaceAuthorizationDomainFuture(): Future[Option[Set[ManagedGroupRef]]] = if (options.contains("workspace.authorizationDomain")) {
+            def workspaceAuthorizationDomainFuture(): Future[Option[Set[ManagedGroupRef]]] = if (options.contains("workspace.authorizationDomain") || options.contains("workspace")) {
               traceWithParent("loadResourceAuthDomain",s2)(_ =>  loadResourceAuthDomain(SamResourceTypeNames.workspace, workspaceContext.workspace.workspaceId, userInfo).map(Option(_)))
             } else {
               noFuture
@@ -273,7 +276,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
               stats <- traceDBIOWithParent("workspaceSubmissionStatsFuture", s2)( _ => workspaceSubmissionStatsFuture())
             } yield {
               // post-process JSON to remove calculated-but-undesired keys
-              val workspaceResponse = WorkspaceResponse(optionalAccessLevelForResponse, canShare, canCompute, canCatalog, WorkspaceDetails.fromWorkspaceAndOptions(workspaceContext.workspace, authDomain, attrSpecs.all || attrSpecs.attrsToSelect.nonEmpty), stats, bucketDetails, owners)
+              val workspaceResponse = WorkspaceResponse(optionalAccessLevelForResponse, canShare, canCompute, canCatalog, WorkspaceDetails.fromWorkspaceAndOptions(workspaceContext.workspace, authDomain, useAttributes), stats, bucketDetails, owners)
               val filteredJson = deepFilterJsObject(workspaceResponse.toJson.asJsObject, options)
               RequestComplete(StatusCodes.OK, filteredJson)
             }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -291,6 +291,22 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
       }
   }
 
+  List("attributes", "authorizationDomain", "bucketName", "createdBy", "createdDate", "isLocked", "lastModified",
+       "name", "namespace", "workflowCollectionName", "workspaceId") foreach { workspaceKey =>
+
+    it should s"include $workspaceKey subkey of workspace when specifying the top-level key" in withTestWorkspacesApiServices { services =>
+      Get(testWorkspaces.workspace.path + "?fields=workspace") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) { status }
+          val actual = responseAs[String].parseJson.asJsObject
+          val workspaceFields  = actual.fields.get("workspace").getOrElse(new JsObject(Map.empty)).asJsObject.fields
+          assert(workspaceFields.contains(workspaceKey))
+        }
+    }
+
+  }
+
   it should "include multiple keys simultaneously when asked to" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=canShare,workspace.attributes,accessLevel") ~>
       sealRoute(services.workspaceRoutes) ~>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -291,9 +291,12 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
       }
   }
 
-  List("attributes", "authorizationDomain", "bucketName", "createdBy", "createdDate", "isLocked", "lastModified",
-       "name", "namespace", "workflowCollectionName", "workspaceId") foreach { workspaceKey =>
-
+  // find all the members of the WorkspaceDetails case class; check that each of them is returned inside the workspace object
+  import scala.reflect.runtime.universe._
+  val workspaceDetailsMembers:List[String] = typeOf[WorkspaceDetails].members.collect {
+    case m: MethodSymbol if m.isCaseAccessor => m.name.toString
+  }.toList
+  workspaceDetailsMembers.foreach { workspaceKey =>
     it should s"include $workspaceKey subkey of workspace when specifying the top-level key" in withTestWorkspacesApiServices { services =>
       Get(testWorkspaces.workspace.path + "?fields=workspace") ~>
         sealRoute(services.workspaceRoutes) ~>
@@ -304,7 +307,6 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
           assert(workspaceFields.contains(workspaceKey))
         }
     }
-
   }
 
   it should "include multiple keys simultaneously when asked to" in withTestWorkspacesApiServices { services =>


### PR DESCRIPTION
Consider the get-workspace API response, which looks like this:
```
{
  "accessLevel": "READER",
  "bucketOptions": {
    "requesterPays": false
  },
  ...
  "workspace": {
    "attributes": {
      "funco_data_sources_tar_gz": "gs://broad-public-datasets/funcotator/funcotator_dataSources.v1.6.20190124s.tar.gz",
      "oncotator_ds_tar_gz": "gs://gatk-best-practices/somatic-b37/oncotator_v1_ds_April052016.tar.gz",
      ...
    },
    "authorizationDomain": [],
    "bucketName": "fc-0269d0d7-6919-4c6b-8875-b818f1cd27bf",
    "createdBy": "bshifaw@broadinstitute.org",
    ...
  },
  "workspaceSubmissionStats": {
    "runningSubmissionsCount": 0
  }
}
```

The `fields` query  parameter on this API was intended to function such that if you included "workspace", you'd get the entire `workspace` object back in the response.  As filed in AS-68, the reality is that if you specified "workspace" you'd get most of the object back, but the response would omit `workspace.attributes` and `workspace.authorizationDomain`.

Fixing this bug would have performance implications, both in response payload size and  in backend computation, for the use case of any callers who specified `fields=workspace` but did not also include `fields=workspace.attributes` and `workspace.authorizationDomain`. This is because we'd suddenly be calculating and returning more data than before this PR, for that use case.

I analyzed the last 30 days of request logs and do not see that use case. Terra UI explicitly specifies all of these (https://github.com/DataBiosphere/terra-ui/blob/dev/src/pages/workspaces/workspace/WorkspaceContainer.js#L183) and AoU does not specify the top-level `workspace` object.

Therefore I believe it is safe to fix this bug as it brings the API to correctness, but will not have performance implications for current clients.

-----

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
