### PR TITLE
Delta Layer companion dataset lifecycle: create [AS-724]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -369,7 +369,6 @@ object Boot extends IOApp with LazyLogging {
         DataRepoEntityProviderConfig(conf.getConfig("dataRepoEntityProvider")),
         conf.getBoolean("entityStatisticsCache.enabled"))
 
-
       val workspaceServiceConstructor: (UserInfo) => WorkspaceService = WorkspaceService.constructor(
         slickDataSource,
         methodRepoDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
@@ -8,6 +8,7 @@ import com.google.auth.Credentials
 import com.google.auth.oauth2.ServiceAccountCredentials
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.apache.commons.io.IOUtils
+import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
@@ -22,7 +23,7 @@ import scala.concurrent.ExecutionContext
  * This factory class contains boilerplate and allows callers to easily and quickly get
  * a new service instance for each user's credentials.
  */
-class GoogleBigQueryServiceFactory(blocker: Blocker)(implicit executionContext: ExecutionContext) {
+class GoogleBigQueryServiceFactory(pathToCredentialJson: String, blocker: Blocker)(implicit executionContext: ExecutionContext) {
 
   implicit lazy val logger = Slf4jLogger.getLogger[IO]
   implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(executionContext)
@@ -33,8 +34,12 @@ class GoogleBigQueryServiceFactory(blocker: Blocker)(implicit executionContext: 
     GoogleBigQueryService.resource[IO](petCredentials, blocker, projectId)
   }
 
-  def getServiceFromCredentialPath(credentialPath: String, projectId: GoogleProject): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
-    GoogleBigQueryService.resource[IO](credentialPath, projectId, blocker)
+  def getServiceForProject(projectId: GoogleProject): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
+    GoogleBigQueryService.resource[IO](pathToCredentialJson, projectId, blocker)
+  }
+
+  def getServiceForProject(projectId: GoogleProjectId): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
+    getServiceForProject(GoogleProject(projectId.value))
   }
 
   def getServiceFromJson(json: String, projectId: GoogleProject): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleBigQueryServiceFactory.scala
@@ -34,12 +34,8 @@ class GoogleBigQueryServiceFactory(pathToCredentialJson: String, blocker: Blocke
     GoogleBigQueryService.resource[IO](petCredentials, blocker, projectId)
   }
 
-  def getServiceForProject(projectId: GoogleProject): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
-    GoogleBigQueryService.resource[IO](pathToCredentialJson, projectId, blocker)
-  }
-
   def getServiceForProject(projectId: GoogleProjectId): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {
-    getServiceForProject(GoogleProject(projectId.value))
+    GoogleBigQueryService.resource[IO](pathToCredentialJson, GoogleProject(projectId.value), blocker)
   }
 
   def getServiceFromJson(json: String, projectId: GoogleProject): cats.effect.Resource[IO, GoogleBigQueryService[IO]] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayer.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayer.scala
@@ -1,9 +1,78 @@
 package org.broadinstitute.dsde.rawls.deltalayer
 
