### PR TITLE
[AS-787] 

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % "test",
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-d060dbbc"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-8223bdce-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.11")
       exclude("com.typesafe.akka", "akka-stream_2.11")
       exclude("bio.terra", "workspace-manager-client"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -53,7 +53,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % "test",
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-14278f08f"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-d060dbbc"
       exclude("com.typesafe.scala-logging", "scala-logging_2.11")
       exclude("com.typesafe.akka", "akka-stream_2.11")
       exclude("bio.terra", "workspace-manager-client"),

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -77,11 +77,11 @@ class SnapshotAPISpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterA
           // validate the snapshot was added correctly: list snapshots in Rawls, should return 1, which we just added.
           // if we can successfully list snapshot references, it means WSM created its copy of the workspace
           val firstListResponse = listSnapshotReferences(projectName, workspaceName)
-          val firstResources = Rawls.parseResponseAs[ResourceList](firstListResponse).getResources.asScala
+          val firstResources = Rawls.parseResponseAs[SnapshotListResponse](firstListResponse).gcpDataRepoSnapshots
           firstResources.size shouldBe 1
           firstResources.head.getMetadata.getName shouldBe "firstSnapshot"
           firstResources.head.getMetadata.getResourceType shouldBe ResourceType.DATA_REPO_SNAPSHOT
-          firstResources.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe dataRepoSnapshotId
+          firstResources.head.getAttributes.getSnapshot shouldBe dataRepoSnapshotId
 
           // add a second snapshot reference to the workspace. Under the covers, this recognizes the workspace
           // already exists in WSM, so it just adds the ref
@@ -90,14 +90,14 @@ class SnapshotAPISpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterA
           // validate the second snapshot was added correctly: list snapshots in Rawls, should return 2, which we just added
           val secondListResponse = listSnapshotReferences(projectName, workspaceName)
           // sort by reference name for easy predictability inside this test: "firstSnapshot" is before "secondSnapshot"
-          val secondResources = Rawls.parseResponseAs[ResourceList](secondListResponse)
-            .getResources.asScala.sortBy(_.getMetadata.getName)
+          val secondResources = Rawls.parseResponseAs[SnapshotListResponse](secondListResponse)
+            .gcpDataRepoSnapshots.sortBy(_.getMetadata.getName)
           secondResources.size shouldBe 2
           secondResources.head.getMetadata.getName shouldBe "firstSnapshot"
-          secondResources.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe dataRepoSnapshotId
+          secondResources.head.getAttributes.getSnapshot shouldBe dataRepoSnapshotId
           secondResources.head.getMetadata.getResourceType shouldBe ResourceType.DATA_REPO_SNAPSHOT
           secondResources(1).getMetadata.getName shouldBe "secondSnapshot"
-          secondResources(1).getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe anotherDataRepoSnapshotId
+          secondResources(1).getAttributes.getSnapshot shouldBe anotherDataRepoSnapshotId
           secondResources(1).getMetadata.getResourceType shouldBe ResourceType.DATA_REPO_SNAPSHOT
         }
       }
@@ -175,11 +175,11 @@ class SnapshotAPISpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterA
           // if we can successfully list snapshot references, it means WSM created its copy of the workspace
           val listResponse = listSnapshotReferences(projectName, workspaceName)
 
-          val resources = Rawls.parseResponseAs[ResourceList](listResponse).getResources.asScala
+          val resources = Rawls.parseResponseAs[SnapshotListResponse](listResponse).gcpDataRepoSnapshots
           resources.size shouldBe 1
           resources.head.getMetadata.getName shouldBe snapshotName
           resources.head.getMetadata.getResourceType shouldBe ResourceType.DATA_REPO_SNAPSHOT
-          resources.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe dataRepoSnapshotId
+          resources.head.getAttributes.getSnapshot shouldBe dataRepoSnapshotId
 
           // create method config in a workspace
           val createMethodConfigUrl  = Uri(Rawls.url).withPath(Path(s"/api/workspaces/$projectName/$workspaceName/methodconfigs"))

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4587,21 +4587,6 @@ components:
           $ref: '#/components/schemas/ResourceMetadata'
         attributes:
           $ref: '#/components/schemas/DataRepoSnapshotAttributes'
