### PR TITLE
update to workbench-libs serviceTest 0.19 [AS-787]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.11.3"
 
-  val serviceTestV = "0.18-23f5ae7"
+  val serviceTestV = "0.19-5edfa7a"
   val workbenchGoogleV = "0.21-24dcd92"
   val workbenchGoogle2V = "0.21-e17afdf"
   val workbenchModelV  = "0.14-65bba14"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
@@ -106,7 +106,9 @@ class BillingApiSpec extends AnyFreeSpec with BillingFixtures with MethodFixture
           participantId,
           "this",
           useCallCache = false,
-          deleteIntermediateOutputFiles = false)
+          deleteIntermediateOutputFiles = false,
+          useReferenceDisks = false,
+          memoryRetryMultiplier = 1.0)
 
         // wait until submission complete
         Submission.waitUntilSubmissionComplete(billingProjectName, workspaceName, submissionId)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
@@ -53,7 +53,9 @@ class MethodLaunchSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
               entityName = "participant1",
               expression = "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
           )
           exception.message.parseJson.asJsObject.fields("message").convertTo[String].contains("Missing inputs:") shouldBe true
@@ -87,7 +89,9 @@ class MethodLaunchSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
             entityName = "participant1",
             expression = "this",
             useCallCache = false,
-            deleteIntermediateOutputFiles = false
+            deleteIntermediateOutputFiles = false,
+            useReferenceDisks = false,
+            memoryRetryMultiplier = 1.0
           )
 
           // make sure the submission has not errored out
@@ -138,7 +142,9 @@ class MethodLaunchSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
             entityName = "participant1",
             expression = "this",
             useCallCache = false,
-            deleteIntermediateOutputFiles = false
+            deleteIntermediateOutputFiles = false,
+            useReferenceDisks = false,
+            memoryRetryMultiplier = 1.0
           )(ownerAuthToken)
 
           val status = Rawls.submissions.getSubmissionStatus(billingProject, workspaceName, submissionId)(readerAuthToken)
@@ -182,7 +188,9 @@ class MethodLaunchSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
               entityName = "participant1",
               expression = "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
           )
           exception.message.parseJson.asJsObject.fields("message").convertTo[String].contains("The expression in your SubmissionRequest matched only entities of the wrong type. (Expected type sample.)") shouldBe true
@@ -221,7 +229,9 @@ class MethodLaunchSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
               entityName = "participantSet1",
               expression = "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
           )
           exception.message.parseJson.asJsObject.fields("message").convertTo[String].contains("The expression in your SubmissionRequest matched only entities of the wrong type") shouldBe true

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -167,7 +167,9 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               SingleParticipant.entityId,
               "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
             // clean up: Abort submission
             register cleanUp Rawls.submissions.abortSubmission(projectName, workspaceName, submissionId)
@@ -269,7 +271,9 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               SingleParticipant.entityId,
               "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
 
             logger.info(s"Submission in $projectName/$workspaceName returned submission ID: $submissionId")
@@ -381,7 +385,9 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               SingleParticipant.entityId,
               "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
 
             logger.info(s"Submission in $projectName/$workspaceName returned submission ID: $submissionId")
@@ -705,7 +711,9 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               SingleParticipant.entityId,
               "this",
               useCallCache = false,
-              deleteIntermediateOutputFiles = false
+              deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
             // clean up: Abort submission
             register cleanUp Rawls.submissions.abortSubmission(projectName, workspaceName, submissionId)
@@ -863,6 +871,8 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
               expression = "this",
               useCallCache = false,
               deleteIntermediateOutputFiles = false,
+              useReferenceDisks = false,
+              memoryRetryMultiplier = 1.0
             )
 
             register cleanUp Rawls.submissions.abortSubmission(projectName, workspaceName, submissionId)
@@ -947,6 +957,8 @@ class RawlsApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLike w
                   expression = "this",
                   useCallCache = false,
                   deleteIntermediateOutputFiles = false,
+                  useReferenceDisks = false,
+                  memoryRetryMultiplier = 1.0
                 )
               )
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -395,7 +395,9 @@ class WorkspaceApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
                     entityName = "participant1",
                     expression = "this",
                     useCallCache = false,
-                    deleteIntermediateOutputFiles = false
+                    deleteIntermediateOutputFiles = false,
+                    useReferenceDisks = false,
+                    memoryRetryMultiplier = 1.0
                   )(studentAToken)
                 }
                 assertExceptionStatusCode(submissionException, 403)
@@ -436,7 +438,9 @@ class WorkspaceApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
                 entityName = "participant1",
                 expression = "this",
                 useCallCache = false,
-                deleteIntermediateOutputFiles = false
+                deleteIntermediateOutputFiles = false,
+                useReferenceDisks = false,
+                memoryRetryMultiplier = 1.0
               )(studentAToken)
               // make sure the submission has not errored out
               eventually {
@@ -480,7 +484,9 @@ class WorkspaceApiSpec extends TestKit(ActorSystem("MySpec")) with AnyFreeSpecLi
                   entityName = "participant1",
                   expression = "this",
                   useCallCache = false,
-                  deleteIntermediateOutputFiles = false
+                  deleteIntermediateOutputFiles = false,
+                  useReferenceDisks = false,
+                  memoryRetryMultiplier = 1.0
                 )(studentAToken)
               }
               assertExceptionStatusCode(submissionException, 403)


### PR DESCRIPTION
following up on #1485 and broadinstitute/workbench-libs#696, this PR updates Rawls automation tests to use the latest version of workbench-libs' serviceTest library.

The upgrade from 0.18 to 0.19 of serviceTest requires adding `useReferenceDisks` and `memoryRetryMultiplier` parameters to `Rawls.submissions.launchWorkflow`; see https://github.com/broadinstitute/workbench-libs/blob/develop/serviceTest/CHANGELOG.md and broadinstitute/workbench-libs#631

`useReferenceDisks` has a default of `false` per #1310: https://github.com/broadinstitute/rawls/blob/0de4f198495c0fa28c7818433bf7f8eb87981359/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala#L31

`memoryRetryMultiplier` has a default of `1.0` per #1444: https://github.com/broadinstitute/rawls/blob/0de4f198495c0fa28c7818433bf7f8eb87981359/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala#L32

so I've used those values everywhere I needed to update signatures.