+import cats.effect.{ContextShift, IO}
+import com.google.cloud.bigquery.{Acl, DatasetId}
+import com.google.cloud.bigquery.Acl.Entity
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, SamDAO}
+import org.broadinstitute.dsde.rawls.model.{SamPolicyWithNameAndEmail, SamResourceTypeNames, SamWorkspacePolicyNames, UserInfo, Workspace}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 
 object DeltaLayer {
-  def generateDatasetName(datasetReferenceId: UUID) = {
-    "deltalayer_" + datasetReferenceId.toString.replace('-', '_')
+  @deprecated(message = "Use generateDatasetNameForWorkspace instead; one delta layer companion per workspace", since = "2021-06-22")
+  def generateDatasetNameForReference(datasetReferenceId: UUID) = {
+    "deltalayer_" + dashesToUnderscores(datasetReferenceId)
   }
+
+  /**
+    * Google's doc on naming datasets:
+    * the dataset name must be unique for each project. The dataset name can contain the following:
+    * Up to 1,024 characters.
+    * Letters (uppercase or lowercase), numbers, and underscores.
+    * Note: In the Cloud Console, datasets that begin with an underscore are hidden from the navigation pane. You can
+    * query tables and views in these datasets even though these datasets aren't visible.
+    * Dataset names are case-sensitive: mydataset and MyDataset can coexist in the same project.
+    * Dataset names cannot contain spaces or special characters such as -, &, @, or %.
+    *
+    * @param workspace Workspace for which to create a Delta Layer dataset name
+    * @return name of the Delta Layer dataset for this workspace
+    */
+  def generateDatasetNameForWorkspace(workspace: Workspace): String = {
+    "deltalayer_forworkspace_" + dashesToUnderscores(workspace.workspaceIdAsUUID)
+  }
+
+  /**
+    * replace dashes in a uuid with underscores
+    * @param uuid uuid in which to replace characters
+    * @return string representation of the uuid after replacing characters
+    */
+  private def dashesToUnderscores(uuid: UUID): String = {
+    uuid.toString.replace('-', '_')
+  }
+
+}
+
+class DeltaLayer(bqServiceFactory: GoogleBigQueryServiceFactory, deltaLayerWriter: DeltaLayerWriter, samDAO: SamDAO, clientEmail: WorkbenchEmail, deltaLayerStreamerEmail: WorkbenchEmail)
+                (implicit protected val executionContext: ExecutionContext, implicit val contextShift: ContextShift[IO]) {
+
+  def createDataset(workspace: Workspace, userInfo: UserInfo): IO[DatasetId] = {
+    val bqService = bqServiceFactory.getServiceForProject(workspace.googleProject)
+    val datasetName = DeltaLayer.generateDatasetNameForWorkspace(workspace)
+    val datasetLabels = Map("workspace_id" -> workspace.workspaceId)
+    for {
+      samPolicies <- IO.fromFuture(IO(samDAO.listPoliciesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, userInfo)))
+      aclBindings = calculateDatasetAcl(samPolicies)
+      datasetId <- bqService.use(_.createDataset(datasetName, datasetLabels, aclBindings))
+    } yield {
+      datasetId // the DatasetId object contains project name and dataset name
+    }
+  }
+
+  def deleteDataset(workspace: Workspace): IO[Boolean] = {
+    val bqService = bqServiceFactory.getServiceForProject(workspace.googleProject)
+    val datasetName = DeltaLayer.generateDatasetNameForWorkspace(workspace)
+    bqService.use(_.deleteDataset(datasetName))
+  }
+
+  private def calculateDatasetAcl(samPolicies: Set[SamPolicyWithNameAndEmail]): Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]] = {
+    val accessPolicies = Seq(SamWorkspacePolicyNames.owner, SamWorkspacePolicyNames.writer, SamWorkspacePolicyNames.reader)
+    val defaultIamRoles = Map(Acl.Role.OWNER -> Seq((clientEmail, Acl.Entity.Type.USER)), Acl.Role.WRITER -> Seq((deltaLayerStreamerEmail, Acl.Entity.Type.USER)))
+    val projectOwnerPolicy = samPolicies.filter(_.policyName == SamWorkspacePolicyNames.projectOwner).head.policy.memberEmails
+    val filteredSamPolicies = samPolicies.filter(samPolicy => accessPolicies.contains(samPolicy.policyName)).map(_.email) ++ projectOwnerPolicy
+    val samAclBindings = Acl.Role.READER -> filteredSamPolicies.map{ filteredSamPolicyEmail =>(filteredSamPolicyEmail, Acl.Entity.Type.GROUP) }.toSeq
+    defaultIamRoles + samAclBindings
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayer.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayer.scala
@@ -138,5 +138,4 @@ class DeltaLayer(bqServiceFactory: GoogleBigQueryServiceFactory, deltaLayerWrite
     defaultIamRoles + samAclBindings
   }
 
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -420,7 +420,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRe
     val inserts = DeltaLayerTranslator.translateEntityUpdates(entityUpdates)
 
     // determine destination BQ dataset, based on snapshot reference.
-    val bqDataset = DeltaLayer.generateDatasetNameForReference(dataReference.getMetadata.getResourceId)
+    val bqDataset = DeltaLayer.generateDatasetNameForWorkspace(requestArguments.workspace)
 
     // create DeltaInsert object
     val insertId = UUID.randomUUID()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -420,7 +420,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel, dataReference: DataRe
     val inserts = DeltaLayerTranslator.translateEntityUpdates(entityUpdates)
 
     // determine destination BQ dataset, based on snapshot reference.
-    val bqDataset = DeltaLayer.generateDatasetName(dataReference.getMetadata.getResourceId)
+    val bqDataset = DeltaLayer.generateDatasetNameForReference(dataReference.getMetadata.getResourceId)
 
     // create DeltaInsert object
     val insertId = UUID.randomUUID()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -44,7 +44,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
       val referenceId = snapshotRef.getMetadata.getResourceId
 
       // attempt to create the BQ dataset, which might already exist
-      val createDatasetIO = deltaLayer.createDatasetIfNotExist(workspaceContext, userInfo)
+      val createDatasetIO = IO.fromFuture(IO(deltaLayer.createDatasetIfNotExist(workspaceContext, userInfo)))
 
       createDatasetIO.unsafeToFuture().recover {
         case t: Throwable =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -43,7 +43,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
 
       val referenceId = snapshotRef.getMetadata.getResourceId
 
-      // create BQ dataset, get workspace policies from Sam, and add those Sam policies to the dataset IAM
+      // create BQ dataset
       val createDatasetIO = deltaLayer.createDataset(workspaceContext, userInfo)
 
       createDatasetIO.unsafeToFuture().recover {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -43,31 +43,36 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
 
       val referenceId = snapshotRef.getMetadata.getResourceId
 
-      // create BQ dataset
-      val createDatasetIO = deltaLayer.createDataset(workspaceContext, userInfo)
+      // attempt to create the BQ dataset, which might already exist
+      val createDatasetIO = deltaLayer.createDatasetIfNotExist(workspaceContext, userInfo)
 
       createDatasetIO.unsafeToFuture().recover {
         case t: Throwable =>
           //fire and forget this undo, we've made our best effort to fix things at this point
           IO.pure(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken)).unsafeToFuture()
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
-      }.flatMap { datasetId =>
+      }.flatMap {
+        case (justCreated, datasetId) =>
+          // if we just created the companion dataset - because it didn't exist - then also create a WSM reference to it
+          if (justCreated) {
+            val createBQReferenceFuture = for {
+              petToken <- samDAO.getPetServiceAccountToken(GoogleProjectId(workspaceName.namespace), SamDAO.defaultScopes + SamDAO.bigQueryReadOnlyScope, userInfo)
+              bigQueryRef = workspaceManagerDAO.createBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, new ReferenceResourceCommonFields().name(datasetId.getDataset).cloningInstructions(CloningInstructionsEnum.NOTHING), new GcpBigQueryDatasetAttributes().projectId(workspaceContext.namespace).datasetId(datasetId.getDataset), OAuth2BearerToken(petToken))
+            } yield { bigQueryRef }
 
-        // TODO: AS-724 - don't create a new ref to the companion dataset every time we add a snapshot
-        val createBQReferenceFuture = for {
-          petToken <- samDAO.getPetServiceAccountToken(GoogleProjectId(workspaceName.namespace), SamDAO.defaultScopes + SamDAO.bigQueryReadOnlyScope, userInfo)
-          bigQueryRef = workspaceManagerDAO.createBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, new ReferenceResourceCommonFields().name(datasetId.getDataset).cloningInstructions(CloningInstructionsEnum.NOTHING), new GcpBigQueryDatasetAttributes().projectId(workspaceContext.namespace).datasetId(datasetId.getDataset), OAuth2BearerToken(petToken))
-        } yield { bigQueryRef }
-
-        createBQReferenceFuture.recover {
-          case t: Throwable =>
-            //fire and forget these undos, we've made our best effort to fix things at this point
-            for {
-              _ <- deltaLayer.deleteDataset(workspaceContext).unsafeToFuture()
-              _ <- Future(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken))
-            } yield {}
-            throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
-        }
+            createBQReferenceFuture.recover {
+              case t: Throwable =>
+                //fire and forget these undos, we've made our best effort to fix things at this point
+                for {
+                  _ <- deltaLayer.deleteDataset(workspaceContext).unsafeToFuture()
+                  _ <- Future(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken))
+                } yield {}
+                throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
+            }
+          } else {
+            Future(workspaceManagerDAO.getBigQueryDatasetReferenceByName(workspaceContext.workspaceIdAsUUID, datasetId.getDataset, userInfo.accessToken))
+            // retrieve existing dataset reference
+          }
       }.map { _ => snapshotRef}
     }
   }
@@ -113,16 +118,6 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
       // check that snapshot exists before deleting it. If the snapshot does not exist, the GET attempt will throw a 404
       val snapshotRef = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
       workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
-
-      val datasetName = DeltaLayer.generateDatasetNameForReference(snapshotRef.getMetadata.getResourceId)
-      deltaLayer.deleteDataset(workspaceContext).unsafeToFuture().map { _ =>
-        val datasetRef = workspaceManagerDAO.getBigQueryDatasetReferenceByName(workspaceContext.workspaceIdAsUUID, datasetName, userInfo.accessToken)
-        workspaceManagerDAO.deleteBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, datasetRef.getMetadata.getResourceId, userInfo.accessToken)
-      }.recover {
-        case t: Throwable =>
-          logger.warn(s"A snapshot reference was deleted, but an error occurred while deleting its Delta Layer companion dataset: snapshot ref ID: ${snapshotRef.getMetadata.getResourceId}, dataset name: ${datasetName}")
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Your snapshot reference was deleted, but an error occurred while deleting its Delta Layer companion dataset. Error: ${t.getMessage}"))
-      }
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -365,6 +365,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
           Success(())
         }
       }
