### PR TITLE
look up snapshot references by referenced snapshot id [AS-778]

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4301,7 +4301,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
@@ -4635,7 +4634,7 @@ components:
           description: A list of DataRepoSnapshotResources from Workspace Manager
           items:
             $ref: '#/components/schemas/DataRepoSnapshotResource'
-            description: List of snapshot resources
+      description: List of snapshot resources
     ErrorReport:
       required:
         - causes

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4318,7 +4318,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: '#/components/schemas/DataRepoSnapshotResourceList'
+                $ref: '#/components/schemas/SnapshotListResponse'
         404:
           description: Workspace not found or user lacks permissions
           content:
@@ -4624,6 +4624,16 @@ components:
           $ref: '#/components/schemas/ResourceMetadata'
         attributes:
           $ref: '#/components/schemas/DataRepoSnapshotAttributes'
+    SnapshotListResponse:
+      type: object
+      required: [ gcpDataRepoSnapshots ]
+      properties:
+        gcpDataRepoSnapshots:
+          type: array
+          description: A list of DataRepoSnapshotResources from Workspace Manager
+          items:
+            $ref: '#/components/schemas/DataRepoSnapshotResource'
+            description: List of snapshot resources
     ResourceAttributesUnion:
       type: object
       required: [ gcpDataRepoSnapshot ]

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4226,7 +4226,7 @@ paths:
       tags:
         - snapshots_v2
       summary: List snapshots
-      description: Enumerate references to snapshots in the Terra Data Repo
+      description: Enumerate references to snapshots in the Terra Data Repo, or return only those that reference a given TDR snapshot id
       operationId: enumerateDataRepoSnapshot_v2
       parameters:
         - name: offset
@@ -4244,6 +4244,12 @@ paths:
           schema:
             type: integer
           example: 10
+        - name: referencedSnapshotId
+          in: query
+          description: Optional; UUID of the Data Repo snapshot being referenced
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: OK
@@ -4285,42 +4291,6 @@ paths:
                 $ref: '#/components/schemas/DataRepoSnapshotResource'
         404:
           description: Workspace or snapshot not found
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/query/{referencedSnapshotId}:
-    get:
-      tags:
-        - snapshots_v2
-      summary: Query snapshots by referenced id
-      description: Return all snapshot references that refer to a given Data Repo snapshot id
-      operationId: queryDataRepoSnapshot_v2
-      parameters:
-        - $ref: '#/components/parameters/workspaceNamespacePathParam'
-        - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: referencedSnapshotId
-          in: path
-          description: ID of the Data Repo snapshot being referenced
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: OK
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/SnapshotListResponse'
-        404:
-          description: Workspace not found or user lacks permissions
           content:
             '*/*':
               schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4295,6 +4295,43 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/query/{referencedSnapshotId}:
+    get:
+      tags:
+        - snapshots_v2
+      summary: Query snapshots by referenced id
+      description: Return all snapshot references that refer to a given Data Repo snapshot id
+      operationId: queryDataRepoSnapshot_v2
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+        - name: referencedSnapshotId
+          in: path
+          description: ID of the Data Repo snapshot being referenced
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DataRepoSnapshotResourceList'
+        404:
+          description: Workspace not found or user lacks permissions
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -12,7 +12,6 @@ import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, Name
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
-import scala.collection.JavaConverters._
 import java.util.UUID
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
@@ -112,11 +111,13 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
   }
 
   /**
-    * return a given page of snapshot references from Workspace Manager.
+    * return a given page of snapshot references from Workspace Manager, optionally returning only those
+    * snapshot references that refer to a supplied TDR snapshotId.
     *
     * @param workspaceName the workspace owning the snapshot references
     * @param offset pagination offset for the list
     * @param limit pagination limit for the list
+    * @param referencedSnapshotId the TDR snapshotId for which to return matching references
     * @return the list of snapshot references
     */
   def enumerateSnapshots(workspaceName: WorkspaceName, offset: Int, limit: Int, referencedSnapshotId: Option[UUID] = None): Future[SnapshotListResponse] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -12,9 +12,9 @@ import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, Name
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
+import java.util.UUID
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -75,17 +75,6 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     }
   }
 
