### PR TITLE
AS-728: Don't use deprecated WSM APIs in Rawls

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -258,13 +258,13 @@ class SnapshotAPISpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterA
   // ==================== Rawls helpers ====================
   private def listSnapshotReferences(projectName: String, workspaceName: String, offset: Int = 0, limit: Int = 10)(implicit authToken: AuthToken) = {
     val targetRawlsUrl  = Uri(Rawls.url)
-      .withPath(Path(s"/api/workspaces/$projectName/$workspaceName/snapshots"))
+      .withPath(Path(s"/api/workspaces/$projectName/$workspaceName/v2/snapshots"))
       .withQuery(Query(Map("offset" -> offset.toString, "limit" ->  limit.toString)))
     Rawls.getRequest(uri = targetRawlsUrl.toString)
   }
 
   private def createSnapshotReference(projectName: String, workspaceName: String, snapshotId: String, snapshotName: String)(implicit authToken: AuthToken) = {
-    val targetRawlsUrl  = Uri(Rawls.url).withPath(Path(s"/api/workspaces/$projectName/$workspaceName/snapshots"))
+    val targetRawlsUrl  = Uri(Rawls.url).withPath(Path(s"/api/workspaces/$projectName/$workspaceName/v2/snapshots"))
     val payload = Map("snapshotId" -> snapshotId, "name" -> snapshotName)
     Rawls.postRequest(
       uri = targetRawlsUrl.toString(),

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -258,13 +258,13 @@ class SnapshotAPISpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterA
   // ==================== Rawls helpers ====================
   private def listSnapshotReferences(projectName: String, workspaceName: String, offset: Int = 0, limit: Int = 10)(implicit authToken: AuthToken) = {
     val targetRawlsUrl  = Uri(Rawls.url)
-      .withPath(Path(s"/api/workspaces/$projectName/$workspaceName/v2/snapshots"))
+      .withPath(Path(s"/api/workspaces/$projectName/$workspaceName/snapshots/v2"))
       .withQuery(Query(Map("offset" -> offset.toString, "limit" ->  limit.toString)))
     Rawls.getRequest(uri = targetRawlsUrl.toString)
   }
 
   private def createSnapshotReference(projectName: String, workspaceName: String, snapshotId: String, snapshotName: String)(implicit authToken: AuthToken) = {
-    val targetRawlsUrl  = Uri(Rawls.url).withPath(Path(s"/api/workspaces/$projectName/$workspaceName/v2/snapshots"))
+    val targetRawlsUrl  = Uri(Rawls.url).withPath(Path(s"/api/workspaces/$projectName/$workspaceName/snapshots/v2"))
     val payload = Map("snapshotId" -> snapshotId, "name" -> snapshotName)
     Rawls.postRequest(
       uri = targetRawlsUrl.toString(),

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -18,6 +18,7 @@ tags:
   - name: notifications
   - name: servicePerimeters
   - name: snapshots
+  - name: snapshots_v2
   - name: status
   - name: submissions
   - name: users
@@ -4027,6 +4028,164 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/snapshots:
+    parameters:
+      - $ref: '#/components/parameters/workspaceNamespacePathParam'
+      - $ref: '#/components/parameters/workspaceNamePathParam'
+    get:
+      tags:
+        - snapshots_v2
+      summary: List snapshots
+      description: Enumerate references to snapshots in the Terra Data Repo
+      operationId: enumerateDataRepoSnapshot_v2
+      parameters:
+        - name: offset
+          in: query
+          description: The number of items to skip before starting to collect the result
+            set.
+          required: true
+          schema:
+            type: integer
+          example: 0
+        - name: limit
+          in: query
+          description: The number of items to return.
+          required: true
+          schema:
+            type: integer
+          example: 10
+      responses:
+        200:
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DataRepoSnapshotResourceList'
+        404:
+          description: Workspace not found or user lacks permissions
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    post:
+      tags:
+        - snapshots_v2
+      summary: Create a snapshot
+      description: Add a reference to a snapshot in the Terra Data Repo
+      operationId: createDataRepoSnapshot_v2
+      requestBody:
+        description: Reference to the Data Repo snapshot
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NamedDataRepoSnapshot'
+        required: true
+      responses:
+        201:
+          description: Created
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DataRepoSnapshotResource'
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+      x-codegen-request-body-name: namedDataRepoSnapshot
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/snapshots/{snapshotId}:
+    parameters:
+      - $ref: '#/components/parameters/workspaceNamespacePathParam'
+      - $ref: '#/components/parameters/workspaceNamePathParam'
+      - $ref: '#/components/parameters/snapshotIdPathParam'
+    get:
+      tags:
+        - snapshots_v2
+      summary: Get a snapshot
+      description: Get a reference to a snapshot in the Terra Data Repo
+      operationId: getDataRepoSnapshot_v2
+      responses:
+        200:
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DataRepoSnapshotResource'
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    patch:
+      summary: Update name or description of a reference to a snapshot in the Terra Data Repo.
+      operationId: updateDataRepoSnapshot_v2
+      tags:
+        - snapshots_v2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateDataReferenceRequestBody'
+      responses:
+        204:
+          description: Successful Request
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    delete:
+      tags:
+        - snapshots_v2
+      summary: Delete a snapshot
+      description: Delete a workspace's reference to a snapshot in the Terra Data
+        Repo
+      operationId: deleteDataRepoSnapshot_v2
+      responses:
+        204:
+          description: Successful Request
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+
   /api/notifications/workspace/{workspaceNamespace}/{workspaceName}:
     get:
       tags:
@@ -4203,6 +4362,68 @@ components:
           items:
             $ref: '#/components/schemas/DataRepoSnapshotReference'
       description: A list of DataRepoSnapshotReferences
+    ResourceMetadata:
+      type: object
+      required: [ workspaceId, resourceId, name, description, resourceType, stewardshipType, cloudPlatform, cloningIntructions ]
+      properties:
+        workspaceId:
+          type: string
+        resourceId:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        resourceType:
+          type: string
+        stewardshipType:
+          type: string
+        cloudPlatform:
+          type: string
+        cloningInstructions:
+          type: string
+     # Add controlled?
+    DataRepoSnapshotAttributes:
+      type: object
+      required: [ instanceName, snapshot ]
+      properties:
+        instanceName:
+          type: string
+        snapshot:
+          type: string
+    DataRepoSnapshotResource:
+      type: object
+      required: [ metadata, attributes ]
+      properties:
+        metadata:
+          $ref: '#/components/schemas/ResourceMetadata'
+        attributes:
+          $ref: '#/components/schemas/DataRepoSnapshotAttributes'
+    ResourceAttributesUnion:
+      type: object
+      required: [ gcpDataRepoSnapshot ]
+      properties:
+        gcpDataRepoSnapshot:
+          $ref: '#/components/schemas/DataRepoSnapshotAttributes'
+    ResourceDescription:
+      type: object
+      required: [ metadata, resourceAttributes ]
+      properties:
+        metadata:
+          $ref: '#/components/schemas/ResourceMetadata'
+        resourceAttributes:
+          $ref: '#/components/schemas/ResourceAttributesUnion'
+      description: resource description
+    DataRepoSnapshotResourceList:
+      type: object
+      required: [ resources ]
+      properties:
+        resources:
+          type: array
+          description: A list of snapshot Data Resource definitions from Workspace Manager
+          items:
+            $ref: '#/components/schemas/ResourceDescription'
+      description: List of snapshot resources
     ErrorReport:
       required:
         - causes

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4034,7 +4034,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
 
-  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/snapshots:
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/v2/snapshots:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
       - $ref: '#/components/parameters/workspaceNamePathParam'
@@ -4112,7 +4112,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       x-codegen-request-body-name: namedDataRepoSnapshot
-  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/snapshots/{snapshotId}:
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/v2/snapshots/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
       - $ref: '#/components/parameters/workspaceNamePathParam'

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4034,7 +4034,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
 
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/v2/snapshots:
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
       - $ref: '#/components/parameters/workspaceNamePathParam'
@@ -4112,7 +4112,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       x-codegen-request-body-name: namedDataRepoSnapshot
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/v2/snapshots/{snapshotId}:
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
       - $ref: '#/components/parameters/workspaceNamePathParam'

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3877,6 +3877,7 @@ paths:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
       - $ref: '#/components/parameters/workspaceNamePathParam'
     get:
+      deprecated: true
       tags:
         - snapshots
       summary: List snapshots
@@ -3918,6 +3919,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
     post:
+      deprecated: true
       tags:
         - snapshots
       summary: Create a snapshot
@@ -3956,6 +3958,7 @@ paths:
       - $ref: '#/components/parameters/workspaceNamePathParam'
       - $ref: '#/components/parameters/snapshotIdPathParam'
     get:
+      deprecated: true
       tags:
         - snapshots
       summary: Get a snapshot
@@ -3981,6 +3984,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
     patch:
+      deprecated: true
       summary: Update name or description of a reference to a snapshot in the Terra Data Repo.
       operationId: updateDataRepoSnapshot
       tags:
@@ -4007,6 +4011,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
     delete:
+      deprecated: true
       tags:
         - snapshots
       summary: Delete a snapshot

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4382,7 +4382,6 @@ components:
           type: string
         cloningInstructions:
           type: string
-     # Add controlled?
     DataRepoSnapshotAttributes:
       type: object
       required: [ instanceName, snapshot ]
@@ -4390,6 +4389,7 @@ components:
         instanceName:
           type: string
         snapshot:
+          description: The snapshot id
           type: string
     DataRepoSnapshotResource:
       type: object

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3951,7 +3951,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      x-codegen-request-body-name: namedDataRepoSnapshot
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
@@ -4111,7 +4110,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      x-codegen-request-body-name: namedDataRepoSnapshot
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -45,11 +45,11 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
     getWorkspaceApi(accessToken).deleteWorkspace(workspaceId)
   }
 
-  override def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: String, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
-    val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId)
-    val metadata = new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
-    description.map(d => metadata.description(d.value))
-    val request = new CreateDataRepoSnapshotReferenceRequestBody().snapshot(snapshot).metadata(metadata)
+  override def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
+    val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId.toString)
+    val commonFields = new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
+    description.map(d => commonFields.description(d.value))
+    val request = new CreateDataRepoSnapshotReferenceRequestBody().snapshot(snapshot).metadata(commonFields)
     getReferencedGcpResourceApi(accessToken).createDataRepoSnapshotReference(request, workspaceId)
   }
 
@@ -61,8 +61,8 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
     getReferencedGcpResourceApi(accessToken).deleteDataRepoSnapshotReference(workspaceId, referenceId)
   }
 
-  override def getDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
-    getReferencedGcpResourceApi(accessToken).getDataRepoSnapshotReference(workspaceId, snapshotId)
+  override def getDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
+    getReferencedGcpResourceApi(accessToken).getDataRepoSnapshotReference(workspaceId, referenceId)
   }
 
   override def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.Materializer
-import bio.terra.workspace.api.{ReferencedGcpResourceApi, WorkspaceApi}
+import bio.terra.workspace.api.{ReferencedGcpResourceApi, ResourceApi, WorkspaceApi}
 import bio.terra.workspace.client.ApiClient
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName}
@@ -29,6 +29,10 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
     new ReferencedGcpResourceApi(getApiClient(accessToken.token))
   }
 
+  private def getResourceApi(accessToken: OAuth2BearerToken): ResourceApi = {
+    new ResourceApi(getApiClient(accessToken.token))
+  }
+
   override def getWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): WorkspaceDescription = {
     getWorkspaceApi(accessToken).getWorkspace(workspaceId)
   }
