### PR TITLE
AS-322: get-entity supports data repo [risk: low]

### DIFF
--- a/core/src/main/resources/swagger/data-repo-only.yaml
+++ b/core/src/main/resources/swagger/data-repo-only.yaml
@@ -29,6 +29,15 @@ paths:
                 $ref: '#/components/schemas/AttributeEntityReference'
         required: true
       x-codegen-request-body-name: entities
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/{entityName}:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+        - $ref: '#/components/parameters/entityTypePathParam'
+        - $ref: '#/components/parameters/entityNamePathParam'
+        - $ref: '#/components/parameters/dataReferenceQueryParam'
+        - $ref: '#/components/parameters/billingProjectQueryParam'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots:
     get:
       tags:
@@ -44,12 +53,16 @@ paths:
           description: The number of items to skip before starting to collect the result
             set.
           required: true
-          schema: {}
+          schema:
+            type: integer
+          example: 0
         - name: limit
           in: query
           description: The number of items to return.
           required: true
-          schema: {}
+          schema:
+            type: integer
+          example: 10
       responses:
         200:
           description: OK
@@ -231,6 +244,20 @@ components:
       name: dataReference
       in: query
       description: Data reference name to query for entity metadata
+      schema:
+        type: string
+    entityNamePathParam:
+      name: entityName
+      in: path
+      description: Entity Name
+      required: true
+      schema:
+        type: string
+    entityTypePathParam:
+      name: entityType
+      in: path
+      description: Entity Type
+      required: true
       schema:
         type: string
     snapshotIdPathParam:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -25,7 +25,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.HttpWorkspaceMa
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess.{ExecutionServiceDAO, _}
-import org.broadinstitute.dsde.rawls.entities.EntityService
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.google.{HttpGoogleAccessContextManagerDAO, HttpGooglePubSubDAO}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
@@ -392,12 +392,14 @@ object Boot extends IOApp with LazyLogging {
         requesterPaysSetupService
       )
 
+      // create the entity manager.
+      val entityManager = EntityManager.defaultEntityManager(slickDataSource, workspaceManagerDAO, dataRepoDAO)
+
       val entityServiceConstructor: (UserInfo) => EntityService = EntityService.constructor(
         slickDataSource,
         samDAO,
         workbenchMetricBaseName = metricsPrefix,
-        workspaceManagerDAO,
-        dataRepoDAO
+        entityManager
       )
 
       val snapshotServiceConstructor: (UserInfo) => SnapshotService = SnapshotService.constructor(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -393,7 +393,7 @@ object Boot extends IOApp with LazyLogging {
       )
 
       // create the entity manager.
-      val entityManager = EntityManager.defaultEntityManager(slickDataSource, workspaceManagerDAO, dataRepoDAO)
+      val entityManager = EntityManager.defaultEntityManager(slickDataSource, workspaceManagerDAO, dataRepoDAO, samDAO)
 
       val entityServiceConstructor: (UserInfo) => EntityService = EntityService.constructor(
         slickDataSource,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -521,7 +521,7 @@ object Boot extends IOApp with LazyLogging {
       httpClient <- BlazeClientBuilder(executionContext).resource
       googleServiceHttp <- GoogleServiceHttp.withRetryAndLogging(httpClient, metadataNotificationConfig)
       topicAdmin <- GoogleTopicAdmin.fromCredentialPath(pathToCredentialJson)
-      bqServiceFactory = new GoogleBigQueryServiceFactory(blocker)
+      bqServiceFactory = new GoogleBigQueryServiceFactory(blocker)(executionContext)
     } yield AppDependencies[F](googleStorage, googleServiceHttp, topicAdmin, bqServiceFactory)
   }
 }
@@ -531,4 +531,4 @@ final case class AppDependencies[F[_]](
   googleStorageService: GoogleStorageService[F],
   googleServiceHttp: GoogleServiceHttp[F],
   topicAdmin: GoogleTopicAdmin[F],
-  bigQueryServiceFactory: GoogleBigQueryServiceFactory[F])
+  bigQueryServiceFactory: GoogleBigQueryServiceFactory)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
@@ -11,6 +11,14 @@ import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 
 import scala.concurrent.ExecutionContext
 
