### PR TITLE
AS-302: use proper project for updating import service job status [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -191,6 +191,15 @@ object Boot extends IOApp with LazyLogging {
         conf.getString("avroUpsertMonitor.arrowPubSubProject"),
         workbenchMetricBaseName = metricsPrefix
       )
+      // Import service uses a different project for its pubsub topic
+      val importServicePubSubDAO = new HttpGooglePubSubDAO(
+        clientEmail,
+        pathToPem,
+        appName,
+        conf.getString("avroUpsertMonitor.updateImportStatusPubSubProject"),
+        workbenchMetricBaseName = metricsPrefix
+      )
+
       val importServiceDAO = new HttpImportServiceDAO(conf.getString("avroUpsertMonitor.server"))
 
       val bigQueryDAO = new HttpGoogleBigQueryDAO(
@@ -405,6 +414,7 @@ object Boot extends IOApp with LazyLogging {
           gcsDAO,
           samDAO,
           pubSubDAO,
+          importServicePubSubDAO,
           arrowPubSubDAO, // remove when cutting over to import service
           importServiceDAO,
           appDependencies.googleStorageService,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -32,6 +32,7 @@ object BootMonitors extends LazyLogging {
                    gcsDAO: GoogleServicesDAO,
                    samDAO: SamDAO,
                    pubSubDAO: GooglePubSubDAO,
+                   importServicePubSubDAO: GooglePubSubDAO,
                    arrowPubSubDAO: GooglePubSubDAO,  // remove when cutting over to import service
                    importServiceDAO: HttpImportServiceDAO,
                    googleStorage: GoogleStorageService[IO],
@@ -92,7 +93,7 @@ object BootMonitors extends LazyLogging {
     )
 
     //Boot the avro upsert monitor to read and process messages in the specified PubSub topic
-    startAvroUpsertMonitor(system, workspaceService, gcsDAO, samDAO, googleStorage, pubSubDAO,
+    startAvroUpsertMonitor(system, workspaceService, gcsDAO, samDAO, googleStorage, pubSubDAO, importServicePubSubDAO,
       arrowPubSubDAO, importServiceDAO, avroUpsertMonitorConfig)
   }
 
@@ -191,7 +192,7 @@ object BootMonitors extends LazyLogging {
     system.actorOf(BucketDeletionMonitor.props(slickDataSource, gcsDAO, 10 seconds, 6 hours))
   }
 
-  private def startAvroUpsertMonitor(system: ActorSystem, workspaceService: UserInfo => WorkspaceService, googleServicesDAO: GoogleServicesDAO, samDAO: SamDAO, googleStorage: GoogleStorageService[IO], googlePubSubDAO: GooglePubSubDAO, arrowPubSubDao: GooglePubSubDAO, importServiceDAO: HttpImportServiceDAO, avroUpsertMonitorConfig: AvroUpsertMonitorConfig)(implicit cs: ContextShift[IO]) = {
+  private def startAvroUpsertMonitor(system: ActorSystem, workspaceService: UserInfo => WorkspaceService, googleServicesDAO: GoogleServicesDAO, samDAO: SamDAO, googleStorage: GoogleStorageService[IO], googlePubSubDAO: GooglePubSubDAO, importServicePubSubDAO: GooglePubSubDAO, arrowPubSubDao: GooglePubSubDAO, importServiceDAO: HttpImportServiceDAO, avroUpsertMonitorConfig: AvroUpsertMonitorConfig)(implicit cs: ContextShift[IO]) = {
     system.actorOf(
       AvroUpsertMonitorSupervisor.props(
         workspaceService,
@@ -199,6 +200,7 @@ object BootMonitors extends LazyLogging {
         samDAO,
         googleStorage,
         googlePubSubDAO,
+        importServicePubSubDAO,
         arrowPubSubDao,
         importServiceDAO,
         avroUpsertMonitorConfig

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -117,6 +117,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
       services.samDAO,
       googleStorage,
       services.gpsDAO,
+      services.gpsDAO,
       services.gpsDAO, // remove when cutting over to import service
       mockImportServiceDAO,
       config


### PR DESCRIPTION
When we originally developed this Rawls code, we were using a hand-rolled dev environment for import service, and the import-service-notify-${ENV} pubsub topic lived in broad-dsde-dev, alongside Rawls. 

That's not our final architecture - that pubsub topic lives in terra-importservice-${ENV}, alongside the import service GAE app.

Therefore, Rawls needs this PR in order to publish to the topic.