+      // TODO: AS-724 Delete the Delta Layer companion dataset, if it exists
       _ <- samDAO.deleteResource(SamResourceTypeNames.workspace, workspaceContext.workspaceIdAsUUID.toString, userInfo)
     } yield {
       aborts.onComplete {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
@@ -7,6 +7,7 @@ import com.google.cloud.bigquery.Acl.Entity
 import com.google.cloud.bigquery.Dataset.Builder
 import com.google.cloud.bigquery.{Acl, BigQuery, Dataset, DatasetId, DatasetInfo, Field, FieldValue, FieldValueList, JobId, LegacySQLTypeName, QueryJobConfiguration, Schema, Table, TableInfo, TableResult}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
@@ -89,19 +90,19 @@ object MockBigQueryServiceFactory {
     lazy val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
     implicit val ec = TestExecutionContext.testExecutionContext
 
-    new MockBigQueryServiceFactory(blocker, queryResponse)
+    new MockBigQueryServiceFactory("dummy-credential-path", blocker, queryResponse)
   }
 
 }
 
-class MockBigQueryServiceFactory(blocker: Blocker, queryResponse: Either[Throwable, TableResult])(implicit val executionContext: ExecutionContext)
-  extends GoogleBigQueryServiceFactory(blocker: Blocker)(executionContext: ExecutionContext) {
+class MockBigQueryServiceFactory(credentialPath: String, blocker: Blocker, queryResponse: Either[Throwable, TableResult])(implicit val executionContext: ExecutionContext)
+  extends GoogleBigQueryServiceFactory(credentialPath: String, blocker: Blocker)(executionContext: ExecutionContext) {
 
   override def getServiceForPet(petKey: String, projectId: GoogleProject): Resource[IO, GoogleBigQueryService[IO]] = {
     Resource.pure[IO, GoogleBigQueryService[IO]](new MockGoogleBigQueryService(queryResponse))
   }
 
-  override def getServiceFromCredentialPath(credentialPath: String, projectId: GoogleProject): Resource[IO, GoogleBigQueryService[IO]] = {
+  override def getServiceForProject(projectId: GoogleProject): Resource[IO, GoogleBigQueryService[IO]] = {
     Resource.pure[IO, GoogleBigQueryService[IO]](new MockGoogleBigQueryService(queryResponse))
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockBigQueryServiceFactory.scala
@@ -102,7 +102,7 @@ class MockBigQueryServiceFactory(credentialPath: String, blocker: Blocker, query
     Resource.pure[IO, GoogleBigQueryService[IO]](new MockGoogleBigQueryService(queryResponse))
   }
 
-  override def getServiceForProject(projectId: GoogleProject): Resource[IO, GoogleBigQueryService[IO]] = {
+  override def getServiceForProject(projectId: GoogleProjectId): Resource[IO, GoogleBigQueryService[IO]] = {
     Resource.pure[IO, GoogleBigQueryService[IO]](new MockGoogleBigQueryService(queryResponse))
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
@@ -1,11 +1,33 @@
 package org.broadinstitute.dsde.rawls.deltalayer
 
-import org.broadinstitute.dsde.rawls.model.Workspace
+import cats.effect.{Blocker, ContextShift, IO}
+import com.google.cloud.bigquery.Acl
+import com.google.cloud.bigquery.Acl.Entity
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO}
+import org.broadinstitute.dsde.rawls.mock.MockSamDAO
+import org.broadinstitute.dsde.rawls.model.{SamPolicy, SamPolicyWithNameAndEmail, SamWorkspacePolicyNames, UserInfo, Workspace}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
+import org.scalatest.PrivateMethodTester
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class DeltaLayerSpec extends AnyFlatSpec with Matchers {
+import scala.concurrent.ExecutionContext
+
+class DeltaLayerSpec extends AnyFlatSpec with TestDriverComponent with PrivateMethodTester with Matchers {
+
+  implicit val ec = TestExecutionContext.testExecutionContext
+  implicit lazy val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
+  implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(executionContext)
+  /*
+    implicit lazy val logger: _root_.io.chrisdavenport.log4cats.StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+  implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(executionContext)
+  implicit lazy val timer: Timer[IO] = cats.effect.IO.timer(executionContext)
+   */
+
+//  new MockBigQueryServiceFactory("dummy-credential-path", blocker, queryResponse)
 
   behavior of "DeltaLayer object"
 
@@ -18,5 +40,128 @@ class DeltaLayerSpec extends AnyFlatSpec with Matchers {
 
     assertResult(expected) { actual }
   }
+
+  behavior of "DeltaLayer class"
+
+  it should "add client and streamer ACLs in calculateDatasetAcl" in {
+    // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
+    val clientEmailUnderTest = WorkbenchEmail("Hugo")
+    val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Nemo")
+
+    // create the Delta Layer object and grab the private method "calculateDatasetAcl"
+    val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+    val deltaLayer = testDeltaLayer(bqFactory,
+      clientEmail = clientEmailUnderTest,
+      deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest)
+    val methodUnderTest = PrivateMethod[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]]('calculateDatasetAcl)
+
+    // minimal set of existing policies to pass to calculateDatasetAcl() - it will fail without a projectOwner policy
+    val existingPolicies = Set(
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("dummy-policy-1"))
+    )
+
+    // assert that the calculated ACLs include OWNER:clientEmail and WRITER:deltaLayerStreamerEmail
+    val actual = deltaLayer invokePrivate methodUnderTest(existingPolicies)
+    actual should contain (Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)))
+    actual should contain (Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)))
+  }
+
+  it should "calculate proper ACLs in calculateDatasetAcl" in {
+    // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
+    val clientEmailUnderTest = WorkbenchEmail("George")
+    val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Mugsy")
+
+    // create the Delta Layer object and grab the private method "calculateDatasetAcl"
+    val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+    val deltaLayer = testDeltaLayer(bqFactory,
+      clientEmail = clientEmailUnderTest,
+      deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest)
+    val methodUnderTest = PrivateMethod[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]]('calculateDatasetAcl)
+
+    // minimal set of existing policies to pass to calculateDatasetAcl() - it will fail without a projectOwner policy
+    Seq(SamWorkspacePolicyNames.owner, SamWorkspacePolicyNames.writer, SamWorkspacePolicyNames.reader) // included
+
+    // these should be dropped from the calculated ACLs
+    val ignoredPolicies = Set(
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.canCompute, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("can-compute")),
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.canCatalog, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("can-catalog")),
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.shareReader, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("share-reader")),
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.shareWriter, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("share-writer"))
+    )
+
+    // these should be included in the calculated ACLs, as readers. The algorithm grabs the _.email, which is the group name
+    val propagatedPolicies = Set(
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.reader, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("reader-group")),
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.writer, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("writer-group")),
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.owner, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("owner-group"))
+    )
+
+    // the first project owner should be included in the calculated ACL, as a reader. The algorithm grabs all _.policy.memberEmails
+    val projectOwnerPolicy = Set(
+      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(WorkbenchEmail("projowner-1"), WorkbenchEmail("projowner-2")), Set(), Set()), WorkbenchEmail("projowner-group-3"))
+    )
+
+    val existingPolicies = ignoredPolicies ++ propagatedPolicies ++ projectOwnerPolicy
+
+    val expected = Map(
+      Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)),
+      Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)),
+      Acl.Role.READER -> Seq(
+        (WorkbenchEmail("reader-group"), Acl.Entity.Type.GROUP),
+        (WorkbenchEmail("writer-group"), Acl.Entity.Type.GROUP),
+        (WorkbenchEmail("owner-group"), Acl.Entity.Type.GROUP),
+        (WorkbenchEmail("projowner-1"), Acl.Entity.Type.GROUP),
+        (WorkbenchEmail("projowner-2"), Acl.Entity.Type.GROUP)
+      )
+    )
+
+    val actual = deltaLayer invokePrivate methodUnderTest(existingPolicies)
+
+    // actual and expected contain lists/vectors as values, which will return unequal if ordered differently.
+    // for the sake of comparison, transform to unordered.
+    val expectedMap = expected.map { kv => kv._1 -> kv._2.toSet }
+    val actualMap = actual.map { kv => kv._1 -> kv._2.toSet }
+    assertResult (expectedMap) { actualMap }
+  }
+
+  it should "catch/ignore 409s from BigQuery in createDatasetIfNotExist" is (pending)
+
+  it should "bubble up 409s from BigQuery in createDataset" is (pending)
+
+  List("createDatasetIfNotExist", "createDataset") foreach { method =>
+    it should s"add appropriate labels to the companion dataset in $method" in {
+      val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+      val deltaLayer = testDeltaLayer(bqFactory)
+      val methodUnderTest = deltaLayer.getClass.getMethod(method, testData.workspace.getClass, userInfo.getClass)
+      methodUnderTest.invoke(deltaLayer, testData.workspace, userInfo)
+    }
+
+    it should s"specify some ACLs for the companion dataset in $method" is (pending)
+
+    it should s"use the specified workspace's project for the companion dataset in $method" is (pending)
+
+    it should s"bubble up non-BigQuery 409s in $method" is (pending)
+
+    it should s"bubble up Sam errors in $method" is (pending)
+
+    it should s"create the companion dataset if it doesn't exist in $method" in {
+      val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+      val deltaLayer = testDeltaLayer(bqFactory)
+      val methodUnderTest = deltaLayer.getClass.getMethod(method, testData.workspace.getClass, userInfo.getClass)
+      methodUnderTest.invoke(deltaLayer, testData.workspace, userInfo)
+    }
+  }
+
+
+  private def testDeltaLayer(bqServiceFactory: GoogleBigQueryServiceFactory,
+                             deltaLayerWriter: DeltaLayerWriter = new MockDeltaLayerWriter,
+                             samDAO: SamDAO = new MockSamDAO(slickDataSource),
+                             clientEmail: WorkbenchEmail = WorkbenchEmail("unittest-clientEmail"),
+                             deltaLayerStreamerEmail: WorkbenchEmail = WorkbenchEmail("unittest-detlaLayerStreamerEmail"))
+                            (implicit executionContext: ExecutionContext, contextShift: ContextShift[IO]): DeltaLayer = {
+
+    new DeltaLayer(bqServiceFactory, deltaLayerWriter, samDAO, clientEmail, deltaLayerStreamerEmail)
+  }
+
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
@@ -166,8 +166,8 @@ class DeltaLayerSpec extends AsyncFreeSpec with TestDriverComponent with Private
       }
 
       futureEx map { caught =>
-        caught.getMessage shouldBe (s"BigQuery 409 errors via createDataset should bubble up")
-        caught.getCode shouldBe (409)
+        caught.getMessage shouldBe s"BigQuery 409 errors via createDataset should bubble up"
+        caught.getCode shouldBe 409
       }
     }
   