+/**
+ * DataRepoEntityProvider, and potential future callers of this class, need to create a new
+ * GoogleBigQueryService for every request. They do this because they need to set different
+ * user credentials for each request.
+ *
+ * This factory class contains boilerplate and allows callers to easily and quickly get
+ * a new service instance for each user's credentials.
+ */
 class GoogleBigQueryServiceFactory(blocker: Blocker)(implicit executionContext: ExecutionContext) {
 
   implicit lazy val logger: _root_.io.chrisdavenport.log4cats.StructuredLogger[IO] = Slf4jLogger.getLogger[IO]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
@@ -1,0 +1,20 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+import java.nio.charset.Charset
+
+import cats.effect.{Blocker, ContextShift, Sync, Timer}
+import com.google.auth.oauth2.ServiceAccountCredentials
+import io.chrisdavenport.log4cats.StructuredLogger
+import org.apache.commons.io.IOUtils
+import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
+
+import scala.language.higherKinds
+
+class GoogleBigQueryServiceFactory[F[_]: Sync: ContextShift: Timer: StructuredLogger](blocker: Blocker) {
+
+  def getServiceForPet(petKey: String): cats.effect.Resource[F, GoogleBigQueryService[F]] = {
+    val petCredentials = ServiceAccountCredentials.fromStream(IOUtils.toInputStream(petKey, Charset.defaultCharset))
+    GoogleBigQueryService.resource[F](petCredentials, blocker)
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
@@ -2,19 +2,24 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import java.nio.charset.Charset
 
-import cats.effect.{Blocker, ContextShift, Sync, Timer}
+import cats.effect.{Blocker, ContextShift, IO, Timer}
 import com.google.auth.oauth2.ServiceAccountCredentials
-import io.chrisdavenport.log4cats.StructuredLogger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.apache.commons.io.IOUtils
+
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 
-import scala.language.higherKinds
+import scala.concurrent.ExecutionContext
 
-class GoogleBigQueryServiceFactory[F[_]: Sync: ContextShift: Timer: StructuredLogger](blocker: Blocker) {
+class GoogleBigQueryServiceFactory(blocker: Blocker)(implicit executionContext: ExecutionContext) {
 
-  def getServiceForPet(petKey: String): cats.effect.Resource[F, GoogleBigQueryService[F]] = {
+  implicit lazy val logger: _root_.io.chrisdavenport.log4cats.StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+  implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(executionContext)
+  implicit lazy val timer: Timer[IO] = cats.effect.IO.timer(executionContext)
+
+  def getServiceForPet(petKey: String): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
     val petCredentials = ServiceAccountCredentials.fromStream(IOUtils.toInputStream(petKey, Charset.defaultCharset))
-    GoogleBigQueryService.resource[F](petCredentials, blocker)
+    GoogleBigQueryService.resource[IO](petCredentials, blocker)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities
 
-import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, EntityProviderBuilder}
@@ -60,12 +60,12 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
 }
 
 object EntityManager {
-  def defaultEntityManager(dataSource: SlickDataSource, workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO)(implicit ec: ExecutionContext): EntityManager = {
+  def defaultEntityManager(dataSource: SlickDataSource, workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO, samDAO: SamDAO)(implicit ec: ExecutionContext): EntityManager = {
     // create the EntityManager along with its associated provider-builders. Since entities are only accessed
     // in the context of a workspace, this is safe/correct to do here. We also want to use the same dataSource
     // and execution context for the rawls entity provider that the entity service uses.
     val defaultEntityProviderBuilder = new LocalEntityProviderBuilder(dataSource) // implicit executionContext
-    val dataRepoEntityProviderBuilder = new DataRepoEntityProviderBuilder(workspaceManagerDAO, dataRepoDAO)
+    val dataRepoEntityProviderBuilder = new DataRepoEntityProviderBuilder(workspaceManagerDAO, dataRepoDAO, samDAO)
 
     new EntityManager(Set(defaultEntityProviderBuilder, dataRepoEntityProviderBuilder))
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.entities
 
-import cats.effect.IO
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -62,7 +61,7 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
 
 object EntityManager {
   def defaultEntityManager(dataSource: SlickDataSource, workspaceManagerDAO: WorkspaceManagerDAO,
-                           dataRepoDAO: DataRepoDAO, samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory[IO])
+                           dataRepoDAO: DataRepoDAO, samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory)
                           (implicit ec: ExecutionContext): EntityManager = {
     // create the EntityManager along with its associated provider-builders. Since entities are only accessed
     // in the context of a workspace, this is safe/correct to do here. We also want to use the same dataSource

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -63,7 +63,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       // TODO: insert the billing project, if present. May want to use EntityRequestArguments or other container class.
       // TODO: now with two methods building EntityRequestArguments, we probably want to factor that out into the
       // EntityService constructor, or other higher-level method
-      val entityRequestArguments = EntityRequestArguments(workspaceContext.workspace, userInfo, dataReference)
+      val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference)
 
       entityManager.resolveProvider(entityRequestArguments).getEntity(entityType, entityName)
         .map { entity => PerRequest.RequestComplete(StatusCodes.OK, entity) }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -3,8 +3,6 @@ package org.broadinstitute.dsde.rawls.entities
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
-import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.exceptions.DeleteEntitiesConflictException
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
@@ -23,11 +21,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object EntityService {
-  def constructor(dataSource: SlickDataSource, samDAO: SamDAO, workbenchMetricBaseName: String, workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO)
+  // TODO: constructor should accept userInfo, dataReferenceName, billingProject, anything else needed to resolve provider
+  def constructor(dataSource: SlickDataSource, samDAO: SamDAO, workbenchMetricBaseName: String, entityManager: EntityManager)
                  (userInfo: UserInfo)
-                 (implicit executionContext: ExecutionContext) = {
+                 (implicit executionContext: ExecutionContext): EntityService = {
 
-    new EntityService(userInfo, dataSource, samDAO, EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO), workbenchMetricBaseName)
+    // TODO: resolve the provider here, pass to EntityService so implementations never have to resolve
+    new EntityService(userInfo, dataSource, samDAO, entityManager, workbenchMetricBaseName)
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -61,6 +61,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
 
       // TODO: insert the billing project, if present. May want to use EntityRequestArguments or other container class.
+      // we haven't done this yet because we don't know the business logic around which billing project to use for each user.
       // TODO: now with two methods building EntityRequestArguments, we probably want to factor that out into the
       // EntityService constructor, or other higher-level method
       val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -20,4 +20,5 @@ trait EntityProvider {
 
   def expressionValidator: ExpressionValidator
 
+  def getEntity(entityType: String, entityName: String): Future[Entity]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -4,7 +4,7 @@ import bio.terra.datarepo.model.TableModel
 import com.google.cloud.bigquery.Field.Mode
 import com.google.cloud.bigquery._
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
-import org.broadinstitute.dsde.rawls.model.{Attribute, AttributeBoolean, AttributeName, AttributeNull, AttributeNumber, AttributeString, AttributeStringifier, AttributeValue, AttributeValueEmptyList, AttributeValueList, Entity}
+import org.broadinstitute.dsde.rawls.model._
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -30,12 +30,13 @@ trait DataRepoBigQuerySupport {
         AttributeBoolean(fv.getBooleanValue)
       case LegacySQLTypeName.STRING =>
         AttributeString(fv.getStringValue)
+      case LegacySQLTypeName.RECORD =>
+        // TODO: unclear what to do with RECORD types; they don't translate cleanly to the entity model
+        AttributeString(fv.getValue.toString)
       case _ =>
-        // DATE, DATETIME, TIME, TIMESTAMP
-        // BYTES
-        // GEOGRAPHY
-        // RECORD
-        // we don't necessarily support these data types, but we'll try:
+        // DATE, DATETIME, TIME, TIMESTAMP, BYTES, GEOGRAPHY
+        // these types don't have strongly-typed equivalents in the entity model, so we treat them
+        // as string values, relying on the caller to parse the string
         AttributeString(fv.getValue.toString)
     }
   }
@@ -108,10 +109,10 @@ trait DataRepoBigQuerySupport {
 
   // create comma-delimited string of field names for use in error messages.
   // list is sorted alphabetically for determinism in unit tests
-  private def asDelimitedString(fieldList: FieldList): String = {
+  def asDelimitedString(fieldList: FieldList): String = {
     fieldList.asScala.toList.map(_.getName).sorted.mkString(",")
   }
-  private def asDelimitedString(fieldValueList: FieldValueList): String = {
+  def asDelimitedString(fieldValueList: FieldValueList): String = {
     fieldValueList.asScala.toList.map(_.toString).sorted.mkString(",")
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 import com.google.cloud.bigquery.Field.Mode
 import com.google.cloud.bigquery._
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
-import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model._
 
 import scala.collection.JavaConverters._
@@ -106,7 +105,7 @@ trait DataRepoBigQuerySupport {
             case Some((_, a: Attribute)) => AttributeStringifier.apply(a)
             case None =>
               // this shouldn't happen, since we validated the pk against the schema
-              throw new DataEntityException(s"could not find primary key column '$primaryKey' in entity attributes: ${asDelimitedString(attrs)}")
+              throw new DataEntityException(s"could not find primary key column '$primaryKey' in row: ${asDelimitedString(row)}")
           }
           Entity(entityName, entityType, attrs)
         }.toList
@@ -142,7 +141,5 @@ trait DataRepoBigQuerySupport {
   def asDelimitedString(fieldValueList: FieldValueList): String = {
     fieldValueList.asScala.toList.map(_.toString).sorted.mkString(",")
   }
-  def asDelimitedString(attributeMap: AttributeMap): String = {
-    attributeMap.keySet.map(_.name).toList.sorted.mkString(",")
-  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 import com.google.cloud.bigquery.Field.Mode
 import com.google.cloud.bigquery._
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model._
 
 import scala.collection.JavaConverters._
@@ -105,7 +106,7 @@ trait DataRepoBigQuerySupport {
             case Some((_, a: Attribute)) => AttributeStringifier.apply(a)
             case None =>
               // this shouldn't happen, since we validated the pk against the schema
-              throw new DataEntityException(s"could not find primary key column '$primaryKey' on record: ${asDelimitedString(schemaFields)}")
+              throw new DataEntityException(s"could not find primary key column '$primaryKey' in entity attributes: ${asDelimitedString(attrs)}")
           }
           Entity(entityName, entityType, attrs)
         }.toList
@@ -141,5 +142,7 @@ trait DataRepoBigQuerySupport {
   def asDelimitedString(fieldValueList: FieldValueList): String = {
     fieldValueList.asScala.toList.map(_.toString).sorted.mkString(",")
   }
-
+  def asDelimitedString(attributeMap: AttributeMap): String = {
+    attributeMap.keySet.map(_.name).toList.sorted.mkString(",")
+  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -1,0 +1,82 @@
+package org.broadinstitute.dsde.rawls.entities.datarepo
+
+import bio.terra.datarepo.model.TableModel
+import com.google.cloud.bigquery.Field.Mode
+import com.google.cloud.bigquery._
+import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
+import org.broadinstitute.dsde.rawls.model.{Attribute, AttributeBoolean, AttributeName, AttributeNumber, AttributeString, AttributeValue, AttributeValueEmptyList, AttributeValueList, Entity}
+
+import scala.collection.JavaConverters._
+
+trait DataRepoBigQuerySupport {
+
+  def pkFromSnapshotTable(tableModel: TableModel): String = {
+    // If data repo returns one and only one primary key, use it.
+    // If data repo returns null or a compound PK, use the built-in rowid for pk instead.
+    scala.Option(tableModel.getPrimaryKey) match {
+      case Some(pk) if pk.size() == 1 => pk.asScala.head
+      case _ => "datarepo_row_id" // default data repo value
+    }
+  }
+
+  def fieldValueToAttributeValue(field: Field, fv: FieldValue): AttributeValue = {
+    field.getType match {
+      case LegacySQLTypeName.FLOAT | LegacySQLTypeName.INTEGER | LegacySQLTypeName.NUMERIC =>
+        AttributeNumber(fv.getNumericValue)
+      case LegacySQLTypeName.BOOLEAN =>
+        AttributeBoolean(fv.getBooleanValue)
+      case LegacySQLTypeName.STRING =>
+        AttributeString(fv.getStringValue)
+      case _ =>
+        // DATE, DATETIME, TIME, TIMESTAMP
+        // BYTES
+        // GEOGRAPHY
+        // RECORD
+        // we don't necessarily support these data types, but we'll try:
+        AttributeString(fv.getValue.toString)
+    }
+  }
+
+  def fieldToAttribute(field: Field, row: FieldValueList): (AttributeName, Attribute) = {
+    val attrName = field.getName
+    // TODO: catch exceptions retrieving values from queryResults
+    val fv = row.get(attrName)
+
+    val attribute = field.getMode match {
+      case Mode.REPEATED =>
+        fv.getRepeatedValue.asScala.toList match {
+          case x if x.isEmpty => AttributeValueEmptyList
+          case members =>
+            // TODO: can a list itself contain a list? Recursion here is difficult because of the Attribute/AttributeValue hierarchy
+            val attrValues = members.map { member => fieldValueToAttributeValue(field, member) }
+            AttributeValueList(attrValues)
+        }
+      case _ => fieldValueToAttributeValue(field, fv)
+    }
+
+    (AttributeName.withDefaultNS(attrName), attribute)
+  }
+
+  def queryResultsToEntities(queryResults:TableResult, entityType: String, entityName: String): List[Entity] = {
+    val fieldDefs:List[Field] = queryResults.getSchema.getFields.iterator().asScala.toList
+
+    queryResults.iterateAll().asScala.map { row =>
+      val attrs = fieldDefs.map { field => fieldToAttribute(field, row) }.toMap
+      Entity(entityName, entityType, attrs)
+    }.toList
+  }
+
+  def queryResultsToEntity(queryResults:TableResult, entityType: String, entityName: String): Entity = {
+    queryResults.getTotalRows match {
+      case 1 =>
+        queryResultsToEntities(queryResults, entityType, entityName).head
+      case 0 =>
+        // TODO: better error messages
+        throw new DataEntityException("BQ succeeded, but returned zero rows") // error not found
+      case _ =>
+        // TODO: better error messages
+        throw new DataEntityException(s"BQ succeeded, but returned ${queryResults.getTotalRows} rows") // unexpected error: too many found
+    }
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -100,7 +100,7 @@ class DataRepoEntityProvider(requestArguments: EntityRequestArguments, workspace
       } yield queryResults
 
       queryResource.use { queryResults: TableResult =>
-        IO.pure(queryResultsToEntity(queryResults, entityType, entityName))
+        IO.pure(queryResultsToEntity(queryResults, entityType, pk))
       }.unsafeRunSync()
 
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 class DataRepoEntityProvider(requestArguments: EntityRequestArguments, workspaceManagerDAO: WorkspaceManagerDAO,
-                             dataRepoDAO: DataRepoDAO, samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory[IO])
+                             dataRepoDAO: DataRepoDAO, samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory)
                             (implicit protected val executionContext: ExecutionContext)
   extends EntityProvider with DataRepoBigQuerySupport with LazyLogging {
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -57,6 +57,20 @@ class DataRepoEntityProvider(requestArguments: EntityRequestArguments, workspace
   override def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities not supported by this provider.")
 
+
+  override def getEntity(entityType: String, entityName: String): Future[Entity] = {
+    // get snapshot UUID from data reference name
+    // query data repo for snapshot schema
+    // extract table definition, with PK, from snapshot schema
+    // get pet service account key for this user
+    // determine project to be billed for the BQ job
+    // create BQ DAO instance
+    // generate BQ SQL for this entity
+    // execute BQ job
+    // return results
+    throw new UnsupportedEntityOperationException("get entity not supported by this provider.")
+  }
+
   // not marked as private to ease unit testing
   def lookupSnapshotForName(dataReferenceName: String): UUID = {
     // contact WSM to retrieve the data reference specified in the request

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import bio.terra.workspace.model.DataReferenceDescription.ReferenceTypeEnum
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -22,7 +23,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-class DataRepoEntityProvider(requestArguments: EntityRequestArguments, workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO)
+class DataRepoEntityProvider(requestArguments: EntityRequestArguments, workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO, samDAO: SamDAO)
   extends EntityProvider with LazyLogging {
 
   val workspace = requestArguments.workspace

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
+import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -7,10 +8,10 @@ import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
 
 import scala.reflect.runtime.universe._
 
-class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO) extends EntityProviderBuilder[DataRepoEntityProvider] {
+class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO, samDAO: SamDAO) extends EntityProviderBuilder[DataRepoEntityProvider] {
   override def builds: TypeTag[DataRepoEntityProvider] = typeTag[DataRepoEntityProvider]
 
   override def build(requestArguments: EntityRequestArguments): DataRepoEntityProvider = {
-    new DataRepoEntityProvider(requestArguments, workspaceManagerDAO, dataRepoDAO)
+    new DataRepoEntityProvider(requestArguments, workspaceManagerDAO, dataRepoDAO, samDAO)
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,14 +1,20 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
-import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
+import cats.effect.IO
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, SamDAO}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
 
+import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._
 
-class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO, samDAO: SamDAO) extends EntityProviderBuilder[DataRepoEntityProvider] {
+class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO,
+                                       samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory[IO])
+                                   (implicit protected val executionContext: ExecutionContext)
+  extends EntityProviderBuilder[DataRepoEntityProvider] {
+
   override def builds: TypeTag[DataRepoEntityProvider] = typeTag[DataRepoEntityProvider]
 
   override def build(requestArguments: EntityRequestArguments): DataRepoEntityProvider = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -18,6 +18,6 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
   override def builds: TypeTag[DataRepoEntityProvider] = typeTag[DataRepoEntityProvider]
 
   override def build(requestArguments: EntityRequestArguments): DataRepoEntityProvider = {
-    new DataRepoEntityProvider(requestArguments, workspaceManagerDAO, dataRepoDAO, samDAO)
+    new DataRepoEntityProvider(requestArguments, workspaceManagerDAO, dataRepoDAO, samDAO, bqServiceFactory)
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
-import cats.effect.IO
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, SamDAO}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -11,7 +10,7 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._
 
 class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO,
-                                       samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory[IO])
+                                       samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory)
                                    (implicit protected val executionContext: ExecutionContext)
   extends EntityProviderBuilder[DataRepoEntityProvider] {
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/EntityNotFoundException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/EntityNotFoundException.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.rawls.entities.exceptions
+
+class EntityNotFoundException(message: String = null, cause: Throwable = null) extends DataEntityException(message, cause)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/EntityTypeNotFoundException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/EntityTypeNotFoundException.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.rawls.entities.exceptions
+
+class EntityTypeNotFoundException(val requestedType: String) extends DataEntityException

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/UnsupportedEntityOperationException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/UnsupportedEntityOperationException.scala
@@ -1,8 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.exceptions
 
-import org.broadinstitute.dsde.rawls.RawlsException
-
 /** Exception related to working with data entities.
  */
-class UnsupportedEntityOperationException(message: String = null, cause: Throwable = null) extends RawlsException(message, cause)
+class UnsupportedEntityOperationException(message: String = null, cause: Throwable = null) extends DataEntityException(message, cause)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -64,7 +64,6 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
     }
   }
 
-
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext, gatherInputsResult: GatherInputsResult): Future[Stream[SubmissionValidationEntityInputs]] = {
     dataSource.inTransaction { dataAccess =>
       withEntityRecsForExpressionEval(expressionEvaluationContext, workspace, dataAccess) { jobEntityRecs =>
@@ -155,4 +154,13 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
     }
     SubmissionValidationValue(attr, None, inputName)
   }
+
+  override def getEntity(entityType: String, entityName: String): Future[Entity] = {
+    dataSource.inTransaction { dataAccess =>
+      withEntity(workspaceContext, entityType, entityName, dataAccess) {
+        entity => DBIO.successful(entity)
+      }
+    }
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
@@ -84,4 +84,12 @@ trait EntitySupport {
       }
     }
   }
+
+  def withEntity[T](workspaceContext: SlickWorkspaceContext, entityType: String, entityName: String, dataAccess: DataAccess)(op: (Entity) => ReadWriteAction[T]): ReadWriteAction[T] = {
+    dataAccess.entityQuery.get(workspaceContext, entityType, entityName) flatMap {
+      case None => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in ${workspaceContext.workspace.toWorkspaceName}")))
+      case Some(entity) => op(entity)
+    }
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
@@ -85,9 +85,9 @@ trait EntitySupport {
     }
   }
 
-  def withEntity[T](workspaceContext: SlickWorkspaceContext, entityType: String, entityName: String, dataAccess: DataAccess)(op: (Entity) => ReadWriteAction[T]): ReadWriteAction[T] = {
+  def withEntity[T](workspaceContext: Workspace, entityType: String, entityName: String, dataAccess: DataAccess)(op: (Entity) => ReadWriteAction[T]): ReadWriteAction[T] = {
     dataAccess.entityQuery.get(workspaceContext, entityType, entityName) flatMap {
-      case None => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in ${workspaceContext.workspace.toWorkspaceName}")))
+      case None => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in ${workspaceContext.toWorkspaceName}")))
       case Some(entity) => op(entity)
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -66,7 +66,7 @@ trait EntityApiService extends UserInfoDirectives {
         } ~
         path("workspaces" / Segment / Segment / "entities" / Segment / Segment) { (workspaceNamespace, workspaceName, entityType, entityName) =>
           get {
-            complete { entityServiceConstructor(userInfo).GetEntity(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityName) }
+            complete { entityServiceConstructor(userInfo).GetEntity(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityName, dataReference) }
           }
         } ~
         path("workspaces" / Segment / Segment / "entities" / Segment / Segment) { (workspaceNamespace, workspaceName, entityType, entityName) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -56,11 +56,12 @@ object WorkspaceService {
                   notificationDAO: NotificationDAO, userServiceConstructor: UserInfo => UserService,
                   genomicsServiceConstructor: UserInfo => GenomicsService, maxActiveWorkflowsTotal: Int,
                   maxActiveWorkflowsPerUser: Int, workbenchMetricBaseName: String, submissionCostService: SubmissionCostService,
-                  config: WorkspaceServiceConfig, requesterPaysSetupService: RequesterPaysSetupService)
+                  config: WorkspaceServiceConfig, requesterPaysSetupService: RequesterPaysSetupService,
+                  entityManager: EntityManager = new EntityManager(Set()))
                  (userInfo: UserInfo)
-                 (implicit executionContext: ExecutionContext) = {
+                 (implicit executionContext: ExecutionContext): WorkspaceService = {
 
-    new WorkspaceService(userInfo, dataSource, EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO), methodRepoDAO, cromiamDAO,
+    new WorkspaceService(userInfo, dataSource, entityManager, methodRepoDAO, cromiamDAO,
       executionServiceCluster, execServiceBatchSize, workspaceManagerDAO,
       methodConfigResolver, gcsDAO, samDAO,
       notificationDAO, userServiceConstructor,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -60,7 +60,7 @@ object WorkspaceService {
                  (userInfo: UserInfo)
                  (implicit executionContext: ExecutionContext) = {
 
-    new WorkspaceService(userInfo, dataSource, EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO), methodRepoDAO, cromiamDAO,
+    new WorkspaceService(userInfo, dataSource, EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO), methodRepoDAO, cromiamDAO,
       executionServiceCluster, execServiceBatchSize, workspaceManagerDAO,
       methodConfigResolver, gcsDAO, samDAO,
       notificationDAO, userServiceConstructor,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -57,7 +57,7 @@ object WorkspaceService {
                   genomicsServiceConstructor: UserInfo => GenomicsService, maxActiveWorkflowsTotal: Int,
                   maxActiveWorkflowsPerUser: Int, workbenchMetricBaseName: String, submissionCostService: SubmissionCostService,
                   config: WorkspaceServiceConfig, requesterPaysSetupService: RequesterPaysSetupService,
-                  entityManager: EntityManager = new EntityManager(Set()))
+                  entityManager: EntityManager)
                  (userInfo: UserInfo)
                  (implicit executionContext: ExecutionContext): WorkspaceService = {
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
@@ -1,39 +1,67 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import java.util.UUID
+
 import cats.effect._
-import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableResult}
-import io.chrisdavenport.log4cats.StructuredLogger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import com.google.cloud.PageImpl
+import com.google.cloud.bigquery.{BigQuery, Field, FieldValue, FieldValueList, JobId, LegacySQLTypeName, QueryJobConfiguration, Schema, TableResult}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 
-import scala.language.higherKinds
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
 
 object MockBigQueryServiceFactory {
 
-  def ioFactory: MockBigQueryServiceFactory[IO] = {
-    implicit lazy val logger: _root_.io.chrisdavenport.log4cats.StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-    implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(TestExecutionContext.testExecutionContext)
-    implicit lazy val timer: Timer[IO] = cats.effect.IO.timer(TestExecutionContext.testExecutionContext)
+  // default fixture data returned by the underlying MockGoogleBigQueryService, unless a caller overrides it
+  val F_INTEGER = Field.of("integer-field", LegacySQLTypeName.INTEGER)
+  val F_BOOLEAN = Field.of("boolean-field", LegacySQLTypeName.BOOLEAN)
+  val F_STRING = Field.of("datarepo_row_id", LegacySQLTypeName.STRING)
+  val F_TIMESTAMP = Field.of("timestamp-field", LegacySQLTypeName.TIMESTAMP)
+
+  val FV_INTEGER = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "42")
+  val FV_BOOLEAN = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "true")
+  val FV_TIMESTAMP = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "1408452095.22")
+
+  val schema: Schema = Schema.of(F_STRING, F_INTEGER, F_BOOLEAN, F_TIMESTAMP)
+
+  val stringKeys = List("the first row", "the second row", "the third row")
+
+  val results = stringKeys map { stringKey  =>
+    FieldValueList.of(List(
+      FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, stringKey),
+      FV_INTEGER, FV_BOOLEAN, FV_TIMESTAMP).asJava,
+      F_STRING, F_INTEGER, F_BOOLEAN, F_TIMESTAMP)
+  }
+
+  val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, results.asJava)
+  val tableResult: TableResult = new TableResult(schema, 3, page)
+
+  def ioFactory(queryResponse: Either[Throwable, TableResult] = Right(tableResult)): MockBigQueryServiceFactory = {
     lazy val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
+    implicit val ec = TestExecutionContext.testExecutionContext
 
-    new MockBigQueryServiceFactory[IO](blocker)
+    new MockBigQueryServiceFactory(blocker, queryResponse)
   }
 
 }
 
+class MockBigQueryServiceFactory(blocker: Blocker, queryResponse: Either[Throwable, TableResult])(implicit val executionContext: ExecutionContext)
+  extends GoogleBigQueryServiceFactory(blocker: Blocker)(executionContext: ExecutionContext) {
 
-class MockBigQueryServiceFactory[F[_]: Sync: ContextShift: Timer: StructuredLogger](blocker: Blocker)
-  extends GoogleBigQueryServiceFactory[F](blocker: Blocker) {
-
-  override def getServiceForPet(petKey: String): Resource[F, GoogleBigQueryService[F]] = {
-    Resource.pure(new MockGoogleBigQueryService[F])
+  override def getServiceForPet(petKey: String): Resource[IO, GoogleBigQueryService[IO]] = {
+    Resource.pure[IO, GoogleBigQueryService[IO]](new MockGoogleBigQueryService(queryResponse))
   }
-
 }
 
-class MockGoogleBigQueryService[F[_]] extends GoogleBigQueryService[F] {
-  override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] = ???
+class MockGoogleBigQueryService(queryResponse: Either[Throwable, TableResult]) extends GoogleBigQueryService[IO] {
+  override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): IO[TableResult] =
+    query(queryJobConfiguration, JobId.newBuilder().setJob(UUID.randomUUID().toString).build(), options: _*)
 
-  override def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): F[TableResult] = ???
+  override def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): IO[TableResult] = {
+    queryResponse match {
+      case Left(t) => throw t
+      case Right(results) => IO.pure(results)
+    }
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
@@ -11,6 +11,16 @@ import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
+/*
+ * Mocks for GoogleBigQueryServiceFactory and GoogleBigQueryService for use in unit tests.
+ *
+ * These mocks allow unit-test callers to specify the BigQuery result payload, and/or
+ * specify that the query() method throws an exception.
+ *
+ * This file also contains the default fixture data returned by MockGoogleBigQueryService.query()
+ * in the case where a caller did not override that result.
+ */
+
 object MockBigQueryServiceFactory {
 
   // default fixture data returned by the underlying MockGoogleBigQueryService, unless a caller overrides it

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
@@ -1,9 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-//import cats.effect.{Blocker, ContextShift, IO, Resource, Sync, Timer}
-//import cats.effect.{Blocker, ContextShift, IO, Resource, Sync, Timer}
 import cats.effect._
-// import cats.implicits._
 import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableResult}
 import io.chrisdavenport.log4cats.StructuredLogger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -15,10 +12,10 @@ import scala.language.higherKinds
 object MockBigQueryServiceFactory {
 
   def ioFactory: MockBigQueryServiceFactory[IO] = {
-    implicit val logger: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-    implicit val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(TestExecutionContext.testExecutionContext)
-    implicit val timer: Timer[IO] = cats.effect.IO.timer(TestExecutionContext.testExecutionContext)
-    val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
+    implicit lazy val logger: _root_.io.chrisdavenport.log4cats.StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+    implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(TestExecutionContext.testExecutionContext)
+    implicit lazy val timer: Timer[IO] = cats.effect.IO.timer(TestExecutionContext.testExecutionContext)
+    lazy val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
 
     new MockBigQueryServiceFactory[IO](blocker)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.rawls.dataaccess
+
+//import cats.effect.{Blocker, ContextShift, IO, Resource, Sync, Timer}
+//import cats.effect.{Blocker, ContextShift, IO, Resource, Sync, Timer}
+import cats.effect._
+// import cats.implicits._
+import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableResult}
+import io.chrisdavenport.log4cats.StructuredLogger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
+
+import scala.language.higherKinds
+
+object MockBigQueryServiceFactory {
+
+  def ioFactory: MockBigQueryServiceFactory[IO] = {
+    implicit val logger: StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+    implicit val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(TestExecutionContext.testExecutionContext)
+    implicit val timer: Timer[IO] = cats.effect.IO.timer(TestExecutionContext.testExecutionContext)
+    val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
+
+    new MockBigQueryServiceFactory[IO](blocker)
+  }
+
+}
+
+
+class MockBigQueryServiceFactory[F[_]: Sync: ContextShift: Timer: StructuredLogger](blocker: Blocker)
+  extends GoogleBigQueryServiceFactory[F](blocker: Blocker) {
+
+  override def getServiceForPet(petKey: String): Resource[F, GoogleBigQueryService[F]] = {
+    Resource.pure(new MockGoogleBigQueryService[F])
+  }
+
+}
+
+class MockGoogleBigQueryService[F[_]] extends GoogleBigQueryService[F] {
+  override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] = ???
+
+  override def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): F[TableResult] = ???
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -65,7 +65,7 @@ class EntityServiceSpec extends FlatSpec with ScalatestRouteTest with Matchers w
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO())
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(), samDAO)
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.entities
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
@@ -60,7 +59,7 @@ class EntityServiceSpec extends FlatSpec with ScalatestRouteTest with Matchers w
     def actorRefFactory = system
     val samDAO = new MockSamDAO(dataSource)
 
-    val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
 
     val testConf = ConfigFactory.load()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -2,9 +2,10 @@ package org.broadinstitute.dsde.rawls.entities
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
-import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO, RemoteServicesMockServer}
@@ -59,13 +60,15 @@ class EntityServiceSpec extends FlatSpec with ScalatestRouteTest with Matchers w
     def actorRefFactory = system
     val samDAO = new MockSamDAO(dataSource)
 
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
+
     val testConf = ConfigFactory.load()
 
     val entityServiceConstructor = EntityService.constructor(
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(), samDAO)
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(), samDAO, bigQueryServiceFactory)
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -65,8 +65,7 @@ class EntityServiceSpec extends FlatSpec with ScalatestRouteTest with Matchers w
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      new MockWorkspaceManagerDAO(),
-      new MockDataRepoDAO()
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO())
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -9,35 +9,9 @@ import org.scalatest.FreeSpec
 
 import scala.collection.JavaConverters._
 
+/* see also the unit tests in DataRepoEntityProviderSpec
+ */
 class DataRepoBigQuerySupportSpec extends FreeSpec with DataRepoBigQuerySupport {
-
-  "DataRepoBigQuerySupport, when finding the primary key for a table, should" - {
-
-    "use primary key of `datarepo_row_id` if snapshot has null primary key" in {
-      val input = new TableModel()
-      input.setPrimaryKey(null)
-      assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
-    }
-
-    "use primary key of `datarepo_row_id` if snapshot has empty-array primary key" in {
-      val input = new TableModel()
-      input.setPrimaryKey(List.empty[String].asJava)
-      assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
-    }
-
-    "use primary key of `datarepo_row_id` if snapshot has multiple primary keys" in {
-      val input = new TableModel()
-      input.setPrimaryKey(List("one", "two", "three").asJava)
-      assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
-    }
-
-    "use primary key from snapshot if one and only one returned" in {
-      val input = new TableModel()
-      input.setPrimaryKey(List("singlekey").asJava)
-      assertResult("singlekey") { pkFromSnapshotTable(input) }
-    }
-
-  }
 
   "DataRepoBigQuerySupport, when translating BQ results to Terra entities, should" - {
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
-import bio.terra.datarepo.model.TableModel
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, LegacySQLTypeName, Schema, TableResult}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -1,0 +1,246 @@
+package org.broadinstitute.dsde.rawls.entities.datarepo
+
+import bio.terra.datarepo.model.TableModel
+import com.google.cloud.PageImpl
+import com.google.cloud.bigquery.{Field, FieldList, FieldValue, FieldValueList, LegacySQLTypeName, Schema, TableResult}
+import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNumber, AttributeString, Entity}
+import org.scalatest.FlatSpec
+
+import scala.collection.JavaConverters._
+
+class DataRepoBigQuerySupportSpec extends FlatSpec with DataRepoBigQuerySupport {
+
+  behavior of "DataRepoBigQuerySupport, when finding the primary key for a table"
+
+  it should "use primary key of `datarepo_row_id` if snapshot has null primary key" in {
+    val input = new TableModel()
+    input.setPrimaryKey(null)
+    assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
+  }
+
+  it should "use primary key of `datarepo_row_id` if snapshot has empty-array primary key" in {
+    val input = new TableModel()
+    input.setPrimaryKey(List.empty[String].asJava)
+    assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
+  }
+
+  it should "use primary key of `datarepo_row_id` if snapshot has multiple primary keys" in {
+    val input = new TableModel()
+    input.setPrimaryKey(List("one", "two", "three").asJava)
+    assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
+  }
+
+  it should "use primary key from snapshot if one and only one returned" in {
+    val input = new TableModel()
+    input.setPrimaryKey(List("singlekey").asJava)
+    assertResult("singlekey") { pkFromSnapshotTable(input) }
+  }
+
+  behavior of "DataRepoBigQuerySupport, when translating BQ results to Terra entities"
+
+  //
+  // create fixture data using BigQuery java client classes
+  //
+  val dateNow = new java.util.Date()
+  val timeNow = java.util.Calendar.getInstance().getTime
+  val byteArray = "text for bytes".getBytes
+
+  val F_FLOAT = Field.of("float-field", LegacySQLTypeName.FLOAT)
+  val F_INTEGER = Field.of("integer-field", LegacySQLTypeName.INTEGER)
+  val F_NUMERIC = Field.of("numeric-field", LegacySQLTypeName.NUMERIC)
+  val F_BOOLEAN = Field.of("boolean-field", LegacySQLTypeName.BOOLEAN)
+  val F_STRING = Field.of("string-field", LegacySQLTypeName.STRING)
+  val F_DATE = Field.of("date-field", LegacySQLTypeName.DATE)
+  val F_DATETIME = Field.of("datetime-field", LegacySQLTypeName.DATETIME)
+  val F_TIME = Field.of("time-field", LegacySQLTypeName.TIME)
+  val F_TIMESTAMP = Field.of("timestamp-field", LegacySQLTypeName.TIMESTAMP)
+  val F_BYTES = Field.of("bytes-field", LegacySQLTypeName.BYTES)
+  val F_GEOGRAPHY = Field.of("geography-field", LegacySQLTypeName.GEOGRAPHY)
+  // TODO: support RECORD types (repeated values/structs)
+
+  val schema = FieldList.of(
+    F_FLOAT, F_INTEGER, F_NUMERIC, F_BOOLEAN, F_STRING,
+    F_DATE, F_DATETIME, F_TIME, F_TIMESTAMP,
+    F_BYTES, F_GEOGRAPHY
+  )
+
+  // Google's FieldValue class documentation says:
+  //  https://github.com/googleapis/java-bigquery/blob/master/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java#L257
+  /*
+   * Creates an instance of {@code FieldValue}, useful for testing.
+   *
+   * <p>If the {@code attribute} is {@link Attribute#PRIMITIVE}, the {@code value} should be the
+   * string representation of the underlying value, eg {@code "123"} for number {@code 123}.
+   *
+   * <p>If the {@code attribute} is {@link Attribute#REPEATED} or {@link Attribute#RECORD}, the
+   * {@code value} should be {@code List} of {@link FieldValue}s or {@link FieldValueList},
+   * respectively.
+   * */
+  val FV_FLOAT = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "123.456")
+  val FV_INTEGER = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "42")
+  val FV_NUMERIC = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "3.14")
+  val FV_BOOLEAN = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "true")
+  val FV_STRING = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "hello world")
+  val FV_DATE = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, dateNow.toString)
+  val FV_DATETIME = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, dateNow.toString)
+  val FV_TIME = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, timeNow.toString)
+  // // timestamps are encoded in the format 1408452095.22 where the integer part is seconds since
+  // epoch (e.g. 1408452095.22 == 2014-08-19 07:41:35.220 -05:00)
+  val FV_TIMESTAMP = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "1408452095.22")
+  val FV_BYTES = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, byteArray.toString)
+  val FV_GEOGRAPHY = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "[-54, 32]")
+
+  it should "translate BQ Float to AttributeNumber" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_FLOAT).asJava, F_FLOAT)
+    val expected = (AttributeName.withDefaultNS("float-field"), AttributeNumber(123.456))
+    assertResult (expected) { fieldToAttribute(F_FLOAT, row) }
+  }
+
+  it should "translate BQ Integer to AttributeNumber" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER).asJava, F_INTEGER)
+    val expected = (AttributeName.withDefaultNS("integer-field"), AttributeNumber(42))
+    assertResult (expected) { fieldToAttribute(F_INTEGER, row) }
+  }
+  it should "translate BQ Numeric to AttributeNumber" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_NUMERIC).asJava, F_NUMERIC)
+    val expected = (AttributeName.withDefaultNS("numeric-field"), AttributeNumber(3.14))
+    assertResult (expected) { fieldToAttribute(F_NUMERIC, row) }
+  }
+  it should "translate BQ Boolean to AttributeBoolean" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_BOOLEAN).asJava, F_BOOLEAN)
+    val expected = (AttributeName.withDefaultNS("boolean-field"), AttributeBoolean(true))
+    assertResult (expected) { fieldToAttribute(F_BOOLEAN, row) }
+  }
+
+  it should "translate BQ String to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_STRING).asJava, F_STRING)
+    val expected = (AttributeName.withDefaultNS("string-field"), AttributeString("hello world"))
+    assertResult (expected) { fieldToAttribute(F_STRING, row) }
+  }
+
+  it should "translate BQ Date to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_DATE).asJava, F_DATE)
+    val expected = (AttributeName.withDefaultNS("date-field"), AttributeString(dateNow.toString))
+    assertResult (expected) { fieldToAttribute(F_DATE, row) }
+  }
+
+  it should "translate BQ Datetime to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_DATETIME).asJava, F_DATETIME)
+    val expected = (AttributeName.withDefaultNS("datetime-field"), AttributeString(dateNow.toString))
+    assertResult (expected) { fieldToAttribute(F_DATETIME, row) }
+  }
+
+  it should "translate BQ Time to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_TIME).asJava, F_TIME)
+    val expected = (AttributeName.withDefaultNS("time-field"), AttributeString(timeNow.toString))
+    assertResult (expected) { fieldToAttribute(F_TIME, row) }
+  }
+
+  it should "translate BQ Timestamp to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_TIMESTAMP).asJava, F_TIMESTAMP)
+    val expected = (AttributeName.withDefaultNS("timestamp-field"), AttributeString("1408452095.22"))
+    assertResult (expected) { fieldToAttribute(F_TIMESTAMP, row) }
+  }
+
+  it should "translate BQ Bytes to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_BYTES).asJava, F_BYTES)
+    val expected = (AttributeName.withDefaultNS("bytes-field"), AttributeString(byteArray.toString))
+    assertResult (expected) { fieldToAttribute(F_BYTES, row) }
+  }
+
+  it should "translate BQ Geography to AttributeString" in {
+    val row:FieldValueList = FieldValueList.of(List(FV_GEOGRAPHY).asJava, F_GEOGRAPHY)
+    val expected = (AttributeName.withDefaultNS("geography-field"), AttributeString("[-54, 32]"))
+    assertResult (expected) { fieldToAttribute(F_GEOGRAPHY, row) }
+  }
+
+  it should "throw error if queryResultsToEntity is given zero rows" in {
+    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val row:FieldValueList = FieldValueList.of(List().asJava)
+    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+    val tableResult:TableResult = new TableResult(schema, 0, page)
+
+    val ex = intercept[DataEntityException] {
+      queryResultsToEntity(tableResult, "entityType", "entityName")
+    }
+
+    assertResult("BQ succeeded, but returned zero rows") { ex.getMessage }
+  }
+
+  it should "throw error if queryResultsToEntity is given more than one row" in {
+    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row, row).asJava)
+    val tableResult:TableResult = new TableResult(schema, 2, page)
+
+    val ex = intercept[DataEntityException] {
+      queryResultsToEntity(tableResult, "entityType", "entityName")
+    }
+
+    assertResult("BQ succeeded, but returned 2 rows") { ex.getMessage }
+  }
+
+  it should "return the Entity if queryResultsToEntity is given one and only one row" in {
+    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+    val tableResult:TableResult = new TableResult(schema, 1, page)
+
+    val expected = Entity("entityName", "entityType", Map(
+        AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+        AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+        AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
+        AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+      ))
+
+    assertResult (expected) { queryResultsToEntity(tableResult, "entityType", "entityName") }
+  }
+
+  it should "return empty array if queryResultsToEntities is given zero rows" in {
+    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val row:FieldValueList = FieldValueList.of(List().asJava)
+    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+    val tableResult:TableResult = new TableResult(schema, 0, page)
+
+    assertResult(List()) { queryResultsToEntities(tableResult, "entityType", "entityName") }
+  }
+
+  it should "return one-element array if queryResultsToEntities is given one row" in {
+    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+    val tableResult:TableResult = new TableResult(schema, 1, page)
+
+    val expected = Entity("entityName", "entityType", Map(
+      AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+      AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+      AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
+      AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+    ))
+
+    assertResult (List(expected)) { queryResultsToEntities(tableResult, "entityType", "entityName") }
+  }
+
+  it should "return multiple-element array if queryResultsToEntities is given more than one row" in {
+    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row, row, row).asJava)
+    val tableResult:TableResult = new TableResult(schema, 3, page)
+
+    val expected = Entity("entityName", "entityType", Map(
+      AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+      AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+      AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
+      AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+    ))
+
+    // TODO: use different values for each record!
+    assertResult (List(expected, expected, expected)) { queryResultsToEntities(tableResult, "entityType", "entityName") }
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -2,269 +2,336 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import bio.terra.datarepo.model.TableModel
 import com.google.cloud.PageImpl
