### PR TITLE
retrieve snapshot reference by name [AS-786]

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4373,6 +4373,38 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/name/{referenceName}:
+    parameters:
+      - $ref: '#/components/parameters/workspaceNamespacePathParam'
+      - $ref: '#/components/parameters/workspaceNamePathParam'
+      - $ref: '#/components/parameters/referenceNamePathParam'
+    get:
+      tags:
+        - snapshots_v2
+      summary: Get a snapshot by name
+      description: Get a reference to a snapshot in the Terra Data Repo by its name
+      operationId: getDataRepoSnapshotByName_v2
+      responses:
+        200:
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DataRepoSnapshotResource'
+        404:
+          description: Workspace or snapshot not found
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+
+
 
   /api/notifications/workspace/{workspaceNamespace}/{workspaceName}:
     get:
@@ -6400,6 +6432,13 @@ components:
       name: snapshotId
       in: path
       description: The snapshot's referenceId
+      required: true
+      schema:
+        type: string
+    referenceNamePathParam:
+      name: referenceName
+      in: path
+      description: The snapshot reference's name
       required: true
       schema:
         type: string

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.deltalayer.DeltaLayer
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, NamedDataRepoSnapshot, SamWorkspaceActions, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, SamWorkspaceActions, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
@@ -68,6 +68,13 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     val referenceUuid = validateSnapshotId(referenceId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceUuid, userInfo.accessToken)
+      Future.successful(ref)
+    }
+  }
+
+  def getSnapshotByName(workspaceName: WorkspaceName, referenceName: String): Future[DataRepoSnapshotResource] = {
+    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
+      val ref = workspaceManagerDAO.getDataRepoSnapshotReferenceByName(workspaceContext.workspaceIdAsUUID, DataReferenceName(referenceName), userInfo.accessToken)
       Future.successful(ref)
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -54,6 +54,11 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       }
     } ~
+    path("workspaces" / Segment / Segment / "snapshots" / "v2" / "name" / Segment) { (workspaceNamespace, workspaceName, referenceName) =>
+      complete {
+        snapshotServiceConstructor(userInfo).getSnapshotByName(WorkspaceName(workspaceNamespace, workspaceName), referenceName).map(StatusCodes.OK -> _)
+      }
+    } ~
     // ---- SNAPSHOT V1 ----
     path("workspaces" / Segment / Segment / "snapshots") { (workspaceNamespace, workspaceName) =>
       post {


### PR DESCRIPTION
New API to retrieve a snapshot reference inside a workspace by its name. Delegates to WSM's https://workspace.dsde-dev.broadinstitute.org/swagger-ui.html#/ReferencedGcpResource/getDataRepoSnapshotReferenceByName