### PR TITLE
AS-395: be resilient to non-uuids in Sam resources during list-workspaces [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -487,8 +487,12 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     for {
       workspacePolicies <- traceWithParent("getPolicies", parentSpan)(_ => samDAO.getPoliciesForType(SamResourceTypeNames.workspace, userInfo))
       // filter out the policies that are not related to access levels, if a user has only those ignore the workspace
-      accessLevelWorkspacePolicies = workspacePolicies.filter(p => WorkspaceAccessLevels.withPolicyName(p.accessPolicyName.value).nonEmpty)
-      accessLevelWorkspacePolicyUUIDs = accessLevelWorkspacePolicies.flatMap(p => Try(UUID.fromString(p.resourceId)).toOption).toSeq
+      // also filter out any policy whose resourceId is not a UUID; these will never match a known workspace
+      accessLevelWorkspacePolicies = workspacePolicies.filter(p =>
+        WorkspaceAccessLevels.withPolicyName(p.accessPolicyName.value).nonEmpty &&
+        Try(UUID.fromString(p.resourceId)).isSuccess
+      )
+      accessLevelWorkspacePolicyUUIDs = accessLevelWorkspacePolicies.map(p => UUID.fromString(p.resourceId)).toSeq
       result <- dataSource.inTransaction({ dataAccess =>
 
         def workspaceSubmissionStatsFuture(): slick.ReadAction[Map[UUID, WorkspaceSubmissionStats]] = if (submissionStatsEnabled) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -491,7 +491,8 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       result <- dataSource.inTransaction({ dataAccess =>
 
         def workspaceSubmissionStatsFuture(): slick.ReadAction[Map[UUID, WorkspaceSubmissionStats]] = if (submissionStatsEnabled) {
-          dataAccess.workspaceQuery.listSubmissionSummaryStats(accessLevelWorkspacePolicies.map(p => UUID.fromString(p.resourceId)).toSeq)
+          val resourceIds = accessLevelWorkspacePolicies.flatMap(p => Try(UUID.fromString(p.resourceId)).toOption)
+          dataAccess.workspaceQuery.listSubmissionSummaryStats(resourceIds.toSeq)
         } else {
           DBIO.from(Future(Map()))
         }


### PR DESCRIPTION
Resilience for non-UUID resourceId values returned by Sam for the `SamResourceTypeNames.workspace` type.

Before this PR, Rawls would throw an error trying to call `UUID.fromString(...)` against these values when listing your workspaces, assuming you had access to the policy in Sam.

I searched the Rawls codebase for other instances of `SamDAO.getPoliciesForType` and this is the only relevant instance. However, there may be other use cases in Rawls where we do not properly catch exceptions on `UUID.fromString()`; looking for those is out of scope for this PR.

Alternatives:
* in `HttpSamDAO.getPoliciesForType`, if the caller asked for policies of type `workspace`, filter out non-UUID results before returning the result set. This would future-proof any other usages, but it feels too black-boxy to me.
* implement configurable validation in Sam, per resource type, and disallow creation of non-UUID policies at that level. This solution would also require cleaning up any pre-existing dirty data.

