### PR TITLE
ensure workspace lastModified is updated when saving data entities [AS-815]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -490,10 +490,10 @@ trait EntityComponent {
     }
 
     def save(workspaceContext: Workspace, entities: Traversable[Entity]): ReadWriteAction[Traversable[Entity]] = {
-      workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
       entities.foreach(validateEntity)
 
       for {
+        _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
         preExistingEntityRecs <- getEntityRecords(workspaceContext.workspaceIdAsUUID, entities.map(_.toReference).toSet)
         savingEntityRecs <- entityQueryWithInlineAttributes.insertNewEntities(workspaceContext, entities, preExistingEntityRecs.map(_.toReference)).map(_ ++ preExistingEntityRecs)
         referencedAndSavingEntityRecs <- lookupNotYetLoadedReferences(workspaceContext, entities, savingEntityRecs.map(_.toReference)).map(_ ++ savingEntityRecs)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -520,6 +520,35 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   }
 
+  it should "update a workspace's lastModified date when saving an entity" in withDefaultTestDatabase {
+
+    withWorkspaceContext(testData.workspace) { context =>
+
+      // get the workspace prior to saving the entity
+      val workspaceBefore = runAndWait(workspaceQuery.findById(context.workspaceId))
+        .getOrElse(fail(s"could not retrieve workspace ${context.workspaceId} before saving entity"))
+
+      // save the entity, assert it saved correctly
+      val pair2 = Entity("pair2", "Pair",
+        Map(
+          AttributeName.withDefaultNS("case") -> AttributeEntityReference("Sample", "sample3"),
+          AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")))
+      runAndWait(entityQuery.save(context, pair2))
+      assert {
+        runAndWait(entityQuery.get(testData.workspace, "Pair", "pair2")).isDefined
+      }
+
+      // get the workspace after to saving the entity
+      val workspaceAfter = runAndWait(workspaceQuery.findById(context.workspaceId))
+        .getOrElse(fail(s"could not retrieve workspace ${context.workspaceId} after saving entity"))
+
+      assert(workspaceAfter.lastModified.isAfter(workspaceBefore.lastModified),
+        s"workspace lastModified of ${workspaceAfter.lastModified} should be after lastModified of ${workspaceBefore.lastModified}, " +
+          s"since we saved an entity to that workspace.")
+    }
+
+  }
+
   it should "not re-update an entity's attributes over many writes if attribute do not change" in withDefaultTestDatabase {
     val pair2 = Entity("pair2", "Pair",
       Map(


### PR DESCRIPTION
The `entityQuery.save()` method did not properly update a workspace's lastModified datetime, because the Slick call was not inside the relevant for-comprehension.

Because the workspace's lastModified datetime was not updated when writing entities, and the entity statistics cache relies on the workspace's lastModified datetime to know if its cache is valid, the entity statistics cache would believe it was up to date even though entities had been modified.

We have multiple user reports of this behavior:
* when adding a new column to a data table, that column takes "a long time" to appear
* updating a workspace's description in the UI makes the new column appear (because it also updates the lastModified datetime)

I suspect that the entity counts shown in the UI were also incorrect, since those also depend on the entity statistics cache, but that nobody noticed this, or at least nobody reported this.

---

from what I can tell via `git blame`, the problem updating lastModified has been present since … 2016 (!?!?!) but it didn't matter much until we implemented the statistics cache in March-April of this year.