-  //AS-787 - rework the data so that it's in the same place in the JSON with a list and get snapshot responses
-  def massageSnapshots(references: ResourceList): SnapshotListResponse = {
-    val snapshots = references.getResources.asScala.map { r =>
-      val massaged = new DataRepoSnapshotResource
-      massaged.setAttributes(r.getResourceAttributes.getGcpDataRepoSnapshot)
-      massaged.setMetadata(r.getMetadata)
-      massaged
-    }
-    SnapshotListResponse(snapshots)
-  }
-
   def getSnapshotByName(workspaceName: WorkspaceName, referenceName: String): Future[DataRepoSnapshotResource] = {
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReferenceByName(workspaceContext.workspaceIdAsUUID, DataReferenceName(referenceName), userInfo.accessToken)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -130,7 +130,7 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     *                  snapshotId.
     * @return the list of all snapshot references that refer to the specified snapshotId
     */
-  def findBySnapshotId(workspaceName: WorkspaceName, snapshotId: UUID, batchSize: Int = 200): Future[List[ResourceDescription]] = {
+  def findBySnapshotId(workspaceName: WorkspaceName, snapshotId: UUID, batchSize: Int = 200): Future[ResourceList] = {
 
     val snapshotIdCriteria = snapshotId.toString // just so we're not calling toString on every iteration through loops
 
@@ -156,8 +156,12 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
         }
       }
 
-      findInPage(0, List.empty[ResourceDescription])
-      // TODO: this should be massaged to return a list of snapshots, not a list of resourcedescriptions
+      val resources = findInPage(0, List.empty[ResourceDescription])
+      // TODO: this should return a list of snapshots, not a ResourceList. When AS-787 lands, use that format/functions
+
+      val res = new ResourceList()
+      res.setResources(resources.asJava)
+      res
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -35,6 +35,13 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       }
     } ~
+    path("workspaces" / Segment / Segment / "snapshots" / "v2" / "query" / Segment) { (workspaceNamespace, workspaceName, referencedSnapshotId) =>
+      get {
+        complete {
+          snapshotServiceConstructor(userInfo).findBySnapshotId(WorkspaceName(workspaceNamespace, workspaceName), java.util.UUID.fromString(referencedSnapshotId)).map(StatusCodes.OK -> _)
+        }
+      }
+    } ~
     path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
       get {
         complete {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -31,17 +31,12 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       } ~
       get {
-        parameters("offset".as[Int], "limit".as[Int]) { (offset, limit) =>
+        // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
+        // that method provides a 400 Bad Request response and nice error message
+        parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) { (offset, limit, referencedSnapshotId) =>
           complete {
-            snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit).map(StatusCodes.OK -> _)
+            snapshotServiceConstructor(userInfo).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit, referencedSnapshotId).map(StatusCodes.OK -> _)
           }
-        }
-      }
-    } ~
-    path("workspaces" / Segment / Segment / "snapshots" / "v2" / "query" / Segment) { (workspaceNamespace, workspaceName, referencedSnapshotId) =>
-      get {
-        complete {
-          snapshotServiceConstructor(userInfo).findBySnapshotId(WorkspaceName(workspaceNamespace, workspaceName), UUID.fromString(referencedSnapshotId), 0, 10).map(StatusCodes.OK -> _)
         }
       }
     } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.rawls.webservice
 
