### PR TITLE
add extra info to waitUntilSubmissionComplete fail message [no ticket; test code only]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/Submission.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/Submission.scala
@@ -31,8 +31,12 @@ object Submission extends LazyLogging with Eventually with RandomUtil {
     * see Rawls' SubmissionStatuses object for canonical submission status values.
     */
   def getSubmissionStatus(billingProject: String, workspaceName: String, submissionId: String)(implicit token: AuthToken): String = {
-    val (status, _) = Rawls.submissions.getSubmissionStatus(billingProject, workspaceName, submissionId)
+    val (status, _) = getSubmissionStatusAndWorkflowIds(billingProject, workspaceName, submissionId)
     status
+  }
+
+  def getSubmissionStatusAndWorkflowIds(billingProject: String, workspaceName: String, submissionId: String)(implicit token: AuthToken): (String, List[String]) = {
+    Rawls.submissions.getSubmissionStatus(billingProject, workspaceName, submissionId)
   }
 
   /*
@@ -42,8 +46,9 @@ object Submission extends LazyLogging with Eventually with RandomUtil {
     implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(20, Minutes)), interval = scaled(Span(30, Seconds)))
 
     eventually {
-      val actualStatus = getSubmissionStatus(billingProjectName, workspaceName, submissionId)
-      withClue(s"Monitoring submission $billingProjectName/$workspaceName/$submissionId until finish") {
+      val (actualStatus, workflowIds) = getSubmissionStatusAndWorkflowIds(billingProjectName, workspaceName, submissionId)
+      withClue(s"Monitoring submission [$billingProjectName/$workspaceName/$submissionId] until finish; " +
+                     s"actual status was [$actualStatus] with first 10 workflow ids [${workflowIds.take(10).mkString(", ")}]") {
         isSubmissionDone(actualStatus) shouldBe true
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/Submission.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/Submission.scala
@@ -49,7 +49,8 @@ object Submission extends LazyLogging with Eventually with RandomUtil {
     eventually {
       val (actualStatus, workflowIds) = getSubmissionStatusAndWorkflowIds(billingProjectName, workspaceName, submissionId)
       withClue(s"Monitoring submission [$billingProjectName/$workspaceName/$submissionId] until finish; " +
-                     s"actual status was [$actualStatus] with first 10 workflow ids [${workflowIds.take(10).mkString(", ")}]") {
+                     s"actual status was [$actualStatus] with first 10 workflow ids [${workflowIds.take(10).mkString(", ")}]. " +
+                     s"Scalatest-generated error message is:") {
         SUBMISSION_COMPLETED_STATES should contain (actualStatus)
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/Submission.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/Submission.scala
@@ -16,6 +16,7 @@ object Submission extends LazyLogging with Eventually with RandomUtil {
 
   private val SUBMISSION_COMPLETED_STATES = List(DONE_STATUS, ABORTED_STATUS)
 
+  // N.B. currently not used anywhere
   def isSubmissionDone(status: String): Boolean = {
     SUBMISSION_COMPLETED_STATES.contains(status)
   }
@@ -49,7 +50,7 @@ object Submission extends LazyLogging with Eventually with RandomUtil {
       val (actualStatus, workflowIds) = getSubmissionStatusAndWorkflowIds(billingProjectName, workspaceName, submissionId)
       withClue(s"Monitoring submission [$billingProjectName/$workspaceName/$submissionId] until finish; " +
                      s"actual status was [$actualStatus] with first 10 workflow ids [${workflowIds.take(10).mkString(", ")}]") {
-        isSubmissionDone(actualStatus) shouldBe true
+        SUBMISSION_COMPLETED_STATES should contain (actualStatus)
       }
     }
   }


### PR DESCRIPTION
Adds extra info to the `waitUntilSubmissionComplete` output for automation tests. If a test fails because a submission doesn't complete in time, we now have more info.

Before this PR, error messages looked like:
> Last failure message: Monitoring submission workspace-namespace/workspace name/123e4567-e89b-12d3-a456-426614174000 until finish false was not equal to true.

After this PR, they will look like:
> Last failure message: Monitoring submission [workspace-namespace/workspace name/123e4567-e89b-12d3-a456-426614174000] until finish; actual status was [Running] with first 10 workflow ids [123e4567-e89b-12d3-a456-426614174000, 123e4567-e89b-12d3-a456-426614174000]. Scalatest-generated error message is: List(Done, Aborted) did not contain element "Running"
