### PR TITLE
simplify filteredCount query for paginated entity results [AS-925]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -307,19 +307,23 @@ trait EntityComponent {
           sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page-1) * entityQuery.pageSize} ) p on p.id = e.id "
         )
 
-        for {
-          unfilteredCount <- findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
-          filteredCount <- if (entityQuery.filterTerms.isEmpty) {
-                            // if the query has no filter, then "filteredCount" and "unfilteredCount" will always be the same; no need to make another query
-                            DBIO.successful(Vector(unfilteredCount))
-                           } else {
-                            val filteredQuery =
-                              sql"""select count(1) from ENTITY e
+        def filteredCountQuery: ReadAction[Vector[Int]] = {
+          val filteredQuery =
+            sql"""select count(1) from ENTITY e
                                    where e.deleted = 0
                                    and e.entity_type = $entityType
                                    and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """
-                            concatSqlActions(filteredQuery, filterSql("and", "e")).as[Int]
-                           }
+          concatSqlActions(filteredQuery, filterSql("and", "e")).as[Int]
+        }
+
+        for {
+          unfilteredCount <- findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
+          filteredCount <- if (entityQuery.filterTerms.isEmpty) {
+                              // if the query has no filter, then "filteredCount" and "unfilteredCount" will always be the same; no need to make another query
+                              DBIO.successful(Vector(unfilteredCount))
+                            } else {
+                              filteredCountQuery
+                            }
           page <- concatSqlActions(sql"#$baseEntityAndAttributeSql", paginationJoin, order("p")).as[EntityAndAttributesResult]
         } yield (unfilteredCount, filteredCount.head, page)
       }


### PR DESCRIPTION
AS-925

See also doc at https://docs.google.com/document/d/1NKvxZbZocV2At_uyuUKn3AFv6raoDlJ0ziGKXyscBes/edit?usp=sharing

This bug surfaced under the following conditions:
* the entity data contained multiple attributes whose names differed only in case; e.g. one entity had an attribute "foo" and another had an attribute "Foo"
* you performed an entity query that sorted by one of these columns, e.g. sorted by "Foo"

Under these conditions, the "filteredCount" value returned in the result metadata was incorrect.

In this PR, I have significantly simplified the SQL query used to generate the "filteredCount" value, and added unit tests.

OLD QUERY:
```sql
select count(1) from (
	select
		e.id,
		e.name,
		e.all_attribute_values,
		sort_a.list_length as sort_list_length,
		sort_a.value_string as sort_field_string,
		sort_a.value_number as sort_field_number
		 sort_a.value_boolean as sort_field_boolean,
		 sort_a.value_json as sort_field_json,
		 sort_e_ref.name as sort_field_ref
	from ENTITY e
		left outer join ENTITY_ATTRIBUTE sort_a on sort_a.owner_id = e.id and sort_a.name = ? and ifnull(sort_a.list_index, 0) = 0
		left outer join ENTITY sort_e_ref on sort_a.value_entity_ref = sort_e_ref.id 
	where
		e.deleted = 'false'
		and e.entity_type = ? and e.workspace_id = ? )
	pagination
	where
		concat(pagination.name, ' ', pagination.all_attribute_values) like ?
```

NEW QUERY:
```sql
select count(1) from ENTITY e
     where e.deleted = 0
     and e.entity_type = ?
     and e.workspace_id = ? and concat(e.name, ' ', e.all_attribute_values) like ?
```

TODO for a future ticket/PR: investigate the other uses of `activeActionForPagination` and `paginationSubquery` to look for any other faulty logic