### PR TITLE
cooldown for workspace lastModified in entity statistics cache [SUP-476]

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -82,6 +82,7 @@ entityStatisticsCache {
   enabled = true
   timeoutPerWorkspace = 3 minutes
   standardPollInterval = 1 minute
+  workspaceCooldown = 4 minutes
 }
 
 akka.http.host-connection-pool.max-open-requests = 16384

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -376,12 +376,18 @@ trait WorkspaceComponent {
       filter(rec => (rec.namespace === namespaceName.value))
     }
 
-    def findMostOutdatedEntityCacheAfter(timestamp: Timestamp): ReadAction[Option[(UUID, Timestamp)]] = {
+    def findMostOutdatedEntityCacheAfter(minCacheTime: Timestamp, maxModifiedTime: Timestamp): ReadAction[Option[(UUID, Timestamp)]] = {
       // Find the workspace that has the entity cache that is the most out of date:
       // A. Workspace has a cacheLastUpdated date that is not current ("current" means equal to lastModified)
       // B. cacheLastUpdated is after @param timestamp
-      // C. Ordered by lastModified from oldest to newest. Meaning, return the workspace that was modified the longest ago
-      uniqueResult[(UUID, Timestamp)](filter(rec => rec.entityCacheLastUpdated < rec.lastModified && rec.entityCacheLastUpdated > timestamp).sortBy(_.lastModified.asc).take(1).map { ws => (ws.id, ws.lastModified) })
+      // C. lastModified is before @param cooldownBound, meaning the workspace isn't likely actively being updated
+      // D. Ordered by lastModified from oldest to newest. Meaning, return the workspace that was modified the longest ago
+      uniqueResult[(UUID, Timestamp)](filter(rec =>
+        rec.entityCacheLastUpdated < rec.lastModified &&
+        rec.entityCacheLastUpdated > minCacheTime &&
+        rec.lastModified < maxModifiedTime
+      )
+        .sortBy(_.lastModified.asc).take(1).map { ws => (ws.id, ws.lastModified) })
     }
 
     def isEntityCacheCurrent(workspaceId: UUID): ReadAction[Boolean] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -84,7 +84,8 @@ object BootMonitors extends LazyLogging {
         system,
         slickDataSource,
         util.toScalaDuration(conf.getDuration("entityStatisticsCache.timeoutPerWorkspace")),
-        util.toScalaDuration(conf.getDuration("entityStatisticsCache.standardPollInterval"))
+        util.toScalaDuration(conf.getDuration("entityStatisticsCache.standardPollInterval")),
+        util.toScalaDuration(conf.getDuration("entityStatisticsCache.workspaceCooldown")),
       )
     }
 
@@ -199,8 +200,8 @@ object BootMonitors extends LazyLogging {
     system.actorOf(BucketDeletionMonitor.props(slickDataSource, gcsDAO, 10 seconds, 6 hours))
   }
 
-  private def startEntityStatisticsCacheMonitor(system: ActorSystem, slickDataSource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration)(implicit cs: ContextShift[IO]) = {
-    system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval))
+  private def startEntityStatisticsCacheMonitor(system: ActorSystem, slickDataSource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration, workspaceCooldown: FiniteDuration)(implicit cs: ContextShift[IO]) = {
+    system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown))
   }
 
   private def startAvroUpsertMonitor(system: ActorSystem, entityService: UserInfo => EntityService, googleServicesDAO: GoogleServicesDAO, samDAO: SamDAO, googleStorage: GoogleStorageService[IO], googlePubSubDAO: GooglePubSubDAO, importServicePubSubDAO: GooglePubSubDAO, importServiceDAO: HttpImportServiceDAO, avroUpsertMonitorConfig: AvroUpsertMonitorConfig, dataSource: SlickDataSource)(implicit cs: ContextShift[IO]) = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -13,14 +13,14 @@ import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.traceDBIOWithParen
 import slick.dbio.DBIO
 
 import java.sql.Timestamp
