### PR TITLE
AS-516: snapshot pagination again [risk: low]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -277,7 +277,8 @@ trait DataRepoBigQuerySupport extends LazyLogging {
    */
   def queryResultsMetadata(queryResults:TableResult, totalRowCount: Int, entityQuery: EntityQuery): EntityQueryResultMetadata = {
     val pageCount = Math.ceil(totalRowCount.toFloat / entityQuery.pageSize).toInt
-    EntityQueryResultMetadata(totalRowCount, queryResults.getTotalRows.toInt, pageCount)
+    // we don't support filtering in BQ, so unfilteredCount and filteredCount are the same
+    EntityQueryResultMetadata(totalRowCount, totalRowCount, pageCount)
   }
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -271,11 +271,10 @@ trait DataRepoBigQuerySupport extends LazyLogging {
 
   /**
    * Translates a BigQuery result set into the pagination metadata that Rawls expects.
-   * @param queryResults the BigQuery result set
    * @param entityQuery the query criteria supplied by the user, which includes page size
    * @return the Rawls-flavor pagination metadata
    */
-  def queryResultsMetadata(queryResults:TableResult, totalRowCount: Int, entityQuery: EntityQuery): EntityQueryResultMetadata = {
+  def queryResultsMetadata(totalRowCount: Int, entityQuery: EntityQuery): EntityQueryResultMetadata = {
     val pageCount = Math.ceil(totalRowCount.toFloat / entityQuery.pageSize).toInt
     // we don't support filtering in BQ, so unfilteredCount and filteredCount are the same
     EntityQueryResultMetadata(totalRowCount, totalRowCount, pageCount)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -138,7 +138,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     } yield {
       // translate the BQ results into a Rawls query result
       val page = queryResultsToEntities(queryResults, entityType, pk)
-      val metadata = queryResultsMetadata(queryResults, tableModel.getRowCount, finalQuery)
+      val metadata = queryResultsMetadata(tableModel.getRowCount, finalQuery)
       EntityQueryResponse(finalQuery, metadata, page)
     }
     resultIO.unsafeToFuture()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -324,13 +324,7 @@ class DataRepoBigQuerySupportSpec extends AnyFreeSpec with DataRepoBigQuerySuppo
       case ((inputPageSize, resultSetSize), expectedPages) =>
         s"compute correct pagination metadata from BQ results for pageSize $inputPageSize and result set size $resultSetSize (expect $expectedPages)" in {
           val entityQuery = EntityQuery(page = 4, pageSize = inputPageSize, sortField = "ignored", sortDirection = SortDirections.Ascending, filterTerms = None)
-
-          val schema: Schema = Schema.of(F_INTEGER)
-          val row: FieldValueList = FieldValueList.of(List(FV_INTEGER).asJava, F_INTEGER)
-          val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, List.fill(inputPageSize)(row).asJava)
-          val queryResults: TableResult = new TableResult(schema, inputPageSize, page)
-
-          val actual = queryResultsMetadata(queryResults, resultSetSize, entityQuery)
+          val actual = queryResultsMetadata(resultSetSize, entityQuery)
 
           assertResult(EntityQueryResultMetadata(resultSetSize, resultSetSize, expectedPages)) { actual }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -332,7 +332,7 @@ class DataRepoBigQuerySupportSpec extends AnyFreeSpec with DataRepoBigQuerySuppo
 
           val actual = queryResultsMetadata(queryResults, resultSetSize, entityQuery)
 
-          assertResult(EntityQueryResultMetadata(resultSetSize, inputPageSize, expectedPages)) { actual }
+          assertResult(EntityQueryResultMetadata(resultSetSize, resultSetSize, expectedPages)) { actual }
         }
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
@@ -40,7 +40,7 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
         AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
       )))
       assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 1, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
       assertResult(expected) { entityQueryResponse.results }
     }
   }
@@ -60,7 +60,7 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
         ))
       }
       assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 3, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
       assertResult(expected) { entityQueryResponse.results }
     }
   }
@@ -92,7 +92,7 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
       // this is the default expected value, should it move to the support trait?
       val expected = Seq.empty[Entity]
       assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 0, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
       assertResult(expected) { entityQueryResponse.results }
     }
   }


### PR DESCRIPTION
part of AS-516 but does not complete that ticket. Fixes the  `filteredCount` value in TDR snapshot pagination metadata.