### PR TITLE
Limit billing cost query to time window (issue WA-270)

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -288,6 +288,7 @@ object Boot extends IOApp with LazyLogging {
         SubmissionCostService.constructor(
           gcsConfig.getString("billingExportTableName"),
           gcsConfig.getString("serviceProject"),
+          gcsConfig.getInt("billingSearchWindowDays"),
           bigQueryDAO
         )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -64,13 +64,13 @@ class SubmissionCostService(tableName: String, serviceProject: String, billingSe
   private def partitionDateClause(submissionDate: DateTime, terminalStatusDate: Option[DateTime]): String = {
     // subtract a day so we never have to deal with timezones
     val windowStartDate = submissionDate.minusDays(1).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
-    val windowEndDate = terminalStatusDate match {
-      // add a day so we never have to deal with timezones
-      case Some(terminalStatusDate) => terminalStatusDate.plusDays(1).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
+    val windowEndDate = terminalStatusDate
       // if this submission has no date at which it reached terminal state, use the default window from config
-      case None => submissionDate.plusDays(billingSearchWindowDays).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
-    }
-
+      .getOrElse(submissionDate.plusDays(billingSearchWindowDays))
+      // add a day so we never have to deal with timezones
+      .plusDays(1)
+      .toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
+    
     s"""AND _PARTITIONDATE BETWEEN "$windowStartDate" AND "$windowEndDate""""
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -63,8 +63,9 @@ class SubmissionCostService(tableName: String, serviceProject: String, bigQueryD
   private def partitionDateClause(submissionDate: Option[DateTime]): String = {
     (submissionDate map { d: DateTime =>
       //subtract a day so we never have to deal with timezones
-      val date = d.minusDays(1).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
-      s"""AND _PARTITIONDATE >= "$date""""
+      val date_start = d.minusDays(1).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
+      val date_end = d.plusDays(14).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
+      s"""AND _PARTITIONDATE BETWEEN "$date_start" AND "$date_end""""
     }).getOrElse("")
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -67,7 +67,7 @@ class SubmissionCostService(tableName: String, serviceProject: String, bigQueryD
       // search up to 2 weeks later (TODO: justify this time duration) to minimize BQ costs
       val date_end = d.plusDays(14).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
       s"""AND _PARTITIONDATE BETWEEN "$date_start" AND "$date_end""""
-    }).getOrElse("")
+    }).getOrElse("")  // TODO: return error rather than scan with no date restriction
   }
 
   private def executeSubmissionCostsQuery(submissionId: String, workspaceNamespace: String, submissionDate: Option[DateTime]): Future[util.List[TableRow]] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostService.scala
@@ -64,6 +64,7 @@ class SubmissionCostService(tableName: String, serviceProject: String, bigQueryD
     (submissionDate map { d: DateTime =>
       //subtract a day so we never have to deal with timezones
       val date_start = d.minusDays(1).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
+      // search up to 2 weeks later (TODO: justify this time duration) to minimize BQ costs
       val date_end = d.plusDays(14).toString(DateTimeFormat.forPattern("yyyy-MM-dd"))
       s"""AND _PARTITIONDATE BETWEEN "$date_start" AND "$date_end""""
     }).getOrElse("")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -91,9 +91,9 @@ object WorkspaceService {
   }
 
   private[workspace] def getSubmissionDoneDate(submission: Submission, workflowID: Option[String]): Option[DateTime] = {
-    // find all worklfows that have finished
+    // find all workflows that have finished
     val terminalWorkflows = submission.workflows.filter(workflow => WorkflowStatuses.terminalStatuses.contains(workflow.status))
-    // if a workflowID was submitted, limit the list to that workflow
+    // optionally limit the list to a specific workflowID
     val workflows = workflowID match {
       case Some(workflowID) => terminalWorkflows.filter(workflow => workflow.workflowId.contains(workflowID))
       case None => terminalWorkflows

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1558,7 +1558,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       // we don't need the Execution Service ID, but we do need to confirm the Workflow is in one for this Submission
       // if we weren't able to do so above
       _ <- executionServiceCluster.findExecService(submissionId, workflowId, userInfo, optExecId)
-      submissionDoneDate = WorkspaceService.getTerminalStatusDate(submission, Some(workflowId))
+      submissionDoneDate = WorkspaceService.getTerminalStatusDate(submission, Option(workflowId))
       costs <- submissionCostService.getWorkflowCost(workflowId, workspaceName.namespace, submission.submissionDate, submissionDoneDate)
     } yield RequestComplete(StatusCodes.OK, WorkflowCost(workflowId, costs.get(workflowId)))
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
@@ -7,11 +7,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MockSubmissionCostService(tableName: String, serviceProject: String, bigQueryDAO: GoogleBigQueryDAO)(implicit executionContext: ExecutionContext) extends SubmissionCostService(tableName, serviceProject, bigQueryDAO) {
   val fixedCost = 1.23f
-  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String, submissionDate: Option[DateTime]): Future[Map[String, Float]] = {
+  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String, submissionDate: DateTime, endDate: DateTime): Future[Map[String, Float]] = {
     Future(workflowIds.map(_ -> fixedCost).toMap)
   }
 
-  override def getWorkflowCost(workflowId: String, workspaceNamespace: String, submissionDate: Option[DateTime]): Future[Map[String, Float]] = {
+  override def getWorkflowCost(workflowId: String, workspaceNamespace: String, submissionDate: DateTime, endDate: DateTime): Future[Map[String, Float]] = {
     Future(Map(workflowId -> fixedCost))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockSubmissionCostService.scala
@@ -5,13 +5,13 @@ import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class MockSubmissionCostService(tableName: String, serviceProject: String, bigQueryDAO: GoogleBigQueryDAO)(implicit executionContext: ExecutionContext) extends SubmissionCostService(tableName, serviceProject, bigQueryDAO) {
+class MockSubmissionCostService(tableName: String, serviceProject: String, billingSearchWindowDays: Int, bigQueryDAO: GoogleBigQueryDAO)(implicit executionContext: ExecutionContext) extends SubmissionCostService(tableName, serviceProject, billingSearchWindowDays, bigQueryDAO) {
   val fixedCost = 1.23f
-  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String, submissionDate: DateTime, endDate: DateTime): Future[Map[String, Float]] = {
+  override def getSubmissionCosts(submissionId: String, workflowIds: Seq[String], workspaceNamespace: String, submissionDate: DateTime, submissionDoneDate: Option[DateTime]): Future[Map[String, Float]] = {
     Future(workflowIds.map(_ -> fixedCost).toMap)
   }
 
-  override def getWorkflowCost(workflowId: String, workspaceNamespace: String, submissionDate: DateTime, endDate: DateTime): Future[Map[String, Float]] = {
+  override def getWorkflowCost(workflowId: String, workspaceNamespace: String, submissionDate: DateTime, submissionDoneDate: Option[DateTime]): Future[Map[String, Float]] = {
     Future(Map(workflowId -> fixedCost))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.google.api.services.bigquery.model.{TableCell, TableRow}
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleBigQueryDAO
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.FlatSpec
 
 import scala.collection.JavaConverters._
@@ -104,7 +104,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
    */
   it should "bypass BigQuery with no workflow IDs" in {
     assertResult(Map.empty) {
-      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", new DateTime(), Some(new DateTime())), 1 minute)
+      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", new DateTime(DateTimeZone.UTC), Option(new DateTime(DateTimeZone.UTC))), 1 minute)
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -30,7 +30,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
     }
   }
 
-  it should "return the expected string for generateSubmissionCostsQuery with an existing end date input" in {
+  it should "return the expected string for generateSubmissionCostsQuery with an existing terminal status date input" in {
     val submissionDate = new DateTime(0)  // 1970-01-01
     val terminalStatusDate = Option(new DateTime(2020, 10, 9, 13, 31))
     val expected =
@@ -47,7 +47,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
     }
   }
 
-  it should "return the expected string for generateSubmissionCostsQuery with no end date input" in {
+  it should "return the expected string for generateSubmissionCostsQuery with no terminal status date input" in {
     val submissionDate = new DateTime(0)  // 1970-01-01
     val terminalStatusDate = None
     val expected =
@@ -64,7 +64,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
     }
   }
 
-  it should "return the expected string for generateWorkflowCostsQuery with an existing end date input" in {
+  it should "return the expected string for generateWorkflowCostsQuery with an existing terminal status date input" in {
     val submissionDate = new DateTime(0)  // 1970-01-01
     val terminalStatusDate = Option(new DateTime(2020, 10, 9, 13, 31))
     val expected =
@@ -80,7 +80,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
     }
   }
 
-  it should "return the expected string for generateWorkflowCostsQuery with no end date input" in {
+  it should "return the expected string for generateWorkflowCostsQuery with no terminal status date input" in {
     val submissionDate = new DateTime(0)  // 1970-01-01
     val terminalStatusDate = None
     val expected =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -15,7 +15,7 @@ import scala.language.postfixOps
 class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
   implicit val actorSystem = ActorSystem("SubmissionCostServiceSpec")
   val mockBigQueryDAO = new MockGoogleBigQueryDAO
-  val submissionCostService = SubmissionCostService.constructor("test", "test", mockBigQueryDAO)
+  val submissionCostService = SubmissionCostService.constructor("test", "test", 31, mockBigQueryDAO)
 
   val rows = List(
     new TableRow().setF(List(new TableCell().setV("wfKey"), new TableCell().setV("wf1"), new TableCell().setV(1.32f)).asJava),
@@ -38,7 +38,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
    */
   it should "bypass BigQuery with no workflow IDs" in {
     assertResult(Map.empty) {
-      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", new DateTime(), new DateTime()), 1 minute)
+      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", new DateTime(), Some(new DateTime())), 1 minute)
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -31,16 +31,18 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
   }
 
   it should "return the expected string for generateSubmissionCostsQuery with an existing terminal status date input" in {
-    val submissionDate = new DateTime(0)  // 1970-01-01
-    val terminalStatusDate = Option(new DateTime(2020, 10, 9, 13, 31))
+    val submissionDate = new DateTime(0, DateTimeZone.UTC)  // 1970-01-01
+    val terminalStatusDate = Option(new DateTime(2020, 10, 9, 13, 31, DateTimeZone.UTC))
+    val expectedStartDateString = "1969-12-31"  // submissionDate - 1 day
+    val expectedEndDateString = "2020-10-10"  // terminalStatusDate + 1 day
     val expected =
-      """SELECT wflabels.key, REPLACE(wflabels.value, "cromwell-", "") as `workflowId`, SUM(billing.cost)
+      s"""SELECT wflabels.key, REPLACE(wflabels.value, "cromwell-", "") as `workflowId`, SUM(billing.cost)
         |FROM `test` as billing, UNNEST(labels) as wflabels
         |CROSS JOIN UNNEST(billing.labels) as blabels
         |WHERE blabels.value = "terra-submission-id"
         |AND wflabels.key = "cromwell-workflow-id"
         |AND project.id = ?
-        |AND _PARTITIONDATE BETWEEN "1969-12-30" AND "2020-10-10"
+        |AND _PARTITIONDATE BETWEEN "$expectedStartDateString" AND "$expectedEndDateString"
         |GROUP BY wflabels.key, workflowId""".stripMargin
     assertResult(expected) {
       submissionCostService.generateSubmissionCostsQuery("submission-id", submissionDate, terminalStatusDate)
@@ -48,16 +50,18 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
   }
 
   it should "return the expected string for generateSubmissionCostsQuery with no terminal status date input" in {
-    val submissionDate = new DateTime(0)  // 1970-01-01
+    val submissionDate = new DateTime(0, DateTimeZone.UTC)  // 1970-01-01
     val terminalStatusDate = None
+    val expectedStartDateString = "1969-12-31"  // submissionDate - 1 day
+    val expectedEndDateString = "1970-02-02"  // submissionDate + 31 day + 1 day
     val expected =
-      """SELECT wflabels.key, REPLACE(wflabels.value, "cromwell-", "") as `workflowId`, SUM(billing.cost)
+      s"""SELECT wflabels.key, REPLACE(wflabels.value, "cromwell-", "") as `workflowId`, SUM(billing.cost)
         |FROM `test` as billing, UNNEST(labels) as wflabels
         |CROSS JOIN UNNEST(billing.labels) as blabels
         |WHERE blabels.value = "terra-submission-id"
         |AND wflabels.key = "cromwell-workflow-id"
         |AND project.id = ?
-        |AND _PARTITIONDATE BETWEEN "1969-12-30" AND "1970-01-31"
+        |AND _PARTITIONDATE BETWEEN "$expectedStartDateString" AND "$expectedEndDateString"
         |GROUP BY wflabels.key, workflowId""".stripMargin
     assertResult(expected) {
       submissionCostService.generateSubmissionCostsQuery("submission-id", submissionDate, terminalStatusDate)
@@ -65,14 +69,16 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
   }
 
   it should "return the expected string for generateWorkflowCostsQuery with an existing terminal status date input" in {
-    val submissionDate = new DateTime(0)  // 1970-01-01
-    val terminalStatusDate = Option(new DateTime(2020, 10, 9, 13, 31))
+    val submissionDate = new DateTime(0, DateTimeZone.UTC)  // 1970-01-01
+    val terminalStatusDate = Option(new DateTime(2020, 10, 9, 13, 31, DateTimeZone.UTC))
+    val expectedStartDateString = "1969-12-31"  // submissionDate - 1 day
+    val expectedEndDateString = "2020-10-10"  // terminalStatusDate + 1 day
     val expected =
-      """SELECT labels.key, REPLACE(labels.value, "cromwell-", "") as `workflowId`, SUM(cost)
+      s"""SELECT labels.key, REPLACE(labels.value, "cromwell-", "") as `workflowId`, SUM(cost)
         |FROM `test`, UNNEST(labels) as labels
         |WHERE project.id = ?
         |AND labels.key LIKE "cromwell-workflow-id"
-        |AND _PARTITIONDATE BETWEEN "1969-12-30" AND "2020-10-10"
+        |AND _PARTITIONDATE BETWEEN "$expectedStartDateString" AND "$expectedEndDateString"
         |GROUP BY labels.key, workflowId
         |HAVING some having clause""".stripMargin
     assertResult(expected) {
@@ -81,14 +87,16 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
   }
 
   it should "return the expected string for generateWorkflowCostsQuery with no terminal status date input" in {
-    val submissionDate = new DateTime(0)  // 1970-01-01
+    val submissionDate = new DateTime(0, DateTimeZone.UTC)  // 1970-01-01
     val terminalStatusDate = None
+    val expectedStartDateString = "1969-12-31"  // submissionDate - 1 day
+    val expectedEndDateString = "1970-02-02"  // submissionDate + 31 day + 1 day
     val expected =
-      """SELECT labels.key, REPLACE(labels.value, "cromwell-", "") as `workflowId`, SUM(cost)
+      s"""SELECT labels.key, REPLACE(labels.value, "cromwell-", "") as `workflowId`, SUM(cost)
         |FROM `test`, UNNEST(labels) as labels
         |WHERE project.id = ?
         |AND labels.key LIKE "cromwell-workflow-id"
-        |AND _PARTITIONDATE BETWEEN "1969-12-30" AND "1970-01-31"
+        |AND _PARTITIONDATE BETWEEN "$expectedStartDateString" AND "$expectedEndDateString"
         |GROUP BY labels.key, workflowId
         |HAVING some having clause""".stripMargin
     assertResult(expected) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/SubmissionCostServiceSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import com.google.api.services.bigquery.model.{TableCell, TableRow}
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleBigQueryDAO
+import org.joda.time.DateTime
 import org.scalatest.FlatSpec
 
 import scala.collection.JavaConverters._
@@ -37,7 +38,7 @@ class SubmissionCostServiceSpec extends FlatSpec with RawlsTestUtils {
    */
   it should "bypass BigQuery with no workflow IDs" in {
     assertResult(Map.empty) {
-      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", None), 1 minute)
+      Await.result(submissionCostService.getSubmissionCosts("submission-id", Seq.empty, "test", new DateTime(), new DateTime()), 1 minute)
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -69,7 +69,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
   val mockServer = RemoteServicesMockServer()
 
   val bigQueryDAO = new MockGoogleBigQueryDAO
-  val mockSubmissionCostService = new MockSubmissionCostService("test", "test", bigQueryDAO)
+  val mockSubmissionCostService = new MockSubmissionCostService("test", "test", 31, bigQueryDAO)
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -186,7 +186,7 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       Seq("my-favorite-group"), Seq.empty, Seq("my-favorite-bucket")))
     override val statusServiceConstructor = StatusService.constructor(healthMonitor)_
     val bigQueryDAO = new MockGoogleBigQueryDAO
-    val submissionCostService = new MockSubmissionCostService("test", "test", bigQueryDAO)
+    val submissionCostService = new MockSubmissionCostService("test", "test", 31, bigQueryDAO)
     val execServiceBatchSize = 3
     val maxActiveWorkflowsTotal = 10
     val maxActiveWorkflowsPerUser = 2

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -118,7 +118,7 @@ class WorkspaceServiceSpec extends FlatSpec with ScalatestRouteTest with Matcher
     )_
 
     val bigQueryDAO = new MockGoogleBigQueryDAO
-    val submissionCostService = new MockSubmissionCostService("test", "test", bigQueryDAO)
+    val submissionCostService = new MockSubmissionCostService("test", "test", 31, bigQueryDAO)
     val execServiceBatchSize = 3
     val maxActiveWorkflowsTotal = 10
     val maxActiveWorkflowsPerUser = 2


### PR DESCRIPTION
jira issue WA-270

this PR updates the query used to calculate workflow & submission costs by adding a window over which to query the billing table, rather than scanning the entire table since the date of submission. 
- in `WorkspaceService`, we retrieve the date that the workflow / submission reached a terminal status
- in `SubmissionCostService`, if the `terminalStatusDate` exists, we use this (plus one day to avoid timezone issues) as the end date for the search window, otherwise we add a fixed number of days (defined in the rawls config as 31 days) to the submission date as the end date for the search window.
- related PR in firecloud-develop to define the config value for the billing search window: https://github.com/broadinstitute/firecloud-develop/pull/2300

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [x] **Submitter**: Make sure Swagger is updated if API changes - N/A
  - [x] **...and Orchestration's Swagger too!** - N/A
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli) - N/A
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate - N/A
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621) - N/A
  DBs in Google Cloud Console
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication - N/A
  * Authorization - N/A
  * Encryption - N/A
  * Audit trails - N/A
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
