### PR TITLE
AS-375: handle spaces in workspace names when talking to import service [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpImportServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpImportServiceDAO.scala
@@ -5,7 +5,8 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.stream.Materializer
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.model.ImportStatuses
@@ -30,7 +31,7 @@ class HttpImportServiceDAO(url: String)(implicit val system: ActorSystem, val ma
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import ImportServiceJsonSupport._
 
-    val requestUrl = s"$url/${workspaceName.namespace}/${workspaceName.name}/imports/$importId"
+    val requestUrl = Uri(url).withPath(Path(s"/${workspaceName.namespace}/${workspaceName.name}/imports/$importId"))
 
     val importStatusResponse: Future[Option[ImportServiceResponse]] =  retry[Option[ImportServiceResponse]](when500) { () =>
         executeRequestWithToken[Option[ImportServiceResponse]](userInfo.accessToken)(Get(requestUrl)) recover {


### PR DESCRIPTION
properly encode spaces in workspace names/urls when talking to import service