### PR TITLE
update automation tests to newer workspace-manager-client [QA-1415]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -25,7 +25,8 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions:_*)
 
-  val dataRepo: ModuleID = "bio.terra" % "datarepo-client" % "1.0.44-SNAPSHOT"
+  val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.0.44-SNAPSHOT"
+  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.16.0-SNAPSHOT"
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
@@ -52,7 +53,9 @@ object Dependencies {
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-14278f08f"
-      exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11"),
+      exclude("com.typesafe.scala-logging", "scala-logging_2.11")
+      exclude("com.typesafe.akka", "akka-stream_2.11")
+      exclude("bio.terra", "workspace-manager-client"),
 
     workbenchModel,
     workbenchMetrics,
@@ -61,6 +64,7 @@ object Dependencies {
     workbenchServiceTest,
 
     dataRepo,
+    workspaceManager,
 
     // required by workbenchGoogle
     "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.6" % "provided"


### PR DESCRIPTION
QA-1415

Tests were failing because the workspace-manager-client in use was old and did not include recent changes to model classes. The tests hit problems attempting to deserialize json responses from WSM into the old model classes.

This PR updates to use the most recent version of the client.

Note that this is a test-only problem; it does not indicate a problem with the app itself. The app had already updated the client lib.

Tests pass for me when run locally with this branch.