### PR TITLE
exclude exception causes from DataEntityException failures [AS-696]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -67,7 +67,7 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
     Future.fromTry(resolveProvider(entityRequestArguments)).recoverWith {
       case regrets: DataEntityException =>
         // bubble up the status code from the DataEntityException
-        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(regrets.code, regrets)))
+        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(regrets.code, regrets.getMessage)))
     }
   }
 }


### PR DESCRIPTION
See AS-696 for context (there's a lot of context).

The problem was occurring in the `RawlsApiService.exceptionHandler`, when trying to process a `RawlsExceptionWithErrorReport`:
https://github.com/broadinstitute/rawls/blob/c39049945867d9d6d1bb5e1cbda30a09a19147f7/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala#L41-L42

If the underlying ErrorReport in question contained a non-empty `causes`, the system would encounter a `NullPointerException` trying to serialize the response payload - but only on JRE 11; JDK 11 and JRE 8 worked (I said, see the Jira ticket for context). I don't fully understand why this was happening, but I was able to pinpoint the faulty data and work around it, simply by excluding the causes from the exception we throw.

Note: I've only fixed this for the use case (`DataEntityException`) that I found through click-testing. It's quite possible other use cases have the same problem and we need a wider fix; I'd like to get this PR in to unblock work while we think about what to do next.

Alternative solution:
* in `RawlsApiService.exceptionHandler`, when processing a `RawlsExceptionWithErrorReport`, make a copy of the error report that always sets `causes` to empty. This would solve all use cases - but it would also suppress potentially helpful debugging information from the error response. Do we ever want to include causes in the response? Or maybe we only log those?