+import java.util.UUID
+
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
@@ -38,7 +40,7 @@ trait SnapshotApiService extends UserInfoDirectives {
     path("workspaces" / Segment / Segment / "snapshots" / "v2" / "query" / Segment) { (workspaceNamespace, workspaceName, referencedSnapshotId) =>
       get {
         complete {
-          snapshotServiceConstructor(userInfo).findBySnapshotId(WorkspaceName(workspaceNamespace, workspaceName), java.util.UUID.fromString(referencedSnapshotId)).map(StatusCodes.OK -> _)
+          snapshotServiceConstructor(userInfo).findBySnapshotId(WorkspaceName(workspaceNamespace, workspaceName), UUID.fromString(referencedSnapshotId)).map(StatusCodes.OK -> _)
         }
       }
     } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -41,7 +41,7 @@ trait SnapshotApiService extends UserInfoDirectives {
     path("workspaces" / Segment / Segment / "snapshots" / "v2" / "query" / Segment) { (workspaceNamespace, workspaceName, referencedSnapshotId) =>
       get {
         complete {
-          snapshotServiceConstructor(userInfo).findBySnapshotId(WorkspaceName(workspaceNamespace, workspaceName), UUID.fromString(referencedSnapshotId)).map(StatusCodes.OK -> _)
+          snapshotServiceConstructor(userInfo).findBySnapshotId(WorkspaceName(workspaceNamespace, workspaceName), UUID.fromString(referencedSnapshotId), 0, 10).map(StatusCodes.OK -> _)
         }
       }
     } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -303,10 +303,10 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val criteria = "00000000-0000-0000-0000-000000000012"
       val found = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 1
-      found.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
+      found.head.getAttributes.getSnapshot shouldBe criteria
     }
 
     "find multiple matching snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
@@ -319,22 +319,22 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val criteria1 = "00000000-0000-0000-0000-000000000005"
       val found1 = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1)),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found1 should have size 2
       found1.foreach { x =>
-        x.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria1
+        x.getAttributes.getSnapshot shouldBe criteria1
       }
 
       // now search for one of the snapshotIds that should NOT be duplicated, to be sure
       val criteria2 = "00000000-0000-0000-0000-000000000015"
       val found2 = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria2)),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found2 should have size 1
       found2.foreach { x =>
-        x.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria2
+        x.getAttributes.getSnapshot shouldBe criteria2
       }
 
     }
@@ -349,7 +349,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val criteria = "00000000-0000-0000-0000-000000000099"
       val found = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 0
     }
@@ -366,10 +366,10 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val criteria = "00000000-0000-0000-0000-000000000006"
       val found = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), batchSize),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 1
-      found.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
+      found.head.getAttributes.getSnapshot shouldBe criteria
 
       // ensure we paged through the resources properly
       verify(snapshotService, times(4))
@@ -390,11 +390,11 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val criteria = "00000000-0000-0000-0000-000000000006"
       val found = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), batchSize),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 2
       found.foreach { x =>
-        x.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
+        x.getAttributes.getSnapshot shouldBe criteria
       }
 
       // ensure we paged through the resources properly
@@ -414,7 +414,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val criteria = "00000000-0000-0000-0000-000000000099"
       val found = Await.result(
         snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), batchSize),
-        Duration.Inf).getResources.asScala
+        Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 0
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -205,7 +205,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000012"
       val found = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), 0, 10),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 10, Option(UUID.fromString(criteria))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 1
@@ -221,7 +221,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // search for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000005"
       val found1 = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1), 0, 10),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 10, Option(UUID.fromString(criteria1))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found1 should have size 2
@@ -232,7 +232,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // now search for one of the snapshotIds that should NOT be duplicated, to be sure
       val criteria2 = "00000000-0000-0000-0000-000000000015"
       val found2 = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria2), 0, 10),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,0, 10, Option(UUID.fromString(criteria2))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found2 should have size 1
@@ -251,7 +251,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // search for one of the snapshotIds that should NOT be in the list
       val criteria = "00000000-0000-0000-0000-000000000099"
       val found = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), 0, 10),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 10, Option(UUID.fromString(criteria))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found should have size 0
@@ -267,9 +267,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000006"
-      val found = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), 0, 10, batchSize),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found = snapshotService
+        .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+          .gcpDataRepoSnapshots
 
       found should have size 1
       found.head.getAttributes.getSnapshot shouldBe criteria
