### PR TITLE
AS-323: queryEntities supports data repo [risk: medium]

### DIFF
--- a/core/src/main/resources/swagger/data-repo-only.yaml
+++ b/core/src/main/resources/swagger/data-repo-only.yaml
@@ -38,6 +38,48 @@ paths:
         - $ref: '#/components/parameters/entityNamePathParam'
         - $ref: '#/components/parameters/dataReferenceQueryParam'
         - $ref: '#/components/parameters/billingProjectQueryParam'
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/entityQuery/{entityType}:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+        - $ref: '#/components/parameters/entityTypePathParam'
+        - name: page
+          in: query
+          description: Page number, 1-indexed (default 1)
+          schema:
+            minimum: 1
+            type: number
+            default: 1
+        - name: pageSize
+          in: query
+          description: Page size (default 10)
+          schema:
+            minimum: 1
+            type: number
+            default: 10
+        - name: sortField
+          in: query
+          description: Sort field (default "name")
+          schema:
+            type: string
+            default: name
+        - name: sortDirection
+          in: query
+          description: Sort direction (asc or desc, default asc)
+          schema:
+            type: string
+            default: asc
+            enum:
+              - asc
+              - desc
+        - name: filterTerms
+          in: query
+          description: Filter terms
+          schema:
+            type: string
+        - $ref: '#/components/parameters/dataReferenceQueryParam'
+        - $ref: '#/components/parameters/billingProjectQueryParam'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots:
     get:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityTypeMetadata, SubmissionValidationEntityInputs}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, SubmissionValidationEntityInputs}
 
 import scala.concurrent.Future
 
@@ -21,4 +21,6 @@ trait EntityProvider {
   def expressionValidator: ExpressionValidator
 
   def getEntity(entityType: String, entityName: String): Future[Entity]
+
+  def queryEntities(entityType: String, query: EntityQuery): Future[EntityQueryResponse]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
+import akka.http.scaladsl.model.StatusCodes
 import com.google.cloud.bigquery.Field.Mode
 import com.google.cloud.bigquery._
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException}
@@ -131,6 +132,57 @@ trait DataRepoBigQuerySupport {
       case _ =>
         throw new DataEntityException(s"Query succeeded, but returned ${queryResults.getTotalRows} rows; expected one row.")
     }
+  }
+
+  /**
+   * Translates a BigQuery result set into the pagination metadata that Rawls expects.
+   * @param queryResults the BigQuery result set
+   * @param entityQuery the query criteria supplied by the user, which includes page size
+   * @return the Rawls-flavor pagination metadata
+   */
+  def queryResultsMetadata(queryResults:TableResult, entityQuery: EntityQuery): EntityQueryResultMetadata = {
+    val totalRowCount = queryResults.getTotalRows
+
+    val pageCount = Math.ceil(totalRowCount.toFloat / entityQuery.pageSize).toInt
+
+    // we don't support filtering in BQ, so unfilteredCount and filteredCount are the same
+    EntityQueryResultMetadata(totalRowCount.toInt, totalRowCount.toInt, pageCount)
+  }
+
+  /**
+   * Given an EntityQuery, which contains page number and page size, generate the correct absolute pagination offset for use in BQ
+   * @param entityQuery the query criteria supplied by the user
+   * @return the offset value to use in an OFFSET sql clause
+   */
+  def translatePaginationOffset(entityQuery: EntityQuery): Int = {
+    if (entityQuery.page < 1)
+      throw new DataEntityException("page value must be at least 1.", code = StatusCodes.BadRequest)
+    (entityQuery.page-1) * entityQuery.pageSize
+  }
+
+  /**
+   * generates the SQL and config to send to BigQuery for use in the queryEntities() method
+   * @param dataProject project containing the BQ data
+   * @param viewName dataset/snapshot to query in BQ
+   * @param entityType table to query in BQ
+   * @param entityQuery user-supplied query criteria
+   * @return the object to pass to BQ to execute a query
+   */
+  def queryConfigForQueryEntities(dataProject: String, viewName: String, entityType: String, entityQuery: EntityQuery): QueryJobConfiguration = {
+    // generate BQ SQL for this entity
+    // TODO: prevent injection in the places BQ doesn't support named params! why doesn't it support params everywhere???
+    val query = s"SELECT * FROM `${dataProject}.${viewName}.${entityType}` " +
+      s"ORDER BY ${entityQuery.sortField} ${SortDirections.toSql(entityQuery.sortDirection)} " +
+      s"LIMIT ${entityQuery.pageSize} " +
+      s"OFFSET ${translatePaginationOffset(entityQuery).toLong};"
+
+    // generate query config, with named param for primary key
+    QueryJobConfiguration.newBuilder(query)
+//      .addNamedParameter("sortcol", QueryParameterValue.string(entityQuery.sortField))
+//      .addNamedParameter("sortdir", QueryParameterValue.string(SortDirections.toSql(entityQuery.sortDirection)))
+//      .addNamedParameter("limit", QueryParameterValue.int64(entityQuery.pageSize.toLong))
+//      .addNamedParameter("offset", QueryParameterValue.int64( translatePaginationOffset(entityQuery).toLong ))
+      .build
   }
 
   // create comma-delimited string of field names for use in error messages.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -173,6 +173,15 @@ trait DataRepoBigQuerySupport {
     // TODO: prevent injection in the places BQ doesn't support named params! why doesn't it support params everywhere???
     // TODO: prevent injection via dataProject, viewName, entityType vars. These are calculated from the snapshot so
     // they should be safe, but we should have layers of protection.