-import com.google.cloud.bigquery.{Field, FieldList, FieldValue, FieldValueList, LegacySQLTypeName, Schema, TableResult}
+import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, LegacySQLTypeName, Schema, TableResult}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNumber, AttributeString, Entity}
-import org.scalatest.FlatSpec
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNull, AttributeNumber, AttributeString, Entity}
+import org.scalatest.FreeSpec
 
 import scala.collection.JavaConverters._
 
-class DataRepoBigQuerySupportSpec extends FlatSpec with DataRepoBigQuerySupport {
+class DataRepoBigQuerySupportSpec extends FreeSpec with DataRepoBigQuerySupport {
 
-  behavior of "DataRepoBigQuerySupport, when finding the primary key for a table"
+  "DataRepoBigQuerySupport, when finding the primary key for a table, should" - {
 
-  it should "use primary key of `datarepo_row_id` if snapshot has null primary key" in {
-    val input = new TableModel()
-    input.setPrimaryKey(null)
-    assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
-  }
-
-  it should "use primary key of `datarepo_row_id` if snapshot has empty-array primary key" in {
-    val input = new TableModel()
-    input.setPrimaryKey(List.empty[String].asJava)
-    assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
-  }
-
-  it should "use primary key of `datarepo_row_id` if snapshot has multiple primary keys" in {
-    val input = new TableModel()
-    input.setPrimaryKey(List("one", "two", "three").asJava)
-    assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
-  }
-
-  it should "use primary key from snapshot if one and only one returned" in {
-    val input = new TableModel()
-    input.setPrimaryKey(List("singlekey").asJava)
-    assertResult("singlekey") { pkFromSnapshotTable(input) }
-  }
-
-  behavior of "DataRepoBigQuerySupport, when translating BQ results to Terra entities"
-
-  //
-  // create fixture data using BigQuery java client classes
-  //
-  val dateNow = new java.util.Date()
-  val timeNow = java.util.Calendar.getInstance().getTime
-  val byteArray = "text for bytes".getBytes
-
-  val F_FLOAT = Field.of("float-field", LegacySQLTypeName.FLOAT)
-  val F_INTEGER = Field.of("integer-field", LegacySQLTypeName.INTEGER)
-  val F_NUMERIC = Field.of("numeric-field", LegacySQLTypeName.NUMERIC)
-  val F_BOOLEAN = Field.of("boolean-field", LegacySQLTypeName.BOOLEAN)
-  val F_STRING = Field.of("string-field", LegacySQLTypeName.STRING)
-  val F_DATE = Field.of("date-field", LegacySQLTypeName.DATE)
-  val F_DATETIME = Field.of("datetime-field", LegacySQLTypeName.DATETIME)
-  val F_TIME = Field.of("time-field", LegacySQLTypeName.TIME)
-  val F_TIMESTAMP = Field.of("timestamp-field", LegacySQLTypeName.TIMESTAMP)
-  val F_BYTES = Field.of("bytes-field", LegacySQLTypeName.BYTES)
-  val F_GEOGRAPHY = Field.of("geography-field", LegacySQLTypeName.GEOGRAPHY)
-  // TODO: support RECORD types (repeated values/structs)
-
-  val schema = FieldList.of(
-    F_FLOAT, F_INTEGER, F_NUMERIC, F_BOOLEAN, F_STRING,
-    F_DATE, F_DATETIME, F_TIME, F_TIMESTAMP,
-    F_BYTES, F_GEOGRAPHY
-  )
-
-  // Google's FieldValue class documentation says:
-  //  https://github.com/googleapis/java-bigquery/blob/master/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java#L257
-  /*
-   * Creates an instance of {@code FieldValue}, useful for testing.
-   *
-   * <p>If the {@code attribute} is {@link Attribute#PRIMITIVE}, the {@code value} should be the
-   * string representation of the underlying value, eg {@code "123"} for number {@code 123}.
-   *
-   * <p>If the {@code attribute} is {@link Attribute#REPEATED} or {@link Attribute#RECORD}, the
-   * {@code value} should be {@code List} of {@link FieldValue}s or {@link FieldValueList},
-   * respectively.
-   * */
-  val FV_FLOAT = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "123.456")
-  val FV_INTEGER = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "42")
-  val FV_NUMERIC = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "3.14")
-  val FV_BOOLEAN = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "true")
-  val FV_STRING = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "hello world")
-  val FV_DATE = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, dateNow.toString)
-  val FV_DATETIME = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, dateNow.toString)
-  val FV_TIME = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, timeNow.toString)
-  // // timestamps are encoded in the format 1408452095.22 where the integer part is seconds since
-  // epoch (e.g. 1408452095.22 == 2014-08-19 07:41:35.220 -05:00)
-  val FV_TIMESTAMP = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "1408452095.22")
-  val FV_BYTES = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, byteArray.toString)
-  val FV_GEOGRAPHY = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "[-54, 32]")
-
-  it should "translate BQ Float to AttributeNumber" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_FLOAT).asJava, F_FLOAT)
-    val expected = (AttributeName.withDefaultNS("float-field"), AttributeNumber(123.456))
-    assertResult (expected) { fieldToAttribute(F_FLOAT, row) }
-  }
-
-  it should "translate BQ Integer to AttributeNumber" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER).asJava, F_INTEGER)
-    val expected = (AttributeName.withDefaultNS("integer-field"), AttributeNumber(42))
-    assertResult (expected) { fieldToAttribute(F_INTEGER, row) }
-  }
-  it should "translate BQ Numeric to AttributeNumber" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_NUMERIC).asJava, F_NUMERIC)
-    val expected = (AttributeName.withDefaultNS("numeric-field"), AttributeNumber(3.14))
-    assertResult (expected) { fieldToAttribute(F_NUMERIC, row) }
-  }
-  it should "translate BQ Boolean to AttributeBoolean" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_BOOLEAN).asJava, F_BOOLEAN)
-    val expected = (AttributeName.withDefaultNS("boolean-field"), AttributeBoolean(true))
-    assertResult (expected) { fieldToAttribute(F_BOOLEAN, row) }
-  }
-
-  it should "translate BQ String to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_STRING).asJava, F_STRING)
-    val expected = (AttributeName.withDefaultNS("string-field"), AttributeString("hello world"))
-    assertResult (expected) { fieldToAttribute(F_STRING, row) }
-  }
-
-  it should "translate BQ Date to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_DATE).asJava, F_DATE)
-    val expected = (AttributeName.withDefaultNS("date-field"), AttributeString(dateNow.toString))
-    assertResult (expected) { fieldToAttribute(F_DATE, row) }
-  }
-
-  it should "translate BQ Datetime to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_DATETIME).asJava, F_DATETIME)
-    val expected = (AttributeName.withDefaultNS("datetime-field"), AttributeString(dateNow.toString))
-    assertResult (expected) { fieldToAttribute(F_DATETIME, row) }
-  }
-
-  it should "translate BQ Time to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_TIME).asJava, F_TIME)
-    val expected = (AttributeName.withDefaultNS("time-field"), AttributeString(timeNow.toString))
-    assertResult (expected) { fieldToAttribute(F_TIME, row) }
-  }
-
-  it should "translate BQ Timestamp to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_TIMESTAMP).asJava, F_TIMESTAMP)
-    val expected = (AttributeName.withDefaultNS("timestamp-field"), AttributeString("1408452095.22"))
-    assertResult (expected) { fieldToAttribute(F_TIMESTAMP, row) }
-  }
-
-  it should "translate BQ Bytes to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_BYTES).asJava, F_BYTES)
-    val expected = (AttributeName.withDefaultNS("bytes-field"), AttributeString(byteArray.toString))
-    assertResult (expected) { fieldToAttribute(F_BYTES, row) }
-  }
-
-  it should "translate BQ Geography to AttributeString" in {
-    val row:FieldValueList = FieldValueList.of(List(FV_GEOGRAPHY).asJava, F_GEOGRAPHY)
-    val expected = (AttributeName.withDefaultNS("geography-field"), AttributeString("[-54, 32]"))
-    assertResult (expected) { fieldToAttribute(F_GEOGRAPHY, row) }
-  }
-
-  it should "throw error if queryResultsToEntity is given zero rows" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List().asJava)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 0, page)
-
-    val ex = intercept[EntityNotFoundException] {
-      queryResultsToEntity(tableResult, "entityType", "entityName")
+    "use primary key of `datarepo_row_id` if snapshot has null primary key" in {
+      val input = new TableModel()
+      input.setPrimaryKey(null)
+      assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
     }
 
-    assertResult("Entity not found.") { ex.getMessage }
-  }
-
-  it should "throw error if queryResultsToEntity is given more than one row" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
-      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row, row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 2, page)
-
-    val ex = intercept[DataEntityException] {
-      queryResultsToEntity(tableResult, "entityType", "entityName")
+    "use primary key of `datarepo_row_id` if snapshot has empty-array primary key" in {
+      val input = new TableModel()
+      input.setPrimaryKey(List.empty[String].asJava)
+      assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
     }
 
-    assertResult("Query succeeded, but returned 2 rows; expected one row.") { ex.getMessage }
+    "use primary key of `datarepo_row_id` if snapshot has multiple primary keys" in {
+      val input = new TableModel()
+      input.setPrimaryKey(List("one", "two", "three").asJava)
+      assertResult("datarepo_row_id") { pkFromSnapshotTable(input) }
+    }
+
+    "use primary key from snapshot if one and only one returned" in {
+      val input = new TableModel()
+      input.setPrimaryKey(List("singlekey").asJava)
+      assertResult("singlekey") { pkFromSnapshotTable(input) }
+    }
+
   }
 
