### PR TITLE
fix data repo DAO base path [no ticket; risk: no]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -311,7 +311,7 @@ object Boot extends IOApp with LazyLogging {
 
       val workspaceManagerDAO = new HttpWorkspaceManagerDAO(conf.getString("workspaceManager.baseUrl"))
 
-      val dataRepoDAO = new HttpDataRepoDAO(conf.getString("dataRepo.terraInstanceName"))
+      val dataRepoDAO = new HttpDataRepoDAO(conf.getString("dataRepo.terraInstanceName"), conf.getString("dataRepo.terraInstance"))
 
       val maxActiveWorkflowsTotal =
         conf.getInt("executionservice.maxActiveWorkflowsPerServer")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/datarepo/HttpDataRepoDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/datarepo/HttpDataRepoDAO.scala
@@ -7,11 +7,11 @@ import java.util.UUID
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.datarepo.model.SnapshotModel
 
-class HttpDataRepoDAO(dataRepoInstanceName: String) extends DataRepoDAO {
+class HttpDataRepoDAO(dataRepoInstanceName: String, dataRepoInstanceBasePath: String) extends DataRepoDAO {
 
   private def getApiClient(accessToken: String): ApiClient = {
     val client: ApiClient = new ApiClient()
-    client.setBasePath(dataRepoInstanceName)
+    client.setBasePath(dataRepoInstanceBasePath)
     client.setAccessToken(accessToken)
 
     client


### PR DESCRIPTION
#1232 broke Rawls' access to Data Repo, by telling the Data Repo DAO to use a human-readable name (e.g. `terra-dev`) as the base for data repo URLs. This PR fixes that!