-    ResourceAttributesUnion:
-      type: object
-      required: [ gcpDataRepoSnapshot ]
-      properties:
-        gcpDataRepoSnapshot:
-          $ref: '#/components/schemas/DataRepoSnapshotAttributes'
-    ResourceDescription:
-      type: object
-      required: [ metadata, resourceAttributes ]
-      properties:
-        metadata:
-          $ref: '#/components/schemas/ResourceMetadata'
-        resourceAttributes:
-          $ref: '#/components/schemas/ResourceAttributesUnion'
-      description: resource description
     SnapshotListResponse:
       type: object
       required: [ gcpDataRepoSnapshots ]

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4250,7 +4250,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/DataRepoSnapshotResourceList'
+                $ref: '#/components/schemas/SnapshotListResponse'
         404:
           description: Workspace not found or user lacks permissions
           content:
@@ -4602,15 +4602,15 @@ components:
         resourceAttributes:
           $ref: '#/components/schemas/ResourceAttributesUnion'
       description: resource description
-    DataRepoSnapshotResourceList:
+    SnapshotListResponse:
       type: object
-      required: [ resources ]
+      required: [ gcpDataRepoSnapshots ]
       properties:
-        resources:
+        gcpDataRepoSnapshots:
           type: array
-          description: A list of snapshot Data Resource definitions from Workspace Manager
+          description: A list of DataRepoSnapshotResources from Workspace Manager
           items:
-            $ref: '#/components/schemas/ResourceDescription'
+            $ref: '#/components/schemas/DataRepoSnapshotResource'
       description: List of snapshot resources
     ErrorReport:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -29,7 +29,7 @@ object SnapshotService {
     new SnapshotService(userInfo, dataSource, samDAO, workspaceManagerDAO, bqServiceFactory, terraDataRepoUrl, pathToCredentialJson, clientEmail, deltaLayerStreamerEmail)
   }
 
-  val GCP_SNAPSHOTS_KEY = "gcpDataRepoSnapshots"
+  final val GCP_SNAPSHOTS_KEY = "gcpDataRepoSnapshots"
 
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -8,11 +8,11 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.deltalayer.DeltaLayer
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, NamedDataRepoSnapshot, SamWorkspaceActions, SnapshotListResponse, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, SamWorkspaceActions, SnapshotListResponse, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import scala.collection.JavaConverters._
 
+import scala.collection.JavaConverters._
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -91,7 +91,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     }
   }
 
