### PR TITLE
[CA-1464] logging delete workspace failures to help debug CA-1206

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -378,7 +378,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             logger.warn(s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceName}. Received ${e.getCode}: [${e.getResponseBody}]")
             Future.successful()
           }
-          else throw e
+          throw e
         }
       }
       // Delete the Delta Layer companion dataset, if it exists

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -363,6 +363,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             logger.warn(s"Unexpected failure deleting workspace in Workspace Manager. Received ${e.getCode}: [${e.getResponseBody}]")
             Future.successful()
           }
+          throw e
         }
       }
       // Delete the Delta Layer companion dataset, if it exists

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -372,8 +372,8 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
       // Delete workspace manager record (which will only exist if there had ever been a TDR snapshot in the WS)
       _ <- Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)).recoverWith {
-        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 404 exceptions here
-        case e: ApiException if e.getCode == StatusCodes.NotFound.intValue => {
+        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 401 exceptions here
+        case e: ApiException if e.getCode == StatusCodes.Unauthorized.intValue => {
           Future.successful()
         }
         case t:Throwable => {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -349,7 +349,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
     for {
 
       workflowsToAbort <- deletionFuture recoverWith {
-        case t:Throwable => { // logging added as part of investigation into https://broadworkbench.atlassian.net/browse/CA-1206
+        case t:Throwable => {
           logger.warn(s"Unexpected failure deleting workspace (while running `deletionFuture`) for workspace `${workspaceName}`", t)
           throw t
         }
@@ -357,7 +357,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
       // Abort running workflows
       aborts = Future.traverse(workflowsToAbort) { wf => executionServiceCluster.abort(wf, userInfo) } recoverWith {
-        case t:Throwable => { // logging added as part of investigation into https://broadworkbench.atlassian.net/browse/CA-1206
+        case t:Throwable => {
           logger.warn(s"Unexpected failure deleting workspace (while aborting workflows) for workspace `${workspaceName}`", t)
           throw t
         }
@@ -365,7 +365,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
 
       // Delete resource in sam outside of DB transaction
       _ <- workspaceContext.workflowCollectionName.map( cn => samDAO.deleteResource(SamResourceTypeNames.workflowCollection, cn, userInfo) ).getOrElse(Future.successful(())) recoverWith {
-        case t:Throwable => { // logging added as part of investigation into https://broadworkbench.atlassian.net/browse/CA-1206
+        case t:Throwable => {
           logger.error(s"Unexpected failure deleting workspace (while deleting workflowCollection in Sam) for workspace `${workspaceName}`", t)
           throw t
         }
@@ -383,13 +383,13 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
       // Delete the Delta Layer companion dataset, if it exists
       _ <- deltaLayer.deleteDataset(workspaceContext) recoverWith {
-        case t:Throwable => { // logging added as part of investigation into https://broadworkbench.atlassian.net/browse/CA-1206
+        case t:Throwable => {
           logger.warn(s"Unexpected failure deleting workspace (while deleting Delta Layer) for workspace `${workspaceName}`", t)
           throw t
         }
       }
       _ <- samDAO.deleteResource(SamResourceTypeNames.workspace, workspaceContext.workspaceIdAsUUID.toString, userInfo) recoverWith {
-        case t:Throwable => { // logging added as part of investigation into https://broadworkbench.atlassian.net/browse/CA-1206
+        case t:Throwable => {
           logger.warn(s"Unexpected failure deleting workspace (while deleting workspace in Sam) for workspace `${workspaceName}`", t)
           throw t
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -378,7 +378,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
             logger.warn(s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceName}. Received ${e.getCode}: [${e.getResponseBody}]")
             Future.successful()
           }
-          throw e
+          else throw e
         }
       }
       // Delete the Delta Layer companion dataset, if it exists

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -376,9 +376,8 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
         case e: ApiException => {
           if(e.getCode != StatusCodes.NotFound.intValue) {
             logger.warn(s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceName}. Received ${e.getCode}: [${e.getResponseBody}]")
-            Future.successful()
           }
-          throw e
+          Future.successful()
         }
       }
       // Delete the Delta Layer companion dataset, if it exists

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -361,8 +361,8 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
         case e: ApiException => {
           if(e.getCode != StatusCodes.NotFound.intValue) {
             logger.warn(s"Unexpected failure deleting workspace in Workspace Manager. Received ${e.getCode}: [${e.getResponseBody}]")
+            Future.successful()
           }
-          Future.successful()
         }
       }
       // Delete the Delta Layer companion dataset, if it exists

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -372,7 +372,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
       // Delete workspace manager record (which will only exist if there had ever been a TDR snapshot in the WS)
       _ <- Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)).recoverWith {
-        //this will only ever succeed if a TDR snapshot had been created in the WS, and if not this returns a 401 so we gracefully handle those exceptions here
+        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 401 exceptions here
         case e: ApiException if e.getCode == StatusCodes.Unauthorized.intValue => {
           Future.successful()
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -372,8 +372,8 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
       // Delete workspace manager record (which will only exist if there had ever been a TDR snapshot in the WS)
       _ <- Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)).recoverWith {
-        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 401 exceptions here
-        case e: ApiException if e.getCode == StatusCodes.Unauthorized.intValue => {
+        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 404 exceptions here
+        case e: ApiException if e.getCode == StatusCodes.NotFound.intValue => {
           Future.successful()
         }
         case t:Throwable => {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -372,13 +372,13 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
       // Delete workspace manager record (which will only exist if there had ever been a TDR snapshot in the WS)
       _ <- Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)).recoverWith {
-        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle all exceptions here
-        case e: ApiException => {
-          if(e.getCode != StatusCodes.NotFound.intValue) {
-            logger.warn(s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceName}. Received ${e.getCode}: [${e.getResponseBody}]")
-            Future.successful()
-          }
-          else throw e
+        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 404 exceptions here
+        case e: ApiException if e.getCode == StatusCodes.NotFound.intValue => {
+          Future.successful()
+        }
+        case t:Throwable => {
+          logger.warn(s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceName}`", t)
+          throw t
         }
       }
       // Delete the Delta Layer companion dataset, if it exists

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -372,7 +372,7 @@ class WorkspaceService(protected val userInfo: UserInfo, val dataSource: SlickDa
       }
       // Delete workspace manager record (which will only exist if there had ever been a TDR snapshot in the WS)
       _ <- Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, userInfo.accessToken)).recoverWith {
-        //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle 401 exceptions here
+        //this will only ever succeed if a TDR snapshot had been created in the WS, and if not this returns a 401 so we gracefully handle those exceptions here
         case e: ApiException if e.getCode == StatusCodes.Unauthorized.intValue => {
           Future.successful()
         }


### PR DESCRIPTION
CA-1464

Changelog:
* Adds logging messages in deleteWorkspace so it is easier for us to track down the root cause of the failed deleteWorkspace calls. 
* makes deleting in Workspace Manager fail if it's not the expected 404. (was this a bug?)
* removes the mixing of try (sync) and future (async) 

---

error message examples:

```
// before:
rawls [ERROR] [08/05/2021 16:31:33.696] [scala-execution-context-global-76] [akka.actor.ActorSystemImpl(rawls)] HttpMethod(DELETE) http://rawls-sbt:8080/api/workspaces/aj-ca-1206-6/aj-test-ws-2020-copy7: 500 Internal Server Error entity: {"causes":[],"message":"aj-test-failures","source":"rawls","stackTrace":[]}
```

```
// after:
rawls [ERROR] [16:31:33.560] [scala-execution-context-global-73] o.b.d.r.workspace.WorkspaceService - Unexpected failure deleting workspace (while deleting workflowCollection in Sam) for workspace `aj-ca-1206-6/aj-test-ws-2020-copy7`
rawls org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport: ErrorReport(rawls,aj-test-failures,None,List(),List(),None)
rawls 	at org.broadinstitute.dsde.rawls.dataaccess.HttpSamDAO.$anonfun$deleteResource$1(HttpSamDAO.scala:159)
rawls 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
rawls 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
rawls 	at scala.util.Success.map(Try.scala:213)
rawls 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
rawls 	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
rawls 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
rawls 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
rawls 	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
rawls 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
rawls 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
rawls 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
rawls 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
rawls 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
rawls [WARN] [16:31:33.648] [scala-execution-context-global-73] io.sentry.dsn.Dsn - *** Couldn't find a suitable DSN, Sentry operations will do nothing! See documentation: https://docs.sentry.io/clients/java/ ***
rawls [ERROR] [08/05/2021 16:31:33.696] [scala-execution-context-global-76] [akka.actor.ActorSystemImpl(rawls)] HttpMethod(DELETE) http://rawls-sbt:8080/api/workspaces/aj-ca-1206-6/aj-test-ws-2020-copy7: 500 Internal Server Error entity: {"causes":[],"message":"aj-test-failures","source":"rawls","stackTrace":[]}
```


---

I decided not to refactor deleteWorkspace too much right now, since we should probably figure out the root cause first before we make a lot of changes.

---

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
