### PR TITLE
remove unused val [QA-1571]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -82,5 +82,4 @@ object SamDAO {
     com.google.api.services.oauth2.Oauth2Scopes.USERINFO_EMAIL,
     com.google.api.services.oauth2.Oauth2Scopes.USERINFO_PROFILE
   )
-  val bigQueryReadOnlyScope = com.google.api.services.bigquery.BigqueryScopes.BIGQUERY_READONLY
 }


### PR DESCRIPTION
helps with QA-1571 but does not complete that ticket.

This PR removes an unused val. That val caused an upgrade problem in #1554 - since it's unused, let's just remove it instead of solving the upgrade problem. See https://github.com/broadinstitute/rawls/pull/1554#discussion_r734604892 for details.