@@ -41,35 +45,36 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
     getWorkspaceApi(accessToken).deleteWorkspace(workspaceId)
   }
 
-  override def createDataReference(workspaceId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], referenceType: ReferenceTypeEnum, reference: DataRepoSnapshot, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataReferenceDescription = {
-    val request = new CreateDataReferenceRequestBody().name(name.value).referenceType(referenceType).reference(reference).cloningInstructions(cloningInstructions)
-    description.map(d => request.description(d.value))
-
-    getWorkspaceApi(accessToken).createDataReference(request, workspaceId)
+  override def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: String, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
+    val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId)
+    val metadata = new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
+    description.map(d => metadata.description(d.value))
+    val request = new CreateDataRepoSnapshotReferenceRequestBody().snapshot(snapshot).metadata(metadata)
+    getReferencedGcpResourceApi(accessToken).createDataRepoSnapshotReference(request, workspaceId)
   }
 
-  override def updateDataReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataReferenceRequestBody, accessToken: OAuth2BearerToken): Unit = {
-    getWorkspaceApi(accessToken).updateDataReference(updateInfo, workspaceId, referenceId)
+  override def updateDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataReferenceRequestBody, accessToken: OAuth2BearerToken): Unit = {
+    getReferencedGcpResourceApi(accessToken).updateDataRepoSnapshotReference(updateInfo, workspaceId, referenceId)
   }
 
-  override def deleteDataReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): Unit = {
-    getWorkspaceApi(accessToken).deleteDataReference(workspaceId, referenceId)
+  override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): Unit = {
+    getReferencedGcpResourceApi(accessToken).deleteDataRepoSnapshotReference(workspaceId, referenceId)
   }
 
-  override def getDataReference(workspaceId: UUID, snapshotId: UUID, accessToken: OAuth2BearerToken): DataReferenceDescription = {
-    getWorkspaceApi(accessToken).getDataReference(workspaceId, snapshotId)
+  override def getDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
+    getReferencedGcpResourceApi(accessToken).getDataRepoSnapshotReference(workspaceId, snapshotId)
   }
 
-  override def getDataReferenceByName(workspaceId: UUID, refType: ReferenceTypeEnum, refName: DataReferenceName, accessToken: OAuth2BearerToken): DataReferenceDescription = {
-    getWorkspaceApi(accessToken).getDataReferenceByName(workspaceId, refType, refName.value)
+  override def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
+    getReferencedGcpResourceApi(accessToken).getDataRepoSnapshotReferenceByName(workspaceId, refName.value)
   }
 
-  override def enumerateDataReferences(workspaceId: UUID, offset: Int, limit: Int, accessToken: OAuth2BearerToken): DataReferenceList = {
-    getWorkspaceApi(accessToken).enumerateReferences(workspaceId, offset, limit)
+  override def enumerateDataRepoSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int, accessToken: OAuth2BearerToken): ResourceList = {
+    getResourceApi(accessToken).enumerateResources(workspaceId, offset, limit, ResourceType.DATA_REPO_SNAPSHOT, StewardshipType.REFERENCED)
   }
 
-  override def createBigQueryDatasetReference(workspaceId: UUID, metadata: DataReferenceRequestMetadata, dataset: GoogleBigQueryDatasetUid, accessToken: OAuth2BearerToken): BigQueryDatasetReference = {
-    val createBigQueryDatasetReference = new CreateBigQueryDatasetReferenceRequestBody().dataset(dataset).metadata(metadata)
+  override def createBigQueryDatasetReference(workspaceId: UUID, metadata: ReferenceResourceCommonFields, dataset: GcpBigQueryDatasetAttributes, accessToken: OAuth2BearerToken): GcpBigQueryDatasetResource = {
+    val createBigQueryDatasetReference = new CreateGcpBigQueryDatasetReferenceRequestBody().dataset(dataset).metadata(metadata)
     getReferencedGcpResourceApi(accessToken).createBigQueryDatasetReference(createBigQueryDatasetReference, workspaceId)
   }
 
@@ -77,7 +82,7 @@ class HttpWorkspaceManagerDAO(baseWorkspaceManagerUrl: String)(implicit val syst
     getReferencedGcpResourceApi(accessToken).deleteBigQueryDatasetReference(workspaceId, resourceId)
   }
 
-  override def getBigQueryDatasetReferenceByName(workspaceId: UUID, name: String, accessToken: OAuth2BearerToken): BigQueryDatasetReference = {
+  override def getBigQueryDatasetReferenceByName(workspaceId: UUID, name: String, accessToken: OAuth2BearerToken): GcpBigQueryDatasetResource = {
     getReferencedGcpResourceApi(accessToken).getBigQueryDatasetReferenceByName(workspaceId, name)
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -13,13 +13,13 @@ trait WorkspaceManagerDAO {
   def getWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): WorkspaceDescription
   def createWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): CreatedWorkspace
   def deleteWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): Unit
-  def createDataReference(workspaceId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], referenceType: ReferenceTypeEnum, reference: DataRepoSnapshot, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataReferenceDescription
-  def updateDataReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataReferenceRequestBody, accessToken: OAuth2BearerToken): Unit
-  def deleteDataReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): Unit
-  def getDataReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): DataReferenceDescription
-  def getDataReferenceByName(workspaceId: UUID, refType: ReferenceTypeEnum, refName: DataReferenceName, accessToken: OAuth2BearerToken): DataReferenceDescription
-  def enumerateDataReferences(workspaceId: UUID, offset: Int, limit: Int, accessToken: OAuth2BearerToken): DataReferenceList
-  def createBigQueryDatasetReference(workspaceId: UUID, metadata: DataReferenceRequestMetadata, dataset: GoogleBigQueryDatasetUid, accessToken: OAuth2BearerToken): BigQueryDatasetReference
+  def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: String, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataRepoSnapshotResource
+  def updateDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataReferenceRequestBody, accessToken: OAuth2BearerToken): Unit
+  def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): Unit
+  def getDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): DataRepoSnapshotResource
+  def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, accessToken: OAuth2BearerToken): DataRepoSnapshotResource
+  def enumerateDataRepoSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int, accessToken: OAuth2BearerToken): ResourceList
+  def createBigQueryDatasetReference(workspaceId: UUID, metadata: ReferenceResourceCommonFields, dataset: GcpBigQueryDatasetAttributes, accessToken: OAuth2BearerToken): GcpBigQueryDatasetResource
   def deleteBigQueryDatasetReference(workspaceId: UUID, resourceId: UUID, accessToken: OAuth2BearerToken): Unit
-  def getBigQueryDatasetReferenceByName(workspaceId: UUID, name: String, accessToken: OAuth2BearerToken): BigQueryDatasetReference
+  def getBigQueryDatasetReferenceByName(workspaceId: UUID, name: String, accessToken: OAuth2BearerToken): GcpBigQueryDatasetResource
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -13,7 +13,7 @@ trait WorkspaceManagerDAO {
   def getWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): WorkspaceDescription
   def createWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): CreatedWorkspace
   def deleteWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): Unit
-  def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: String, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataRepoSnapshotResource
+  def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataRepoSnapshotResource
   def updateDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataReferenceRequestBody, accessToken: OAuth2BearerToken): Unit
   def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): Unit
   def getDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): DataRepoSnapshotResource

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -15,8 +15,7 @@ import org.broadinstitute.dsde.rawls.deltalayer.DeltaLayerWriter
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ErrorReportFormat
-import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport}
+import org.broadinstitute.dsde.rawls.model.DataReferenceName
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,10 +1,11 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import java.util.UUID
+
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.client.{ApiException => DatarepoApiException}
 import bio.terra.workspace.client.{ApiException => WorkspaceApiException}
-import bio.terra.workspace.model.ReferenceTypeEnum
+import bio.terra.workspace.model.{ReferenceTypeEnum, ResourceType}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -78,7 +79,7 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
     val dataRef = dataRefTry.get
 
     // verify it's a TDR snapshot. should be a noop, since getDataReferenceByName enforces this.
-    if (ReferenceTypeEnum.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
+    if (ResourceType.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
       throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}")
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -64,8 +64,7 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
   private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName, requestArguments: EntityRequestArguments): UUID = {
     // contact WSM to retrieve the data reference specified in the request
-    val dataRefTry = Try(workspaceManagerDAO.getDataReferenceByName(UUID.fromString(requestArguments.workspace.workspaceId),
-      ReferenceTypeEnum.DATA_REPO_SNAPSHOT,
+    val dataRefTry = Try(workspaceManagerDAO.getDataRepoSnapshotReferenceByName(UUID.fromString(requestArguments.workspace.workspaceId),
       dataReferenceName,
       requestArguments.userInfo.accessToken)).recoverWith {
 
@@ -79,11 +78,11 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
     val dataRef = dataRefTry.get
 
     // verify it's a TDR snapshot. should be a noop, since getDataReferenceByName enforces this.
-    if (ReferenceTypeEnum.DATA_REPO_SNAPSHOT != dataRef.getReferenceType) {
+    if (ReferenceTypeEnum.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
       throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}")
     }
 
-    val dataReference = dataRef.getReference
+    val dataReference = dataRef.getAttributes
 
     // verify the instance matches our target instance
     // TODO: AS-321 is this the right place to validate this? We could add a "validateInstanceURL" method to the DAO itself, for instance

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.workspace.model._
-import cats.data.NonEmptyList
 import cats.effect.{ContextShift, IO}
 import com.google.cloud.bigquery.Acl
 import com.google.cloud.bigquery.Acl.Entity
@@ -57,7 +56,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
       createDatasetIO.unsafeToFuture().recover {
         case t: Throwable =>
           //fire and forget this undo, we've made our best effort to fix things at this point
-          IO.pure(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID,referenceId, userInfo.accessToken)).unsafeToFuture()
+          IO.pure(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken)).unsafeToFuture()
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
       }.flatMap { _ =>
 
@@ -79,10 +78,10 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     }
   }
 
-  def getSnapshot(workspaceName: WorkspaceName, resourceId: String): Future[DataRepoSnapshotResource] = {
-    val resourceUuid = validateSnapshotId(resourceId)
+  def getSnapshot(workspaceName: WorkspaceName, referenceId: String): Future[DataRepoSnapshotResource] = {
+    val referenceUuid = validateSnapshotId(referenceId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
-      val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, resourceUuid, userInfo.accessToken)
+      val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceUuid, userInfo.accessToken)
       Future.successful(ref)
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -167,6 +167,6 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
 
   private[snapshot] def generateDatasetName(datasetReferenceId: UUID) = {
     "deltalayer_" + datasetReferenceId.toString.replace('-', '_')
-}
+  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -79,10 +79,10 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     }
   }
 
