### PR TITLE
Fix hog limit bug [WA-173]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -299,9 +299,8 @@ object Boot extends IOApp with LazyLogging {
         metricsPrefix
       )
 
-      val maxActiveWorkflowsTotal = conf.getInt(
-        "executionservice.maxActiveWorkflowsPerServer"
-      ) * executionServiceServers.size
+      val maxActiveWorkflowsTotal =
+        conf.getInt("executionservice.maxActiveWorkflowsPerServer")
       val maxActiveWorkflowsPerUser = maxActiveWorkflowsTotal / conf.getInt(
         "executionservice.activeWorkflowHogFactor"
       )


### PR DESCRIPTION
Don't use number of Cromwell servers to calculate how many workflows per user to allow.

Closes https://broadworkbench.atlassian.net/browse/WA-173
