### PR TITLE
Improve error messages for case sensitivity errors [AS-979]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -230,15 +230,19 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
 
           traceDBIOWithParent("saveAction", rootSpan)(_ => saveAction)
         } recover {
+          case icve:com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException =>
+            val userMessage =
+              s"Database error occurred. Check if you are uploading entity names or entity types that differ only in case " +
+                s"from pre-existing entities."
+            throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
           case bue:java.sql.BatchUpdateException =>
             val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
             val userMessage = if (maybeCaseIssue) {
               s"Database error occurred. Check if you are uploading entity names or entity types that differ only in case " +
-                s"from pre-existing entities. Underlying error message: ${bue.getMessage}"
+                s"from pre-existing entities."
             } else {
               s"Database error occurred. Underlying error message: ${bue.getMessage}"
             }
-
             throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, bue))
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -354,7 +354,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     }
 
 
-    "return helpful error message when upserting case-divergent entity names (create method)" in withLocalEntityProviderTestDatabase { dataSource =>
+    "return helpful error message when upserting case-divergent entity names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
@@ -377,7 +377,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    "return helpful error message when upserting case-divergent entity names (batchUpsert method)" in withLocalEntityProviderTestDatabase { dataSource =>
+    "return helpful error message when upserting case-divergent entity names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
@@ -400,7 +400,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    "return helpful error message when upserting case-divergent type names (create method)" in withLocalEntityProviderTestDatabase { dataSource =>
+    "return helpful error message when upserting case-divergent type names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
@@ -423,7 +423,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    "return helpful error message when upserting case-divergent type names (batchUpsert method)" in withLocalEntityProviderTestDatabase { dataSource =>
+    "return helpful error message when upserting case-divergent type names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -394,8 +394,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
 
       ex match {
         case er:RawlsExceptionWithErrorReport =>
-          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities. Underlying error message:"
-          er.errorReport.message should startWith (expectedMessage)
+          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities."
+          er.errorReport.message shouldBe expectedMessage
         case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
       }
     }
@@ -440,8 +440,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
 
       ex match {
         case er:RawlsExceptionWithErrorReport =>
-          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities. Underlying error message:"
-          er.errorReport.message should startWith (expectedMessage)
+          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities."
+          er.errorReport.message shouldBe expectedMessage
         case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -394,8 +394,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
 
       ex match {
         case er:RawlsExceptionWithErrorReport =>
-          val expectedMessage = s"${upsert2.head.entityType} ${upsert2.head.name} already exists in ${workspaceContext.toWorkspaceName}"
-          er.errorReport.message shouldBe expectedMessage
+          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities. Underlying error message:"
+          er.errorReport.message should startWith (expectedMessage)
         case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
       }
     }
@@ -440,8 +440,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
 
       ex match {
         case er:RawlsExceptionWithErrorReport =>
-          val expectedMessage = s"${upsert2.head.entityType} ${upsert2.head.name} already exists in ${workspaceContext.toWorkspaceName}"
-          er.errorReport.message shouldBe expectedMessage
+          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities. Underlying error message:"
+          er.errorReport.message should startWith (expectedMessage)
         case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
       }
     }


### PR DESCRIPTION
Note that I used the wrong jira ticket in the branch name. AS-979 is the right one.

This is an interim/iterative change. We have specific use cases that currently return very ugly errors to the end user. This PR makes those error messages more helpful and less scary. It does not fix the underlying problem; we need more thought and decisions on that front. But, let's not wait on those decisions to change the error messages.

Before:
![Screenshot-case-before](https://user-images.githubusercontent.com/6041577/136270683-4a2b9bce-3690-4c9d-b5ce-d4c24c3ae2ab.png)

After:
![Screenshot-case-after](https://user-images.githubusercontent.com/6041577/136270700-f0b4c2a2-562d-4892-94a8-02a39bf36177.png)