+    // Google's doc on table naming (https://cloud.google.com/bigquery/docs/tables) says:
+    //   * Contain up to 1,024 characters
+    //   * Contain letters (upper or lower case), numbers, and underscores
+    // Google's doc on dataset naming (https://cloud.google.com/bigquery/docs/datasets) has the exact same requirements
+    // Google's doc on view naming (https://cloud.google.com/bigquery/docs/views) has the exact same requirements
+    // Google's doc on project naming (https://cloud.google.com/resource-manager/docs/creating-managing-projects) says:
+    //   * The project ID must be a unique string of 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter, and cannot have a trailing hyphen.
+    // Google's doc on column naming (https://cloud.google.com/bigquery/docs/schemas) says:
+    //   * A column name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and it must start with a letter or underscore. The maximum column name length is 128 characters
     val query = s"SELECT * FROM `${dataProject}.${viewName}.${entityType}` " +
       s"ORDER BY ${entityQuery.sortField} ${SortDirections.toSql(entityQuery.sortDirection)} " +
       s"LIMIT ${entityQuery.pageSize} " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -171,6 +171,8 @@ trait DataRepoBigQuerySupport {
   def queryConfigForQueryEntities(dataProject: String, viewName: String, entityType: String, entityQuery: EntityQuery): QueryJobConfiguration = {
     // generate BQ SQL for this entity
     // TODO: prevent injection in the places BQ doesn't support named params! why doesn't it support params everywhere???
+    // TODO: prevent injection via dataProject, viewName, entityType vars. These are calculated from the snapshot so
+    // they should be safe, but we should have layers of protection.
     val query = s"SELECT * FROM `${dataProject}.${viewName}.${entityType}` " +
       s"ORDER BY ${entityQuery.sortField} ${SortDirections.toSql(entityQuery.sortDirection)} " +
       s"LIMIT ${entityQuery.pageSize} " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -10,6 +10,9 @@ import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEv
 import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityTypeNotFoundException, UnsupportedEntityOperationException}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityTypeMetadata, SubmissionValidationEntityInputs}
+import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport.TerraDataRepoSnapshotRequestFormat
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, DataReferenceName, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, SubmissionValidationEntityInputs, TerraDataRepoSnapshotRequest}
+import spray.json._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -98,13 +98,6 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
       throw new UnsupportedEntityOperationException("term filtering not supported by this provider.")
     }
 
-    // TODO: lots duplicated here from getEntity
-    // get snapshot UUID from data reference name
-    val snapshotId = lookupSnapshotForName(dataReferenceName)
-
-    // contact TDR to describe the snapshot
-    val snapshotModel = dataRepoDAO.getSnapshot(snapshotId, userInfo.accessToken)
-
     // extract table definition, with PK, from snapshot schema
     val tableModel = snapshotModel.getTables.asScala.find(_.getName == entityType) match {
       case Some(table) => table

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityTypeNotFoundExce
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityTypeMetadata, SubmissionValidationEntityInputs}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport.TerraDataRepoSnapshotRequestFormat
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, DataReferenceName, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, SortDirections, SubmissionValidationEntityInputs, TerraDataRepoSnapshotRequest}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, DataReferenceName, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, SubmissionValidationEntityInputs, TerraDataRepoSnapshotRequest}
 import spray.json._
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -69,7 +69,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     // generate BQ SQL for this entity
     // TODO: prevent injection via dataProject, viewName, entityType vars. These are calculated from the snapshot so
     // they should be safe, but we should have layers of protection.
