### PR TITLE
Write point correction to GCS for Delta Layer [AS-769]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -355,7 +355,8 @@ object Boot extends IOApp with LazyLogging {
 
       // create the entity manager.
       val deltaLayerWriter = new GcsDeltaLayerWriter(appDependencies.googleStorageService,
-        GcsBucketName(conf.getString("deltaLayer.deltaLayerSourceBucket")))
+        GcsBucketName(conf.getString("deltaLayer.deltaLayerSourceBucket")),
+        metricsPrefix)
       val entityManager = EntityManager.defaultEntityManager(slickDataSource, workspaceManagerDAO, dataRepoDAO, samDAO,
         appDependencies.bigQueryServiceFactory, deltaLayerWriter,
         DataRepoEntityProviderConfig(conf.getConfig("dataRepoEntityProvider")),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerException.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerException.scala
@@ -1,0 +1,9 @@
+package org.broadinstitute.dsde.rawls.deltalayer
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import org.broadinstitute.dsde.rawls.RawlsException
+
+/** Exception related to working with Delta Layer.
+ */
+class DeltaLayerException(message: String = null, cause: Throwable = null, val code: StatusCode = StatusCodes.InternalServerError) extends RawlsException(message, cause)
+

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerWriter.scala
@@ -1,6 +1,9 @@
 package org.broadinstitute.dsde.rawls.deltalayer
 
+import akka.http.scaladsl.model.Uri
 import org.broadinstitute.dsde.rawls.model.DeltaInsert
+
+import scala.concurrent.Future
 
 trait DeltaLayerWriter {
 
@@ -8,6 +11,6 @@ trait DeltaLayerWriter {
    * write the delta file to its destination
    * @param writeObject the delta file to be written
    */
-  def writeFile(writeObject: DeltaInsert)
+  def writeFile(writeObject: DeltaInsert): Future[Uri]
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerWriter.scala
@@ -5,8 +5,8 @@ import org.broadinstitute.dsde.rawls.model.DeltaInsert
 trait DeltaLayerWriter {
 
   /**
-   * write the delta file to the cloud
-   * @param writeObject
+   * write the delta file to its destination
+   * @param writeObject the delta file to be written
    */
   def writeFile(writeObject: DeltaInsert)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerWriter.scala
@@ -1,5 +1,13 @@
 package org.broadinstitute.dsde.rawls.deltalayer
 
+import org.broadinstitute.dsde.rawls.model.DeltaInsert
+
 trait DeltaLayerWriter {
+
+  /**
+   * write the delta file to the cloud
+   * @param writeObject
+   */
+  def writeFile(writeObject: DeltaInsert)
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
@@ -41,6 +41,10 @@ class GcsDeltaLayerWriter(val storageService: GoogleStorageService[IO],
       // file multiple times?
       case t: HttpResponseException =>
         logger.warn(s"encountered error [${t.getStatusMessage}] with status code [${t.getStatusCode}] when writing delta file [${sourceBucket.value}/${destinationPath.value}]")
+        throw t
+      case e: Exception =>
+        logger.warn(s"encountered error [${e.getMessage}] when writing delta file [${sourceBucket.value}/${destinationPath.value}]")
+        throw e
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
@@ -1,12 +1,46 @@
 package org.broadinstitute.dsde.rawls.deltalayer
 
 import cats.effect.IO
-import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
+import fs2._
+import org.broadinstitute.dsde.rawls.model.DeltaInsert
+import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 class GcsDeltaLayerWriter(val storageService: GoogleStorageService[IO],
                           val sourceBucket: GcsBucketName)
   extends DeltaLayerWriter {
 
+  // calculate the GCS path to which we should save the file
+  private[deltalayer] def filePath(writeObject: DeltaInsert): GcsBlobName = {
+    // workspace/${workspaceId}/reference/${referenceId}/insert/${insertId}.json
+    GcsBlobName(s"workspace/${writeObject.destination.workspaceId}/reference/${writeObject.destination.referenceId}/insert/${writeObject.insertId}.json")
+  }
+
+  // generate the string representation (json) of the file
+  private[deltalayer] def serializeFile(writeObject: DeltaInsert): String = {
+    val updateJson = writeObject.inserts.toJson.prettyPrint
+
+    // TODO: this should use real JsonFormat classes! For now, since the model is in such flux, just hand-roll
+    // the json
+    s"""{
+       |  "insertId": "${writeObject.insertId}",
+       |  "workspaceId": "${writeObject.destination.workspaceId}",
+       |  "referenceId": "${writeObject.destination.referenceId}",
+       |  "insertTimestamp": "${writeObject.insertTimestamp.toString}",
+       |  "insertingUser": "${writeObject.insertingUser.value}",
+       |  "inserts": $updateJson
+       |}
+       |""".stripMargin.parseJson.prettyPrint
+  }
+
+  override def writeFile(writeObject: DeltaInsert): Unit = {
+    // TODO: set overwrite value and traceId value
+    val writePipe = storageService.streamUploadBlob(sourceBucket, filePath(writeObject))
+    val fileContents = serializeFile(writeObject)
+    // TODO: retries and error-handling
+    text.utf8Encode(Stream.emit(fileContents)).through(writePipe).compile.drain.unsafeRunSync()
+  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
@@ -22,7 +22,7 @@ class GcsDeltaLayerWriter(val storageService: GoogleStorageService[IO],
   private[deltalayer] def serializeFile(writeObject: DeltaInsert): String = {
     val updateJson = writeObject.inserts.toJson.prettyPrint
 
-    // TODO: this should use real JsonFormat classes! For now, since the model is in such flux, just hand-roll
+    // TODO AS-770: use real JsonFormat classes! For now, since the model is in such flux, just hand-roll
     // the json
     s"""{
        |  "insertId": "${writeObject.insertId}",
@@ -36,7 +36,7 @@ class GcsDeltaLayerWriter(val storageService: GoogleStorageService[IO],
   }
 
   override def writeFile(writeObject: DeltaInsert): Unit = {
-    // TODO: set overwrite value and traceId value
+    // TODO: set overwrite value if desired and traceId value for tracing
     val writePipe = storageService.streamUploadBlob(sourceBucket, filePath(writeObject))
     val fileContents = serializeFile(writeObject)
     // TODO: retries and error-handling

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriter.scala
@@ -1,9 +1,8 @@
 package org.broadinstitute.dsde.rawls.deltalayer
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.Uri
 import cats.effect.IO
-import com.google.api.client.http.HttpResponseException
 import com.google.cloud.storage.StorageException
 import fs2._
 import org.broadinstitute.dsde.rawls.google.GoogleUtilities

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -431,12 +431,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRe
 
     // consider making this async, so we respond to the user quicker. For now, leave as synchronous
     // so we return any errors
-    deltaLayerWriter.writeFile(ins)
-
+    deltaLayerWriter.writeFile(ins) map { _ =>
+      Seq.empty[Entity]
+    }
     // This method signature claims to return Traversable[Entity] - and we leave it that way for compatibility -
     // but note that in practice we don't return any entities. That's good - we don't have access to the
     // updated entities yet because they will be updated asynchronously by the code that reads the file
     // we just wrote.
-    Future.successful(Seq.empty[Entity])
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -414,12 +414,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRe
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
   override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = {
-    // TODO: validate incoming EntityUpdateDefinitions (disallow deletes, etc)
-    // TODO: translate incoming EntityUpdateDefinitions into key-value writes, including destination BQ datatypes
-    // TODO: determine destination BQDL dataset, based on snapshot reference
-    // SnapshotService.generateDatasetName: "deltalayer_" + datasetReferenceId.toString.replace('-', '_')
+    // TODO AS-770: validate incoming EntityUpdateDefinitions (disallow deletes, etc)
+    // TODO AS-770: translate incoming EntityUpdateDefinitions into key-value writes, including destination BQ datatypes
+    // TODO AS-770: determine destination BQDL dataset, based on snapshot reference. Currently in SnapshotService.generateDatasetName
 
     // create DeltaInsert object
+    // TODO AS-770: populate with everything we need, including model versioning
     val dest = Destination(workspaceId = requestArguments.workspace.workspaceIdAsUUID,
                            referenceId = dataReference.getReferenceId)
     val ins = DeltaInsert(version = "v0",

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -429,11 +429,14 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRe
                           destination = dest,
                           inserts = entityUpdates)
 
-    // TODO: should this be async, so we respond to the user quicker?
+    // consider making this async, so we respond to the user quicker. For now, leave as synchronous
+    // so we return any errors
     deltaLayerWriter.writeFile(ins)
 
-    // TODO: what should this return? Can we look up the changed entities and return them? What does the local
-    // provider return?
+    // This method signature claims to return Traversable[Entity] - and we leave it that way for compatibility -
+    // but note that in practice we don't return any entities. That's good - we don't have access to the
+    // updated entities yet because they will be updated asynchronously by the code that reads the file
+    // we just wrote.
     Future.successful(Seq.empty[Entity])
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.model.{SnapshotModel, TableModel}
-import bio.terra.workspace.model.DataReferenceDescription
+import bio.terra.workspace.model.DataRepoSnapshotResource
 import cats.effect.{ContextShift, IO}
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.Field.Mode
@@ -33,7 +33,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataReferenceDescription,
+class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRepoSnapshotResource,
                              requestArguments: EntityRequestArguments,
                              samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory,
                              deltaLayerWriter: DeltaLayerWriter,
@@ -422,7 +422,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRe
     // create DeltaInsert object
     // TODO AS-770: populate with everything we need, including model versioning
     val dest = Destination(workspaceId = requestArguments.workspace.workspaceIdAsUUID,
-                           referenceId = dataReference.getReferenceId)
+                           referenceId = dataReference.getMetadata.getResourceId)
     val ins = DeltaInsert(version = "v0",
                           insertId = UUID.randomUUID(),
                           insertTimestamp = new DateTime(),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -35,7 +35,8 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
       dataReferenceName <- requestArguments.dataReference.toRight(new DataEntityException("data reference must be defined for this provider")).toTry
 
       // get snapshot UUID from data reference name
-      snapshotId <- Try(lookupSnapshotForName(dataReferenceName, requestArguments))
+      dataReference <- Try(lookupSnapshotForName(dataReferenceName, requestArguments))
+      snapshotId = UUID.fromString(dataReference.getReference.getSnapshot)
 
       // contact TDR to describe the snapshot
       snapshotModel <- Try(dataRepoDAO.getSnapshot(snapshotId, requestArguments.userInfo.accessToken)).recoverWith {
@@ -59,10 +60,10 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
           logger.warn(finalErrMessage, forbidden)
           Failure(new DataEntityException(code = StatusCodes.Forbidden, message = finalErrMessage))
       }
-    } yield new DataRepoEntityProvider(snapshotModel, requestArguments, samDAO, bqServiceFactory, deltaLayerWriter, config)
+    } yield new DataRepoEntityProvider(snapshotModel, dataReference, requestArguments, samDAO, bqServiceFactory, deltaLayerWriter, config)
   }
 
-  private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName, requestArguments: EntityRequestArguments): UUID = {
+  private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName, requestArguments: EntityRequestArguments): DataReferenceDescription = {
     // contact WSM to retrieve the data reference specified in the request
     val dataRefTry = Try(workspaceManagerDAO.getDataRepoSnapshotReferenceByName(UUID.fromString(requestArguments.workspace.workspaceId),
       dataReferenceName,
@@ -76,6 +77,8 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
     // trigger any exceptions
     val dataRef = dataRefTry.get
+
+    // ultimately this method will return dataRef, but we'll validate its contents before returning it
 
     // verify it's a TDR snapshot. should be a noop, since getDataReferenceByName enforces this.
     if (ResourceType.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
@@ -93,10 +96,12 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
     // verify snapshotId value is a UUID
     Try(UUID.fromString(dataReference.getSnapshot)) match {
-      case Success(uuid) => uuid
+      case Success(uuid) => // success; noop
       case Failure(ex) =>
         logger.error(s"invalid UUID for snapshotId in reference: ${dataReference.getSnapshot}")
         throw new DataEntityException(s"Reference value for $dataReferenceName contains an unexpected snapshot value", ex)
     }
+
+    dataRef
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import java.util.UUID
-
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.client.{ApiException => DatarepoApiException}
 import bio.terra.workspace.client.{ApiException => WorkspaceApiException}
-import bio.terra.workspace.model.{ReferenceTypeEnum, ResourceType}
+import bio.terra.workspace.model.{DataRepoSnapshotResource, ReferenceTypeEnum, ResourceType}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -36,7 +35,7 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
       // get snapshot UUID from data reference name
       dataReference <- Try(lookupSnapshotForName(dataReferenceName, requestArguments))
-      snapshotId = UUID.fromString(dataReference.getReference.getSnapshot)
+      snapshotId = UUID.fromString(dataReference.getAttributes.getSnapshot)
 
       // contact TDR to describe the snapshot
       snapshotModel <- Try(dataRepoDAO.getSnapshot(snapshotId, requestArguments.userInfo.accessToken)).recoverWith {
@@ -63,7 +62,7 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
     } yield new DataRepoEntityProvider(snapshotModel, dataReference, requestArguments, samDAO, bqServiceFactory, deltaLayerWriter, config)
   }
 
-  private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName, requestArguments: EntityRequestArguments): DataReferenceDescription = {
+  private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName, requestArguments: EntityRequestArguments): DataRepoSnapshotResource = {
     // contact WSM to retrieve the data reference specified in the request
     val dataRefTry = Try(workspaceManagerDAO.getDataRepoSnapshotReferenceByName(UUID.fromString(requestArguments.workspace.workspaceId),
       dataReferenceName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriterSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriterSpec.scala
@@ -5,15 +5,17 @@ import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.scalatest.flatspec.AnyFlatSpec
 import TestExecutionContext.testExecutionContext
 import akka.actor.ActorSystem
-
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString, DeltaInsert, Destination, RawlsUserSubjectId}
 import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.joda.time.DateTime
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
 
 import java.util.UUID
 
-class GcsDeltaLayerWriterSpec extends AnyFlatSpec {
+class GcsDeltaLayerWriterSpec extends AnyFlatSpec with Eventually with Matchers {
 
   implicit val actorSystem: ActorSystem = ActorSystem("GcsDeltaLayerWriterSpec")
 
@@ -26,24 +28,39 @@ class GcsDeltaLayerWriterSpec extends AnyFlatSpec {
   behavior of "GcsDeltaLayerWriter"
 
   it should "write the specified file to the bucket" in {
+    // create the object to be written
     val dest = Destination(UUID.randomUUID(), UUID.randomUUID())
     val attrUpdates: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(AttributeName.withDefaultNS("attrName"), AttributeString("attrValue")))
     val entityUpdates: Seq[EntityUpdateDefinition] = Seq(EntityUpdateDefinition("name", "type", attrUpdates))
     val testInsert = DeltaInsert("vTest", UUID.randomUUID(), new DateTime(), RawlsUserSubjectId("1234"), dest, entityUpdates)
 
+    // calculate expected file path and contents
     val expectedPath = deltaLayerWriter.filePath(testInsert)
     val expectedContents = deltaLayerWriter.serializeFile(testInsert)
 
+    // write the object via Delta Layer
     deltaLayerWriter.writeFile(testInsert)
 
-    val optBlob = localStorage.unsafeGetBlobBody(bucket, expectedPath).unsafeRunSync()
-
-    assert(optBlob.nonEmpty, "file should have been written to storage")
-    optBlob.map { actual =>
-      assertResult(expectedContents) {
-        actual
+    // confirm we wrote the file correctly. The FakeGoogleStorageInterpreter in-memory storage engine
+    // seems to have some delays, so use eventually to allow for delays and retries
+    eventually (timeout(Span(30, Seconds)), interval(Span(500, Millis))) {
+      val optBlob = localStorage.unsafeGetBlobBody(bucket, expectedPath).unsafeRunSync()
+      optBlob should not be empty
+      optBlob.map { actual =>
+        assertResult(expectedContents) {
+          actual
+        }
       }
     }
   }
+
+  it should "bubble up errors during write" is (pending)
+
+  it should "calculate the desired file path to which we will write" is (pending)
+
+  it should "serialize DeltaInsert correctly" is (pending) // NB not worth testing until model class is stable
+
+  // TODO: should write a test from the EntityApiService layer down, too
+
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriterSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriterSpec.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.rawls.deltalayer
+
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.scalatest.flatspec.AnyFlatSpec
+import TestExecutionContext.testExecutionContext
+import akka.actor.ActorSystem
+
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString, DeltaInsert, Destination, RawlsUserSubjectId}
+import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
+import org.joda.time.DateTime
+
+import java.util.UUID
+
+class GcsDeltaLayerWriterSpec extends AnyFlatSpec {
+
+  implicit val actorSystem: ActorSystem = ActorSystem("GcsDeltaLayerWriterSpec")
+
+  val localStorage = FakeGoogleStorageInterpreter
+
+  val bucket = GcsBucketName("unittest-bucket-name")
+
+  val deltaLayerWriter = new GcsDeltaLayerWriter(localStorage, bucket, "metricsPrefix")
+
+  behavior of "GcsDeltaLayerWriter"
+
+  it should "write the specified file to the bucket" in {
+    val dest = Destination(UUID.randomUUID(), UUID.randomUUID())
+    val attrUpdates: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(AttributeName.withDefaultNS("attrName"), AttributeString("attrValue")))
+    val entityUpdates: Seq[EntityUpdateDefinition] = Seq(EntityUpdateDefinition("name", "type", attrUpdates))
+    val testInsert = DeltaInsert("vTest", UUID.randomUUID(), new DateTime(), RawlsUserSubjectId("1234"), dest, entityUpdates)
+
+    val expectedPath = deltaLayerWriter.filePath(testInsert)
+    val expectedContents = deltaLayerWriter.serializeFile(testInsert)
+
+    deltaLayerWriter.writeFile(testInsert)
+
+    val optBlob = localStorage.unsafeGetBlobBody(bucket, expectedPath).unsafeRunSync()
+
+    assert(optBlob.nonEmpty, "file should have been written to storage")
+    optBlob.map { actual =>
+      assertResult(expectedContents) {
+        actual
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriterSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsDeltaLayerWriterSpec.scala
@@ -8,36 +8,37 @@ import akka.actor.ActorSystem
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, IO}
 import com.google.cloud.storage.Storage.BlobWriteOption
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 import com.google.cloud.storage.{BlobInfo, Storage, StorageException}
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString, DeltaInsert, Destination, RawlsUserSubjectId}
-import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreterSpec.{cs, logger, timer}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageInterpreter}
-import org.broadinstitute.dsde.workbench.google2.mock.FakeGoogleStorageInterpreter
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
+import org.scalatest.RecoverMethods.recoverToExceptionIf
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext.global
+import scala.util.Try
 
 class GcsDeltaLayerWriterSpec extends AnyFlatSpec with Eventually with Matchers {
 
   implicit val actorSystem: ActorSystem = ActorSystem("GcsDeltaLayerWriterSpec")
 
-  val localStorage = FakeGoogleStorageInterpreter
-
-  val bucket = GcsBucketName("unittest-bucket-name")
-
-  val deltaLayerWriter = new GcsDeltaLayerWriter(localStorage, bucket, "metricsPrefix")
-
   behavior of "GcsDeltaLayerWriter"
 
   it should "write the specified file to the bucket" in {
+    val bucket = GcsBucketName("successful-write")
+
+    // explicitly create the storage so we can query it directly
+    val storage = LocalStorageHelper.getOptions.getService
+    val deltaLayerWriter = getGcsWriter(bucket, Some(storage))
+
     // create the object to be written
     val dest = Destination(UUID.randomUUID(), UUID.randomUUID())
     val attrUpdates: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(AttributeName.withDefaultNS("attrName"), AttributeString("attrValue")))
@@ -49,22 +50,23 @@ class GcsDeltaLayerWriterSpec extends AnyFlatSpec with Eventually with Matchers 
     val expectedContents = deltaLayerWriter.serializeFile(testInsert)
 
     // write the object via Delta Layer
-    deltaLayerWriter.writeFile(testInsert)
-
-    // confirm we wrote the file correctly. The FakeGoogleStorageInterpreter in-memory storage engine
-    // seems to have some delays, so use eventually to allow for delays and retries
-    eventually (timeout(Span(30, Seconds)), interval(Span(500, Millis))) {
-      val optBlob = localStorage.unsafeGetBlobBody(bucket, expectedPath).unsafeRunSync()
-      optBlob should not be empty
-      optBlob.map { actual =>
-        assertResult(expectedContents) {
-          actual
+    deltaLayerWriter.writeFile(testInsert) map { _ =>
+      // confirm we wrote the file correctly. The LocalStorageHelper in-memory storage engine
+      // seems to have some delays, so use eventually to allow for delays and retries
+      eventually (timeout(Span(30, Seconds)), interval(Span(500, Millis))) {
+        val optBlob = Try(storage.get(bucket.value, expectedPath.value).getContent()).toOption
+        optBlob should not be empty
+        optBlob.map { actual =>
+          assertResult(expectedContents) {
+            actual.mkString
+          }
         }
       }
     }
   }
 
   it should "bubble up errors during write" in {
+    val bucket = GcsBucketName("this-should-throw-error")
 
     // under the covers, Storage.writer is the Google library method that gets called. So, mock that
     // and force it to throw
@@ -73,10 +75,7 @@ class GcsDeltaLayerWriterSpec extends AnyFlatSpec with Eventually with Matchers 
     when(throwingStorageHelper.writer(any[BlobInfo], any[BlobWriteOption]))
       .thenThrow(mockedException)
 
-    val blocker = Blocker.liftExecutionContext(global)
-    val semaphore = Semaphore[IO](1).unsafeRunSync
-    val throwingStorageInterpreter = GoogleStorageInterpreter[IO](throwingStorageHelper, blocker, Some(semaphore))
-    val throwingWriter = new GcsDeltaLayerWriter(throwingStorageInterpreter, bucket, "metricsPrefix")
+    val throwingWriter = getGcsWriter(bucket, Some(throwingStorageHelper))
 
     // create the object to be written
     val dest = Destination(UUID.randomUUID(), UUID.randomUUID())
@@ -85,15 +84,20 @@ class GcsDeltaLayerWriterSpec extends AnyFlatSpec with Eventually with Matchers 
     val testInsert = DeltaInsert("vTest", UUID.randomUUID(), new DateTime(), RawlsUserSubjectId("1234"), dest, entityUpdates)
 
     // write the object via the Delta Layer writer we have configured to run into an exception
-    val caught = intercept[Exception] {
+    val caught = recoverToExceptionIf[StorageException] {
        throwingWriter.writeFile(testInsert)
     }
 
-    caught shouldBe mockedException
+    caught.map { ex =>
+      ex shouldBe mockedException
+    }
 
   }
 
   it should "calculate the desired file path to which we will write" in {
+    val bucket = GcsBucketName("path-calculation")
+    val deltaLayerWriter = getGcsWriter(bucket)
+
     // workspace/${workspaceId}/reference/${referenceId}/insert/${insertId}.json
     val insertId = UUID.randomUUID()
     val workspaceId = UUID.randomUUID()
@@ -114,7 +118,18 @@ class GcsDeltaLayerWriterSpec extends AnyFlatSpec with Eventually with Matchers 
 
   it should "serialize DeltaInsert correctly" is (pending) // NB not worth testing until model class is stable
 
-  // TODO: should write a test from the EntityApiService layer down, too
+  def getGcsWriter(bucket: GcsBucketName, storage: Option[Storage] = None): GcsDeltaLayerWriter = {
+    implicit val cs = IO.contextShift(testExecutionContext)
+    implicit val timer = IO.timer(testExecutionContext)
+    implicit val logger = Slf4jLogger.getLogger[IO]
 
+    val db = storage.getOrElse(LocalStorageHelper.getOptions().getService())
+    val blocker = Blocker.liftExecutionContext(testExecutionContext)
+    val semaphore = Semaphore[IO](1).unsafeRunSync
+
+    val localStorage = GoogleStorageInterpreter[IO](db, blocker, Some(semaphore))
+
+    new GcsDeltaLayerWriter(localStorage, bucket, "metricsPrefix")
+  }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsStorageTestSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/GcsStorageTestSupport.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.rawls.deltalayer
+
+import akka.actor.ActorSystem
+import cats.effect.{Blocker, IO}
+import cats.effect.concurrent.Semaphore
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.broadinstitute.dsde.rawls.TestExecutionContext.testExecutionContext
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreter
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+
+trait GcsStorageTestSupport {
+
+  def getGcsWriter(bucket: GcsBucketName, storage: Option[Storage] = None)(implicit actorSystem: ActorSystem): GcsDeltaLayerWriter = {
+    implicit val cs = IO.contextShift(testExecutionContext)
+    implicit val timer = IO.timer(testExecutionContext)
+    implicit val logger = Slf4jLogger.getLogger[IO]
+
+    val db = storage.getOrElse(LocalStorageHelper.getOptions().getService())
+    val blocker = Blocker.liftExecutionContext(testExecutionContext)
+    val semaphore = Semaphore[IO](1).unsafeRunSync
+
+    val localStorage = GoogleStorageInterpreter[IO](db, blocker, Some(semaphore))
+
+    new GcsDeltaLayerWriter(localStorage, bucket, "metricsPrefix")
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/MockDeltaLayerWriter.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/MockDeltaLayerWriter.scala
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsde.rawls.deltalayer
+import akka.http.scaladsl.model.Uri
 import org.broadinstitute.dsde.rawls.model.DeltaInsert
+
+import scala.concurrent.Future
 
 class MockDeltaLayerWriter extends DeltaLayerWriter {
   // TODO: flesh out for unit tests, ideally using a mocked Google storage service
-  override def writeFile(writeObject: DeltaInsert): Unit = ???
+  override def writeFile(writeObject: DeltaInsert): Future[Uri] = ???
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/MockDeltaLayerWriter.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/MockDeltaLayerWriter.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.deltalayer
+import org.broadinstitute.dsde.rawls.model.DeltaInsert
 
 class MockDeltaLayerWriter extends DeltaLayerWriter {
-
+  override def writeFile(writeObject: DeltaInsert): Unit = ???
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/MockDeltaLayerWriter.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/MockDeltaLayerWriter.scala
@@ -2,5 +2,6 @@ package org.broadinstitute.dsde.rawls.deltalayer
 import org.broadinstitute.dsde.rawls.model.DeltaInsert
 
 class MockDeltaLayerWriter extends DeltaLayerWriter {
+  // TODO: flesh out for unit tests, ideally using a mocked Google storage service
   override def writeFile(writeObject: DeltaInsert): Unit = ???
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -73,7 +73,7 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(), samDAO, bigQueryServiceFactory, new MockDeltaLayerWriter(), DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, new MockDeltaLayerWriter(), DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
@@ -72,7 +72,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     // isn't mistakenly passing by using defaults where it shouldn't
     val randomName = scala.util.Random.alphanumeric.take(16).mkString
 
-    val expected = createDataRefDescription(
+    val expected = createDataRepoSnapshotResource(
       name = randomName,
       refSnapshot = UUID.randomUUID().toString)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
@@ -67,10 +67,23 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
 
   behavior of "DataRepoEntityProviderBuilder.lookupSnapshotForName()"
 
-  it should "return snapshot id in the golden path" in {
-    val builder = createTestBuilder()
-    val actual = builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments)
-    assertResult(UUID.fromString(snapshot)) { actual }
+  it should "return DataReferenceDescription id in the golden path" in {
+    // modify the DataReferenceDescription used by this test to ensure the test
+    // isn't mistakenly passing by using defaults where it shouldn't
+    val randomName = scala.util.Random.alphanumeric.take(16).mkString
+
+    val expected = createDataRefDescription(
+      name = randomName,
+      refSnapshot = UUID.randomUUID().toString)
+
+    val builder = createTestBuilder(
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(expected))
+    )
+
+    // NB see comment in SpecWorkspaceManagerDAO; the name we use for lookup is ignored
+    val actual = builder.lookupSnapshotForName(DataReferenceName(randomName), defaultEntityRequestArguments)
+
+    assertResult(expected) { actual }
   }
 
   it should "bubble up error if workspace manager errors" in  {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -129,7 +129,7 @@ trait DataRepoEntityProviderSpecSupport {
    * Mock for DataRepoDAO that allows the caller to specify behavior for the getSnapshot and getBaseURL methods.
    *  method.
    */
-  class SpecDataRepoDAO(getSnapshotResponse:Either[Throwable, SnapshotModel], baseURL: String = dataRepoInstanceName) extends MockDataRepoDAO {
+  class SpecDataRepoDAO(getSnapshotResponse:Either[Throwable, SnapshotModel], baseURL: String = dataRepoInstanceName) extends MockDataRepoDAO(baseURL) {
 
     override def getInstanceName: String = baseURL
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -46,9 +46,8 @@ trait DataRepoEntityProviderSpecSupport {
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some(DataReferenceName("referenceName"))),
                          config: DataRepoEntityProviderConfig = DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
                         ): DataRepoEntityProvider = {
-    // TODO: shouldn't use an empty DataReferenceDescription here
-    val ref = new DataReferenceDescription()
-    new DataRepoEntityProvider(snapshotModel, ref, entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
+    // we may find that tests need to override the DataReferenceDescription provided by createDataRefDescription() on the next line
+    new DataRepoEntityProvider(snapshotModel, createDataRefDescription(), entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
   }
 
   def createTestBuilder(workspaceManagerDAO: WorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource())),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -46,7 +46,7 @@ trait DataRepoEntityProviderSpecSupport {
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some(DataReferenceName("referenceName"))),
                          config: DataRepoEntityProviderConfig = DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
                         ): DataRepoEntityProvider = {
-    // FIXME
+    // TODO: shouldn't use an empty DataReferenceDescription here
     val ref = new DataReferenceDescription()
     new DataRepoEntityProvider(snapshotModel, ref, entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -46,7 +46,9 @@ trait DataRepoEntityProviderSpecSupport {
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some(DataReferenceName("referenceName"))),
                          config: DataRepoEntityProviderConfig = DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
                         ): DataRepoEntityProvider = {
-    new DataRepoEntityProvider(snapshotModel, entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
+    // FIXME
+    val ref = new DataReferenceDescription()
+    new DataRepoEntityProvider(snapshotModel, ref, entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
   }
 
   def createTestBuilder(workspaceManagerDAO: WorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource())),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -46,8 +46,8 @@ trait DataRepoEntityProviderSpecSupport {
                          entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, userInfo, Some(DataReferenceName("referenceName"))),
                          config: DataRepoEntityProviderConfig = DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
                         ): DataRepoEntityProvider = {
-    // we may find that tests need to override the DataReferenceDescription provided by createDataRefDescription() on the next line
-    new DataRepoEntityProvider(snapshotModel, createDataRefDescription(), entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
+    // we may find that tests need to override the DataReferenceDescription provided by createDataRepoSnapshotResource() on the next line
+    new DataRepoEntityProvider(snapshotModel, createDataRepoSnapshotResource(), entityRequestArguments, samDAO, bqFactory, new MockDeltaLayerWriter(), config)
   }
 
   def createTestBuilder(workspaceManagerDAO: WorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource())),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.datarepo.model.SnapshotModel
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 
-class MockDataRepoDAO extends DataRepoDAO {
-  override def getInstanceName: String = "http://localhost:30001"
+class MockDataRepoDAO(instanceName: String) extends DataRepoDAO {
+  override def getInstanceName: String = instanceName
 
   override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = {
     val snap = new SnapshotModel()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
@@ -7,7 +7,15 @@ import bio.terra.datarepo.model.SnapshotModel
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 
 class MockDataRepoDAO extends DataRepoDAO {
-  override def getInstanceName: String = ???
+  override def getInstanceName: String = "http://localhost:30001"
 
-  override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = ???
+  override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = {
+    val snap = new SnapshotModel()
+    snap.id(snapshotId.toString)
+    snap.name("snapshotName")
+    snap.description("snapshotDescription")
+
+    snap
+
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -124,7 +124,7 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
 
     val workspaceManagerDAO: WorkspaceManagerDAO = new MockWorkspaceManagerDAO()
 
-    val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO()
+    val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
 
     val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceDeltaLayerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceDeltaLayerSpec.scala
@@ -1,0 +1,150 @@
+package org.broadinstitute.dsde.rawls.webservice
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import bio.terra.workspace.model.DataReferenceDescription
+import com.google.cloud.storage.Storage.BlobWriteOption
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
+import com.google.cloud.storage.{Blob, BlobInfo, Storage, StorageException}
+import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
+import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.deltalayer.GcsStorageTestSupport
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
+import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
+import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.time.{Millis, Seconds, Span}
+import spray.json.DefaultJsonProtocol._
+
+import java.util.UUID
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+import scala.language.postfixOps
+
+// This spec tests Delta Layer functionality from the entity APIs down.
+// See also EntityApiServiceSpec for other coverage of entity APIs.
+class EntityApiServiceDeltaLayerSpec extends ApiServiceSpec with GcsStorageTestSupport {
+
+  implicit val actorSystem: ActorSystem = ActorSystem("EntityApiServiceDeltaLayerSpec")
+
+  val bucket = GcsBucketName("unittest-bucket-name")
+
+  // in-memory GCS Storage mock
+  val storage = LocalStorageHelper.getOptions.getService
+
+  // GCS Storage mock that will throw an exception
+  val mockedException = new StorageException(418, "intentional unit test failure")
+  val throwingStorage = mock[Storage]
+  when(throwingStorage.writer(any[BlobInfo], any[BlobWriteOption]))
+    .thenThrow(mockedException)
+
+  case class TestApiServiceLocalGcsStorage(dataSource: SlickDataSource, storageImpl: Storage, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives {
+    // create in-memory local GCS storage instead of real cloud-based GCS storage
+    val deltaLayerWriter = getGcsWriter(bucket, Some(storageImpl))
+
+    // create EntityManager that will return a real GcsDeltaLayerWriter pointing at the in-memory local storage
+    override val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory, deltaLayerWriter, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
+
+    override val entityServiceConstructor: UserInfo => EntityService = EntityService.constructor(
+      dataSource,
+      samDAO,
+      workbenchMetricBaseName = workbenchMetricBaseName,
+      entityManager
+    )
+  }
+
+  def withApiServices[T](dataSource: SlickDataSource, storageImpl: Storage)(testCode: TestApiServiceLocalGcsStorage => T): T = {
+    val apiService = new TestApiServiceLocalGcsStorage(dataSource, storageImpl: Storage, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
+    try {
+      testCode(apiService)
+    } finally {
+      apiService.cleanupSupervisor
+    }
+  }
+
+  def withTestDataApiServices[T](storageImpl: Storage)(testCode: TestApiServiceLocalGcsStorage => T): T = {
+    withMinimalTestDatabase { dataSource: SlickDataSource =>
+      withApiServices(dataSource, storageImpl)(testCode)
+    }
+  }
+
+
+  behavior of "Entity APIs for Delta Layer"
+
+  it should "return 204 when batch upserting into Delta Layer succeeds" in withTestDataApiServices(storage) { services =>
+    // at the start of the test, confirm that the storage impl does NOT contain a file that starts with our expected path.
+    // since we can't predict the insertid, we can't verify the full path.
+    val storageList = storage.list(bucket.value)
+    assert(!storageList.getValues.asScala.toList.map(_.getName).exists(_.startsWith(s"workspace/${testData.workspace.workspaceId}/reference")))
+
+    // add snapshot to workspace
+    val defaultNamedSnapshotJson = httpJson(NamedDataRepoSnapshot(
+      name = DataReferenceName("testsnap"),
+      description = Some(DataReferenceDescriptionField("desc")),
+      snapshotId = UUID.randomUUID().toString
+    ))
+    Post(s"${testData.workspace.path}/snapshots", defaultNamedSnapshotJson) ~>
+      sealRoute(services.snapshotRoutes) ~>
+      check {
+        // assert the snapshot reference was created correctly
+        assertResult(StatusCodes.Created) {
+          status
+        }
+        // get the id of the reference we just created
+        val refId = responseAs[DataReferenceDescription].getReferenceId
+        // issue batchUpsert against snapshot reference
+        val update1 = EntityUpdateDefinition("newSample", "Sample", Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo"))))
+        Post(s"${testData.workspace.path}/entities/batchUpsert?dataReference=testsnap", httpJson(Seq(update1))) ~>
+          sealRoute(services.entityRoutes) ~>
+          // assert 204 returned from batchUpsert
+          check {
+            assertResult(StatusCodes.NoContent) {
+              status
+            }
+            // confirm that the storage impl contains a file that starts with our expected path.
+            // since we can't predict the insertid, we can't verify the full path.
+            // The LocalStorageHelper in-memory storage engine
+            // seems to have some delays, so use eventually to allow for delays and retries
+            eventually(timeout(Span(30, Seconds)), interval(Span(500, Millis))) {
+              val storageList: List[Blob] = storage.list(bucket.value).getValues.asScala.toList
+              storageList.map(_.getName).exists(_.startsWith(s"workspace/${testData.workspace.workspaceId}/reference/$refId/insert/"))
+            }
+          }
+      }
+  }
+
+  it should "return 500 when batch upserting into Delta Layer encounters an error"  in withTestDataApiServices(throwingStorage) { services =>
+    // add snapshot to workspace
+    val defaultNamedSnapshotJson = httpJson(NamedDataRepoSnapshot(
+      name = DataReferenceName("testsnap"),
+      description = Some(DataReferenceDescriptionField("desc")),
+      snapshotId = UUID.randomUUID().toString
+    ))
+    Post(s"${testData.workspace.path}/snapshots", defaultNamedSnapshotJson) ~>
+      sealRoute(services.snapshotRoutes) ~>
+      check {
+        // assert the snapshot reference was created correctly
+        assertResult(StatusCodes.Created) {
+          status
+        }
+        // issue batchUpsert against snapshot reference
+        val update1 = EntityUpdateDefinition("newSample", "Sample", Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo"))))
+        Post(s"${testData.workspace.path}/entities/batchUpsert?dataReference=testsnap", httpJson(Seq(update1))) ~>
+          sealRoute(services.entityRoutes) ~>
+          // the underlying throwingStorage storage impl will throw an error; that error should be propagated up
+          // to us here.
+          check {
+            assertResult(StatusCodes.ImATeapot) {
+              status
+            }
+          }
+      }
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceDeltaLayerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceDeltaLayerSpec.scala
@@ -87,7 +87,7 @@ class EntityApiServiceDeltaLayerSpec extends ApiServiceSpec with GcsStorageTestS
     val defaultNamedSnapshotJson = httpJson(NamedDataRepoSnapshot(
       name = DataReferenceName("testsnap"),
       description = Some(DataReferenceDescriptionField("desc")),
-      snapshotId = UUID.randomUUID().toString
+      snapshotId = UUID.randomUUID()
     ))
     Post(s"${testData.workspace.path}/snapshots", defaultNamedSnapshotJson) ~>
       sealRoute(services.snapshotRoutes) ~>
@@ -124,7 +124,7 @@ class EntityApiServiceDeltaLayerSpec extends ApiServiceSpec with GcsStorageTestS
     val defaultNamedSnapshotJson = httpJson(NamedDataRepoSnapshot(
       name = DataReferenceName("testsnap"),
       description = Some(DataReferenceDescriptionField("desc")),
-      snapshotId = UUID.randomUUID().toString
+      snapshotId = UUID.randomUUID()
     ))
     Post(s"${testData.workspace.path}/snapshots", defaultNamedSnapshotJson) ~>
       sealRoute(services.snapshotRoutes) ~>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -87,7 +87,7 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val samDAO = new MockSamDAO(dataSource)
     val gpsDAO = new MockGooglePubSubDAO
     val workspaceManagerDAO = mock[MockWorkspaceManagerDAO](RETURNS_SMART_NULLS)
-    val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO()
+    val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
 
     val notificationTopic = "test-notification-topic"
     val notificationDAO = new PubSubNotificationDAO(gpsDAO, notificationTopic)

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DeltaLayer.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DeltaLayer.scala
@@ -1,0 +1,28 @@
+package org.broadinstitute.dsde.rawls.model
+
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
+import org.joda.time.DateTime
+
+import java.util.UUID
+
+// TODO: nest under some version tag; we will likely need a way to track different model versions
+
+case class Destination(workspaceId: UUID,
+                       referenceId: UUID)
+                       // TODO: will also need:
+                       // bqDataset: String,
+                       // datasetProject: GoogleProjectId,
+                       // projectToBill: GoogleProjectId)
+
+case class DeltaInsert(version: String,
+                            insertId: UUID,
+                            insertTimestamp: DateTime,
+                            insertingUser: RawlsUserSubjectId,
+                            destination: Destination,
+                            inserts: Seq[EntityUpdateDefinition])
+
+
+
+
+
+//

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DeltaLayer.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DeltaLayer.scala
@@ -5,24 +5,22 @@ import org.joda.time.DateTime
 
 import java.util.UUID
 
-// TODO: nest under some version tag; we will likely need a way to track different model versions
+// TODO AS-770: nest under some version tag; we will likely need a way to track different model versions
+// TODO AS-770: flesh out with everything these model classes need
+// TODO AS-770: use something more generic than Seq[EntityUpdateDefinition]?
+// TODO AS-770: JSON de/serializers
+// TODO AS-770: class naming?
 
 case class Destination(workspaceId: UUID,
                        referenceId: UUID)
-                       // TODO: will also need:
+                       // will also need, at least:
                        // bqDataset: String,
                        // datasetProject: GoogleProjectId,
                        // projectToBill: GoogleProjectId)
 
 case class DeltaInsert(version: String,
-                            insertId: UUID,
-                            insertTimestamp: DateTime,
-                            insertingUser: RawlsUserSubjectId,
-                            destination: Destination,
-                            inserts: Seq[EntityUpdateDefinition])
-
-
-
-
-
-//
+                       insertId: UUID,
+                       insertTimestamp: DateTime,
+                       insertingUser: RawlsUserSubjectId,
+                       destination: Destination,
+                       inserts: Seq[EntityUpdateDefinition])

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,7 +101,7 @@ object Dependencies {
   val workbenchGoogleMocks: ModuleID =  workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests")
   val workbenchGoogle2: ModuleID =      workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V)
   val workbenchGoogle2Tests: ModuleID = workbenchGoogleExcludes("org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests")
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.111.0-alpha" % "test"
+  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.122.11" % "test"
 
   val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-d4b4838" excludeAll(excludeWorkbenchModel)
 


### PR DESCRIPTION
Objective of this PR, for AS-769: complete a spike that connects a user's API call for a point correction all the way to writing the point correction file to the Delta Layer source bucket. 

Out of scope, targeted for AS-770: populating that file with all the necessary data and validating the point correction's contents.

The API underlying point corrections is [batchUpsert](https://rawls.dsde-dev.broadinstitute.org/#/entities/batch_upsert_entities). We should also tackle [batchUpdate](https://rawls.dsde-dev.broadinstitute.org/#/entities/batch_update_entities) at some point because they are so similar, but I also considered that out of scope for this PR.

Reviewer: if you want to run this locally, I suggest adding
```
        - $ref: '#/components/parameters/dataReferenceQueryParam'
```
to the swagger definition for the batchUpsert API; this will allow you to easily test batchUpsert against a snapshot reference. I have not updated swagger as part of this PR in order to keep this functionality somewhat obscured, since it is incomplete.