-  def getSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[DataRepoSnapshotResource] = {
-    val snapshotUuid = validateSnapshotId(snapshotId)
+  def getSnapshot(workspaceName: WorkspaceName, resourceId: String): Future[DataRepoSnapshotResource] = {
+    val resourceUuid = validateSnapshotId(resourceId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
-      val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
+      val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, resourceUuid, userInfo.accessToken)
       Future.successful(ref)
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -44,7 +44,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
       val referenceId = snapshotRef.getMetadata.getResourceId
       val datasetName = generateDatasetName(referenceId)
 
-      val datasetLabels = Map("workspace_id" -> workspaceContext.workspaceId, "snapshot_id" -> snapshot.snapshotId)
+      val datasetLabels = Map("workspace_id" -> workspaceContext.workspaceId, "snapshot_id" -> snapshot.snapshotId.toString)
 
       // create BQ dataset, get workspace policies from Sam, and add those Sam policies to the dataset IAM
       val createDatasetIO = for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -33,16 +33,16 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
                      (implicit protected val executionContext: ExecutionContext, implicit val contextShift: ContextShift[IO])
   extends FutureSupport with WorkspaceSupport with LazyLogging {
 
-  def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataReferenceDescription] = {
+  def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataRepoSnapshotResource] = {
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
       if(!workspaceStubExists(workspaceContext.workspaceIdAsUUID, userInfo)) {
         workspaceManagerDAO.createWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)
       }
 
-      val dataRepoReference = new DataRepoSnapshot().instanceName(terraDataRepoInstanceName).snapshot(snapshot.snapshotId)
-      val snapshotRef = workspaceManagerDAO.createDataReference(workspaceContext.workspaceIdAsUUID, snapshot.name, snapshot.description, ReferenceTypeEnum.DATA_REPO_SNAPSHOT, dataRepoReference, CloningInstructionsEnum.NOTHING, userInfo.accessToken)
+      val snapshotRef = workspaceManagerDAO.createDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshot.snapshotId, snapshot.name, snapshot.description, terraDataRepoInstanceName, CloningInstructionsEnum.NOTHING, userInfo.accessToken)
 
-      val datasetName = generateDatasetName(snapshotRef.getReferenceId)
+      val referenceId = snapshotRef.getMetadata.getResourceId
+      val datasetName = generateDatasetName(referenceId)
 
       val datasetLabels = Map("workspace_id" -> workspaceContext.workspaceId, "snapshot_id" -> snapshot.snapshotId)
 
@@ -57,13 +57,13 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
       createDatasetIO.unsafeToFuture().recover {
         case t: Throwable =>
           //fire and forget this undo, we've made our best effort to fix things at this point
-          IO.pure(workspaceManagerDAO.deleteDataReference(workspaceContext.workspaceIdAsUUID, snapshotRef.getReferenceId, userInfo.accessToken)).unsafeToFuture()
+          IO.pure(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID,referenceId, userInfo.accessToken)).unsafeToFuture()
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
       }.flatMap { _ =>
 
         val createBQReferenceFuture = for {
           petToken <- samDAO.getPetServiceAccountToken(GoogleProjectId(workspaceName.namespace), SamDAO.defaultScopes + SamDAO.bigQueryReadOnlyScope, userInfo)
-          bigQueryRef = workspaceManagerDAO.createBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, new DataReferenceRequestMetadata().name(datasetName).cloningInstructions(CloningInstructionsEnum.NOTHING), new GoogleBigQueryDatasetUid().projectId(workspaceContext.namespace).datasetId(datasetName), OAuth2BearerToken(petToken))
+          bigQueryRef = workspaceManagerDAO.createBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, new ReferenceResourceCommonFields().name(datasetName).cloningInstructions(CloningInstructionsEnum.NOTHING), new GcpBigQueryDatasetAttributes().projectId(workspaceContext.namespace).datasetId(datasetName), OAuth2BearerToken(petToken))
         } yield { bigQueryRef }
 
         createBQReferenceFuture.recover {
@@ -71,7 +71,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
             //fire and forget these undos, we've made our best effort to fix things at this point
             for {
               _ <- deleteBigQueryDataset(workspaceName, datasetName).unsafeToFuture()
-              _ <- IO.pure(workspaceManagerDAO.deleteDataReference(workspaceContext.workspaceIdAsUUID, snapshotRef.getReferenceId, userInfo.accessToken)).unsafeToFuture()
+              _ <- IO.pure(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken)).unsafeToFuture()
             } yield {}
             throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
         }
@@ -79,21 +79,21 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     }
   }
 
-  def getSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[DataReferenceDescription] = {
+  def getSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[DataRepoSnapshotResource] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
-      val ref = workspaceManagerDAO.getDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
+      val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
       Future.successful(ref)
     }
   }
 
-  def enumerateSnapshots(workspaceName: WorkspaceName, offset: Int, limit: Int): Future[DataReferenceList] = {
+  def enumerateSnapshots(workspaceName: WorkspaceName, offset: Int, limit: Int): Future[ResourceList] = {
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
-      Try(workspaceManagerDAO.enumerateDataReferences(workspaceContext.workspaceIdAsUUID, offset, limit, userInfo.accessToken)) match {
+      Try(workspaceManagerDAO.enumerateDataRepoSnapshotReferences(workspaceContext.workspaceIdAsUUID, offset, limit, userInfo.accessToken)) match {
         case Success(references) => references
         // if we fail with a 404, it means we have no stub in WSM yet. This is benign and functionally equivalent
         // to having no references, so return the empty list.
-        case Failure(ex: bio.terra.workspace.client.ApiException) if ex.getCode == 404 => new DataReferenceList()
+        case Failure(ex: bio.terra.workspace.client.ApiException) if ex.getCode == 404 => new ResourceList()
         // but if we hit a different error, it's a valid error; rethrow it
         case Failure(ex: bio.terra.workspace.client.ApiException) =>
           throw new RawlsExceptionWithErrorReport(ErrorReport(ex.getCode, ex))
@@ -109,8 +109,8 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
       // check that snapshot exists before updating it. If the snapshot does not exist, the GET attempt will throw a 404
       // TODO: these WSM APIs are in the process of being deprecated. We should update with new APIs as they become available
-      workspaceManagerDAO.getDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
-      workspaceManagerDAO.updateDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, updateInfo, userInfo.accessToken)
+      workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
+      workspaceManagerDAO.updateDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, updateInfo, userInfo.accessToken)
     }
   }
 
@@ -118,16 +118,16 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     val snapshotUuid = validateSnapshotId(snapshotId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
       // check that snapshot exists before deleting it. If the snapshot does not exist, the GET attempt will throw a 404
-      val snapshotRef = workspaceManagerDAO.getDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
-      workspaceManagerDAO.deleteDataReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
+      val snapshotRef = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
+      workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
 
-      val datasetName = generateDatasetName(snapshotRef.getReferenceId)
+      val datasetName = generateDatasetName(snapshotRef.getMetadata.getResourceId)
       deleteBigQueryDataset(workspaceName, datasetName).unsafeToFuture().map { _ =>
         val datasetRef = workspaceManagerDAO.getBigQueryDatasetReferenceByName(workspaceContext.workspaceIdAsUUID, datasetName, userInfo.accessToken)
-        workspaceManagerDAO.deleteBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, datasetRef.getMetadata.getReferenceId, userInfo.accessToken)
+        workspaceManagerDAO.deleteBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, datasetRef.getMetadata.getResourceId, userInfo.accessToken)
       }.recover {
         case t: Throwable =>
-          logger.warn(s"A snapshot reference was deleted, but an error occurred while deleting its Delta Layer companion dataset: snapshot ref ID: ${snapshotRef.getReferenceId}, dataset name: ${datasetName}")
+          logger.warn(s"A snapshot reference was deleted, but an error occurred while deleting its Delta Layer companion dataset: snapshot ref ID: ${snapshotRef.getMetadata.getResourceId}, dataset name: ${datasetName}")
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Your snapshot reference was deleted, but an error occurred while deleting its Delta Layer companion dataset. Error: ${t.getMessage}"))
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
-import bio.terra.workspace.model.UpdateDataReferenceRequestBody
+import bio.terra.workspace.model.{DataReferenceDescription, DataReferenceList, DataRepoSnapshot, DataRepoSnapshotResource, ReferenceTypeEnum, ResourceDescription, ResourceList, ResourceMetadata, UpdateDataReferenceRequestBody}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model.{NamedDataRepoSnapshot, UserInfo, WorkspaceName}
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
@@ -19,7 +19,7 @@ trait SnapshotApiService extends UserInfoDirectives {
   val snapshotServiceConstructor: UserInfo => SnapshotService
 
   val snapshotRoutes: server.Route = requireUserInfo() { userInfo =>
-    path("workspaces" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
+    path("workspaces" / "v2" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
       post {
         entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
           complete {
@@ -27,10 +27,52 @@ trait SnapshotApiService extends UserInfoDirectives {
           }
         }
       } ~
+        get {
+          parameters("offset".as[Int], "limit".as[Int]) { (offset, limit) =>
+            complete {
+              snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit).map(StatusCodes.OK -> _)
+            }
+          }
+        }
+    } ~
+    path("workspaces" / "v2" / Segment / Segment / "snapshots" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
+      get {
+        complete {
+          snapshotServiceConstructor(userInfo).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(StatusCodes.OK -> _)
+        }
+      } ~
+        patch {
+          entity(as[UpdateDataReferenceRequestBody]) { updateDataReferenceRequestBody =>
+            complete {
+              snapshotServiceConstructor(userInfo).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataReferenceRequestBody).map(_ => StatusCodes.NoContent)
+            }
+          }
+        } ~
+        delete {
+          complete {
+            snapshotServiceConstructor(userInfo).deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(_ => StatusCodes.NoContent)
+          }
+        }
+    }
+
+    // -------  V1 SNAPSHOT ENDPOINTS -------
+
+    path("workspaces" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
+      post {
+        entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
+          complete {
+            snapshotServiceConstructor(userInfo).createSnapshot(WorkspaceName(workspaceNamespace, workspaceName), namedDataRepoSnapshot)
+              .map(dataRepoSnapshotResourceToDataReferenceDescription)
+              .map(StatusCodes.Created -> _)
+          }
+        }
+      } ~
       get {
         parameters("offset".as[Int], "limit".as[Int]) { (offset, limit) =>
           complete {
-            snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit).map(StatusCodes.OK -> _)
+            snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit)
+              .map(resourceListToDataReferenceList)
+              .map(StatusCodes.OK -> _)
           }
         }
       }
@@ -38,7 +80,9 @@ trait SnapshotApiService extends UserInfoDirectives {
     path("workspaces" / Segment / Segment / "snapshots" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
       get {
         complete {
-          snapshotServiceConstructor(userInfo).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(StatusCodes.OK -> _)
+          snapshotServiceConstructor(userInfo).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId)
+            .map(dataRepoSnapshotResourceToDataReferenceDescription)
+            .map(StatusCodes.OK -> _)
         }
       } ~
       patch {
@@ -54,5 +98,33 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       }
     }
