### PR TITLE
enable travis sbt caching [no ticket; risk: low]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,15 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - docker rm -f mysql
+
+# https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html#Caching
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  directories:
+    - $HOME/.cache/coursier
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt


### PR DESCRIPTION
enable sbt dependency caching in Travis.

see:
* https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html#Caching
* broadinstitute/firecloud-orchestration#778