### PR TITLE
fail fast if user specifies too many pages for a snapshot entity query [AS-686]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -106,12 +106,6 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     // extract table definition, with PK, from snapshot schema
     val tableModel = getTableModel(snapshotModel, entityType)
 
-    // validate pagination parameters
-    val pageCount = Math.ceil(tableModel.getRowCount.toFloat / incomingQuery.pageSize).toInt
-    if (incomingQuery.page > pageCount) {
-      throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${incomingQuery.page} is greater than the number of pages $pageCount")
-    }
-
     // validate sort column exists in the snapshot's table description, or sort column is
     // one of the magic fields "datarepo_row_id" or "name"
     if (datarepoRowIdColumn != incomingQuery.sortField &&
@@ -129,6 +123,14 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
       incomingQuery
     }
 
+    // calculate the pagination metadata
+    val metadata = queryResultsMetadata(tableModel.getRowCount, finalQuery)
+
+    // validate requested page against actual number of pages
+    if (finalQuery.page > metadata.filteredPageCount) {
+      throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${incomingQuery.page} is greater than the number of pages ${metadata.filteredPageCount}")
+    }
+
     // determine data project
     val dataProject = snapshotModel.getDataProject
     // determine view name
@@ -144,7 +146,6 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     } yield {
       // translate the BQ results into a Rawls query result
       val page = queryResultsToEntities(queryResults, entityType, pk)
-      val metadata = queryResultsMetadata(tableModel.getRowCount, finalQuery)
       EntityQueryResponse(finalQuery, metadata, page)
     }
     resultIO.unsafeToFuture()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -106,6 +106,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     // extract table definition, with PK, from snapshot schema
     val tableModel = getTableModel(snapshotModel, entityType)
 
+    // validate pagination parameters
+    val pageCount = Math.ceil(tableModel.getRowCount / incomingQuery.pageSize).toInt
+    if (incomingQuery.page > pageCount) {
+      throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${incomingQuery.page} is greater than the number of pages $pageCount")
+    }
+
     // validate sort column exists in the snapshot's table description, or sort column is
     // one of the magic fields "datarepo_row_id" or "name"
     if (datarepoRowIdColumn != incomingQuery.sortField &&

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -107,7 +107,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     val tableModel = getTableModel(snapshotModel, entityType)
 
     // validate pagination parameters
-    val pageCount = Math.ceil(tableModel.getRowCount / incomingQuery.pageSize).toInt
+    val pageCount = Math.ceil(tableModel.getRowCount.toFloat / incomingQuery.pageSize).toInt
     if (incomingQuery.page > pageCount) {
       throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${incomingQuery.page} is greater than the number of pages $pageCount")
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
@@ -109,13 +109,22 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     }
   }
 
-  it should "throw bad request the supplied sort field does not exist in the target table" in {
+  it should "throw bad request if the supplied sort field does not exist in the target table" in {
     val provider = createTestProvider()
 
     val ex = intercept[DataEntityException] {
       provider.queryEntities("table1", defaultEntityQuery.copy(sortField = "unknownColumn"))
     }
     assertResult("sortField not valid for this entity type") { ex.getMessage }
+  }
+
+  it should "throw bad request if the requested page is greater than actual pages" in {
+    val provider = createTestProvider()
+
+    val ex = intercept[DataEntityException] {
+      provider.queryEntities("table1", defaultEntityQuery.copy(page = 42))
+    }
+    assertResult("requested page 42 is greater than the number of pages 1") { ex.getMessage }
   }
 
   it should "throw bad request if a filter is supplied" in {


### PR DESCRIPTION
AS-686

When querying snapshot entities, If the user specified a page value higher than what exists, we would execute the request to BigQuery but return an empty array. Now, we fail fast with an error message. This matches the behavior when querying Rawls-based entities.