+  }
+  
+  // -------  REMOVE WHEN GETTING RID OF V1 SNAPSHOT ENDPOINTS -------
+
+  private def dataRepoSnapshotResourceToDataReferenceDescription(resource: DataRepoSnapshotResource): DataReferenceDescription = {
+    new DataReferenceDescription()
+      .name(resource.getMetadata.getName)
+      .description(resource.getMetadata.getDescription)
+      .referenceId(resource.getMetadata.getResourceId)
+      .referenceType(ReferenceTypeEnum.fromValue(resource.getMetadata.getResourceType.getValue))
+      .workspaceId(resource.getMetadata.getWorkspaceId)
+      .reference(new DataRepoSnapshot().instanceName(resource.getAttributes.getInstanceName).snapshot(resource.getAttributes.getSnapshot))
+      .cloningInstructions(resource.getMetadata.getCloningInstructions)
+  }
+
+  private def resourceListToDataReferenceList(refList: ResourceList): DataReferenceList= {
+    import scala.collection.JavaConverters._
+    val resources = refList.getResources.asScala.map{ res =>
+      new DataReferenceDescription()
+        .name(res.getMetadata.getName)
+        .description(res.getMetadata.getDescription)
+        .referenceId(res.getMetadata.getResourceId)
+        .referenceType(ReferenceTypeEnum.fromValue(res.getMetadata.getResourceType.getValue))
+        .workspaceId(res.getMetadata.getWorkspaceId)
+        .reference(new DataRepoSnapshot().instanceName(res.getResourceAttributes.getGcpDataRepoSnapshot.getInstanceName).snapshot(res.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot))
+        .cloningInstructions(res.getMetadata.getCloningInstructions)
+    }.asJava
+    new DataReferenceList().resources(resources)
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -19,7 +19,7 @@ trait SnapshotApiService extends UserInfoDirectives {
   val snapshotServiceConstructor: UserInfo => SnapshotService
 
   val snapshotRoutes: server.Route = requireUserInfo() { userInfo =>
-    path("workspaces" /  Segment / Segment / "v2" / "snapshots") { (workspaceNamespace, workspaceName) =>
+    path("workspaces" /  Segment / Segment / "snapshots" / "v2") { (workspaceNamespace, workspaceName) =>
       post {
         entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
           complete {
@@ -35,7 +35,7 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       }
     } ~
-    path("workspaces" / Segment / Segment / "v2" / "snapshots" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
+    path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
       get {
         complete {
           snapshotServiceConstructor(userInfo).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(StatusCodes.OK -> _)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -99,7 +99,7 @@ trait SnapshotApiService extends UserInfoDirectives {
       }
     }
   }
-  
+
   // -------  REMOVE WHEN GETTING RID OF V1 SNAPSHOT ENDPOINTS -------
 
   private def dataRepoSnapshotResourceToDataReferenceDescription(resource: DataRepoSnapshotResource): DataReferenceDescription = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -19,7 +19,7 @@ trait SnapshotApiService extends UserInfoDirectives {
   val snapshotServiceConstructor: UserInfo => SnapshotService
 
   val snapshotRoutes: server.Route = requireUserInfo() { userInfo =>
-    path("workspaces" / "v2" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
+    path("workspaces" /  Segment / Segment / "v2" / "snapshots") { (workspaceNamespace, workspaceName) =>
       post {
         entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
           complete {
@@ -27,36 +27,33 @@ trait SnapshotApiService extends UserInfoDirectives {
           }
         }
       } ~
-        get {
-          parameters("offset".as[Int], "limit".as[Int]) { (offset, limit) =>
-            complete {
-              snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit).map(StatusCodes.OK -> _)
-            }
+      get {
+        parameters("offset".as[Int], "limit".as[Int]) { (offset, limit) =>
+          complete {
+            snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit).map(StatusCodes.OK -> _)
           }
         }
+      }
     } ~
-    path("workspaces" / "v2" / Segment / Segment / "snapshots" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
+    path("workspaces" / Segment / Segment / "v2" / "snapshots" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
       get {
         complete {
           snapshotServiceConstructor(userInfo).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(StatusCodes.OK -> _)
         }
       } ~
-        patch {
-          entity(as[UpdateDataReferenceRequestBody]) { updateDataReferenceRequestBody =>
-            complete {
-              snapshotServiceConstructor(userInfo).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataReferenceRequestBody).map(_ => StatusCodes.NoContent)
-            }
-          }
-        } ~
-        delete {
+      patch {
+        entity(as[UpdateDataReferenceRequestBody]) { updateDataReferenceRequestBody =>
           complete {
-            snapshotServiceConstructor(userInfo).deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(_ => StatusCodes.NoContent)
+            snapshotServiceConstructor(userInfo).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataReferenceRequestBody).map(_ => StatusCodes.NoContent)
           }
         }
-    }
-
-    // -------  V1 SNAPSHOT ENDPOINTS -------
-
+      } ~
+      delete {
+        complete {
+          snapshotServiceConstructor(userInfo).deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(_ => StatusCodes.NoContent)
+        }
+      }
+    } ~
     path("workspaces" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
       post {
         entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
-import bio.terra.workspace.model.{DataReferenceDescription, DataReferenceList, DataRepoSnapshot, DataRepoSnapshotResource, ReferenceTypeEnum, ResourceDescription, ResourceList, ResourceMetadata, UpdateDataReferenceRequestBody}
+import bio.terra.workspace.model.{DataReferenceDescription, DataReferenceList, DataRepoSnapshot, DataRepoSnapshotResource, ReferenceTypeEnum, ResourceList, UpdateDataReferenceRequestBody}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model.{NamedDataRepoSnapshot, UserInfo, WorkspaceName}
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
@@ -54,6 +54,7 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       }
     } ~
+    // ---- SNAPSHOT V1 ----
     path("workspaces" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
       post {
         entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
@@ -58,7 +58,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
 
   it should "bubble up lookupSnapshotForName error" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRefDescription(referenceType = null)))
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(resourceType = null)))
     )
 
     val ex = intercept[DataEntityException] { builder.build(defaultEntityRequestArguments).get }
@@ -83,7 +83,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
 
   it should "error if workspace manager returns a non-snapshot reference type" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRefDescription(referenceType = null)))
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(resourceType = null)))
     )
 
     val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
@@ -92,7 +92,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
 
   it should "error if workspace manager reference json `instanceName` value does not match DataRepoDAO's base url" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRefDescription(refInstanceName = "this is wrong")))
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(refInstanceName = "this is wrong")))
     )
 
     val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
@@ -101,7 +101,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
 
   it should "error if workspace manager reference json `snapshot` value is not a valid UUID" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRefDescription(refSnapshot = "this is not a uuid")))
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(refSnapshot = "this is not a uuid")))
     )
 
     val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.datarepo.model.{ColumnModel, RelationshipModel, SnapshotModel, TableModel}
-import bio.terra.workspace.model.{CloningInstructionsEnum, CloudPlatform, DataReferenceDescription, DataRepoSnapshot, DataRepoSnapshotAttributes, DataRepoSnapshotResource, ReferenceTypeEnum, ResourceMetadata, ResourceType}
+import bio.terra.workspace.model.{CloningInstructionsEnum, CloudPlatform, DataRepoSnapshotAttributes, DataRepoSnapshotResource, ResourceMetadata, ResourceType}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO, SlickDataSource}
@@ -59,7 +59,7 @@ trait DataRepoEntityProviderSpecSupport {
   }
 
 
-  /* A "factory" method to create DataReferenceDescription objects, with defaults.
+  /* A "factory" method to create DataRepoSnapshotResource objects, with defaults.
    * Allows callers to only specify the arguments they want to override.
    */
   def createDataRepoSnapshotResource(name: String = "refName",
@@ -140,7 +140,6 @@ trait DataRepoEntityProviderSpecSupport {
 
   /**
    * Mock for DataRepoDAO that allows the caller to specify behavior for the getSnapshot and getBaseURL methods.
-   *  method.
    */
   class SpecSamDAO(dataSource: SlickDataSource = slickDataSource,
                    petKeyForUserResponse: Either[Throwable, String]) extends MockSamDAO(dataSource) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -1121,14 +1121,12 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     when(dataRepoDAO.getInstanceName).thenReturn("dataRepoInstance")
 
     val dataReferenceName = DataReferenceName("dataref")
-    val dataReferenceDescription = "description"
+    val dataReferenceDescription = DataReferenceDescriptionField("description")
 
     val methodConfig = MethodConfiguration("dsde", "DataRepoMethodConfig", Some(tableName), prerequisites = None, inputs = Map("three_step.cgrep.pattern" -> AttributeString(s"this.$columnName")), outputs = Map.empty, AgoraMethod("dsde", "three_step", 1), dataReferenceName = Option(dataReferenceName))
 
     withDataAndService({ workspaceService =>
-      val metadata = new ReferenceResourceCommonFields().name(dataReferenceName.value).description(dataReferenceDescription).cloningInstructions(CloningInstructionsEnum.NOTHING)
-      val attributes = new DataRepoSnapshotAttributes().snapshot(snapshotUUID.toString).instanceName(dataRepoDAO.getInstanceName)
-      workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(minimalTestData.workspace.workspaceIdAsUUID, metadata, attributes, userInfo.accessToken )
+      workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(minimalTestData.workspace.workspaceIdAsUUID, snapshotUUID, dataReferenceName, Option(dataReferenceDescription), dataRepoDAO.getInstanceName, CloningInstructionsEnum.NOTHING, userInfo.accessToken )
       runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig))
       test(workspaceService, methodConfig, snapshotUUID)
     }, withMinimalTestDatabase[Any], bigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)), dataRepoDAO = dataRepoDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import bio.terra.datarepo.model.{ColumnModel, TableModel}
-import bio.terra.workspace.model.{CloningInstructionsEnum, DataRepoSnapshot, ReferenceTypeEnum}
+import bio.terra.workspace.model.{CloningInstructionsEnum, DataRepoSnapshot, DataRepoSnapshotAttributes, ReferenceResourceCommonFields, ReferenceTypeEnum}
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, LegacySQLTypeName, Schema, TableResult}
 import com.typesafe.config.ConfigFactory
@@ -1121,12 +1121,14 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     when(dataRepoDAO.getInstanceName).thenReturn("dataRepoInstance")
 
     val dataReferenceName = DataReferenceName("dataref")
-    val dataReferenceDescription = Option(DataReferenceDescriptionField("description"))
+    val dataReferenceDescription = "description"
 
     val methodConfig = MethodConfiguration("dsde", "DataRepoMethodConfig", Some(tableName), prerequisites = None, inputs = Map("three_step.cgrep.pattern" -> AttributeString(s"this.$columnName")), outputs = Map.empty, AgoraMethod("dsde", "three_step", 1), dataReferenceName = Option(dataReferenceName))
 
     withDataAndService({ workspaceService =>
-      workspaceService.workspaceManagerDAO.createDataReference(minimalTestData.workspace.workspaceIdAsUUID, dataReferenceName, dataReferenceDescription, ReferenceTypeEnum.DATA_REPO_SNAPSHOT, new DataRepoSnapshot().instanceName(dataRepoDAO.getInstanceName).snapshot(snapshotUUID.toString), CloningInstructionsEnum.NOTHING, userInfo.accessToken)
+      val metadata = new ReferenceResourceCommonFields().name(dataReferenceName.value).description(dataReferenceDescription).cloningInstructions(CloningInstructionsEnum.NOTHING)
+      val attributes = new DataRepoSnapshotAttributes().snapshot(snapshotUUID.toString).instanceName(dataRepoDAO.getInstanceName)
+      workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(minimalTestData.workspace.workspaceIdAsUUID, metadata, attributes, userInfo.accessToken )
       runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig))
       test(workspaceService, methodConfig, snapshotUUID)
     }, withMinimalTestDatabase[Any], bigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)), dataRepoDAO = dataRepoDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -1121,12 +1121,12 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     when(dataRepoDAO.getInstanceName).thenReturn("dataRepoInstance")
 
     val dataReferenceName = DataReferenceName("dataref")