-  it should "return the Entity if queryResultsToEntity is given one and only one row" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
-      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 1, page)
+  "DataRepoBigQuerySupport, when translating BQ results to Terra entities, should" - {
 
-    val expected = Entity("hello world", "entityType", Map(
+    //
+    // create fixture data using BigQuery java client classes
+    //
+    val dateNow = new java.util.Date()
+    val timeNow = java.util.Calendar.getInstance().getTime
+    val byteArray = "text for bytes".getBytes
+
+    val F_FLOAT = Field.of("float-field", LegacySQLTypeName.FLOAT)
+    val F_INTEGER = Field.of("integer-field", LegacySQLTypeName.INTEGER)
+    val F_NUMERIC = Field.of("numeric-field", LegacySQLTypeName.NUMERIC)
+    val F_BOOLEAN = Field.of("boolean-field", LegacySQLTypeName.BOOLEAN)
+    val F_STRING = Field.of("string-field", LegacySQLTypeName.STRING)
+    val F_DATE = Field.of("date-field", LegacySQLTypeName.DATE)
+    val F_DATETIME = Field.of("datetime-field", LegacySQLTypeName.DATETIME)
+    val F_TIME = Field.of("time-field", LegacySQLTypeName.TIME)
+    val F_TIMESTAMP = Field.of("timestamp-field", LegacySQLTypeName.TIMESTAMP)
+    val F_BYTES = Field.of("bytes-field", LegacySQLTypeName.BYTES)
+    val F_GEOGRAPHY = Field.of("geography-field", LegacySQLTypeName.GEOGRAPHY)
+    // TODO: tests for RECORD types and repeated-value types
+
+    // Google's FieldValue class documentation says:
+    //  https://github.com/googleapis/java-bigquery/blob/master/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/FieldValue.java#L257
+    /*
+     * Creates an instance of {@code FieldValue}, useful for testing.
+     *
+     * <p>If the {@code attribute} is {@link Attribute#PRIMITIVE}, the {@code value} should be the
+     * string representation of the underlying value, eg {@code "123"} for number {@code 123}.
+     *
+     * <p>If the {@code attribute} is {@link Attribute#REPEATED} or {@link Attribute#RECORD}, the
+     * {@code value} should be {@code List} of {@link FieldValue}s or {@link FieldValueList},
+     * respectively.
+     * */
+    val FV_FLOAT = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "123.456")
+    val FV_INTEGER = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "42")
+    val FV_NUMERIC = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "3.14")
+    val FV_BOOLEAN = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "true")
+    val FV_STRING = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "hello world")
+    val FV_DATE = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, dateNow.toString)
+    val FV_DATETIME = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, dateNow.toString)
+    val FV_TIME = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, timeNow.toString)
+    // // timestamps are encoded in the format 1408452095.22 where the integer part is seconds since
+    // epoch (e.g. 1408452095.22 == 2014-08-19 07:41:35.220 -05:00)
+    val FV_TIMESTAMP = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "1408452095.22")
+    val FV_BYTES = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, byteArray.toString)
+    val FV_GEOGRAPHY = FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, "[-54, 32]")
+
+    "throw an error if requested field is not present in field values" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_FLOAT, FV_BOOLEAN, FV_STRING).asJava, F_FLOAT, F_BOOLEAN, F_STRING)
+      val ex = intercept[DataEntityException] {
+        fieldToAttribute(F_INTEGER, row)
+      }
+      assertResult(s"field ${F_INTEGER.getName} not found in row ${asDelimitedString(row)}") {
+        ex.getMessage
+      }
+    }
+
+    "translate BQ Float to AttributeNumber" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_FLOAT).asJava, F_FLOAT)
+      val expected = (AttributeName.withDefaultNS("float-field"), AttributeNumber(123.456))
+      assertResult(expected) {
+        fieldToAttribute(F_FLOAT, row)
+      }
+    }
+
+    "translate BQ Integer to AttributeNumber" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_INTEGER).asJava, F_INTEGER)
+      val expected = (AttributeName.withDefaultNS("integer-field"), AttributeNumber(42))
+      assertResult(expected) {
+        fieldToAttribute(F_INTEGER, row)
+      }
+    }
+    "translate BQ Numeric to AttributeNumber" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_NUMERIC).asJava, F_NUMERIC)
+      val expected = (AttributeName.withDefaultNS("numeric-field"), AttributeNumber(3.14))
+      assertResult(expected) {
+        fieldToAttribute(F_NUMERIC, row)
+      }
+    }
+    "translate BQ Boolean to AttributeBoolean" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_BOOLEAN).asJava, F_BOOLEAN)
+      val expected = (AttributeName.withDefaultNS("boolean-field"), AttributeBoolean(true))
+      assertResult(expected) {
+        fieldToAttribute(F_BOOLEAN, row)
+      }
+    }
+
+    "translate BQ String to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_STRING).asJava, F_STRING)
+      val expected = (AttributeName.withDefaultNS("string-field"), AttributeString("hello world"))
+      assertResult(expected) {
+        fieldToAttribute(F_STRING, row)
+      }
+    }
+
+    "translate BQ Date to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_DATE).asJava, F_DATE)
+      val expected = (AttributeName.withDefaultNS("date-field"), AttributeString(dateNow.toString))
+      assertResult(expected) {
+        fieldToAttribute(F_DATE, row)
+      }
+    }
+
+    "translate BQ Datetime to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_DATETIME).asJava, F_DATETIME)
+      val expected = (AttributeName.withDefaultNS("datetime-field"), AttributeString(dateNow.toString))
+      assertResult(expected) {
+        fieldToAttribute(F_DATETIME, row)
+      }
+    }
+
+    "translate BQ Time to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_TIME).asJava, F_TIME)
+      val expected = (AttributeName.withDefaultNS("time-field"), AttributeString(timeNow.toString))
+      assertResult(expected) {
+        fieldToAttribute(F_TIME, row)
+      }
+    }
+
+    "translate BQ Timestamp to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_TIMESTAMP).asJava, F_TIMESTAMP)
+      val expected = (AttributeName.withDefaultNS("timestamp-field"), AttributeString("1408452095.22"))
+      assertResult(expected) {
+        fieldToAttribute(F_TIMESTAMP, row)
+      }
+    }
+
+    "translate BQ Bytes to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_BYTES).asJava, F_BYTES)
+      val expected = (AttributeName.withDefaultNS("bytes-field"), AttributeString(byteArray.toString))
+      assertResult(expected) {
+        fieldToAttribute(F_BYTES, row)
+      }
+    }
+
+    "translate BQ Geography to AttributeString" in {
+      val row: FieldValueList = FieldValueList.of(List(FV_GEOGRAPHY).asJava, F_GEOGRAPHY)
+      val expected = (AttributeName.withDefaultNS("geography-field"), AttributeString("[-54, 32]"))
+      assertResult(expected) {
+        fieldToAttribute(F_GEOGRAPHY, row)
+      }
+    }
+
+    // LegacySQLTypeName.values() does not work here, unfortunately
+    // skip RECORD types, which require definition of sub-fields
+    List(LegacySQLTypeName.BOOLEAN, LegacySQLTypeName.BYTES, LegacySQLTypeName.DATE, LegacySQLTypeName.DATETIME,
+      LegacySQLTypeName.FLOAT, LegacySQLTypeName.GEOGRAPHY, LegacySQLTypeName.INTEGER, LegacySQLTypeName.NUMERIC,
+      LegacySQLTypeName.STRING, LegacySQLTypeName.TIME, LegacySQLTypeName.TIMESTAMP).foreach { typename =>
+      s"translate nulls of BQ ${typename.toString} to AttributeNull" in {
+        val fld = Field.of(s"${typename.toString}-field", typename)
+
+        val row: FieldValueList = FieldValueList.of(List(
+          FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, null)
+        ).asJava, fld)
+
+        assertResult((AttributeName.withDefaultNS(s"${typename.toString}-field"), AttributeNull)) {
+          fieldToAttribute(fld, row)
+        }
+      }
+    }
+
+    "throw error if queryResultsToEntity is given zero rows" in {
+      val schema: Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val row: FieldValueList = FieldValueList.of(List().asJava)
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+      val tableResult: TableResult = new TableResult(schema, 0, page)
+
+      val ex = intercept[EntityNotFoundException] {
+        queryResultsToEntity(tableResult, "entityType", "entityName")
+      }
+
+      assertResult("Entity not found.") {
+        ex.getMessage
+      }
+    }
+
+    "throw error if queryResultsToEntity is given more than one row" in {
+      val schema: Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val row: FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+        F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row, row).asJava)
+      val tableResult: TableResult = new TableResult(schema, 2, page)
+
+      val ex = intercept[DataEntityException] {
+        queryResultsToEntity(tableResult, "entityType", "entityName")
+      }
+
+      assertResult("Query succeeded, but returned 2 rows; expected one row.") {
+        ex.getMessage
+      }
+    }
+
+    "return the Entity if queryResultsToEntity is given one and only one row" in {
+      val schema: Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val row: FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+        F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+      val tableResult: TableResult = new TableResult(schema, 1, page)
+
+      val expected = Entity("hello world", "entityType", Map(
         AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
         AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
         AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
         AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
       ))
 
-    assertResult (expected) { queryResultsToEntity(tableResult, "entityType", "string-field") }
-  }
-
-  it should "throw error if requested primary key does not exist in query results" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
-      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 1, page)
-
-    val expected = Entity("hello world", "entityType", Map(
-      AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
-      AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
-      AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
-      AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
-    ))
-
-    val ex = intercept[DataEntityException] {
-      queryResultsToEntity(tableResult, "entityType", "invalid-pk")
+      assertResult(expected) {
+        queryResultsToEntity(tableResult, "entityType", "string-field")
+      }
     }
 
