### PR TITLE
fix ExecutionJsonSupport imports in rawls-model [AS-787]

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -281,7 +281,7 @@ case class SubmissionWorkflowStatusResponse(
                                              count: Int)
 
 //noinspection TypeAnnotation,ScalaUnusedSymbol
-class ExecutionJsonSupport extends JsonSupport {
+trait ExecutionJsonSupport extends JsonSupport {
   import spray.json.DefaultJsonProtocol._
 
   type OutputType = Either[Attribute, UnsupportedOutputType]


### PR DESCRIPTION
The Rawls automation tests (in the `automation` subdir) were hitting ugly compilation errors trying to simply import from `ExecutionJsonSupport`:
```
import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
```

making it a trait instead of a class seems to fix it, with no other side effects.