### PR TITLE
standalone entity cache table [AS-929]

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -90,4 +90,5 @@
     <include file="changesets/20210609_add_workspace_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210609_change_workspace_attr_temp_owner_id.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210510_add_billing_project_export_columns.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210915_create_entity_cache_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210915_create_entity_cache_table.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210915_create_entity_cache_table.xml
@@ -9,7 +9,7 @@
                              referencedTableName="WORKSPACE" referencedColumnNames="id"
                              foreignKeyName="FK_WEC_WORKSPACE" deleteCascade="true"/>
             </column>
-            <column name="entity_cache_last_updated" type="TIMESTAMP(6)" defaultValueDate="1970-01-01 00:00:02">
+            <column name="entity_cache_last_updated" type="TIMESTAMP(6)" defaultValueDate="1970-01-01 00:00:01">
                 <constraints nullable="false"/>
             </column>
             <column name="error_message" type="TEXT">
@@ -29,6 +29,8 @@
         </rollback>
     </changeSet>
 
-    <!-- TODO: drop entity_cache_last_updated from WORKSPACE -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="drop_WORKSPACE_entity_cache_last_updated">
+        <dropColumn tableName="WORKSPACE" columnName="entity_cache_last_updated"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210915_create_entity_cache_table.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210915_create_entity_cache_table.xml
@@ -9,7 +9,7 @@
                              referencedTableName="WORKSPACE" referencedColumnNames="id"
                              foreignKeyName="FK_WEC_WORKSPACE" deleteCascade="true"/>
             </column>
-            <column name="entity_cache_last_updated" type="TIMESTAMP(6)" defaultValueDate="1970-01-01 00:00:01">
+            <column name="entity_cache_last_updated" type="TIMESTAMP(6)" defaultValueDate="1970-01-01 00:00:02">
                 <constraints nullable="false"/>
             </column>
             <column name="error_message" type="TEXT">

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210915_create_entity_cache_table.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210915_create_entity_cache_table.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="create_WORKSPACE_ENTITY_CACHE">
+        <createTable tableName="WORKSPACE_ENTITY_CACHE">
+            <column name="workspace_id" type="BINARY(16)">
+                <constraints primaryKey="true"
+                             nullable="false"
+                             referencedTableName="WORKSPACE" referencedColumnNames="id"
+                             foreignKeyName="FK_WEC_WORKSPACE" deleteCascade="true"/>
+            </column>
+            <column name="entity_cache_last_updated" type="TIMESTAMP(6)" defaultValueDate="1970-01-01 00:00:02">
+                <constraints nullable="false"/>
+            </column>
+            <column name="error_message" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_WORKSPACE_ENTITY_CACHE">
+        <sql>
+            INSERT INTO WORKSPACE_ENTITY_CACHE(workspace_id, entity_cache_last_updated)
+                SELECT id, entity_cache_last_updated
+                FROM WORKSPACE;
+        </sql>
+        <rollback>
+            DELETE FROM WORKSPACE_ENTITY_CACHE;
+        </rollback>
+    </changeSet>
+
+    <!-- TODO: drop entity_cache_last_updated from WORKSPACE -->
+
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -20,6 +20,7 @@ trait DataAccess
   with WorkspaceRequesterPaysComponent
   with EntityTypeStatisticsComponent
   with EntityAttributeStatisticsComponent