-    val dataReferenceDescription = DataReferenceDescriptionField("description")
+    val dataReferenceDescription = Option(DataReferenceDescriptionField("description"))
 
     val methodConfig = MethodConfiguration("dsde", "DataRepoMethodConfig", Some(tableName), prerequisites = None, inputs = Map("three_step.cgrep.pattern" -> AttributeString(s"this.$columnName")), outputs = Map.empty, AgoraMethod("dsde", "three_step", 1), dataReferenceName = Option(dataReferenceName))
 
     withDataAndService({ workspaceService =>
-      workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(minimalTestData.workspace.workspaceIdAsUUID, snapshotUUID, dataReferenceName, Option(dataReferenceDescription), dataRepoDAO.getInstanceName, CloningInstructionsEnum.NOTHING, userInfo.accessToken )
+      workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(minimalTestData.workspace.workspaceIdAsUUID, snapshotUUID, dataReferenceName, dataReferenceDescription, dataRepoDAO.getInstanceName, CloningInstructionsEnum.NOTHING, userInfo.accessToken )
       runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig))
       test(workspaceService, methodConfig, snapshotUUID)
     }, withMinimalTestDatabase[Any], bigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)), dataRepoDAO = dataRepoDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -30,8 +30,8 @@ class MockWorkspaceManagerDAO extends WorkspaceManagerDAO {
 
   override def deleteWorkspace(workspaceId: UUID, accessToken: OAuth2BearerToken): Unit = ()
 
-  override def createDataReference(workspaceId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], referenceType: ReferenceTypeEnum, reference: DataRepoSnapshot, cloningInstructions: CloningInstructionsEnum, accessToken: OAuth2BearerToken): DataReferenceDescription = {
-    if(reference.toString.contains("fakesnapshot"))
+  def createDataRepoSnapshotReference(workspaceId: UUID, metadata: ReferenceResourceCommonFields, attributes: DataRepoSnapshotAttributes, accessToken: OAuth2BearerToken): DataRepoSnapshotResource = {
+    if(attributes.getSnapshot.contains("fakesnapshot"))
       throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "Not found"))
     else {
       val newId = UUID.randomUUID()
@@ -41,6 +41,7 @@ class MockWorkspaceManagerDAO extends WorkspaceManagerDAO {
       mockReferenceResponse(workspaceId, newId)
     }
   }
+
 
   override def getDataReference(workspaceId: UUID, referenceId: UUID, accessToken: OAuth2BearerToken): DataReferenceDescription = {
     mockReferenceResponse(workspaceId, referenceId)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -2,17 +2,14 @@ package org.broadinstitute.dsde.rawls.snapshot
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.{CloningInstructionsEnum, DataReferenceDescription, DataReferenceMetadata, DataReferenceRequestMetadata, DataRepoSnapshot, DataRepoSnapshotAttributes, DataRepoSnapshotResource, GcpBigQueryDatasetAttributes, GcpBigQueryDatasetResource, ReferenceResourceCommonFields, ReferenceTypeEnum, ResourceMetadata}
-import cats.effect.{IO, Resource}
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import bio.terra.workspace.model.{CloningInstructionsEnum, DataRepoSnapshotAttributes, DataRepoSnapshotResource, GcpBigQueryDatasetAttributes, GcpBigQueryDatasetResource, ReferenceResourceCommonFields, ResourceMetadata}
+import cats.effect.IO
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, doThrow, times, verify, when}
-import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, ErrorReport, GoogleProjectId, NamedDataRepoSnapshot, SamPolicy, SamPolicyWithNameAndEmail, SamResourceAction, SamResourceTypeName, SamResourceTypeNames, SamWorkspacePolicyNames, UserInfo}
-import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, times, verify, when}
+import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, GoogleProjectId, NamedDataRepoSnapshot, SamPolicy, SamPolicyWithNameAndEmail, SamResourceAction, SamResourceTypeName, SamResourceTypeNames, SamWorkspacePolicyNames, UserInfo}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.mockito.ArgumentMatchers

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.snapshot
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.{BigQueryDatasetReference, CloningInstructionsEnum, DataReferenceDescription, DataReferenceMetadata, DataReferenceRequestMetadata, DataRepoSnapshot, GoogleBigQueryDatasetUid, ReferenceTypeEnum}
+import bio.terra.workspace.model.{CloningInstructionsEnum, DataReferenceDescription, DataReferenceMetadata, DataReferenceRequestMetadata, DataRepoSnapshot, DataRepoSnapshotAttributes, DataRepoSnapshotResource, GcpBigQueryDatasetAttributes, GcpBigQueryDatasetResource, ReferenceResourceCommonFields, ReferenceTypeEnum, ResourceMetadata}
 import cats.effect.{IO, Resource}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO}
@@ -20,8 +20,8 @@ import org.mockito.ArgumentMatchers.any
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
-
 import java.util.UUID
+
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration.Duration
@@ -48,7 +48,8 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockBigQueryServiceFactory.getServiceFromCredentialPath(any[String], any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
-      when(mockWorkspaceManagerDAO.createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])).thenReturn(new DataReferenceDescription().referenceId(UUID.randomUUID()).name("foo").description("").workspaceId(UUID.randomUUID()).cloningInstructions(CloningInstructionsEnum.NOTHING))
+      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
+        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
 
       val workspace = minimalTestData.workspace
 
@@ -63,12 +64,12 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         fakeDeltaLayerStreamerEmail
       )(userInfo)
 
-      Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), "bar")), Duration.Inf)
+      Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(1)).getServiceFromCredentialPath(fakeCredentialPath, GoogleProject(workspace.namespace))
-      verify(mockWorkspaceManagerDAO, times(1)).createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[DataReferenceRequestMetadata], any[GoogleBigQueryDatasetUid], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
 
     "not leave an orphaned bq dataset if creating a snapshot reference fails" in withMinimalTestDatabase { dataSource =>
@@ -85,7 +86,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
-      when(mockWorkspaceManagerDAO.createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])).thenThrow(new RuntimeException("oh no!"))
+      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])).thenThrow(new RuntimeException("oh no!"))
 
       val workspace = minimalTestData.workspace
 
@@ -101,14 +102,14 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )(userInfo)
 
       val createException = intercept[RuntimeException] {
-        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), "bar")), Duration.Inf)
+        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
       }
       createException.getMessage shouldBe "oh no!"
 
       verify(mockSamDAO, times(0)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(0)).getServiceFromCredentialPath(fakeCredentialPath, GoogleProject(workspace.namespace))
-      verify(mockWorkspaceManagerDAO, times(1)).createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[DataReferenceRequestMetadata], any[GoogleBigQueryDatasetUid], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
 
     "not leave an orphaned snapshot data reference if creating a BQ dataset in Google fails" in withMinimalTestDatabase { dataSource =>
@@ -125,7 +126,8 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
-      when(mockWorkspaceManagerDAO.createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])).thenReturn(new DataReferenceDescription().referenceId(UUID.randomUUID()).name("foo").description("").workspaceId(UUID.randomUUID()).cloningInstructions(CloningInstructionsEnum.NOTHING))
+      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
+        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
 
       val workspace = minimalTestData.workspace
 
@@ -141,16 +143,16 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )(userInfo)
 
       val createException = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), "bar")), Duration.Inf)
+        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
       }
       createException.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
       assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(1)).getServiceFromCredentialPath(fakeCredentialPath, GoogleProject(workspace.namespace))
-      verify(mockWorkspaceManagerDAO, times(1)).createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataReference(any[UUID], any[UUID], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[DataReferenceRequestMetadata], any[GoogleBigQueryDatasetUid], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
 
     "not leave an orphaned snapshot data reference nor an orphaned BQ dataset if creating a BQ data reference in WSM fails" in withMinimalTestDatabase { dataSource =>
@@ -167,8 +169,10 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
-      when(mockWorkspaceManagerDAO.createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])).thenReturn(new DataReferenceDescription().referenceId(UUID.randomUUID()).name("foo").description("").workspaceId(UUID.randomUUID()).cloningInstructions(CloningInstructionsEnum.NOTHING))
-      when(mockWorkspaceManagerDAO.createBigQueryDatasetReference(any[UUID], any[DataReferenceRequestMetadata], any[GoogleBigQueryDatasetUid], any[OAuth2BearerToken])).thenThrow(new RuntimeException)
+      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
+        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
+
+      when(mockWorkspaceManagerDAO.createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])).thenThrow(new RuntimeException)
 
       val workspace = minimalTestData.workspace
 
@@ -184,16 +188,16 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )(userInfo)
 
       val createException = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), "bar")), Duration.Inf)
+        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
       }
       createException.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
       assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(2)).getServiceFromCredentialPath(fakeCredentialPath, GoogleProject(workspace.namespace))
-      verify(mockWorkspaceManagerDAO, times(1)).createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataReference(any[UUID], any[UUID], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[DataReferenceRequestMetadata], any[GoogleBigQueryDatasetUid], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
 
     "not leave an orphaned snapshot data reference nor an orphaned BQ dataset if getting a pet token from Sam fails" in withMinimalTestDatabase { dataSource =>
@@ -210,7 +214,8 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
-      when(mockWorkspaceManagerDAO.createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])).thenReturn(new DataReferenceDescription().referenceId(UUID.randomUUID()).name("foo").description("").workspaceId(UUID.randomUUID()).cloningInstructions(CloningInstructionsEnum.NOTHING))
+      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
+        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
 
       val workspace = minimalTestData.workspace
 
@@ -226,16 +231,16 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )(userInfo)
 
       val createException = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), "bar")), Duration.Inf)
+        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
       }
       createException.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
       assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(2)).getServiceFromCredentialPath(fakeCredentialPath, GoogleProject(workspace.namespace))
-      verify(mockWorkspaceManagerDAO, times(1)).createDataReference(any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[ReferenceTypeEnum], any[DataRepoSnapshot], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataReference(any[UUID], any[UUID], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[DataReferenceRequestMetadata], any[GoogleBigQueryDatasetUid], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
 
     "remove all resources when a snapshot reference is deleted" in withMinimalTestDatabase { dataSource =>
@@ -249,9 +254,12 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
       val snapshotDataReferenceId = UUID.randomUUID()
-      when(mockWorkspaceManagerDAO.getDataReference(any[UUID], any[UUID], any[OAuth2BearerToken])).thenReturn(new DataReferenceDescription().referenceId(snapshotDataReferenceId).name("foo").description("").workspaceId(UUID.randomUUID()).cloningInstructions(CloningInstructionsEnum.NOTHING))
+      when(mockWorkspaceManagerDAO.getDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken]))
+        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(snapshotDataReferenceId).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
 
-      when(mockWorkspaceManagerDAO.getBigQueryDatasetReferenceByName(any[UUID], any[String], any[OAuth2BearerToken])).thenReturn(new BigQueryDatasetReference().metadata(new DataReferenceMetadata().referenceId(UUID.randomUUID())).dataset(new GoogleBigQueryDatasetUid))
+      when(mockWorkspaceManagerDAO.getBigQueryDatasetReferenceByName(any[UUID], any[String], any[OAuth2BearerToken]))
+        //.thenReturn(new BigQueryDatasetReference().metadata(new DataReferenceMetadata().referenceId(UUID.randomUUID())).dataset(new GoogleBigQueryDatasetUid))
+        .thenReturn(new GcpBigQueryDatasetResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID())).attributes(new GcpBigQueryDatasetAttributes()))
 
       val workspace = minimalTestData.workspace
 
@@ -272,8 +280,8 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       Await.result(snapshotService.deleteSnapshot(workspace.toWorkspaceName, snapshotUUID.toString), Duration.Inf)
 
