### PR TITLE
AS-525: update WSM client to remove auth tokens in bodies [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -31,11 +31,11 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
   }
 
   override def createWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): CreatedWorkspace = {
-    getWorkspaceApi(accessToken).createWorkspace(new CreateWorkspaceRequestBody().id(workspaceId).authToken(accessToken.token))
+    getWorkspaceApi(accessToken).createWorkspace(new CreateWorkspaceRequestBody().id(workspaceId))
   }
 
   override def deleteWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): Unit = {
-    getWorkspaceApi(accessToken).deleteWorkspace(new DeleteWorkspaceRequestBody().authToken(accessToken.token), workspaceId)
+    getWorkspaceApi(accessToken).deleteWorkspace(workspaceId)
   }
 
   override def createDataReference(workspaceId: UUID, name: DataReferenceName, referenceType: ReferenceTypeEnum, reference: DataRepoSnapshot, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataReferenceDescription = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,7 @@ object Dependencies {
 
   val accessContextManager = "com.google.apis" % "google-api-services-accesscontextmanager" % "v1beta-rev55-1.25.0"
 
-  val workspaceManager = excludeGuavaJDK5("bio.terra" % "workspace-manager-client" % "0.2.0-SNAPSHOT")
+  val workspaceManager = excludeGuavaJDK5("bio.terra" % "workspace-manager-client" % "0.3.0-SNAPSHOT")
   val dataRepo = excludeGuavaJDK5("bio.terra" % "datarepo-client" % "1.0.44-SNAPSHOT")
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.0-M2"


### PR DESCRIPTION
This PR adopts the 0.3.0-SNAPSHOT version of the workspace manager client. That client, from DataBiosphere/terra-workspace-manager#129, removes auth tokens in request bodies for create- and delete-workspace APIs.

Minor syntax updates for compatibility.

Tested by running locally and hitting both the create- and delete-workspace WSM endpoints through Rawls.