### PR TITLE
handle nulls when serializing StackTraceElement [AS-696]

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -868,10 +868,10 @@ class WorkspaceJsonSupport extends JsonSupport {
     val LINE_NUMBER = "lineNumber"
 
     def write(stackTraceElement: StackTraceElement) =
-      JsObject( CLASS_NAME -> JsString(stackTraceElement.getClassName),
-                METHOD_NAME -> JsString(stackTraceElement.getMethodName),
-                FILE_NAME -> JsString(stackTraceElement.getFileName),
-                LINE_NUMBER -> JsNumber(stackTraceElement.getLineNumber) )
+      JsObject( CLASS_NAME -> Option(stackTraceElement.getClassName).map(JsString(_)).getOrElse(JsNull),
+                METHOD_NAME -> Option(stackTraceElement.getMethodName).map(JsString(_)).getOrElse(JsNull),
+                FILE_NAME -> Option(stackTraceElement.getFileName).map(JsString(_)).getOrElse(JsNull),
+                LINE_NUMBER -> Option(stackTraceElement.getLineNumber).map(JsNumber(_)).getOrElse(JsNull) )
 
     def read(json: JsValue) =
       json.asJsObject.getFields(CLASS_NAME,METHOD_NAME,FILE_NAME,LINE_NUMBER) match {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -876,15 +876,16 @@ class WorkspaceJsonSupport extends JsonSupport {
     def read(json: JsValue) =
       json.asJsObject.getFields(CLASS_NAME,METHOD_NAME,FILE_NAME,LINE_NUMBER) match {
         case Seq(JsString(className), JsString(methodName), JsString(fileName), JsNumber(lineNumber)) =>
-          new StackTraceElement(className,methodName,fileName,lineNumber.toInt)
+          new StackTraceElement(className, methodName, fileName, lineNumber.toInt)
         case Seq(JsString(className), JsString(methodName), JsNull, JsNumber(lineNumber)) =>
           // null in fileName indicates "Unknown Source" for the file
-          new StackTraceElement(className,methodName,null,lineNumber.toInt)
+          new StackTraceElement(className, methodName, null, lineNumber.toInt)
         case _ =>
           // it is technically possible for the write() method to serialize JsNull into
           // className, methodName, and lineNumber - but those would indicate a very malformed
           // stack trace; we don't want to deserialize those; error in that case is ok
           throw new DeserializationException("unable to deserialize StackTraceElement")
+      }
   }
 
   implicit object ClassFormat extends RootJsonFormat[Class[_]] {


### PR DESCRIPTION
I still don't fully understand why, but when running on the JRE, stacktraces contain null fileNames, while when running on the JDK those fileNames are populated. Compare the partial stacktrace examples below.

This nulls inside stacktraces caused problems when serializing an `ErrorReport` to the response. Our `RootJsonFormat[StackTraceElement] ` was not null-safe when writing; now it is.

partial stacktrace on JRE:
```
    {
      "className": "scala.concurrent.impl.CallbackRunnable",
      "fileName": "Promise.scala",
      "lineNumber": 64,
      "methodName": "run"
    },
    {
      "className": "java.util.concurrent.ForkJoinTask$RunnableExecuteAction",
      "fileName": null,
      "lineNumber": -1,
      "methodName": "exec"
    },
```

same stacktrace on JDK:
```
    {
      "className": "scala.concurrent.impl.CallbackRunnable",
      "fileName": "Promise.scala",
      "lineNumber": 64,
      "methodName": "run"
    },
    {
      "className": "java.util.concurrent.ForkJoinTask$RunnableExecuteAction",
      "fileName": "ForkJoinTask.java",
      "lineNumber": 1426,
      "methodName": "exec"
    },
```

This is a follow-on PR to #1392. That other PR solved the problem for one specific click path. Hopefully this PR solves it for all paths.

**REVIEWER:** note that you cannot easily reproduce this running Rawls locally, because our local-run scripts use the JDK as their base image. https://docs.google.com/document/d/1H1ib08LHs6XNNBMltWkmJedsTIMc0sblhAFsbNGT3kc/edit has instructions on running/reproducing locally.