### PR TITLE
Move upserts/updates to EntityProvider classes [AS-586]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -206,11 +206,11 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference, billingProject)
       for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        entities <- if (upsert) {
-                      entityProvider.batchUpsertEntities(entityUpdates)
-                    } else {
-                      entityProvider.batchUpdateEntities(entityUpdates)
-                    }
+        entities       <- if (upsert) {
+                            entityProvider.batchUpsertEntities(entityUpdates)
+                          } else {
+                            entityProvider.batchUpdateEntities(entityUpdates)
+                          }
       } yield {
         entities
       }
@@ -223,19 +223,6 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   def batchUpsertEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[PerRequestMessage] =
     batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject).map (_ =>
       RequestComplete(StatusCodes.NoContent))
-
-  /**
-    * Applies the sequence of operations in order to the entity.
-    *
-    * @param entity to update
-    * @param operations sequence of operations
-    * @throws org.broadinstitute.dsde.rawls.workspace.AttributeNotFoundException when removing from a list attribute that does not exist
-    * @throws AttributeUpdateOperationException when adding or removing from an attribute that is not a list
-    * @return the updated entity
-    */
-  def applyOperationsToEntity(entity: Entity, operations: Seq[AttributeUpdateOperation]): Entity = {
-    entity.copy(attributes = applyAttributeUpdateOperations(entity, operations))
-  }
 
   private def bigQueryRecover: PartialFunction[Throwable, PerRequestMessage] = {
     case dee:DataEntityException =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -206,9 +206,9 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
         entities <- if (upsert) {
-                      entityProvider.batchUpdateEntities(entityUpdates)
-                    } else {
                       entityProvider.batchUpsertEntities(entityUpdates)
+                    } else {
+                      entityProvider.batchUpdateEntities(entityUpdates)
                     }
       } yield {
         entities

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -180,6 +180,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   }
 
   def copyEntities(entityCopyDef: EntityCopyDefinition, uri: Uri, linkExistingEntities: Boolean): Future[PerRequestMessage] =
+
     getWorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { destWorkspaceContext =>
       getWorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { sourceWorkspaceContext =>
         dataSource.inTransaction { dataAccess =>
@@ -216,14 +217,12 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
     }
 
   def batchUpdateEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[PerRequestMessage] =
-    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject) map { _ =>
-      PerRequest.RequestComplete(StatusCodes.NoContent)
-    }
+    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject).map (_ =>
+      RequestComplete(StatusCodes.NoContent))
 
   def batchUpsertEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[PerRequestMessage] =
-    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject) map { _ =>
-      PerRequest.RequestComplete(StatusCodes.NoContent)
-    }
+    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject).map (_ =>
+      RequestComplete(StatusCodes.NoContent))
 
   /**
     * Applies the sequence of operations in order to the entity.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -53,5 +53,4 @@ trait EntityProvider {
   def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
 
   def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.entities.base
 
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
 import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeValue, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, SubmissionValidationEntityInputs}
 
 import scala.concurrent.Future
@@ -48,4 +49,9 @@ trait EntityProvider {
   def getEntity(entityType: String, entityName: String): Future[Entity]
 
   def queryEntities(entityType: String, query: EntityQuery): Future[EntityQueryResponse]
+
+  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+
+  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -404,7 +404,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
 
   override def expressionValidator: ExpressionValidator = new DataRepoEntityExpressionValidator(snapshotModel)
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = ???
+  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
+    throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = ???
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
+    throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -16,7 +16,8 @@ import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoBigQuerySupport._
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, UnsupportedEntityOperationException}
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{AntlrTerraExpressionParser, DataRepoEvaluateToAttributeVisitor, LookupExpressionExtractionVisitor, ParsedEntityLookupExpression}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeNull, AttributeNumber, AttributeString, AttributeValue, AttributeValueList, AttributeValueRawJson, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, ErrorReport, GoogleProjectId, SubmissionValidationEntityInputs}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeNull, AttributeNumber, AttributeString, AttributeUpdateOperations, AttributeValue, AttributeValueList, AttributeValueRawJson, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, ErrorReport, GoogleProjectId, SubmissionValidationEntityInputs}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -403,4 +404,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, requestArguments: Ent
 
   override def expressionValidator: ExpressionValidator = new DataRepoEntityExpressionValidator(snapshotModel)
 
+  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = ???
+
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = ???
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -209,18 +209,4 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true)
 
-  // TODO: this tiny method is copied from EntityService; should be DRY
-  /**
-   * Applies the sequence of operations in order to the entity.
-   *
-   * @param entity to update
-   * @param operations sequence of operations
-   * @throws org.broadinstitute.dsde.rawls.workspace.AttributeNotFoundException when removing from a list attribute that does not exist
-   * @throws AttributeUpdateOperationException when adding or removing from an attribute that is not a list
-   * @return the updated entity
-   */
-  def applyOperationsToEntity(entity: Entity, operations: Seq[AttributeUpdateOperation]): Entity = {
-    entity.copy(attributes = applyAttributeUpdateOperations(entity, operations))
-  }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -161,7 +161,7 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
     }
   }
 
