### PR TITLE
[CA-1460] Delete Errored V1 Billing Projects

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -20,7 +20,7 @@ import spray.json.JsObject
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   val errorReportSource = ErrorReportSource("google")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -20,7 +20,7 @@ import spray.json.JsObject
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   val errorReportSource = ErrorReportSource("google")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -886,17 +886,6 @@ class HttpGoogleServicesDAO(
   }
 
   override def getGoogleProject(googleProject: GoogleProjectId): Future[Project] = {
-    // Sadly when500orGoogleError retries on 404s which is not always the behaviour we want. 404s
-    // mean different things in different contexts. Sometimes they mean the resource does not
-    // exist/you can't access it; sometimes it means it does not exist *yet* and sometimes something
-    // else. As such, it should have been handled explicitly depending on the context and not rolled
-    // into a default retrying handler. This ship has sailed - it's used everywhere and changing it
-    // might cause a bunch of failures.
-    def when500orNon404GoogleError(throwable: Throwable) = throwable match {
-      case e: HttpResponseException if e.getStatusCode == 404 => false
-      case t => when500orGoogleError(t)
-    }
-
     implicit val service = GoogleInstrumentedService.Billing
     val cloudResManager = getCloudResourceManagerWithBillingServiceAccountCredential
     retryExponentially(when500orNon404GoogleError)(() =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -886,13 +886,22 @@ class HttpGoogleServicesDAO(
   }
 
   override def getGoogleProject(googleProject: GoogleProjectId): Future[Project] = {
+    // Sadly when500orGoogleError retries on 404s which is not always the behaviour we want. 404s
+    // mean different things in different contexts. Sometimes they mean the resource does not
+    // exist/you can't access it; sometimes it means it does not exist *yet* and sometimes something
+    // else. As such, it should have been handled explicitly depending on the context and not rolled
+    // into a default retrying handler. This ship has sailed - it's used everywhere and changing it
+    // might cause a bunch of failures.
+    def when500orNon404GoogleError(throwable: Throwable) = throwable match {
+      case e: HttpResponseException if e.getStatusCode == 404 => false
+      case t => when500orGoogleError(t)
+    }
+
     implicit val service = GoogleInstrumentedService.Billing
-
     val cloudResManager = getCloudResourceManagerWithBillingServiceAccountCredential
-
-    retryWhen500orGoogleError(() => {
-      executeGoogleRequest(cloudResManager.projects().get(googleProject.value))
-    })
+    retryExponentially(when500orNon404GoogleError)(() =>
+      Future(blocking(executeGoogleRequest(cloudResManager.projects().get(googleProject.value))))
+    )
   }
 
   def getDMConfigYamlString(googleProject: GoogleProjectId, dmTemplatePath: String, properties: Map[String, JsValue]): String = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -25,7 +25,7 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryTableName, GoogleProject}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 /**
  * Created by dvoet on 10/27/15.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.typesafe.config.{Config, ConfigFactory}
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
@@ -25,7 +26,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, Future}
 
 class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with MockitoSugar with BeforeAndAfterAll with Matchers with ScalaFutures {
   import driver.api._
@@ -207,6 +208,7 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       when(mockGcsDAO.getUserInfoUsingJson(petSAJson)).thenReturn(Future.successful(userInfo))
       when(mockGcsDAO.deleteV1Project(project.googleProjectId)).thenReturn(Future.successful())
+      when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(Future.successful(new Project()))
 
       val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)
       val actual = userService.deleteBillingProject(defaultBillingProjectName).futureValue
@@ -215,6 +217,39 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)
       verify(mockGcsDAO).deleteV1Project(project.googleProjectId)
+
+      runAndWait(rawlsBillingProjectQuery.load(defaultBillingProjectName)) shouldBe empty
+      actual shouldEqual RequestComplete(StatusCodes.NoContent)
+    }
+  }
+
+  it should "Successfully to delete a billing project when the google project does not exist" in {
+    withEmptyTestDatabase { dataSource: SlickDataSource =>
+      val project = defaultBillingProject
+      val userIdInfo = UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId"))
+      val petSAJson = "petJson"
+      runAndWait(rawlsBillingProjectQuery.create(project))
+
+      val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
+      when(mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(userIdInfo)))
+      when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))))
+      when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful())
+      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)).thenReturn(Future.successful())
+
+      val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(Future.failed(
+        new HttpResponseException.Builder(404, "project not found", new HttpHeaders())
+          .build()
+      ))
+
+      val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)
+      val actual = userService.deleteBillingProject(defaultBillingProjectName).futureValue
+
+      verify(mockSamDAO, never()).deleteUserPetServiceAccount(project.googleProjectId, userInfo)
+      verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+      verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)
+      verify(mockGcsDAO, never()).deleteV1Project(project.googleProjectId)
 
       runAndWait(rawlsBillingProjectQuery.load(defaultBillingProjectName)) shouldBe empty
       actual shouldEqual RequestComplete(StatusCodes.NoContent)
@@ -289,6 +324,7 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       when(mockGcsDAO.isAdmin(any[String])).thenReturn(Future.successful(true))
       when(mockGcsDAO.getUserInfoUsingJson(petSAJson)).thenReturn(Future.successful(ownerUserInfo))
+      when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(Future.successful(new Project()))
       when(mockGcsDAO.deleteV1Project(project.googleProjectId)).thenReturn(Future.successful())
 
       val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -223,7 +223,7 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
     }
   }
 
-  it should "Successfully to delete a billing project when the google project does not exist" in {
+  it should "Successfully to delete a billing project when the google project does not exist on GCP" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val project = defaultBillingProject
       val userIdInfo = UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId"))

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilities.scala
@@ -24,8 +24,7 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
 
   protected def when500orGoogleError(throwable: Throwable): Boolean = {
     throwable match {
-      case t: HttpResponseException if t.getStatusCode/100 == 4 => t.getStatusCode != 404
-      case t: HttpResponseException => t.getStatusCode/100 == 5
+      case t: HttpResponseException => t.getStatusCode/100 == 5 || t.getStatusCode/100 == 4
       case ioe: IOException => true
       case _ => false
     }

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilities.scala
@@ -24,7 +24,8 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
 
   protected def when500orGoogleError(throwable: Throwable): Boolean = {
     throwable match {
-      case t: HttpResponseException => t.getStatusCode/100 == 5 || t.getStatusCode/100 == 4
+      case t: HttpResponseException if t.getStatusCode/100 == 4 => t.getStatusCode != 404
+      case t: HttpResponseException => t.getStatusCode/100 == 5
       case ioe: IOException => true
       case _ => false
     }

--- a/google/src/test/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilitiesSpec.scala
@@ -75,8 +75,7 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     when500orGoogleError(buildGoogleJsonResponseException(403)) shouldBe true
     when500orGoogleError(buildGoogleJsonResponseException(429)) shouldBe true
     when500orGoogleError(buildGoogleJsonResponseException(400)) shouldBe true
-    // 404 requires special handing
-    when500orGoogleError(buildGoogleJsonResponseException(404)) shouldBe false
+    when500orGoogleError(buildGoogleJsonResponseException(404)) shouldBe true
 
     when500orGoogleError(buildGoogleJsonResponseException(500)) shouldBe true
     when500orGoogleError(buildGoogleJsonResponseException(502)) shouldBe true

--- a/google/src/test/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilitiesSpec.scala
@@ -88,6 +88,14 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     when500orGoogleError(new IOException("boom")) shouldBe true
   }
 
+  "when500orNon404GoogleError" should "return true for 500 or Google errors except 404s" in {
+    when500orNon404GoogleError(buildGoogleJsonResponseException(400)) shouldBe true
+    when500orNon404GoogleError(buildGoogleJsonResponseException(404)) shouldBe false
+    when500orNon404GoogleError(buildGoogleJsonResponseException(500)) shouldBe true
+    when500orNon404GoogleError(buildHttpResponseException(500)) shouldBe true
+    when500orNon404GoogleError(new IOException("boom")) shouldBe true
+  }
+
   "retryWhen500orGoogleError" should "retry once per backoff interval and then fail" in {
     withStatsD {
       val counter = new Counter()

--- a/google/src/test/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/rawls/google/GoogleUtilitiesSpec.scala
@@ -75,7 +75,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     when500orGoogleError(buildGoogleJsonResponseException(403)) shouldBe true
     when500orGoogleError(buildGoogleJsonResponseException(429)) shouldBe true
     when500orGoogleError(buildGoogleJsonResponseException(400)) shouldBe true
-    when500orGoogleError(buildGoogleJsonResponseException(404)) shouldBe true
+    // 404 requires special handing
+    when500orGoogleError(buildGoogleJsonResponseException(404)) shouldBe false
 
     when500orGoogleError(buildGoogleJsonResponseException(500)) shouldBe true
     when500orGoogleError(buildGoogleJsonResponseException(502)) shouldBe true


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1460

When a user creates a v1 billing account, rawls creates the resource for the google project in sam BEFORE it creates the google project proper. If the project creation fails, we delete the project from rawl’s database but we never tell sam.

When listing billing projects, we ask sam for all resources with resource type billing project. Since it doesn’t know that the billing project and google project don’t exist, it returns us all the resources AS IF it existed.

TLDR; we can’t trust that a resource exists just because sam says it does. This is seems reasonable because a user could stab us in the back and delete these resources in google and we’d be in the same situation.

Fix: Test that google project that backs the billing project exists before trying to delete it.

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