@@ -288,7 +288,7 @@ class DeltaLayerSpec extends AsyncFreeSpec with TestDriverComponent with Private
           }
 
           futureEx map { caught =>
-            caught.getMessage shouldBe (s"Errors getting the GoogleBigQueryService via $method should bubble up")
+            caught.getMessage shouldBe s"Errors getting the GoogleBigQueryService via $method should bubble up"
           }
         }
 
@@ -311,8 +311,8 @@ class DeltaLayerSpec extends AsyncFreeSpec with TestDriverComponent with Private
           }
 
           futureEx map { caught =>
-            caught.getMessage shouldBe (s"BigQuery non-409 errors via $method should bubble up")
-            caught.getCode shouldBe (444)
+            caught.getMessage shouldBe s"BigQuery non-409 errors via $method should bubble up"
+            caught.getCode shouldBe 444
           }
         }
     
@@ -334,7 +334,7 @@ class DeltaLayerSpec extends AsyncFreeSpec with TestDriverComponent with Private
     
             Option(caught.getCause) should not be empty
             caught.getCause shouldBe a [RuntimeException]
-            caught.getCause.getMessage shouldBe (s"Sam synchronous errors should bubble up in $method")
+            caught.getCause.getMessage shouldBe s"Sam synchronous errors should bubble up in $method"
           }
         }
 
@@ -355,7 +355,7 @@ class DeltaLayerSpec extends AsyncFreeSpec with TestDriverComponent with Private
           }
 
           futureEx map { caught =>
-            caught.getMessage shouldBe (s"Sam async errors should bubble up in $method")
+            caught.getMessage shouldBe s"Sam async errors should bubble up in $method"
           }
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
@@ -1,0 +1,22 @@
+package org.broadinstitute.dsde.rawls.deltalayer
+
+import org.broadinstitute.dsde.rawls.model.Workspace
+import org.joda.time.DateTime
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DeltaLayerSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "DeltaLayer object"
+
+  it should "generate expected name of companion dataset for a workspace" in {
+    val inputUuid = "123e4567-e89b-12d3-a456-426614174000"
+    val expected = "deltalayer_forworkspace_123e4567_e89b_12d3_a456_426614174000"
+
+    val dummyWorkspace = Workspace("namespace", "name", inputUuid, "bucketName", None, DateTime.now(), DateTime.now(), "createdBy", Map())
+    val actual = DeltaLayer.generateDatasetNameForWorkspace(dummyWorkspace)
+
+    assertResult(expected) { actual }
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/deltalayer/DeltaLayerSpec.scala
@@ -7,8 +7,7 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO}
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
-import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, SamPolicy, SamPolicyWithNameAndEmail, SamWorkspacePolicyNames, UserInfo, Workspace}
-import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
+import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, SamPolicy, SamPolicyWithNameAndEmail, SamWorkspacePolicyNames, Workspace}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
 import org.mockito.ArgumentCaptor
@@ -17,233 +16,252 @@ import org.mockito.Mockito._
 import org.scalatest.PrivateMethodTester
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
 
