### PR TITLE
log pfb-import partial failures; include partial failures in response [SUP-476]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -357,9 +357,9 @@ class AvroUpsertMonitorActor(
           } yield {
             attempt match {
               case Failure(regrets:RawlsExceptionWithErrorReport) =>
-                // TODO: should we log more than the first 10?
+                // should we log more than the first 10?
                 val loggedErrors = regrets.errorReport.causes.take(10).map(_.message)
-                logger.warn(s"upsert batch #$idx for jobId ${jobId.toString} contained errors: ${loggedErrors.mkString(", ")}")
+                logger.warn(s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The first 10 errors are: ${loggedErrors.mkString(", ")}")
               case _ => // noop; here for completeness of matching
             }
             logger.info(s"completed upsert batch #$idx for jobId ${jobId.toString}...")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -362,7 +362,6 @@ class AvroUpsertMonitorActor(
           } yield {
             attempt match {
               case Failure(regrets:RawlsExceptionWithErrorReport) =>
-                // should we log more than the first 10?
                 val loggedErrors = stringMessageFromFailures(regrets.errorReport.causes.toList, 100)
                 logger.warn(s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The first 100 errors are: $loggedErrors")
               case _ => // noop; here for completeness of matching
@@ -403,7 +402,6 @@ class AvroUpsertMonitorActor(
       logger.info(s"upsert process for $jobId succeeded after $elapsed ms: $numSuccesses upserted," +
         s" ${failureReports.size} failed$additionalErrorString Errors: ${failureReportsForCaller.map(_.message).mkString(", ")}")
 
-      //
       Future.successful(ImportUpsertResults(numSuccesses, failureReports))
 
     } catch {


### PR DESCRIPTION
This PR handles logging of partial failures during PFB import, and attempts to send some of those failure messages back up to the user.