### PR TITLE
code and logic cleanup for Delta Layer companion reference [AS-724]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -35,48 +35,36 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
 
   def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataRepoSnapshotResource] = {
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
-      if(!workspaceStubExists(workspaceContext.workspaceIdAsUUID, userInfo)) {
-        workspaceManagerDAO.createWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)
+      val wsid = workspaceContext.workspaceIdAsUUID // to avoid UUID parsing multiple times
+      // create the stub workspace in WSM if it does not already exist
+      if(!workspaceStubExists(wsid, userInfo)) {
+        workspaceManagerDAO.createWorkspace(wsid, userInfo.accessToken)
       }
-
-      val snapshotRef = workspaceManagerDAO.createDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshot.snapshotId, snapshot.name, snapshot.description, terraDataRepoInstanceName, CloningInstructionsEnum.NOTHING, userInfo.accessToken)
-
-      val referenceId = snapshotRef.getMetadata.getResourceId
+      // create the requested snapshot reference
+      val snapshotRef = workspaceManagerDAO.createDataRepoSnapshotReference(wsid, snapshot.snapshotId, snapshot.name,
+        snapshot.description, terraDataRepoInstanceName, CloningInstructionsEnum.NOTHING, userInfo.accessToken)
 
       // attempt to create the BQ dataset, which might already exist
-      val createDatasetIO = IO.fromFuture(IO(deltaLayer.createDatasetIfNotExist(workspaceContext, userInfo)))
-
-      createDatasetIO.unsafeToFuture().recover {
+      deltaLayer.createDatasetIfNotExist(workspaceContext, userInfo).recover {
         case t: Throwable =>
-          //fire and forget this undo, we've made our best effort to fix things at this point
-          IO.pure(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken)).unsafeToFuture()
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
-      }.flatMap {
-        case (justCreated, datasetId) =>
-          // if we just created the companion dataset - because it didn't exist - then also create a WSM reference to it
-          if (justCreated) {
-            val createBQReferenceFuture = for {
-              petToken <- samDAO.getPetServiceAccountToken(GoogleProjectId(workspaceName.namespace), SamDAO.defaultScopes + SamDAO.bigQueryReadOnlyScope, userInfo)
-              bigQueryRef = workspaceManagerDAO.createBigQueryDatasetReference(workspaceContext.workspaceIdAsUUID, new ReferenceResourceCommonFields().name(datasetId.getDataset).cloningInstructions(CloningInstructionsEnum.NOTHING), new GcpBigQueryDatasetAttributes().projectId(workspaceContext.namespace).datasetId(datasetId.getDataset), OAuth2BearerToken(petToken))
-            } yield { bigQueryRef }
-
-            createBQReferenceFuture.recover {
-              case t: Throwable =>
-                //fire and forget these undos, we've made our best effort to fix things at this point
-                for {
-                  // TODO: AS-724 is it worth deleting the companion and its ref here? If the user attempted to add a snapref,
-                  // they are likely to do so again, and we can just reuse whatever companion was already created.
-                  // This will prevent continual creation/deletion of the same-named dataset.
-                  _ <- deltaLayer.deleteDataset(workspaceContext)
-                  _ <- Future(workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceId, userInfo.accessToken))
-                } yield {}
-                throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId}. Error: ${t.getMessage}"))
-            }
-          } else {
-            Future(workspaceManagerDAO.getBigQueryDatasetReferenceByName(workspaceContext.workspaceIdAsUUID, datasetId.getDataset, userInfo.accessToken))
-            // retrieve existing dataset reference
+          // something went wrong creating the companion dataset
+          logger.warn(s"Error creating Delta Layer companion dataset for workspace ${workspaceName}: ${t.getMessage}")
+          // since companion dataset creation failed, try to clean up this snapshot reference so the user can try again
+          Try(workspaceManagerDAO.deleteDataRepoSnapshotReference(wsid, snapshotRef.getMetadata.getResourceId, userInfo.accessToken)) match {
+            case Success(_) =>
+              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError,
+                s"Unable to create snapshot reference in workspace ${workspaceContext.workspaceId} due to problems creating " +
+                  s"the Delta Layer companion dataset. Error: [${t.getMessage}]"))
+            case Failure(ex) =>
+              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError,
+                s"Error while creating snapshot reference in workspace ${workspaceContext.workspaceId}. Additionally, there " +
+                  s"was an error cleaning up the snapshot reference. The reference may be in an unusable state. Original error " +
+                  s"during Delta Layer companion dataset creation was: [${t.getMessage}]. " +
+                  s"Error during snapshot reference cleanup: [${ex.getMessage}]."))
           }
