### PR TITLE
assist with transaction debugging [do not merge]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -455,6 +455,7 @@ trait EntityComponent {
       } yield entities
     }
 
+    // only called from saveEntityPatch
     private def applyEntityPatch(workspaceContext: Workspace, entityRecord: EntityRecord, upserts: AttributeMap, deletes: Traversable[AttributeName]) = {
       //yank the attribute list for this entity to determine what to do with upserts
       entityAttributeQuery.findByOwnerQuery(Seq(entityRecord.id)).map(attr => (attr.namespace, attr.name, attr.id)).result flatMap { attrCols =>
@@ -536,11 +537,12 @@ trait EntityComponent {
 
           val totalDeleteIds = deleteIds ++ extraDeleteIds
 
-          entityAttributeQuery.patchAttributesAction(insertRecs, updateRecs, totalDeleteIds, entityAttributeTempQuery.insertScratchAttributes)
+          entityAttributeQuery.patchAttributesAction(insertRecs, updateRecs, totalDeleteIds, entityAttributeTempQuery.insertScratchAttributes, "ecaep")
         }
       }
     }
 
+    // only called from SubmissionMonitorActor.saveEntities
     //"patch" this entity by applying the upserts and the deletes to its attributes, then save. a little more database efficient than a "full" save, but requires the entity already exist.
     def saveEntityPatch(workspaceContext: Workspace, entityRef: AttributeEntityReference, upserts: AttributeMap, deletes: Traversable[AttributeName]) = {
       val deleteIntersectUpsert = deletes.toSet intersect upserts.keySet

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -526,11 +526,11 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     val insert = WorkspaceAttributeRecord(3, workspaceId, AttributeName.defaultNamespace, "test3", None, None, Option(false), None, None, None, None, deleted = false, None)
 
     //test insert and update
-    runAndWait(workspaceAttributeQuery.patchAttributesAction(Seq(insert), Seq(update), Seq(), workspaceAttributeScratchQuery.insertScratchAttributes))
+    runAndWait(workspaceAttributeQuery.patchAttributesAction(Seq(insert), Seq(update), Seq(), workspaceAttributeScratchQuery.insertScratchAttributes, "unittest"))
     assertExpectedRecords(Seq(existing.head, update, insert):_*)
 
     //test delete
-    runAndWait(workspaceAttributeQuery.patchAttributesAction(Seq(), Seq(), existing.map(_.id), workspaceAttributeScratchQuery.insertScratchAttributes))
+    runAndWait(workspaceAttributeQuery.patchAttributesAction(Seq(), Seq(), existing.map(_.id), workspaceAttributeScratchQuery.insertScratchAttributes, "unittest"))
     assertExpectedRecords(Seq(insert):_*)
   }
 
@@ -749,7 +749,8 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
       updatesCaptor.capture(),
       deletesCaptor.capture(),
-      any())
+      any(),
+      "unittest")
 
     assert(insertsCaptor.getValue.isEmpty, "inserts should be empty")
     assert(updatesCaptor.getValue.isEmpty, "updates should be empty")
@@ -789,7 +790,8 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
       updatesCaptor.capture(),
       deletesCaptor.capture(),
-      any())
+      any(),
+      "unittest")
 
     assert(insertsCaptor.getValue.isEmpty, "insertsCaptor should be empty")
     withClue("should have one update"){ assertSameElements(updates, updatesCaptor.getValue) }
@@ -829,7 +831,8 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
       updatesCaptor.capture(),
       deletesCaptor.capture(),
-      any())
+      any(),
+      "unittest")
 
     withClue("should have one insert"){ assertSameElements(inserts, insertsCaptor.getValue) }
     assert(updatesCaptor.getValue.isEmpty, "updates should be empty")
@@ -865,7 +868,8 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
       updatesCaptor.capture(),
       deletesCaptor.capture(),
-      any())
+      any(),
+      "unittest")
 
     assert(insertsCaptor.getValue.isEmpty, "inserts should be empty")
     assert(updatesCaptor.getValue.isEmpty, "updates should be empty")
@@ -909,7 +913,8 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
       updatesCaptor.capture(),
       deletesCaptor.capture(),
-      any())
+      any(),
+      "unittest")
 
     withClue("should have one insert"){ assertSameElements(inserts, insertsCaptor.getValue) }
     withClue("should have one update"){ assertSameElements(updates, updatesCaptor.getValue) }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -750,7 +750,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       updatesCaptor.capture(),
       deletesCaptor.capture(),
       any(),
-      "unittest")
+      any())
 
     assert(insertsCaptor.getValue.isEmpty, "inserts should be empty")
     assert(updatesCaptor.getValue.isEmpty, "updates should be empty")
@@ -791,7 +791,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       updatesCaptor.capture(),
       deletesCaptor.capture(),
       any(),
-      "unittest")
+      any())
 
     assert(insertsCaptor.getValue.isEmpty, "insertsCaptor should be empty")
     withClue("should have one update"){ assertSameElements(updates, updatesCaptor.getValue) }
@@ -832,7 +832,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       updatesCaptor.capture(),
       deletesCaptor.capture(),
       any(),
-      "unittest")
+      any())
 
     withClue("should have one insert"){ assertSameElements(inserts, insertsCaptor.getValue) }
     assert(updatesCaptor.getValue.isEmpty, "updates should be empty")
@@ -869,7 +869,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       updatesCaptor.capture(),
       deletesCaptor.capture(),
       any(),
-      "unittest")
+      any())
 
     assert(insertsCaptor.getValue.isEmpty, "inserts should be empty")
     assert(updatesCaptor.getValue.isEmpty, "updates should be empty")
@@ -914,7 +914,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
       updatesCaptor.capture(),
       deletesCaptor.capture(),
       any(),
-      "unittest")
+      any())
 
     withClue("should have one insert"){ assertSameElements(inserts, insertsCaptor.getValue) }
     withClue("should have one update"){ assertSameElements(updates, updatesCaptor.getValue) }


### PR DESCRIPTION
DRAFT to gather opinions ... is this a good idea? Is this worth it?

-----

When looking at transactions in innotop, the `update ENTITY_ATTRIBUTE a ... ` query stood out as slow. That query could be spawned from either the `handleOutputs` method inside the submission monitor, OR from one of the various user-facing entity APIs such as batchUpsert or its parent TSV uploads. There is no way to tell directly from innotop which code path triggered this sql statement.

This PR hacks the sql a bit, so that different code paths use different table aliases. SQL statements that originate in the submission monitor will be `update ENTITY_ATTRIBUTE ecaep ... ` while SQL statements that originate in one of the entity APIs will be `update ENTITY_ATTRIBUTE acraa ...`. Queries visible in innotop should now have identifiable origins.

fyi, `ecaep` stands for `EntityComponent.applyEntityPatch` and `acraa` stands for `AttributeComponent. rewriteAttrsAction`. I realize these are indecipherable acronyms unless you dive into the code. We could change these, but they must be short (to fit in innotop) and SQL-legal. Maybe `ent` and `sub`?
