### PR TITLE
entity provider refactor part 2 [no ticket; risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, EntityProvid
 import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoEntityProvider
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{UserInfo, Workspace}
 
 import scala.reflect.runtime.universe._
 
@@ -50,7 +50,7 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
   }
 
   // convenience for a likely-common pattern
-  def resolveProvider(workspace: Workspace, userInfo: UserInfo) =
+  def resolveProvider(workspace: Workspace, userInfo: UserInfo): EntityProvider =
     resolveProvider(EntityRequestArguments(workspace, userInfo))
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -1,39 +1,56 @@
 package org.broadinstitute.dsde.rawls.entities
 
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, EntityProviderBuilder}
+import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoEntityProvider
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, Workspace}
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
-import scala.concurrent.Future
 import scala.reflect.runtime.universe._
 
 /**
- * Requests for entity operations enter here. This is the interface that calling code should use; calling
- * code should not directly access entity providers.
- * This manager will inspect the request and route it to the appropriate provider.
+ * Here's the philosophy behind the important entity classes:
+ *
+ * EntityProvider:
+ *    these do the nuts-and-bolts work of connecting to a datasource and manipulating the entities therein.
+ *    EntityProvider authors should not have to worry too much about thread safety, multitenancy, concurrency, etc - so,
+ *    we create a new EntityProvider instance for each request.
+ *
+ *    Subclasses are:
+ *      - LocalEntityProvider: the default. Legacy Rawls/CloudSQL implementation.
+ *      - DataRepoEntityProvider: for working with Terra Data Repo snapshots.
+ *
+ * EntityProviderBuilder:
+ *    since we create many instances of EntityProvider, we want a factory pattern. These builders are responsible
+ *    for making the various EntityProvider instances. Builders should be singletons, and can be instantiated
+ *    once with config values or other arguments that the provider instances will need.
+ *
+ * EntityManager:
+ *    another singleton, the EntityManager is instantiated with the set of ProviderBuilders that this application
+ *    knows about. The manager is responsible for inspecting the inbound request, determining which builder should
+ *    be used to satisfy the request, and using that builder to create and return a provider instance.
+ *
  */
 class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvider]]) {
 
-  /** create the supplied entity inside the supplied workspace.
-   */
-  def createEntity(workspace: Workspace, entity: Entity): Future[Entity] = {
-    resolveProvider(workspace).createEntity(entity)
-  }
+  // should we combine any of these arguments into a "EntityRequestArguments" case class,
+  // for encapsulation/abstraction?
+  def resolveProvider(workspace: Workspace,
+                      userInfo: UserInfo,
+                      dataReference: Option[String] = None,
+                      billingProject: Option[RawlsBillingProject] = None): EntityProvider = {
 
-  // soon: this interface will have multiple other methods, for example:
-  def getEntity(workspace: Workspace, entityRef: AttributeEntityReference) = ???
+    // soon: look up the reference name to ensure it exists.
+    // for now, this simplistic logic illustrates the approach: choose the right builder for the job.
+    val targetTag = if (dataReference.isDefined) {
+      typeTag[DataRepoEntityProvider]
+    } else {
+      typeTag[LocalEntityProvider]
+    }
 
-  // internal method to figure out which entityprovider should be used for a given request
-  private def resolveProvider(workspace: Workspace): EntityProvider = {
-    // soon: inspect the workspace's registered snapshots plus request parameters,
-    // and route to the appropriate entity provider. This will likely require a method signature change
-    // to accept request details. For now, just find the builder for DefaultEntityProvider.
-    val defaultEntityProviderBuilder = providerBuilders.find(_.builds == typeTag[LocalEntityProvider])
-
-    defaultEntityProviderBuilder match {
+    providerBuilders.find(_.builds == targetTag) match {
       case None => throw new DataEntityException(s"no entity provider available for ${workspace.toWorkspaceName}")
-      case Some(builder) =>builder.build(workspace)
+      case Some(builder) => builder.build(workspace, userInfo, dataReference, billingProject)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityRequestArguments.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityRequestArguments.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.rawls.entities
+
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
+
+case class EntityRequestArguments(workspace: Workspace,
+                                  userInfo: UserInfo,
+                                  dataReference: Option[String] = None,
+                                  billingProject: Option[RawlsBillingProject] = None)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.{StatusCodes, Uri}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource, SlickWorkspaceContext}
+import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoEntityProviderBuilder
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProviderBuilder
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
@@ -30,8 +31,9 @@ object EntityService {
     // in the context of a workspace, this is safe/correct to do here. We also want to use the same dataSource
     // and execution context for the rawls entity provider that the entity service uses.
     val defaultEntityProviderBuilder = new LocalEntityProviderBuilder(dataSource) // implicit executionContext
-    // soon: create a provider-builder for data repo and add it to the entity manager
-    val entityManager = new EntityManager(Set(defaultEntityProviderBuilder))
+    val dataRepoEntityProviderBuilder = new DataRepoEntityProviderBuilder
+
+    val entityManager = new EntityManager(Set(defaultEntityProviderBuilder, dataRepoEntityProviderBuilder))
 
     new EntityService(userInfo, dataSource, samDAO, entityManager, workbenchMetricBaseName)
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -59,7 +59,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[Entity] =
     withAttributeNamespaceCheck(entity) {
       getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
-        entityManager.createEntity(workspaceContext.workspace, entity)
+        entityManager.resolveProvider(workspaceContext.workspace, userInfo).createEntity(entity)
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
-import org.broadinstitute.dsde.rawls.model.Entity
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity}
 
 import scala.concurrent.Future
 
@@ -10,5 +10,7 @@ import scala.concurrent.Future
 trait EntityProvider {
 
   def createEntity(entity: Entity): Future[Entity]
+
+  def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int]
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderBuilder.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
 import scala.reflect.runtime.universe._
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderBuilder.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
+import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
 import scala.reflect.runtime.universe._
@@ -14,8 +15,5 @@ trait EntityProviderBuilder[T <: EntityProvider] {
 
   /** create the EntityProvider this builder knows how to create.
     */
-  def build(workspace: Workspace,
-            userInfo: UserInfo,
-            dataReference: Option[String] = None,
-            billingProject: Option[RawlsBillingProject] = None): T
+  def build(requestArguments: EntityRequestArguments): T
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProviderBuilder.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
-import org.broadinstitute.dsde.rawls.model.Workspace
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
 import scala.reflect.runtime.universe._
 
@@ -14,5 +14,8 @@ trait EntityProviderBuilder[T <: EntityProvider] {
 
   /** create the EntityProvider this builder knows how to create.
     */
-  def build(workspace: Workspace): T
+  def build(workspace: Workspace,
+            userInfo: UserInfo,
+            dataReference: Option[String] = None,
+            billingProject: Option[RawlsBillingProject] = None): T
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.rawls.entities.datarepo
+
+import org.broadinstitute.dsde.rawls.entities.base.EntityProvider
+import org.broadinstitute.dsde.rawls.entities.exceptions.UnsupportedEntityOperationException
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity}
+
+import scala.concurrent.Future
+
+class DataRepoEntityProvider extends EntityProvider {
+  override def createEntity(entity: Entity): Future[Entity] =
+    throw new UnsupportedEntityOperationException("create entity not supported by this provider.")
+
+  override def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int] =
+    throw new UnsupportedEntityOperationException("delete entities not supported by this provider.")
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,0 +1,15 @@
+package org.broadinstitute.dsde.rawls.entities.datarepo
+
+import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
+
+import scala.reflect.runtime.universe._
+
+class DataRepoEntityProviderBuilder extends EntityProviderBuilder[DataRepoEntityProvider] {
+  override def builds: TypeTag[DataRepoEntityProvider] = typeTag[DataRepoEntityProvider]
+
+  override def build(workspace: Workspace,
+                     userInfo: UserInfo,
+                     dataReference: Option[String] = None,
+                     billingProject: Option[RawlsBillingProject] = None): DataRepoEntityProvider = new DataRepoEntityProvider
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
 import scala.reflect.runtime.universe._
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
+import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
 import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
@@ -8,8 +9,5 @@ import scala.reflect.runtime.universe._
 class DataRepoEntityProviderBuilder extends EntityProviderBuilder[DataRepoEntityProvider] {
   override def builds: TypeTag[DataRepoEntityProvider] = typeTag[DataRepoEntityProvider]
 
-  override def build(workspace: Workspace,
-                     userInfo: UserInfo,
-                     dataReference: Option[String] = None,
-                     billingProject: Option[RawlsBillingProject] = None): DataRepoEntityProvider = new DataRepoEntityProvider
+  override def build(requestArguments: EntityRequestArguments): DataRepoEntityProvider = new DataRepoEntityProvider
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/UnsupportedEntityOperationException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/UnsupportedEntityOperationException.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.rawls.entities.exceptions
+
+import org.broadinstitute.dsde.rawls.RawlsException
+
+/** Exception related to working with data entities.
+ */
+class UnsupportedEntityOperationException(message: String = null, cause: Throwable = null) extends RawlsException(message, cause)
+

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.{SlickDataSource, SlickWorkspaceContext}
 import org.broadinstitute.dsde.rawls.entities.base.EntityProvider
-import org.broadinstitute.dsde.rawls.model.{Entity, ErrorReport, Workspace}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, ErrorReport, Workspace}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -29,4 +29,5 @@ class LocalEntityProvider(workspace: Workspace, dataSource: SlickDataSource)
     }
   }
 
+  override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] = ???
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.rawls.entities.local
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.local
 
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
 import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
@@ -16,11 +17,8 @@ class LocalEntityProviderBuilder(dataSource: SlickDataSource)
 
   override def builds: TypeTag[LocalEntityProvider] = typeTag[LocalEntityProvider]
 
-  override def build(workspace: Workspace,
-                     userInfo: UserInfo,
-                     dataReference: Option[String] = None,
-                     billingProject: Option[RawlsBillingProject] = None): LocalEntityProvider = {
-    new LocalEntityProvider(workspace, dataSource)
+  override def build(requestArguments: EntityRequestArguments): LocalEntityProvider = {
+    new LocalEntityProvider(requestArguments.workspace, dataSource)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.entities.local
 
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
-import org.broadinstitute.dsde.rawls.model.Workspace
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProject, UserInfo, Workspace}
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._
@@ -16,7 +16,10 @@ class LocalEntityProviderBuilder(dataSource: SlickDataSource)
 
   override def builds: TypeTag[LocalEntityProvider] = typeTag[LocalEntityProvider]
 
-  override def build(workspace: Workspace): LocalEntityProvider = {
+  override def build(workspace: Workspace,
+                     userInfo: UserInfo,
+                     dataReference: Option[String] = None,
+                     billingProject: Option[RawlsBillingProject] = None): LocalEntityProvider = {
     new LocalEntityProvider(workspace, dataSource)
   }
 


### PR DESCRIPTION
Aiming to make the entity provider and its surrounding classes more understandable and ready for multiple developers to contribute.