### PR TITLE
Add support for creating and cloning workspace buckets in a specified region [BW-427][BW-443]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.11.3"
 
-  val serviceTestV = "0.18-52697a02-SNAP" // TODO: Change it from SNAP to actual version
+  val serviceTestV = "0.18-c9edd8e"
   val workbenchGoogleV = "0.21-64a7b29"
-  val workbenchGoogle2V = "0.17-52697a02-SNAP" // TODO: Change it from SNAP to actual version
+  val workbenchGoogle2V = "0.18-c9edd8e"
   val workbenchModelV  = "0.14-65bba14"
   val workbenchMetricsV  = "0.5-64a7b29"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.11.3"
 
-  val serviceTestV = "0.18-135086e1-SNAP"
+  val serviceTestV = "0.18-ea190386-SNAP"
   val workbenchGoogleV = "0.21-64a7b29"
-  val workbenchGoogle2V = "0.17-135086e1-SNAP"
+  val workbenchGoogle2V = "0.17-ea190386-SNAP"
   val workbenchModelV  = "0.14-65bba14"
   val workbenchMetricsV  = "0.5-64a7b29"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   val serviceTestV = "0.18-c9edd8e"
   val workbenchGoogleV = "0.21-64a7b29"
-  val workbenchGoogle2V = "0.18-c9edd8e"
+  val workbenchGoogle2V = "0.18-4631ebf"
   val workbenchModelV  = "0.14-65bba14"
   val workbenchMetricsV  = "0.5-64a7b29"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,10 +8,10 @@ object Dependencies {
   val jacksonV      = "2.11.3"
 
   val serviceTestV = "0.18-135086e1-SNAP"
-  val workbenchGoogleV = "0.21-890a74f"
+  val workbenchGoogleV = "0.21-64a7b29"
   val workbenchGoogle2V = "0.17-135086e1-SNAP"
-  val workbenchModelV  = "0.13-58c913d"
-  val workbenchMetricsV  = "0.5-4c7acd5"
+  val workbenchModelV  = "0.14-65bba14"
+  val workbenchMetricsV  = "0.5-64a7b29"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val workbenchMetrics: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-metrics" % workbenchMetricsV

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.11.3"
 
-  val serviceTestV = "0.18-ea190386-SNAP"
+  val serviceTestV = "0.18-52697a02-SNAP" // TODO: Change it from SNAP to actual version
   val workbenchGoogleV = "0.21-64a7b29"
-  val workbenchGoogle2V = "0.17-ea190386-SNAP"
+  val workbenchGoogle2V = "0.17-52697a02-SNAP" // TODO: Change it from SNAP to actual version
   val workbenchModelV  = "0.14-65bba14"
   val workbenchMetricsV  = "0.5-64a7b29"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.11.3"
 
-  val serviceTestV = "0.18-d7bebc7"
+  val serviceTestV = "0.18-135086e1-SNAP"
   val workbenchGoogleV = "0.21-890a74f"
-  val workbenchGoogle2V = "0.6-c91d96b"
+  val workbenchGoogle2V = "0.17-135086e1-SNAP"
   val workbenchModelV  = "0.13-58c913d"
   val workbenchMetricsV  = "0.5-4c7acd5"
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -320,9 +320,7 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               callZones foreach { _.split(",") foreach { zone => zone should startWith (europeNorth1ZonesPrefix) } }
 
               workerAssignedExecEvents should not be (empty)
-              workerAssignedExecEvents foreach { event =>
-                event should include (europeNorth1ZonesPrefix)
-              }
+              workerAssignedExecEvents foreach { event => event should include (europeNorth1ZonesPrefix) }
             }
           }
         }
@@ -416,9 +414,7 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               callZones foreach { _.split(",") foreach { zone => zone should startWith (europeNorth1ZonesPrefix) } }
 
               workerAssignedExecEvents should not be (empty)
-              workerAssignedExecEvents foreach { event =>
-                event should include (europeNorth1ZonesPrefix)
-              }
+              workerAssignedExecEvents foreach { event => event should include (europeNorth1ZonesPrefix) }
             }
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -113,14 +113,14 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
     metadataJson.get("submittedFiles").get("options").asText()
   }
 