-    assertResult("could not find primary key column 'invalid-pk' in query results: boolean-field,integer-field,string-field,timestamp-field") { ex.getMessage }
+    "throw error if requested primary key does not exist in query results" in {
+      val schema: Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val row: FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+        F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+      val tableResult: TableResult = new TableResult(schema, 1, page)
+
+      val expected = Entity("hello world", "entityType", Map(
+        AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+        AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+        AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
+        AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+      ))
+
+      val ex = intercept[DataEntityException] {
+        queryResultsToEntity(tableResult, "entityType", "invalid-pk")
+      }
+
+      assertResult("could not find primary key column 'invalid-pk' in query results: boolean-field,integer-field,string-field,timestamp-field") {
+        ex.getMessage
+      }
+    }
+
+    "return empty array if queryResultsToEntities is given zero rows" in {
+      val schema: Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val row: FieldValueList = FieldValueList.of(List().asJava)
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+      val tableResult: TableResult = new TableResult(schema, 0, page)
+
+      assertResult(List()) {
+        queryResultsToEntities(tableResult, "entityType", "irrelevant")
+      }
+    }
+
+    "return one-element array if queryResultsToEntities is given one row" in {
+      val schema: Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val row: FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
+        F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
+      val tableResult: TableResult = new TableResult(schema, 1, page)
+
+      val expected = Entity("hello world", "entityType", Map(
+        AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+        AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+        AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
+        AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+      ))
+
+      assertResult(List(expected)) {
+        queryResultsToEntities(tableResult, "entityType", "string-field")
+      }
+    }
+
+    "return multiple-element array if queryResultsToEntities is given more than one row" in {
+      val schema: Schema = Schema.of(F_STRING, F_INTEGER, F_BOOLEAN, F_TIMESTAMP)
+
+      val stringKeys = List("the first row", "the second row", "the third row")
+
+      val results = stringKeys map { stringKey  =>
+        FieldValueList.of(List(
+          FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, stringKey),
+          FV_INTEGER, FV_BOOLEAN, FV_TIMESTAMP).asJava,
+          F_STRING, F_INTEGER, F_BOOLEAN, F_TIMESTAMP)
+      }
+
+      val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, results.asJava)
+      val tableResult: TableResult = new TableResult(schema, 3, page)
+
+      val expected = stringKeys.map { stringKey =>
+        Entity(stringKey, "entityType", Map(
+          AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+          AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+          AttributeName.withDefaultNS("string-field") -> AttributeString(stringKey),
+          AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+        ))
+      }
+
+      assertResult(expected) {
+        queryResultsToEntities(tableResult, "entityType", "string-field")
+      }
+    }
   }
