### PR TITLE
AS-955 query optimizations

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -258,10 +258,6 @@ trait EntityComponent {
         * @return
         */
       private def paginationSubquery(workspaceId: UUID, entityType: String, sortFieldName: String) = {
-        /* TODO: can we eliminate the SELECT ... e.all_attribute_values by being smarter about our where clauses?
-            while not returned to the end user, it still causes mysql extra work
-         */
-
         val (sortColumns, sortJoin) = sortFieldName match {
           case "name" => (
             // no additional sort columns
@@ -336,7 +332,6 @@ trait EntityComponent {
         }
 
         // additional joins-to-subquery to provide proper pagination
-        // TODO: we don't need the nested "select * from (select ... ))", this causes extra work for MySQL
         val paginationJoin = concatSqlActions(
           sql""" join (""",
           paginationSubquery(workspaceContext.workspaceIdAsUUID, entityType, entityQuery.sortField),


### PR DESCRIPTION
This PR addresses two TODOs found during AS-955, improving the SQL generated during `queryEntities()`.

Specifically, the two fixes are:
* remove one level of subquery. Previously we had `select * from (select … )` as the inner `p` subquery, now we just have `select … `.
* because we no longer need two levels of subquery, we also remove the very large `ENTITY.all_attribute_values` from the select list of the subquery (we still use it in a where clause). This means that MySQL does not have to materialize that value into a temporary result set during query processing. It was never returned to the user, but now we don't even have to materialize it.

Execution plan before:
![explain-before](https://user-images.githubusercontent.com/6041577/136102305-b2c90f2f-ebd6-4dc3-a108-988de55960b3.png)

Execution plan after:
![explain-after](https://user-images.githubusercontent.com/6041577/136102000-b53cae69-c487-47ad-af9d-82d59748f27b.png)

SQL before:

```sql
select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
	a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
	e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
	from ENTITY e
	left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted  and  ((a.namespace = ? AND a.name = ?) or (a.namespace = ? AND a.name = ?) or (a.namespace = ? AND a.name = ?))
	left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id
	join
		(select * from
			(select e.id, e.name, e.all_attribute_values ,
					sort_a.list_length as sort_list_length, sort_a.value_string as sort_field_string, sort_a.value_number as sort_field_number, sort_a.value_boolean as sort_field_boolean,
					sort_a.value_json as sort_field_json, sort_e_ref.name as sort_field_ref
				from ENTITY e
					left outer join ENTITY_ATTRIBUTE sort_a on sort_a.owner_id = e.id and sort_a.name = ? and ifnull(sort_a.list_index, 0) = 0
					left outer join ENTITY sort_e_ref on sort_a.value_entity_ref = sort_e_ref.id
				where e.deleted = 'false' and e.entity_type = ? and e.workspace_id = ? ) pagination
                where concat(pagination.name, ' ', pagination.all_attribute_values) like ?
		order by pagination.sort_list_length asc, pagination.sort_field_string asc, pagination.sort_field_number asc, pagination.sort_field_boolean asc, pagination.sort_field_ref asc, pagination.name asc
		limit 25 offset 0 ) p
	on p.id = e.id  order by p.sort_list_length asc, p.sort_field_string asc, p.sort_field_number asc, p.sort_field_boolean asc, p.sort_field_ref asc, p.name asc 
```

SQL after:
```sql
select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
	a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
	e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
	from ENTITY e
	left outer join ENTITY_ATTRIBUTE a on a.owner_id = e.id and a.deleted = e.deleted  and  ((a.namespace = ? AND a.name = ?) or (a.namespace = ? AND a.name = ?) or (a.namespace = ? AND a.name = ?))
	left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id
	join
		(select e.id, e.name ,
			sort_a.list_length as sort_list_length, sort_a.value_string as sort_field_string, sort_a.value_number as sort_field_number, sort_a.value_boolean as sort_field_boolean,
			sort_a.value_json as sort_field_json, sort_e_ref.name as sort_field_ref
		from ENTITY e
			left outer join ENTITY_ATTRIBUTE sort_a on sort_a.owner_id = e.id and sort_a.name = ? and ifnull(sort_a.list_index, 0) = 0
			left outer join ENTITY sort_e_ref on sort_a.value_entity_ref = sort_e_ref.id
		where e.deleted = 'false' and e.entity_type = ? and e.workspace_id = ?
                and concat(e.name, ' ', e.all_attribute_values) like ?
		order by sort_list_length asc, sort_field_string asc, sort_field_number asc, sort_field_boolean asc, sort_field_ref asc, name asc
		limit 25 offset 0 ) p
	on p.id = e.id  order by p.sort_list_length asc, p.sort_field_string asc, p.sort_field_number asc, p.sort_field_boolean asc, p.sort_field_ref asc, p.name asc 
```