-  def batchUpdateEntitiesInternal(entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean): Future[Traversable[Entity]] = {
+  def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean): Future[Traversable[Entity]] = {
     val namesToCheck = for {
       update <- entityUpdates
       operation <- update.operations
@@ -204,10 +204,10 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   }
 
   override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
-    batchUpdateEntitiesInternal(entityUpdates, upsert = false)
+    batchUpdateEntitiesImpl(entityUpdates, upsert = false)
 
   override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
-    batchUpdateEntitiesInternal(entityUpdates, upsert = true)
+    batchUpdateEntitiesImpl(entityUpdates, upsert = true)
 
   // TODO: this tiny method is copied from EntityService; should be DRY
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -333,7 +333,7 @@ class AvroUpsertMonitorActor(
         logger.info(s"upserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProject, userEmail)
-          upsertResults <- entityService.apply(petUserInfo).batchUpdateEntitiesInternal(workspace.toWorkspaceName, upsertBatch, upsert = true)
+          upsertResults <- entityService.apply(petUserInfo).batchUpdateEntitiesInternal(workspace.toWorkspaceName, upsertBatch, upsert = true, None, None)
         } yield {
           upsertResults
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/AttributeSupport.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, AttributeUpdateOperation, CreateAttributeEntityReferenceList, CreateAttributeValueList, RemoveAttribute, RemoveListMember}
-import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeValue, AttributeValueEmptyList, AttributeValueList, ErrorReport, MethodConfiguration}
+import org.broadinstitute.dsde.rawls.model.{Attributable, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeValue, AttributeValueEmptyList, AttributeValueList, Entity, ErrorReport, MethodConfiguration}
 import org.broadinstitute.dsde.rawls.workspace.{AttributeNotFoundException, AttributeUpdateOperationException}
 
 import scala.concurrent.Future
@@ -130,5 +130,18 @@ trait AttributeSupport {
           }
       }
     }
+  }
+
+ /**
+   * Applies the sequence of operations in order to the entity.
+   *
+   * @param entity to update
+   * @param operations sequence of operations
+   * @throws org.broadinstitute.dsde.rawls.workspace.AttributeNotFoundException when removing from a list attribute that does not exist
+   * @throws AttributeUpdateOperationException when adding or removing from an attribute that is not a list
+   * @return the updated entity
+   */
+  def applyOperationsToEntity(entity: Entity, operations: Seq[AttributeUpdateOperation]): Entity = {
+    entity.copy(attributes = applyAttributeUpdateOperations(entity, operations))
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -97,7 +97,7 @@ trait EntityApiService extends UserInfoDirectives {
             withSizeLimit(batchUpsertMaxBytes) {
               entity(as[Array[EntityUpdateDefinition]]) { operations =>
                 complete {
-                  entityServiceConstructor(userInfo).batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName), operations)
+                  entityServiceConstructor(userInfo).batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName), operations, dataReference, billingProject)
                 }
               }
             }
@@ -106,7 +106,7 @@ trait EntityApiService extends UserInfoDirectives {
         path("workspaces" / Segment / Segment / "entities" / "batchUpdate") { (workspaceNamespace, workspaceName) =>
           post {
             entity(as[Array[EntityUpdateDefinition]]) { operations =>
-              complete { entityServiceConstructor(userInfo).batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName), operations) }
+              complete { entityServiceConstructor(userInfo).batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName), operations, dataReference, billingProject) }
             }
           }
         } ~


### PR DESCRIPTION
part of AS-586 but does not complete that ticket.

This PR should not change any functionality. It is purely a refactoring/reorganization, which will be necessary to build the real functionality. I thought it would be useful to do the reorg in a standalone PR to make it easier to review.

At a high level, this PR enables the entity batchUpdate and batchUpsert (which is called for point correction) APIs for data repo integration. It does this by moving the implementation out of EntityService and into LocalEntityProvider, with appropriate changes to the EntityProvider trait. In detail:
* the batchUpsert and batchUpdate APIs now accept `dataReference` and `billingProject` query params. I have intentionally not updated swagger yet, since these params don't work fully yet.
* the `batchUpdateEntities()` and `batchUpsertEntities()` functions move to the `EntityProvider` trait and the `LocalEntityProvider` and `DataRepoEntityProvider` implementations
    * `DataRepoEntityProvider` is currently a no-op implementation that throws immediately; this will change in future PRs when we build the real functionality
* the utility function `applyOperationsToEntity()` moves from `EntityService` to `AttributeSupport`, where both `EntityService` and `LocalEntityProvider` can access it
* the `getWorkspaceContextAndPermissions` permission check for upserts/updates moves a bit higher in the chain, out of `batchUpdateEntitiesInternal` and into the top-level methods in `EntityService`. This mirrors other provider-enabled EntityService methods, and keeps `LocalEntityProvider` from having to query workspaces.

This illustrates the changes:
![Entity Provider Flow](https://user-images.githubusercontent.com/6041577/114878709-84b1ca00-9dce-11eb-88a1-317be42c0276.png)

