### PR TITLE
remove unwanted billingProject/dataReference params

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1784,8 +1784,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - $ref: '#/components/parameters/dataReferenceQueryParam'
-        - $ref: '#/components/parameters/billingProjectQueryParam'
       requestBody:
         description: Set of entities to delete
         content:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1541,7 +1541,6 @@ paths:
             type: boolean
             default: false
         - $ref: '#/components/parameters/dataReferenceQueryParam'
-        - $ref: '#/components/parameters/billingProjectQueryParam'
       responses:
         200:
           description: Successful Request

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -42,7 +42,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   def DeleteEntities(workspaceName: WorkspaceName, entities: Seq[AttributeEntityReference], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]) = deleteEntities(workspaceName, entities, dataReference, billingProject)
   def RenameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String) = renameEntity(workspaceName, entityType, entityName, newName)
   def EvaluateExpression(workspaceName: WorkspaceName, entityType: String, entityName: String, expression: String) = evaluateExpression(workspaceName, entityType, entityName, expression)
-  def GetEntityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId], useCache: Boolean) = entityTypeMetadata(workspaceName, dataReference, billingProject, useCache)
+  def GetEntityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], useCache: Boolean) = entityTypeMetadata(workspaceName, dataReference, useCache)
   def ListEntities(workspaceName: WorkspaceName, entityType: String) = listEntities(workspaceName, entityType)
   def QueryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId]) = queryEntities(workspaceName, dataReference, entityType, query, billingProject)
   def CopyEntities(entityCopyDefinition: EntityCopyDefinition, uri:Uri, linkExistingEntities: Boolean) = copyEntities(entityCopyDefinition, uri, linkExistingEntities)
@@ -155,10 +155,10 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       }
     }
 
-  def entityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId], useCache: Boolean): Future[PerRequestMessage] =
+  def entityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], useCache: Boolean): Future[PerRequestMessage] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
 
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference, billingProject)
+      val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference, None)
 
       val metadataFuture = for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -42,7 +42,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   def DeleteEntities(workspaceName: WorkspaceName, entities: Seq[AttributeEntityReference], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]) = deleteEntities(workspaceName, entities, dataReference, billingProject)
   def RenameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String) = renameEntity(workspaceName, entityType, entityName, newName)
   def EvaluateExpression(workspaceName: WorkspaceName, entityType: String, entityName: String, expression: String) = evaluateExpression(workspaceName, entityType, entityName, expression)
-  def GetEntityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], useCache: Boolean) = entityTypeMetadata(workspaceName, dataReference, useCache)
+  def GetEntityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId], useCache: Boolean) = entityTypeMetadata(workspaceName, dataReference, billingProject, useCache)
   def ListEntities(workspaceName: WorkspaceName, entityType: String) = listEntities(workspaceName, entityType)
   def QueryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId]) = queryEntities(workspaceName, dataReference, entityType, query, billingProject)
   def CopyEntities(entityCopyDefinition: EntityCopyDefinition, uri:Uri, linkExistingEntities: Boolean) = copyEntities(entityCopyDefinition, uri, linkExistingEntities)
@@ -155,10 +155,10 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       }
     }
 
-  def entityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], useCache: Boolean): Future[PerRequestMessage] =
+  def entityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId], useCache: Boolean): Future[PerRequestMessage] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
 
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference, None)
+      val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference, billingProject)
 
       val metadataFuture = for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -87,7 +87,7 @@ trait EntityApiService extends UserInfoDirectives {
         path("workspaces" / Segment / Segment / "entities" / "delete") { (workspaceNamespace, workspaceName) =>
           post {
             entity(as[Array[AttributeEntityReference]]) { entities =>
-              complete { entityServiceConstructor(userInfo).DeleteEntities(WorkspaceName(workspaceNamespace, workspaceName), entities, dataReference, billingProject) }
+              complete { entityServiceConstructor(userInfo).DeleteEntities(WorkspaceName(workspaceNamespace, workspaceName), entities, None, None) }
             }
           }
         } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -56,7 +56,7 @@ trait EntityApiService extends UserInfoDirectives {
             parameters('useCache.?) { (useCache) =>
               val useCacheBool = Try(useCache.getOrElse("false").toBoolean).getOrElse(false)
               complete {
-                entityServiceConstructor(userInfo).GetEntityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName), dataReference, billingProject, useCacheBool)
+                entityServiceConstructor(userInfo).GetEntityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName), dataReference, useCacheBool)
               }
             }
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -56,7 +56,7 @@ trait EntityApiService extends UserInfoDirectives {
             parameters('useCache.?) { (useCache) =>
               val useCacheBool = Try(useCache.getOrElse("false").toBoolean).getOrElse(false)
               complete {
-                entityServiceConstructor(userInfo).GetEntityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName), dataReference, useCacheBool)
+                entityServiceConstructor(userInfo).GetEntityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName), dataReference, None, useCacheBool)
               }
             }
           }


### PR DESCRIPTION
**Note that this PR is looking to merge into `mb-as-668`, not into `develop`!!** Since that other PR has a lot of swagger changes, I thought it would be easier to combine all this work into that PR.

This PR covers AS-687 and AS-680. It removes the billingProject and dataReference query param from the delete-entity API, and removes the billingProject query param from the entity-type-metadata API.
