### PR TITLE
field selection for entityQuery [AS-955]

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1625,6 +1625,16 @@ paths:
           description: Filter terms
           schema:
             type: string
+        - name: fields
+          in: query
+          description: |
+            When specified, include only these attributes in the response payload and exclude other attributes. Accepts a comma-delimited list of values. If omitted, will return the full response payload.
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
         - $ref: '#/components/parameters/dataReferenceQueryParam'
         - $ref: '#/components/parameters/billingProjectQueryParam'
       responses:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -229,12 +229,6 @@ trait EntityComponent {
           left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted
           left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id"""
 
-      // NB: the "null" as the last column here is important! It allows this query to be translated into
-      // EntityAndAttributesResult objects; the null represents the lack of any attributes for this entity
-      val baseEntitySql =
-        s"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date, null
-          from ENTITY e"""
-
       // Active actions: only return entities and attributes with their deleted flag set to false
 
       def activeActionForType(workspaceContext: Workspace, entityType: String): ReadAction[Seq[EntityAndAttributesResult]] = {
@@ -264,6 +258,9 @@ trait EntityComponent {
         * @return
         */
       private def paginationSubquery(workspaceId: UUID, entityType: String, sortFieldName: String) = {
+        /* TODO: can we eliminate the SELECT ... e.all_attribute_values by being smarter about our where clauses?
+            while not returned to the end user, it still causes mysql extra work
+         */
 
         val (sortColumns, sortJoin) = sortFieldName match {
           case "name" => (
@@ -282,16 +279,24 @@ trait EntityComponent {
       }
 
       def activeActionForPagination(workspaceContext: Workspace, entityType: String, entityQuery: model.EntityQuery, parentSpan: Span = null): ReadWriteAction[(Int, Int, Seq[EntityAndAttributesResult])] = {
-        // TODO: when sorting by name (the default) AND no fields requested beyond name/entityType,
-        // don't bother with the extra join to ENTITY_ATTRIBUTE and its additional join to ENTITY
-        // TODO: when sorting by name, do we need the extra join to pagination?
         /*
-        The query here starts with baseEntityAndAttributeSql which is the typical select
-        to pull entities will all attributes and references. A join is added on a sub select from ENTITY
-        (and ENTITY_ATTRIBUTE if there is a sort field other than name) which constrains to only entities of the
-        right type, workspace, and matches the filters then sorts and slices out the appropriate page of entities.
+          Lots of conditionals in here, to achieve the optimal SQL query for any given request. Pseudocode:
+
+          When sorting by name, and requesting no attributes:
+            select from ENTITY e order by e.name, with optional filter on e.all_attribute_values, limit, offset.
+
+          All other requests:
+            select from ENTITY e
+              left outer join ENTITY_ATTRIBUTE to get entity values, restricting to just those requested by the user
+              left outer join ENTITY to populate any attribute references
+              join (subquery of select attribute-being-sorted-on from ENTITY
+                      left join ENTITY_ATTRIBUTE
+                      left join ENTITY
+                      optional filter on e.all_attribute_values
+                      sort by attribute, limit, offset) to get the proper pagination
          */
 
+        // generate the clause to filter based on user search terms
         def filterSql(prefix: String, alias: String) = {
           val filtersOption = entityQuery.filterTerms.map { _.split(" ").toSeq.map { term =>
             sql"concat(#$alias.name, ' ', #$alias.all_attribute_values) like ${'%' + term.toLowerCase + '%'}"
@@ -304,6 +309,7 @@ trait EntityComponent {
           }
         }
 
+        // generate the clauses to limit the attributes returned to the user
         def attrSelectionSql(prefix: String) = {
           val fieldsOption = entityQuery.fields.fields.map { fieldList =>
             val attributeNameList: Set[AttributeName] = fieldList.map(AttributeName.fromDelimitedName)
@@ -316,11 +322,13 @@ trait EntityComponent {
           fieldsOption.getOrElse(sql"")
         }
 
+        // sorting clauses
         def order(alias: String) = entityQuery.sortField match {
           case "name" => sql" order by #$alias.name #${SortDirections.toSql(entityQuery.sortDirection)} "
           case _ => sql" order by #$alias.sort_list_length #${SortDirections.toSql(entityQuery.sortDirection)}, #$alias.sort_field_string #${SortDirections.toSql(entityQuery.sortDirection)}, #$alias.sort_field_number #${SortDirections.toSql(entityQuery.sortDirection)}, #$alias.sort_field_boolean #${SortDirections.toSql(entityQuery.sortDirection)}, #$alias.sort_field_ref #${SortDirections.toSql(entityQuery.sortDirection)}, #$alias.name #${SortDirections.toSql(entityQuery.sortDirection)} "
         }
 
+        // additional joins-to-subquery to provide proper pagination
         val paginationJoin = concatSqlActions(
           sql""" join (select * from (""",
           paginationSubquery(workspaceContext.workspaceIdAsUUID, entityType, entityQuery.sortField),
@@ -330,6 +338,7 @@ trait EntityComponent {
           sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page-1) * entityQuery.pageSize} ) p on p.id = e.id "
         )
 
+        // standalone query to calculate the count of results that match our filter
         def filteredCountQuery: ReadAction[Vector[Int]] = {
           val filteredQuery =
             sql"""select count(1) from ENTITY e
@@ -339,30 +348,38 @@ trait EntityComponent {
           concatSqlActions(filteredQuery, filterSql("and", "e")).as[Int]
         }
 
+        // the full query to generate the page of results, as requested by the user
         def pageQuery = {
-          /* when sorting by name (the default) AND no fields requested beyond name/entityType,
-              don't bother with the extra join to ENTITY_ATTRIBUTE and its additional join to ENTITY
-           */
-          val attrsRequested: Boolean = entityQuery.fields.fields.forall { fieldSel =>
+          // did the user request any attributes other than "name" and "entityType"?
+          val isRequestingAttrs: Boolean = entityQuery.fields.fields.forall { fieldSel =>
             (fieldSel diff Set("name", "entityType")).nonEmpty
           }
 
-          if (entityQuery.sortField == "name" && !attrsRequested) {
-            // skip the join
-            // TODO: remove the copy/paste here and centralize
-            concatSqlActions(sql"#$baseEntitySql",
-              sql" where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} ",
+          // different cases for which query to execute:
+          if (entityQuery.sortField == "name" && !isRequestingAttrs) {
+            // simplest; the user is sorting by ENTITY.name and doesn't want any attributes; we only need to
+            // query the ENTITY table
+            // NB: the "null" as the last column in the select is important! It allows this query to be translated into
+            // EntityAndAttributesResult objects; the null represents the lack of any attributes for this entity
+            concatSqlActions(
+              sql"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date, null
+                             from ENTITY e
+                             where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
               filterSql("and", "e"),
               order("e"),
               sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page-1) * entityQuery.pageSize}").as[EntityAndAttributesResult]
           } else {
-            // fully paginated, sorted, filtered query
+            // user is sorting by an attribute value, so we need the largest number of joins
+            // this query is very similar to baseEntityAndAttributeSql
+            /* TODO: include "where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId"
+                in the top-level select, to reduce what MySQL needs to look at
+             */
             concatSqlActions(
               sql"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
-                   |          a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
-                   |          e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
-                   |          from ENTITY e
-                   |          left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted """.stripMargin,
+                             a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
+                             e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
+                             from ENTITY e
+                             left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted """,
               attrSelectionSql(" and "),
               sql""" left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id """,
               paginationJoin, order("p")).as[EntityAndAttributesResult]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -310,7 +310,7 @@ trait EntityComponent {
             val attrClauses = attributeNameList.map(attrName =>
               sql"(a.namespace = ${attrName.namespace} AND a.name = ${attrName.name})"
             )
-            concatSqlActions(sql"#$prefix ", reduceSqlActionsWithDelim(attrClauses.toSeq, sql" or "))
+            concatSqlActions(sql"#$prefix (", reduceSqlActionsWithDelim(attrClauses.toSeq, sql" or "), sql") ")
           }
 
           fieldsOption.getOrElse(sql"")
@@ -363,8 +363,8 @@ trait EntityComponent {
                    |          e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
                    |          from ENTITY e
                    |          left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted """.stripMargin,
-              attrSelectionSql(" and ( "),
-              sql""") left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id """,
+              attrSelectionSql(" and "),
+              sql""" left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id """,
               paginationJoin, order("p")).as[EntityAndAttributesResult]
           }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -2163,7 +2163,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   def calculateNumPages(count: Int, pageSize: Int) = Math.ceil(count.toDouble / pageSize).toInt
 
-  it should "return 400 bad request on entity query when page is not a number" in withPaginationTestDataApiServices { services =>
+  "entityQuery API" should "return 400 bad request on entity query when page is not a number" in withPaginationTestDataApiServices { services =>
     Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=asdf") ~>
       sealRoute(services.entityRoutes) ~>
       check {
@@ -2539,7 +2539,208 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "pass true by default to useCache argument" in withMockedEntityService { services =>
+  // TODO: *********** START implement entityQuery field-selection tests
+
+  // creates 30 entities, in groups of 10; each group has different attributes, with some overlap.
+  class FieldSelectionTestData extends TestData {
+    val userOwner = RawlsUser(UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345")))
+    val wsName = WorkspaceName("myNamespace", "myWorkspace")
+    val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
+    val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set())
+    val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set())
+
+    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+
+    val colorGroup1 = List("allgroups", "group1and2", "red", "yellow", "blue", "brown", "orange")
+    val colorGroup2 = List("allgroups", "group1and2", "group2and3", "green", "violet", "black", "carnation", "white")
+    val colorGroup3 = List("allgroups", "group2and3", "dandelion", "cerulean", "apricot", "scarlet", "gray")
+
+    val numEntities = 100
+    val entityType = "fieldselect"
+
+    val entities = List(colorGroup1, colorGroup2, colorGroup3).zipWithIndex.flatMap {
+      case (colorList, groupIdx) =>
+        (0 to 9) map { idx =>
+          val attributes = colorList.map(color => AttributeName.withDefaultNS(color) -> AttributeString(s"$color value")).toMap
+          // default sorting for entityQuery is by name, so ensure the names we generate here are in
+          // ascending order of insertion
+          Entity(s"$groupIdx-$idx", entityType, attributes)
+        }
+    }
+
+    override def save(): ReadWriteAction[Unit] = {
+      import driver.api._
+
+      DBIO.seq(
+        workspaceQuery.createOrUpdate(workspace),
+        entityQuery.save(workspace, entities)
+      )
+    }
+  }
+
+  val fieldSelectionTestData = new FieldSelectionTestData()
+
+  def withFieldSelectionTestDataApiServices[T](testCode: TestApiService => T): T = {
+    withCustomTestDatabase(fieldSelectionTestData) { dataSource: SlickDataSource =>
+      withApiServices(dataSource)(testCode)
+    }
+  }
+
+  val fieldSelectionApiPath = s"${fieldSelectionTestData.workspace.path}/entityQuery/${fieldSelectionTestData.entityType}"
+
+  def assertFieldSelection(actualResponse: EntityQueryResponse, expected: List[String]) = {
+    // calculate actual field list
+    val actual = actualResponse.results.flatMap(e => e.attributes.keySet.map(a => AttributeName.toDelimitedName(a)))
+    actual.toSet should contain theSameElementsAs expected.toSet
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (all entities)" in withFieldSelectionTestDataApiServices { services =>
+    // query for all entities
+    Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        val expected = fieldSelectionTestData.colorGroup1 ++ fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
+        assertFieldSelection(resp, expected)
+      }
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (first page)" in withFieldSelectionTestDataApiServices { services =>
+    // query for first page of results
+    Get(s"$fieldSelectionApiPath?pageSize=10") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        val expected = fieldSelectionTestData.colorGroup1
+        assertFieldSelection(resp, expected)
+      }
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (second page)" in withFieldSelectionTestDataApiServices { services =>
+    // query for second page of results
+    Get(s"$fieldSelectionApiPath?pageSize=10&page=2") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        val expected = fieldSelectionTestData.colorGroup2
+        assertFieldSelection(resp, expected)
+      }
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (second page extending into third page)" in withFieldSelectionTestDataApiServices { services =>
+    // query for the second page of results, with a page size that extends us into the third
+    // group of entities from fieldSelectionTestData
+    Get(s"$fieldSelectionApiPath?pageSize=15&page=2") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        val expected = fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
+        assertFieldSelection(resp, expected)
+      }
+  }
+
+  List(List("name"), List("entityType"), List("name", "entityType")) foreach { fieldsUnderTest =>
+    it should s"return [${fieldsUnderTest.mkString(", ")}] if requested in fields" ignore withFieldSelectionTestDataApiServices { services =>
+      Get(s"$fieldSelectionApiPath?pageSize=25&page=1&fields=${fieldsUnderTest.mkString(",")}") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          assertFieldSelection(resp, fieldsUnderTest)
+        }
+    }
+  }
+
+  /*
+    val colorGroup1 = List("allgroups", "group1and2", "red", "yellow", "blue", "brown", "orange")
+    val colorGroup2 = List("allgroups", "group1and2", "group2and3", "green", "violet", "black", "carnation", "white")
+    val colorGroup3 = List("allgroups", "group2and3", "dandelion", "cerulean", "apricot", "scarlet", "gray")
+   */
+  case class FieldsTestCase(pageSize: Int, page: Int, fieldsUnderTest: List[String])
+  // see FieldSelectionTestData for expected attribute names
+  val testCases = List(
+    // test cases for the first group
+    FieldsTestCase(10, 1, fieldSelectionTestData.colorGroup1),
+    FieldsTestCase(10, 1, List("allgroups", "group1and2", "red")),
+    FieldsTestCase(10, 1, List("red", "yellow")),
+    FieldsTestCase(10, 1, List("orange")),
+    // test cases for the second group
+    FieldsTestCase(10, 2, fieldSelectionTestData.colorGroup2),
+    FieldsTestCase(10, 2, List("allgroups", "group1and2", "group2and3", "green")),
+    FieldsTestCase(10, 2, List("black", "carnation")),
+    FieldsTestCase(10, 2, List("violet")),
+    // test cases for the third group
+    FieldsTestCase(10, 3, fieldSelectionTestData.colorGroup3),
+    FieldsTestCase(10, 3, List("allgroups", "group2and3", "dandelion")),
+    FieldsTestCase(10, 3, List("cerulean", "apricot")),
+    FieldsTestCase(10, 3, List("gray")),
+    // test cases for all three groups combined
+    FieldsTestCase(25, 1, fieldSelectionTestData.colorGroup1 ++ fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3),
+    FieldsTestCase(25, 1, List("allgroups", "group1and2", "group2and3", "red", "green", "dandelion")),
+    FieldsTestCase(25, 1, List("yellow", "blue", "violet", "black", "cerulean", "apricot")),
+    FieldsTestCase(25, 1, List("yellow", "blue")),
+    FieldsTestCase(25, 1, List("violet", "black")),
+    FieldsTestCase(25, 1, List("cerulean", "apricot")),
+    FieldsTestCase(25, 1, List("orange", "scarlet")),
+  )
+
+  testCases foreach { testCase =>
+    val fieldsUnderTest = testCase.fieldsUnderTest
+    it should s"return only the requested fields (pageSize ${testCase.pageSize}, page ${testCase.page}, fields ${testCase.fieldsUnderTest})" in withFieldSelectionTestDataApiServices { services =>
+      Get(s"$fieldSelectionApiPath?pageSize=${testCase.pageSize}&page=${testCase.page}&fields=${fieldsUnderTest.mkString(",")}") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          assertFieldSelection(resp, fieldsUnderTest)
+        }
+    }
+  }
+
+  it should "return no attributes if requested field exists, but not in this page of results" in withFieldSelectionTestDataApiServices { services =>
+    // get the first page of results, but request a field from the second page
+    Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=violet") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        assertFieldSelection(resp, List())
+      }
+  }
+
+  it should "return no attributes if unrecognized field names in parameter" in withFieldSelectionTestDataApiServices { services =>
+    // request a totally nonexistent field
+    Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=nonexistent") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        assertFieldSelection(resp, List())
+      }
+  }
+
+  it should "return requested fields in conjunction with sort and filter" in withFieldSelectionTestDataApiServices { services =>
+    // request all 30 results, but use a filter term that should only return the third page.
+    // request fields from all pages, but expect only the third page's fields back.
+    Get(s"$fieldSelectionApiPath?pageSize=30&page=1&filterTerms=gray&sortField=red&sortDirection=desc&fields=yellow,green,apricot") ~>
+      sealRoute(services.entityRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[EntityQueryResponse]
+        val expected = List("apricot")
+        assertFieldSelection(resp, expected)
+      }
+  }
+
+
+  // TODO: *********** END implement entityQuery field-selection tests
+
+
+  "Entity type metadata API" should "pass true by default to useCache argument" in withMockedEntityService { services =>
     Get(s"${constantData.workspace.path}/entities") ~>
       sealRoute(services.entityRoutes) ~>
       check {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -2539,7 +2539,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  // TODO: *********** START implement entityQuery field-selection tests
+  // *********** START entityQuery field-selection tests
 
   // creates 30 entities, in groups of 10; each group has different attributes, with some overlap.
   class FieldSelectionTestData extends TestData {
@@ -2750,10 +2750,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertFieldSelection(resp, expected, fieldSelectionTestData.entities.size)
       }
   }
-
-
-  // TODO: *********** END implement entityQuery field-selection tests
-
+  // *********** END entityQuery field-selection tests
 
   "Entity type metadata API" should "pass true by default to useCache argument" in withMockedEntityService { services =>
     Get(s"${constantData.workspace.path}/entities") ~>

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -248,7 +248,10 @@ object SortDirections {
 
   def toSql(direction: SortDirection) = toString(direction)
 }
-case class EntityQuery(page: Int, pageSize: Int, sortField: String, sortDirection: SortDirections.SortDirection, filterTerms: Option[String])
+case class EntityQuery(page: Int, pageSize: Int,
+                       sortField: String, sortDirection: SortDirections.SortDirection,
+                       filterTerms: Option[String],
+                       fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs())
 
 case class EntityQueryResultMetadata(unfilteredCount: Int, filteredCount: Int, filteredPageCount: Int)
 
@@ -799,11 +802,13 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceRequestFormat = jsonFormat7(WorkspaceRequest)
 
+  implicit val workspaceFieldSpecsFormat = jsonFormat1(WorkspaceFieldSpecs.apply)
+
   implicit val EntityNameFormat = jsonFormat1(EntityName)
 
   implicit val EntityTypeMetadataFormat = jsonFormat3(EntityTypeMetadata)
 
-  implicit val EntityQueryFormat = jsonFormat5(EntityQuery)
+  implicit val EntityQueryFormat = jsonFormat6(EntityQuery)
 
   implicit val EntityQueryResultMetadataFormat = jsonFormat3(EntityQueryResultMetadata)
 


### PR DESCRIPTION
adds a `?fields=` query parameter to the entityQuery API, so an end user can control which attributes are returned by the query.

If the user requests no fields, via `?fields=`, we skip all the extra SQL joins and make a more efficient query just to the `ENTITY` table. The initial use case for this is for the Terra UI to streamline its select-all API query.

The `entityType`, `name`, and `attributes` keys are always returned in the response payload. If the entities have no matching attributes, the response will have `attributes: {}`.

One potential improvement is to exclude `entityType` unless the user requests it. This would cause a lot of code change - I would like to save that for a future follow-on PR.

I've also identified a few places where we can improve the SQL statements underlying entityQuery. I'd also like to save those for future follow-on PRs, and am looking forward to tackling those.

_**REVIEWER:**_ ignore whitespace! Especially important for `EntityApiService`.
