### PR TITLE
remove arrow/avro-import [no ticket; risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -175,15 +175,6 @@ object Boot extends IOApp with LazyLogging {
         workbenchMetricBaseName = metricsPrefix
       )
 
-      // Avro upsert uses a different project for its pubsub topics
-      // remove when cutting over to import service
-      val arrowPubSubDAO = new HttpGooglePubSubDAO(
-        clientEmail,
-        pathToPem,
-        appName,
-        conf.getString("avroUpsertMonitor.arrowPubSubProject"),
-        workbenchMetricBaseName = metricsPrefix
-      )
       // Import service uses a different project for its pubsub topic
       val importServicePubSubDAO = new HttpGooglePubSubDAO(
         clientEmail,
@@ -214,7 +205,7 @@ object Boot extends IOApp with LazyLogging {
       }
 
       val executionServiceConfig = conf.getConfig("executionservice")
-      val submissionTimeout = util.toScalaDuration(
+      val submissionTimeout = org.broadinstitute.dsde.rawls.util.toScalaDuration(
         executionServiceConfig.getDuration("workflowSubmissionTimeout")
       )
 
@@ -435,7 +426,6 @@ object Boot extends IOApp with LazyLogging {
           samDAO,
           pubSubDAO,
           importServicePubSubDAO,
-          arrowPubSubDAO, // remove when cutting over to import service
           importServiceDAO,
           appDependencies.googleStorageService,
           methodRepoDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -66,9 +66,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
   val workspaceName =  testData.workspace.toWorkspaceName
   val googleStorage = FakeGoogleStorageInterpreter
-  val arrowPubSubTopic = "fake-arrow-pub-sub-topic"          // remove when cutting over to import service
-  val arrowPubSubSubscription = "arrow-pub-sub-subscription" // remove when cutting over to import service
-  val arrowBucketName = "arrow-bucket-name"                  // remove when cutting over to import service
   val importReadPubSubTopic = "request-topic"
   val importReadSubscriptionName = "request-sub"
   val importWritePubSubTopic = "status-topic"
@@ -91,9 +88,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   val config = AvroUpsertMonitorSupervisor.AvroUpsertMonitorConfig(
     FiniteDuration.apply(1, TimeUnit.SECONDS),
     FiniteDuration.apply(1, TimeUnit.SECONDS),
-    arrowPubSubTopic,        // remove when cutting over to import service
-    arrowPubSubSubscription, // remove when cutting over to import service
-    arrowBucketName,         // remove when cutting over to import service
     importReadPubSubTopic,
     importReadSubscriptionName,
     importWritePubSubTopic,
@@ -106,7 +100,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     // create the two topics
     services.gpsDAO.createTopic(importReadPubSubTopic)
     services.gpsDAO.createTopic(importWritePubSubTopic)
-    services.gpsDAO.createTopic(arrowPubSubTopic)      // remove when cutting over to import service
 
     val mockImportServiceDAO =  new MockImportServiceDAO()
 
@@ -118,7 +111,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
       googleStorage,
       services.gpsDAO,
       services.gpsDAO,
-      services.gpsDAO, // remove when cutting over to import service
       mockImportServiceDAO,
       config
     ))


### PR DESCRIPTION
removes code that is currently unused. Once we switched over to using the new Import Service, these code paths were obsolete.

Still todo: remove these configs from rawls.conf via firecloud-develop.