### PR TITLE
Delete entity optimizations [AS-808]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -612,12 +612,10 @@ trait EntityComponent {
     }
 
     // "delete" entities by hiding and renaming
-
     def hide(workspaceContext: Workspace, entRefs: Seq[AttributeEntityReference]): ReadWriteAction[Int] = {
       workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
         getEntityRecords(workspaceContext.workspaceIdAsUUID, entRefs.toSet) flatMap { entRecs =>
           val hideAction = entRecs map { rec =>
-            hideEntityAttributes(rec.id) andThen
               hideEntityAction(rec)
           }
           DBIO.sequence(hideAction).map(_.sum)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -616,7 +616,10 @@ trait EntityComponent {
       workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
         getEntityRecords(workspaceContext.workspaceIdAsUUID, entRefs.toSet) flatMap { entRecs =>
           val hideAction = entRecs map { rec =>
-              hideEntityAction(rec)
+            // N.B. we do not hide the entity's attributes, just the entity itself.
+            // since the entity itself is considered when checking uniqueness of attributes,
+            // renaming the entity will effectively hide its attributes.
+            hideEntityAction(rec)
           }
           DBIO.sequence(hideAction).map(_.sum)
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -646,25 +646,6 @@ trait EntityComponent {
         EntityRecordRawSqlQuery.batchHide(workspaceContext.workspaceIdAsUUID, entRefs).map( res => res.sum)
     }
 
-    // currently unused
-    private def hideEntityAttributes(entityId: Long): ReadWriteAction[Seq[Int]] = {
-      findActiveAttributesByEntityId(entityId).result flatMap { attrRecs =>
-        DBIO.sequence(attrRecs map hideEntityAttribute)
-      }
-    }
-
-    // currently unused, except from hideEntityAttributes(entityId: Long) above
-    private def hideEntityAttribute(attrRec: EntityAttributeRecord): WriteAction[Int] = {
-      val currentTime = new Timestamp(new Date().getTime)
-      entityAttributeQuery.filter(_.id === attrRec.id).map(rec => (rec.deleted, rec.name, rec.deletedDate)).update(true, renameForHiding(attrRec.id, attrRec.name), Option(currentTime))
-    }
-
-    // currently unused
-    private def hideEntityAction(entRec: EntityRecord): WriteAction[Int] = {
-      val currentTime = new Timestamp(new Date().getTime)
-      findEntityById(entRec.id).map(rec => (rec.deleted, rec.name, rec.deletedDate)).update(true, renameForHiding(entRec.id, entRec.name), Option(currentTime))
-    }
-
     // perform actual deletion (not hiding) of all entities in a workspace
 
     def deleteFromDb(workspaceId: UUID): WriteAction[Int] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -76,6 +76,8 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] = {
     dataSource.inTransaction { dataAccess =>
       // withAllEntities throws exception if some entities not found; passes through if all ok
+      // TODO: davidan: withAllEntities issues individual SELECT statements for each entity, in order to collect
+      // error messages on which are missing. This could be significantly optimized.
       withAllEntities(workspaceContext, dataAccess, entRefs) { entities =>
         dataAccess.entityQuery.getAllReferringEntities(workspaceContext, entRefs.toSet) flatMap { referringEntities =>
           if (referringEntities != entRefs.toSet)


### PR DESCRIPTION
This PR optimizes Rawls' interaction with the database, when a user deletes multiple entities from a workspace. Note that we do not actually delete rows from the db; we update those rows to set a deleted flag. So, we use the terminology "hide" instead of delete.

The relevant Rawls API for this is https://rawls.dsde-dev.broadinstitute.org/#/entities/delete_entities.

**Before this PR**, Rawls would:
* re-query the `ENTITY` table to retrieve all entities-to-be-hidden, just before hiding them (1 SQL statement)
* for each of N entities to be hidden, re-query to list all of that entity's attributes (N SQL statements)
* for each of M attributes to be hidden, call the relatively CPU-expensive `getSufficientlyRandomSuffix()` method
* for each of M attributes to be hidden, issue an individual `UPDATE` to the db (M SQL statements)
* for each of N entities to be hidden, call the relatively CPU-expensive `getSufficientlyRandomSuffix()` method
* for each of N entities to be hidden, issue an individual `UPDATE` to the db (N SQL statements)

This equates to `2N + (N*M) + 1` SQL statements. So, **if the user chose to hide 20 entities, each of which had 10 attributes, we would issue 241 SQL statements and invoke `getSufficientlyRandomSuffix()` 220 times.**. The number of SQL statements and method invocations is O(N) to the number of entities*attributes.

**After this PR**, Rawls will:
* _not_ re-query the `ENTITY` table to retrieve all entities-to-be-hidden, just before hiding them
* _not_ re-query to list each entity's attributes
* call `getSufficientlyRandomSuffix()` twice, once for the entire batch of attributes and once for the entire batch of entities
* issue one SQL statement to hide all relevant attributes
* issue one SQL statement to hide all relevant entities

**This is a total of 2 SQL statements and 2 invocations of `getSufficientlyRandomSuffix()`**. This is a fixed number, not O(N), though the SQL statements involved become longer as the number of entities rises.

The new SQL statements involved are … 

To hide entities:
```
update ENTITY set deleted=1, deleted_date=?, name=CONCAT(name, ?) where deleted=0 AND workspace_id=? and (entity_type, name) in ((?, ?),(?, ?),(?, ?))
```

To hide attributes:
```
update ENTITY_ATTRIBUTE ea join ENTITY e on ea.owner_id = e.id
    set ea.deleted=1, ea.deleted_date=?, ea.name=CONCAT(ea.name, ?)
    where e.workspace_id=? and ea.deleted=0 and (e.entity_type, e.name) in ((?, ?),(?, ?),(?, ?))
```
(both examples illustrate hiding three entities, but will support any number)