-    val query = s"SELECT * FROM `${dataProject}.${viewName}.${entityType}` WHERE $pk = @pkvalue;"
+    val query = s"SELECT * FROM `${sanitizeSql(dataProject)}.${sanitizeSql(viewName)}.${sanitizeSql(entityType)}` WHERE $pk = @pkvalue;"
     // generate query config, with named param for primary key
     val queryConfig = QueryJobConfiguration.newBuilder(query)
       .addNamedParameter("pkvalue", QueryParameterValue.string(entityName))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityTypeNotFoundExce
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityTypeMetadata, SubmissionValidationEntityInputs}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport.TerraDataRepoSnapshotRequestFormat
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, DataReferenceName, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, SubmissionValidationEntityInputs, TerraDataRepoSnapshotRequest}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, DataReferenceName, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, SortDirections, SubmissionValidationEntityInputs, TerraDataRepoSnapshotRequest}
 import spray.json._
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -64,6 +64,8 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     // determine view name
     val viewName = snapshotModel.getName
     // generate BQ SQL for this entity
+    // TODO: prevent injection via dataProject, viewName, entityType vars. These are calculated from the snapshot so
+    // they should be safe, but we should have layers of protection.
     val query = s"SELECT * FROM `${dataProject}.${viewName}.${entityType}` WHERE $pk = @pkvalue;"
     // generate query config, with named param for primary key
     val queryConfig = QueryJobConfiguration.newBuilder(query)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -62,9 +62,8 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     // determine view name
     val viewName = snapshotModel.getName
     // generate BQ SQL for this entity
-    // TODO: prevent injection via dataProject, viewName, entityType vars. These are calculated from the snapshot so
     // they should be safe, but we should have layers of protection.
-    val query = s"SELECT * FROM `${sanitizeSql(dataProject)}.${sanitizeSql(viewName)}.${sanitizeSql(entityType)}` WHERE $pk = @pkvalue;"
+    val query = s"SELECT * FROM `${validateSql(dataProject)}.${validateSql(viewName)}.${validateSql(entityType)}` WHERE $pk = @pkvalue;"
     // generate query config, with named param for primary key
     val queryConfig = QueryJobConfiguration.newBuilder(query)
       .addNamedParameter("pkvalue", QueryParameterValue.string(entityName))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/DataEntityException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/DataEntityException.scala
@@ -1,8 +1,9 @@
 package org.broadinstitute.dsde.rawls.entities.exceptions
 
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import org.broadinstitute.dsde.rawls.RawlsException
 
 /** Exception related to working with data entities.
  */