-
-  it should "return empty array if queryResultsToEntities is given zero rows" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List().asJava)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 0, page)
-
-    assertResult(List()) { queryResultsToEntities(tableResult, "entityType", "irrelevant") }
-  }
-
-  it should "return one-element array if queryResultsToEntities is given one row" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
-      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 1, page)
-
-    val expected = Entity("hello world", "entityType", Map(
-      AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
-      AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
-      AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
-      AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
-    ))
-
-    assertResult (List(expected)) { queryResultsToEntities(tableResult, "entityType", "string-field") }
-  }
-
-  it should "return multiple-element array if queryResultsToEntities is given more than one row" in {
-    val schema:Schema = Schema.of(F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val row:FieldValueList = FieldValueList.of(List(FV_INTEGER, FV_BOOLEAN, FV_STRING, FV_TIMESTAMP).asJava,
-      F_INTEGER, F_BOOLEAN, F_STRING, F_TIMESTAMP)
-    val page:PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List(row, row, row).asJava)
-    val tableResult:TableResult = new TableResult(schema, 3, page)
-
-    val expected = Entity("hello world", "entityType", Map(
-      AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
-      AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
-      AttributeName.withDefaultNS("string-field") -> AttributeString("hello world"),
-      AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
-    ))
-
-    // TODO: use different values for each record!
-    assertResult (List(expected, expected, expected)) { queryResultsToEntities(tableResult, "entityType", "string-field") }
-  }
-
-  // TODO: test for null value
-  // TODO: test for fieldToAttribute looking for field not in values
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -179,6 +179,48 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     assertResult("Reference value for foo contains an unexpected snapshot value") { ex.getMessage }
   }
 
