### PR TITLE
AS-322: upgrade google2 [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -517,8 +517,8 @@ object Boot extends IOApp with LazyLogging {
       googleStorage <- GoogleStorageService.resource[F](pathToCredentialJson, blocker, None, Option(serviceProject))
       httpClient <- BlazeClientBuilder(executionContext).resource
       googleServiceHttp <- GoogleServiceHttp.withRetryAndLogging(httpClient, metadataNotificationConfig)
-//      topicAdmin <- GoogleTopicAdmin.fromCredentialPath(pathToCredentialJson)
-    } yield AppDependencies[F](googleStorage, googleServiceHttp, null)
+      topicAdmin <- GoogleTopicAdmin.fromCredentialPath(pathToCredentialJson)
+    } yield AppDependencies[F](googleStorage, googleServiceHttp, topicAdmin)
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -517,8 +517,8 @@ object Boot extends IOApp with LazyLogging {
       googleStorage <- GoogleStorageService.resource[F](pathToCredentialJson, blocker, None, Option(serviceProject))
       httpClient <- BlazeClientBuilder(executionContext).resource
       googleServiceHttp <- GoogleServiceHttp.withRetryAndLogging(httpClient, metadataNotificationConfig)
-      topicAdmin <- GoogleTopicAdmin.fromCredentialPath(pathToCredentialJson)
-    } yield AppDependencies[F](googleStorage, googleServiceHttp, topicAdmin)
+//      topicAdmin <- GoogleTopicAdmin.fromCredentialPath(pathToCredentialJson)
+    } yield AppDependencies[F](googleStorage, googleServiceHttp, null)
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -509,6 +509,8 @@ object Boot extends IOApp with LazyLogging {
     val googleApiUri = Uri.unsafeFromString(gcsConfig.getString("google-api-uri"))
     val metadataNotificationConfig = NotificationCreaterConfig(pathToCredentialJson, googleApiUri)
 
+    implicit val logger = Slf4jLogger.getLogger[F]
+
     for {
       blockingEc <- ExecutionContexts.fixedThreadPool[F](256) //scala.concurrent.blocking has default max extra thread number 256, so use this number to start with
       blocker = Blocker.liftExecutionContext(blockingEc)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -188,7 +188,7 @@ class HttpGoogleServicesDAO(
       _ <- googleStorageService.setIamPolicy(hammCromwellMetadata.bucketName, Map(StorageRole.StorageAdmin -> NonEmptyList.of(Identity.serviceAccount(clientEmail))), Some(traceId))
       _ <- googleStorageService.setBucketLifecycle(hammCromwellMetadata.bucketName, List(lifecyleRule), Some(traceId))
       projectServiceAccount <- Stream.eval(googleServiceHttp.getProjectServiceAccount(GoogleProject(serviceProject), Some(traceId)))
-//      _ <- topicAdmin.createWithPublisherMembers(hammCromwellMetadata.topicName, List(projectServiceAccount), Some(traceId))
+      _ <- topicAdmin.createWithPublisherMembers(hammCromwellMetadata.topicName, List(projectServiceAccount), Some(traceId))
       _ <- Stream.eval(googleServiceHttp.createNotification(hammCromwellMetadata.topicName, hammCromwellMetadata.bucketName, Filters(List(NotificationEventTypes.ObjectFinalize), None), Some(traceId)))
     } yield ()
     // unsafeRunSync is not desired, but return type for initBuckets dictates execution has to happen immediately when the method is called.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -188,7 +188,7 @@ class HttpGoogleServicesDAO(
       _ <- googleStorageService.setIamPolicy(hammCromwellMetadata.bucketName, Map(StorageRole.StorageAdmin -> NonEmptyList.of(Identity.serviceAccount(clientEmail))), Some(traceId))
       _ <- googleStorageService.setBucketLifecycle(hammCromwellMetadata.bucketName, List(lifecyleRule), Some(traceId))
       projectServiceAccount <- Stream.eval(googleServiceHttp.getProjectServiceAccount(GoogleProject(serviceProject), Some(traceId)))
-      _ <- topicAdmin.createWithPublisherMembers(hammCromwellMetadata.topicName, List(projectServiceAccount), Some(traceId))
+//      _ <- topicAdmin.createWithPublisherMembers(hammCromwellMetadata.topicName, List(projectServiceAccount), Some(traceId))
       _ <- Stream.eval(googleServiceHttp.createNotification(hammCromwellMetadata.topicName, hammCromwellMetadata.bucketName, Filters(List(NotificationEventTypes.ObjectFinalize), None), Some(traceId)))
     } yield ()
     // unsafeRunSync is not desired, but return type for initBuckets dictates execution has to happen immediately when the method is called.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -342,7 +342,8 @@ class AvroUpsertMonitorActor(
     logger.info(s"reading ${if (decompress) "compressed " else ""}object $blobName from bucket $bucketName ...")
     val compiled = googleStorage.getBlobBody(bucketName, blobName).compile
 
-    compiled.to[Array].unsafeToFuture().map { byteArray =>
+    compiled.toList.unsafeToFuture().map { byteList =>
+      val byteArray = byteList.toArray
       val bytes = if (decompress) decompressGzip(byteArray) else byteArray
       logger.info(s"successfully read $blobName from bucket $bucketName; parsing ...")
       val obj = bytes.map(_.toChar).mkString.parseJson.convertTo[T]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,11 @@ object Dependencies {
   val googleServicemanagement: ModuleID = "com.google.apis"   % "google-api-services-servicemanagement" % ("v1-rev17-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20181207-1.28.0")
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "19.0"
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.24.0"
+
+  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.30.0"
+  val googleRpcNettyShaded: ModuleID =    "io.grpc" % "grpc-netty-shaded" % "1.30.0"
+  val googleCloudCoreGrpc: ModuleID =     "com.google.cloud" % "google-cloud-core-grpc" % "1.93.6"
+
   val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.0"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
@@ -154,6 +158,15 @@ object Dependencies {
     googleGuava
   )
 
+  // google2 lib requires specific versions of rpc libs:
+  val google2Dependencies = Seq(
+    workbenchGoogle2,
+    googleCloudCoreGrpc,
+    googleRpc,
+    googleRpcNettyShaded,
+    workbenchGoogle2Tests
+  )
+
   val utilDependencies = Seq(
     scalaLogging,
     akkaActor,
@@ -180,7 +193,7 @@ object Dependencies {
     scalatest
   )
 
-  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
+  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
     typesafeConfig,
     parserCombinators,
     sentryLogback,
@@ -200,12 +213,9 @@ object Dependencies {
     akkaHttpTestKit,
     mockserverNetty,
     mockito,
-    googleRpc,
     log4cats,
     workbenchModel,
     workbenchGoogle,
-    workbenchGoogle2,
-    workbenchGoogle2Tests,
     googleStorageLocal,
     workbenchGoogleMocks,
     workbenchUtil,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,6 +21,14 @@ object Dependencies {
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchUtil =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
 
+  val excludeSundrCodegen =     ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
+  val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
+  val excludeProtobufJavalite =  ExclusionRule(organization = "com.google.protobuf", name = "protobuf-javalite")
+
+  def workbenchGoogleExcludes(m: ModuleID): ModuleID = m.excludeAll(
+    excludeWorkbenchModel, excludeWorkbenchUtil,
+    excludeSundrCodegen, excludeBouncyCastleExt, excludeProtobufJavalite)
+
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV
   val akkaContrib: ModuleID =       "com.typesafe.akka"   %%  "akka-contrib"         % akkaV
@@ -81,10 +89,10 @@ object Dependencies {
   val workbenchModelV  = "0.13-58c913d"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model"  % workbenchModelV
   val workbenchGoogleV = "0.21-890a74f"
-  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll(excludeWorkbenchModel, excludeWorkbenchUtil)
-  val workbenchGoogleMocks: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests" excludeAll(excludeWorkbenchModel, excludeWorkbenchUtil)
-  val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll(excludeWorkbenchModel, excludeWorkbenchUtil)
-  val workbenchGoogle2Tests: ModuleID =    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests" excludeAll(excludeWorkbenchUtil, excludeWorkbenchModel)
+  val workbenchGoogle: ModuleID =       workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV)
+  val workbenchGoogleMocks: ModuleID =  workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests")
+  val workbenchGoogle2: ModuleID =      workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V)
+  val workbenchGoogle2Tests: ModuleID = workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests")
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.111.0-alpha" % "test"
 
   val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-d4b4838" excludeAll(excludeWorkbenchModel)
@@ -99,7 +107,7 @@ object Dependencies {
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.0-M2"
   val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.0-M2"
-  val opencensusStackDriverExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-stackdriver" % "0.23.0"
+  val opencensusStackDriverExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-stackdriver" % "0.23.0" excludeAll(excludeProtobufJavalite)
   val opencensusLoggingExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging"     % "0.23.0"
 
   val openCensusDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val googleV = "1.22.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
-  val workbenchGoogle2V = "0.6-4df42ca"
+  val workbenchGoogle2V = "0.10-bd284e7"
 
   val cromwellVersion = "40-2754783"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,14 +21,13 @@ object Dependencies {
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchUtil =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
 
-  val excludeSundrCore =     ExclusionRule(organization = "io.sundr", name = s"sundr-core")
   val excludeSundrCodegen =     ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
   val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
   val excludeProtobufJavalite =  ExclusionRule(organization = "com.google.protobuf", name = "protobuf-javalite")
 
   def workbenchGoogleExcludes(m: ModuleID): ModuleID = m.excludeAll(
     excludeWorkbenchModel, excludeWorkbenchUtil,
-    excludeSundrCore, excludeSundrCodegen,
+    excludeSundrCodegen,
     excludeBouncyCastleExt, excludeProtobufJavalite)
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,13 +21,15 @@ object Dependencies {
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
   val excludeWorkbenchUtil =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
 
+  val excludeSundrCore =     ExclusionRule(organization = "io.sundr", name = s"sundr-core")
   val excludeSundrCodegen =     ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
   val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
   val excludeProtobufJavalite =  ExclusionRule(organization = "com.google.protobuf", name = "protobuf-javalite")
 
   def workbenchGoogleExcludes(m: ModuleID): ModuleID = m.excludeAll(
     excludeWorkbenchModel, excludeWorkbenchUtil,
-    excludeSundrCodegen, excludeBouncyCastleExt, excludeProtobufJavalite)
+    excludeSundrCore, excludeSundrCodegen,
+    excludeBouncyCastleExt, excludeProtobufJavalite)
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,16 +19,15 @@ object Dependencies {
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
   val excludeWorkbenchModel =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.12")
-  val excludeWorkbenchUtil =   ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
+  val excludeWorkbenchUtil =    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_2.12")
 
-  val excludeSundrCodegen =     ExclusionRule(organization = "io.sundr", name = s"sundr-codegen")
-  val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
-  val excludeProtobufJavalite =  ExclusionRule(organization = "com.google.protobuf", name = "protobuf-javalite")
+  val excludeBouncyCastle =     ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
+  val excludeProtobufJavalite = ExclusionRule(organization = "com.google.protobuf", name = "protobuf-javalite")
 
   def workbenchGoogleExcludes(m: ModuleID): ModuleID = m.excludeAll(
     excludeWorkbenchModel, excludeWorkbenchUtil,
-    excludeSundrCodegen,
-    excludeBouncyCastleExt, excludeProtobufJavalite)
+    excludeBouncyCastle,
+    excludeProtobufJavalite)
 
   val akkaActor: ModuleID =         "com.typesafe.akka"   %%  "akka-actor"           % akkaV
   val akkaStream: ModuleID =        "com.typesafe.akka"   %%  "akka-stream"          % akkaV

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -8,6 +8,7 @@ object Merging {
     case PathList("org", "apache", xs @ _*) => MergeStrategy.last
     case PathList("com", "typesafe", xs @ _*) => MergeStrategy.last
     case PathList("com", "google", "auto", "value", xs @ _*) => MergeStrategy.last
+    case PathList("io", "sundr", xs @ _*) => MergeStrategy.last
     case "application.conf" => MergeStrategy.first
     case "version.conf" => MergeStrategy.concat
     case "logback.xml" => MergeStrategy.first


### PR DESCRIPTION
This is part of AS-322 but does not complete that ticket.

We want the latest workbench-libs/google2 library, because it contains an updated BigQuery client; that client will give us pagination and a more modern approach to querying BQ.

This PR upgrades the google2 lib, with necessary compatibility fixes, but makes no other code changes. Let's keep this PR small and targeted and separate from business logic changes. I'll add the business logic for AS-322 in #1230, after this PR merges and I rebase that other one.