### PR TITLE
AS-456: read batchupsert as stream [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -224,7 +224,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       }
     }
 
-  def batchUpdateEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean = false): Future[PerRequestMessage] = {
+  def batchUpdateEntitiesInternal(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean = false): Future[Traversable[Entity]] = {
     val namesToCheck = for {
       update <- entityUpdates
       operation <- update.operations
@@ -262,11 +262,16 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
             }
           }
 
-          saveAction.map(_ => RequestComplete(StatusCodes.NoContent))
+          saveAction
         }
       }
     }
   }
+
+  def batchUpdateEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean = false): Future[PerRequestMessage] = {
+    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert).map(_ => RequestComplete(StatusCodes.NoContent))
+  }
+
 
   /**
     * Applies the sequence of operations in order to the entity.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -249,12 +249,7 @@ class AvroUpsertMonitorActor(
       }
     } yield ()
 
-    importFuture recover {
-      case ex:Exception =>
-        logger.error(s"import jobid ${attributes.importId} failed unexpectedly, in recover: ${ex.getMessage}", ex)
-        publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option(ex.getMessage))
-        // potential for retry here, in case the error was transient
-    } map(_ => ImportComplete) pipeTo self
+    importFuture.map(_ => ImportComplete) pipeTo self
   }
 
   private def publishMessageToUpdateImportStatus(importId: UUID, currentImportStatus: Option[ImportStatus], newImportStatus: ImportStatus, errorMessage: Option[String]) = {
@@ -372,7 +367,6 @@ class AvroUpsertMonitorActor(
   }
 
   case class AvroUpsertAttributes(workspace: WorkspaceName, userEmail: RawlsUserEmail, importId: UUID, upsertFile: String)
-
 
   private def parseMessage(message: PubSubMessage) = {
     val workspaceNamespace = "workspaceNamespace"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -15,9 +15,8 @@ import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
-import org.broadinstitute.dsde.rawls.model.{ErrorReport => RawlsErrorReport}
+import org.broadinstitute.dsde.rawls.model.{Entity, ImportStatuses, RawlsUserEmail, UserInfo, WorkspaceName, ErrorReport => RawlsErrorReport}
 import org.broadinstitute.dsde.rawls.model.ImportStatuses.ImportStatus
-import org.broadinstitute.dsde.rawls.model.{ImportStatuses, RawlsUserEmail, UserInfo, WorkspaceName}
 import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.{AvroUpsertMonitorConfig, updateImportStatusFormat}
 import org.broadinstitute.dsde.rawls.util.AuthUtil
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
@@ -226,45 +225,36 @@ class AvroUpsertMonitorActor(
   private def importEntities(message: PubSubMessage) = {
     val attributes = parseMessage(message)
 
-    try {
-      val importFuture = for {
-        petUserInfo <- getPetServiceAccountUserInfo(attributes.workspace.namespace, attributes.userEmail)
-        importStatus <- importServiceDAO.getImportStatus(attributes.importId, attributes.workspace, petUserInfo)
-        _ <- importStatus match {
-          // Currently, there is only one upsert monitor thread - but if we decide to make more threads, we might
-          // end up with a race condition where multiple threads are attempting the same import / updating the status
-          // of the same import.
-          case Some(status) if status == ImportStatuses.ReadyForUpsert => {
-            publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Upserting, None)
-            toFutureTry(initUpsert(attributes.upsertFile, attributes.importId, message.ackId, attributes.workspace, petUserInfo)) map {
-              case Success(importUpsertResults) =>
-                val msg = s"Successfully updated ${importUpsertResults.successes} entities; ${importUpsertResults.failures.size} updates failed."
-                publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Done, Option(msg))
-              case Failure(t) => publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Error, Option(t.getMessage))
-            }
+    val importFuture = for {
+      petUserInfo <- getPetServiceAccountUserInfo(attributes.workspace.namespace, attributes.userEmail)
+      importStatus <- importServiceDAO.getImportStatus(attributes.importId, attributes.workspace, petUserInfo)
+      _ <- importStatus match {
+        // Currently, there is only one upsert monitor thread - but if we decide to make more threads, we might
+        // end up with a race condition where multiple threads are attempting the same import / updating the status
+        // of the same import.
+        case Some(status) if status == ImportStatuses.ReadyForUpsert => {
+          publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Upserting, None)
+          toFutureTry(initUpsert(attributes.upsertFile, attributes.importId, message.ackId, attributes.workspace, petUserInfo)) map {
+            case Success(importUpsertResults) =>
+              val msg = s"Successfully updated ${importUpsertResults.successes} entities; ${importUpsertResults.failures.size} updates failed."
+              publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Done, Option(msg))
+            case Failure(t) => publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Error, Option(t.getMessage))
           }
-          case Some(_) => {
-            logger.warn(s"Received a double message delivery for import ID [${attributes.importId}]")
-            Future.unit
-          }
-          case None => publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option("Import status not found"))
         }
-      } yield ()
+        case Some(_) => {
+          logger.warn(s"Received a double message delivery for import ID [${attributes.importId}]")
+          Future.unit
+        }
+        case None => publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option("Import status not found"))
+      }
+    } yield ()
 
-      importFuture recover {
-        case ex:Exception =>
-          logger.error(s"import jobid ${attributes.importId} failed unexpectedly, in recover: ${ex.getMessage}", ex)
-          publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option(ex.getMessage))
-          // potential for retry here, in case the error was transient
-      } map(_ => ImportComplete) pipeTo self
-
-    } catch {
+    importFuture recover {
       case ex:Exception =>
-        logger.error(s"import jobid ${attributes.importId} failed unexpectedly, in catch: ${ex.getMessage}", ex)
-        publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option(ex.getMessage)) map (_ =>
-          ImportComplete) pipeTo self
+        logger.error(s"import jobid ${attributes.importId} failed unexpectedly, in recover: ${ex.getMessage}", ex)
+        publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option(ex.getMessage))
         // potential for retry here, in case the error was transient
-    }
+    } map(_ => ImportComplete) pipeTo self
   }
 
   private def publishMessageToUpdateImportStatus(importId: UUID, currentImportStatus: Option[ImportStatus], newImportStatus: ImportStatus, errorMessage: Option[String]) = {
@@ -278,67 +268,101 @@ class AvroUpsertMonitorActor(
 
 
   private def initUpsert(upsertFile: String, jobId: UUID, ackId: String, workspaceName: WorkspaceName, userInfo: UserInfo): Future[ImportUpsertResults] = {
+    val startTime = System.currentTimeMillis()
     logger.info(s"beginning upsert process for $jobId ...")
 
-    // Start reading the file. This returns a stream
-    logger.info(s"checking access to $upsertFile for jobId ${jobId.toString} ...")
-    val upsertStream = getUpsertStream(upsertFile)
+    try {
 
-    // Ensure that the file has some contents. Our implementation of GoogleStorageInterpreter will return an empty
-    // stream instead of an error in cases where it could not read the file. We check to see if there is at least
-    // one valid byte in the stream.
-    val nonEmptyStream = Try(upsertStream.exists(_.isValidByte).compile.toList.unsafeRunSync().head) match {
-      case Success(true) => true
-      case _ => false
-    }
-    if (!nonEmptyStream) {
-      throw new RawlsExceptionWithErrorReport(RawlsErrorReport(StatusCodes.BadRequest,
-        s"Intermediate batch upsert file $upsertFile not found, or file was empty for jobId $jobId"))
-    }
+      // Start reading the file. This returns a stream
+      logger.info(s"checking access to $upsertFile for jobId ${jobId.toString} ...")
+      val upsertStream = getUpsertStream(upsertFile)
 
-    // Ack the pubsub message as soon as we know we can read the file. pro: don't have to worry about ack timeouts for long operations, con: if someone restarts rawls here the upsert is lost
-    logger.info(s"acking upsert pubsub message for jobId ${jobId.toString} ...")
-    acknowledgeMessage(ackId)
-    // translate the stream of bytes to a stream of json
-    val jsonStream = upsertStream.through(byteArrayParser)
-
-    // translate the stream of json to a stream of EntityUpdateDefinition. This is awkward, because we break out
-    // of Circe and use spray-json parsing, since we have complex custom spray-json decoders for EntityUpdateDefinition
-    // and I would prefer not to have multiple complex custom decoders
-    val entityUpdateDefinitionStream = jsonStream.map { circeJson =>
-      circeJson.toString().parseJson.convertTo[EntityUpdateDefinition]
-    }
-
-    // chunk the stream into batches.
-    val batchStream = entityUpdateDefinitionStream.chunkN(batchSize)
-
-    // upsert each chunk
-    val upsertFuturesStream = batchStream map { chunk =>
-      val upsertBatch: List[EntityUpdateDefinition] = chunk.toList
-      logger.info(s"inserting a batch of ${upsertBatch.size} for jobId ${jobId.toString} ...")
-      toFutureTry(entityService.apply(userInfo).batchUpdateEntitiesInternal(workspaceName, upsertBatch, true))
-    }
-
-    // wait for all upserts
-    Future.sequence(upsertFuturesStream.compile.toList.unsafeRunSync()) map { upsertResults =>
-
-      val numSuccesses:Int = upsertResults.collect {
-        case Success(entityList) => entityList.size
-      }.sum
-
-      val failureReports:List[RawlsErrorReport] = upsertResults collect {
-        case Failure(regrets:RawlsExceptionWithErrorReport) => regrets.errorReport.causes
-      } flatten
-
-      // fail if nothing at all succeeded
-      if (numSuccesses == 0) {
-        // TODO: this could be a LOT of error reports, should we omit if large?
-        throw new RawlsExceptionWithErrorReport(RawlsErrorReport(StatusCodes.BadRequest, "All entities could not be updated.", failureReports))
+      // Ensure that the file has some contents. Our implementation of GoogleStorageInterpreter will return an empty
+      // stream instead of an error in cases where it could not read the file. We check to see if there is at least
+      // one valid byte in the stream.
+      val nonEmptyStream = Try(upsertStream.exists(_.isValidByte).compile.toList.unsafeRunSync().head) match {
+        case Success(true) => true
+        case _ => false
+      }
+      if (!nonEmptyStream) {
+        throw new RawlsExceptionWithErrorReport(RawlsErrorReport(StatusCodes.BadRequest,
+          s"Intermediate batch upsert file $upsertFile not found, or file was empty for jobId $jobId"))
       }
 
-      ImportUpsertResults(numSuccesses, failureReports)
-    }
+      // Ack the pubsub message as soon as we know we can read the file. pro: don't have to worry about ack timeouts for long operations, con: if someone restarts rawls here the upsert is lost
+      logger.info(s"acking upsert pubsub message for jobId ${jobId.toString} ...")
+      acknowledgeMessage(ackId)
+      // translate the stream of bytes to a stream of json
+      val jsonStream = upsertStream.through(byteArrayParser)
 
+      // translate the stream of json to a stream of EntityUpdateDefinition. This is awkward, because we break out
+      // of Circe and use spray-json parsing, since we have complex custom spray-json decoders for EntityUpdateDefinition
+      // and I would prefer not to have multiple complex custom decoders
+      val entityUpdateDefinitionStream = jsonStream.map { circeJson =>
+        circeJson.toString().parseJson.convertTo[EntityUpdateDefinition]
+      }
+
+      // chunk the stream into batches.
+      val batchStream = entityUpdateDefinitionStream.chunkN(batchSize)
+
+      // convenience method to encapsulate the call to EntityService's batchUpdateEntitiesInternal
+      def performUpsertBatch(idx: Long, upsertBatch: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = {
+        logger.info(s"inserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
+        entityService.apply(userInfo).batchUpdateEntitiesInternal(workspaceName, upsertBatch, upsert = true)
+      }
+
+      // upsert each chunk
+      val upsertFuturesStream = batchStream.zipWithIndex.map {
+        case (chunk, idx) => toFutureTry(performUpsertBatch(idx, chunk.toList))
+      }
+
+      // wait for all upserts
+      Future.sequence(upsertFuturesStream.compile.toList.unsafeRunSync()) map { upsertResults =>
+
+        val numSuccesses:Int = upsertResults.collect {
+          case Success(entityList) => entityList.size
+        }.sum
+
+        val failureReports:List[RawlsErrorReport] = upsertResults collect {
+          case Failure(regrets:RawlsExceptionWithErrorReport) => regrets.errorReport.causes
+        } flatten
+
+        // fail if nothing at all succeeded
+        if (numSuccesses == 0) {
+          // this could be a LOT of error reports, we don't want to send an enormous packet back to the caller.
+          // Cap the failure reports at 100.
+          val failureReportsForCaller = failureReports.take(100)
+          val additionalErrorString = if (failureReports.size > failureReportsForCaller.size) {
+            "; only the first 100 errors are shown."
+          } else {
+            "."
+          }
+          throw new RawlsExceptionWithErrorReport(RawlsErrorReport(StatusCodes.BadRequest,
+            s"All entities failed to update. There were ${failureReports.size} errors in total$additionalErrorString",
+            failureReportsForCaller))
+        }
+
+        val elapsed = System.currentTimeMillis() - startTime
+        logger.info(s"upsert process for $jobId succeeded after $elapsed ms: $numSuccesses upserted, ${failureReports.size} failed.")
+
+        ImportUpsertResults(numSuccesses, failureReports)
+
+      } recoverWith {
+        // recoverWith for any uncaught errors in Futures. Potential for retry here, in case of transient failures
+        case ex:Exception =>
+          val elapsed = System.currentTimeMillis() - startTime
+          logger.error(s"upsert process for $jobId FAILED after $elapsed ms: ${ex.getMessage}")
+          acknowledgeMessage(ackId) // just in case
+          Future.failed(ex)
+      }
+    } catch {
+      // try/catch for any synchronous exceptions, not covered by a Future.recover(). Potential for retry here, in case of transient failures
+      case ex:Exception =>
+        val elapsed = System.currentTimeMillis() - startTime
+        logger.error(s"upsert process for $jobId FAILED after $elapsed ms: ${ex.getMessage}")
+        acknowledgeMessage(ackId) // just in case
+        Future.failed(ex)
+    }
   }
 
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -55,7 +55,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   def this() = this(ActorSystem("AvroUpsertMonitorSpec"))
 
   override def beforeAll(): Unit = {
-
     super.beforeAll()
   }
 
@@ -64,6 +63,8 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     super.afterAll()
   }
 
+
+
   val workspaceName =  testData.workspace.toWorkspaceName
   val googleStorage = FakeGoogleStorageInterpreter
   val importReadPubSubTopic = "request-topic"
@@ -71,16 +72,14 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   val importWritePubSubTopic = "status-topic"
   val importWriteSubscriptionName = "status-sub"
   val bucketName = GcsBucketName("fake-bucket")
-  val blobName = GcsBlobName("fake-file")
   val entityName = "avro-entity"
   val entityType = "test-type"
-  val sampleMessage = "here's a sample message"
 
   def testAttributes(importId: UUID) = Map(
     "workspaceName" -> workspaceName.name,
     "workspaceNamespace" -> workspaceName.namespace,
     "userEmail" -> userInfo.userEmail.toString,
-    "upsertFile" ->  s"$bucketName/${blobName.value}",
+    "upsertFile" ->  s"$bucketName/${importId.toString}",
     "jobId" -> importId.toString
   )
 
@@ -142,16 +141,16 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
       val contents = s"[${upsertOps.mkString(",")}]"
 
       // Store upsert json file
-      Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
-      val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
       // Publish message on the request topic
-      services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+      services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId1.toString, testAttributes(importId1))))
 
       // check if correct message was posted on request topic
       eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
       }
       // Check in db if entities are there
       withWorkspaceContext(testData.workspace) { context =>
@@ -182,13 +181,15 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     mockImportServiceDAO.imports += (importId3 -> ImportStatuses.Done)
     mockImportServiceDAO.imports += (importId4 -> ImportStatuses.Error)
 
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId2))))
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId3))))
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId4))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId2.toString, testAttributes(importId2))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId3.toString, testAttributes(importId3))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId4.toString, testAttributes(importId4))))
 
     Thread.sleep(1000)
 
-    assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 3))
+    assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId2.toString, 1))
+    assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId3.toString, 1))
+    assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId4.toString, 1))
 
   }
 
@@ -205,16 +206,16 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val contents = "hey, this isn't valid json! {{{"
 
     // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
-    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
     // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId1.toString, testAttributes(importId1))))
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
     }
 
     // upsert will fail; check that a pubsub message was published to set the import job to error.
@@ -242,16 +243,16 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val contents = """[{"foo":"bar"},{"baz":"qux"}]"""
 
     // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
-    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
     // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId1.toString, testAttributes(importId1))))
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
     }
 
     // upsert will fail; check that a pubsub message was published to set the import job to error.
@@ -275,12 +276,21 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val mockImportServiceDAO =  setUp(services)
     mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+    // create a valid json file that doesn't contain entities
+    val contents = s"""[{"name": "avro-entity", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}]"""
+
+    // Store upsert json file, even though we expect the code to look elsewhere and miss this file
+    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+    // Publish message on the request topic - but ensure that the gcs: location in the pubsub message is incorrect
+    val badMessageAttrs = testAttributes(importId1) ++ Map("upsertFile" ->  s"$bucketName/intentionally.nonexistent.unittest")
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(importId1.toString, badMessageAttrs)))
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
     }
 
     // upsert will fail; check that a pubsub message was published to set the import job to error.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -63,8 +63,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     super.afterAll()
   }
 
-
-
   val workspaceName =  testData.workspace.toWorkspaceName
   val googleStorage = FakeGoogleStorageInterpreter
   val importReadPubSubTopic = "request-topic"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -99,7 +99,9 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   def setUp(services: TestApiService) = {
     // create the two topics
     services.gpsDAO.createTopic(importReadPubSubTopic)
-    services.gpsDAO.createTopic(importWritePubSubTopic)
+    services.gpsDAO.createTopic(importWritePubSubTopic) map { _ =>
+      services.gpsDAO.createSubscription(importWritePubSubTopic, importWriteSubscriptionName)
+    }
 
     val mockImportServiceDAO =  new MockImportServiceDAO()
 
@@ -118,43 +120,59 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     mockImportServiceDAO
   }
 
+  behavior of "AvroUpsertMonitor"
 
-  "AvroUpsertMonitor" should "upsert entities" in withTestDataApiServices { services =>
-    val timeout = 5000 milliseconds
-    val interval = 250 milliseconds
-    val importId1 = UUID.randomUUID()
+  List(1,2,20,250,2345,12345) foreach { upsertQuantity =>
+    it should s"upsert $upsertQuantity entities" in withTestDataApiServices { services =>
+      val timeout = 120000 milliseconds
+      val interval = 500 milliseconds
+      val importId1 = UUID.randomUUID()
 
-    // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
-    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      // add the imports and their statuses to the mock importserviceDAO
+      val mockImportServiceDAO =  setUp(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-    // create compressed file
-    val contents = """[{"name": "avro-entity", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}]"""
+      // create indexed range of ints
+      val upsertRange: List[Int] = List.range(1, upsertQuantity+1)
 
-    // Store compressed file
-    Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
-    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // create upsert json file
+      val upsertOps = upsertRange map ( idx => s"""{"name": "avro-entity-$idx", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}""" )
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+      val contents = s"[${upsertOps.mkString(",")}]"
 
-    // check if correct message was posted on request topic
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
-    }
-    // Check in db if entities are there
-    withWorkspaceContext(testData.workspace) { context =>
-      val entity = Entity(entityName, entityType, Map(AttributeName("default", "avro-attribute") -> AttributeString("foo")))
+      // Store upsert json file
+      Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
 
+      val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+
+      // check if correct message was posted on request topic
       eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-        assertResult(Some(entity)) { runAndWait(entityQuery.get(context, entityType, entityName)) }
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+      }
+      // Check in db if entities are there
+      withWorkspaceContext(testData.workspace) { context =>
+
+        eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+          val entitiesOfType = runAndWait(entityQuery.listActiveEntitiesOfType(context, entityType))
+          assertResult(upsertQuantity) { entitiesOfType.size }
+          upsertRange foreach { idx =>
+            val name = s"avro-entity-$idx"
+            val entity = Entity(name, entityType, Map(AttributeName("default", "avro-attribute") -> AttributeString("foo")))
+            val actual = entitiesOfType.find(_.name == name)
+            assertResult(Some(entity)) { actual }
+          }
+        }
+
       }
     }
   }
 
 
-  "AvroUpsertMonitor" should "return error for imports with the wrong status" in withTestDataApiServices { services =>
+  it should "return error for imports with the wrong status" in withTestDataApiServices { services =>
     val importId2 = UUID.randomUUID()
     val importId3 = UUID.randomUUID()
     val importId4 = UUID.randomUUID()
@@ -173,4 +191,108 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 3))
 
   }
+
+  it should "mark the import job as failed on malformed json file" in withTestDataApiServices { services =>
+    val timeout = 30000 milliseconds
+    val interval = 250 milliseconds
+    val importId1 = UUID.randomUUID()
+
+    // add the imports and their statuses to the mock importserviceDAO
+    val mockImportServiceDAO =  setUp(services)
+    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+
+    // create a -malformed- upsert json file, which will cause problems when reading
+    val contents = "hey, this isn't valid json! {{{"
+
+    // Store upsert json file
+    Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+    // Publish message on the request topic
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+
+    // check if correct message was posted on request topic. This will start the upsert attempt.
+    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+    }
+
+    // upsert will fail; check that a pubsub message was published to set the import job to error.
+    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
+
+      assert(statusMessages.exists { msg =>
+        msg.attributes.get("importId").contains(importId1.toString) &&
+          msg.attributes.get("newStatus").contains("Error") &&
+          msg.attributes.get("action").contains("status")
+      })
+    }
+  }
+
+  it should "mark the import job as failed on valid json that doesn't match our model" in withTestDataApiServices { services =>
+    val timeout = 30000 milliseconds
+    val interval = 250 milliseconds
+    val importId1 = UUID.randomUUID()
+
+    // add the imports and their statuses to the mock importserviceDAO
+    val mockImportServiceDAO =  setUp(services)
+    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+
+    // create a valid json file that doesn't contain entities
+    val contents = """[{"foo":"bar"},{"baz":"qux"}]"""
+
+    // Store upsert json file
+    Await.result(googleStorage.createBlob(bucketName, blobName, contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, blobName).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+
+    // Publish message on the request topic
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+
+    // check if correct message was posted on request topic. This will start the upsert attempt.
+    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+    }
+
+    // upsert will fail; check that a pubsub message was published to set the import job to error.
+    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
+
+      assert(statusMessages.exists { msg =>
+        msg.attributes.get("importId").contains(importId1.toString) &&
+          msg.attributes.get("newStatus").contains("Error") &&
+          msg.attributes.get("action").contains("status")
+      })
+    }
+  }
+
+  it should "mark the import job as failed if upsert file doesn't exist" in withTestDataApiServices { services =>
+    val timeout = 30000 milliseconds
+    val interval = 250 milliseconds
+    val importId1 = UUID.randomUUID()
+
+    // add the imports and their statuses to the mock importserviceDAO
+    val mockImportServiceDAO =  setUp(services)
+    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+
+    // Publish message on the request topic
+    services.gpsDAO.publishMessages(importReadPubSubTopic, Seq(MessageRequest(sampleMessage, testAttributes(importId1))))
+
+    // check if correct message was posted on request topic. This will start the upsert attempt.
+    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, sampleMessage, 1))
+    }
+
+    // upsert will fail; check that a pubsub message was published to set the import job to error.
+    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
+
+      assert(statusMessages.exists { msg =>
+        msg.attributes.get("importId").contains(importId1.toString) &&
+          msg.attributes.get("newStatus").contains("Error") &&
+          msg.attributes.get("action").contains("status")
+      })
+    }
+  }
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,7 +104,6 @@ object Dependencies {
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.9.0"
   val circeFS2: ModuleID = "io.circe" %% "circe-fs2" % "0.13.0"
-  val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % "0.14.0-M1"
 
   val accessContextManager = "com.google.apis" % "google-api-services-accesscontextmanager" % "v1beta-rev55-1.25.0"
 
@@ -207,7 +206,6 @@ object Dependencies {
     swaggerUI,
     circeYAML,
     circeFS2,
-    circeGeneric,
     commonsJEXL,
     cromwellClient,
     cats,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,6 +103,8 @@ object Dependencies {
   val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.9.0"
+  val circeFS2: ModuleID = "io.circe" %% "circe-fs2" % "0.13.0"
+  val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % "0.14.0-M1"
 
   val accessContextManager = "com.google.apis" % "google-api-services-accesscontextmanager" % "v1beta-rev55-1.25.0"
 
@@ -204,6 +206,8 @@ object Dependencies {
     akkaStream,
     swaggerUI,
     circeYAML,
+    circeFS2,
+    circeGeneric,
     commonsJEXL,
     cromwellClient,
     cats,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AS-456

This PR:
* removes the code that attempted to read and parse potentially-large batchUpsert json files as a whole file
* replaces that code with a stream, with which we pull N entity upserts at a time and process them, then keep streaming through the file (N is 1000)
* adds unit test coverage
* adds logging statements to help with forensic debugging (it's almost too chatty now)
* adds `try/catch` and `recover` around the `initUpsert` method so we should now always fail any job with an error, mark it as Failed for the end user, and ack the relevant pubsub message that started the import
* adds detail to the responses we send to the user, indicating successes and failures