### PR TITLE
increase timeout for avro upsert monitor unit tests [AS-706]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -149,9 +149,11 @@ object AvroUpsertMonitor {
              importStatusPubSubTopic: String,
              importServiceDAO: ImportServiceDAO,
              batchSize: Int,
-             dataSource: SlickDataSource)(implicit cs: ContextShift[IO]): Props =
+             dataSource: SlickDataSource)(implicit cs: ContextShift[IO]): Props = {
+    System.err.println(s"starting AvroUpsertMonitorActor for pull:$pubSubSubscriptionName and publish:$importStatusPubSubTopic")
     Props(new AvroUpsertMonitorActor(pollInterval, pollIntervalJitter, entityService, googleServicesDAO, samDAO, googleStorage, pubSubDao, importServicePubSubDAO,
       pubSubSubscriptionName, importStatusPubSubTopic, importServiceDAO, batchSize, dataSource))
+  }
 }
 
 class AvroUpsertMonitorActor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -195,7 +195,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   }
 
   it should "mark the import job as failed on malformed json file" in withTestDataApiServices { services =>
-    val timeout = 90000 milliseconds
+    val timeout = 120000 milliseconds
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 
@@ -227,12 +227,12 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
         msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      })
+      }, s"statusMessages was: ${statusMessages}")
     }
   }
 
   it should "mark the import job as failed on valid json that doesn't match our model" in withTestDataApiServices { services =>
-    val timeout = 90000 milliseconds
+    val timeout = 120000 milliseconds
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 
@@ -264,12 +264,12 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
         msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      })
+      }, s"statusMessages was: ${statusMessages}")
     }
   }
 
   it should "mark the import job as failed if upsert file doesn't exist" in withTestDataApiServices { services =>
-    val timeout = 90000 milliseconds
+    val timeout = 120000 milliseconds
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 
@@ -302,7 +302,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
         msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      })
+      }, s"statusMessages was: ${statusMessages}")
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -98,11 +98,14 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   }
 
   def setUp(services: TestApiService, pubsubPrefix: String) = {
+    val duration = Duration.apply(10, TimeUnit.SECONDS)
+
     // create the two topics
-    services.gpsDAO.createTopic(importReadPubSubTopic(pubsubPrefix))
-    services.gpsDAO.createTopic(importWritePubSubTopic(pubsubPrefix)) map { _ =>
+    // TODO: AS-706 these are futures, we need to wait for them to complete before continuing on!
+    Await.result(services.gpsDAO.createTopic(importReadPubSubTopic(pubsubPrefix)), duration)
+    Await.result(services.gpsDAO.createTopic(importWritePubSubTopic(pubsubPrefix)) map { _ =>
       services.gpsDAO.createSubscription(importWritePubSubTopic(pubsubPrefix), importWriteSubscriptionName(pubsubPrefix))
-    }
+    }, duration)
 
     val mockImportServiceDAO =  new MockImportServiceDAO()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -195,7 +195,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   }
 
   it should "mark the import job as failed on malformed json file" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
+    val timeout = 90000 milliseconds
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 
@@ -232,7 +232,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   }
 
   it should "mark the import job as failed on valid json that doesn't match our model" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
+    val timeout = 90000 milliseconds
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 
@@ -269,7 +269,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   }
 
   it should "mark the import job as failed if upsert file doesn't exist" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
+    val timeout = 90000 milliseconds
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -228,11 +228,17 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
       val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName(pubsubPrefix), 1), Duration.apply(10, TimeUnit.SECONDS))
 
+      if (statusMessages.nonEmpty) {
+        statusMessages foreach { msg =>
+          logger.warn(s">>>>>>> found message looking for $importId1 on ${importWriteSubscriptionName(pubsubPrefix)}: ${msg.contents} | ${msg.attributes}")
+        }
+      }
+
       assert(statusMessages.exists { msg =>
         msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      }, s"statusMessages was: ${statusMessages}")
+      }, s"statusMessages looking for $importId1 on ${importWriteSubscriptionName(pubsubPrefix)} was: ${statusMessages}")
     }
   }
 
@@ -266,11 +272,17 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
       val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName(pubsubPrefix), 1), Duration.apply(10, TimeUnit.SECONDS))
 