+  behavior of "DataEntityProvider.getEntity()"
+
+  ignore should "return exactly one entity if all OK" in {
+    fail("not implemented")
+  }
+
+  ignore should "bubble up error if workspace manager errors (includes reference not found?)" in {
+    fail("not implemented")
+  }
+
+  ignore should "fail if data reference not found in workspace manager" in {
+    fail("not implemented")
+  }
+
+  ignore should "fail if user is a workspace Reader but did not specify a billing project (canCompute?)" in {
+    fail("not implemented")
+  }
+
+  ignore should "bubble up error if data repo errors (includes snapshot not found/not allowed?)" in {
+    fail("not implemented")
+  }
+
+  ignore should "fail if snapshot not found in data repo" in {
+    fail("not implemented")
+  }
+
+  ignore should "fail if snapshot has no tables in data repo" in {
+    fail("not implemented")
+  }
+
+  ignore should "fail if snapshot table not found in data repo's response" in {
+    fail("not implemented")
+  }
+
+  ignore should "bubble up error if BigQuery errors" in {
+    fail("not implemented")
+  }
+
+  ignore should "fail if BigQuery returns zero rows" in {
+    fail("not implemented")
+  }
+
 
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -213,6 +213,10 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     fail("not implemented")
   }
 
+  ignore should "fail if pet credentials not available from Sam" in {
+    fail("not implemented")
+  }
+
   ignore should "bubble up error if BigQuery errors" in {
     fail("not implemented")
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -4,12 +4,16 @@ import java.util.UUID
 
 import bio.terra.datarepo.model.TableModel
 import bio.terra.workspace.model.DataReferenceDescription.ReferenceTypeEnum
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.model.EntityTypeMetadata
 import org.scalatest.{AsyncFlatSpec, Matchers}
 import spray.json.{JsArray, JsNumber, JsObject, JsString}
 
-class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProviderSpecSupport with Matchers {
+class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProviderSpecSupport with TestDriverComponent with Matchers {
+
+  override implicit val executionContext = TestExecutionContext.testExecutionContext
 
   behavior of "DataEntityProvider.entityTypeMetadata()"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.datarepo.model.{ColumnModel, SnapshotModel, TableModel}
 import bio.terra.workspace.model.DataReferenceDescription
 import bio.terra.workspace.model.DataReferenceDescription.{CloningInstructionsEnum, ReferenceTypeEnum}
-import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{MockBigQueryServiceFactory, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.{UserInfo, Workspace}
@@ -32,6 +32,8 @@ trait DataRepoEntityProviderSpecSupport {
   val workspace = new Workspace("namespace", "name", wsId.toString, "bucketName", None,
     DateTime.now(), DateTime.now(), "createdBy", Map.empty, false)
 
+  val bqFactory = MockBigQueryServiceFactory.ioFactory
+
   /* A "factory" method to create a DataRepoEntityProvider, with defaults.
    * Individual unit tests should call this to reduce boilerplate.
    */
@@ -40,7 +42,7 @@ trait DataRepoEntityProviderSpecSupport {
                          samDAO: SamDAO = new MockSamDAO(slickDataSource),
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some("referenceName"))
                         ): DataRepoEntityProvider = {
-    new DataRepoEntityProvider(entityRequestArguments, workspaceManagerDAO, dataRepoDAO, samDAO)
+    new DataRepoEntityProvider(entityRequestArguments, workspaceManagerDAO, dataRepoDAO, samDAO, bqFactory)
   }
 
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.datarepo.model.{ColumnModel, SnapshotModel, TableModel}
 import bio.terra.workspace.model.DataReferenceDescription
 import bio.terra.workspace.model.DataReferenceDescription.{CloningInstructionsEnum, ReferenceTypeEnum}
-import org.broadinstitute.dsde.rawls.dataaccess.{MockBigQueryServiceFactory, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.{UserInfo, Workspace}
@@ -32,14 +32,13 @@ trait DataRepoEntityProviderSpecSupport {
   val workspace = new Workspace("namespace", "name", wsId.toString, "bucketName", None,
     DateTime.now(), DateTime.now(), "createdBy", Map.empty, false)
 
-  val bqFactory = MockBigQueryServiceFactory.ioFactory
-
   /* A "factory" method to create a DataRepoEntityProvider, with defaults.
    * Individual unit tests should call this to reduce boilerplate.
    */
   def createTestProvider(workspaceManagerDAO: SpecWorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRefDescription())),
                          dataRepoDAO: SpecDataRepoDAO = new SpecDataRepoDAO(Right(createSnapshotModel())),
                          samDAO: SamDAO = new MockSamDAO(slickDataSource),
+                         bqFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(),
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some("referenceName"))
                         ): DataRepoEntityProvider = {
     new DataRepoEntityProvider(entityRequestArguments, workspaceManagerDAO, dataRepoDAO, samDAO, bqFactory)
@@ -118,7 +117,6 @@ trait DataRepoEntityProviderSpecSupport {
       case Right(snap) => snap
     }
   }
-
 
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -6,15 +6,21 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.datarepo.model.{ColumnModel, SnapshotModel, TableModel}
 import bio.terra.workspace.model.DataReferenceDescription
 import bio.terra.workspace.model.DataReferenceDescription.{CloningInstructionsEnum, ReferenceTypeEnum}
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
-import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockWorkspaceManagerDAO}
-import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, RawlsUserSubjectId, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
+import org.broadinstitute.dsde.rawls.model.{UserInfo, Workspace}
 import org.joda.time.DateTime
 import spray.json.{JsObject, JsString}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
 
 trait DataRepoEntityProviderSpecSupport {
+
+  val slickDataSource: SlickDataSource
+  val userInfo: UserInfo
+  implicit val executionContext: ExecutionContext
 
   // default values for some important attributes
   val wsId: UUID = UUID.randomUUID()
@@ -26,18 +32,15 @@ trait DataRepoEntityProviderSpecSupport {
   val workspace = new Workspace("namespace", "name", wsId.toString, "bucketName", None,
     DateTime.now(), DateTime.now(), "createdBy", Map.empty, false)
 
-  // default UserInfo object, mostly irrelevant for DataRepoEntityProviderSpec but necessary to exist
-  val userInfo = UserInfo(RawlsUserEmail("email"), OAuth2BearerToken(""), 123L, RawlsUserSubjectId("456"))
-
-
   /* A "factory" method to create a DataRepoEntityProvider, with defaults.
    * Individual unit tests should call this to reduce boilerplate.
    */
   def createTestProvider(workspaceManagerDAO: SpecWorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRefDescription())),
                          dataRepoDAO: SpecDataRepoDAO = new SpecDataRepoDAO(Right(createSnapshotModel())),
+                         samDAO: SamDAO = new MockSamDAO(slickDataSource),
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some("referenceName"))
                         ): DataRepoEntityProvider = {
-    new DataRepoEntityProvider(entityRequestArguments, workspaceManagerDAO, dataRepoDAO)
+    new DataRepoEntityProvider(entityRequestArguments, workspaceManagerDAO, dataRepoDAO, samDAO)
   }
 
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -9,12 +9,12 @@ import bio.terra.workspace.model.DataReferenceDescription.{CloningInstructionsEn
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
-import org.broadinstitute.dsde.rawls.model.{UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, UserInfo, Workspace}
 import org.joda.time.DateTime
 import spray.json.{JsObject, JsString}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 trait DataRepoEntityProviderSpecSupport {
 
@@ -115,6 +115,20 @@ trait DataRepoEntityProviderSpecSupport {
     override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = getSnapshotResponse match {
       case Left(t) => throw t
       case Right(snap) => snap
+    }
+  }
+
+  /**
+   * Mock for DataRepoDAO that allows the caller to specify behavior for the getSnapshot and getBaseURL methods.
+   *  method.
+   */
+  class SpecSamDAO(dataSource: SlickDataSource = slickDataSource,
+                   petKeyForUserResponse: Either[Throwable, String]) extends MockSamDAO(dataSource) {
+    override def getPetServiceAccountKeyForUser(googleProject: String, userEmail: RawlsUserEmail): Future[String] = {
+      petKeyForUserResponse match {
+        case Left(t) => Future.failed(t)
+        case Right(key) => Future.successful(key)
+      }
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.stream.ActorMaterializer
-import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.{DeploymentManagerConfig, MethodRepoConfig}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
@@ -327,7 +326,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
       val requesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
-      val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
+      val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
       val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory)
 
       val workspaceServiceConstructor = WorkspaceService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -31,7 +31,6 @@ import spray.json._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
-import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.{DeploymentManagerConfig, MethodRepoConfig, SwaggerConfig}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
@@ -123,7 +122,7 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
 
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO()
 
-    val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
 
     override val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName), slickDataSource)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -198,6 +198,8 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
     val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
     val requesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
+    val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory)
+
     override val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       methodRepoDAO,
@@ -217,14 +219,15 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       workbenchMetricBaseName,
       submissionCostService,
       workspaceServiceConfig,
-      requesterPaysSetupService
+      requesterPaysSetupService,
+      entityManager
     )_
 
     override val entityServiceConstructor = EntityService.constructor(
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory)
+      entityManager
     )_
 
     def cleanupSupervisor = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -35,7 +35,7 @@ import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.{DeploymentManagerConfig, MethodRepoConfig, SwaggerConfig}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
