### PR TITLE
optimize entity rewrites when no attributes changed [AS-763]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -341,6 +341,16 @@ trait AttributeComponent {
       }
     }
 
+    /**
+     * Compares a collection of pre-existing attributes to a collection of attributes requested to save by a user,
+     * finds the differences, saves the differences, and then returns the ids of the parent (entity|workspace) objects
+     * that were affected.
+     *
+     * @param attributesToSave collection of attributes to be written
+     * @param existingAttributes collection of pre-existing attributes to compare against
+     * @param insertFunction function to use when writing attributes to the db (allows rewriteAttrsAction to be generic)
+     * @return the ids of the parent (entity|workspace) objects that had attribute inserts/updates/deletes
+     */
     def rewriteAttrsAction(attributesToSave: Traversable[RECORD], existingAttributes: Traversable[RECORD], insertFunction: Seq[RECORD] => String => WriteAction[Int]): ReadWriteAction[Set[OWNER_ID]] = {
       val toSaveAttrMap = toPrimaryKeyMap(attributesToSave)
       val existingAttrMap = toPrimaryKeyMap(existingAttributes)
@@ -381,7 +391,7 @@ trait AttributeComponent {
             !existingAttributes.exists(equalRecords(_, v)) // if the attribute exists and is unchanged, don't update it
       }
 
-      // collect the parent entities that have writes, so we know which entity rows to re-calculate
+      // collect the parent objects (e.g. entity, workspace) that have writes, so we know which object rows to re-calculate
       val ownersWithWrites: Set[OWNER_ID] = (attributesToInsert.values.map(_.ownerId) ++
         attributesToUpdate.values.map(_.ownerId) ++
         attributesToDelete.values.map(_.ownerId))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -520,7 +520,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   }
 
-  it should "update an entity's attributes many times concurrently" in withDefaultTestDatabase {
+  it should "not re-update an entity's attributes over many writes if attribute do not change" in withDefaultTestDatabase {
     val pair2 = Entity("pair2", "Pair",
       Map(
         AttributeName.withDefaultNS("case") -> AttributeEntityReference("Sample", "sample3"),
@@ -539,9 +539,44 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       assert {
         runAndWait(entityQuery.get(testData.workspace, "Pair", "pair2")).isDefined
       }
-      assertResult(count+1) {
+      assertResult(0) { // the additional writes should not increment this entity's version
         runAndWait(entityQuery.findEntityByName(testData.workspace.workspaceIdAsUUID, "Pair", "pair2").map(_.version).result).head
       }
+    }
+  }
+
+  it should "update an entity's attributes many times concurrently if attributes change" in withDefaultTestDatabase {
+    def makeEntity(idx: Int): Entity = {
+      Entity("some-sample", "Sample",
+        Map(
+          AttributeName.withDefaultNS("indexValue") -> AttributeString(s"index-$idx")
+        )
+      )
+    }
+
+    withWorkspaceContext(testData.workspace) { context =>
+      runAndWait(entityQuery.save(context, makeEntity(0)))
+
+      // did we save the entity?
+      // did we populate its all_attribute_values?
+      val entityWithAllAttrs = runAndWait(entityQueryWithInlineAttributes.findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample").result)
+      entityWithAllAttrs should have length 1
+      entityWithAllAttrs.head.recordVersion shouldBe 0
+      entityWithAllAttrs.head.allAttributeValues should not be empty
+      entityWithAllAttrs.head.allAttributeValues.get should include ("index-0")
+    }
+
+    withWorkspaceContext(testData.workspace) { context =>
+      val count = 20
+      runMultipleAndWait(count)(idx => entityQuery.save(context, makeEntity(idx)))
+
+      // did we update the record versions and populate its all_attribute_values?
+      val entityWithAllAttrs = runAndWait(entityQueryWithInlineAttributes.findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample").result)
+      entityWithAllAttrs should have length 1
+      entityWithAllAttrs.head.recordVersion shouldBe count
+      entityWithAllAttrs.head.allAttributeValues should not be empty
+      entityWithAllAttrs.head.allAttributeValues.get should not be empty
+      entityWithAllAttrs.head.allAttributeValues.get should not include ("index-0") // we should have updated to newer values
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -568,7 +568,9 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
     withWorkspaceContext(testData.workspace) { context =>
       val count = 20
-      runMultipleAndWait(count)(idx => entityQuery.save(context, makeEntity(idx)))
+      (1 to count) foreach { idx =>
+        runAndWait(entityQuery.save(context, makeEntity(idx)))
+      }
 
       // did we update the record versions and populate its all_attribute_values?
       val entityWithAllAttrs = runAndWait(entityQueryWithInlineAttributes.findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample").result)
@@ -576,7 +578,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       entityWithAllAttrs.head.recordVersion shouldBe count
       entityWithAllAttrs.head.allAttributeValues should not be empty
       entityWithAllAttrs.head.allAttributeValues.get should not be empty
-      entityWithAllAttrs.head.allAttributeValues.get should not include ("index-0") // we should have updated to newer values
+      entityWithAllAttrs.head.allAttributeValues.get should include ("index-20") // we should have updated to the newest value
     }
   }
 


### PR DESCRIPTION
Use case: a user has a workspace containing a collection of 2000 data entities of type "sample." The user downloads a TSV of those entities, modifies one row, and re-uploads the TSV in order to tweak their data. This is a not-uncommon click path for users.

Before this PR: Rawls recalculated the "all_attribute_values" string for ALL 2000 entities, and issues 2000 individual `update ENTITY ... ` sql statements, overwriting each entity - including the potentially large "all_attribute_values" column - and incrementing each entity's record version.

After this PR: Rawls only recalculates the "all_attribute_values" string for the one entity that actually had its attributes change, and only issues one `update ENTITY ...` sql statement. This single entity is the only one whose record version is incremented.

-----

I did take a look at the other suggestion in AS-763 - to fail fast on `updateTrials` if any of the entities the user is trying to update do not exist (and it's an update, not an upsert). I don't think that's a big win - it doesn't change database interaction, and it only affects in-memory data munging - so I didn't make changes there for fear of regression.

