### PR TITLE
improve rewriteAttrsAction speed [AS-803]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -360,14 +360,13 @@ trait AttributeComponent {
       // note this does not include transactionId for AttributeScratchRecords. We do not expect AttributeScratchRecords
       // here, and transactionId will eventually be going away, so don't bother
       object ComparableRecord {
-        def fromRecord[OWNER_ID](rec: RECORD): ComparableRecord[OWNER_ID] = {
-          // TODO: davidan: is the asInstanceOf safe here?? I'm not sure why rec.ownerId doesn't compile on its own
-          new ComparableRecord[OWNER_ID](rec.ownerId.asInstanceOf[OWNER_ID], rec.namespace, rec.name, rec.valueString, rec.valueNumber, rec.valueBoolean,
+        def fromRecord(rec: RECORD): ComparableRecord = {
+          new ComparableRecord(rec.ownerId, rec.namespace, rec.name, rec.valueString, rec.valueNumber, rec.valueBoolean,
             rec.valueJson, rec.valueEntityRef, rec.listIndex, rec.listLength, rec.deleted, rec.deletedDate)
         }
       }
 
-      case class ComparableRecord[OWNER_ID] (
+      case class ComparableRecord (
         ownerId: OWNER_ID,
         namespace: String,
         name: String,
@@ -383,7 +382,7 @@ trait AttributeComponent {
       )
 
       // create a set of ComparableRecords representing the existing attributes
-      val existingAttributesSet: Set[ComparableRecord[OWNER_ID]] = existingAttributes.toSet.map(r => ComparableRecord.fromRecord[OWNER_ID](r))
+      val existingAttributesSet: Set[ComparableRecord] = existingAttributes.toSet.map(r => ComparableRecord.fromRecord(r))
 
       val existingKeys = existingAttrMap.keySet
 
@@ -396,7 +395,7 @@ trait AttributeComponent {
       val attributesToUpdate = toSaveAttrMap.filter {
         case (k, v) =>
             existingKeys.contains(k) && // if the attribute doesn't already exist, don't attempt to update it
-            !existingAttributesSet.contains(ComparableRecord.fromRecord[OWNER_ID](v)) // if the attribute exists and is unchanged, don't update it
+            !existingAttributesSet.contains(ComparableRecord.fromRecord(v)) // if the attribute exists and is unchanged, don't update it
       }
 
       // collect the parent objects (e.g. entity, workspace) that have writes, so we know which object rows to re-calculate

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -355,6 +355,36 @@ trait AttributeComponent {
       val toSaveAttrMap = toPrimaryKeyMap(attributesToSave)
       val existingAttrMap = toPrimaryKeyMap(existingAttributes)
 
+      // note that currently-existing attributes will have a populated id e.g. "1234", but to-save will have an id of "0"
+      // therefore, we use this ComparableRecord class which omits the id when checking equality between existing and to-save.
+      // note this does not include transactionId for AttributeScratchRecords. We do not expect AttributeScratchRecords
+      // here, and transactionId will eventually be going away, so don't bother
+      object ComparableRecord {
+        def fromRecord[OWNER_ID](rec: RECORD): ComparableRecord[OWNER_ID] = {
+          // TODO: davidan: is the asInstanceOf safe here?? I'm not sure why rec.ownerId doesn't compile on its own
+          new ComparableRecord[OWNER_ID](rec.ownerId.asInstanceOf[OWNER_ID], rec.namespace, rec.name, rec.valueString, rec.valueNumber, rec.valueBoolean,
+            rec.valueJson, rec.valueEntityRef, rec.listIndex, rec.listLength, rec.deleted, rec.deletedDate)
+        }
+      }
+
+      case class ComparableRecord[OWNER_ID] (
+        ownerId: OWNER_ID,
+        namespace: String,
+        name: String,
+        valueString: Option[String],
+        valueNumber: Option[Double],
+        valueBoolean: Option[Boolean],
+        valueJson: Option[String],
+        valueEntityRef: Option[Long],
+        listIndex: Option[Int],
+        listLength: Option[Int],
+        deleted: Boolean,
+        deletedDate: Option[Timestamp]
+      )
+
+      // create a set of ComparableRecords representing the existing attributes
+      val existingAttributesSet: Set[ComparableRecord[OWNER_ID]] = existingAttributes.toSet.map(r => ComparableRecord.fromRecord[OWNER_ID](r))
+
       val existingKeys = existingAttrMap.keySet
 
       // insert attributes which are in save but not exists
@@ -363,32 +393,10 @@ trait AttributeComponent {
       // delete attributes which are in exists but not save
       val attributesToDelete = existingAttrMap.filterKeys(! toSaveAttrMap.keySet.contains(_))
 
-      // update attributes which are in both to-save and currently-exists, but have different values.
-      // note that currently-existing attributes will have a populated id e.g. "1234", but to-save will have an id of "0"
-      // therefore, use a comparison function that looks at everything except id
-      // note this does not compare transactionId for AttributeScratchRecords. We do not expect AttributeScratchRecords
-      // here, and transactionId will eventually be going away, so don't bother
-      // TODO: should this compare function move closer to the AttributeRecord class?
-      def equalRecords(left: RECORD, right: RECORD): Boolean = {
-        // compare everything except id
-        left.name == right.name &&
-        left.valueString == right.valueString &&
-        left.valueNumber == right.valueNumber &&
-        left.valueBoolean == right.valueBoolean &&
-        left.valueJson == right.valueJson &&
-        left.valueEntityRef == right.valueEntityRef &&
-        left.listIndex == right.listIndex &&
-        left.listLength == right.listLength &&
-        left.namespace == right.namespace &&
-        left.ownerId == right.ownerId &&
-        left.deleted == right.deleted &&
-        left.deletedDate == right.deletedDate
-      }
-
       val attributesToUpdate = toSaveAttrMap.filter {
         case (k, v) =>
             existingKeys.contains(k) && // if the attribute doesn't already exist, don't attempt to update it
-            !existingAttributes.exists(equalRecords(_, v)) // if the attribute exists and is unchanged, don't update it
+            !existingAttributesSet.contains(ComparableRecord.fromRecord[OWNER_ID](v)) // if the attribute exists and is unchanged, don't update it
       }
 
       // collect the parent objects (e.g. entity, workspace) that have writes, so we know which object rows to re-calculate

--- a/core/src/test/resources/fixtures/batchUpsert/README.md
+++ b/core/src/test/resources/fixtures/batchUpsert/README.md
@@ -1,0 +1,2 @@
+* mediumtext-initial.json: anonymized data with 2304 rows and
+  59 columns. Some of the columns contain values 200-300 characters long.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -84,7 +84,8 @@ class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Ma
 
   behavior of "Batch Upsert scaling"
 
-  it should "calculate perf stats for a medium-sized data table, updating one cell and ignoring unchanged cells" in withTestDataServices { testApiService =>
+  // test is currently ignored; manually re-enable it in order to run tests locally
+  it should "calculate perf stats for a medium-sized data table, updating one cell and ignoring unchanged cells" ignore withTestDataServices { testApiService =>
 
     // =========== START DATA SETUP ===========
     // read batch upsert file from src/test/resources

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -1,0 +1,167 @@
+package org.broadinstitute.dsde.rawls.entities.local
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import breeze.linalg._
+import breeze.stats._
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
+import org.broadinstitute.dsde.rawls.deltalayer.MockDeltaLayerWriter
+import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
+import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
+import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO, RemoteServicesMockServer}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeString, RawlsUser, UserInfo}
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.rawls.webservice.EntityApiService
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+import scala.io.Source
+
+class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with TestDriverComponent with RawlsTestUtils with Eventually with MockitoTestUtils with RawlsStatsDTestUtils with BeforeAndAfterAll  with LazyLogging {
+
+  // =========== START SERVICES AND MOCKS SETUP ===========
+  // copied from EntityServiceSpec
+  val mockServer = RemoteServicesMockServer()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    mockServer.startServer()
+  }
+
+  override def afterAll(): Unit = {
+    mockServer.stopServer
+    super.afterAll()
+  }
+
+  //noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit val executionContext: ExecutionContext) extends EntityApiService with MockUserInfoDirectivesWithUser {
+    private val userInfo1 = UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId)
+    lazy val entityService: EntityService = entityServiceConstructor(userInfo1)
+
+    def actorRefFactory = system
+    val samDAO = new MockSamDAO(dataSource)
+
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
+
+    val testConf = ConfigFactory.load()
+
+    override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
+
+    val entityServiceConstructor = EntityService.constructor(
+      slickDataSource,
+      samDAO,
+      workbenchMetricBaseName,
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, new MockDeltaLayerWriter(), DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
+    )_
+  }
+
+  def withTestDataServices[T](testCode: TestApiService => T): T = {
+    withMinimalTestDatabase { dataSource: SlickDataSource =>
+      withServices(dataSource, testData.userOwner)(testCode)
+    }
+  }
+
+  private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: (TestApiService) => T) = {
+    val apiService = new TestApiService(dataSource, user)
+    testCode(apiService)
+  }
+  // =========== END SERVICES AND MOCKS SETUP ===========
+
+  behavior of "Batch Upsert scaling"
+
+  it should "calculate perf stats for a medium-sized data table, updating one cell and ignoring unchanged cells" in withTestDataServices { testApiService =>
+
+    // =========== START DATA SETUP ===========
+    // read batch upsert file from src/test/resources
+    val batchUpsertFile: String = Source.fromResource("fixtures/batchUpsert/mediumtext-initial.json").getLines().mkString
+
+    // parse into EntityUpdateDefinition. This is our initial load file, as if the user had an empty workspace
+    // and uploaded a TSV to create a new data table.
+    val initialUpsert: Seq[EntityUpdateDefinition] = batchUpsertFile.parseJson.convertTo[Seq[EntityUpdateDefinition]]
+
+    // copy the initial upsert, but change one value. This is as if the user downloaded a data table to TSV,
+    // modified one cell, and re-uploaded the entire TSV.
+    val firstUpdateDef: EntityUpdateDefinition = initialUpsert.head
+    val firstAddUpdate: AddUpdateAttribute = (firstUpdateDef.operations.collectFirst {
+      case aua:AddUpdateAttribute => aua
+    }).getOrElse(fail("test or fixture invalid: expected first operation in first update to be an AddUpdateAttribute"))
+    val modifiedAddUpdate: AttributeUpdateOperation = firstAddUpdate.copy(addUpdateAttribute = AttributeString(s"${firstAddUpdate.addUpdateAttribute.toString}-changed"))
+    val modifiedUpdateDef = firstUpdateDef.copy(operations = (modifiedAddUpdate +: firstUpdateDef.operations.tail))
+    val modifiedUpsert: Seq[EntityUpdateDefinition] = modifiedUpdateDef +: initialUpsert.tail
+
+    // find all entity refs in the initial file; this represents all the entities we need to delete to remove the entire table
+    val refsToDelete: Seq[AttributeEntityReference] = initialUpsert.map { updateDef =>
+      AttributeEntityReference(updateDef.entityType, updateDef.name)
+    }
+    // =========== END DATA SETUP ===========
+
+    /**
+      * timer function
+      */
+    def profile[T](op: => T): (Long, T) = {
+      val tick = System.nanoTime()
+      val result = op
+      val duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime - tick) // could just stick with nanos for more precision
+      (duration, result)
+    }
+
+    // container class for the timings we measure
+    case class Timing(load: Long, change: Long, delete: Long)
+
+    val NUM_ITERATIONS = 20                 // how many times should we loop over the calls-to-be-profiled?
+    val waitDuration: Duration = 10.minutes // how long should we wait for any call?
+
+    // recursive function to execute the service calls NUM_ITERATIONS times
+    def repeatCalls(iteration: Int, previousTimings: Seq[Timing]): Seq[Timing] = {
+      if (iteration+1 > NUM_ITERATIONS) {
+        previousTimings
+      } else {
+        val (loadDuration, _) = profile {
+          Await.result(testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, initialUpsert, None, None), waitDuration)
+        }
+        val (changeDuration, _) = profile {
+          Await.result(testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, modifiedUpsert, None, None), waitDuration)
+        }
+        val (deleteDuration, _) = profile {
+          Await.result(testApiService.entityService.deleteEntities(minimalTestData.wsName, refsToDelete, None, None), waitDuration)
+        }
+        val thisTiming = Timing(loadDuration, changeDuration, deleteDuration)
+
+        logger.error(s"iteration ${iteration+1} of $NUM_ITERATIONS: load ${loadDuration}ms, change ${changeDuration}ms, delete ${deleteDuration}ms")
+
+        repeatCalls(iteration+1, previousTimings :+ thisTiming)
+      }
+    }
+
+    // launch the loop
+    val initialTimings = Seq.empty[Timing]
+    val finalTimings = repeatCalls(0, initialTimings)
+
+    // write the timings to the log
+    def outputStats(label: String, timings: Seq[Double]): Unit = {
+      logger.error(s"$label: mean ${mean(timings).toInt}ms, min ${min(timings).toInt}ms, max ${max(timings).toInt}ms, stddev ${stddev(timings).toInt}ms, over $NUM_ITERATIONS iterations")
+    }
+    outputStats("batchUpsert all entities from empty", finalTimings.map(_.load.toDouble))
+    outputStats("batchUpsert single value on top of existing", finalTimings.map(_.change.toDouble))
+    outputStats("Delete (hide) all entities", finalTimings.map(_.delete.toDouble))
+
+    // beyond outputting timings to the log, this test doesn't assert anything (well, an exception will fail the test)
+
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -32,6 +32,18 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 import scala.io.Source
 
+/**
+  * This spec contains one test and that test is ignored by default; it does not run as part of the main unit test suite.
+  *
+  * The "test" is a pseudo perf test for batchUpsert-entity and delete-entity (which is actually hide-entity). The goal
+  * of this test is to allow you, the developer, to quickly and easily test before/after changes to the
+  * batchUpsert-entity and delete-entity code paths. Furthermore, the test always passes unless something throws an
+  * exception; it is up to you to look at the console/log output and find the performance timings it outputs.
+  *
+  * Because this test runs on your laptop, or potentially in Jenkins or GHA, the numbers it produces should not be
+  * considered to be objective results, and they do not translate to performance on production. They should only be used
+  * to compare before/after your code changes.
+  */
 class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with TestDriverComponent with RawlsTestUtils with Eventually with MockitoTestUtils with RawlsStatsDTestUtils with BeforeAndAfterAll  with LazyLogging {
 
   // =========== START SERVICES AND MOCKS SETUP ===========

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,6 +89,7 @@ object Dependencies {
   val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.2.2" % "test"
   val mockito: ModuleID =         "org.scalatestplus"             %% "mockito-3-4"          % "3.2.2.0" % Test
   val mockserverNetty: ModuleID = "org.mock-server"               % "mockserver-netty"      % "5.11.2" % "test"
+  val breeze: ModuleID =          "org.scalanlp"                  %% "breeze"               % "1.2"% "test"
   val ficus: ModuleID =           "com.iheart"                    %% "ficus"                % "1.4.0"
   val scalaCache: ModuleID =      "com.github.cb372"              %% "scalacache-caffeine"  % "0.24.2"
   val apacheCommonsIO: ModuleID = "commons-io"                    % "commons-io"            % "2.6"
@@ -223,6 +224,7 @@ object Dependencies {
     akkaHttpTestKit,
     mockserverNetty,
     mockito,
+    breeze,
     workbenchModel,
     workbenchGoogle,
     googleStorageLocal,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,7 +89,7 @@ object Dependencies {
   val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.2.2" % "test"
   val mockito: ModuleID =         "org.scalatestplus"             %% "mockito-3-4"          % "3.2.2.0" % Test
   val mockserverNetty: ModuleID = "org.mock-server"               % "mockserver-netty"      % "5.11.2" % "test"
-  val breeze: ModuleID =          "org.scalanlp"                  %% "breeze"               % "1.2"% "test"
+  val breeze: ModuleID =          "org.scalanlp"                  %% "breeze"               % "1.2" % "test"
   val ficus: ModuleID =           "com.iheart"                    %% "ficus"                % "1.4.0"
   val scalaCache: ModuleID =      "com.github.cb372"              %% "scalacache-caffeine"  % "0.24.2"
   val apacheCommonsIO: ModuleID = "commons-io"                    % "commons-io"            % "2.6"


### PR DESCRIPTION
When working with large entities/attributes, the `rewriteAttrsAction` had a perf bottleneck in its comparison of attributes provided by the user and attributes pre-existing in the db. This PR significantly improves performance in this case.

The bottleneck was my bad - it was introduced in #1425. I believe the bottleneck only applies to entities with long strings; so that PR helped in some cases but made it worse in others.

Using the "performance test" included in this PR, I measured before and after the changes in this PR. There are three use cases in the test:
* starting with 0 entities, load 2304 entities with 59 attributes each. This is the "load" test.
* after those entities load, send a batchUpsert of those same 2304 entities/59 attributes, with only one entity/attribute containing a changed value. This mimics downloading a TSV, changing one value, and re-uploading it. This is the "change" test.
* delete all 2304 entities. This is the "delete" test.

Repeating the above tests over 20 iterations, I saw:

&nbsp; | after, ms | before, ms
-- | -- | --
load mean | 3970 | 3653
load min | 3180 | 3059
load max | 5317 | 4483
load sttdev | 492 | 404
change mean | **2934** | **308287**
change min | **2094** | **181005**
change max | **4878** | **345957**
change stddev | **678** | **42672**
delete mean | 6947 | 6304
delete min | 6333 | 5893
delete max | 7521 | 7108
delete stddev | 370 | 308

The tests at the bottom of `AttributeComponentSpec` validate this PR for correctness.

Reviewer: this PR contains both the important runtime fix and the "perf" test to validate it. The perf test must be run manually, it is not by default part of the unit test suite. If you have any objections to the perf test, I would happily split that off into a separate PR and just merge the runtime fix.