+import java.lang.reflect.InvocationTargetException
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class DeltaLayerSpec extends AnyFlatSpec with TestDriverComponent with PrivateMethodTester with Matchers with Eventually  {
+class DeltaLayerSpec extends AnyFreeSpec with TestDriverComponent with PrivateMethodTester with MockitoSugar with Matchers with Eventually  {
 
   implicit val ec = TestExecutionContext.testExecutionContext
   implicit lazy val blocker = Blocker.liftExecutionContext(TestExecutionContext.testExecutionContext)
   implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(executionContext)
 
-  val timeout = 120000.milliseconds
-  val interval = 500.milliseconds
+  // durations for async/eventually calls
+  val timeout: FiniteDuration = 10000.milliseconds
+  val interval: FiniteDuration = 500.milliseconds
 
+  "DeltaLayer object" - {
+    "should generate expected name of companion dataset for a workspace" in {
+      val inputUuid = "123e4567-e89b-12d3-a456-426614174000"
+      val expected = "deltalayer_forworkspace_123e4567_e89b_12d3_a456_426614174000"
 
-  /*
-    implicit lazy val logger: _root_.io.chrisdavenport.log4cats.StructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-  implicit lazy val contextShift: ContextShift[IO] = cats.effect.IO.contextShift(executionContext)
-  implicit lazy val timer: Timer[IO] = cats.effect.IO.timer(executionContext)
-   */
+      val dummyWorkspace = Workspace("namespace", "name", inputUuid, "bucketName", None, DateTime.now(), DateTime.now(), "createdBy", Map())
+      val actual = DeltaLayer.generateDatasetNameForWorkspace(dummyWorkspace)
 
-//  new MockBigQueryServiceFactory("dummy-credential-path", blocker, queryResponse)
-
-  behavior of "DeltaLayer object"
-
-  it should "generate expected name of companion dataset for a workspace" in {
-    val inputUuid = "123e4567-e89b-12d3-a456-426614174000"
-    val expected = "deltalayer_forworkspace_123e4567_e89b_12d3_a456_426614174000"
-
-    val dummyWorkspace = Workspace("namespace", "name", inputUuid, "bucketName", None, DateTime.now(), DateTime.now(), "createdBy", Map())
-    val actual = DeltaLayer.generateDatasetNameForWorkspace(dummyWorkspace)
-
-    assertResult(expected) { actual }
-  }
-
-  behavior of "DeltaLayer class"
-
-  it should "add client and streamer ACLs in calculateDatasetAcl" in {
-    // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
-    val clientEmailUnderTest = WorkbenchEmail("Hugo")
-    val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Nemo")
-
-    // create the Delta Layer object and grab the private method "calculateDatasetAcl"
-    val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
-    val deltaLayer = testDeltaLayer(bqFactory,
-      clientEmail = clientEmailUnderTest,
-      deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest)
-    val methodUnderTest = PrivateMethod[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]]('calculateDatasetAcl)
-
-    // minimal set of existing policies to pass to calculateDatasetAcl() - it will fail without a projectOwner policy
-    val existingPolicies = Set(
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("dummy-policy-1"))
-    )
-
-    // assert that the calculated ACLs include OWNER:clientEmail and WRITER:deltaLayerStreamerEmail
-    val actual = deltaLayer invokePrivate methodUnderTest(existingPolicies)
-    actual should contain (Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)))
-    actual should contain (Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)))
-  }
-
-  it should "calculate proper ACLs in calculateDatasetAcl" in {
-    // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
-    val clientEmailUnderTest = WorkbenchEmail("George")
-    val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Mugsy")
-
-    // create the Delta Layer object and grab the private method "calculateDatasetAcl"
-    val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
-    val deltaLayer = testDeltaLayer(bqFactory,
-      clientEmail = clientEmailUnderTest,
-      deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest)
-    val methodUnderTest = PrivateMethod[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]]('calculateDatasetAcl)
-
-    // minimal set of existing policies to pass to calculateDatasetAcl() - it will fail without a projectOwner policy
-    Seq(SamWorkspacePolicyNames.owner, SamWorkspacePolicyNames.writer, SamWorkspacePolicyNames.reader) // included
-
-    // these should be dropped from the calculated ACLs
-    val ignoredPolicies = Set(
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.canCompute, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("can-compute")),
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.canCatalog, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("can-catalog")),
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.shareReader, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("share-reader")),
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.shareWriter, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("share-writer"))
-    )
-
-    // these should be included in the calculated ACLs, as readers. The algorithm grabs the _.email, which is the group name
-    val propagatedPolicies = Set(
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.reader, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("reader-group")),
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.writer, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("writer-group")),
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.owner, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("owner-group"))
-    )
-
-    // the first project owner should be included in the calculated ACL, as a reader. The algorithm grabs all _.policy.memberEmails
-    val projectOwnerPolicy = Set(
-      SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(WorkbenchEmail("projowner-1"), WorkbenchEmail("projowner-2")), Set(), Set()), WorkbenchEmail("projowner-group-3"))
-    )
-
-    val existingPolicies = ignoredPolicies ++ propagatedPolicies ++ projectOwnerPolicy
-
-    val expected = Map(
-      Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)),
-      Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)),
-      Acl.Role.READER -> Seq(
-        (WorkbenchEmail("reader-group"), Acl.Entity.Type.GROUP),
-        (WorkbenchEmail("writer-group"), Acl.Entity.Type.GROUP),
-        (WorkbenchEmail("owner-group"), Acl.Entity.Type.GROUP),
-        (WorkbenchEmail("projowner-1"), Acl.Entity.Type.GROUP),
-        (WorkbenchEmail("projowner-2"), Acl.Entity.Type.GROUP)
-      )
-    )
-
-    val actual = deltaLayer invokePrivate methodUnderTest(existingPolicies)
-
-    // actual and expected contain lists/vectors as values, which will return unequal if ordered differently.
-    // for the sake of comparison, transform to unordered.
-    val expectedMap = expected.map { kv => kv._1 -> kv._2.toSet }
-    val actualMap = actual.map { kv => kv._1 -> kv._2.toSet }
-    assertResult (expectedMap) { actualMap }
-  }
-
-  it should "catch/ignore 409s from BigQuery in createDatasetIfNotExist" is (pending)
-
-  it should "bubble up 409s from BigQuery in createDataset" is (pending)
-
-  List("createDatasetIfNotExist", "createDataset") foreach { method =>
-    it should s"create the companion dataset if it doesn't exist in $method" in {
-      // for unit tests, we don't actually check to see if a call goes out to the cloud to create the dataset.
-      // we just test that we properly call the low-level DeltaLayer.bqCreate method, which contains the call to the cloud
-
-      // TODO: AS-724: don't specify this throws an exception
-      // create the Delta Layer instance and spy on it
-      val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
-      val deltaLayerSpy = spy(testDeltaLayer(bqFactory))
-      // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
-      val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
-      methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
-
-      // wait on futures until we see the bqCreate method being invoked
-      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-        verify(deltaLayerSpy, times(1)).bqCreate(any(), any(), any(), any())
-      }
-    }
-
-    it should s"add appropriate labels to the companion dataset in $method" in {
-      // TODO: AS-724: don't specify this throws an exception
-      // create the Delta Layer instance and spy on it
-      val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
-      val deltaLayerSpy = spy(testDeltaLayer(bqFactory))
-      // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
-      val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
-      methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
-      // capture the labels being sent to the lowlevel create-bigquery-dataset call
-      val datasetLabelsCaptor: ArgumentCaptor[Map[String, String]] = ArgumentCaptor.forClass(classOf[Map[String, String]])
-      // wait on futures until we see the bqCreate method being invoked
-      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-        verify(deltaLayerSpy, times(1)).bqCreate(any(), any(), datasetLabelsCaptor.capture(), any())
-      }
-      // assert the labels actually in use match what we want
-      val actual = datasetLabelsCaptor.getValue
-      val expected = Map("workspace_id" -> constantData.workspace.workspaceId)
       assertResult(expected) { actual }
     }
