### PR TITLE
optimize withAllEntities [AS-808]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -76,9 +76,7 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] = {
     dataSource.inTransaction { dataAccess =>
       // withAllEntities throws exception if some entities not found; passes through if all ok
-      // TODO: davidan: withAllEntities issues individual SELECT statements for each entity, in order to collect
-      // error messages on which are missing. This could be significantly optimized.
-      withAllEntities(workspaceContext, dataAccess, entRefs) { entities =>
+      withAllEntityRefs(workspaceContext, dataAccess, entRefs) { _ =>
         dataAccess.entityQuery.getAllReferringEntities(workspaceContext, entRefs.toSet) flatMap { referringEntities =>
           if (referringEntities != entRefs.toSet)
             throw new DeleteEntitiesConflictException(referringEntities)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -75,7 +75,7 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   // EntityApiServiceSpec has good test coverage for this api
   override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] = {
     dataSource.inTransaction { dataAccess =>
-      // withAllEntities throws exception if some entities not found; passes through if all ok
+      // withAllEntityRefs throws exception if some entities not found; passes through if all ok
       withAllEntityRefs(workspaceContext, dataAccess, entRefs) { _ =>
         dataAccess.entityQuery.getAllReferringEntities(workspaceContext, entRefs.toSet) flatMap { referringEntities =>
           if (referringEntities != entRefs.toSet)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
@@ -38,10 +38,8 @@ trait EntitySupport {
       val notFound = entities diff found
       if (notFound.nonEmpty) {
         // generate error messages
-        val failures = notFound.map { e =>
-          Failure(new RawlsException(s"${e.entityType} ${e.entityName} does not exist in ${workspaceContext.toWorkspaceName}"))
-        }
-        val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = (Seq("Entities were not found:") ++ failures) mkString System.lineSeparator())
+        val failureMessages = notFound.map { e => s"${e.entityType} ${e.entityName} does not exist in ${workspaceContext.toWorkspaceName}" }
+        val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = (Seq("Entities were not found:") ++ failureMessages) mkString System.lineSeparator())
         DBIO.failed(new RawlsExceptionWithErrorReport(err))
       } else {
         op(found)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
@@ -31,20 +31,20 @@ trait EntitySupport {
     }
   }
 
-  def withAllEntities[T](workspaceContext: Workspace, dataAccess: DataAccess, entities: Seq[AttributeEntityReference])(op: (Seq[Entity]) => ReadWriteAction[T]): ReadWriteAction[T] = {
-    val entityActions: Seq[ReadAction[Try[Entity]]] = entities map { e =>
-      dataAccess.entityQuery.get(workspaceContext, e.entityType, e.entityName) map {
-        case None => Failure(new RawlsException(s"${e.entityType} ${e.entityName} does not exist in ${workspaceContext.toWorkspaceName}"))
-        case Some(entity) => Success(entity)
-      }
-    }
-
-    DBIO.sequence(entityActions) flatMap { entityTries =>
-      val failures = entityTries.collect { case Failure(y) => y.getMessage }
-      if (failures.isEmpty) op(entityTries collect { case Success(e) => e })
-      else {
+  def withAllEntityRefs[T](workspaceContext: Workspace, dataAccess: DataAccess, entities: Seq[AttributeEntityReference])(op: (Seq[AttributeEntityReference]) => ReadWriteAction[T]): ReadWriteAction[T] = {
+    // query the db to see which of the specified entity refs exist in the workspace and are active
+    dataAccess.entityQuery.getActiveRefs(workspaceContext.workspaceIdAsUUID, entities.toSet) flatMap { found =>
+      // were any of the user's entities not found in our query?
+      val notFound = entities diff found
+      if (notFound.nonEmpty) {
+        // generate error messages
+        val failures = notFound.map { e =>
+          Failure(new RawlsException(s"${e.entityType} ${e.entityName} does not exist in ${workspaceContext.toWorkspaceName}"))
+        }
         val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = (Seq("Entities were not found:") ++ failures) mkString System.lineSeparator())
         DBIO.failed(new RawlsExceptionWithErrorReport(err))
+      } else {
+        op(found)
       }
     }
   }


### PR DESCRIPTION
Optimizes database interactions for `withAllEntityRefs`, previously named `withAllEntities`.

This method is only called in the code path for deleting/hiding entities. The intention of the method is to validate that all of the entities specified by the end user for deletion do actually exist in the workspace and are active.

Before this PR, this method issued N individual SQL statements, one for each entity to be deleted. The SQL statement itself was a three-table join and returned many extraneous columns:
```
select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
    a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
    e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
    from ENTITY e
    left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted
    left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id where e.name = ? and e.entity_type = ? and e.workspace_id = ?
```

After this PR, this method issues one and only one SQL statement, which is now slimmed down to a single table and only returns the two columns we need:
```
select entity_type, name from ENTITY where workspace_id = ? and deleted = 0 and (entity_type, name) in ((?, ?),(?, ?),(?, ?))
```

This reduces SQL statements from O(N) to 1. 

To be fair, the 1 sql statement can grow to have a large `IN` clause, but that seems worth it.


