### PR TITLE
fix rawls-model compile errors in automation by excluding from serviceTest [AS-787]

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ VAULT_TOKEN=$(cat ~/.vault-token) ARTIFACTORY_USERNAME=dsdejenkins ARTIFACTORY_P
 
 You can view what is in the artifactory here: https://broadinstitute.jfrog.io/broadinstitute/webapp/#/home
 
-After publishing, update [model/CHANGELOG.md](model/CHANGELOG.md) properly.
+After publishing:
+* update [model/CHANGELOG.md](model/CHANGELOG.md) properly
+* update the rawls-model dependency in the automation subdirectory, and ensure that sbt project is healthy
+* update the rawls-model dependency in workbench-libs serviceTest, and ensure that sbt project is healthy
 
 
 ## Troubleshooting

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -20,10 +20,11 @@ object Dependencies {
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-util_" + scalaV),
     ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_" + scalaV)
   )
+  val rawlsModelExclusion = ExclusionRule(organization = "org.broadinstitute.dsde", name = "rawls-model_" + scalaV)
 
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll(workbenchExclusions:_*)
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
-  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions:_*)
+  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions :+ rawlsModelExclusion:_*)
 
   val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.5-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
@@ -53,7 +54,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % "test",
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-14278f08f"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-90eae81cd"
       exclude("com.typesafe.scala-logging", "scala-logging_2.11")
       exclude("com.typesafe.akka", "akka-stream_2.11")
       exclude("bio.terra", "workspace-manager-client"),

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -6,5 +6,6 @@ This file documents changes to the `rawls-model` library, including notes on how
 
 Added:
 - Support 2.13
+- ExecutionModel classes moved from core to model
 
-SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "0.1-2356e282"`
+SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "0.1-90eae81cd"`


### PR DESCRIPTION
This PR adds an exclusion rule to workbench-libs' `serviceTest` - in automation - to exclude `rawls-model`.

workbench-libs currently depends on an older version `0.1-2356e282` of `rawls-model`; see https://github.com/broadinstitute/workbench-libs/blob/1d672fd6638d43947464d029053ed7c450628f7a/project/Dependencies.scala#L90. Automation was trying to use a newer version. Scala/sbt was having problems with both of these versions in its dependency tree, resulting in confounding errors where compile could not find classes inside `ExecutionModel.scala`.

Excluding rawls-model from workbench-libs fixes this issue.