-  def enumerateSnapshots(workspaceName: WorkspaceName, offset: Int, limit: Int): Future[ResourceList] = {
+  def enumerateSnapshots(workspaceName: WorkspaceName, offset: Int, limit: Int): Future[SnapshotListResponse] = {
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
       Try(workspaceManagerDAO.enumerateDataRepoSnapshotReferences(workspaceContext.workspaceIdAsUUID, offset, limit, userInfo.accessToken)) match {
         case Success(references) => massageSnapshots(references)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.snapshot
 
-import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.workspace.model._
@@ -16,8 +15,8 @@ import org.broadinstitute.dsde.rawls.model.{ErrorReport, GoogleProjectId, NamedD
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 
+import java.util.UUID
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.rawls.model.{ErrorReport, GoogleProjectId, NamedD
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import spray.json.DefaultJsonProtocol._
 
 import java.util.UUID
 import scala.collection.mutable.ListBuffer

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.webservice
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
@@ -69,7 +70,6 @@ trait SnapshotApiService extends UserInfoDirectives {
         parameters("offset".as[Int], "limit".as[Int]) { (offset, limit) =>
           complete {
             snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit)
-              .map(resourceListToDataReferenceList)
               .map(StatusCodes.OK -> _)
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -111,18 +111,4 @@ trait SnapshotApiService extends UserInfoDirectives {
       .cloningInstructions(resource.getMetadata.getCloningInstructions)
   }
 
-  private def resourceListToDataReferenceList(refList: ResourceList): DataReferenceList= {
-    import scala.collection.JavaConverters._
-    val resources = refList.getResources.asScala.map{ res =>
-      new DataReferenceDescription()
-        .name(res.getMetadata.getName)
-        .description(res.getMetadata.getDescription)
-        .referenceId(res.getMetadata.getResourceId)
-        .referenceType(ReferenceTypeEnum.fromValue(res.getMetadata.getResourceType.getValue))
-        .workspaceId(res.getMetadata.getWorkspaceId)
-        .reference(new DataRepoSnapshot().instanceName(res.getResourceAttributes.getGcpDataRepoSnapshot.getInstanceName).snapshot(res.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot))
-        .cloningInstructions(res.getMetadata.getCloningInstructions)
-    }.asJava
-    new DataReferenceList().resources(resources)
-  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{MockGoogleServicesDAO, SlickDat
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
+import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 
@@ -240,15 +241,15 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             Get(s"${v2BaseSnapshotsPath}?offset=0&limit=10") ~>
               sealRoute(services.snapshotRoutes) ~>
               check {
-                val response = responseAs[ResourceList]
+                val response = responseAs[Seq[DataRepoSnapshotResource]]
                 assertResult(StatusCodes.OK) {
                   status
                 }
                 // Our mock doesn't guarantee order, so we just check that there are two
                 // elements, that one is named "foo", and that one is named "bar"
-                assert(response.getResources.size == 2)
+                assert(response.size == 2)
                 assertResult(Set("foo", "bar")) {
-                  response.getResources.asScala.map(_.getMetadata.getName).toSet
+                  response.map(_.getMetadata.getName).toSet
                 }
               }
           }
@@ -282,11 +283,11 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots/v2?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
-        val response = responseAs[ResourceList]
+        val response = responseAs[Seq[DataRepoSnapshotResource]]
         assertResult(StatusCodes.OK) {
           status
         }
-        assert(response.getResources.isEmpty)
+        assert(response.isEmpty)
       }
   }
 
@@ -584,15 +585,15 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             Get(s"${baseSnapshotsPath}?offset=0&limit=10") ~>
               sealRoute(services.snapshotRoutes) ~>
               check {
-                val response = responseAs[DataReferenceList]
+                val response = responseAs[Seq[DataRepoSnapshotResource]]
                 assertResult(StatusCodes.OK) {
                   status
                 }
                 // Our mock doesn't guarantee order, so we just check that there are two
                 // elements, that one is named "foo", and that one is named "bar"
-                assert(response.getResources.size == 2)
+                assert(response.size == 2)
                 assertResult(Set("foo", "bar")) {
-                  response.getResources.asScala.map(_.getName).toSet
+                  response.map(_.getMetadata.getName).toSet
                 }
               }
           }
@@ -626,11 +627,11 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
-        val response = responseAs[DataReferenceList]
+        val response = responseAs[Seq[DataRepoSnapshotResource]]
         assertResult(StatusCodes.OK) {
           status
         }
-        assert(response.getResources.isEmpty)
+        assert(response.isEmpty)
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -241,13 +241,13 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             Get(s"${v2BaseSnapshotsPath}?offset=0&limit=10") ~>
               sealRoute(services.snapshotRoutes) ~>
               check {
-                val response = responseAs[Map[String, Seq[DataRepoSnapshotResource]]]
+                val response = responseAs[SnapshotListResponse]
                 assertResult(StatusCodes.OK) {
                   status
                 }
                 // Our mock doesn't guarantee order, so we just check that there are two
                 // elements, that one is named "foo", and that one is named "bar"
-                val resources = response(SnapshotService.GCP_SNAPSHOTS_KEY)
+                val resources = response.gcpDataRepoSnapshots
                 assert(resources.size == 2)
                 assertResult(Set("foo", "bar")) {
                   resources.map(_.getMetadata.getName).toSet
@@ -284,11 +284,11 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots/v2?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
-        val response = responseAs[Map[String, Seq[DataRepoSnapshotResource]]]
+        val response = responseAs[SnapshotListResponse]
         assertResult(StatusCodes.OK) {
           status
         }
-        assert(response(SnapshotService.GCP_SNAPSHOTS_KEY).isEmpty)
+        assert(response.gcpDataRepoSnapshots.isEmpty)
       }
   }
 
@@ -586,13 +586,13 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             Get(s"${baseSnapshotsPath}?offset=0&limit=10") ~>
               sealRoute(services.snapshotRoutes) ~>
               check {
-                val response = responseAs[Map[String, Seq[DataRepoSnapshotResource]]]
+                val response = responseAs[SnapshotListResponse]
                 assertResult(StatusCodes.OK) {
                   status
                 }
                 // Our mock doesn't guarantee order, so we just check that there are two
                 // elements, that one is named "foo", and that one is named "bar"
-                val snaps = response(SnapshotService.GCP_SNAPSHOTS_KEY)
+                val snaps = response.gcpDataRepoSnapshots
                 assert(snaps.size == 2)
                 assertResult(Set("foo", "bar")) {
                   snaps.map(_.getMetadata.getName).toSet
@@ -629,11 +629,11 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
-        val response = responseAs[Map[String, Seq[DataRepoSnapshotResource]]]
+        val response = responseAs[SnapshotListResponse]
         assertResult(StatusCodes.OK) {
           status
         }
-        assert(response(SnapshotService.GCP_SNAPSHOTS_KEY).isEmpty)
+        assert(response.gcpDataRepoSnapshots.isEmpty)
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -586,16 +586,15 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             Get(s"${baseSnapshotsPath}?offset=0&limit=10") ~>
               sealRoute(services.snapshotRoutes) ~>
               check {
-                val response = responseAs[SnapshotListResponse]
+                val response = responseAs[DataReferenceList]
                 assertResult(StatusCodes.OK) {
                   status
                 }
                 // Our mock doesn't guarantee order, so we just check that there are two
                 // elements, that one is named "foo", and that one is named "bar"
-                val snaps = response.gcpDataRepoSnapshots
-                assert(snaps.size == 2)
+                assert(response.getResources.size == 2)
                 assertResult(Set("foo", "bar")) {
-                  snaps.map(_.getMetadata.getName).toSet
+                  response.getResources.asScala.map(_.getName).toSet
                 }
               }
           }
@@ -629,11 +628,11 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
-        val response = responseAs[SnapshotListResponse]
+        val response = responseAs[DataReferenceList]
         assertResult(StatusCodes.OK) {
           status
         }
-        assert(response.gcpDataRepoSnapshots.isEmpty)
+        assert(response.getResources.isEmpty)
       }
   }
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -12,6 +12,7 @@ import scala.collection.JavaConverters._
 case class DataReferenceName(value: String) extends ValueObject
 case class DataReferenceDescriptionField(value: String = "") extends ValueObject
 case class NamedDataRepoSnapshot(name: DataReferenceName, description: Option[DataReferenceDescriptionField], snapshotId: UUID)
+case class SnapshotListResponse(gcpDataRepoSnapshots: Seq[DataRepoSnapshotResource])
 
 object DataReferenceModelJsonSupport extends JsonSupport {
   def stringOrNull(in: Any): JsValue = Option(in) match {
@@ -259,4 +260,5 @@ object DataReferenceModelJsonSupport extends JsonSupport {
   implicit val DataReferenceNameFormat = ValueObjectFormat(DataReferenceName)
   implicit val dataReferenceDescriptionFieldFormat = ValueObjectFormat(DataReferenceDescriptionField)
   implicit val NamedDataRepoSnapshotFormat = jsonFormat3(NamedDataRepoSnapshot)
+  implicit val SnapshotListResponseFormat = jsonFormat1(SnapshotListResponse)
 }


### PR DESCRIPTION
It's working for me locally, but I'm looking for guidance on my scala (not idiomatic I'm sure) and on what do about versioning/preserving the old API response.  ~~For now I've replaced the v2 snapshot list end point in place, which is probably wrong, but I didn't want to guess.  It should be easy enough to move things around based on reviewer consensus :crossed_fingers:~~ David looked at the production logs and we've had no callers to the v2 list end point in the last 30 days so seems safe to replace in place. 

Here's some sample JSON responses:

```
//get
{
  "attributes": {
    "instanceName": "terra",
    "snapshot": "6b073ea9-caea-4a64-9cbf-745d17d5a0c8"
  },
  "metadata": {
    "cloningInstructions": "COPY_NOTHING",
    "description": null,
    "name": "testshot",
    "resourceId": "6173b23e-2f87-4fde-9970-747de1a076c1",
    "resourceType": "DATA_REPO_SNAPSHOT",
    "stewardshipType": "REFERENCED",
    "workspaceId": "8f080501-96c3-4aee-8a73-bfab347a2f65"
  }
}

//list 
{ "gcpDataRepoSnapshots": [
  {
    "attributes": {
      "instanceName": "terra",
      "snapshot": "6b073ea9-caea-4a64-9cbf-745d17d5a0c8"
    },
    "metadata": {
      "cloningInstructions": "COPY_NOTHING",
      "description": null,
      "name": "testshot",
      "resourceId": "6173b23e-2f87-4fde-9970-747de1a076c1",
      "resourceType": "DATA_REPO_SNAPSHOT",
      "stewardshipType": "REFERENCED",
      "workspaceId": "8f080501-96c3-4aee-8a73-bfab347a2f65"
    }
  }
]}
```