### PR TITLE
querying snapshot tables with zero rows should return success [AS-698]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupport.scala
@@ -275,7 +275,9 @@ trait DataRepoBigQuerySupport extends LazyLogging {
    * @return the Rawls-flavor pagination metadata
    */
   def queryResultsMetadata(totalRowCount: Int, entityQuery: EntityQuery): EntityQueryResultMetadata = {
-    val pageCount = Math.ceil(totalRowCount.toFloat / entityQuery.pageSize).toInt
+    // calculate page count, ensuring a min of 1. We always return at least one page,
+    // even if that single page contains zero entities.
+    val pageCount = Math.max(Math.ceil(totalRowCount.toFloat / entityQuery.pageSize).toInt,1)
     // we don't support filtering in BQ, so unfilteredCount and filteredCount are the same
     EntityQueryResultMetadata(totalRowCount, totalRowCount, pageCount)
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -124,7 +124,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
     }
 
     // if Data Repo indicates this table is empty, return immediately without error, don't query BigQuery
-    if (tableModel.getRowCount == 0) {
+    if (tableModel.getRowCount == 0 && finalQuery.page == 1) {
       // pagination metadata indicates 0 results but 1 page - it's 1 page of 0 - we never want to indicate 0 pages
       Future.successful(EntityQueryResponse(finalQuery, EntityQueryResultMetadata(0, 0, 1), List.empty[Entity]))
     } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -123,10 +123,14 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
       incomingQuery
     }
 
-    // if Data Repo indicates this table is empty, return immediately without error, don't query BigQuery
-    if (tableModel.getRowCount == 0 && finalQuery.page == 1) {
-      // pagination metadata indicates 0 results but 1 page - it's 1 page of 0 - we never want to indicate 0 pages
-      Future.successful(EntityQueryResponse(finalQuery, EntityQueryResultMetadata(0, 0, 1), List.empty[Entity]))
+    // if Data Repo indicates this table is empty, return immediately, don't query BigQuery
+    if (tableModel.getRowCount == 0 ) {
+      if (finalQuery.page == 1) {
+        // pagination metadata indicates 0 results but 1 page - it's 1 page of 0 - we never want to indicate 0 pages
+        Future.successful(EntityQueryResponse(finalQuery, EntityQueryResultMetadata(0, 0, 1), List.empty[Entity]))
+      } else {
+        throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${incomingQuery.page} is greater than the number of pages 1")
+      }
     } else {
       // calculate the pagination metadata
       val metadata = queryResultsMetadata(tableModel.getRowCount, finalQuery)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoBigQuerySupportSpec.scala
@@ -309,7 +309,7 @@ class DataRepoBigQuerySupportSpec extends AnyFreeSpec with DataRepoBigQuerySuppo
 
     // (input pageSize, result set size) -> expected number of pages in result set
     val pagination = Map(
-      (10, 0) -> 0,
+      (10, 0) -> 1,
       (10, 1) -> 1,
       (10, 9) -> 1,
       (10, 10) -> 1,


### PR DESCRIPTION
It is possible for a Data Repo snapshot table to contain zero rows.

Previously, if you requested the first page of results from such a table, we would throw an error ("requested page 1 is greater than the number of pages 0").

After this PR, requesting page 1 of a zero-row table returns success, with 0 results. Requesting page 2 or greater of such a table will still throw an error.

This is only relevant to snapshots. It is not possible for Rawls-based entities to have a table with zero rows.

This is a regression from #1386.

Tested by running local UI against local rawls.

REVIEWER: I suggest ignoring whitespace in the diff; I moved around lines of code in `DataRepoEntityProvider.scala` but the functional change is fairly small.