### PR TITLE
AS-456: use workbench libs streaming [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -310,7 +310,12 @@ class AvroUpsertMonitorActor(
       // convenience method to encapsulate the call to EntityService's batchUpdateEntitiesInternal
       def performUpsertBatch(idx: Long, upsertBatch: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = {
         logger.info(s"upserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
-        entityService.apply(userInfo).batchUpdateEntitiesInternal(workspaceName, upsertBatch, upsert = true)
+        for {
+          petUserInfo <- getPetServiceAccountUserInfo(workspaceName.namespace, userInfo.userEmail)
+          upsertResults <- entityService.apply(petUserInfo).batchUpdateEntitiesInternal(workspaceName, upsertBatch, upsert = true)
+        } yield {
+          upsertResults
+        }
       }
 
       // create our pause signal. We use this to control when the stream should pause and resume.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val googleV = "1.22.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
-  val workbenchGoogle2V = "0.10-956a642"
+  val workbenchGoogle2V = "0.11-b9da9fc-SNAP"
 
   val cromwellVersion = "40-2754783"
 
@@ -60,6 +60,8 @@ object Dependencies {
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.30.0"
   val googleRpcNettyShaded: ModuleID =    "io.grpc" % "grpc-netty-shaded" % "1.30.0"
   val googleCloudCoreGrpc: ModuleID =     "com.google.cloud" % "google-cloud-core-grpc" % "1.93.6"
+
+  val googleAutoValue: ModuleID =         "com.google.auto.value" % "auto-value-annotations" % "1.7.4"
 
   val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.0"
 
@@ -165,7 +167,8 @@ object Dependencies {
     googleCloudCoreGrpc,
     googleRpc,
     googleRpcNettyShaded,
-    workbenchGoogle2Tests
+    workbenchGoogle2Tests,
+    googleAutoValue // workbench-libs/google2 fails to correctly pull this as a dependency, so we do it manually
   )
 
   val utilDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   val googleV = "1.22.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
-  val workbenchGoogle2V = "0.11-b9da9fc-SNAP"
+  val workbenchGoogle2V = "0.11-0d87698"
 
   val cromwellVersion = "40-2754783"
 


### PR DESCRIPTION
A few changes in this PR:
1. Use true GCS blob streaming, by adopting the latest version of workbench-libs that incorporates broadinstitute/workbench-libs#333.
2. During the batchUpsert loop, send keepalive messages back to the actor. Otherwise, if the loop takes > 20 minutes (approx), the actor will kill itself because it hasn't received a message in too long. Now, it will only kill itself if a single batch of 1000 operations takes > 20 minutes.
3. During the batchUpsert loop, use a pet SA to perform each batch of db writes. Otherwise, if the total loop takes > 60 minutes (approx), the user's credentials will expire. Now, this limitation should be eliminated.