-class DataEntityException(message: String = null, cause: Throwable = null) extends RawlsException(message, cause)
+class DataEntityException(message: String = null, cause: Throwable = null, val code: StatusCode = StatusCodes.InternalServerError) extends RawlsException(message, cause)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/IllegalIdentifierException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/IllegalIdentifierException.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.rawls.entities.exceptions
+
+class IllegalIdentifierException(message: String = null, cause: Throwable = null) extends DataEntityException(message, cause)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -42,7 +42,7 @@ trait EntityApiService extends UserInfoDirectives {
 
             if (errors.isEmpty) {
               val entityQuery = EntityQuery(toIntTries("page").get.getOrElse(1), toIntTries("pageSize").get.getOrElse(10), sortField.getOrElse("name"), sortDirectionTry.get, filterTerms)
-              complete { entityServiceConstructor(userInfo).QueryEntities(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityQuery) }
+              complete { entityServiceConstructor(userInfo).QueryEntities(WorkspaceName(workspaceNamespace, workspaceName), dataReference, entityType, entityQuery) }
             } else {
               complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
             }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySanitizationSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySanitizationSpec.scala
@@ -1,0 +1,70 @@
+package org.broadinstitute.dsde.rawls.entities.datarepo
+
+import java.nio.charset.Charset
+
+import com.google.common.io.Resources
+import org.scalatest.{BeforeAndAfterAll, FreeSpec}
+import spray.json._
+
+class DataRepoBigQuerySanitizationSpec extends FreeSpec with DataRepoBigQuerySupport with BeforeAndAfterAll {
+
+  // read the list of naughty strings from https://github.com/minimaxir/big-list-of-naughty-strings.
+  // We expect a json array, containing base64-encoded strings.
+  val blnsData = Resources.toString(
+    new java.net.URL("https://raw.githubusercontent.com/minimaxir/big-list-of-naughty-strings/master/blns.base64.json"),
+    Charset.defaultCharset())
+
+  val naughtyStrings = blnsData.parseJson match {
+    case blns:JsArray =>
+      blns.elements.map {
+        case s:JsString => new String(java.util.Base64.getDecoder.decode(s.value))
+        case _ => fail("found something not a string in BLNS")
+      }.toList
+    case _ => fail("BLNS was not a json array")
+  }
+
+  override protected def beforeAll(): Unit = {
+    // create a new variable to hold the size; this prevents Scalatest from attempting to output
+    // anything about the contents of the list itself, if the assertion fails
+    val nSize = naughtyStrings.size
+    assert(nSize > 0, "fixture data was empty; failing test. Size: " + nSize)
+
+    super.beforeAll()
+  }
+
+
+  "DataRepoBigQuerySupport, when sanitizing SQL strings, should" - {
+    "pass legal strings untouched" in {
+      val input = "thisIsALegalString"
+      val expected = "thisIsALegalString"
+      assertResult(expected) { sanitizeSql(input) }
+    }
+
+    "remove illegal characters in strings" in {
+      val input = "this has bad characters; it's no good!"
+      val expected = "thishasbadcharactersitsnogood"
+      assertResult(expected) { sanitizeSql(input) }
+    }
+
+    s"do the right things across ${naughtyStrings.size} inputs from github.com/minimaxir/big-list-of-naughty-strings" in {
+      // use this instead of regex to ensure the test has a different implementation than the runtime implementation
+      def isLegalSqlChar(c: Char): Boolean = {
+        val i = c.toInt
+        (i >= 48 && i <= 57) || // 0-9
+        (i >= 65 && i <= 90) || // A-Z
+        (i >= 97 && i <= 122) || // a-z
+         i == 95 || // underscore
+         i == 45 // hyphen
+      }
+
+      def isLegalSqlString(s: String): Boolean = s.toCharArray.forall(isLegalSqlChar)
+
+      naughtyStrings.foreach { input =>
+        val actual = sanitizeSql(input)
+        assert(isLegalSqlString(actual), s"found an illegal character in '$input' which sanitized to '$actual'")
+      }
+    }
+
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory.{results, schema}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityTypeNotFoundException, UnsupportedEntityOperationException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityTypeNotFoundException, UnsupportedEntityOperationException}
 import org.broadinstitute.dsde.rawls.model._
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
@@ -97,6 +97,15 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     futureEx map { ex =>
       assertResult("sam error") { ex.getMessage }
     }
+  }
+
+  it should "throw bad request the supplied sort field does not exist in the target table" in {
+    val provider = createTestProvider()
+
+    val ex = intercept[DataEntityException] {
+      provider.queryEntities("table1", defaultEntityQuery.copy(sortField = "unknownColumn"))
+    }
+    assertResult("sortField not valid for this entity type") { ex.getMessage }
   }
 
   it should "throw bad request if a filter is supplied" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
@@ -1,0 +1,173 @@
+package org.broadinstitute.dsde.rawls.entities.datarepo
+
+import bio.terra.datarepo.model.TableModel
+import com.google.cloud.PageImpl
+import com.google.cloud.bigquery._
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory
+import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory.{results, schema}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.entities.exceptions.EntityTypeNotFoundException
+import org.broadinstitute.dsde.rawls.model._
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRepoEntityProviderSpecSupport with TestDriverComponent with Matchers {
+
+  override implicit val executionContext = TestExecutionContext.testExecutionContext
+
+  behavior of "DataEntityProvider.queryEntities()"
+
+  val defaultEntityQuery: EntityQuery = EntityQuery(page = 1, pageSize = 10, sortField = "datarepo_row_id", sortDirection = SortDirections.Ascending, filterTerms = None)
+
+  it should "return one entity if all OK and BQ returned one" in {
+
+    // set up a provider with a mock that returns exactly one BQ row
+    val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, results.take(1).asJava)
+    val tableResult: TableResult = new TableResult(schema, 1, page)
+    val provider = createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)))
+
+    provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
+      // this is the default expected value, should it move to the support trait?
+      val expected = Seq(Entity("the first row", "table1", Map(
+        AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString("the first row"),
+        AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+        AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+        AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+      )))
+      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 1, filteredCount = 1, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
+      assertResult(expected) { entityQueryResponse.results }
+    }
+  }
+
+  it should "return three entities if all OK and BQ returned three" in {
+
+    val provider = createTestProvider() // default behavior returns three rows
+
+    provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
+      // this is the default expected value, should it move to the support trait?
+      val expected = Seq("the first row", "the second row", "the third row") map { stringKey  =>
+        Entity(stringKey, "table1", Map(
+          AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString(stringKey),
+          AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+          AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+          AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+        ))
+      }
+      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 3, filteredCount = 3, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
+      assertResult(expected) { entityQueryResponse.results }
+    }
+  }
+
+  it should "return empty Seq and appropriate metadata if BigQuery returns zero rows" in {
+    val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List.empty[FieldValueList].asJava)
+    val tableResult: TableResult = new TableResult(Schema.of(List.empty[Field].asJava), 0, page)
+
+    val provider = createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)))
+
+    provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
+      // this is the default expected value, should it move to the support trait?
+      val expected = Seq.empty[Entity]
+      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 0, filteredCount = 0, filteredPageCount = 0)) { entityQueryResponse.resultMetadata }
+      assertResult(expected) { entityQueryResponse.results }
+    }
+  }
+
+  it should "bubble up error if workspace manager errors (includes reference not found)" in {
+    val provider = createTestProvider(
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Left(new bio.terra.workspace.client.ApiException("whoops 1"))))
+
+    val ex = intercept[bio.terra.workspace.client.ApiException] {
+      provider.queryEntities("table1", defaultEntityQuery)
+    }
+    assertResult("whoops 1") { ex.getMessage }
+  }
+
+  it should "fail if pet credentials not available from Sam" in {
+    val provider = createTestProvider(
+      samDAO = new SpecSamDAO(petKeyForUserResponse = Left(new Exception("sam error"))))
+
+    val futureEx = recoverToExceptionIf[Exception] {
+      provider.queryEntities("table1", defaultEntityQuery)
+    }
+    futureEx map { ex =>
+      assertResult("sam error") { ex.getMessage }
+    }
+  }
+
+  ignore should "compute pagination metadata based on BQ metadata" in {
+    // we don't want to test that BQ produces the right pagination; that's BQ's problem. We only test that we interpret it.
+    fail("unit test not written")
+  }
+
+  ignore should "pass sort column and sort order to BigQuery" in {
+    // we don't want to test that results are sorted; that's BQ's problem. We only test that we send the params to BQ.
+    fail("unit test not written")
+  }
+
+  ignore should "pass pagination offset and limit to BigQuery" in {
+    // we don't want to test that results are paginated; that's BQ's problem. We only test that we send the params to BQ.
+    fail("unit test not written")
+  }
+
+  ignore should "throw bad request if a filter is supplied" in {
+    // TODO: alternately, should we silently ignore filters?
+    fail("not implemented in runtime code yet")
+  }
+
+  ignore should "fail if user is a workspace Reader but did not specify a billing project (canCompute?)" in {
+    // we haven't implemented the runtime logic for this because we don't have PO input,
+    // so we don't know exactly what to unit test
+    fail("not implemented in runtime code yet")
+  }
+
+  it should "bubble up error if data repo errors (includes snapshot not found/not allowed)" in {
+    val provider = createTestProvider(
+      dataRepoDAO = new SpecDataRepoDAO(Left(new bio.terra.datarepo.client.ApiException("whoops 2"))))
+
+    val ex = intercept[bio.terra.datarepo.client.ApiException] {
+      provider.queryEntities("table1", defaultEntityQuery)
+    }
+    assertResult("whoops 2") { ex.getMessage }
+  }
+
+  it should "fail if snapshot has no tables in data repo" in {
+    val provider = createTestProvider(
+      dataRepoDAO = new SpecDataRepoDAO(Right( createSnapshotModel( List.empty[TableModel] ) )))
+
+    val ex = intercept[EntityTypeNotFoundException] {
+      provider.queryEntities("table1", defaultEntityQuery)
+    }
+    assertResult("table1") { ex.requestedType }
+  }
+
+  it should "fail if snapshot table not found in data repo's response" in {
+    val provider = createTestProvider() // default behavior returns three rows
+
+    val ex = intercept[EntityTypeNotFoundException] {
+      provider.queryEntities("this_table_is_unknown", defaultEntityQuery)
+    }
+    assertResult("this_table_is_unknown") { ex.requestedType }
+  }
+
+  it should "bubble up error if BigQuery errors" in {
+    val provider = createTestProvider(
+      bqFactory = MockBigQueryServiceFactory.ioFactory(Left(new BigQueryException(555, "unit test exception message"))))
+
+    val futureEx = recoverToExceptionIf[BigQueryException] {
+      provider.queryEntities("table1", defaultEntityQuery)
+    }
+    futureEx map { ex =>
+      assertResult("unit test exception message") { ex.getMessage }
+    }
+  }
+
+
+}
+
+
+

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory.{results, schema}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-import org.broadinstitute.dsde.rawls.entities.exceptions.EntityTypeNotFoundException
+import org.broadinstitute.dsde.rawls.entities.exceptions.{EntityTypeNotFoundException, UnsupportedEntityOperationException}
 import org.broadinstitute.dsde.rawls.model._
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
@@ -99,24 +99,13 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     }
   }
 
