### PR TITLE
downgrade sbt to address sourceclear compatibility [no ticket; risk: no]

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.2.8


### PR DESCRIPTION
getting potentially-false positives from sourceclear when rawls uses sbt 1.3 .... sourceclear appears to be scanned excluded transitive dependencies, when it should ignore them.

this PR downgrades to sbt 1.2.8 ... let's see if this is better.

I am unclear if this is a problem with the sourceclear scan itself, or if this is a problem with sbt/coursier.

- sbt/sbt  issue 5170
- coursier/coursier issue 1590
- coursier/sbt-coursier pull 235

are all relevant links, and we should revisit Rawls' sbt version once the coursier fixes are released and sbt adopts them in one of their releases.

(I'm not linking them directly to avoid spamming the issues with extraneous references)