-  def parseRuntimeAttributeKeyFromMetadata(metadata: List[JsonNode], attributeKey: String): List[String] = {
+  def parseRuntimeAttributeKeyFromCallMetadata(metadata: List[JsonNode], attributeKey: String): List[String] = {
     metadata.map(_.get("runtimeAttributes").get("zones").asText())
   }
 
-  def parseWorkerAssignedExecEvents(metadata: List[JsonNode]): List[String] = {
-    metadata.flatMap{ call =>
-      val flattenedExecutionEvents = call.get("executionEvents").elements().asScala.toList
-      val descriptions = flattenedExecutionEvents.map(_.get("description").asText())
+  def parseWorkerAssignedExecEventsFromCallMetadata(metadata: List[JsonNode]): List[String] = {
+    metadata.flatMap { call =>
+      val executionEvents = call.get("executionEvents").elements().asScala.toList
+      val descriptions = executionEvents.map(_.get("description").asText())
       descriptions.filter(desc => desc.startsWith("Worker") && desc.contains("assigned"))
     }
   }
@@ -311,8 +311,8 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
             eventually {
               val subWorkflowsMetadata = subWorkflowIds map { Rawls.submissions.getWorkflowMetadata(projectName, workspaceName, submissionId, _) }
               val subWorkflowCallMetadata = subWorkflowsMetadata flatMap parseCallsFromMetadata
-              val callZones = parseRuntimeAttributeKeyFromMetadata(subWorkflowCallMetadata, "zones")
-              val workerAssignedExecEvents = parseWorkerAssignedExecEvents(subWorkflowCallMetadata)
+              val callZones = parseRuntimeAttributeKeyFromCallMetadata(subWorkflowCallMetadata, "zones")
+              val workerAssignedExecEvents = parseWorkerAssignedExecEventsFromCallMetadata(subWorkflowCallMetadata)
 
               subWorkflowsMetadata foreach { x => x should include (""""executionStatus":"Done"""") }
 
@@ -406,8 +406,8 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
             eventually {
               val subWorkflowsMetadata = subWorkflowIds map { Rawls.submissions.getWorkflowMetadata(projectName, workspaceName, submissionId, _) }
               val subWorkflowCallMetadata = subWorkflowsMetadata flatMap parseCallsFromMetadata
-              val callZones = parseRuntimeAttributeKeyFromMetadata(subWorkflowCallMetadata, "zones")
-              val workerAssignedExecEvents = parseWorkerAssignedExecEvents(subWorkflowCallMetadata)
+              val callZones = parseRuntimeAttributeKeyFromCallMetadata(subWorkflowCallMetadata, "zones")
+              val workerAssignedExecEvents = parseWorkerAssignedExecEventsFromCallMetadata(subWorkflowCallMetadata)
 
               subWorkflowsMetadata foreach { x => x should include (""""executionStatus":"Done"""") }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -195,7 +195,6 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               val workflowOptions = parseWorkflowOptionsFromMetadata(cromwellMetadata)
               val subIds = parseSubWorkflowIdsFromMetadata(cromwellMetadata)
               withClue(getWorkflowResponse(projectName, workspaceName, submissionId, firstWorkflowId)) {
-                // check the computes zones belong to `us-central1`
                 workflowOptions should include ("us-central1-")
 
                 subIds should not be (empty)
@@ -239,7 +238,7 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
     "should be able to create workspace and run sub-workflow tasks in non-US regions" in {
       implicit val token: AuthToken = studentBToken
 
-      // this will create a method with 2 levels and 3 scatter count i.e. it will create a workflow with 3 sub-workflows
+      // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
 
       val europeNorth1ZonesPrefix = "europe-north1-"
@@ -330,7 +329,7 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
     "should be able to run sub-workflow tasks in a cloned workspace in non-US regions" in {
       implicit val token: AuthToken = studentBToken
 
-      // this will create a method with 2 levels and 3 scatter count i.e. it will create a workflow with 3 sub-workflows
+      // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
 
       val europeNorth1ZonesPrefix = "europe-north1-"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -245,7 +245,7 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
       val europeNorth1ZonesPrefix = "europe-north1-"
 
       withCleanBillingProject(studentB) { projectName =>
-        withWorkspace(projectName, "rawls-subworkflows-in-regions", workspaceRegion = Option("europe-north1")) { workspaceName =>
+        withWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("europe-north1")) { workspaceName =>
           withCleanUp {
             Orchestration.methodConfigurations.createMethodConfigInWorkspace(
               projectName, workspaceName,
@@ -337,8 +337,9 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
 
       withCleanBillingProject(studentB) { projectName =>
         // `withClonedWorkspace()` will create a new workspace, clone it and run the workflow in the cloned workspace
-        withClonedWorkspace(projectName, "rawls-subworkflows-in-regions", workspaceRegion = Option("europe-north1")) { workspaceName =>
+        withClonedWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("europe-north1")) { workspaceName =>
           withCleanUp {
+            // `withClonedWorkspace()` appends `_clone` to the original workspace. Check that workspace returned is actually a clone
             workspaceName should include ("_clone")
 
             Orchestration.methodConfigurations.createMethodConfigInWorkspace(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -62,6 +62,17 @@ class WorkspaceApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
         }
       }
 
+      "to create a workspace with a workspace bucket in a specified invalid region" in {
+        implicit val token: AuthToken = ownerAuthToken
+
+        val p = claimGPAllocProject(owner)
+        val workspaceName = prependUUID("owner-invalid-region-workspace")
+        val exception = intercept[RestException](Orchestration.workspaces.create(p.projectName, workspaceName, Set.empty, Option("invalid-region1"))).message.parseJson.asJsObject
+
+        exception.fields("statusCode").convertTo[Int] should equal(400)
+        exception.fields("message").convertTo[String] should endWith(s" in Google project `${p.projectName}` in region `invalid-region1`.")
+      }
+
       "to add readers with can-share access" in {
         withCleanBillingProject(owner) { projectName =>
           withWorkspace(projectName, prependUUID("share-reader")) { workspaceName =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -62,15 +62,17 @@ class WorkspaceApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
         }
       }
 
-      "to create a workspace with a workspace bucket in a specified invalid region" in {
+      "to get an error message when they try to create a workspace with a bucket region that is invalid" in {
         implicit val token: AuthToken = ownerAuthToken
+        val invalidRegion = "invalid-region1"
 
         val p = claimGPAllocProject(owner)
         val workspaceName = prependUUID("owner-invalid-region-workspace")
-        val exception = intercept[RestException](Orchestration.workspaces.create(p.projectName, workspaceName, Set.empty, Option("invalid-region1"))).message.parseJson.asJsObject
+        val exception = intercept[RestException](Orchestration.workspaces.create(p.projectName, workspaceName, Set.empty, Option(invalidRegion))).message.parseJson.asJsObject
 
         exception.fields("statusCode").convertTo[Int] should equal(400)
-        exception.fields("message").convertTo[String] should endWith(s" in Google project `${p.projectName}` in region `invalid-region1`.")
+        exception.fields("message").convertTo[String] should startWith("Workspace creation failed. Error trying to create bucket ")
+        exception.fields("message").convertTo[String] should endWith(s" in Google project `${p.projectName}` in region `${invalidRegion}`.")
       }
 
       "to add readers with can-share access" in {

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5671,7 +5671,8 @@ components:
           default: false
         bucketLocation:
           type: string
-          description: Region in which bucket attached to the workspace should be created. It is optional. If not provided, the bucket will be created in `us-central1`
+          required: false
+          description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
       description: ""
     WorkspaceRequestClone:
       required:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5669,6 +5669,9 @@ components:
           type: boolean
           description: Optional, false if not specified. If true, the workspace is created with a Billing Project owner but no workspace owner. Requires being a Billing Project owner.
           default: false
+        bucketLocation:
+          type: string
+          description: Region in which bucket attached to the workspace should be created. It is optional. If not provided, the bucket will be created in `us-central1`
       description: ""
     WorkspaceRequestClone:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -28,7 +28,13 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   val billingGroupEmail: String
 
   // returns bucket and group information
-  def setupWorkspace(userInfo: UserInfo, googleProject: GoogleProjectId, policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail], bucketName: String, labels: Map[String, String], parentSpan: Span = null): Future[GoogleWorkspaceInfo]
+  def setupWorkspace(userInfo: UserInfo,
+                     googleProject: GoogleProjectId,
+                     policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail],
+                     bucketName: String,
+                     labels: Map[String, String],
+                     parentSpan: Span = null,
+                     bucketLocation: Option[String]): Future[GoogleWorkspaceInfo]
 
   def getGoogleProject(googleProject: GoogleProjectId): Future[Project]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -454,17 +454,6 @@ class HttpGoogleServicesDAO(
     }
   }
 
-  // TODO: REMOVE BEFORE MERGING. Another PR (#1319) already has implemented this
-  override def getRegionForRegionalBucket(bucketName: String): Future[Option[String]] = {
-    getBucket(bucketName) map { maybeBucket =>
-      val bucket = maybeBucket.getOrElse(throw new RawlsException(s"Failed to retrieve bucket `$bucketName`"))
-      bucket.getLocationType match {
-        case "region" => Option(bucket.getLocation.toLowerCase)
-        case _ => None
-      }
-    }
-  }
-
   override def addEmailToGoogleGroup(groupEmail: String, emailToAdd: String): Future[Unit] = {
     implicit val service = GoogleInstrumentedService.Groups
     val inserter = getGroupDirectory.members.insert(groupEmail, new Member().setEmail(emailToAdd).setRole(groupMemberRole))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -438,6 +438,14 @@ class HttpGoogleServicesDAO(
     }
   }
 
+  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]] = {
+    implicit val service = GoogleInstrumentedService.Storage
+    val getter = getComputeManager(getBucketServiceAccountCredential).regions().get(googleProject.value, region)
+    retryWithRecoverWhen500orGoogleError(() => { Option(executeGoogleRequest(getter).getZones.asScala.toList) }) {
+      case e: HttpResponseException => None
+    }
+  }
+
   override def addEmailToGoogleGroup(groupEmail: String, emailToAdd: String): Future[Unit] = {
     implicit val service = GoogleInstrumentedService.Groups
     val inserter = getGroupDirectory.members.insert(groupEmail, new Member().setEmail(emailToAdd).setRole(groupMemberRole))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -68,7 +68,6 @@ import scala.io.Source
 import scala.util.matching.Regex
 
 import io.opencensus.scala.Tracing._
-import org.apache.commons.lang3.exception.ExceptionUtils
 
 case class Resources (
                        name: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -440,9 +440,13 @@ class HttpGoogleServicesDAO(
 
   override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]] = {
     implicit val service = GoogleInstrumentedService.Storage
-    val getter = getComputeManager(getBucketServiceAccountCredential).regions().get(googleProject.value, region)
-    retryWithRecoverWhen500orGoogleError(() => { Option(executeGoogleRequest(getter).getZones.asScala.toList) }) {
-      case e: HttpResponseException => None
+    val getter = getComputeManager(getBillingServiceAccountCredential).regions().get(googleProject.value, region)
+    retryWithRecoverWhen500orGoogleError(() => {
+      val zonesAsResourceUrls = executeGoogleRequest(getter).getZones.asScala.toList
+      val zones = zonesAsResourceUrls.map(_.split("/").last)
+      Option(zones)
+    }) {
+      case e => None
     }
   }
 
@@ -1070,7 +1074,7 @@ class HttpGoogleServicesDAO(
   }
 
   def getBillingServiceAccountCredential: Credential = {
-    new GoogleCredential.Builder()
+    val abc = new GoogleCredential.Builder()
       .setTransport(httpTransport)
       .setJsonFactory(jsonFactory)
       .setServiceAccountScopes(Seq(ComputeScopes.CLOUD_PLATFORM).asJava) // need this broad scope to create/manage projects
@@ -1078,6 +1082,10 @@ class HttpGoogleServicesDAO(
       .setServiceAccountPrivateKeyFromPemFile(new java.io.File(billingPemFile))
       .setServiceAccountUser(billingEmail)
       .build()
+
+    println(s"******* FIND ME TOKEN getBillingServiceAccountCredential: ${abc.getAccessToken}")
+
+    abc
   }
 
   def toGoogleGroupName(groupName: RawlsGroupName) = s"${proxyNamePrefix}GROUP_${groupName.value}@${appsDomain}"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -68,6 +68,7 @@ import scala.io.Source
 import scala.util.matching.Regex
 
 import io.opencensus.scala.Tracing._
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 case class Resources (
                        name: String,
@@ -438,15 +439,15 @@ class HttpGoogleServicesDAO(
     }
   }
 
-  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[Option[List[String]]] = {
+  override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = {
     implicit val service = GoogleInstrumentedService.Storage
-    val getter = getComputeManager(getBillingServiceAccountCredential).regions().get(googleProject.value, region)
     retryWithRecoverWhen500orGoogleError(() => {
+      val getter = getComputeManager(getBucketServiceAccountCredential).regions().get(googleProject.value, region)
       val zonesAsResourceUrls = executeGoogleRequest(getter).getZones.asScala.toList
-      val zones = zonesAsResourceUrls.map(_.split("/").last)
-      Option(zones)
+      zonesAsResourceUrls.map(_.split("/").last)
     }) {
-      case e => None
+      case e => throw new RawlsException(s"Something went wrong while retrieving zones for region `$region` under Google " +
+        s"project `${googleProject.value}`. Error: ${ExceptionUtils.getMessage(e)}")
     }
   }
 
@@ -1074,7 +1075,7 @@ class HttpGoogleServicesDAO(
   }
 
   def getBillingServiceAccountCredential: Credential = {
-    val abc = new GoogleCredential.Builder()
+    new GoogleCredential.Builder()
       .setTransport(httpTransport)
       .setJsonFactory(jsonFactory)
       .setServiceAccountScopes(Seq(ComputeScopes.CLOUD_PLATFORM).asJava) // need this broad scope to create/manage projects
@@ -1082,10 +1083,6 @@ class HttpGoogleServicesDAO(
       .setServiceAccountPrivateKeyFromPemFile(new java.io.File(billingPemFile))
       .setServiceAccountUser(billingEmail)
       .build()
-
-    println(s"******* FIND ME TOKEN getBillingServiceAccountCredential: ${abc.getAccessToken}")
-
-    abc
   }
 
   def toGoogleGroupName(groupName: RawlsGroupName) = s"${proxyNamePrefix}GROUP_${groupName.value}@${appsDomain}"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -439,6 +439,16 @@ class HttpGoogleServicesDAO(
     }
   }
 
+  override def getRegionForRegionalBucket(bucketName: String): Future[Option[String]] = {
+    getBucket(bucketName) map { maybeBucket =>
+      val bucket = maybeBucket.getOrElse(throw new RawlsException(s"Failed to retrieve bucket `$bucketName`"))
+      bucket.getLocationType match {
+        case SingleRegionLocationType => Option(bucket.getLocation.toLowerCase)
+        case _ => None
+      }
+    }
+  }
+
   override def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]] = {
     implicit val service = GoogleInstrumentedService.Storage
     retryWithRecoverWhen500orGoogleError(() => {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -146,7 +146,7 @@ trait WorkspaceSupport {
   def withWorkspaceBucketRegionCheck[T](bucketRegion: Option[String])(op: => Future[T]): Future[T] = {
     bucketRegion match {
       case Some(region) =>
-        // we currently only support creating buckets in a single region or default it to US (which is multi-region)
+        // if the user specifies a region for the workspace bucket, it must be in the proper format for a single region
         val singleRegionPattern = "[A-Za-z]+-[A-Za-z]+[0-9]+"
         if (region.matches(singleRegionPattern)) op
         else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -150,8 +150,8 @@ trait WorkspaceSupport {
         val singleRegionPattern = "[A-Za-z]+-[A-Za-z]+[0-9]+"
         if (region.matches(singleRegionPattern)) op
         else {
-          val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace Bucket Location should be " +
-            s"of format: $singleRegionPattern.")
+          val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace bucket location must be a single " +
+            s"(not multi-) region of format: $singleRegionPattern.")
           throw new RawlsExceptionWithErrorReport(errorReport = err)
         }
       case None => op

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1936,7 +1936,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
                   }.flatten.toMap)
 
                   _ <- traceDBIOWithParent("gcsDAO.setupWorkspace", s2)(s3 => DBIO.from(gcsDAO.setupWorkspace(userInfo, savedWorkspace.googleProject, policyEmails, bucketName, getLabels(workspaceRequest.authorizationDomain.getOrElse(Set.empty).toList), s3, workspaceRequest.bucketLocation)))
-                  _ = workspaceRequest.bucketLocation.foreach(location => logger.info(s"Internal bucket for workspace `${workspaceRequest.name}` in namespace `${workspaceRequest.namespace}` is created in region `$location`."))
+                  _ = workspaceRequest.bucketLocation.foreach(location => logger.info(s"Internal bucket for workspace `${workspaceRequest.name}` in namespace `${workspaceRequest.namespace}` was created in region `$location`."))
                   response <- traceDBIOWithParent("doOp", s2)(_ => op(savedWorkspace))
                 } yield response
               })

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1934,6 +1934,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
                   }.flatten.toMap)
 
                   _ <- traceDBIOWithParent("gcsDAO.setupWorkspace", s2)(s3 => DBIO.from(gcsDAO.setupWorkspace(userInfo, savedWorkspace.googleProject, policyEmails, bucketName, getLabels(workspaceRequest.authorizationDomain.getOrElse(Set.empty).toList), s3, workspaceRequest.bucketLocation)))
+                  _ = workspaceRequest.bucketLocation.foreach(location => logger.info(s"Internal bucket for workspace `${workspaceRequest.name}` in namespace `${workspaceRequest.namespace}` is created in region `$location`."))
                   response <- traceDBIOWithParent("doOp", s2)(_ => op(savedWorkspace))
                 } yield response
               })

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1916,6 +1916,9 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             // add the workspace id to the span so we can find and correlate it later with other services
             s1.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId))
 
+            // TODO: Before creating the bucket make sure the location passed is of form `europe-north1`
+            // We should validate that location passed like `EU` or `US` should not be allowed
+
             traceDBIOWithParent("getPolicySyncStatus", s1)(_ => DBIO.from(samDAO.getPolicySyncStatus(SamResourceTypeNames.billingProject, workspaceRequest.namespace, SamBillingProjectPolicyNames.owner, userInfo).map(_.email))).flatMap { projectOwnerPolicyEmail =>
               traceDBIOWithParent("saveNewWorkspace", s1)(s2 => saveNewWorkspace(workspaceId, workspaceRequest, bucketName, projectOwnerPolicyEmail, dataAccess, s2).flatMap { case (savedWorkspace, policyMap) =>
                 for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1918,9 +1918,6 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             // add the workspace id to the span so we can find and correlate it later with other services
             s1.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId))
 
-            // TODO: Before creating the bucket make sure the location passed is of form `europe-north1`
-            // We should validate that location passed like `EU` or `US` should not be allowed
-
             traceDBIOWithParent("getPolicySyncStatus", s1)(_ => DBIO.from(samDAO.getPolicySyncStatus(SamResourceTypeNames.billingProject, workspaceRequest.namespace, SamBillingProjectPolicyNames.owner, userInfo).map(_.email))).flatMap { projectOwnerPolicyEmail =>
               traceDBIOWithParent("saveNewWorkspace", s1)(s2 => saveNewWorkspace(workspaceId, workspaceRequest, bucketName, projectOwnerPolicyEmail, dataAccess, s2).flatMap { case (savedWorkspace, policyMap) =>
                 for {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -92,8 +92,13 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
   var mockProxyGroups = mutable.Map[RawlsUser, Boolean]()
 
-  override def setupWorkspace(userInfo: UserInfo, googleProject: GoogleProjectId, policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail], bucketName: String, labels: Map[String, String], parentSpan: Span =  null
-                             ): Future[GoogleWorkspaceInfo] = {
+  override def setupWorkspace(userInfo: UserInfo,
+                              googleProject: GoogleProjectId,
+                              policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail],
+                              bucketName: String,
+                              labels: Map[String, String],
+                              parentSpan: Span =  null,
+                              bucketLocation: Option[String]): Future[GoogleWorkspaceInfo] = {
 
     val googleWorkspaceInfo: GoogleWorkspaceInfo = GoogleWorkspaceInfo(bucketName, policyGroupsByAccessLevel)
     Future.successful(googleWorkspaceInfo)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -775,17 +775,17 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     val newWorkspace = WorkspaceRequest(
       namespace = testData.wsName.namespace,
       name = "newWorkspace",
-      Map.empty,
-      None,
-      Option("US")
+      attributes = Map.empty,
+      authorizationDomain = None,
+      bucketLocation = Option("US")
     )
 
     Post(s"/workspaces", httpJson(newWorkspace)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.BadRequest) {
-          status
-        }
+        val errorText = responseAs[ErrorReport].message
+        assert(status == StatusCodes.BadRequest)
+        assert(errorText.contains("Workspace Bucket Location should be of format: [A-Za-z]+-[A-Za-z]+[0-9]+"))
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -771,6 +771,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  // TODO: add unit test for withWorkspaceBucketRegionCheck
+
   it should "concurrently update workspace attributes" in withTestDataApiServices { services =>
     def generator(i: Int): ReadAction[Option[Workspace]] = {
       Patch(testData.workspace.path, httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString(s"bang$i")): AttributeUpdateOperation))) ~>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -785,7 +785,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       check {
         val errorText = responseAs[ErrorReport].message
         assert(status == StatusCodes.BadRequest)
-        assert(errorText.contains("Workspace Bucket Location should be of format: [A-Za-z]+-[A-Za-z]+[0-9]+"))
+        assert(errorText.contains("Workspace bucket location must be a single (not multi-) region of format: [A-Za-z]+-[A-Za-z]+[0-9]+"))
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -771,7 +771,23 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  // TODO: add unit test for withWorkspaceBucketRegionCheck
+  it should "return 400 if the bucket location requested is in an invalid format" in withTestDataApiServices { services =>
+    val newWorkspace = WorkspaceRequest(
+      namespace = testData.wsName.namespace,
+      name = "newWorkspace",
+      Map.empty,
+      None,
+      Option("US")
+    )
+
+    Post(s"/workspaces", httpJson(newWorkspace)) ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+      }
+  }
 
   it should "concurrently update workspace attributes" in withTestDataApiServices { services =>
     def generator(i: Int): ReadAction[Option[Workspace]] = {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -105,14 +105,13 @@ object WorkspaceVersions {
   }
 }
 
-case class WorkspaceRequest (
-                              namespace: String,
-                              name: String,
-                              attributes: AttributeMap,
-                              authorizationDomain: Option[Set[ManagedGroupRef]] = Option(Set.empty),
-                              copyFilesWithPrefix: Option[String] = None,
-                              noWorkspaceOwner: Option[Boolean] = None
-                      ) extends Attributable {
+case class WorkspaceRequest(namespace: String,
+                            name: String,
+                            attributes: AttributeMap,
+                            authorizationDomain: Option[Set[ManagedGroupRef]] = Option(Set.empty),
+                            copyFilesWithPrefix: Option[String] = None,
+                            noWorkspaceOwner: Option[Boolean] = None,
+                            bucketLocation: Option[String] = None) extends Attributable {
   def toWorkspaceName = WorkspaceName(namespace,name)
   def briefName: String = toWorkspaceName.toString
   def path: String = toWorkspaceName.path
@@ -708,7 +707,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val EntityFormat = jsonFormat3(Entity)
 
-  implicit val WorkspaceRequestFormat = jsonFormat6(WorkspaceRequest)
+  implicit val WorkspaceRequestFormat = jsonFormat7(WorkspaceRequest)
 
   implicit val EntityNameFormat = jsonFormat1(EntityName)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -68,7 +68,7 @@ object Settings {
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde",
     scalaVersion  := "2.12.11", // `cromwell-client` needs to support 2.13 for rawls to be able to upgrade
-    resolvers := proxyResolvers ++: resolvers.value ++: commonResolvers,
+    resolvers := proxyResolvers ++: resolvers.value ++: (commonResolvers ++ List(Resolver.mavenLocal)), // TODO: Remove this change
     scalacOptions ++= commonCompilerSettings
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -68,7 +68,7 @@ object Settings {
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde",
     scalaVersion  := "2.12.11", // `cromwell-client` needs to support 2.13 for rawls to be able to upgrade
-    resolvers := proxyResolvers ++: resolvers.value ++: (commonResolvers ++ List(Resolver.mavenLocal)), // TODO: Remove this change
+    resolvers := proxyResolvers ++: resolvers.value ++: commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )
 


### PR DESCRIPTION
This PR provides an optional parameter called `bucketLocation` for workspace creation. It also adds support for non-default bucket locations when the workspace is cloned.