@@ -291,9 +291,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000006"
-      val found = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), 0, 10, batchSize),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found = snapshotService
+        .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+          .gcpDataRepoSnapshots
 
       found should have size 2
       found.foreach { x =>
@@ -315,9 +315,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000099"
-      val found = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), 0, 10, batchSize),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found = snapshotService
+        .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+          .gcpDataRepoSnapshots
 
       found should have size 0
 
@@ -338,7 +338,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // search for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000002"
       val found1 = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1), pageOffset, pageLimit),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, pageOffset, pageLimit, Option(UUID.fromString(criteria1))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found1 should have size 11
@@ -356,7 +356,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // return the first 8 results for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000003"
       val found1 = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1), 0, 8),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 8, Option(UUID.fromString(criteria1))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found1 should have size 8
@@ -366,7 +366,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // now, perform the same search but with an offset of 4 and limit of 3
       val found2 = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1), 4, 3),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 4, 3, Option(UUID.fromString(criteria1))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found2 should have size 3
@@ -391,7 +391,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // search for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000002"
       val found1 = Await.result(
-        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1), pageOffset, pageLimit),
+        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, pageOffset, pageLimit, Option(UUID.fromString(criteria1))),
         Duration.Inf).gcpDataRepoSnapshots
 
       found1 should have size 5

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, M
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.deltalayer.{DeltaLayer, MockDeltaLayerWriter}
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, times, verify, when}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, spy, times, verify, when}
 import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, GoogleProjectId, NamedDataRepoSnapshot, SamPolicy, SamPolicyWithNameAndEmail, SamResourceAction, SamResourceTypeName, SamResourceTypeNames, SamWorkspacePolicyNames, UserInfo}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -21,6 +21,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
+import scala.collection.JavaConverters._
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration.Duration
@@ -292,6 +293,184 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
     }
 
+    "find one matching snapshot reference by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
+      // generate a single page of ResourceDescriptions
+      val resources = generateTestReferences(20)
+
+      val snapshotService = mockSnapshotServiceForReferences(resources)
+
+      // search for one of the snapshotIds that should be in the list
+      val criteria = "00000000-0000-0000-0000-000000000012"
+      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)), Duration.Inf)
+
+      found should have size 1
+      found.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
+    }
+
+    "find multiple matching snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
+      // generate a single page of ResourceDescriptions, but duplicate the first 10 snapshotIds
+      val resources = generateTestReferences(20) ++ generateTestReferences(10)
+
+      val snapshotService = mockSnapshotServiceForReferences(resources)
+
+      // search for one of the snapshotIds that should be duplicated
+      val criteria1 = "00000000-0000-0000-0000-000000000005"
+      val found1 = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1)), Duration.Inf)
+
+      found1 should have size 2
+      found1.foreach { x =>
+        x.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria1
+      }
+
+      // now search for one of the snapshotIds that should NOT be duplicated, to be sure
+      val criteria2 = "00000000-0000-0000-0000-000000000015"
+      val found2 = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria2)), Duration.Inf)
+
+      found2 should have size 1
+      found2.foreach { x =>
+        x.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria2
+      }
+
+    }
+
+    "return an empty list of snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
+      // generate a single page of ResourceDescriptions
+      val resources = generateTestReferences(20)
+
+      val snapshotService = mockSnapshotServiceForReferences(resources)
+
+      // search for one of the snapshotIds that should NOT be in the list
+      val criteria = "00000000-0000-0000-0000-000000000099"
+      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)), Duration.Inf)
+
+      found should have size 0
+    }
+
+    "find one matching snapshot reference by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase { _ =>
+      // 10 resources and batchsize of 3 means we should make 4 queries to WSM
+      val resources = generateTestReferences(10)
+      val batchSize = 3
+
+      // yes we're spying on a mock
+      val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+
+      // search for one of the snapshotIds that should be in the list
+      val criteria = "00000000-0000-0000-0000-000000000006"
+      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria),
+        batchSize), Duration.Inf)
+
+      found should have size 1
+      found.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
+
+      // ensure we paged through the resources properly
+      verify(snapshotService, times(4))
+        .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID), any[Int], ArgumentMatchers.eq(batchSize))
+    }
+
+    "find multiple matching snapshot references by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase { _ =>
+      // 21 resources total and batchsize of 5 means we should make 5 queries to WSM
+      val resources = generateTestReferences(10) ++ // contains snapshotId "...0006"
+        generateTestReferences(4) ++                // does not contain snapshotId "...0006"
+        generateTestReferences(7)                   // contains snapshotId "...0006"
+      val batchSize = 5
+
+      // yes we're spying on a mock
+      val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+
+      // search for one of the snapshotIds that should be in the list
+      val criteria = "00000000-0000-0000-0000-000000000006"
+      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria),
+        batchSize), Duration.Inf)
+
+      found should have size 2
+      found.foreach { x =>
+        x.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
+      }
+
+      // ensure we paged through the resources properly
+      verify(snapshotService, times(5))
+        .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID), any[Int], ArgumentMatchers.eq(batchSize))
+    }
+
+    "return an empty list of snapshot references by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase { _ =>
+      // 10 resources and batchsize of 3 means we should make 4 queries to WSM
+      val resources = generateTestReferences(10)
+      val batchSize = 3
+
+      // yes we're spying on a mock
+      val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+
+      // search for one of the snapshotIds that should be in the list
+      val criteria = "00000000-0000-0000-0000-000000000099"
+      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria),
+        batchSize), Duration.Inf)
+
+      found should have size 0
+
+      // ensure we paged through the resources properly
+      verify(snapshotService, times(4))
+        .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID), any[Int], ArgumentMatchers.eq(batchSize))
+    }
+
   }
