### PR TITLE
[AS-134] Expose requireAccess as checkSamActionWithLock

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2423,7 +2423,7 @@ paths:
       responses:
         '204':
           description: User can perform the given action on the workspace
-        '401':
+        '403':
           description: User may not perform the given action on the workspace (including if it doesn't exist)
           schema:
             $ref: '#/definitions/ErrorReport'

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2418,6 +2418,41 @@ paths:
             - openid
             - email
             - profile
+  '/api/workspaces/{workspaceNamespace}/{workspaceName}/checkSamActionWithLock/{samActionName}':
+    get:
+      responses:
+        '204':
+          description: User can perform the given action on the workspace
+        '401':
+          description: User may not perform the given action on the workspace (including if it doesn't exist)
+          schema:
+            $ref: '#/definitions/ErrorReport'
+      description: Check to see if the user has the given action on a workspace. Takes into account if the workspace is locked too.
+      tags:
+        - workspaces
+      summary: Check sam action with lock
+      operationId: checkSamActionWithLock
+      parameters:
+        - in: path
+          description: Workspace Namespace
+          name: workspaceNamespace
+          required: true
+          type: string
+        - in: path
+          description: Workspace Name
+          name: workspaceName
+          required: true
+          type: string
+        - in: path
+          description: Sam action
+          name: samActionName
+          required: true
+          type: string
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   '/api/workspaces/{workspaceNamespace}/{workspaceName}/lock':
     put:
       responses:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2425,6 +2425,8 @@ paths:
           description: User can perform the given action on the workspace
         '403':
           description: User may not perform the given action on the workspace (including if it doesn't exist)
+        '500':
+          description: Rawls Internal Error
           schema:
             $ref: '#/definitions/ErrorReport'
       description: Check to see if the user has the given action on a workspace in Sam. Takes into account if the workspace is locked too.

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2418,7 +2418,7 @@ paths:
             - openid
             - email
             - profile
-  '/api/workspaces/{workspaceNamespace}/{workspaceName}/checkSamActionWithLock/{samActionName}':
+  '/api/workspaces/{workspaceNamespace}/{workspaceName}/checkIamActionWithLock/{samActionName}':
     get:
       responses:
         '204':
@@ -2427,11 +2427,11 @@ paths:
           description: User may not perform the given action on the workspace (including if it doesn't exist)
           schema:
             $ref: '#/definitions/ErrorReport'
-      description: Check to see if the user has the given action on a workspace. Takes into account if the workspace is locked too.
+      description: Check to see if the user has the given action on a workspace in Sam. Takes into account if the workspace is locked too.
       tags:
         - workspaces
-      summary: Check sam action with lock
-      operationId: checkSamActionWithLock
+      summary: Check IAM action with lock
+      operationId: checkIamActionWithLock
       parameters:
         - in: path
           description: Workspace Namespace

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -126,6 +126,11 @@ trait WorkspaceApiService extends UserInfoDirectives {
           complete { workspaceServiceConstructor(userInfo).CheckBucketReadAccess(WorkspaceName(workspaceNamespace, workspaceName)) }
         }
       } ~
+      path("workspaces" / Segment / Segment / "checkSamActionWithLock" / Segment) { (workspaceNamespace, workspaceName, requiredAction) =>
+        get {
+          complete { workspaceServiceConstructor(userInfo).CheckSamActionWithLock(WorkspaceName(workspaceNamespace, workspaceName), SamResourceAction(requiredAction)) }
+        }
+      } ~
       path("workspaces" / Segment / Segment / "lock") { (workspaceNamespace, workspaceName) =>
         put {
           complete { workspaceServiceConstructor(userInfo).LockWorkspace(WorkspaceName(workspaceNamespace, workspaceName)) }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -126,7 +126,7 @@ trait WorkspaceApiService extends UserInfoDirectives {
           complete { workspaceServiceConstructor(userInfo).CheckBucketReadAccess(WorkspaceName(workspaceNamespace, workspaceName)) }
         }
       } ~
-      path("workspaces" / Segment / Segment / "checkSamActionWithLock" / Segment) { (workspaceNamespace, workspaceName, requiredAction) =>
+      path("workspaces" / Segment / Segment / "checkIamActionWithLock" / Segment) { (workspaceNamespace, workspaceName, requiredAction) =>
         get {
           complete { workspaceServiceConstructor(userInfo).CheckSamActionWithLock(WorkspaceName(workspaceNamespace, workspaceName), SamResourceAction(requiredAction)) }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1840,7 +1840,9 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
     }
     //if we failed for any reason, the user can't do that thing on the workspace
-    testFuture.recover { case _ => RequestComplete(StatusCodes.Unauthorized) }
+    testFuture.recover { case _ =>
+      println("huh")
+      RequestComplete(StatusCodes.Unauthorized) }
   }
 
   def listAllActiveSubmissions() = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1841,7 +1841,6 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     }
     //if we failed for any reason, the user can't do that thing on the workspace
     testFuture.recover { case _ =>
-      println("huh")
       RequestComplete(StatusCodes.Unauthorized) }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -160,6 +160,14 @@ class CustomizableMockSamDAO(dataSource: SlickDataSource)(implicit executionCont
     Future.successful(())
   }
 
+  override def userHasAction(resourceTypeName: SamResourceTypeName, resourceId: String, action: SamResourceAction, userInfo: UserInfo): Future[Boolean] = {
+    val pol = policies((resourceTypeName, resourceId))
+    //iterate through map and find a value that contains the action and the user
+    Future.successful(pol.exists(p =>
+      p._2.policy.actions.contains(action) &&
+        p._2.policy.memberEmails.contains(WorkbenchEmail(userInfo.userEmail.value))) )
+  }
+
   override def getPoliciesForType(resourceTypeName: SamResourceTypeName, userInfo: UserInfo): Future[Set[SamResourceIdWithPolicyName]] = {
     val policiesForType = for {
       ((typeName, resourceId), resourcePolicies) <- policies if typeName == resourceTypeName

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -535,7 +535,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
   it should "fail sam write action check for a user with read access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(testData.userReader) { services =>
     populateWorkspacePolicies(services)
     val rqComplete = Await.result(services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.write), Duration.Inf).asInstanceOf[RequestComplete[StatusCode]]
-    assertResult(StatusCodes.Unauthorized) {
+    assertResult(StatusCodes.Forbidden) {
       rqComplete.response
     }
   }
@@ -557,7 +557,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     //now as a writer, ask if we can write it. but it's locked!
     val readerWorkspaceService = services.workspaceServiceConstructor(UserInfo(testData.userWriter.userEmail, OAuth2BearerToken("token"), 0, testData.userWriter.userSubjectId))
     val rqComplete = Await.result(readerWorkspaceService.checkSamActionWithLock(testData.workspaceNoSubmissions.toWorkspaceName, SamWorkspaceActions.write), Duration.Inf).asInstanceOf[RequestComplete[StatusCode]]
-    assertResult(StatusCodes.Unauthorized) {
+    assertResult(StatusCodes.Forbidden) {
       rqComplete.response
     }
   }


### PR DESCRIPTION
In import-service-land we need to check to see if the user can actually import data. It is not as simple as "has the write action in Sam", as you can't import if the workspace is locked. Our current approach is to do an empty import first -- try it and see. This strikes me as Weird :tm: . So this PR essentially exposes `requireAccess` as an endpoint so we can test it and leave the implementation on the Rawls side.

I will open an Orch swagger PR if this gets thumbed.