### PR TITLE
[noticket] Bump scala-compiler version for sourceclear vuln

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -48,7 +48,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde",
-    scalaVersion  := "2.12.2",
+    scalaVersion  := "2.12.4",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )


### PR DESCRIPTION
@ssyms alerted me to a sourceclear vuln in Rawls for scala-compiler. Revving the version removes the vuln.