-import java.util.UUID
+import java.util.{Calendar, UUID}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 object EntityStatisticsCacheMonitor {
-  def props(datasource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration)(implicit executionContext: ExecutionContext): Props = {
-    Props(new EntityStatisticsCacheMonitorActor(datasource, timeoutPerWorkspace, standardPollInterval))
+  def props(datasource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration, workspaceCooldown: FiniteDuration)(implicit executionContext: ExecutionContext): Props = {
+    Props(new EntityStatisticsCacheMonitorActor(datasource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown))
   }
 
   sealed trait EntityStatisticsCacheMessage
@@ -28,7 +28,7 @@ object EntityStatisticsCacheMonitor {
   case object ScheduleDelayedSweep extends EntityStatisticsCacheMessage
 }
 
-class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val timeoutPerWorkspace: Duration, val standardPollInterval: FiniteDuration)(implicit val executionContext: ExecutionContext) extends Actor with EntityStatisticsCacheMonitor with LazyLogging {
+class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val timeoutPerWorkspace: Duration, val standardPollInterval: FiniteDuration, val workspaceCooldown: FiniteDuration)(implicit val executionContext: ExecutionContext) extends Actor with EntityStatisticsCacheMonitor with LazyLogging {
   import context._
 
   setReceiveTimeout(timeoutPerWorkspace)
@@ -50,12 +50,17 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
   implicit val executionContext: ExecutionContext
   val dataSource: SlickDataSource
   val standardPollInterval: FiniteDuration
+  val workspaceCooldown: FiniteDuration
 
   def sweep() = {
     trace("EntityStatisticsCacheMonitor.sweep") { rootSpan =>
       dataSource.inTransaction { dataAccess =>
+        // calculate now - workspaceCooldown as the upper bound for workspace last_modified
+        val maxModifiedTime = nowMinus(workspaceCooldown)
         //Note: Ignored workspaces have a cacheLastUpdated timestamp of 1000ms after epoch
-        dataAccess.workspaceQuery.findMostOutdatedEntityCacheAfter(new Timestamp(1000)).flatMap {
+        val minCacheTime = new Timestamp(1000)
+
+        dataAccess.workspaceQuery.findMostOutdatedEntityCacheAfter(minCacheTime, maxModifiedTime).flatMap {
           case Some((workspaceId, lastModified)) =>
             rootSpan.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId.toString))
             traceDBIOWithParent("updateStatisticsCache", rootSpan) { _ =>
@@ -101,6 +106,13 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
           dataAccess.workspaceQuery.updateCacheLastUpdated(workspaceId, new Timestamp(1000))
         }
     }
+  }
+
+  private def nowMinus(duration: FiniteDuration): Timestamp = {
+    val durationSeconds = duration.toSeconds.toInt
+    val nowTime = Calendar.getInstance
+    nowTime.add(Calendar.SECOND, durationSeconds * -1)
+    new Timestamp(nowTime.getTime.toInstant.toEpochMilli)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -108,7 +108,7 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
     }
   }
 
-  private def nowMinus(duration: FiniteDuration): Timestamp = {
+  def nowMinus(duration: FiniteDuration): Timestamp = {
     val durationSeconds = duration.toSeconds.toInt
     val nowTime = Calendar.getInstance
     nowTime.add(Calendar.SECOND, durationSeconds * -1)

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -74,6 +74,7 @@ entityStatisticsCache {
   enabled = true
   timeoutPerWorkspace = 1 minute
   standardPollInterval = 1 minute
+  workspaceCooldown = 2 minutes
 }
 
 gcs {

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -74,7 +74,7 @@ entityStatisticsCache {
   enabled = true
   timeoutPerWorkspace = 1 minute
   standardPollInterval = 1 minute
-  workspaceCooldown = 2 minutes
+  workspaceCooldown = 0 minutes
 }
 
 gcs {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -47,6 +47,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override val dataSource: SlickDataSource = slickDataSource
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first sweep should return Sweep,
@@ -65,6 +66,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override val dataSource: SlickDataSource = slickDataSource
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first time we sweep,
@@ -79,6 +81,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override val dataSource: SlickDataSource = slickDataSource
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -113,6 +116,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override val dataSource: SlickDataSource = slickDataSource
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get


### PR DESCRIPTION
See https://docs.google.com/document/d/1rqqJrLh2ln-U7MLg0rjYQD4PPwAwj6irLN8p3tY9FMI/edit# ... this PR adds a "cooldown", such that the entity statistics cache doesn't attempt to calculate/persist its cache unless a workspace has been quiet for at least N minutes. We define "quiet" as the workspace's lastModified column is N minutes before now.