+
+  def generateTestReferences(numReferences: Int): List[ResourceDescription] = {
+    (1 to numReferences).toList.map { idx =>
+      val paddedIdx = "%08d".format(idx)
+
+      val metadata = new ResourceMetadata()
+      metadata.setResourceType(ResourceType.DATA_REPO_SNAPSHOT)
+      metadata.setName(s"snapshot_reference_$idx")
+      metadata.setResourceId(UUID.randomUUID())
+      metadata.setWorkspaceId(minimalTestData.workspace.workspaceIdAsUUID)
+
+      val snaprefAttrs = new DataRepoSnapshotAttributes()
+      snaprefAttrs.setSnapshot(s"00000000-0000-0000-0000-0000$paddedIdx")
+      snaprefAttrs.setInstanceName("terra")
+
+      val attrsUnion = new ResourceAttributesUnion()
+      attrsUnion.setGcpDataRepoSnapshot(snaprefAttrs)
+
+      val rd = new ResourceDescription()
+      rd.setMetadata(metadata)
+      rd.setResourceAttributes(attrsUnion)
+
+      rd
+    }
+  }
+
+  def mockSnapshotServiceForReferences(resources: List[ResourceDescription]) = {
+    // mock sam that always says we have permission
+    val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
+    // mock GoogleBigQueryServiceFactory
+    val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
+    when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
+    // mock WorkspaceManagerDAO, don't set up any method responses yet
+    val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
+
+    when(mockWorkspaceManagerDAO.enumerateDataRepoSnapshotReferences(any[UUID], any[Int], any[Int], any[OAuth2BearerToken]))
+      .thenAnswer{ answer =>
+        val offset = answer.getArgument[Int](1)
+        val limit = answer.getArgument[Int](2)
+        val resList = new ResourceList()
+        resList.setResources(resources.slice(offset, offset+limit).asJava)
+        resList
+      }
+
+    val deltaLayer = new DeltaLayer(mockBigQueryServiceFactory, new MockDeltaLayerWriter, mockSamDAO, fakeRawlsClientEmail, fakeDeltaLayerStreamerEmail)
+
+    SnapshotService.constructor(
+      slickDataSource,
+      mockSamDAO,
+      mockWorkspaceManagerDAO,
+      deltaLayer,
+      "fake-terra-data-repo-dev",
+      fakeRawlsClientEmail,
+      fakeDeltaLayerStreamerEmail
+    )(userInfo)
+
+  }
+
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -301,7 +301,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000012"
-      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)), Duration.Inf)
+      val found = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)),
+        Duration.Inf).getResources.asScala
 
       found should have size 1
       found.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
