### PR TITLE
manage invalid entity statistic caches [AS-930]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           -Denv.type=test
           -Dmysql.host=localhost
           -Dmysql.port=3310
+          -Duser.timezone=UTC
           it:compile
 
       # A known github bug results in 'annotations generated in a Github action during a step executed in

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd rawls
 sbt antlr4:antlr4Generate # Generates source code for IntellIJ IDEA
 ./minnie-kenny.sh -f
 ./docker/run-mysql.sh start
-export SBT_OPTS="-Xmx2G -Xms1G -Dmysql.host=localhost -Dmysql.port=3310"
+export SBT_OPTS="-Xmx2G -Xms1G -Dmysql.host=localhost -Dmysql.port=3310 -Duser.timezone=UTC"
 sbt clean compile test
 ```
 
@@ -52,7 +52,7 @@ Spin up mysql locally and validate that it is working:
 Run tests.
 
 ```sh
-export SBT_OPTS="-Xmx2G -Xms1G -Dmysql.host=localhost -Dmysql.port=3310"
+export SBT_OPTS="-Xmx2G -Xms1G -Dmysql.host=localhost -Dmysql.port=3310 -Duser.timezone=UTC"
 sbt clean compile test
 ```
 

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -935,6 +935,35 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+  /api/admin/workspaces/entities/cache:
+    get:
+      tags:
+        - admin
+        - workspaces
+      summary: list workspaces with an invalid entity statistics cache
+      description: list workspaces with an invalid entity statistics cache
+      operationId: listInvalidEntityCacheWorkspaces
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceDetails'
+        403:
+          description: You must be an admin to list workspaces
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/admin/refreshToken/{userSubjectId}:
     delete:
       deprecated: true

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -951,7 +951,46 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkspaceDetails'
+                  $ref: '#/components/schemas/WorkspaceDetailsAndCacheError'
+        403:
+          description: You must be an admin to list workspaces
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    post:
+      tags:
+        - admin
+        - workspaces
+      summary: reset entity statistics cache on specific workspaces
+      description: reset entity statistics cache on specific workspaces
+      operationId: resetInvalidEntityCacheWorkspaces
+      requestBody:
+          description: workspace ids for which to reset caches
+          required: true
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  type: string
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: object
+                properties:
+                  numReset:
+                    type: number
+                    description: number of workspace caches actually updated
         403:
           description: You must be an admin to list workspaces
           content:
@@ -5926,6 +5965,14 @@ components:
             in yyyy-MM-ddTHH:mm:ss.SSSZZ format
           format: date-time
       description: ""
+    WorkspaceDetailsAndCacheError:
+      type: object
+      properties:
+        cacheError:
+          type: string
+        workspace:
+          $ref: '#/components/schemas/WorkspaceDetails'
+    description: ""
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -65,8 +65,8 @@ trait EntityCacheComponent {
       }
     }
 
-    def listInvalidCaches: ReadAction[Seq[(UUID, String)]] = {
-      sql"""select c.workspace_id, c.error_message from WORKSPACE_ENTITY_CACHE c where c.entity_cache_last_updated = ${MIN_CACHE_TIME}""".as[(UUID, String)]
+    def listInvalidCaches: ReadAction[Seq[(UUID, Option[String])]] = {
+      sql"""select c.workspace_id, c.error_message from WORKSPACE_ENTITY_CACHE c where c.entity_cache_last_updated = ${MIN_CACHE_TIME}""".as[(UUID,Option[String])]
     }
 
     def resetInvalidCaches(workspaceIds: Seq[UUID]) = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor
+import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor.MIN_CACHE_TIME
 import slick.jdbc.JdbcProfile
 
 import java.sql.Timestamp
@@ -64,6 +65,9 @@ trait EntityCacheComponent {
       }
     }
 
+    def listInvalidCaches: ReadAction[Seq[(UUID, String)]] = {
+      sql"""select c.workspace_id, c.error_message from WORKSPACE_ENTITY_CACHE c where c.entity_cache_last_updated = ${MIN_CACHE_TIME}""".as[(UUID, String)]
+    }
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -28,6 +28,8 @@ object EntityStatisticsCacheMonitor {
 
   //Note: Ignored workspaces have a cacheLastUpdated timestamp of 1000ms after epoch
   val MIN_CACHE_TIME = new Timestamp(1000)
+  // when resetting an invalid cache so that it can be recalculated, use this timestamp
+  val RESET_CACHE_TIME = new Timestamp(2000)
 
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 import spray.json.DefaultJsonProtocol._
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 trait AdminApiService extends UserInfoDirectives {
@@ -93,6 +94,11 @@ trait AdminApiService extends UserInfoDirectives {
     path("admin" / "workspaces" / "entities" / "cache") {
       get {
         complete { workspaceServiceConstructor(userInfo).adminListWorkspacesWithInvalidEntityCaches }
+      } ~
+      post {
+        entity(as[Seq[String]]) { workspaceIds =>
+          complete { workspaceServiceConstructor(userInfo).adminResetWorkspaceEntityCaches(workspaceIds) }
+        }
       }
     } ~
     path("admin" / "refreshToken" / Segment ) { userSubjectId =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -90,6 +90,11 @@ trait AdminApiService extends UserInfoDirectives {
         }
       }
     } ~
+    path("admin" / "workspaces" / "entities" / "cache") {
+      get {
+        complete { workspaceServiceConstructor(userInfo).adminListWorkspacesWithInvalidEntityCaches }
+      }
+    } ~
     path("admin" / "refreshToken" / Segment ) { userSubjectId =>
       delete {
         complete { userServiceConstructor(userInfo).adminDeleteRefreshToken(RawlsUserRef(RawlsUserSubjectId(userSubjectId))) }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1882,7 +1882,7 @@ class WorkspaceService(protected val userInfo: UserInfo,
           } yield {
             val errorMap = workspaceIdsAndErrors.toMap
             workspaces.map { w =>
-              (w, errorMap.getOrElse(w.workspaceIdAsUUID, ""))
+              (w, errorMap.get(w.workspaceIdAsUUID).flatten.getOrElse(""))
             }
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1898,6 +1898,20 @@ class WorkspaceService(protected val userInfo: UserInfo,
     }
   }
 
+  def adminResetWorkspaceEntityCaches(ids: Seq[String]) = {
+    asFCAdmin {
+      // validate workspaceIds
+      val workspaceIds = ids.map(s => Try(UUID.fromString(s)).getOrElse(throw new RawlsException(s"all ids must be valid UUIDs. Found: $s")))
+      val updated = dataSource.inTransaction { dataAccess =>
+        dataAccess.entityCacheQuery.resetInvalidCaches(workspaceIds)
+      }
+      updated map { num =>
+        RequestComplete(StatusCodes.OK, Map("numReset" -> num))
+      }
+    }
+
+  }
+
   def getBucketUsage(workspaceName: WorkspaceName): Future[PerRequestMessage] = {
     //don't do the sam REST call inside the db transaction.
     getWorkspaceContext(workspaceName) flatMap { workspaceContext =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -349,6 +349,8 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     // in live environments, both server and client use UTC timezone; test behavior should mimic that.
     val min = MIN_CACHE_TIME
     min shouldBe new Timestamp(1000)
+    withClue("this failure may indicate a time zone mismatch between the mysql server and the client running the unit tests. " +
+      "Do you have -Duser.timezone=UTC set in your SBT_OPTS? Underlying test failure message: ")
     min.toString shouldBe "1970-01-01 00:00:01.0"
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -4,15 +4,18 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.{ActiveSubmissionFormat, WorkflowQueueStatusByUserResponseFormat}
 import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport.RawlsBillingProjectTransferFormat
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{AttributeReferenceFormat, WorkspaceDetailsFormat}
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{AttributeReferenceFormat, WorkspaceDetailsAndCacheErrorFormat, WorkspaceDetailsFormat}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import spray.json.DefaultJsonProtocol._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor.{MIN_CACHE_TIME, RESET_CACHE_TIME}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
+import java.sql.Timestamp
+import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 /**
@@ -272,5 +275,152 @@ class AdminApiServiceSpec extends ApiServiceSpec {
           responseAs[WorkflowQueueStatusByUserResponse]
         }
       }
+  }
+
+  // utility functions used by the entity statistics cache tests, following
+  def assertInvalidCacheCount(services: TestApiService, expectedCount: Int, expectedWorkspaces: Seq[Workspace] = Seq(),
+                              clue: String = "") = {
+    Get("/admin/workspaces/entities/cache") ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val actual = responseAs[Seq[WorkspaceDetailsAndCacheError]]
+        withClue(s"$clue, checking the API's count of invalid caches: ") {
+          actual.length shouldBe expectedCount
+          actual.map(_.workspace.toWorkspace.toWorkspaceName) should contain theSameElementsAs
+            expectedWorkspaces.map(_.toWorkspaceName)
+        }
+      }
+  }
+
+  def assertDatabaseCacheCount(services: TestApiService, expectedCount: Int, clue: String = "") = {
+    // ensure they inserted
+    import driver.api._
+    val cacheQuery = services.dataSource.dataAccess.entityCacheQuery
+    val cacheRowCount = runAndWait(cacheQuery.length.result)
+    withClue(s"$clue, checking the database row count for WORKSPACE_ENTITY_CACHE") {
+      cacheRowCount shouldBe expectedCount
+    }
+  }
+
+  def setValidCaches(services: TestApiService, workspaces: Seq[Workspace]) =
+    setCaches(services, workspaces.map( w => (w.workspaceIdAsUUID, new Timestamp(w.lastModified.getMillis))))
+
+  // TODO: why is this failing??????
+  def setInvalidCaches(services: TestApiService, workspaces: Seq[Workspace]) =
+//    workspaces.map(w => services.dataSource.dataAccess.entityCacheQuery.setCacheInvalid(Seq(w.workspaceIdAsUUID)))
+    setCaches(services, workspaces.map( w => (w.workspaceIdAsUUID, MIN_CACHE_TIME)))
+
+  def setCaches(services: TestApiService, workspaceIdsAndTimestamps: Seq[(UUID, Timestamp)]) = {
+    workspaceIdsAndTimestamps foreach {
+      case (workspaceId, timestamp) =>
+        val upsert = runAndWait(services.dataSource.dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, timestamp))
+        upsert shouldBe 1
+    }
+  }
+
+  it should "return empty array if no invalid statistics caches" in withTestDataApiServices { services =>
+    // at this point there should be zero rows in WORKSPACE_ENTITY_CACHE
+    assertInvalidCacheCount(services, 0)
+    // insert some valid rows into WORKSPACE_ENTITY_CACHE
+    setValidCaches(services, Seq(testData.workspace, testData.workspaceNoAttrs, testData.workspacePublished))
+    // check again
+    assertInvalidCacheCount(services, 0, clue = "after inserting two valid cache rows")
+  }
+
+  it should "return all invalid statistics caches" in withTestDataApiServices { services =>
+    // at this point there should be zero rows in WORKSPACE_ENTITY_CACHE
+    assertInvalidCacheCount(services, 0)
+    // insert one valid and two invalid caches into WORKSPACE_ENTITY_CACHE
+    setValidCaches(services, Seq(testData.workspaceNoAttrs))
+
+    val invalidCaches = Seq(testData.workspace, testData.workspacePublished)
+    setInvalidCaches(services, invalidCaches)
+
+    // ensure they inserted
+    assertDatabaseCacheCount(services, 3, "after inserting one valid and two invalid cache rows")
+
+    // check again
+    assertInvalidCacheCount(services, 2, invalidCaches, "after inserting one valid and two invalid cache rows")
+  }
+
+  it should "translate timestamps correctly" in {
+    // this test validates the timezone negotation/translation between mysql server and client.
+    // in live environments, both server and client use UTC timezone; test behavior should mimic that.
+    val min = MIN_CACHE_TIME
+    min shouldBe new Timestamp(1000)
+    min.toString shouldBe "1970-01-01 00:00:01.0"
+  }
+
+  it should "reset any invalid statistics caches" in withTestDataApiServices { services =>
+    // at this point there should be zero rows in WORKSPACE_ENTITY_CACHE
+    assertInvalidCacheCount(services, 0)
+    // insert one valid and two invalid caches into WORKSPACE_ENTITY_CACHE
+    setValidCaches(services, Seq(testData.workspaceNoAttrs))
+
+    val invalidCaches = Seq(testData.workspace, testData.workspacePublished)
+    setInvalidCaches(services, invalidCaches)
+
+    // ensure they inserted
+    assertDatabaseCacheCount(services, 3, "after inserting one valid and two invalid cache rows")
+
+    // check again
+    assertInvalidCacheCount(services, 2, invalidCaches, "after inserting one valid and two invalid cache rows")
+
+    // now reset the cache value for one of the invalid workspaces
+    val payload = Seq(testData.workspacePublished.workspaceId)
+    Post("/admin/workspaces/entities/cache", payload) ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val actual = responseAs[Map[String, Int]]
+        actual.keySet should contain theSameElementsAs Set("numReset")
+        actual("numReset") shouldBe 1
+      }
+
+    import driver.api._
+
+    // query db directly for reset cache value
+    val actualTimestamp = runAndWait(uniqueResult[Timestamp](entityCacheQuery.filter(_.workspaceId === testData.workspacePublished.workspaceIdAsUUID).map(_.entityCacheLastUpdated).result))
+    actualTimestamp should contain (RESET_CACHE_TIME)
+
+    // check API again
+    assertInvalidCacheCount(services, 1, Seq(testData.workspace), "after resetting one workspace's cache validity")
+  }
+
+  it should "not reset any valid statistics caches" in withTestDataApiServices { services =>
+    // at this point there should be zero rows in WORKSPACE_ENTITY_CACHE
+    assertInvalidCacheCount(services, 0)
+    // insert one valid and two invalid caches into WORKSPACE_ENTITY_CACHE
+    setValidCaches(services, Seq(testData.workspaceNoAttrs))
+
+    val invalidCaches = Seq(testData.workspace, testData.workspacePublished)
+    setInvalidCaches(services, invalidCaches)
+
+    // ensure they inserted
+    assertDatabaseCacheCount(services, 3, "after inserting one valid and two invalid cache rows")
+
+    // check again
+    assertInvalidCacheCount(services, 2, invalidCaches, "after inserting one valid and two invalid cache rows")
+
+    // now *attempt* to reset the cache value for the valid workspace
+    val payload = Seq(testData.workspaceNoAttrs.workspaceId)
+    Post("/admin/workspaces/entities/cache", payload) ~>
+      sealRoute(services.adminRoutes) ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val actual = responseAs[Map[String, Int]]
+        actual.keySet should contain theSameElementsAs Set("numReset")
+        actual("numReset") shouldBe 0
+      }
+
+    import driver.api._
+
+    // query db directly for the cache time - should be unmodified
+    val actualTimestamp = runAndWait(uniqueResult[Timestamp](entityCacheQuery.filter(_.workspaceId === testData.workspaceNoAttrs.workspaceIdAsUUID).map(_.entityCacheLastUpdated).result))
+    actualTimestamp should contain (new Timestamp(testData.workspaceNoAttrs.lastModified.getMillis))
+
+    // check API again
+    assertInvalidCacheCount(services, 2, invalidCaches, "after resetting one workspace's cache validity")
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -350,8 +350,9 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     val min = MIN_CACHE_TIME
     min shouldBe new Timestamp(1000)
     withClue("this failure may indicate a time zone mismatch between the mysql server and the client running the unit tests. " +
-      "Do you have -Duser.timezone=UTC set in your SBT_OPTS? Underlying test failure message: ")
-    min.toString shouldBe "1970-01-01 00:00:01.0"
+                   "Do you have -Duser.timezone=UTC set in your SBT_OPTS? Underlying test failure message: ") {
+      min.toString shouldBe "1970-01-01 00:00:01.0"
+    }
   }
 
   it should "reset any invalid statistics caches" in withTestDataApiServices { services =>

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -16,7 +16,7 @@ if [ "$SKIP_TESTS" = "skip-tests" ]; then
 	echo skipping tests
 else
   echo "starting sbt test ..."
-	sbt -J-Xms5g -J-Xmx5g -J-XX:MaxMetaspaceSize=5g test -Dmysql.host=mysql -Dmysql.port=3306 -Dsecrets.skip=true
+	sbt -J-Xms5g -J-Xmx5g -J-XX:MaxMetaspaceSize=5g test -Dmysql.host=mysql -Dmysql.port=3306 -Duser.timezone=UTC -Dsecrets.skip=true
 	echo "sbt test done"
 fi
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -665,6 +665,8 @@ object WorkspaceDetails {
   }
 }
 
+case class WorkspaceDetailsAndCacheError(workspace: WorkspaceDetails, cacheError: String)
+
 case class PendingCloneWorkspaceFileTransfer(destWorkspaceId: UUID, sourceWorkspaceBucketName: String, destWorkspaceBucketName: String, copyFilesWithPrefix: String, destWorkspaceGoogleProjectId: GoogleProjectId)
 
 case class ManagedGroupAccessInstructions(groupName: String, instructions: String)
@@ -890,6 +892,8 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val WorkspaceBucketOptionsFormat = jsonFormat1(WorkspaceBucketOptions)
 
   implicit val WorkspaceDetailsFormat = jsonFormat17(WorkspaceDetails.apply)
+
+  implicit val WorkspaceDetailsAndCacheErrorFormat = jsonFormat2(WorkspaceDetailsAndCacheError)
 
   implicit val WorkspaceListResponseFormat = jsonFormat4(WorkspaceListResponse)
 


### PR DESCRIPTION
**_I have created an alert that should ping the #dsp-appservices-notifications Slack channel if any statistics caches become invalid. The alert is viewable via cloud console [here](https://console.cloud.google.com/monitoring/alerting/policies/11623762382109243788?project=broad-dsde-prod) (requires @ firecloud.org account)_**


This adds two new admin APIs:
* list those workspaces which have an invalid entity statistics cache, along with the cache's error message
* reset the entity statistics cache for specific workspaces, so the cache can be rebuilt and become valid again

I tested this a bunch manually, as well as adding unit tests for the APIs.

IMPORTANT: this PR also carries a change for anyone running unit tests locally. The flag `-Duser.timezone=UTC` is now required in `SBT_OPTS` in order for unit tests to pass. The new unit tests rely on sql `Timestamp`s, and when the client (Rawls) generated a timestamp and sent it over JDBC, the timestamp would be converted based on the time zone difference between Rawls and the MySQL server. In live environments like dev and prod, as well as in Jenkins and Github Actions, both the client and the server were in UTC so no conversions occurred. But, if you're running unit tests locally on your laptop, you are likely in the Eastern timezone, and therefore timestamps would be offset by a few hours.

This specifically caused a problem with the `MIN_CACHE_TIME` value used by the entity statistics cache. When MySQL translated it, it resulted in a value of `1969-12-31 19:00:01.0` instead of the UTC `1970-01-01 00:00:01.0` … and that translated value is actually below the minimum allowable value for a timestamp column in MySQL. Thus, the translation caused rows to fail to insert.

I've addressed this issue by running the unit tests in UTC, via the addition of the `-Duser.timezone=UTC` flag. This seemed the most appropriate approach, since it mimics the behavior of our live envs; other rejected options include fussing with JDBC connection string options, but that would make test connections behave differently than live connections.

-----

See also #1551, which is an alternate approach to AS-930.

My take on how the two PRs compare:

| #1549 (this PR) - admin APIs | #1551 - helper scripts |
| ------ | ------- |
| unit testable, has tests | manual testing only |
| adds more runtime code to Rawls | standalone, doesn't make Rawls bigger |
| all invocations are logged | no audit logging |
| more of a black box, need Scala source to understand behavior | easier for a developer to read code |
| requires only a browser | requires source code to exist locally, docker, and VPN |
| may be overkill, since invalid caches should now be rare | easier to excise, if we eliminate invalid caches |
| behavior changes require releasing/deploying Rawls | behavior changes require a merge to github and/or tweaks to local code |
| does not require devs to write directly to the database | but it's ok for devs to write directly to the database |
