### PR TITLE
cleaner error messages for data repo integration [no ticket; risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -65,8 +65,11 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
     */
   def resolveProviderFuture(entityRequestArguments: EntityRequestArguments)(implicit executionContext: ExecutionContext): Future[EntityProvider] = {
     Future.fromTry(resolveProvider(entityRequestArguments)).recoverWith {
+      // pass DataEntityExceptions untouched; wrap any other exception in an ErrorReport
       case regrets: DataEntityException =>
-        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, regrets)))
+        Future.failed(regrets)
+      case ex: Exception =>
+        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex)))
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -193,8 +193,10 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       }
 
       queryFuture.recover {
-        case dee:DataEntityException => RequestComplete(dee.code, dee.getMessage)
-        case ex => RequestComplete(StatusCodes.InternalServerError, ex)
+        case dee:DataEntityException =>
+          throw new RawlsExceptionWithErrorReport(ErrorReport(dee.code, dee.getMessage))
+        case ex =>
+          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex))
       }
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -55,9 +55,9 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
       requestArguments.userInfo.accessToken)).recoverWith {
 
       case notFound: WorkspaceApiException if notFound.getCode == StatusCodes.NotFound.intValue =>
-        Failure(new DataEntityException(s"Reference name ${dataReferenceName.value} does not exist in workspace ${requestArguments.workspace.toWorkspaceName}.", notFound))
+        Failure(new DataEntityException(code = StatusCodes.BadRequest, message = s"Reference name does not exist in workspace ${requestArguments.workspace.toWorkspaceName}."))
       case forbidden: WorkspaceApiException if forbidden.getCode == StatusCodes.Forbidden.intValue =>
-        Failure(new DataEntityException(s"Access denied for reference name ${dataReferenceName.value}.", forbidden))
+        Failure(new DataEntityException(code = StatusCodes.BadRequest, message = s"Access denied for reference name."))
     }
 
     // trigger any exceptions

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/EntityTypeNotFoundException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/exceptions/EntityTypeNotFoundException.scala
@@ -1,3 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.exceptions
 
-class EntityTypeNotFoundException(val requestedType: String) extends DataEntityException
+import akka.http.scaladsl.model.StatusCodes
+
+class EntityTypeNotFoundException(val requestedType: String)
+  extends DataEntityException(code = StatusCodes.BadRequest, message = "Entity type not found")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestData, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoEntityProviderSpecSupport
+import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.metrics.StatsDTestUtils
@@ -1231,11 +1232,11 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
         deleteIntermediateOutputFiles = false
       )
 
-      val ex = intercept[RawlsExceptionWithErrorReport] {
+      val ex = intercept[DataEntityException] {
         Await.result(workspaceService.validateSubmission( minimalTestData.wsName, submissionRq ), Duration.Inf)
       }
-      ex.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
-      ex.errorReport.message shouldBe "Reference name unknown does not exist in workspace myNamespace/myWorkspace."
+      ex.code shouldBe StatusCodes.BadRequest
+      ex.getMessage shouldBe "Reference name does not exist in workspace myNamespace/myWorkspace."
     }
   }
 


### PR DESCRIPTION
some loose-end cleanup in this PR, in which we return cleaner error responses - including leaving out unhelpful stack traces - when calling the entityQuery API and:
* specifying a snapshot reference name that could not be found
* specifying an entityType that could not be found inside a snapshot

Previously, we returned stack traces that only included Akka forkJoin nonsense, and some of the exceptions were wrapped multiple times and then toString-ed, making it very hard to find the real messages. We also returned `InternalServerError` for these, when they really should be `BadRequest`.