### PR TITLE
remove hamm from reference.conf [no ticket; risk: no]

### DIFF
--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -69,10 +69,6 @@ liquibase {
 gcs {
   bucketLogsMaxAge = "180"
   pathToCredentialJson = "fakePathToCredential"
-  hamm-cromwell-metadata = {
-    bucket-name = "fakeBucketName"
-    topic-name = "fakeTopicName"
-  }
 
   deploymentManager {
     #these aren't real


### PR DESCRIPTION
followup to #1243 ... now that Hamm code no longer exists in Rawls, let's remove the relevant stanza from the test reference.conf.