### PR TITLE
ensure workflow messages are returned [BW-845]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -462,16 +462,9 @@ trait SubmissionComponent {
         val workflowRec = WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
         val rootEntityTypeOption: Option[String] = r.<<
 
-        // val entityRec = workflowRec.workflowEntityId.map(EntityRecord(_, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
-        val entityRec = workflowRec.workflowEntityId match {
-          case Some(eid) => Option(EntityRecord(eid, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
-          case None =>
-            // consume the entity record columns, but ignore the result
-            val _ = EntityRecord(-1, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
-            None
-        }
-
         val messageOption: Option[String] = r.<<
+
+        val entityRec = workflowRec.workflowEntityId.map(EntityRecord(_, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
 
         val externalEntityOption = for {
           rootEntityType <- rootEntityTypeOption
@@ -484,8 +477,8 @@ trait SubmissionComponent {
       def action(submissionId: UUID) = {
         sql"""select w.ID, w.EXTERNAL_ID, w.SUBMISSION_ID, w.STATUS, w.STATUS_LAST_CHANGED, w.ENTITY_ID, w.record_version, w.EXEC_SERVICE_KEY, w.EXTERNAL_ENTITY_ID,
         s.ROOT_ENTITY_TYPE,
-        e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
-        m.MESSAGE
+        m.MESSAGE,
+        e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date
         from WORKFLOW w
         join SUBMISSION s on w.submission_id = s.id
         left outer join ENTITY e on w.ENTITY_ID = e.id

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -461,7 +461,15 @@ trait SubmissionComponent {
       implicit val getWorkflowMessagesListResult = GetResult { r =>
         val workflowRec = WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
         val rootEntityTypeOption: Option[String] = r.<<
-        val entityRec = workflowRec.workflowEntityId.map(EntityRecord(_, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
+
+        // val entityRec = workflowRec.workflowEntityId.map(EntityRecord(_, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
+        val entityRec = workflowRec.workflowEntityId match {
+          case Some(eid) => Option(EntityRecord(eid, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
+          case None =>
+            // consume the entity record columns, but ignore the result
+            val _ = EntityRecord(-1, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
+            None
+        }
 
         val messageOption: Option[String] = r.<<
 


### PR DESCRIPTION
I helped debug some failed workflows … the user needed help because the workflow failure messages were not displayed in the Terra UI, nor were they returned from the get-submission API that powers the UI.

I got curious why they weren't returned, and here's the seed of a fix. This problem happens for any workflow whose `WORKFLOW.ENTITY_ID` column is null in the database. In the use case I debugged, the user hit an error in DRS resolution when trying to start the workflow.

The problem happens because if `WORKFLOW.ENTITY_ID` is null, `workflowRec.workflowEntityId.map` never processed its code, and thus `getWorkflowMessagesListResult` method never called a bunch of `r.<<` column extractors. Since these were never called, by the time it tried to extract the message, it was still on column 11, which is `ENTITY.name`, and `ENTITY.name` was null. So it thought it had no messages.

![Screenshot](https://user-images.githubusercontent.com/6041577/136440685-994047e1-31db-48ea-8d67-40def5ca8ad9.png)

