### PR TITLE
AS-774: Workflows in Requester Pays enabled workspaces fail

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -200,7 +200,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
     }
 
     for {
-      regionOption <- googleServicesDAO.getRegionForRegionalBucket(bucketName, None)
+      regionOption <- googleServicesDAO.getRegionForRegionalBucket(bucketName, Option(GoogleProjectId(googleProjectId)))
       runtimeOptions <- {
         regionOption match {
           case Some(region) => googleServicesDAO.getComputeZonesForRegion(GoogleProjectId(googleProjectId), region).map(updateRuntimeOptions)


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/AS-774 on how to reproduce. I have a workspace on dev that I can share with you if you'd rather not go through the hassle of creating your own RP workspace.

This PR fixes a bug in Requester Pays workspaces where workflows immediately fail after a submission starts because, under the hood, they're trying to get the workspace bucket without specifying a project to be billed.

I added an API test that tests running a submission in an RP workspace, which I realized we actually didn't have.