### PR TITLE
AS-456: read batchUpsert via fs2-blobstore, not workbench-libs [risk: low]

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -71,7 +71,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     }
   }
 
-//  implicit val cs = IO.contextShift(global)
   def this() = this(ActorSystem("AvroUpsertMonitorSpec"))
 
   override def beforeAll(): Unit = {
@@ -84,8 +83,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   }
 
   val workspaceName =  testData.workspace.toWorkspaceName
-  // val googleStorage = FakeGoogleStorageInterpreter
-  // val gcsBlobstore = GcsStore[IO](LocalStorageHelper.getOptions.getService, Blocker.liftExecutionContext(scala.concurrent.ExecutionContext.global))
   val importReadPubSubTopic = "request-topic"
   val importReadSubscriptionName = "request-sub"
   val importWritePubSubTopic = "status-topic"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,6 +104,7 @@ object Dependencies {
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.9.0"
   val circeFS2: ModuleID = "io.circe" %% "circe-fs2" % "0.13.0"
+  val fs2Blobstore: ModuleID = "com.github.fs2-blobstore" %% "gcs" % "0.7.3"
 
   val accessContextManager = "com.google.apis" % "google-api-services-accesscontextmanager" % "v1beta-rev55-1.25.0"
 
@@ -206,6 +207,7 @@ object Dependencies {
     swaggerUI,
     circeYAML,
     circeFS2,
+    fs2Blobstore,
     commonsJEXL,
     cromwellClient,
     cats,


### PR DESCRIPTION
Use [fs2-blobstore](https://github.com/fs2-blobstore/fs2-blobstore#gcsstore) to read the batchUpsert json file as a true stream, instead of using workbench-libs, which reads the entire file into memory.

Accompanying changes to make various constructors and unit tests work