+      if (statusMessages.nonEmpty) {
+        statusMessages foreach { msg =>
+          logger.warn(s">>>>>>> found message looking for $importId1 on ${importWriteSubscriptionName(pubsubPrefix)}: ${msg.contents} | ${msg.attributes}")
+        }
+      }
+
       assert(statusMessages.exists { msg =>
         msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      }, s"statusMessages was: ${statusMessages}")
+      }, s"statusMessages looking for $importId1 on ${importWriteSubscriptionName(pubsubPrefix)} was: ${statusMessages}")
     }
   }
 
@@ -305,11 +317,17 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
       val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName(pubsubPrefix), 1), Duration.apply(10, TimeUnit.SECONDS))
 
+      if (statusMessages.nonEmpty) {
+        statusMessages foreach { msg =>
+          logger.warn(s">>>>>>> found message looking for $importId1 on ${importWriteSubscriptionName(pubsubPrefix)}: ${msg.contents} | ${msg.attributes}")
+        }
+      }
+
       assert(statusMessages.exists { msg =>
         msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      }, s"statusMessages was: ${statusMessages}")
+      }, s"statusMessages looking for $importId1 on ${importWriteSubscriptionName(pubsubPrefix)} was: ${statusMessages}")
     }
   }
 

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/MockGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/MockGooglePubSubDAO.scala
@@ -39,7 +39,9 @@ class MockGooglePubSubDAO extends GooglePubSubDAO {
   override def pullMessages(subscriptionName: String, maxMessages: Int): Future[scala.collection.immutable.Seq[PubSubMessage]] = Future {
     val subscription = subscriptionsByName.getOrElse(subscriptionName, throw new RawlsException(s"no subscription named $subscriptionName"))
     (0 until maxMessages).map(_ => Option(subscription.queue.poll())).collect {
-      case Some(message) => PubSubMessage(UUID.randomUUID().toString, message.text, message.attributes)
+      case Some(message) =>
+        System.err.println(s"****************** pull: ${subscription.topic}|$subscriptionName|${message.text}|${message.attributes}")
+        PubSubMessage(UUID.randomUUID().toString, message.text, message.attributes)
     }
   }
 
@@ -53,6 +55,7 @@ class MockGooglePubSubDAO extends GooglePubSubDAO {
     for {
       sub <- subscriptions
       message <- messages
+      _ = System.err.println(s"****************** publish: $topicName|${sub.name}|${message.text}|${message.attributes}")
     } yield {
       sub.queue.add(message)
     }


### PR DESCRIPTION
_... commit 1, increase test timeouts ..._
unit test run 1: passed
unit test run 2: passed
unit test run 3: passed
unit test run 4: passed
unit test run 5: passed
unit test run 6: passed (an unrelated test in DataAccessSpec failed, but avro tests were fine)
unit test run 7: **boo, AvroUpsertMonitor still had a failure**
unit test run 8: passed
unit test run 9: passed
_... commit 2, increase timeouts and add clues ..._
unit test run 10: **boo, AvroUpsertMonitor still had a failure**
_... commit 3, different topics/subscriptions for each test ..._ 
unit test run 11: passed
unit test run 12: passed
unit test run 13: passed
unit test run 14: passed
unit test run 16: passed
unit test run 17: passed
unit test run 18: **boo, AvroUpsertMonitor still had a failure**
_... commit 4, more debug logging ..._ 
unit test run 19: passed
unit test run 20: passed
unit test run 21: **boo, AvroUpsertMonitor still had a failure**
_... commit 5, even yet more debug logging ..._ 
unit test run 22: passed
unit test run 23: passed
unit test run 24: passed
unit test run 25: passed
unit test run 26: passed
unit test run 27: passed (an unrelated test in DataAccessSpec failed, but avro tests were fine)
unit test run 28: passed
unit test run 30: passed
unit test run 31: **boo, AvroUpsertMonitor still had a failure**
_... commit 6, debug logging again again again ..._ 
unit test run 32: **boo, AvroUpsertMonitor still had a failure**
_... commit 7, found the futures ..._ 
unit test run 33: passed

failed in run 6:
```
[info] DataAccessSpec:
[info] DataAccess
[info] - should not deadlock due to too few threads *** FAILED ***
[info]   A timeout occurred waiting for a future to complete. Waited 10 seconds. (DataAccessSpec.scala:69)
```

failed in run 7:
```
[info] AvroUpsertMonitorSpec:
[info] AvroUpsertMonitor
[info] - should mark the import job as failed on valid json that doesn't match our model *** FAILED ***
[info]   The code passed to eventually never returned normally. Attempted 370 times over 1.5026975176666668 minutes. Last failure message: statusMessages.exists(((msg: org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage) => msg.attributes.get("importId").contains[String](importId1.toString()).&&(msg.attributes.get("newStatus").contains[String]("Error")).&&(msg.attributes.get("action").contains[String]("status")))) was false. (AvroUpsertMonitorSpec.scala:260)
```

failed in run 10:
```
[info] AvroUpsertMonitorSpec:
[info] AvroUpsertMonitor
[info] - should mark the import job as failed on malformed json file *** FAILED ***
[info]   The code passed to eventually never returned normally. Attempted 489 times over 2.0004598388666666 minutes. Last failure message: statusMessages.exists(((msg: org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage) => msg.attributes.get("importId").contains[String](importId1.toString()).&&(msg.attributes.get("newStatus").contains[String]("Error")).&&(msg.attributes.get("action").contains[String]("status")))) was false statusMessages was: Vector(). (AvroUpsertMonitorSpec.scala:223)
```

failed in run 18:
```
[info] AvroUpsertMonitorSpec:
[info] AvroUpsertMonitor
[info] - should mark the import job as failed on valid json that doesn't match our model *** FAILED ***
[info]   The code passed to eventually never returned normally. Attempted 489 times over 2.0003777801166667 minutes. Last failure message: statusMessages.exists(((msg: org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage) => msg.attributes.get("importId").contains[String](importId1.toString()).&&(msg.attributes.get("newStatus").contains[String]("Error")).&&(msg.attributes.get("action").contains[String]("status")))) was false statusMessages was: Vector(). (AvroUpsertMonitorSpec.scala:266)
```

failed in run 21:
```
[info] AvroUpsertMonitorSpec:
[info] AvroUpsertMonitor
[info] - should mark the import job as failed if upsert file doesn't exist *** FAILED ***
[info]   The code passed to eventually never returned normally. Attempted 489 times over 2.00076528705 minutes. Last failure message: statusMessages.exists(((msg: org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage) => msg.attributes.get("importId").contains[String](importId1.toString()).&&(msg.attributes.get("newStatus").contains[String]("Error")).&&(msg.attributes.get("action").contains[String]("status")))) was false statusMessages looking for f8236ec4-5754-4c72-a085-40d21c3c37c3 on nonexistent-status-sub was: Vector(). (AvroUpsertMonitorSpec.scala:317)
```

failed in run 27:
```
[info] DataAccessSpec:
[info] DataAccess
[info] - should not deadlock due to too few threads *** FAILED ***
[info]   A timeout occurred waiting for a future to complete. Waited 10 seconds. (DataAccessSpec.scala:69)
```

failed in run 31:
```
[info] AvroUpsertMonitorSpec:
[info] AvroUpsertMonitor
[info] - should mark the import job as failed on valid json that doesn't match our model *** FAILED ***
[info]   The code passed to eventually never returned normally. Attempted 489 times over 2.0003699772 minutes. Last failure message: statusMessages.exists(((msg: org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage) => msg.attributes.get("importId").contains[String](importId1.toString()).&&(msg.attributes.get("newStatus").contains[String]("Error")).&&(msg.attributes.get("action").contains[String]("status")))) was false statusMessages looking for b59cf8c2-0e19-4595-a1b2-bcc0280b7f58 on badmodel-status-sub was: Vector(). (AvroUpsertMonitorSpec.scala:272)
```

failed in run 32:
```
[info] AvroUpsertMonitorSpec:
[info] AvroUpsertMonitor

[info] - should mark the import job as failed if upsert file doesn't exist *** FAILED ***
[info]   The code passed to eventually never returned normally. Attempted 489 times over 2.0004377440166667 minutes. Last failure message: statusMessages.exists(((msg: org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage) => msg.attributes.get("importId").contains[String](importId1.toString()).&&(msg.attributes.get("newStatus").contains[String]("Error")).&&(msg.attributes.get("action").contains[String]("status")))) was false statusMessages looking for 7c954b7c-7727-4165-8b3b-3f648e985199 on nonexistent-status-sub was: Vector(). (AvroUpsertMonitorSpec.scala:317)
```