@@ -315,7 +317,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000005"
-      val found1 = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1)), Duration.Inf)
+      val found1 = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria1)),
+        Duration.Inf).getResources.asScala
 
       found1 should have size 2
       found1.foreach { x =>
@@ -324,7 +328,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // now search for one of the snapshotIds that should NOT be duplicated, to be sure
       val criteria2 = "00000000-0000-0000-0000-000000000015"
-      val found2 = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria2)), Duration.Inf)
+      val found2 = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria2)),
+        Duration.Inf).getResources.asScala
 
       found2 should have size 1
       found2.foreach { x =>
@@ -341,7 +347,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should NOT be in the list
       val criteria = "00000000-0000-0000-0000-000000000099"
-      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)), Duration.Inf)
+      val found = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria)),
+        Duration.Inf).getResources.asScala
 
       found should have size 0
     }
@@ -356,8 +364,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000006"
-      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria),
-        batchSize), Duration.Inf)
+      val found = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), batchSize),
+        Duration.Inf).getResources.asScala
 
       found should have size 1
       found.head.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot shouldBe criteria
@@ -379,8 +388,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000006"
-      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria),
-        batchSize), Duration.Inf)
+      val found = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), batchSize),
+        Duration.Inf).getResources.asScala
 
       found should have size 2
       found.foreach { x =>
@@ -402,8 +412,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be in the list
       val criteria = "00000000-0000-0000-0000-000000000099"
-      val found = Await.result(snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria),
-        batchSize), Duration.Inf)
+      val found = Await.result(
+        snapshotService.findBySnapshotId(minimalTestData.workspace.toWorkspaceName, UUID.fromString(criteria), batchSize),
+        Duration.Inf).getResources.asScala
 
       found should have size 0
 
@@ -439,7 +450,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     }
   }
 
-  def mockSnapshotServiceForReferences(resources: List[ResourceDescription]) = {
+  def mockSnapshotServiceForReferences(resources: List[ResourceDescription]): SnapshotService = {
     // mock sam that always says we have permission
     val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -12,6 +12,7 @@ import scala.collection.JavaConverters._
 case class DataReferenceName(value: String) extends ValueObject
 case class DataReferenceDescriptionField(value: String = "") extends ValueObject
 case class NamedDataRepoSnapshot(name: DataReferenceName, description: Option[DataReferenceDescriptionField], snapshotId: UUID)
+case class SnapshotListResponse(gcpDataRepoSnapshots: Seq[DataRepoSnapshotResource])
 
 object DataReferenceModelJsonSupport extends JsonSupport {
   def stringOrNull(in: Any): JsValue = Option(in) match {
@@ -259,4 +260,5 @@ object DataReferenceModelJsonSupport extends JsonSupport {
   implicit val DataReferenceNameFormat = ValueObjectFormat(DataReferenceName)
   implicit val dataReferenceDescriptionFieldFormat = ValueObjectFormat(DataReferenceDescriptionField)
   implicit val NamedDataRepoSnapshotFormat = jsonFormat3(NamedDataRepoSnapshot)
+  implicit val SnapshotListResponseFormat = jsonFormat1(SnapshotListResponse)
 }


### PR DESCRIPTION
This PR adds a new `referencedSnapshotId` query parameter to the v2 list-snapshots API. When supplied by an end user, it returns only those snapshot references that refer to the supplied snapshot id.