+  }
 
-    it should s"specify some ACLs for the companion dataset in $method" in {
+
+  "DeltaLayer class" - {
+
+    "should add client and streamer ACLs in calculateDatasetAcl" in {
       // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
-      val clientEmailUnderTest = WorkbenchEmail("Fluffy")
-      val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Patches")
-
-      // TODO: AS-724: don't specify this throws an exception
-      // create the Delta Layer instance and spy on it
+      val clientEmailUnderTest = WorkbenchEmail("Hugo")
+      val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Nemo")
+  
+      // create the Delta Layer object and grab the private method "calculateDatasetAcl"
       val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
-      val deltaLayerSpy = spy(testDeltaLayer(bqFactory,
+      val deltaLayer = testDeltaLayer(bqFactory,
         clientEmail = clientEmailUnderTest,
-        deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest))
-      // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
-      val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
-      methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
-      // capture the ACLs being sent to the lowlevel create-bigquery-dataset call
-      val aclBindingsCaptor: ArgumentCaptor[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]] = ArgumentCaptor.forClass(classOf[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]])
-      // wait on futures until we see the bqCreate method being invoked
-      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-        verify(deltaLayerSpy, times(1)).bqCreate(any(), any(), any(), aclBindingsCaptor.capture())
-      }
-      // assert the ACLs actually in use matches what we want
-      val actual = aclBindingsCaptor.getValue
-
-      // expected ACLs add the clientEmail as owner, deltaLayerStreamerEmail as writer, and the pre-existing workspace owner/writer/reader as reader
+        deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest)
+      val methodUnderTest = PrivateMethod[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]]('calculateDatasetAcl)
+  
+      // minimal set of existing policies to pass to calculateDatasetAcl() - it will fail without a projectOwner policy
+      val existingPolicies = Set(
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("dummy-policy-1"))
+      )
+  
+      // assert that the calculated ACLs include OWNER:clientEmail and WRITER:deltaLayerStreamerEmail
+      val actual = deltaLayer invokePrivate methodUnderTest(existingPolicies)
+      actual should contain (Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)))
+      actual should contain (Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)))
+    }
+  
+    "should calculate proper ACLs in calculateDatasetAcl" in {
+      // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
+      val clientEmailUnderTest = WorkbenchEmail("George")
+      val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Mugsy")
+  
+      // create the Delta Layer object and grab the private method "calculateDatasetAcl"
+      val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+      val deltaLayer = testDeltaLayer(bqFactory,
+        clientEmail = clientEmailUnderTest,
+        deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest)
+      val methodUnderTest = PrivateMethod[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]]('calculateDatasetAcl)
+  
+      // minimal set of existing policies to pass to calculateDatasetAcl() - it will fail without a projectOwner policy
+      Seq(SamWorkspacePolicyNames.owner, SamWorkspacePolicyNames.writer, SamWorkspacePolicyNames.reader) // included
+  
+      // these should be dropped from the calculated ACLs
+      val ignoredPolicies = Set(
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.canCompute, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("can-compute")),
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.canCatalog, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("can-catalog")),
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.shareReader, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("share-reader")),
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.shareWriter, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("share-writer"))
+      )
+  
+      // these should be included in the calculated ACLs, as readers. The algorithm grabs the _.email, which is the group name
+      val propagatedPolicies = Set(
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.reader, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("reader-group")),
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.writer, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("writer-group")),
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.owner, SamPolicy(Set(), Set(), Set()), WorkbenchEmail("owner-group"))
+      )
+  
+      // the first project owner should be included in the calculated ACL, as a reader. The algorithm grabs all _.policy.memberEmails
+      val projectOwnerPolicy = Set(
+        SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(WorkbenchEmail("projowner-1"), WorkbenchEmail("projowner-2")), Set(), Set()), WorkbenchEmail("projowner-group-3"))
+      )
+  
+      val existingPolicies = ignoredPolicies ++ propagatedPolicies ++ projectOwnerPolicy
+  
       val expected = Map(
         Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)),
         Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)),
         Acl.Role.READER -> Seq(
-          // the *@example.com values below match what is returned from MockSamDAO's listPoliciesForResource
-          (WorkbenchEmail("owner@example.com"), Acl.Entity.Type.GROUP),
-          (WorkbenchEmail("writer@example.com"), Acl.Entity.Type.GROUP),
-          (WorkbenchEmail("reader@example.com"), Acl.Entity.Type.GROUP)
+          (WorkbenchEmail("reader-group"), Acl.Entity.Type.GROUP),
+          (WorkbenchEmail("writer-group"), Acl.Entity.Type.GROUP),
+          (WorkbenchEmail("owner-group"), Acl.Entity.Type.GROUP),
+          (WorkbenchEmail("projowner-1"), Acl.Entity.Type.GROUP),
+          (WorkbenchEmail("projowner-2"), Acl.Entity.Type.GROUP)
         )
       )
