### PR TITLE
optimize workspaceAttributeQuery.rewriteAttrsAction [AS-751]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -381,14 +381,6 @@ trait AttributeComponent {
             !existingAttributes.exists(equalRecords(_, v)) // if the attribute exists and is unchanged, don't update it
       }
 
-      // N.B. attributesToIgnore is only used for debugging/logging! TODO: delete this entire block when done debugging
-//      val attributesToIgnore = existingKeys -- attributesToInsert.keys -- attributesToUpdate.keys -- attributesToDelete.keys
-//
-//      System.err.println(s"********** CALCULATED attributesToInsert: ${attributesToInsert.keys.map(_.name).toList.sorted}")
-//      System.err.println(s"********** CALCULATED attributesToDelete: ${attributesToDelete.keys.map(_.name).toList.sorted}")
-//      System.err.println(s"********** CALCULATED attributesToUpdate: ${attributesToUpdate.keys.map(_.name).toList.sorted}")
-//      System.err.println(s"********** CALCULATED attributesToIgnore: ${attributesToIgnore.map(_.name).toList.sorted}")
-//
       patchAttributesAction(attributesToInsert.values,
         attributesToUpdate.values,
         attributesToDelete.values.map(_.id),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -330,14 +330,8 @@ trait AttributeComponent {
 
     def patchAttributesAction(inserts: Traversable[RECORD], updates: Traversable[RECORD], deleteIds: Traversable[Long], insertFunction: Seq[RECORD] => String => WriteAction[Int]) = {
       for {
-        _ <- if (deleteIds.nonEmpty)
-                deleteAttributeRecordsById(deleteIds.toSeq)
-              else
-                DBIO.successful(0)
-        _ <- if (inserts.nonEmpty)
-                batchInsertAttributes(inserts.toSeq)
-              else
-                DBIO.successful(0)
+        _ <- if (deleteIds.nonEmpty) deleteAttributeRecordsById(deleteIds.toSeq) else DBIO.successful(0)
+        _ <- if (inserts.nonEmpty) batchInsertAttributes(inserts.toSeq) else DBIO.successful(0)
         updateResult <- if (updates.nonEmpty)
                           AlterAttributesUsingScratchTableQueries.updateAction(insertFunction(updates.toSeq))
                         else


### PR DESCRIPTION
`workspaceAttributeQuery.rewriteAttrsAction` is called from `EntityComponent.save` and `WorkspaceComponent.save`, which means it exists in many places, including the batchUpsert API.

Changes to `workspaceAttributeQuery.rewriteAttrsAction` in this PR:
* Don't issue noop queries. If there are no attributes to delete, don't issue a `DELETE from table where false` statement. Same with updates; if there are no attributes to update, don't issue a statement at all. Inserts already bypassed the db.
* When adding new attributes to entities, insert those attributes into ENTITY_ATTRIBUTE and be done. Previously, we would insert them into ENTITY_ATTRIBUTE, then insert them into ENTITY_ATTRIBUTE_TEMP, then update ENTITY_ATTRIBUTE with the (exact same) value from ENTITY_ATTRIBUTE_TEMP.
* When updating pre-existing attribute values on an entity, only update those rows that actually changed. Previously, we would update _*every attribute*_ on the entity whether or not it changed, by inserting both the changed and unchanged attributes into ENTITY_ATTRIBUTE_TEMP and updating ENTITY_ATTRIBUTE based on what's in ENTITY_ATTRIBUTE_TEMP.

Consider a data table with 25 columns. If a user issued a point correction to one column, we now update 1 row instead of 25.

Test coverage seems generally good for high-level functionality - "can I save an entity?" for instance. I've added low-level targeted tests to verify the specific changes in this PR.

This does NOT optimize workflow outputs. That code uses a separate path, which I will look at in the future.

If you run this locally, I found it useful to toggle on logging for `slick.jdbc.JdbcBackend.statement` and `slick.jdbc.JdbcBackend.parameter`; see https://scala-slick.org/doc/3.3.3/config.html#logging

One more use case: consider a Terra data table of aliquots, with 2434 rows and 6 columns. As a user, I download a TSV of that table, change one value, and reupload the TSV. This is a not-uncommon use case, though users tend to edit more than one value in the TSV before re-uploading. As measured by Rawls:
* before this PR: 14,613 rows inserted to ENTITY_ATTRIBUTE_TEMP, 14,613 rows updated in ENTITY_ATTRIBUTE
* after this PR: 1 row inserted to ENTITY_ATTRIBUTE_TEMP, 1 rows updated in ENTITY_ATTRIBUTE