### PR TITLE
Retrieve location for a regional bucket [BW-438]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -232,6 +232,9 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
 
   def testBillingAccountAccess(billingAccount: RawlsBillingAccountName, userInfo: UserInfo): Future[Boolean]
 
+  /**
+    * Returns location of a regional bucket. If the bucket's location type is `multi-region`, it returns None
+    */
   def getRegionForRegionalBucket(bucketName: String): Future[Option[String]]
 
   def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -231,6 +231,8 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def getFolderId(folderName: String): Future[Option[String]]
 
   def testBillingAccountAccess(billingAccount: RawlsBillingAccountName, userInfo: UserInfo): Future[Boolean]
+
+  def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]]
 }
 
 object GoogleApiTypes {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -232,6 +232,8 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
 
   def testBillingAccountAccess(billingAccount: RawlsBillingAccountName, userInfo: UserInfo): Future[Boolean]
 
+  def getRegionForRegionalBucket(bucketName: String): Future[Option[String]]
+
   def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]]
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -232,7 +232,7 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
 
   def testBillingAccountAccess(billingAccount: RawlsBillingAccountName, userInfo: UserInfo): Future[Boolean]
 
-  def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]]
+  def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]]
 }
 
 object GoogleApiTypes {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -401,9 +401,11 @@ class HttpGoogleServicesDAO(
 
   override def getBucket(bucketName: String)(implicit executionContext: ExecutionContext): Future[Option[Bucket]] = {
     implicit val service = GoogleInstrumentedService.Storage
-    val getter = getStorage(getBucketServiceAccountCredential).buckets().get(bucketName)
-    retryWithRecoverWhen500orGoogleError(() => { Option(executeGoogleRequest(getter)) }) {
-      case e: HttpResponseException => None
+    retryWithRecoverWhen500orGoogleError(() => {
+      val getter = getStorage(getBucketServiceAccountCredential).buckets().get(bucketName)
+      Option(executeGoogleRequest(getter))
+    }) {
+      case _: HttpResponseException => None
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -68,7 +68,6 @@ import scala.io.Source
 import scala.util.matching.Regex
 
 import io.opencensus.scala.Tracing._
-import org.apache.commons.lang3.exception.ExceptionUtils
 
 case class Resources (
                        name: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -404,6 +404,14 @@ class HttpGoogleServicesDAO(
     }
   }
 
+  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]] = {
+    implicit val service = GoogleInstrumentedService.Storage
+    val getter = getComputeManager(getBucketServiceAccountCredential).regions().get(googleProject.value, region)
+    retryWithRecoverWhen500orGoogleError(() => { Option(executeGoogleRequest(getter).getZones.asScala.toList) }) {
+      case e: HttpResponseException => None
+    }
+  }
+
   override def addEmailToGoogleGroup(groupEmail: String, emailToAdd: String): Future[Unit] = {
     implicit val service = GoogleInstrumentedService.Groups
     val inserter = getGroupDirectory.members.insert(groupEmail, new Member().setEmail(emailToAdd).setRole(groupMemberRole))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -189,7 +189,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
   def getRuntimeOptions(googleProjectId: String, bucketName: String)(implicit executionContext: ExecutionContext): Future[Option[JsValue]] = {
     for {
       regionOption <- googleServicesDAO.getRegionForRegionalBucket(bucketName)
-      maybeRuntimeOptions <- {
+      runtimeOptions <- {
         regionOption match {
           case Some(region) =>
             for {
@@ -202,7 +202,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
             Future.successful(defaultRuntimeOptions)
         }
       }
-    } yield maybeRuntimeOptions
+    } yield runtimeOptions
   }
 
   def buildWorkflowOpts(workspace: WorkspaceRecord,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -191,12 +191,9 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       regionOption <- googleServicesDAO.getRegionForRegionalBucket(bucketName)
       runtimeOptions <- {
         regionOption match {
-          case Some(region) =>
-            for {
-              zones <- googleServicesDAO.getComputeZonesForRegion(GoogleProjectId(googleProjectId), region)
-            } yield {
-              Option(JsObject("zones" -> JsString(zones.mkString(" "))))
-            }
+          case Some(region) => googleServicesDAO.getComputeZonesForRegion(GoogleProjectId(googleProjectId), region) map { zones =>
+            Option(JsObject("zones" -> JsString(zones.mkString(" "))))
+          }
           case None =>
             // if the location is `multi-region` we want the default zones from config
             Future.successful(defaultRuntimeOptions)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -223,5 +223,5 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(billingAccount == accessibleBillingAccountName)
   }
 
-  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]] = Future.successful(None)
+  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = Future.successful(List.empty[String])
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -224,4 +224,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
   }
 
   override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = Future.successful(List.empty[String])
+
+  override def getRegionForRegionalBucket(bucketName: String): Future[Option[String]] = Future.successful(None)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -223,4 +223,5 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(billingAccount == accessibleBillingAccountName)
   }
 
+  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]] = Future.successful(None)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -226,7 +226,7 @@ class MockGoogleServicesDAO(groupsPrefix: String,
   override def getRegionForRegionalBucket(bucketName: String): Future[Option[String]] = {
     Future.successful {
       bucketName match {
-        case "fc-regional-bucket" => Option("europe-north1")
+        case "fc-regional-bucket" => Option("EUROPE-NORTH1")
         case _ => None
       }
     }
@@ -234,7 +234,7 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
   override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = {
     Future.successful {
-      region match {
+      region.toLowerCase match {
         case "europe-north1" => List("europe-north1-a", "europe-north1-b", "europe-north1-c")
         case _ => List("us-central1-b", "us-central1-c", "us-central1-f")
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -223,7 +223,21 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(billingAccount == accessibleBillingAccountName)
   }
 
-  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = Future.successful(List.empty[String])
+  override def getRegionForRegionalBucket(bucketName: String): Future[Option[String]] = {
+    Future.successful {
+      bucketName match {
+        case "fc-regional-bucket" => Option("europe-north1")
+        case _ => None
+      }
+    }
+  }
 
-  override def getRegionForRegionalBucket(bucketName: String): Future[Option[String]] = Future.successful(None)
+  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = {
+    Future.successful {
+      region match {
+        case "europe-north1" => List("europe-north1-a", "europe-north1-b", "europe-north1-c")
+        case _ => List("us-central1-b", "us-central1-c", "us-central1-f")
+      }
+    }
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
@@ -27,7 +27,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryArecords = runAndWait(queryA.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(19) { queryArecords.length }
+    assertResult(22) { queryArecords.length }
 
     assertResult(queryArecords) {
       runAndWait(concatSqlActions(Seq(select, where):_*).as[WorkflowRecord])
@@ -40,7 +40,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryBrecords = runAndWait(queryB.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(19) { queryBrecords.length }
+    assertResult(22) { queryBrecords.length }
 
     assertResult(queryBrecords) {
       runAndWait(concatSqlActions(Seq(select, where1, sql",", where2):_*).as[WorkflowRecord])
@@ -69,7 +69,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val queryRecords = runAndWait(query.as[WorkflowRecord])
 
     // first check that we're not just comparing empty seqs
-    assertResult(30) { queryRecords.length }
+    assertResult(33) { queryRecords.length }
 
     assertResult(queryRecords) {
       runAndWait(concatSqlActions(select, where1, reduceSqlActionsWithDelim(statuses), where2).as[WorkflowRecord])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -203,9 +203,9 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
       runAndWait(submissionQuery.get(workspaceContext, testData.submission2.submissionId))
     }
 
-    // should return {"Submitted" : 4, "Done" : 1, "Aborted" : 1}
+    // should return {"Submitted" : 6, "Done" : 1, "Aborted" : 1}
     assert(3 == runAndWait(submissionQuery.countByStatus(workspaceContext)).size)
-    assert(Option(5) == runAndWait(submissionQuery.countByStatus(workspaceContext)).get(SubmissionStatuses.Submitted.toString))
+    assert(Option(6) == runAndWait(submissionQuery.countByStatus(workspaceContext)).get(SubmissionStatuses.Submitted.toString))
     assert(Option(1) == runAndWait(submissionQuery.countByStatus(workspaceContext)).get(SubmissionStatuses.Done.toString))
     assert(Option(1) == runAndWait(submissionQuery.countByStatus(workspaceContext)).get(SubmissionStatuses.Aborted.toString))
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -222,6 +222,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val wsNameConfigCopyDestination = WorkspaceName("myNamespace", "configCopyDestinationWS")
     val wsInterleaved = WorkspaceName("myNamespace", "myWSToTestInterleavedSubs")
     val wsWorkflowFailureMode = WorkspaceName("myNamespace", "myWSToTestWFFailureMode")
+    val wsRegionalName = WorkspaceName("myNamespace", "myRegionalWorkspace")
     val workspaceToTestGrantId = UUID.randomUUID()
 
     val nestedProjectGroup = makeRawlsGroup("nested_project_group", Set(userOwner))
@@ -248,6 +249,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val workspaceNoGroups = Workspace(wsName.namespace, wsName.name + "3", UUID.randomUUID().toString, "aBucket2", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs)
 
     val (workspace) = makeWorkspaceWithUsers(billingProject, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+
+    val (regionalWorkspace) = makeWorkspaceWithUsers(billingProject, wsRegionalName.name, UUID.randomUUID().toString, "fc-regional-bucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
 
     val workspacePublished = Workspace(wsName.namespace, wsName.name + "_published", UUID.randomUUID().toString, "aBucket3", Some("workflow-collection"), currentTime(), currentTime(), "testUser",
       wsAttrs + (AttributeName.withLibraryNS("published") -> AttributeBoolean(true)))
@@ -457,6 +460,9 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       Seq.empty, Map.empty,
       Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
     val submission1 = createTestSubmission(workspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
+    val regionalSubmission = createTestSubmission(regionalWorkspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
       Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
       Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
     val costedSubmission1 = createTestSubmission(workspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
@@ -820,7 +826,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       workspaceInterleavedSubmissions,
       workspaceWorkflowFailureMode,
       workspaceToTestGrant,
-      workspaceConfigCopyDestination)
+      workspaceConfigCopyDestination,
+      regionalWorkspace)
     val saveAllWorkspacesAction = DBIO.sequence(allWorkspaces.map(workspaceQuery.save))
 
     override def save() = {
@@ -860,6 +867,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
                 submissionQuery.create(context, submissionTerminateTest),
                 submissionQuery.create(context, submissionNoWorkflows),
                 submissionQuery.create(context, submission1),
+                submissionQuery.create(context, regionalSubmission),
                 submissionQuery.create(context, costedSubmission1),
                 submissionQuery.create(context, submission2),
                 submissionQuery.create(context, submissionUpdateEntity),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -57,7 +57,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem) extends TestKit(_system) with
     val pollInterval: FiniteDuration = 1 second,
     val maxActiveWorkflowsTotal: Int = 100,
     val maxActiveWorkflowsPerUser: Int = 100,
-    val runtimeOptions: Option[JsValue] = None,
+    val defaultRuntimeOptions: Option[JsValue] = None,
     val trackDetailedSubmissionMetrics: Boolean = true,
     override val workbenchMetricBaseName: String = "test",
     val requesterPaysRole: String = requesterPaysRole,
@@ -226,7 +226,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem) extends TestKit(_system) with
 
   it should "submit a workflow with the right parameters and options" in withDefaultTestDatabase {
     val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workflowSubmission = new TestWorkflowSubmission(slickDataSource, 100, runtimeOptions = Some(JsObject(Map("zones" -> JsString("us-central-someother"))))) {
+    val workflowSubmission = new TestWorkflowSubmission(slickDataSource, 100, defaultRuntimeOptions = Some(JsObject(Map("zones" -> JsString("us-central-someother"))))) {
       override val executionServiceCluster = mockExecCluster
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -276,7 +276,11 @@ class WorkflowSubmissionSpec(_system: ActorSystem) extends TestKit(_system) with
 
       val workflowOptions = mockExecCluster.getDefaultSubmitMember.asInstanceOf[MockExecutionServiceDAO].submitOptions.map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
 
-      workflowOptions.get.default_runtime_attributes shouldBe Some(JsObject(Map("zones" -> JsString("europe-north1-a europe-north1-b europe-north1-c"))))
+      val actualZones: JsValue = workflowOptions.get.default_runtime_attributes.get.asJsObject.fields("zones")
+      val actualZonesList: List[String] = actualZones.convertTo[String].split(" ").toList
+
+      actualZonesList should not be (empty)
+      actualZonesList.foreach { z => z should startWith("europe-north1-") }
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -492,6 +492,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           expectedResponse(testData.costedSubmission1),
           expectedResponse(testData.submission2),
           expectedResponse(testData.submissionUpdateEntity),
+          expectedResponse(testData.regionalSubmission),
           expectedResponse(testData.submissionUpdateWorkspace))) {
           responseAs[Seq[SubmissionListResponse]].toSet
         }
@@ -505,7 +506,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
           assertResult(StatusCodes.OK) {
             status
           }
-          assertResult(Map("Submitted" -> 7)) {
+          assertResult(Map("Submitted" -> 8)) {
             responseAs[Map[String, Int]]
           }
         }
@@ -552,7 +553,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
     // also insert a dummy audit record with a different workflow id to attempt to confuse the code
     runAndWait( workflowAuditStatusQuery.save( WorkflowAuditStatusRecord(0, 42, WorkflowStatuses.Queued.toString, new java.sql.Timestamp(queuedTime-6000)) ) )
 
-    val existingSubmittedWorkflowCount = 19
+    val existingSubmittedWorkflowCount = 22
     val existingWorkflowCounts = Map("Submitted" -> existingSubmittedWorkflowCount)
 
     val resp = getQueueStatus(services.submissionRoutes)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -662,7 +662,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
         val dateTime = currentTime()
         assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails(testData.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(None, None, 7)), false),
+          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails(testData.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(None, None, 8)), false),
           WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails(testData.workspaceFailedSubmission.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(None, Option(testDate), 0)), false),
         )) {
           responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))


### PR DESCRIPTION
This PR **only** retrieves compute zones for a regional bucket i.e. bucket whose location type is `region`. For buckets that are `multi-region` (which are default type of bucket created by Rawls) we pass default runtime zone attributes to Cromwell while submitting a workflow as before.

Closes https://broadworkbench.atlassian.net/browse/BW-438