-  ignore should "compute pagination metadata based on BQ metadata" in {
-    // we don't want to test that BQ produces the right pagination; that's BQ's problem. We only test that we interpret it.
-    fail("unit test not written")
-  }
+  it should "throw bad request if a filter is supplied" in {
+    val provider = createTestProvider()
 
-  ignore should "pass sort column and sort order to BigQuery" in {
-    // we don't want to test that results are sorted; that's BQ's problem. We only test that we send the params to BQ.
-    fail("unit test not written")
-  }
-
-  ignore should "pass pagination offset and limit to BigQuery" in {
-    // we don't want to test that results are paginated; that's BQ's problem. We only test that we send the params to BQ.
-    fail("unit test not written")
-  }
-
-  ignore should "throw bad request if a filter is supplied" in {
-    // TODO: alternately, should we silently ignore filters?
-    fail("not implemented in runtime code yet")
+    val ex = intercept[UnsupportedEntityOperationException] {
+      provider.queryEntities("table1", defaultEntityQuery.copy(filterTerms = Some("my filter terms")))
+    }
+    assertResult("term filtering not supported by this provider.") { ex.getMessage }
   }
 
   ignore should "fail if user is a workspace Reader but did not specify a billing project (canCompute?)" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -32,7 +32,7 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     provider.entityTypeMetadata() map { metadata: Map[String, EntityTypeMetadata] =>
       // this is the default expected value, should it move to the support trait?
       val expected = Map(
-        ("table1", EntityTypeMetadata(0, "datarepo_row_id", Seq())),
+        ("table1", EntityTypeMetadata(0, "datarepo_row_id", Seq("datarepo_row_id", "integer-field", "boolean-field", "timestamp-field"))),
         ("table2", EntityTypeMetadata(123, "table2PK", Seq("col2.1", "col2.2"))),
         ("table3", EntityTypeMetadata(456, "datarepo_row_id", Seq("col3.1", "col3.2"))))
       assertResult(expected) { metadata }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -84,7 +84,7 @@ trait DataRepoEntityProviderSpecSupport {
 
   val defaultTables: List[TableModel] = List(
     new TableModel().name("table1").primaryKey(null).rowCount(0)
-      .columns(List().map(new ColumnModel().name(_)).asJava),
+      .columns(List("datarepo_row_id", "integer-field", "boolean-field", "timestamp-field").map(new ColumnModel().name(_)).asJava),
     new TableModel().name("table2").primaryKey(List("table2PK").asJava).rowCount(123)
       .columns(List("col2.1", "col2.2").map(new ColumnModel().name(_)).asJava),
     new TableModel().name("table3").primaryKey(List("compound","pk").asJava).rowCount(456)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -94,7 +94,10 @@ trait DataRepoEntityProviderSpecSupport {
   /* A "factory" method to create SnapshotModel objects, with default.
    */
   def createSnapshotModel( tables: List[TableModel] = defaultTables): SnapshotModel =
-    new SnapshotModel().tables(tables.asJava)
+    new SnapshotModel()
+      .tables(tables.asJava)
+      .dataProject("unittest-dataproject")
+      .name("unittest-name")
 
   /**
    * Mock for WorkspaceManagerDAO that allows the caller to specify behavior for the getDataReferenceByName method.


### PR DESCRIPTION
This PR adds support for Data Repo in the `entityQuery` API.

If the end user specifies a dataReference value for this API, via querystring, we will retrieve that reference from Workspace Manager, find its snapshot in Data Repo, and then formulate a paginated request to BigQuery to return results.

Fulltext search is not supported. If the user specifies search terms, they will get a BadRequest.

BigQuery, and its associated Java client, is lacking in support for SQL sanitization. I had to implement that myself, and very much want close inspection of that.
