### PR TITLE
remove hamm [no ticket; risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -12,7 +12,6 @@ import cats.implicits._
 import com.codahale.metrics.SharedMetricRegistries
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.pubsub.v1.ProjectTopicName
 import com.readytalk.metrics.{StatsDReporter, WorkbenchStatsD}
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
 import com.typesafe.scalalogging.LazyLogging
@@ -43,7 +42,7 @@ import org.broadinstitute.dsde.rawls.workspace.{WorkspaceService, WorkspaceServi
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.Json
 import org.broadinstitute.dsde.workbench.google.HttpGoogleBigQueryDAO
 import org.broadinstitute.dsde.workbench.google2._
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util.ExecutionContexts
 import org.http4s.Uri
 import org.http4s.client.blaze.BlazeClientBuilder
@@ -118,15 +117,9 @@ object Boot extends IOApp with LazyLogging {
     val clientSecrets = GoogleClientSecrets.load(jsonFactory, new StringReader(gcsConfig.getString("secrets")))
     val clientEmail = gcsConfig.getString("serviceClientEmail")
 
-    val hammCromwellMetadataConfig = gcsConfig.getConfig("hamm-cromwell-metadata")
     val serviceProject = gcsConfig.getString("serviceProject")
     val appName = gcsConfig.getString("appName")
     val pathToPem = gcsConfig.getString("pathToPem")
-
-    val hammCromwellMetadata = HammCromwellMetadata(
-      GcsBucketName(hammCromwellMetadataConfig.getString("bucket-name")),
-      ProjectTopicName.of(serviceProject, hammCromwellMetadataConfig.getString("topic-name "))
-    )
 
     //Sanity check deployment manager template path.
     val dmConfig = DeploymentManagerConfig(gcsConfig.getConfig("deploymentManager"))
@@ -161,7 +154,6 @@ object Boot extends IOApp with LazyLogging {
         gcsConfig.getStringList("billingGroupEmailAliases").asScala.toList,
         dmConfig.billingProbeEmail,
         gcsConfig.getInt("bucketLogsMaxAge"),
-        hammCromwellMetadata = hammCromwellMetadata,
         googleStorageService = appDependencies.googleStorageService,
         googleServiceHttp = appDependencies.googleServiceHttp,
         topicAdmin = appDependencies.topicAdmin,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -1,22 +1,17 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import cats.effect.IO
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.services.admin.directory.model.Group
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.google.api.services.storage.model.{Bucket, BucketAccessControl, StorageObject}
-import com.google.pubsub.v1.ProjectTopicName
 import com.typesafe.config.Config
-import fs2.Stream
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess.slick.RawlsBillingProjectOperationRecord
 import org.broadinstitute.dsde.rawls.google.AccessContextManagerDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 import spray.json.JsObject
 
@@ -102,8 +97,6 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def diagnosticBucketRead(userInfo: UserInfo, bucketName: String): Future[Option[ErrorReport]]
 
   def listObjectsWithPrefix(bucketName: String, objectNamePrefix: String): Future[List[StorageObject]]
-
-  def storeCromwellMetadata(objectName: GcsBlobName, body: fs2.Stream[fs2.Pure, Byte]): Stream[IO, Unit]
 
   def copyFile(sourceBucket: String, sourceObject: String, destinationBucket: String, destinationObject: String): Future[Option[StorageObject]]
 
@@ -301,7 +294,6 @@ case class OperationId(apiType: GoogleApiTypes.GoogleApiType, operationId: Strin
 case class OperationStatus(done: Boolean, errorMessage: Option[String])
 case class GoogleWorkspaceInfo(bucketName: String, policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail])
 case class ProjectTemplate(owners: Seq[String], editors: Seq[String])
-final case class HammCromwellMetadata(bucketName: GcsBucketName, topicName: ProjectTopicName)
 
 case object ProjectTemplate {
   def from(projectTemplateConfig: Config): ProjectTemplate = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBillingHttpGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBillingHttpGoogleServicesDAO.scala
@@ -7,10 +7,8 @@ import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import com.google.api.services.cloudbilling.model.BillingAccount
-import com.google.pubsub.v1.ProjectTopicName
 import org.broadinstitute.dsde.rawls.google.MockGoogleAccessContextManagerDAO
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 
 import scala.collection.mutable
@@ -57,7 +55,6 @@ class MockBillingHttpGoogleServicesDAO( useServiceAccountForBuckets: Boolean,
     billingGroupEmailAliases,
     billingProbeEmail = "billingprobe@deployment-manager-project.iam.gserviceaccount.com",
     bucketLogsMaxAge,
-    hammCromwellMetadata = HammCromwellMetadata(GcsBucketName("fakeBucketName"), ProjectTopicName.of(serviceProject, "fakeTopic")),
     googleStorageService = null,
     googleServiceHttp = null,
     topicAdmin = null,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -1,20 +1,17 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import cats.effect.IO
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import com.google.api.services.admin.directory.model.Group
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.google.api.services.storage.model.{Bucket, BucketAccessControl, StorageObject}
-import fs2.Stream
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess.slick.RawlsBillingProjectOperationRecord
 import org.broadinstitute.dsde.rawls.google.{AccessContextManagerDAO, MockGoogleAccessContextManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
 import spray.json._
@@ -122,8 +119,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
   override def diagnosticBucketRead(userInfo: UserInfo, bucketName: String) = Future.successful(None)
 
   override def listObjectsWithPrefix(bucketName: String, objectNamePrefix: String): Future[List[StorageObject]] = Future.successful(List.empty)
-
-  override def storeCromwellMetadata(objectName: GcsBlobName, body: fs2.Stream[fs2.Pure, Byte]): Stream[IO, Unit] = Stream.empty
 
   override def copyFile(sourceBucket: String, sourceObject: String, destinationBucket: String, destinationObject: String): Future[Option[StorageObject]] = Future.successful(None)
 


### PR DESCRIPTION
[Hamm](https://github.com/DataBiosphere/hamm) is an abandoned cost-tracking effort that is not in use. But, Rawls contains code to upload Hamm cost info to a bucket, where Hamm would have read it if Hamm was active. This Rawls code is chatty in the logs and pollutes the codebase. Let's remove it.

-----

remaining TODOs, for which I will file follow-on Jira tickets:
* [ ] remove Hamm's bucket and its contents, after confirming we don't want that data
* [ ] remove Hamm values from conf files
