### PR TITLE
workspace manager client should ignore any pre-existing servers [no ticket; risk: no]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -15,6 +15,9 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
 
   private def getApiClient(accessToken: String): ApiClient = {
     val client: ApiClient = new ApiClient()
+    // ignore any ServerConfigurations that pre-exist in the client by setting serverIndex to null
+    client.setServerIndex(null)
+    // and instead, rely solely on the basePath, which we read from env-specific Rawls config
     client.setBasePath(baseWorkspaceManagerUrl)
     client.setBearerToken(accessToken)
 


### PR DESCRIPTION
see code comments.

for reference, the generated client has this implementation:
```
public <T> ApiResponse<T> invokeAPI(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, GenericType<T> returnType) throws ApiException {
        this.updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
        String targetURL;
        if (this.serverIndex != null) {
            Integer index;
            List serverConfigurations;
            Map variables;
            if (this.operationServers.containsKey(operation)) {
                index = (Integer)this.operationServerIndex.getOrDefault(operation, this.serverIndex);
                variables = (Map)this.operationServerVariables.getOrDefault(operation, this.serverVariables);
                serverConfigurations = (List)this.operationServers.get(operation);
            } else {
                index = this.serverIndex;
                variables = this.serverVariables;
                serverConfigurations = this.servers;
            }

            if (index < 0 || index >= serverConfigurations.size()) {
                throw new ArrayIndexOutOfBoundsException(String.format("Invalid index %d when selecting the host settings. Must be less than %d", index, serverConfigurations.size()));
            }

            targetURL = ((ServerConfiguration)serverConfigurations.get(index)).URL(variables) + path;
        } else {
            targetURL = this.basePath + path;
        }

   ...
   ...
   ...

```