### PR TITLE
AS-339: better debugging for jenkins builds [risk: low]

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -21,6 +21,8 @@ EOF
 # Enable strict evaluation semantics
 set -e
 
+echo "rawls docker/build.sh starting ..."
+
 # Set default variables
 DOCKER_CMD=
 BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}  # default to current branch
@@ -187,3 +189,5 @@ if $RUN_DOCKER; then
 fi
 
 cleanup
+
+echo "rawls docker/build.sh done"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -107,7 +107,7 @@ function make_jar()
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 broadinstitute/scala-baseimage /working/docker/install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -a stdout -a stderr -e SKIP_TESTS=$SKIP_TESTS -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier broadinstitute/scala-baseimage /working/docker/install.sh /working"
     JAR_CMD=$($DOCKER_RUN)
     EXIT_CODE=$?
 
@@ -128,7 +128,7 @@ function artifactory_push()
     ARTIFACTORY_USERNAME=dsdejenkins
     ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox vault read -field=password secret/dsp/accts/artifactory/dsdejenkins)
     echo "Publishing to artifactory..."
-    docker run --rm -v $PWD:/$PROJECT -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD broadinstitute/scala-baseimage:scala-2.11.8 /$PROJECT/core/src/bin/publishSnapshot.sh
+    docker run --rm -v $PWD:/$PROJECT -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier -w="/$PROJECT" -e ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME -e ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD broadinstitute/scala-baseimage:scala-2.11.8 /$PROJECT/core/src/bin/publishSnapshot.sh
 }
 
 function docker_cmd()

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -96,6 +96,7 @@ function make_jar()
 {
     echo "building jar..."
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
+        echo "starting mysql..."
         bash ./docker/run-mysql.sh start
     fi
 
@@ -107,12 +108,13 @@ function make_jar()
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -a stdout -a stderr -e SKIP_TESTS=$SKIP_TESTS -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier broadinstitute/scala-baseimage /working/docker/install.sh /working"
-    JAR_CMD=$($DOCKER_RUN)
+    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_MODEL_HASH=$GIT_MODEL_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier broadinstitute/scala-baseimage /working/docker/install.sh /working"
+    JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
 
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         # stop mysql
+        echo "stopping mysql..."
         bash ./docker/run-mysql.sh stop
     fi
 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -eux
+
+echo "rawls docker/install.sh starting ..."
 
 RAWLS_DIR=$1
 cd $RAWLS_DIR
@@ -13,10 +15,17 @@ fi
 if [ "$SKIP_TESTS" = "skip-tests" ]; then
 	echo skipping tests
 else
+  echo "starting sbt test ..."
 	sbt -J-Xms5g -J-Xmx5g -J-XX:MaxMetaspaceSize=5g test -Dmysql.host=mysql -Dmysql.port=3306
+	echo "sbt test done"
 fi
 
+echo "starting sbt assembly ..."
 sbt -J-Xms5g -J-Xmx5g -J-XX:MaxMetaspaceSize=5g assembly
+echo "... assembly complete, finding and moving jar ..."
 RAWLS_JAR=$(find target | grep 'rawls.*\.jar')
 mv $RAWLS_JAR .
+echo "... jar moved, cleaning ..."
 sbt clean
+
+echo "rawls docker/install.sh done"

--- a/jenkins/jenkins_build.sh
+++ b/jenkins/jenkins_build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 set -eux
+
+echo "rawls jenkins/jenkins_build.sh starting ..."
+
 SVCACCT_FILE="dspci-wb-gcr-service-account.json"
 GCR_SVCACCT_VAULT="secret/dsde/dsp-techops/common/$SVCACCT_FILE"
 VAULT_TOKEN=${VAULT_TOKEN:-$(cat /etc/vault-token-dsde)}
@@ -13,3 +16,5 @@ docker run --rm  -e VAULT_TOKEN=$VAULT_TOKEN \
 
 # clean up
 rm -f ${SVCACCT_FILE}
+
+echo "rawls jenkins/jenkins_build.sh done"


### PR DESCRIPTION
1. add debugging log statements to help diagnose jenkins build problems
2. send the stdout of `sbt test` to Jenkins console; since this was run in a subshell it needed a tweak to not suppress stdout. Previously we only saw stderr.
3. fix the ivy/sbt/coursier cache mounts, I don't expect this to show much difference.

Reviewer: if you're curious, click through to the jenkins build to see its output:
https://fc-jenkins.dsp-techops.broadinstitute.org/job/rawls-build/2914/console