### PR TITLE
eager/early validation of snapshot UUID strings [no ticket; risk: no]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -2,18 +2,20 @@ package org.broadinstitute.dsde.rawls.snapshot
 
 import java.util.UUID
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.workspace.model.DataReferenceDescription.{CloningInstructionsEnum, ReferenceTypeEnum}
 import com.google.api.client.auth.oauth2.Credential
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{DataRepoSnapshot, DataRepoSnapshotList, DataRepoSnapshotReference, SamWorkspaceActions, TerraDataRepoSnapshotRequest, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{DataRepoSnapshot, DataRepoSnapshotList, DataRepoSnapshotReference, ErrorReport, SamWorkspaceActions, TerraDataRepoSnapshotRequest, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object SnapshotService {
 
@@ -45,8 +47,9 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
   }
 
   def getSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[DataRepoSnapshotReference] = {
+    val snapshotUuid = validateSnapshotId(snapshotId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
-      val ref = workspaceManagerDAO.getDataReference(workspaceContext.workspaceIdAsUUID, UUID.fromString(snapshotId), userInfo.accessToken)
+      val ref = workspaceManagerDAO.getDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
       Future.successful(DataRepoSnapshotReference(ref))
     }
   }
@@ -59,8 +62,9 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
   }
 
   def deleteSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[Unit] = {
+    val snapshotUuid = validateSnapshotId(snapshotId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
-      workspaceManagerDAO.deleteDataReference(workspaceContext.workspaceIdAsUUID, UUID.fromString(snapshotId), userInfo.accessToken)
+      workspaceManagerDAO.deleteDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
     }
   }
 
@@ -75,4 +79,13 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     }
     OAuth2BearerToken(serviceAccountCreds.getAccessToken)
   }
+
+  private def validateSnapshotId(snapshotId: String): UUID = {
+    Try(UUID.fromString(snapshotId)) match {
+      case Success(snapshotUuid) => snapshotUuid
+      case Failure(_) =>
+        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "SnapshotId must be a valid UUID."))
+    }
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -135,6 +135,16 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "return 400 when getting a reference to a snapshot that is not a valid UUID" in withTestDataApiServices { services =>
+    Get(s"${testData.wsName.path}/snapshots/not-a-valid-uuid") ~>
+      sealRoute(services.snapshotRoutes) ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+      }
+  }
+
   it should "return 404 when getting a reference to a snapshot that doesn't exist" in withTestDataApiServices { services =>
     Get(s"${testData.wsName.path}/snapshots/${UUID.randomUUID().toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
@@ -146,7 +156,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 when getting a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices { services =>
-    Get(s"/workspaces/foo/bar/snapshots/doesntmatter") ~>
+    Get(s"/workspaces/foo/bar/snapshots/${UUID.randomUUID().toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -275,8 +285,18 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "return 400 when a user tries to delete a snapshot that is not a valid UUID" in withTestDataApiServices { services =>
+    Delete(s"${testData.wsName.path}/snapshots/not-a-valid-uuid") ~>
+      sealRoute(services.snapshotRoutes) ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+      }
+  }
+
   it should "return 403 when a user can only read a workspace and tries to delete a snapshot" in withTestDataApiServicesAndUser("reader-access") { services =>
-    Delete(s"${testData.wsName.path}/snapshots/doesntmatter") ~>
+    Delete(s"${testData.wsName.path}/snapshots/${UUID.randomUUID().toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
       check { assertResult(StatusCodes.Forbidden) {status} }
   }


### PR DESCRIPTION
for snapshot GET and DELETE apis, perform early validation of the input UUID strings, before querying for workspaces.