-
-      // test the ordered seqs/lists/vectors individually
-      actual.keys should contain theSameElementsAs expected.keys
-      actual.keys foreach { key =>
-        actual(key) should contain theSameElementsAs expected(key)
+  
+      val actual = deltaLayer invokePrivate methodUnderTest(existingPolicies)
+  
+      // actual and expected contain lists/vectors as values, which will return unequal if ordered differently.
+      // for the sake of comparison, transform to unordered.
+      val expectedMap = expected.map { kv => kv._1 -> kv._2.toSet }
+      val actualMap = actual.map { kv => kv._1 -> kv._2.toSet }
+      assertResult (expectedMap) { actualMap }
+    }
+  
+    "should catch/ignore 409s from BigQuery in createDatasetIfNotExist" is (pending)
+  
+    "should bubble up 409s from BigQuery in createDataset" is (pending)
+  
+    List("createDatasetIfNotExist", "createDataset") foreach { method =>
+      s"$method method" - {
+      
+        s"should create the companion dataset if it doesn't exist in $method" in {
+          // for unit tests, we don't actually check to see if a call goes out to the cloud to create the dataset.
+          // we just test that we properly call the low-level DeltaLayer.bqCreate method, which contains the call to the cloud
+    
+          // TODO: AS-724: don't specify this throws an exception
+          // create the Delta Layer instance and spy on it
+          val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+          val deltaLayerSpy = spy(testDeltaLayer(bqFactory))
+          // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
+          val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
+          methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
+    
+          // wait on futures until we see the bqCreate method being invoked
+          eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+            verify(deltaLayerSpy, times(1)).bqCreate(any(), any(), any(), any())
+          }
+        }
+    
+        s"should add appropriate labels to the companion dataset in $method" in {
+          // TODO: AS-724: don't specify this throws an exception
+          // create the Delta Layer instance and spy on it
+          val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+          val deltaLayerSpy = spy(testDeltaLayer(bqFactory))
+          // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
+          val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
+          methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
+          // capture the labels being sent to the lowlevel create-bigquery-dataset call
+          val datasetLabelsCaptor: ArgumentCaptor[Map[String, String]] = ArgumentCaptor.forClass(classOf[Map[String, String]])
+          // wait on futures until we see the bqCreate method being invoked
+          eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+            verify(deltaLayerSpy, times(1)).bqCreate(any(), any(), datasetLabelsCaptor.capture(), any())
+          }
+          // assert the labels actually in use match what we want
+          val actual = datasetLabelsCaptor.getValue
+          val expected = Map("workspace_id" -> constantData.workspace.workspaceId)
+          assertResult(expected) { actual }
+        }
+    
+        s"should specify some ACLs for the companion dataset in $method" in {
+          // create unique "clientEmail" and "deltaLayerStreamerEmail" values for this test
+          val clientEmailUnderTest = WorkbenchEmail("Fluffy")
+          val deltaLayerStreamerEmailUnderTest = WorkbenchEmail("Patches")
+    
+          // TODO: AS-724: don't specify this throws an exception
+          // create the Delta Layer instance and spy on it
+          val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+          val deltaLayerSpy = spy(testDeltaLayer(bqFactory,
+            clientEmail = clientEmailUnderTest,
+            deltaLayerStreamerEmail = deltaLayerStreamerEmailUnderTest))
+          // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
+          val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
+          methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
+          // capture the ACLs being sent to the lowlevel create-bigquery-dataset call
+          val aclBindingsCaptor: ArgumentCaptor[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]] = ArgumentCaptor.forClass(classOf[Map[Acl.Role, Seq[(WorkbenchEmail, Entity.Type)]]])
+          // wait on futures until we see the bqCreate method being invoked
+          eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+            verify(deltaLayerSpy, times(1)).bqCreate(any(), any(), any(), aclBindingsCaptor.capture())
+          }
+          // assert the ACLs actually in use matches what we want
+          val actual = aclBindingsCaptor.getValue
+    
+          // expected ACLs add the clientEmail as owner, deltaLayerStreamerEmail as writer, and the pre-existing workspace owner/writer/reader as reader
+          val expected = Map(
+            Acl.Role.OWNER -> Seq((clientEmailUnderTest, Acl.Entity.Type.USER)),
+            Acl.Role.WRITER -> Seq((deltaLayerStreamerEmailUnderTest, Acl.Entity.Type.USER)),
+            Acl.Role.READER -> Seq(
+              // the *@example.com values below match what is returned from MockSamDAO's listPoliciesForResource
+              (WorkbenchEmail("owner@example.com"), Acl.Entity.Type.GROUP),
+              (WorkbenchEmail("writer@example.com"), Acl.Entity.Type.GROUP),
+              (WorkbenchEmail("reader@example.com"), Acl.Entity.Type.GROUP)
+            )
+          )
+    
+          // test the ordered seqs/lists/vectors individually
+          actual.keys should contain theSameElementsAs expected.keys
+          actual.keys foreach { key =>
+            actual(key) should contain theSameElementsAs expected(key)
+          }
+        }
+    
+        s"should use the specified workspace's project for the companion dataset in $method" in {
+          // TODO: AS-724: don't specify this throws an exception
+          // create the Delta Layer instance and spy on it
+          val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+          val deltaLayerSpy = spy(testDeltaLayer(bqFactory))
+          // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
+          val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
+          methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
+          // capture the google project being sent to the lowlevel create-bigquery-dataset call
+          val googleProjectIdCaptor: ArgumentCaptor[GoogleProjectId] = ArgumentCaptor.forClass(classOf[GoogleProjectId])
+          // wait on futures until we see the bqCreate method being invoked
+          eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+            verify(deltaLayerSpy, times(1)).bqCreate(googleProjectIdCaptor.capture(), any(), any(), any())
+          }
+          // assert the google project actually in use matches what we want
+          val actual = googleProjectIdCaptor.getValue
+          val expected = constantData.workspace.googleProject
+          assertResult(expected) { actual }
+        }
+    
+        s"should bubble up non-BigQuery 409s in $method" is (pending)
+    
+        s"should bubble up Sam errors in $method" in {
+          // create a mock Sam dao that will throw an error
+          val throwingSamDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+          when(throwingSamDAO.listPoliciesForResource(any(), any(), any())).thenThrow(new RuntimeException("Sam errors should bubble up"))
+          // create the Delta Layer instance (no need to spy), using the throwing SamDAO
+          val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
+          val deltaLayer = testDeltaLayer(bqFactory, samDAO = throwingSamDAO)
+          // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
+          val methodUnderTest = deltaLayer.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
+    
+          // wait on futures until we see the bqCreate method being invoked
+          eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+            val caught = intercept[InvocationTargetException] {
+              methodUnderTest.invoke(deltaLayer, constantData.workspace, userInfo)
+            }
+    
+            Option(caught.getCause) should not be empty
+            caught.getCause shouldBe a [RuntimeException]
+            caught.getCause.getMessage shouldBe ("Sam errors should bubble up")
+          }
+        }
       }
     }
-
-    it should s"use the specified workspace's project for the companion dataset in $method" in {
-      // TODO: AS-724: don't specify this throws an exception
-      // create the Delta Layer instance and spy on it
-      val bqFactory = new MockBigQueryServiceFactory("credentialPath", blocker, Left(new RuntimeException))
-      val deltaLayerSpy = spy(testDeltaLayer(bqFactory))
-      // find the createDataset/createDatasetIfNotExist method we want to test, then invoke it
-      val methodUnderTest = deltaLayerSpy.getClass.getMethod(method, constantData.workspace.getClass, userInfo.getClass)
-      methodUnderTest.invoke(deltaLayerSpy, constantData.workspace, userInfo)
-      // capture the google project being sent to the lowlevel create-bigquery-dataset call
-      val googleProjectIdCaptor: ArgumentCaptor[GoogleProjectId] = ArgumentCaptor.forClass(classOf[GoogleProjectId])
-      // wait on futures until we see the bqCreate method being invoked
-      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-        verify(deltaLayerSpy, times(1)).bqCreate(googleProjectIdCaptor.capture(), any(), any(), any())
-      }
-      // assert the google project actually in use matches what we want
-      val actual = googleProjectIdCaptor.getValue
-      val expected = constantData.workspace.googleProject
-      assertResult(expected) { actual }
-    }
-
-    it should s"bubble up non-BigQuery 409s in $method" is (pending)
-
-    it should s"bubble up Sam errors in $method" is (pending)
   }
   // end tests common to both createDatasetIfNotExist and createDataset
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -47,6 +47,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
+      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
       when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