-      }.map { _ => snapshotRef}
+      }.map { _ =>
+        snapshotRef
+      }
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -66,7 +66,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
     }
 
     "not leave an orphaned bq dataset if creating a snapshot reference fails" in withMinimalTestDatabase { dataSource =>
@@ -147,101 +146,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
       verify(mockBigQueryServiceFactory, times(1)).getServiceForProject(workspace.googleProject)
-      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
-    }
-
-    "not leave an orphaned snapshot data reference nor an orphaned BQ dataset if creating a BQ data reference in WSM fails" in withMinimalTestDatabase { dataSource =>
-      val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-
-      when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
-
-      when(mockSamDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[UserInfo])).thenReturn(Future.successful(Set(SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(WorkbenchEmail(userInfo.userEmail.value)), Set.empty, Set.empty), WorkbenchEmail("")))))
-
-      when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.successful("fake-token"))
-
-      val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
-
-      val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
-
-      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
-        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
-
-      when(mockWorkspaceManagerDAO.createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])).thenThrow(new RuntimeException)
-
-      val workspace = minimalTestData.workspace
-      val deltaLayer = new DeltaLayer(mockBigQueryServiceFactory, new MockDeltaLayerWriter, mockSamDAO, fakeRawlsClientEmail, fakeDeltaLayerStreamerEmail)
-
-      val snapshotService = SnapshotService.constructor(
-        slickDataSource,
-        mockSamDAO,
-        mockWorkspaceManagerDAO,
-        deltaLayer,
-        "fake-terra-data-repo-dev",
-        fakeRawlsClientEmail,
-        fakeDeltaLayerStreamerEmail
-      )(userInfo)
-
-      val createException = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
-      }
-      createException.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
-      assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
-
-      verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(2)).getServiceForProject(workspace.googleProject)
-      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
-      verify(mockWorkspaceManagerDAO, times(1)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])
-
-      // see SnapshotService line 65, "fire and forget these undos, we've made our best effort to fix things at this point"
-      // because the call to workspaceManagerDAO.deleteDataRepoSnapshotReference is fire-and-forget, we can't count on it happening
-      // by this point of this test. We need an eventually here:
-      eventually {
-        verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
-      }
-
-    }
-
-    "not leave an orphaned snapshot data reference nor an orphaned BQ dataset if getting a pet token from Sam fails" in withMinimalTestDatabase { dataSource =>
-      val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-
-      when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
-
-      when(mockSamDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[UserInfo])).thenReturn(Future.successful(Set(SamPolicyWithNameAndEmail(SamWorkspacePolicyNames.projectOwner, SamPolicy(Set(WorkbenchEmail(userInfo.userEmail.value)), Set.empty, Set.empty), WorkbenchEmail("")))))
-
-      when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.failed(new RuntimeException))
-
-      val mockBigQueryServiceFactory = mock[GoogleBigQueryServiceFactory](RETURNS_SMART_NULLS)
-      when(mockBigQueryServiceFactory.getServiceForProject(any[GoogleProjectId])).thenReturn(MockBigQueryServiceFactory.ioFactory().getServiceForPet("foo", GoogleProject("foo")))
-
-      val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
-
-      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken]))
-        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
-
-      val workspace = minimalTestData.workspace
-      val deltaLayer = new DeltaLayer(mockBigQueryServiceFactory, new MockDeltaLayerWriter, mockSamDAO, fakeRawlsClientEmail, fakeDeltaLayerStreamerEmail)
-
-      val snapshotService = SnapshotService.constructor(
-        slickDataSource,
-        mockSamDAO,
-        mockWorkspaceManagerDAO,
-        deltaLayer,
-        "fake-terra-data-repo-dev",
-        fakeRawlsClientEmail,
-        fakeDeltaLayerStreamerEmail
-      )(userInfo)
-
-      val createException = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
-      }
-      createException.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
-      assert(createException.errorReport.message.contains("Unable to create snapshot reference in workspace"))
-
-      verify(mockSamDAO, times(1)).listPoliciesForResource(any[SamResourceTypeName], any[String], any[UserInfo])
-      verify(mockBigQueryServiceFactory, times(2)).getServiceForProject(workspace.googleProject)
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(any[UUID], any[UUID], any[OAuth2BearerToken])
       verify(mockWorkspaceManagerDAO, times(0)).createBigQueryDatasetReference(any[UUID], any[ReferenceResourceCommonFields], any[GcpBigQueryDatasetAttributes], any[OAuth2BearerToken])


### PR DESCRIPTION
Follwup to #1475.

Don't create a WSM reference for the Delta Layer companion dataset; we don't need this. By not creating this reference, we simplify the error-handling/cleanup logic inside the create-snapshot-reference method.

This PR also includes a handful of syntax tweaks to resolve IntelliJ warnings, sorry for lumping it all together.