### PR TITLE
upgrade datarepo client lib [AS-628, AS-692]

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
+import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.model.{ColumnModel, RelationshipModel, RelationshipTermModel, TableModel}
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery._
@@ -7,6 +8,7 @@ import cromwell.client.model.{ToolInputParameter, ValueType}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory._
+import org.broadinstitute.dsde.rawls.dataaccess.datarepo.HttpDataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
@@ -17,6 +19,10 @@ import org.broadinstitute.dsde.rawls.expressions.parser.antlr.ParsedEntityLookup
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNumber, AttributeString, AttributeValue, AttributeValueRawJson, DataReferenceName, Entity, EntityTypeMetadata, GoogleProjectId, SubmissionValidationEntityInputs, SubmissionValidationValue}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.Header
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
@@ -791,6 +797,35 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
         |LEFT JOIN `proj.view.debTable` `dep` ON `root`.`fk` = `dep`.`fk`
         |LEFT JOIN `proj.view.debTable2` `dep2` ON `dep`.`fk2` = `dep2`.`fk2`
         |GROUP BY `root`.`zoe`, `root`.`bob`;""".stripMargin
+  }
+
+  it should "connect to a Data Repo instance via client" in {
+    /* This test uses the data repo client lib to connect to a mock data repo server.
+        It verifies that the client lib version in use by Rawls is functional
+        and has no inherent runtime errors. Anything beyond this simple connectivity test
+        should likely be an integration test talking to a real Data Repo instance.
+     */
+    val jsonHeader = new Header("Content-Type", "application/json")
+    val mockSnapshotId = java.util.UUID.randomUUID()
+    val mockPort = 32123
+
+    val mockServer = startClientAndServer(mockPort)
+    mockServer.when(
+      request()
+        .withMethod("GET")
+        .withPath(s"/api/repository/v1/snapshots/${mockSnapshotId.toString}")
+    ).respond(
+      response()
+        .withHeaders(jsonHeader)
+        .withBody(s"""{"id":"${mockSnapshotId.toString}"}""")
+        .withStatusCode(StatusCodes.OK.intValue)
+    )
+
+    val dataRepoDAO = new HttpDataRepoDAO("mock", s"http://localhost:$mockPort")
+    val snapshotResponse = dataRepoDAO.getSnapshot(mockSnapshotId, userInfo.accessToken)
+    mockServer.stopAsync()
+
+    snapshotResponse.getId shouldBe mockSnapshotId.toString
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,6 +112,7 @@ object Dependencies {
 
   val workspaceManager = excludeJakartaActivationApi("bio.terra" % "workspace-manager-client" % "0.16.0-SNAPSHOT")
   val dataRepo = excludeJakartaActivationApi("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
+  val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.0-M2"
   val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.0-M2"
@@ -230,6 +231,7 @@ object Dependencies {
     apacheCommonsIO,
     workspaceManager,
     dataRepo,
+    dataRepoJersey,
     antlrParser
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,7 +111,7 @@ object Dependencies {
   def excludeJakartaActivationApi(m: ModuleID): ModuleID = m.exclude("jakarta.activation", "jakarta.activation-api")
 
   val workspaceManager = excludeJakartaActivationApi("bio.terra" % "workspace-manager-client" % "0.16.0-SNAPSHOT")
-  val dataRepo = excludeJakartaActivationApi("bio.terra" % "datarepo-client" % "1.0.44-SNAPSHOT")
+  val dataRepo = excludeJakartaActivationApi("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.0-M2"
   val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.0-M2"


### PR DESCRIPTION
* Upgrades the data repo client lib to 1.41.0, which is the version currently in prod
* Includes the `jersey-hk2` library as a dependency, which the newer data repo client requires
* Adds a unit test to exercise the data repo client connectivity/runtime success

Tested by running Rawls locally and manually hitting the entity-type-metadata API and the entity-query API, both of which connect to Data Repo. And of course the new unit test.