### PR TITLE
skip tests: fix swagger merge for tags, add security for snapshot apis [no ticket; risk: no]

### DIFF
--- a/core/src/main/resources/swagger/data-repo-only.yaml
+++ b/core/src/main/resources/swagger/data-repo-only.yaml
@@ -38,6 +38,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/DataRepoSnapshot'
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   '/api/workspaces/{namespace}/{name}/snapshots/{snapshotId}':
     get:
       responses:
@@ -74,10 +79,11 @@ paths:
           name: snapshotId
           required: true
           type: string
-
-tags:
-  - name: snapshots
-    description: Data Repo snapshot API
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
 
 definitions:
   DataRepoSnapshot:


### PR DESCRIPTION
two fixes:
1. add a `security` section for the snapshot APIs. I believe I commented on a previous PR that these could be left out because the swagger had a global default ... but it doesn't. It has a global `securityDefinitions` but not a global `security`.
2. remove the `tags` section from `data-repo-only.yaml`. When merging yamls, the underlying [deepMerge](https://circe.github.io/circe/api/io/circe/Json.html#deepMerge(that:io.circe.Json):io.circe.Json) does not concatenate arrays - so, the final yaml had *only* the value from `data-repo-only.yaml` and none from `api-docs.yaml`. Now `api-docs.yaml` is the source of truth for tags, and the UI hides the unused "snapshots" tag if it has no endpoints.