### PR TITLE
HTTP request log level error -> debug [BW-706]

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -84,6 +84,13 @@
         <appender-ref ref="Sentry" />
     </logger>
 
+    <logger name="org.broadinstitute.dsde.rawls.util.HttpClientUtils" level="debug" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+        <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
+    </logger>
+
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -88,13 +88,13 @@
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
     </logger>
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
     </logger>
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -95,7 +95,6 @@
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
     </logger>
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/HttpClientUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/HttpClientUtils.scala
@@ -38,7 +38,7 @@ trait HttpClientUtils extends LazyLogging {
         Unmarshal(response.entity).to[T]
       } else {
         Unmarshal(response.entity).to[String] map { entityAsString =>
-          logger.error(s"HTTP error status ${response.status} calling URI ${httpRequest.uri}. Response: $entityAsString")
+          logger.debug(s"HTTP error status ${response.status} calling URI ${httpRequest.uri}. Response: $entityAsString")
           val message = if (response.status == StatusCodes.Unauthorized)
             s"The service indicated that this call was unauthorized. " +
               s"If you believe this is a mistake, please try your request again. " +
@@ -65,7 +65,7 @@ trait HttpClientUtils extends LazyLogging {
         }
       } else {
         Unmarshal(response.entity).to[String] map { entityAsString =>
-          logger.error(s"HTTP error status ${response.status} calling URI ${httpRequest.uri}. Response: $entityAsString")
+          logger.debug(s"HTTP error status ${response.status} calling URI ${httpRequest.uri}. Response: $entityAsString")
           throw new RawlsExceptionWithErrorReport(ErrorReport(response.status, s"HTTP error calling URI ${httpRequest.uri}. Response: ${entityAsString.take(1000)}"))
         }
       }


### PR DESCRIPTION
We formerly had this at `debug` and were perplexed as to why it wasn't showing up.

Upgrading to `error` did fix the problem of logs going missing, but had undesired side effects in Sentry.

`debug` didn't work only because we did not know about adding the class to `logback.xml`.