+  with EntityCacheComponent
   with LocalEntityExpressionQueries {
 
 
@@ -48,6 +49,7 @@ trait DataAccess
       TableQuery[WorkspaceRequesterPaysTable].delete andThen      // FK to workspace
       TableQuery[EntityTypeStatisticsTable].delete andThen        // FK to workspace
       TableQuery[EntityAttributeStatisticsTable].delete andThen   // FK to workspace
+      TableQuery[EntityCacheTable].delete andThen                 // FK to workspace
       TableQuery[WorkspaceTable].delete andThen
       TableQuery[RawlsBillingProjectTable].delete andThen
       TableQuery[WorkflowAuditStatusTable].delete andThen

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -34,7 +34,7 @@ trait EntityCacheComponent {
       // C. lastModified is before @param cooldownBound, meaning the workspace isn't likely actively being updated
       // D. Ordered by lastModified from oldest to newest. Meaning, return the workspace that was modified the longest ago
 
-      val baseQuery = sql"""SELECT * FROM (
+      val baseQuery = sql"""SELECT id, last_modified, entity_cache_last_updated FROM (
               |  SELECT w.id, w.last_modified, c.entity_cache_last_updated
               |    FROM WORKSPACE w LEFT OUTER JOIN WORKSPACE_ENTITY_CACHE c
               |    on w.id = c.workspace_id

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -39,7 +39,7 @@ trait EntityCacheComponent {
       |      FROM WORKSPACE w LEFT OUTER JOIN WORKSPACE_ENTITY_CACHE c
       |      on w.id = c.workspace_id
       |      where w.last_modified < $maxModifiedTime
-      |    ) outerJoin
+      |    ) workspacesAndCacheTimes
       |    WHERE entity_cache_last_updated IS NULL or ($minCacheTime < entity_cache_last_updated AND entity_cache_last_updated < last_modified)
         |  ORDER BY last_modified asc
         |  LIMIT 1;
@@ -50,9 +50,7 @@ trait EntityCacheComponent {
 
     // insert if not exist
     def updateCacheLastUpdated(workspaceId: UUID, timestamp: Timestamp, errorMessage: Option[String] = None): ReadWriteAction[Int] = {
-      val dbResult = entityCacheQuery.insertOrUpdate(EntityCacheRecord(workspaceId, timestamp, errorMessage))
-      logger.info(s"******* updated cache record for $workspaceId to $timestamp")
-      dbResult
+      entityCacheQuery.insertOrUpdate(EntityCacheRecord(workspaceId, timestamp, errorMessage))
     }
 
     def isEntityCacheCurrent(workspaceId: UUID): ReadAction[Boolean] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -37,7 +37,8 @@ trait EntityCacheComponent {
                                 |FROM WORKSPACE w LEFT OUTER JOIN WORKSPACE_ENTITY_CACHE c
                                 |    on w.id = c.workspace_id
                                 |where (c.entity_cache_last_updated > $minCacheTime or c.entity_cache_last_updated is null)
-                                |and w.last_modified < $maxModifiedTime and c.entity_cache_last_updated < w.last_modified
+                                |  and w.last_modified < $maxModifiedTime
+                                |  and (c.entity_cache_last_updated < w.last_modified or c.entity_cache_last_updated is null)
                                 |order by w.last_modified asc limit 1""".stripMargin.as[(UUID, Timestamp, Option[Timestamp])]
 
       uniqueResult[(UUID, Timestamp, Option[Timestamp])](baseQuery)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -1,0 +1,75 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor
+import slick.jdbc.JdbcProfile
+
+import java.sql.Timestamp
+import java.util.UUID
+
+case class EntityCacheRecord(workspaceId: UUID, entityCacheLastUpdated: Timestamp, errorMessage: Option[String])
+
+trait EntityCacheComponent {
+  this: DriverComponent =>
+
+  import driver.api._
+
+  class EntityCacheTable(tag: Tag) extends Table[EntityCacheRecord](tag, "WORKSPACE_ENTITY_CACHE") {
+    def workspaceId = column[UUID]("workspace_id", O.PrimaryKey)
+    def entityCacheLastUpdated = column[Timestamp]("entity_cache_last_updated",
+      O.SqlType("TIMESTAMP(6)"), O.Default(EntityStatisticsCacheMonitor.MIN_CACHE_TIME))
+    def errorMessage = column[Option[String]]("error_message")
+
+    def * = (workspaceId, entityCacheLastUpdated, errorMessage) <> (EntityCacheRecord.tupled, EntityCacheRecord.unapply)
+  }
+
+  object entityCacheQuery extends TableQuery(new EntityCacheTable(_)) with RawSqlQuery with LazyLogging {
+
+    val driver: JdbcProfile = EntityCacheComponent.this.driver
+
+    def findMostOutdatedEntityCacheAfter(minCacheTime: Timestamp, maxModifiedTime: Timestamp): ReadAction[Option[(UUID, Timestamp, Option[Timestamp])]] = {
+      // Find the workspace that has the entity cache that is the most out of date:
+      // A. Workspace has a cacheLastUpdated date that is not current ("current" means equal to lastModified)
+      // B. cacheLastUpdated is after @param timestamp
+      // C. lastModified is before @param cooldownBound, meaning the workspace isn't likely actively being updated
+      // D. Ordered by lastModified from oldest to newest. Meaning, return the workspace that was modified the longest ago
+
+      val baseQuery = sql"""SELECT * FROM (
+      |    SELECT w.id, w.last_modified, c.entity_cache_last_updated
+      |      FROM WORKSPACE w LEFT OUTER JOIN WORKSPACE_ENTITY_CACHE c
+      |      on w.id = c.workspace_id
+      |      where w.last_modified < $maxModifiedTime
+      |    ) outerJoin
+      |    WHERE entity_cache_last_updated IS NULL or ($minCacheTime < entity_cache_last_updated AND entity_cache_last_updated < last_modified)
+        |  ORDER BY last_modified asc
+        |  LIMIT 1;
+        |""".stripMargin.as[(UUID, Timestamp, Option[Timestamp])]
+
+      uniqueResult[(UUID, Timestamp, Option[Timestamp])](baseQuery)
+    }
+
+    // insert if not exist
+    def updateCacheLastUpdated(workspaceId: UUID, timestamp: Timestamp, errorMessage: Option[String] = None): ReadWriteAction[Int] = {
+      val dbResult = entityCacheQuery.insertOrUpdate(EntityCacheRecord(workspaceId, timestamp, errorMessage))
+      logger.info(s"******* updated cache record for $workspaceId to $timestamp")
+      dbResult
+    }
+
+    def isEntityCacheCurrent(workspaceId: UUID): ReadAction[Boolean] = {
+      val baseQuery = sql"""SELECT EXISTS(
+              SELECT 1
+                FROM WORKSPACE w, WORKSPACE_ENTITY_CACHE c
+                WHERE
+                  w.id = $workspaceId
+                  and w.id = c.workspace_id
+                  and w.last_modified = c.entity_cache_last_updated
+                LIMIT 1);""".as[Int]
+
+      uniqueResult[Int](baseQuery).map { existsResult =>
+        existsResult.contains(1)
+      }
+    }
+
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -35,15 +35,15 @@ trait EntityCacheComponent {
       // D. Ordered by lastModified from oldest to newest. Meaning, return the workspace that was modified the longest ago
 
       val baseQuery = sql"""SELECT * FROM (
-      |    SELECT w.id, w.last_modified, c.entity_cache_last_updated
-      |      FROM WORKSPACE w LEFT OUTER JOIN WORKSPACE_ENTITY_CACHE c
-      |      on w.id = c.workspace_id
-      |      where w.last_modified < $maxModifiedTime
-      |    ) workspacesAndCacheTimes
-      |    WHERE entity_cache_last_updated IS NULL or ($minCacheTime < entity_cache_last_updated AND entity_cache_last_updated < last_modified)
-        |  ORDER BY last_modified asc
-        |  LIMIT 1;
-        |""".stripMargin.as[(UUID, Timestamp, Option[Timestamp])]
+              |  SELECT w.id, w.last_modified, c.entity_cache_last_updated
+              |    FROM WORKSPACE w LEFT OUTER JOIN WORKSPACE_ENTITY_CACHE c
+              |    on w.id = c.workspace_id
+              |    where w.last_modified < $maxModifiedTime) workspacesAndCacheTimes
+              |  WHERE entity_cache_last_updated IS NULL
+              |    or ($minCacheTime < entity_cache_last_updated AND entity_cache_last_updated < last_modified)
+              |  ORDER BY last_modified asc
+              |  LIMIT 1;
+              |""".stripMargin.as[(UUID, Timestamp, Option[Timestamp])]
 
       uniqueResult[(UUID, Timestamp, Option[Timestamp])](baseQuery)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -26,7 +26,6 @@ case class WorkspaceRecord(
                             workflowCollection: Option[String],
                             createdDate: Timestamp,
                             lastModified: Timestamp,
-                            entityCacheLastUpdated: Timestamp,
                             createdBy: String,
                             isLocked: Boolean,
                             recordVersion: Long,
@@ -58,7 +57,6 @@ trait WorkspaceComponent {
     def workflowCollection = column[Option[String]]("workflow_collection", O.Length(255))
     def createdDate = column[Timestamp]("created_date", O.SqlType("TIMESTAMP(6)"), O.Default(defaultTimeStamp))
     def lastModified = column[Timestamp]("last_modified", O.SqlType("TIMESTAMP(6)"), O.Default(defaultTimeStamp))
-    def entityCacheLastUpdated = column[Timestamp]("entity_cache_last_updated", O.SqlType("TIMESTAMP(6)"))
     def createdBy = column[String]("created_by", O.Length(254))
     def isLocked = column[Boolean]("is_locked")
     def recordVersion = column[Long]("record_version")
@@ -70,7 +68,7 @@ trait WorkspaceComponent {
 
     def uniqueNamespaceName = index("IDX_WS_UNIQUE_NAMESPACE_NAME", (namespace, name), unique = true)
 
-    def * = (namespace, name, id, bucketName, workflowCollection, createdDate, lastModified, entityCacheLastUpdated, createdBy, isLocked, recordVersion, workspaceVersion, googleProjectId, googleProjectNumber, currentBillingAccountOnGoogleProject, billingAccountErrorMessage) <> (WorkspaceRecord.tupled, WorkspaceRecord.unapply)
+    def * = (namespace, name, id, bucketName, workflowCollection, createdDate, lastModified, createdBy, isLocked, recordVersion, workspaceVersion, googleProjectId, googleProjectNumber, currentBillingAccountOnGoogleProject, billingAccountErrorMessage) <> (WorkspaceRecord.tupled, WorkspaceRecord.unapply)
   }
 
   /** raw/optimized SQL queries for working with workspace attributes
@@ -466,7 +464,7 @@ trait WorkspaceComponent {
     }
 
     private def marshalNewWorkspace(workspace: Workspace) = {
-      WorkspaceRecord(workspace.namespace, workspace.name, UUID.fromString(workspace.workspaceId), workspace.bucketName, workspace.workflowCollectionName, new Timestamp(workspace.createdDate.getMillis), new Timestamp(workspace.lastModified.getMillis), new Timestamp(workspace.lastModified.getMillis), workspace.createdBy, workspace.isLocked, 0, workspace.workspaceVersion.value, workspace.googleProjectId.value, workspace.googleProjectNumber.map(_.value), workspace.currentBillingAccountOnGoogleProject.map(_.value), workspace.billingAccountErrorMessage)
+      WorkspaceRecord(workspace.namespace, workspace.name, UUID.fromString(workspace.workspaceId), workspace.bucketName, workspace.workflowCollectionName, new Timestamp(workspace.createdDate.getMillis), new Timestamp(workspace.lastModified.getMillis), workspace.createdBy, workspace.isLocked, 0, workspace.workspaceVersion.value, workspace.googleProjectId.value, workspace.googleProjectNumber.map(_.value), workspace.currentBillingAccountOnGoogleProject.map(_.value), workspace.billingAccountErrorMessage)
     }
 
     private def unmarshalWorkspace(workspaceRec: WorkspaceRecord): Workspace = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -41,7 +41,7 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
       rootSpan.putAttribute("workspace", OpenCensusAttributeValue.stringAttributeValue(workspace.toWorkspaceName.toString))
       dataSource.inTransaction { dataAccess =>
         traceDBIOWithParent("isEntityCacheCurrent", rootSpan) { outerSpan =>
-          dataAccess.workspaceQuery.isEntityCacheCurrent(workspaceContext.workspaceIdAsUUID).flatMap { isEntityCacheCurrent =>
+          dataAccess.entityCacheQuery.isEntityCacheCurrent(workspaceContext.workspaceIdAsUUID).flatMap { isEntityCacheCurrent =>
             //If the cache is current, and the user wants to use it, and we have it enabled at the app-level: return the cached metadata
             if(isEntityCacheCurrent && useCache && cacheEnabled) {
               traceDBIOWithParent("retrieve-cached-results", outerSpan) { _ =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -6,6 +6,7 @@ import cats.effect.{ContextShift, IO}
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.trace
 import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue}
+import org.apache.commons.lang3.exception.ExceptionUtils
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor._
@@ -106,7 +107,8 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
           //We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
           // This is a "magic" value that allows the monitor to skip this problematic workspace
           // so it does not get caught in a loop. These workspaces will require manual intervention.
-          dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME)
+          val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
+          dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
         }
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -83,6 +83,9 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
 
   def updateStatisticsCache(workspaceId: UUID, timestamp: Timestamp): Future[Unit] = {
     val updateFuture = dataSource.inTransaction { dataAccess =>
+      // TODO: beware contention on the approach of delete-all and batch-insert all below
+      // if we see contention we could move to encoding the entire metadata object as json
+      // and storing in a single column on WORKSPACE_ENTITY_CACHE
       for {
         //update entity statistics
         entityTypesWithCounts <- dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -1,13 +1,11 @@
 package org.broadinstitute.dsde.rawls.monitor
 
 import akka.actor._
-import akka.pattern._
-import cats.effect.{ContextShift, IO}
+import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.trace
 import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue}
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor._
 import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.traceDBIOWithParent
@@ -15,8 +13,8 @@ import slick.dbio.DBIO
 
 import java.sql.Timestamp
 import java.util.{Calendar, UUID}
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 
 object EntityStatisticsCacheMonitor {
@@ -34,7 +32,7 @@ object EntityStatisticsCacheMonitor {
 }
 
 class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val timeoutPerWorkspace: Duration, val standardPollInterval: FiniteDuration, val workspaceCooldown: FiniteDuration)(implicit val executionContext: ExecutionContext) extends Actor with EntityStatisticsCacheMonitor with LazyLogging {
-  import context._
+  import context.setReceiveTimeout
 
   setReceiveTimeout(timeoutPerWorkspace)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.traceDBIOWithParen
 import slick.dbio.DBIO
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.{Calendar, UUID}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -26,6 +27,10 @@ object EntityStatisticsCacheMonitor {
   sealed trait EntityStatisticsCacheMessage
   case object Sweep extends EntityStatisticsCacheMessage
   case object ScheduleDelayedSweep extends EntityStatisticsCacheMessage
+
+  //Note: Ignored workspaces have a cacheLastUpdated timestamp of 1000ms after epoch
+  val MIN_CACHE_TIME = new Timestamp(1000)
+
 }
 
 class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val timeoutPerWorkspace: Duration, val standardPollInterval: FiniteDuration, val workspaceCooldown: FiniteDuration)(implicit val executionContext: ExecutionContext) extends Actor with EntityStatisticsCacheMonitor with LazyLogging {
@@ -57,21 +62,20 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
       dataSource.inTransaction { dataAccess =>
         // calculate now - workspaceCooldown as the upper bound for workspace last_modified
         val maxModifiedTime = nowMinus(workspaceCooldown)
-        //Note: Ignored workspaces have a cacheLastUpdated timestamp of 1000ms after epoch
-        val minCacheTime = new Timestamp(1000)
 
-        dataAccess.workspaceQuery.findMostOutdatedEntityCacheAfter(minCacheTime, maxModifiedTime).flatMap {
-          case Some((workspaceId, lastModified)) =>
+        dataAccess.entityCacheQuery.findMostOutdatedEntityCacheAfter(MIN_CACHE_TIME, maxModifiedTime).flatMap {
+          case Some((workspaceId, lastModified, cacheLastUpdated)) =>
             rootSpan.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId.toString))
             traceDBIOWithParent("updateStatisticsCache", rootSpan) { _ =>
               DBIO.from(updateStatisticsCache(workspaceId, lastModified).map { _ =>
-                logger.info(s"Updated entity cache for workspace $workspaceId. Cache was ${System.currentTimeMillis() - lastModified.getTime}ms out of date.")
+                val outDated = cacheLastUpdated.getOrElse(Timestamp.from(Instant.now())).getTime - lastModified.getTime
+                logger.info(s"Updated entity cache for workspace $workspaceId. Cache was ${outDated}ms out of date.")
                 Sweep
               })
             }
           case None =>
             traceDBIOWithParent("nothing-to-update", rootSpan) { _ =>
-              logger.info(s"All workspace entity caches are up to date. Sleeping for ${standardPollInterval}")
+              logger.info(s"All workspace entity caches are up to date. Sleeping for $standardPollInterval")
               DBIO.successful(ScheduleDelayedSweep)
             }
         }
@@ -91,19 +95,19 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
         _ <- dataAccess.entityAttributeStatisticsQuery.deleteAllForWorkspace(workspaceId)
         _ <- dataAccess.entityAttributeStatisticsQuery.batchInsert(workspaceId, entityTypesWithAttrNames)
         //update cache update date
-        _ <- dataAccess.workspaceQuery.updateCacheLastUpdated(workspaceId, timestamp)
+        _ <- dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, timestamp)
       } yield ()
     }
 
     updateFuture.recover {
       case t: Throwable =>
-        logger.error(s"Error updating statistics cache for workspaceId ${workspaceId}", t)
+        logger.error(s"Error updating statistics cache for workspaceId $workspaceId: ${t.getMessage}", t)
         dataSource.inTransaction { dataAccess =>
-          logger.error(s"Workspace ${workspaceId} will be ignored by the entity cache monitor.")
+          logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
           //We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
           // This is a "magic" value that allows the monitor to skip this problematic workspace
           // so it does not get caught in a loop. These workspaces will require manual intervention.
-          dataAccess.workspaceQuery.updateCacheLastUpdated(workspaceId, new Timestamp(1000))
+          dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME)
         }
     }
   }

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -30,15 +30,21 @@
 
     <!--
     <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-    </logger>
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+    </logger>
     -->
     <!--
     <logger name="slick.jdbc.StatementInvoker.result" level="DEBUG" additivity="false">
-        <appender-ref ref="file"/>
-        <appender-ref ref="console"/>
-    </logger>
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+    </logger>
+    -->
+    <!--
+    <logger name="slick.jdbc.StatementInvoker.result" level="DEBUG" additivity="false">
+        <appender-ref ref="file"/>
+        <appender-ref ref="console"/>
+    </logger>
     -->
     <!-- netty (mock server) produces a huge amount of DEBUG output during tests without this line -->
     <logger name="io.netty" level="WARN"/>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -168,7 +168,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
   }
 
   it should "insert entity reference attribute" in withEmptyTestDatabase {
-    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname1", workspaceId, "bucket", Some("workflow-collection"), defaultTimeStamp, defaultTimeStamp, defaultTimeStamp, "me", false, 0, WorkspaceVersions.V1.value, "gp", None, None, None))
+    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname1", workspaceId, "bucket", Some("workflow-collection"), defaultTimeStamp, defaultTimeStamp, "me", false, 0, WorkspaceVersions.V1.value, "gp", None, None, None))
     val entityId = runAndWait((entityQuery returning entityQuery.map(_.id)) += EntityRecord(0, "name", "type", workspaceId, 0, deleted = false, None))
     val testAttribute = AttributeEntityReference("type", "name")
     runAndWait(insertWorkspaceAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute))
@@ -177,7 +177,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
   }
 
   it should "insert entity reference attribute list" in withEmptyTestDatabase {
-    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname2", workspaceId, "bucket", Some("workflow-collection"), defaultTimeStamp, defaultTimeStamp, defaultTimeStamp, "me", false, 0, WorkspaceVersions.V1.value, "gp", None, None, None))
+    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname2", workspaceId, "bucket", Some("workflow-collection"), defaultTimeStamp, defaultTimeStamp, "me", false, 0, WorkspaceVersions.V1.value, "gp", None, None, None))
     val entityId1 = runAndWait((entityQuery returning entityQuery.map(_.id)) += EntityRecord(0, "name1", "type", workspaceId, 0, deleted = false, None))
     val entityId2 = runAndWait((entityQuery returning entityQuery.map(_.id)) += EntityRecord(0, "name2", "type", workspaceId, 0, deleted = false, None))
     val entityId3 = runAndWait((entityQuery returning entityQuery.map(_.id)) += EntityRecord(0, "name3", "type", workspaceId, 0, deleted = false, None))
@@ -195,7 +195,7 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
   }
 
   it should "throw exception inserting ref to nonexistent entity" in withEmptyTestDatabase {
-    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname3", workspaceId, "bucket", Some("workflow-collection"), defaultTimeStamp, defaultTimeStamp, defaultTimeStamp, "me", false, 0, WorkspaceVersions.V1.value, "gp", None, None, None))
+    runAndWait(workspaceQuery += WorkspaceRecord("testns", "testname3", workspaceId, "bucket", Some("workflow-collection"), defaultTimeStamp, defaultTimeStamp, "me", false, 0, WorkspaceVersions.V1.value, "gp", None, None, None))
     val testAttribute = AttributeEntityReference("type", "name")
     intercept[RawlsException] {
       runAndWait(insertWorkspaceAttributeRecords(workspaceId, AttributeName.withDefaultNS("test"), testAttribute))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -302,13 +302,13 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with TestDri
       // save a cache entry that includes a failure
       runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, EntityStatisticsCacheMonitor.MIN_CACHE_TIME, Some(expectedErrorMsg)))
 
-      val actualMessage = runAndWait(workspaceFilter.map(_.errorMessage).result)
+      val actualMessage = runAndWait(uniqueResult(workspaceFilter.map(_.errorMessage)))
       actualMessage should contain(expectedErrorMsg)
 
       // save a cache entry that is successful
       runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, Timestamp.from(Instant.now())))
 
-      val secondMessage = runAndWait(workspaceFilter.map(_.errorMessage).result)
+      val secondMessage = runAndWait(uniqueResult(workspaceFilter.map(_.errorMessage)))
       secondMessage shouldBe empty
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -302,13 +302,13 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with TestDri
       // save a cache entry that includes a failure
       runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, EntityStatisticsCacheMonitor.MIN_CACHE_TIME, Some(expectedErrorMsg)))
 
-      val actualMessage = runAndWait(uniqueResult(workspaceFilter.map(_.errorMessage)))
+      val actualMessage = runAndWait(uniqueResult[Option[String]](workspaceFilter.map(_.errorMessage))).flatten
       actualMessage should contain(expectedErrorMsg)
 
       // save a cache entry that is successful
       runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, Timestamp.from(Instant.now())))
 
-      val secondMessage = runAndWait(uniqueResult(workspaceFilter.map(_.errorMessage)))
+      val secondMessage = runAndWait(uniqueResult[Option[String]](workspaceFilter.map(_.errorMessage))).flatten
       secondMessage shouldBe empty
     }
 


### PR DESCRIPTION
AS-929: goal is to move all entity-cache writes away from the `WORKSPACE` table. We should now never need to lock any rows on `WORKSPACE` due to the entity cache.

In this PR:
* create a new `WORKSPACE_ENTITY_CACHE` table with workspace_id, entity_cache_last_updated, error_message columns
* copy all values from `WORKSPACE.entity_cache_last_updated` to `WORKSPACE_ENTITY_CACHE.entity_cache_last_updated`
* drop the `entity_cache_last_updated` column from `WORKSPACE`
* use the new `WORKSPACE_ENTITY_CACHE` table for all cache-timestamp reads and writes
* move SQL queries related to cache-timestamps out of `WorkspaceComponent` and into `EntityCacheComponent`. Because they're joins now, hand-roll them instead of using Slick
* in the case of a cache-update failure:
    * log the error message on the same line as the indication of failure, to make it easy to find in Kibana/Cloud Logging
    * write the error message and stack trace to the `WORKSPACE_ENTITY_CACHE` table for easy debugging after the fact
