### PR TITLE
[CA-1482] Allow default bucket location to be explicitly set

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -140,7 +140,7 @@ trait WorkspaceSupport {
       case Some(region) =>
         // if the user specifies a region for the workspace bucket, it must be in the proper format for a single region or the default bucket location (US multi region)
         val singleRegionPattern = "[A-Za-z]+-[A-Za-z]+[0-9]+"
-        val defaultBucketRegion = "US"
+        val validUSPattern = "US"
         if (region.matches(singleRegionPattern) || region.equals(defaultBucketRegion)) op
         else {
           val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace bucket location must be a single " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -138,9 +138,10 @@ trait WorkspaceSupport {
   def withWorkspaceBucketRegionCheck[T](bucketRegion: Option[String])(op: => Future[T]): Future[T] = {
     bucketRegion match {
       case Some(region) =>
-        // if the user specifies a region for the workspace bucket, it must be in the proper format for a single region
+        // if the user specifies a region for the workspace bucket, it must be in the proper format for a single region or the default bucket location (US multi region)
         val singleRegionPattern = "[A-Za-z]+-[A-Za-z]+[0-9]+"
-        if (region.matches(singleRegionPattern)) op
+        val defaultBucketRegion = "US"
+        if (region.matches(singleRegionPattern) || region.equals(defaultBucketRegion)) op
         else {
           val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace bucket location must be a single " +
             s"(not multi-) region of format: $singleRegionPattern.")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -141,7 +141,7 @@ trait WorkspaceSupport {
         // if the user specifies a region for the workspace bucket, it must be in the proper format for a single region or the default bucket location (US multi region)
         val singleRegionPattern = "[A-Za-z]+-[A-Za-z]+[0-9]+"
         val validUSPattern = "US"
-        if (region.matches(singleRegionPattern) || region.equals(defaultBucketRegion)) op
+        if (region.matches(singleRegionPattern) || region.equals(validUSPattern)) op
         else {
           val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace bucket location must be a single " +
             s"region of format: $singleRegionPattern or the default bucket location ('US').")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -144,7 +144,7 @@ trait WorkspaceSupport {
         if (region.matches(singleRegionPattern) || region.equals(defaultBucketRegion)) op
         else {
           val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace bucket location must be a single " +
-            s"(not multi-) region of format: $singleRegionPattern.")
+            s"region of format: $singleRegionPattern or the default bucket location ('US').")
           throw new RawlsExceptionWithErrorReport(errorReport = err)
         }
       case None => op

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1304,7 +1304,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 if the cloned bucket location requested is in an invalid format" in withTestDataApiServices { services =>
+  it should "return 201 if the cloned bucket location requested is the default bucket location" in withTestDataApiServices { services =>
     val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, bucketLocation = Option("US"))
     Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>
@@ -1313,7 +1313,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 if the cloned bucket location requested is the default bucket location" in withTestDataApiServices { services =>
+  it should "return 400 if the cloned bucket location requested is in an invalid format" in withTestDataApiServices { services =>
     val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, bucketLocation = Option("EU"))
     Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -874,7 +874,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       name = "newWorkspace",
       attributes = Map.empty,
       authorizationDomain = None,
-      bucketLocation = Option("US")
+      bucketLocation = Option("EU")
     )
 
     Post(s"/workspaces", httpJson(newWorkspace)) ~>
@@ -882,7 +882,23 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       check {
         val errorText = responseAs[ErrorReport].message
         assert(status == StatusCodes.BadRequest)
-        assert(errorText.contains("Workspace bucket location must be a single (not multi-) region of format: [A-Za-z]+-[A-Za-z]+[0-9]+"))
+        assert(errorText.contains("Workspace bucket location must be a single region of format: [A-Za-z]+-[A-Za-z]+[0-9]+ or the default bucket location ('US')."))
+      }
+  }
+
+  it should "return 201 if the bucket location requested is the default bucket location" in withTestDataApiServices { services =>
+    val newWorkspace = WorkspaceRequest(
+      namespace = testData.wsName.namespace,
+      name = "newWorkspace",
+      attributes = Map.empty,
+      authorizationDomain = None,
+      bucketLocation = Option("US")
+    )
+
+    Post(s"/workspaces", httpJson(newWorkspace)) ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assert(status == StatusCodes.Created)
       }
   }
 
@@ -1293,9 +1309,18 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
+        assert(status == StatusCodes.Created)
+      }
+  }
+
+  it should "return 400 if the cloned bucket location requested is the default bucket location" in withTestDataApiServices { services =>
+    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, bucketLocation = Option("EU"))
+    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
         val errorText = responseAs[ErrorReport].message
         assert(status == StatusCodes.BadRequest)
-        assert(errorText.contains("Workspace bucket location must be a single (not multi-) region of format: [A-Za-z]+-[A-Za-z]+[0-9]+"))
+        assert(errorText.contains("Workspace bucket location must be a single region of format: [A-Za-z]+-[A-Za-z]+[0-9]+ or the default bucket location ('US')."))
       }
   }
 


### PR DESCRIPTION
Ticket: [CA-1482](https://broadworkbench.atlassian.net/browse/CA-1482)
At the moment, we only allow users to specify single regions when creating workspace buckets in different locations. If a bucket location is not specified at all, then we default to `US` which is the GCP default bucket region. This PR allows us to explicitly set the bucket location to the default bucket location. This is part of a workaround to fix `cloneWorkspace` for workspaces in service perimeters in PPW. See https://docs.google.com/document/d/1Ua6Y-denNXjqaqwqtq2sHP1xyVv9zG1ptYpiCy93KIg/edit?resourcekey=0-uwpf2YJb0vXgeNtDu-iVMA#heading=h.2oppleodrwq0 for more information.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