@@ -84,6 +85,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
+      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
@@ -124,6 +126,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenThrow(new RuntimeException)
+      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenThrow(new RuntimeException)
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
@@ -167,6 +170,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
+      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
@@ -212,6 +216,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
+      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
@@ -251,6 +256,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
+      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -259,7 +259,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(snapshotDataReferenceId).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
 
       when(mockWorkspaceManagerDAO.getBigQueryDatasetReferenceByName(any[UUID], any[String], any[OAuth2BearerToken]))
-        //.thenReturn(new BigQueryDatasetReference().metadata(new DataReferenceMetadata().referenceId(UUID.randomUUID())).dataset(new GoogleBigQueryDatasetUid))
         .thenReturn(new GcpBigQueryDatasetResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID())).attributes(new GcpBigQueryDatasetAttributes()))
 
       val workspace = minimalTestData.workspace
@@ -283,9 +282,10 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       verify(mockWorkspaceManagerDAO, times(1)).getDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID),any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID), any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).getBigQueryDatasetReferenceByName(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(deltaLayerDatasetName), any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteBigQueryDatasetReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), any[UUID], any[OAuth2BearerToken])
-      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(any[GoogleProjectId])
+      // assert we do NOT attempt to delete the companion dataset or its WSM reference
+      verify(mockWorkspaceManagerDAO, times(0)).getBigQueryDatasetReferenceByName(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(deltaLayerDatasetName), any[OAuth2BearerToken])
+      verify(mockWorkspaceManagerDAO, times(0)).deleteBigQueryDatasetReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), any[UUID], any[OAuth2BearerToken])
+      verify(mockBigQueryServiceFactory, times(0)).getServiceForProject(any[GoogleProjectId])
 
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -30,10 +30,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
   implicit val cs = IO.contextShift(global)
 
-  val testConf = ConfigFactory.load()
-
   //test constants
-  val fakeCredentialPath = testConf.getString("gcs.pathToCredentialJson")
   val fakeRawlsClientEmail = WorkbenchEmail("fake-rawls-service-account@serviceaccounts.google.com")
   val fakeDeltaLayerStreamerEmail = WorkbenchEmail("fake-rawls-service-account@serviceaccounts.google.com")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -271,7 +271,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         fakeDeltaLayerStreamerEmail
       )(userInfo)
 
-      val deltaLayerDatasetName = DeltaLayer.generateDatasetNameForReference(snapshotDataReferenceId)
+      val deltaLayerDatasetName = DeltaLayer.generateDatasetNameForWorkspace(workspace)
 
       val snapshotUUID = UUID.randomUUID()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -46,7 +46,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.successful("fake-token"))
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
@@ -69,7 +68,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(GoogleProject(workspace.namespace))
+      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
@@ -84,7 +83,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.successful("fake-token"))
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
@@ -110,7 +108,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       createException.getMessage shouldBe "oh no!"
 
       verify(mockSamDAO, times(0)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(0)).getServiceForProject(GoogleProject(workspace.namespace))
+      verify(mockBigQueryServiceFactory, times(0)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
@@ -125,7 +123,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.successful("fake-token"))
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenThrow(new RuntimeException)
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenThrow(new RuntimeException)
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
@@ -153,7 +150,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(GoogleProject(workspace.namespace))
+      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
@@ -169,7 +166,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.successful("fake-token"))
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
@@ -199,7 +195,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(2)).getServiceForProject(GoogleProject(workspace.namespace))
+      verify(mockBigQueryServiceFactory, times(2)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
@@ -215,7 +211,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.failed(new RuntimeException))
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
@@ -243,7 +238,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(2)).getServiceForProject(GoogleProject(workspace.namespace))
+      verify(mockBigQueryServiceFactory, times(2)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
@@ -255,7 +250,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       when(mockSamDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[UserInfo])).thenReturn(Future.successful(Set(SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(WorkbenchEmail(userInfo.userEmail.value)), Set.empty, Set.empty), WorkbenchEmail("")))))
 
       val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProject])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
       when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
@@ -291,7 +285,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID), any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).getBigQueryDatasetReferenceByName(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(deltaLayerDatasetName), any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteBigQueryDatasetReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), any[UUID], any[OAuth2BearerToken])
-      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(any[GoogleProject])
+      verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(any[GoogleProjectId])
 
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -37,7 +37,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.martha.MarthaResolver
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.deltalayer.MockDeltaLayerWriter
+import org.broadinstitute.dsde.rawls.deltalayer.{DeltaLayer, MockDeltaLayerWriter}
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
@@ -164,13 +164,15 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       ProjectTemplate.from(testConf.getConfig("gcs.projectTemplate"))
     )_
 
+    val deltaLayer = new DeltaLayer(bigQueryServiceFactory, new MockDeltaLayerWriter, samDAO,
+      WorkbenchEmail("fake-rawls-service-account@serviceaccounts.google.com"),
+      WorkbenchEmail("fake-delta-layer-service-account@serviceaccounts.google.com"))
     override val snapshotServiceConstructor = SnapshotService.constructor(
       slickDataSource,
       samDAO,
       workspaceManagerDAO,
-      bigQueryServiceFactory,
+      deltaLayer,
       mockServer.mockServerBaseUrl,
-      "fakeCredentialPath",
       WorkbenchEmail("fake-rawls-service-account@serviceaccounts.google.com"),
       WorkbenchEmail("fake-delta-layer-service-account@serviceaccounts.google.com")
     )


### PR DESCRIPTION
This is PR 1 of 2 for AS-724.

Highlights of this PR:
* moves create- and delete-BigQuery dataset code out of SnapshotService and into a new DeltaLayer class, so that those methods can be called from multiple places
* changes naming of the Delta Layer companion dataset so that there is one companion per workspace, not one per reference.
* changes behavior of SnapshotService so that on snapshot-reference-create, we attempt to create the Delta Layer companion dataset but ignore 409 conflicts if it already exists. Previously, we would create a new companion dataset for each reference.
* changes behavior of SnapshotService so that we no longer delete the companion dataset when a snapshot reference is deleted. Companion deletion will move to the delete-workspace event, in an upcoming PR.
* adds test coverage for the create- and delete-companion methods

REVIEWERS: is it ok to merge this PR before adding the delete-companion step to delete-workspace? That would mean until the second PR merges, we wouldn't delete companion datasets. The empty dataset should be free, and we don't have many users of this feature. Also, this PR has no functionality to delete "old-style" per-reference datasets; those will hang around, also being free. Is that ok? I want to push this PR through since it is already big, but if you think I need to hold it to get other functionality in, I understand.