### PR TITLE
unit tests should use utf8 database [AS-927]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,22 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-#    services:
-#      mysql:
-#        image: mysql/mysql-server:5.6
-#        env:
-#          MYSQL_ROOT_PASSWORD: rawls-test
-#          MYSQL_USER: rawls-test
-#          MYSQL_PASSWORD: rawls-test
-#          MYSQL_DATABASE: testdb
-#        options: >-
-#          --health-cmd="mysqladmin ping"
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 5
-#        ports:
-#          - 3306:3306
-
     steps:
 
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
 
+      - name: Shutdown Ubuntu MySQL (SUDO)
+        run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary, please not remove it
+
       # run this step first to give it time to start up
       - name: Set up MySQL
         uses: mirromutth/mysql-action@v1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql/mysql-server:5.6
+        image: 'mysql/mysql-server:5.6 --character-set-server=utf8'
         env:
           MYSQL_ROOT_PASSWORD: rawls-test
           MYSQL_USER: rawls-test
@@ -24,7 +24,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-          --character-set-server=utf8
         ports:
           - 3306:3306
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --character-set-server=utf8
         ports:
           - 3306:3306
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           sbt clean coverage test coverageReport
           -J-Xmx3g
           -Denv.type=test
-          -Dmysql.host=localhost
+          -Dmysql.host=127.0.0.1
           -Dmysql.port=3306
           it:compile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,22 +11,27 @@ jobs:
 
     runs-on: ubuntu-latest
 
+#    services:
+#      mysql:
+#        image: mysql/mysql-server:5.6
+#        env:
+#          MYSQL_ROOT_PASSWORD: rawls-test
+#          MYSQL_USER: rawls-test
+#          MYSQL_PASSWORD: rawls-test
+#          MYSQL_DATABASE: testdb
+#        options: >-
+#          --health-cmd="mysqladmin ping"
+#          --health-interval 10s
+#          --health-timeout 5s
+#          --health-retries 5
+#        ports:
+#          - 3306:3306
+
     steps:
 
-      - name: Shutdown Ubuntu MySQL (SUDO)
-        run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary, please not remove it
-
-      # run this step first to give it time to start up
-      - name: Set up MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          character set server: 'utf8'
-          collation server: 'utf8_general_ci'
-          mysql version: '5.6'
-          mysql database: 'testdb'
-          mysql root password: 'rawls-test'
-          mysql user: 'rawls-test'
-          mysql password: 'rawls-test'
+      - name: Start MySQL
+        run: |
+          sh docker/run-mysql.sh start
 
       - uses: actions/checkout@v2
 
@@ -51,20 +56,14 @@ jobs:
           ./minnie-kenny.sh --force
           git secrets --scan-history
 
-      - name: Wait for MySQL
-        run: |
-          while ! mysqladmin ping --host=127.0.0.1 --password=rawls-test --silent; do
-            sleep 1
-          done
-
       - name: Run tests
         id: tests
         run: >-
           sbt clean coverage test coverageReport
           -J-Xmx3g
           -Denv.type=test
-          -Dmysql.host=127.0.0.1
-          -Dmysql.port=3306
+          -Dmysql.host=localhost
+          -Dmysql.port=3310
           it:compile
 
       # A known github bug results in 'annotations generated in a Github action during a step executed in
@@ -84,3 +83,7 @@ jobs:
       - name: Codecov upload
         uses: codecov/codecov-action@v1
         if: ${{ always() }}
+
+      - name: Stop MySQL
+        run: |
+          sh docker/run-mysql.sh stop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
 
-      - name: Start MySQL
-        run: |
-          sh docker/run-mysql.sh start
-
       - uses: actions/checkout@v2
 
       # coursier cache action caches both coursier and sbt caches
       - name: coursier-cache-action
         uses: coursier/cache-action@v5
+
+      - name: Start MySQL
+        run: |
+          sh docker/run-mysql.sh start
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,18 @@ jobs:
 
     steps:
 
+      # run this step first to give it time to start up
+      - name: Set up MySQL
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          character set server: 'utf8'
+          collation server: 'utf8_general_ci'
+          mysql version: '5.6'
+          mysql database: 'testdb'
+          mysql root password: 'rawls-test'
+          mysql user: 'rawls-test'
+          mysql password: 'rawls-test'
+
       - uses: actions/checkout@v2
 
       # coursier cache action caches both coursier and sbt caches
@@ -36,16 +48,11 @@ jobs:
           ./minnie-kenny.sh --force
           git secrets --scan-history
 
-      - name: Set up MySQL
-        uses: mirromutth/mysql-action@v1.1
-        with:
-          character set server: 'utf8'
-          collation server: 'utf8_general_ci'
-          mysql version: '5.6'
-          mysql database: 'testdb'
-          mysql root password: 'rawls-test'
-          mysql user: 'rawls-test'
-          mysql password: 'rawls-test'
+      - name: Wait for MySQL
+        run: |
+          while ! mysqladmin ping --host=127.0.0.1 --password=rawls-test --silent; do
+            sleep 1
+          done
 
       - name: Run tests
         id: tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       mysql:
-        image: 'mysql/mysql-server:5.6 --character-set-server=utf8'
+        image: mysql/mysql-server:5.6
         env:
           MYSQL_ROOT_PASSWORD: rawls-test
           MYSQL_USER: rawls-test
@@ -24,6 +24,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          -e="--character-set-server=utf8"
         ports:
           - 3306:3306
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,23 +11,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql/mysql-server:5.6
-        env:
-          MYSQL_ROOT_PASSWORD: rawls-test
-          MYSQL_USER: rawls-test
-          MYSQL_PASSWORD: rawls-test
-          MYSQL_DATABASE: testdb
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          -e="--character-set-server=utf8"
-        ports:
-          - 3306:3306
-
     steps:
 
       - uses: actions/checkout@v2
@@ -52,6 +35,17 @@ jobs:
         run: |
           ./minnie-kenny.sh --force
           git secrets --scan-history
+
+      - name: Set up MySQL
+        uses: mirromutth/mysql-action@v1.1
+        with:
+          character set server: 'utf8'
+          collation server: 'utf8_general_ci'
+          mysql version: '5.6'
+          mysql database: 'testdb'
+          mysql root password: 'rawls-test'
+          mysql user: 'rawls-test'
+          mysql password: 'rawls-test'
 
       - name: Run tests
         id: tests

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessSpec.scala
@@ -70,4 +70,21 @@ class DataAccessSpec extends TestDriverComponentWithFlatSpecAndMatchers with Sca
       }
     }
   }
+
+  it should "use utf8 for MySQL's character_set_server" in withEmptyTestDatabase {
+    /* Our live-environment CloudSQL instances, including production, use character_set_server=utf8.
+       This setting is critical for SQL queries that specify/override a collation, such as to make a
+       case-sensitive query against a column that is case-insensitive by default, e.g. the column
+       uses utf8_general_ci collation.
+
+       A failure of this test likely means that our test environment is not set up correctly; the mysql
+       instance used by tests does not have the right setting. If the test-instance mysql is not set up
+       correctly, other tests can fail and/or return false positives.
+     */
+    val charsetLookup = runAndWait(sql"""SHOW VARIABLES WHERE Variable_name = 'character_set_server';""".as[(String, String)])
+    charsetLookup should have size 1
+    withClue("is the mysql against which these unit tests ran set up correctly with --character-set-server=utf8 or equivalent?") {
+      charsetLookup.head._2 shouldBe "utf8"
+    }
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -987,7 +987,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
     }
   }
 
-  private val userComment1000character = RandomStringUtils.random(1000)
+  private val userComment1000character = RandomStringUtils.randomGraph(1000)
   private val validUserCommentCases = Table(
     ("description", "userCommentInput", "userCommentResult"),
     ("allow submission with userComment unset", None, JsNull),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -1033,7 +1033,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
       val methodConfigurationName = MethodConfigurationName("no_input", "dsde", workspaceName)
       ensureMethodConfigs(services, workspaceName, methodConfigurationName)
 
-      val invalidUserComment = RandomStringUtils.random(1010)
+      val invalidUserComment = RandomStringUtils.randomGraph(1010)
 
       Post(
         s"${workspaceName.path}/submissions",

--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -10,7 +10,7 @@ start() {
 
     # start up mysql
     echo "starting up mysql container..."
-    docker run --name $CONTAINER -e MYSQL_ROOT_HOST='%' -e MYSQL_ROOT_PASSWORD=rawls-test -e MYSQL_USER=rawls-test -e MYSQL_PASSWORD=rawls-test -e MYSQL_DATABASE=testdb -d -p 3310:3306 mysql/mysql-server:$MYSQL_VERSION
+    docker run --name $CONTAINER -e MYSQL_ROOT_HOST='%' -e MYSQL_ROOT_PASSWORD=rawls-test -e MYSQL_USER=rawls-test -e MYSQL_PASSWORD=rawls-test -e MYSQL_DATABASE=testdb -d -p 3310:3306 mysql/mysql-server:$MYSQL_VERSION --character-set-server=utf8
 
     # validate mysql
     echo "running mysql validation..."


### PR DESCRIPTION
Part of AS-927 but does not complete that ticket.

Tell our unit tests to set `character_set_server=utf8` on their mysql instance.

This makes our unit tests consistent with our live environments, which is always a good thing. Additionally, that utf8 setting is a critical prerequisite for any SQL queries that attempt to override a collation, since not all collations work with all character sets. Specifically, this setting is required to fix AS-927. Without this setting, unit tests for AS-927 would fail, even though the runtime code would work correctly against our live Cloud SQL instances.

