### PR TITLE
upgrade data repo client lib in automation [AS-692]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions:_*)
 
-  val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.0.44-SNAPSHOT"
+  val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.16.0-SNAPSHOT"
 
   val rootDependencies = Seq(

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -25,8 +25,9 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions:_*)
 
-  val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.16.0-SNAPSHOT"
+  val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
+  val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
@@ -64,6 +65,7 @@ object Dependencies {
     workbenchServiceTest,
 
     dataRepo,
+    dataRepoJersey,
     workspaceManager,
 
     // required by workbenchGoogle

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -299,7 +299,7 @@ class SnapshotAPISpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterA
 
     logger.info(s"calling data repo at $dataRepoBaseUrl as user ${credentials.email} ... ")
     val drSnapshots = Try(dataRepoApi.enumerateSnapshots(
-      0, numSnapshots, "created_date", "desc", "")) match {
+      0, numSnapshots, "created_date", "desc", "", java.util.Collections.emptyList() )) match {
       case Success(s) => s
       case Failure(ex) =>
         logger.error(s"data repo call as user ${credentials.email} failed: ${ex.getMessage}", ex)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -25,7 +25,7 @@ import spray.json._
 import DefaultJsonProtocol._
 
 import scala.concurrent.duration._
-
+import scala.language.postfixOps
 
 
 //noinspection JavaAccessorEmptyParenCall,TypeAnnotation


### PR DESCRIPTION
follow-on to #1393, which updated the data repo client in the main runtime code. This PR updates it in automation tests. See #1393 and https://broadworkbench.atlassian.net/browse/DR-1715 for discussion on why we need to include `jersey-hk2`.

Verified by manually running `SnapshotAPISpec` against alpha and seeing everything pass.