### PR TITLE
more accurate workspace-does-not-exist message [AS-685]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -158,6 +158,6 @@ trait WorkspaceSupport {
     }
   }
 
-  def noSuchWorkspaceMessage(workspaceName: WorkspaceName) = s"${workspaceName} does not exist"
+  def noSuchWorkspaceMessage(workspaceName: WorkspaceName) = s"${workspaceName} does not exist or you do not have permission to use it"
   def accessDeniedMessage(workspaceName: WorkspaceName) = s"insufficient permissions to perform operation on ${workspaceName}"
 }


### PR DESCRIPTION
Changes a user-visible error message from `"${workspaceName} does not exist"` to `
"${workspaceName} does not exist or you do not have permission to use it"`.

This doesn't change *when* we display the error message; that message was previously displayed even when the workspace existed but the user did not have appropriate permissions. However, the previous message led to internal confusion when testing.

This also does not change the 404 http response code that accompanies this message.

I manually tested the following cases and saw the new message displayed:

- [x] get-workspace of a nonexistent workspace
- [x] list-snapshots in a nonexistent workspace
- [x] create-snapshot in a nonexistent workspace
- [x] get-workspace of an existent workspace to which I do not have READ access
- [x] list-snapshots in an existent workspace to which I do not have READ access
- [x] create-snapshot in an existent workspace to which I do not have READ access
- [x] get-workspace of an existent workspace with an auth domain to which I do not have READ access
- [x] list-snapshots in an existent workspace to which I do not have READ access
- [x] create-snapshot in an existent workspace to which I do not have READ access
- [x] get-workspace of an existent workspace to which I have READ access but not auth-domain membership
- [x] list-snapshots in an existent workspace to which I have READ access but not auth-domain membership
- [x] create-snapshot in an existent workspace to which I have WRITE access but not auth-domain membership
- [x] get-snapshot in a workspace to which I do not have READ access
- [x] edit-snapshot in a workspace to which I do not have READ access
- [x] delete-snapshot in a workspace to which I do not have READ access