-      verify(mockWorkspaceManagerDAO, times(1)).getDataReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID),any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID), any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).getDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID),any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID), any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).getBigQueryDatasetReferenceByName(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(deltaLayerDatasetName), any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteBigQueryDatasetReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), any[UUID], any[OAuth2BearerToken])
       verify(mockBigQueryServiceFactory, times(1)).getServiceFromCredentialPath(any[String], any[GoogleProject])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -126,7 +126,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 when creating a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices { services =>
-    Post("/workspaces/foo/bar/v2/snapshots", defaultNamedSnapshotJson) ~>
+    Post("/workspaces/foo/bar/snapshots/v2", defaultNamedSnapshotJson) ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -175,7 +175,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 when getting a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices { services =>
-    Get(s"/workspaces/foo/bar/v2/snapshots/${UUID.randomUUID().toString}") ~>
+    Get(s"/workspaces/foo/bar/snapshots/v2/${UUID.randomUUID().toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -267,7 +267,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 when a user lists references in a workspace that doesn't exist" in withTestDataApiServicesAndUser(testData.userReader.userEmail.value) { services =>
-    Get("/workspaces/test/value/v2/snapshots?offset=0&limit=10") ~>
+    Get("/workspaces/test/value/snapshots/v2?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -279,7 +279,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "return 200 and empty list when a user lists all snapshots in a workspace that exists in Rawls but not Workspace Manager" in withTestDataApiServices { services =>
     // We hijack the "workspaceTerminatedSubmissions" workspace in the shared testData to represent
     // a workspace that exists in Rawls but returns 404 from Workspace Manager.
-    Get(s"${testData.workspaceTerminatedSubmissions.path}/v2/snapshots?offset=0&limit=10") ~>
+    Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots/v2?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
         val response = responseAs[ResourceList]
@@ -293,7 +293,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
   it should "bubble up non-404 errors from Workspace Manager" in withTestDataApiServices { services =>
     // We hijack the "workspaceSubmittedSubmission" workspace in the shared testData to represent
     // a workspace that throws a 418 error.
-    Get(s"${testData.workspaceSubmittedSubmission.path}/v2/snapshots?offset=0&limit=10") ~>
+    Get(s"${testData.workspaceSubmittedSubmission.path}/snapshots/v2?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
         assertResult(StatusCodes.ImATeapot) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   val baseSnapshotsPath = s"${testData.wsName.path}/snapshots"
-  val v2BaseSnapshotsPath = s"${testData.wsName.path}/v2/snapshots"
+  val v2BaseSnapshotsPath = s"${testData.wsName.path}/snapshots/v2"
 
   val defaultNamedSnapshotJson = httpJson(NamedDataRepoSnapshot(
     name = DataReferenceName("foo"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotV2ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotV2ApiServiceSpec.scala
@@ -1,5 +1,0 @@
-package org.broadinstitute.dsde.rawls.webservice
-
-class SnapshotV2ApiServiceSpec {
-
-}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotV2ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotV2ApiServiceSpec.scala
@@ -1,0 +1,5 @@
+package org.broadinstitute.dsde.rawls.webservice
+
+class SnapshotV2ApiServiceSpec {
+
+}

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -26,7 +26,7 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     val RESOURCE_ID = "resourceId"
     val NAME = "name"
     val DESCRIPTION = "description"
-    val RESOURCE_TYPE = "referenceType"
+    val RESOURCE_TYPE = "resourceType"
     val STEWARDSHIP_TYPE = "stewardshipType"
     val CLONING_INSTRUCTIONS = "cloningInstructions"
 
@@ -74,7 +74,6 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     }
   }
 
-  // Only handling supported fields for now, resourceDescription and credentialId aren't used currently
   implicit object DataRepoSnapshotResourceFormat extends RootJsonFormat[DataRepoSnapshotResource] {
     val METADATA = "metadata"
     val ATTRIBUTES = "attributes"

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -121,6 +121,7 @@ object DataReferenceModelJsonSupport extends JsonSupport {
             .resourceType(ResourceType.fromValue(resourceType))
             .stewardshipType(StewardshipType.fromValue(stewardshipType))
             .cloningInstructions(CloningInstructionsEnum.fromValue(cloningInstructions))
+        case _ => throw DeserializationException("ResourceMetadata expected")
       }
     }
   }
@@ -140,6 +141,7 @@ object DataReferenceModelJsonSupport extends JsonSupport {
           new DataRepoSnapshotAttributes()
             .instanceName(instanceName)
             .snapshot(snapshot)
+        case _ => throw DeserializationException("DataRepoSnapshotAttributes expected")
       }
     }
   }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -20,6 +20,76 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     case Some(notStr) => JsString(notStr.toString)
   }
 
+  implicit object DataRepoSnapshotFormat extends RootJsonFormat[DataRepoSnapshot] {
+    val INSTANCE_NAME = "instanceName"
+    val SNAPSHOT = "snapshot"
+
+    override def write(snap: DataRepoSnapshot) = JsObject(
+      INSTANCE_NAME -> stringOrNull(snap.getInstanceName),
+      SNAPSHOT -> stringOrNull(snap.getSnapshot)
+    )
+
+    override def read(json: JsValue) = {
+      json.asJsObject.getFields(INSTANCE_NAME, SNAPSHOT) match {
+        case Seq(JsString(instanceName), JsString(snapshot)) =>
+          new DataRepoSnapshot().instanceName(instanceName).snapshot(snapshot)
+        case _ => throw DeserializationException("DataRepoSnapshot expected")
+      }
+    }
+  }
+
+  // Only handling supported fields for now, resourceDescription and credentialId aren't used currently
+  implicit object DataReferenceDescriptionFormat extends RootJsonFormat[DataReferenceDescription] {
+    val REFERENCE_ID = "referenceId"
+    val NAME = "name"
+    val DESCRIPTION = "description"
+    val WORKSPACE_ID = "workspaceId"
+    val REFERENCE_TYPE = "referenceType"
+    val REFERENCE = "reference"
+    val CLONING_INSTRUCTIONS = "cloningInstructions"
+
+    override def write(description: DataReferenceDescription) = JsObject(
+      REFERENCE_ID -> stringOrNull(description.getReferenceId),
+      NAME -> stringOrNull(description.getName),
+      DESCRIPTION -> stringOrNull(description.getDescription),
+      WORKSPACE_ID -> stringOrNull(description.getWorkspaceId),
+      REFERENCE_TYPE -> stringOrNull(description.getReferenceType),
+      REFERENCE -> description.getReference.toJson,
+      CLONING_INSTRUCTIONS -> stringOrNull(description.getCloningInstructions)
+    )
+
+    override def read(json: JsValue): DataReferenceDescription = {
+      json.asJsObject.getFields(REFERENCE_ID, NAME, DESCRIPTION, WORKSPACE_ID, REFERENCE_TYPE, REFERENCE, CLONING_INSTRUCTIONS) match {
+        case Seq(referenceId, JsString(name), JsString(description), workspaceId, JsString(referenceType), reference, JsString(cloningInstructions)) =>
+          new DataReferenceDescription()
+            .referenceId(referenceId.convertTo[UUID])
+            .name(name)
+            .description(description)
+            .workspaceId(workspaceId.convertTo[UUID])
+            .referenceType(ReferenceTypeEnum.fromValue(referenceType))
+            .reference(reference.convertTo[DataRepoSnapshot])
+            .cloningInstructions(CloningInstructionsEnum.fromValue(cloningInstructions))
+        case _ => throw DeserializationException("DataReferenceDescription expected")
+      }
+    }
+  }
+
+  implicit object DataReferenceListFormat extends RootJsonFormat[DataReferenceList] {
+    val RESOURCES = "resources"
+
+    override def write(refList: DataReferenceList) = JsObject(
+      RESOURCES -> refList.getResources.asScala.toList.toJson
+    )
+
+    override def read(json: JsValue): DataReferenceList = {
+      json.asJsObject.getFields(RESOURCES) match {
+        case Seq(JsArray(resources)) =>
+          new DataReferenceList().resources(resources.map(_.convertTo[DataReferenceDescription]).asJava)
+        case _ => throw DeserializationException("DataReferenceList expected")
+      }
+    }
+  }
+
 
   implicit object ResourceMetadataFormat extends RootJsonFormat[ResourceMetadata] {
     val WORKSPACE_ID = "workspaceId"
@@ -179,6 +249,8 @@ object DataReferenceModelJsonSupport extends JsonSupport {
       }
     }
   }
+
+
 
 
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.model
 
 import java.util.UUID
 
-import bio.terra.workspace.model._
+import bio.terra.workspace.model.{ResourceMetadata, _}
 import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat}
 import spray.json.DefaultJsonProtocol._
 import spray.json.{DeserializationException, JsArray, JsNull, JsObject, JsString, JsValue, RootJsonFormat, enrichAny}
@@ -20,56 +20,78 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     case Some(notStr) => JsString(notStr.toString)
   }
 
-  implicit object DataRepoSnapshotFormat extends RootJsonFormat[DataRepoSnapshot] {
+
+  implicit object ResourceMetadataFormat extends RootJsonFormat[ResourceMetadata] {
+    val WORKSPACE_ID = "workspaceId"
+    val RESOURCE_ID = "resourceId"
+    val NAME = "name"
+    val DESCRIPTION = "description"
+    val RESOURCE_TYPE = "referenceType"
+    val STEWARDSHIP_TYPE = "stewardshipType"
+    val CLONING_INSTRUCTIONS = "cloningInstructions"
+
+    override def write(metadata: ResourceMetadata)= JsObject(
+      WORKSPACE_ID -> stringOrNull(metadata.getWorkspaceId),
+      RESOURCE_ID -> stringOrNull(metadata.getResourceId),
+      NAME -> stringOrNull(metadata.getName),
+      DESCRIPTION -> stringOrNull(metadata.getDescription),
+      RESOURCE_TYPE -> stringOrNull(metadata.getResourceType),
+      STEWARDSHIP_TYPE -> stringOrNull(metadata.getStewardshipType),
+      CLONING_INSTRUCTIONS -> stringOrNull(metadata.getCloningInstructions)
+    )
+
+    override def read(json: JsValue): ResourceMetadata = {
+      json.asJsObject.getFields(WORKSPACE_ID, RESOURCE_ID, NAME, DESCRIPTION, RESOURCE_TYPE, STEWARDSHIP_TYPE, CLONING_INSTRUCTIONS) match {
+        case Seq(workspaceId, resourceId, JsString(name), JsString(description), JsString(resourceType), JsString(stewardshipType), JsString(cloningInstructions)) =>
+          new ResourceMetadata()
+            .workspaceId(workspaceId.convertTo[UUID])
+            .resourceId(resourceId.convertTo[UUID])
+            .name(name)
+            .description(description)
+            .resourceType(ResourceType.fromValue(resourceType))
+            .stewardshipType(StewardshipType.fromValue(stewardshipType))
+            .cloningInstructions(CloningInstructionsEnum.fromValue(cloningInstructions))
+      }
+    }
+  }
+
+  implicit object DataRepoSnapshotAttributesFormat extends RootJsonFormat[DataRepoSnapshotAttributes] {
     val INSTANCE_NAME = "instanceName"
     val SNAPSHOT = "snapshot"
 
-    override def write(snap: DataRepoSnapshot) = JsObject(
-      INSTANCE_NAME -> stringOrNull(snap.getInstanceName),
-      SNAPSHOT -> stringOrNull(snap.getSnapshot)
+    override def write(attributes: DataRepoSnapshotAttributes) = JsObject(
+      INSTANCE_NAME -> stringOrNull(attributes.getInstanceName),
+      SNAPSHOT -> stringOrNull(attributes.getSnapshot)
     )
 
-    override def read(json: JsValue) = {
-      json.asJsObject.getFields(INSTANCE_NAME, SNAPSHOT) match {
+    override def read(json: JsValue): DataRepoSnapshotAttributes = {
+      json.asJsObject.getFields() match {
         case Seq(JsString(instanceName), JsString(snapshot)) =>
-          new DataRepoSnapshot().instanceName(instanceName).snapshot(snapshot)
-        case _ => throw DeserializationException("DataRepoSnapshot expected")
+          new DataRepoSnapshotAttributes()
+            .instanceName(instanceName)
+            .snapshot(snapshot)
       }
     }
   }
 
   // Only handling supported fields for now, resourceDescription and credentialId aren't used currently
-  implicit object DataReferenceDescriptionFormat extends RootJsonFormat[DataReferenceDescription] {
-    val REFERENCE_ID = "referenceId"
-    val NAME = "name"
-    val DESCRIPTION = "description"
-    val WORKSPACE_ID = "workspaceId"
-    val REFERENCE_TYPE = "referenceType"
-    val REFERENCE = "reference"
-    val CLONING_INSTRUCTIONS = "cloningInstructions"
+  implicit object DataRepoSnapshotResourceFormat extends RootJsonFormat[DataRepoSnapshotResource] {
+    val METADATA = "referenceId"
+    val ATTRIBUTES = "name"
 
-    override def write(description: DataReferenceDescription) = JsObject(
-      REFERENCE_ID -> stringOrNull(description.getReferenceId),
-      NAME -> stringOrNull(description.getName),
-      DESCRIPTION -> stringOrNull(description.getDescription),
-      WORKSPACE_ID -> stringOrNull(description.getWorkspaceId),
-      REFERENCE_TYPE -> stringOrNull(description.getReferenceType),
-      REFERENCE -> description.getReference.toJson,
-      CLONING_INSTRUCTIONS -> stringOrNull(description.getCloningInstructions)
+
+    override def write(resource: DataRepoSnapshotResource) = JsObject(
+      METADATA -> ResourceMetadataFormat.write(resource.getMetadata),
+      ATTRIBUTES -> DataRepoSnapshotAttributesFormat.write(resource.getAttributes)
     )
 
-    override def read(json: JsValue): DataReferenceDescription = {
-      json.asJsObject.getFields(REFERENCE_ID, NAME, DESCRIPTION, WORKSPACE_ID, REFERENCE_TYPE, REFERENCE, CLONING_INSTRUCTIONS) match {
-        case Seq(referenceId, JsString(name), JsString(description), workspaceId, JsString(referenceType), reference, JsString(cloningInstructions)) =>
-          new DataReferenceDescription()
-            .referenceId(referenceId.convertTo[UUID])
-            .name(name)
-            .description(description)
-            .workspaceId(workspaceId.convertTo[UUID])
-            .referenceType(ReferenceTypeEnum.fromValue(referenceType))
-            .reference(reference.convertTo[DataRepoSnapshot])
-            .cloningInstructions(CloningInstructionsEnum.fromValue(cloningInstructions))
-        case _ => throw DeserializationException("DataReferenceDescription expected")
+    override def read(json: JsValue): DataRepoSnapshotResource = {
+      json.asJsObject.getFields() match {
+        case Seq(metadata @ JsObject(_), attributes @ JsObject(_)) =>
+          new DataRepoSnapshotResource()
+            .metadata(metadata.convertTo[ResourceMetadata])
+            .attributes(attributes.convertTo[DataRepoSnapshotAttributes])
+        case _ => throw DeserializationException("DataRepoSnapshotResource expected")
       }
     }
   }
@@ -106,21 +128,59 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     }
   }
 
-  implicit object DataReferenceListFormat extends RootJsonFormat[DataReferenceList] {
-    val RESOURCES = "resources"
 
-    override def write(refList: DataReferenceList) = JsObject(
-      RESOURCES -> refList.getResources.asScala.toList.toJson
+  implicit object ResourceAttributesUnionFormat extends RootJsonFormat[ResourceAttributesUnion] {
+    val GCP_DATA_REPO_SNAPSHOT = "gcpDataRepoSnapshot"
+
+    override def write(attributesUnion: ResourceAttributesUnion) = JsObject(
+      GCP_DATA_REPO_SNAPSHOT -> DataRepoSnapshotAttributesFormat.write(attributesUnion.getGcpDataRepoSnapshot)
     )
 
-    override def read(json: JsValue): DataReferenceList = {
-      json.asJsObject.getFields(RESOURCES) match {
-        case Seq(JsArray(resources)) =>
-          new DataReferenceList().resources(resources.map(_.convertTo[DataReferenceDescription]).asJava)
-        case _ => throw DeserializationException("DataReferenceList expected")
+    override def read(json: JsValue): ResourceAttributesUnion = {
+      json.asJsObject.getFields(GCP_DATA_REPO_SNAPSHOT) match {
+        case Seq(gcpDataRepoSnapshot @ JsObject(_)) =>
+          new ResourceAttributesUnion().gcpDataRepoSnapshot(gcpDataRepoSnapshot.convertTo[DataRepoSnapshotAttributes])
+        case _ => throw DeserializationException("ResourceAttributesUnion expected")
       }
     }
   }
+
+  implicit object ResourceDescriptionFormat extends RootJsonFormat[ResourceDescription] {
+    val METADATA = "metadata"
+    val RESOURCE_ATTRIBUTES = "resourceAttributes"
+
+    override def write(description: ResourceDescription) = JsObject(
+      METADATA -> ResourceMetadataFormat.write(description.getMetadata),
+      RESOURCE_ATTRIBUTES -> ResourceAttributesUnionFormat.write(description.getResourceAttributes)
+    )
+
+    override def read(json: JsValue): ResourceDescription = {
+      json.asJsObject.getFields() match {
+        case Seq(metadata, resourceAttributes) =>
+          new ResourceDescription()
+            .metadata(metadata.convertTo[ResourceMetadata])
+            .resourceAttributes(resourceAttributes.convertTo[ResourceAttributesUnion])
+      }
+    }
+  }
+
+  implicit object ResourceListFormat extends RootJsonFormat[ResourceList] {
+    val RESOURCES = "resources"
+
+    override def write(refList: ResourceList) = JsObject(
+      RESOURCES -> refList.getResources.asScala.toList.toJson
+    )
+
+    override def read(json: JsValue): ResourceList = {
+      json.asJsObject.getFields(RESOURCES) match {
+        case Seq(JsArray(resources)) =>
+          new ResourceList().resources(resources.map(_.convertTo[ResourceDescription]).asJava)
+        case _ => throw DeserializationException("ResourceList expected")
+      }
+    }
+  }
+
+
 
   implicit val DataReferenceNameFormat = ValueObjectFormat(DataReferenceName)
   implicit val dataReferenceDescriptionFieldFormat = ValueObjectFormat(DataReferenceDescriptionField)

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -184,6 +184,57 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
         }
       }
 
+      "DataRepoSnapshotAttributes should fail with nulls" in {
+        val snapshotId = UUID.randomUUID()
+        assertThrows[DeserializationException] {
+          s"""{"instanceName": null, "snapshot": "$snapshotId"}""".parseJson.convertTo[DataRepoSnapshotAttributes]
+        }
+
+        assertThrows[DeserializationException] {
+          s"""{"instanceName": "fake-instance", "snapshot": null}""".parseJson.convertTo[DataRepoSnapshotAttributes]
+        }
+      }
+
+      "ResourceMetadata should fail with nulls" in {
+        val workspaceId = UUID.randomUUID()
+        val resourceId = UUID.randomUUID()
+        assertThrows[DeserializationException] {
+          s"""{ "workspaceId": "$workspaceId",
+                "resourceId": "resourceId",
+                "name": null,
+                "description": "this is my snapshot",
+                "resourceType": "DATA_REPO_SNAPSHOT",
+                "resourceId": "$resourceId",
+                "stewardshipType": "REFERENCED",
+                "cloningInstructions": "COPY_NOTHING"
+             }""".parseJson.convertTo[ResourceMetadata]
+        }
+      }
+
+      "ResourceMetadata should succeed with nulls on fields we are not translating" in {
+        val workspaceId = UUID.randomUUID()
+        val resourceId = UUID.randomUUID()
+        assertResult { s"""{ "workspaceId": "$workspaceId",
+                             "resourceId": "resourceId",
+                             "name": "mysnapshot",
+                             "description": "this is my snapshot",
+                             "resourceType": "DATA_REPO_SNAPSHOT",
+                             "resourceId": "$resourceId",
+                             "stewardshipType": "REFERENCED",
+                             "cloudPlatform": null,
+                             "cloningInstructions": "COPY_NOTHING" } """.parseJson.convertTo[ResourceMetadata]
+        } {
+          new ResourceMetadata()
+            .name("mysnapshot")
+            .description("this is my snapshot")
+            .resourceId(resourceId)
+            .resourceType(ResourceType.DATA_REPO_SNAPSHOT)
+            .stewardshipType(StewardshipType.REFERENCED)
+            .workspaceId(workspaceId)
+            .cloningInstructions(CloningInstructionsEnum.NOTHING)
+        }
+      }
+
       "UpdateDataReferenceRequestBody should work when updating name and description" in {
         assertResult { s"""{"name":"foo","description":"bar"}""".parseJson } {
           new UpdateDataReferenceRequestBody().name("foo").description("bar").toJson

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import bio.terra.workspace.model.CloningInstructionsEnum.NOTHING
 import bio.terra.workspace.model.ReferenceTypeEnum.DATA_REPO_SNAPSHOT
-import bio.terra.workspace.model.{DataReferenceDescription, DataReferenceList, DataRepoSnapshot, UpdateDataReferenceRequestBody}
+import bio.terra.workspace.model.{CloningInstructionsEnum, DataReferenceDescription, DataReferenceList, DataRepoSnapshot, DataRepoSnapshotAttributes, DataRepoSnapshotResource, GcpBigQueryDatasetAttributes, ResourceAttributesUnion, ResourceDescription, ResourceList, ResourceMetadata, ResourceType, StewardshipType, UpdateDataReferenceRequestBody}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import spray.json._
 
@@ -30,30 +30,133 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
 
     "JSON logic" - {
 
-//      "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
-//        val referenceId = UUID.randomUUID()
-//        val workspaceId = UUID.randomUUID()
-//        assertResult {
-//          s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
-//        } {
-//          new DataReferenceList().resources(ArrayBuffer(
-//            new DataReferenceDescription()
-//              .referenceId(referenceId)
-//              .name("test-ref")
-//              .description("test description")
-//              .workspaceId(workspaceId)
-//              .referenceType(DATA_REPO_SNAPSHOT)
-//              .reference(new DataRepoSnapshot().instanceName("test-instance").snapshot("test-snapshot"))
-//              .cloningInstructions(NOTHING)
-//          ).asJava).toJson
-//        }
-//      }
+      "DataRepoSnapshotResource, ResourceMetadata, DataRepoSnapshotAttributes" in {
+        val resourceId = UUID.randomUUID()
+        val workspaceId = UUID.randomUUID()
+        val snapshotId = UUID.randomUUID()
+        assertResult {
+          s"""{
+              "attributes": {
+                             "instanceName": "test-instance",
+                             "snapshot": "$snapshotId"
+              },
+              "metadata": {
+                            "workspaceId": "$workspaceId",
+                            "resourceId": "$resourceId",
+                            "name": "testReference",
+                            "description": "hello",
+                            "resourceType": "DATA_REPO_SNAPSHOT",
+                            "stewardshipType": "REFERENCED",
+                            "cloningInstructions": "COPY_NOTHING"
+              }
+             }
+          """.parseJson
+        } {
+          new DataRepoSnapshotResource()
+            .metadata(
+              new ResourceMetadata()
+                .name("testReference")
+                .resourceId(resourceId)
+                .workspaceId(workspaceId)
+                .description("hello")
+                .resourceType(ResourceType.DATA_REPO_SNAPSHOT)
+                .stewardshipType(StewardshipType.REFERENCED)
+                .cloningInstructions(CloningInstructionsEnum.NOTHING)
+            )
+            .attributes(
+              new DataRepoSnapshotAttributes()
+                .instanceName("test-instance")
+                .snapshot(snapshotId.toString)
+            ).toJson
+        }
 
-//      "DataReferenceDescription with bad UUID's should fail" in {
-//        assertThrows[DeserializationException] {
-//          s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
-//        }
-//      }
+      }
+
+      "ResourceList, ResourceDescription, ResourceMetadata, ResourceAttributesUnion, DataRepoSnapshotAttributes" in {
+        val snapshotResourceId = UUID.randomUUID()
+        val workspaceId = UUID.randomUUID()
+        val snapshotId = UUID.randomUUID()
+        assertResult {
+          s"""
+             {
+               "resources": [
+                             {
+                               "metadata": {
+                                             "cloningInstructions":"COPY_NOTHING",
+                                             "description":"im a lil snapshot",
+                                             "name":"snapshot1",
+                                             "resourceId":"$snapshotResourceId",
+                                             "resourceType":"DATA_REPO_SNAPSHOT",
+                                             "stewardshipType":"REFERENCED",
+                                             "workspaceId":"$workspaceId"
+                                            },
+                               "resourceAttributes": { "gcpDataRepoSnapshot": {
+                                                                                "instanceName":"test-instance",
+                                                                                "snapshot":"$snapshotId"
+                                                                               }
+                                                     }
+                             }
+                            ]
+             }
+             """.parseJson
+        } {
+          new ResourceList().resources(
+            List(
+              new ResourceDescription()
+                .metadata(
+                  new ResourceMetadata()
+                    .name("snapshot1")
+                    .description("im a lil snapshot")
+                    .resourceId(snapshotResourceId)
+                    .resourceType(ResourceType.DATA_REPO_SNAPSHOT)
+                    .stewardshipType(StewardshipType.REFERENCED)
+                    .workspaceId(workspaceId)
+                    .cloningInstructions(CloningInstructionsEnum.NOTHING)
+
+                )
+                .resourceAttributes(
+                  new ResourceAttributesUnion()
+                    .gcpDataRepoSnapshot(
+                      new DataRepoSnapshotAttributes()
+                        .instanceName("test-instance")
+                        .snapshot(snapshotId.toString)
+                    ))
+            ).asJava
+          ).toJson
+        }
+      }
+
+      "Parsing ResourceMetadata should fail if resource id string is not a UUID" in {
+        val workspaceId = UUID.randomUUID()
+        assertThrows[DeserializationException] {
+          s"""
+             {
+               "cloningInstructions": "COPY_NOTHING",
+               "description": "im a lil snapshot",
+               "name": "snapshot1",
+               "resourceId": "not-an-id",
+               "resourceType": "DATA_REPO_SNAPSHOT",
+               "stewardshipType": "REFERENCED",
+               "workspaceId": "$workspaceId"
+              }""".parseJson.convertTo[ResourceMetadata]
+        }
+      }
+
+      "should fail if workspace id string is not a UUID" in {
+        val resourceId = UUID.randomUUID()
+        assertThrows[DeserializationException] {
+          s"""
+             {
+               "cloningInstructions":"COPY_NOTHING",
+               "description": "im a lil snapshot",
+               "name": "snapshot1",
+               "resourceId": "$resourceId",
+               "resourceType": "DATA_REPO_SNAPSHOT",
+               "stewardshipType": "REFERENCED",
+               "workspaceId": "not-an-id"
+              }""".parseJson.convertTo[ResourceMetadata]
+        }
+      }
 
       "UpdateDataReferenceRequestBody should work when updating name and description" in {
         assertResult { s"""{"name":"foo","description":"bar"}""".parseJson } {

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -30,30 +30,30 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
 
     "JSON logic" - {
 
-      "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
-        val referenceId = UUID.randomUUID()
-        val workspaceId = UUID.randomUUID()
-        assertResult {
-          s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
-        } {
-          new DataReferenceList().resources(ArrayBuffer(
-            new DataReferenceDescription()
-              .referenceId(referenceId)
-              .name("test-ref")
-              .description("test description")
-              .workspaceId(workspaceId)
-              .referenceType(DATA_REPO_SNAPSHOT)
-              .reference(new DataRepoSnapshot().instanceName("test-instance").snapshot("test-snapshot"))
-              .cloningInstructions(NOTHING)
-          ).asJava).toJson
-        }
-      }
+//      "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
+//        val referenceId = UUID.randomUUID()
+//        val workspaceId = UUID.randomUUID()
+//        assertResult {
+//          s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
+//        } {
+//          new DataReferenceList().resources(ArrayBuffer(
+//            new DataReferenceDescription()
+//              .referenceId(referenceId)
+//              .name("test-ref")
+//              .description("test description")
+//              .workspaceId(workspaceId)
+//              .referenceType(DATA_REPO_SNAPSHOT)
+//              .reference(new DataRepoSnapshot().instanceName("test-instance").snapshot("test-snapshot"))
+//              .cloningInstructions(NOTHING)
+//          ).asJava).toJson
+//        }
+//      }
 
-      "DataReferenceDescription with bad UUID's should fail" in {
-        assertThrows[DeserializationException] {
-          s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
-        }
-      }
+//      "DataReferenceDescription with bad UUID's should fail" in {
+//        assertThrows[DeserializationException] {
+//          s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
+//        }
+//      }
 
       "UpdateDataReferenceRequestBody should work when updating name and description" in {
         assertResult { s"""{"name":"foo","description":"bar"}""".parseJson } {

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import bio.terra.workspace.model.CloningInstructionsEnum.NOTHING
 import bio.terra.workspace.model.ReferenceTypeEnum.DATA_REPO_SNAPSHOT
-import bio.terra.workspace.model.{CloningInstructionsEnum, DataReferenceDescription, DataReferenceList, DataRepoSnapshot, DataRepoSnapshotAttributes, DataRepoSnapshotResource, GcpBigQueryDatasetAttributes, ResourceAttributesUnion, ResourceDescription, ResourceList, ResourceMetadata, ResourceType, StewardshipType, UpdateDataReferenceRequestBody}
+import bio.terra.workspace.model.{CloningInstructionsEnum, DataReferenceDescription, DataReferenceList, DataRepoSnapshot, DataRepoSnapshotAttributes, DataRepoSnapshotResource, ResourceAttributesUnion, ResourceDescription, ResourceList, ResourceMetadata, ResourceType, StewardshipType, UpdateDataReferenceRequestBody}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import spray.json._
 
@@ -61,19 +61,19 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
         val snapshotId = UUID.randomUUID()
         assertResult {
           s"""{
-              "attributes": {
-                             "instanceName": "test-instance",
-                             "snapshot": "$snapshotId"
-              },
-              "metadata": {
-                            "workspaceId": "$workspaceId",
-                            "resourceId": "$resourceId",
-                            "name": "testReference",
-                            "description": "hello",
-                            "resourceType": "DATA_REPO_SNAPSHOT",
-                            "stewardshipType": "REFERENCED",
-                            "cloningInstructions": "COPY_NOTHING"
-              }
+                "attributes": {
+                  "instanceName": "test-instance",
+                  "snapshot": "$snapshotId"
+                },
+                "metadata": {
+                  "workspaceId": "$workspaceId",
+                  "resourceId": "$resourceId",
+                  "name": "testReference",
+                  "description": "hello",
+                  "resourceType": "DATA_REPO_SNAPSHOT",
+                  "stewardshipType": "REFERENCED",
+                  "cloningInstructions": "COPY_NOTHING"
+                }
              }
           """.parseJson
         } {
@@ -105,23 +105,24 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
           s"""
              {
                "resources": [
-                             {
-                               "metadata": {
-                                             "cloningInstructions":"COPY_NOTHING",
-                                             "description":"im a lil snapshot",
-                                             "name":"snapshot1",
-                                             "resourceId":"$snapshotResourceId",
-                                             "resourceType":"DATA_REPO_SNAPSHOT",
-                                             "stewardshipType":"REFERENCED",
-                                             "workspaceId":"$workspaceId"
-                                            },
-                               "resourceAttributes": { "gcpDataRepoSnapshot": {
-                                                                                "instanceName":"test-instance",
-                                                                                "snapshot":"$snapshotId"
-                                                                               }
-                                                     }
-                             }
-                            ]
+                 {
+                   "metadata": {
+                     "cloningInstructions":"COPY_NOTHING",
+                     "description":"im a lil snapshot",
+                     "name":"snapshot1",
+                     "resourceId":"$snapshotResourceId",
+                     "resourceType":"DATA_REPO_SNAPSHOT",
+                     "stewardshipType":"REFERENCED",
+                     "workspaceId":"$workspaceId"
+                   },
+                   "resourceAttributes": {
+                     "gcpDataRepoSnapshot": {
+                        "instanceName":"test-instance",
+                        "snapshot":"$snapshotId"
+                     }
+                   }
+                 }
+               ]
              }
              """.parseJson
         } {

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -30,6 +30,31 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
 
     "JSON logic" - {
 
+      "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
+        val referenceId = UUID.randomUUID()
+        val workspaceId = UUID.randomUUID()
+        assertResult {
+          s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
+        } {
+          new DataReferenceList().resources(ArrayBuffer(
+            new DataReferenceDescription()
+              .referenceId(referenceId)
+              .name("test-ref")
+              .description("test description")
+              .workspaceId(workspaceId)
+              .referenceType(DATA_REPO_SNAPSHOT)
+              .reference(new DataRepoSnapshot().instanceName("test-instance").snapshot("test-snapshot"))
+              .cloningInstructions(NOTHING)
+          ).asJava).toJson
+        }
+      }
+
+      "DataReferenceDescription with bad UUID's should fail" in {
+        assertThrows[DeserializationException] {
+          s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
+        }
+      }
+
       "DataRepoSnapshotResource, ResourceMetadata, DataRepoSnapshotAttributes" in {
         val resourceId = UUID.randomUUID()
         val workspaceId = UUID.randomUUID()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -111,7 +111,7 @@ object Dependencies {
 
   def excludeJakartaActivationApi(m: ModuleID): ModuleID = m.exclude("jakarta.activation", "jakarta.activation-api")
 
-  val workspaceManager = excludeJakartaActivationApi("bio.terra" % "workspace-manager-client" % "0.19.0-SNAPSHOT")
+  val workspaceManager = excludeJakartaActivationApi("bio.terra" % "workspace-manager-client" % "0.254.5-SNAPSHOT")
   val dataRepo = excludeJakartaActivationApi("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
   val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
 


### PR DESCRIPTION
This PR's changes are:
- Updating the version of Workspace Manager in Dependencies.scala
- Changing HttpWorkspaceManagerDAO.scala to use the new APIs. These endpoints used to return `DataReferenceDescription` and `DataReferenceList`, which have been replaced with `DataRepoSnapshotResource` and `ResourceList` respectively 
- V2 routes are added to SnapshotApiService.scala. Both V1 and V2 routes call the same methods, but V1 routes convert the response into the old, expected response objects.
- SnapshotApiServiceSpec now has two sets of tests for V1 and V2 routes
- New swagger for V2 routes
- The rest of it is test fallout