-import org.broadinstitute.dsde.rawls.entities.EntityService
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 
@@ -221,8 +221,7 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      workspaceManagerDAO,
-      dataRepoDAO
+      EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO)
     )_
 
     def cleanupSupervisor = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -31,6 +31,7 @@ import spray.json._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
+import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.{DeploymentManagerConfig, MethodRepoConfig, SwaggerConfig}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
@@ -121,6 +122,8 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
     val workspaceManagerDAO: WorkspaceManagerDAO = new MockWorkspaceManagerDAO()
 
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO()
+
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
 
     override val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName), slickDataSource)
 
@@ -221,7 +224,7 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO)
+      EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory)
     )_
 
     def cleanupSupervisor = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -221,7 +221,7 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO)
+      EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO)
     )_
 
     def cleanupSupervisor = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -25,7 +25,6 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.{DeploymentManagerConfig, MethodRepoConfig}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
@@ -131,7 +130,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
     val requesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
-    val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
     val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory)
 
     val workspaceServiceConstructor = WorkspaceService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -25,10 +25,12 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.effect.IO
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.{DeploymentManagerConfig, MethodRepoConfig}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
+import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito
@@ -129,6 +131,9 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
     val requesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory[IO] = MockBigQueryServiceFactory.ioFactory
+    val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory)
+
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
       new HttpMethodRepoDAO(
@@ -151,7 +156,8 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
       workbenchMetricBaseName,
       submissionCostService,
       workspaceServiceConfig,
-      requesterPaysSetupService
+      requesterPaysSetupService,
+      entityManager
     )_
 
     def cleanupSupervisor = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
 
   val googleV = "1.22.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
-  val workbenchGoogle2V = "0.10-bd284e7"
-  // val workbenchGoogle2V = "0.10-ae0b940"
+  // latest as of this writing: 85d499a; PR-tested with: bd284e7; lowest version with the BQ changes we need: ae0b940
+  val workbenchGoogle2V = "0.10-85d499a"
 
   val cromwellVersion = "40-2754783"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   val googleV = "1.22.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
   val workbenchGoogle2V = "0.10-bd284e7"
+  // val workbenchGoogle2V = "0.10-ae0b940"
 
   val cromwellVersion = "40-2754783"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.5.31"
-  val akkaHttpV = "10.1.12"
+  val akkaV = "2.5.19"
+  val akkaHttpV = "10.1.7"
   val slickV = "3.3.2"
 
   val googleV = "1.22.0"
@@ -19,7 +19,6 @@ object Dependencies {
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
-
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
 
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
+
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.5.19"
-  val akkaHttpV = "10.1.7"
+  val akkaV = "2.5.31"
+  val akkaHttpV = "10.1.12"
   val slickV = "3.3.2"
 
   val googleV = "1.22.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,7 @@ object Dependencies {
 
   val googleV = "1.22.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
-  // latest as of this writing: 85d499a; PR-tested with: bd284e7; lowest version with the BQ changes we need: ae0b940
-  val workbenchGoogle2V = "0.10-85d499a"
+  val workbenchGoogle2V = "0.10-956a642"
 
   val cromwellVersion = "40-2754783"
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -5,6 +5,7 @@ object Merging {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.discard
     case x if x.endsWith("Resource$AuthenticationType.class") => MergeStrategy.first
     case x if x.endsWith("module-info.class") => MergeStrategy.discard
+    case x if x.endsWith("field_mask.proto") => MergeStrategy.first
     case PathList("org", "apache", xs @ _*) => MergeStrategy.last
     case PathList("com", "typesafe", xs @ _*) => MergeStrategy.last
     case PathList("com", "google", "auto", "value", xs @ _*) => MergeStrategy.last

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -5,7 +5,6 @@ object Merging {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.discard
     case x if x.endsWith("Resource$AuthenticationType.class") => MergeStrategy.first
     case x if x.endsWith("module-info.class") => MergeStrategy.discard
-    case x if x.endsWith("field_mask.proto") => MergeStrategy.first
     case PathList("org", "apache", xs @ _*) => MergeStrategy.last
     case PathList("com", "typesafe", xs @ _*) => MergeStrategy.last
     case PathList("com", "google", "auto", "value", xs @ _*) => MergeStrategy.last

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.2")


### PR DESCRIPTION
This PR:
* updates to the latest workbench-libs  google2 library, which has a new BigQuery client.
* moves the `getEntity.getEntity()` implementations behind the EntityProvider interface.
* adds a getEntity implementation for DataRepoEntityProvider. This implementation queries Workspace Manager and Data Repo to identify the named snapshot's underlying BigQuery tables, then queries BigQuery to get the specified row and returns it as a Rawls Entity.
* contains a ton of boilerplate/helper methods/utilities to make future entity-related BigQuery work easier.

outstanding TODOs, which I'll file as follow-on Jira tickets for future PRs:
* [ ] get billing project business requirements from PO and implement them (to which project should we bill BigQuery operations, if the user is a READER on the workspace?) [needs PO input]
* [ ] handle RECORD and repeated-value datatypes; these types are awkward in the current client and entity model [needs input from data repo team to find sample data]
* [ ] refactor and simplify where we resolve the EntityProvider impl to be used for any given request, and simplify how we pass arguments around [invasive, should be done in a separate PR]