### PR TITLE
remove compile warnings due to sbt upgrade [QA-1571]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,13 +52,13 @@ lazy val rawls = project.in(file("."))
 Revolver.settings
 Global / excludeLintKeys += debugSettings // To avoid lint warning
 
-mainClass in reStart := Some("org.broadinstitute.dsde.rawls.Boot")
+reStart / mainClass := Some("org.broadinstitute.dsde.rawls.Boot")
 
 // When JAVA_OPTS are specified in the environment, they are usually meant for the application
 // itself rather than sbt, but they are not passed by default to the application, which is a forked
 // process. This passes them through to the "re-start" command, which is probably what a developer
 // would normally expect.
-javaOptions in reStart ++= sys.env.getOrElse("JAVA_OPTS", "")
+reStart / javaOptions ++= sys.env.getOrElse("JAVA_OPTS", "")
   .concat(" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5050")
   .split(" ")
   .toSeq

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -22,7 +22,7 @@ object Testing {
 
   val commonTestSettings: Seq[Setting[_]] = List(
 
-    testOptions in Test += Tests.Setup(() =>
+    Test / testOptions += Tests.Setup(() =>
       sys.props += "mockserver.logLevel" -> "WARN"
     ),
     // SLF4J initializes itself upon the first logging call.  Because sbt
@@ -43,21 +43,21 @@ object Testing {
     //   http://stackoverflow.com/a/12095245
     //   http://jira.qos.ch/browse/SLF4J-167
     //   http://jira.qos.ch/browse/SLF4J-97
-    testOptions in Test += Tests.Setup(classLoader =>
+    Test / testOptions += Tests.Setup(classLoader =>
       classLoader
         .loadClass("org.slf4j.LoggerFactory")
         .getMethod("getLogger", classLoader.loadClass("java.lang.String"))
         .invoke(null, "ROOT")
     ),
-    testOptions in Test ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
-    testOptions in IntegrationTest := Seq(Tests.Filter(s => isIntegrationTest(s))),
+    Test / testOptions ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
+    IntegrationTest / testOptions := Seq(Tests.Filter(s => isIntegrationTest(s))),
 
     validMySqlHostSetting,
 
-    (test in Test) := ((test in Test) dependsOn validMySqlHost).value,
-    (testOnly in Test) := ((testOnly in Test) dependsOn validMySqlHost).evaluated,
+    (Test / test) := ((Test / test) dependsOn validMySqlHost).value,
+    (Test / testOnly) := ((Test / testOnly) dependsOn validMySqlHost).evaluated,
 
-    parallelExecution in Test := false
+    Test / parallelExecution := false
   ) ++ (if (sys.props.getOrElse("secrets.skip", "false") != "true") MinnieKenny.testSettings else List())
 
   implicit class ProjectTestSettings(val project: Project) extends AnyVal {


### PR DESCRIPTION
followup to #1554. Removes deprecation warnings during compile that appeared when sbt was upgraded.

My compile looked like this:
```Scala
➜  rawls git:(develop) sbt clean reload update compile test:compile
[info] welcome to sbt 1.5.5 (AdoptOpenJDK Java 11.0.11)
[info] loading global plugins from /Users/davidan/.sbt/1.0/plugins
[info] loading settings for project rawls-build from plugins.sbt ...
[info] loading project definition from /Users/davidan/work/src/rawls/project
[info] compiling 4 Scala sources to /Users/davidan/work/src/rawls/project/target/scala-2.12/sbt-1.0/classes ...
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:25:17: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     testOptions in Test += Tests.Setup(() =>
[warn]                 ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:46:17: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     testOptions in Test += Tests.Setup(classLoader =>
[warn]                 ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:52:17: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     testOptions in Test ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
[warn]                 ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:53:17: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     testOptions in IntegrationTest := Seq(Tests.Filter(s => isIntegrationTest(s))),
[warn]                 ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:57:11: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     (test in Test) := ((test in Test) dependsOn validMySqlHost).value,
[warn]           ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:57:30: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     (test in Test) := ((test in Test) dependsOn validMySqlHost).value,
[warn]                              ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:58:15: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     (testOnly in Test) := ((testOnly in Test) dependsOn validMySqlHost).evaluated,
[warn]               ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:58:38: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     (testOnly in Test) := ((testOnly in Test) dependsOn validMySqlHost).evaluated,
[warn]                                      ^
[warn] /Users/davidan/work/src/rawls/project/Testing.scala:60:23: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]     parallelExecution in Test := false
[warn]                       ^
[warn] one feature warning; re-run with -feature for details
[warn] 10 warnings found
/Users/davidan/work/src/rawls/build.sbt:55: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
mainClass in reStart := Some("org.broadinstitute.dsde.rawls.Boot")
          ^
/Users/davidan/work/src/rawls/build.sbt:61: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
javaOptions in reStart ++= sys.env.getOrElse("JAVA_OPTS", "")
            ^
[info] loading settings for project rawls from build.sbt ...
[info] resolving key references (11029 settings) ...
[info] set current project to rawls (in build file:/Users/davidan/work/src/rawls/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 1 s, completed Oct 26, 2021, 12:41:02 PM
[info] welcome to sbt 1.5.5 (AdoptOpenJDK Java 11.0.11)
[info] loading global plugins from /Users/davidan/.sbt/1.0/plugins
[info] loading settings for project rawls-build from plugins.sbt ...
[info] loading project definition from /Users/davidan/work/src/rawls/project
[info] loading settings for project rawls from build.sbt ...
[info] resolving key references (11029 settings) ...
[info] set current project to rawls (in build file:/Users/davidan/work/src/rawls/)
[info] Updating 
https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/bio/terra/workspace-manager-client/0.254.5-SNAPSHOT/workspace-manager-client-0.254.5-SNAPSHOT.pom
  No new update since 2021-05-10 09:48:17
[info] Resolved  dependencies
[info] Updating 
https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/bio/terra/datarepo-client/1.41.0-SNAPSHOT/datarepo-client-1.41.0-SNAPSHOT.pom
  No new update since 2021-03-17 09:12:43
https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/bio/terra/terra-resource-buffer-client/0.4.3-SNAPSHOT/terra-resource-buffer-client-0.4.3-SNAPSHOT.pom
  No new update since 2020-12-04 17:55:04
[info] Resolved  dependencies
[info] Fetching artifacts of 
https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/bio/terra/datarepo-client/1.41.0-SNAPSHOT/datarepo-client-1.41.0-SNAPSHOT.jar
  No new update since 2021-03-17 09:12:42
https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/bio/terra/terra-resource-buffer-client/0.4.3-SNAPSHOT/terra-resource-buffer-client-0.4.3-SNAPSHOT.jar
  No new update since 2020-12-04 17:55:04
[info] Fetched artifacts of 
[success] Total time: 15 s, completed Oct 26, 2021, 12:41:19 PM
[info] compiling 4 Scala sources to /Users/davidan/work/src/rawls/util/target/scala-2.12/classes ...
[info] compiling 16 Scala sources to /Users/davidan/work/src/rawls/model/target/scala-2.12/classes ...
[info] compiling 3 Scala sources to /Users/davidan/work/src/rawls/metrics/target/scala-2.12/classes ...
[info] compiling 10 Scala sources to /Users/davidan/work/src/rawls/google/target/scala-2.12/classes ...
[info] compiling 172 Scala sources and 4 Java sources to /Users/davidan/work/src/rawls/core/target/scala-2.12/classes ...
[success] Total time: 52 s, completed Oct 26, 2021, 12:42:11 PM
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: workbenchUtil / Test / compile, rawlsModel / Test / compile, rawlsCore / Test / compile, workbenchMetrics / Test / compile, workbenchGoogle / Test / compile, Test / compile
[info] compiling 3 Scala sources to /Users/davidan/work/src/rawls/util/target/scala-2.12/test-classes ...
[info] compiling 6 Scala sources to /Users/davidan/work/src/rawls/model/target/scala-2.12/test-classes ...
[info] compiling 3 Scala sources to /Users/davidan/work/src/rawls/metrics/target/scala-2.12/test-classes ...
[info] compiling 4 Scala sources to /Users/davidan/work/src/rawls/google/target/scala-2.12/test-classes ...
[info] compiling 110 Scala sources to /Users/davidan/work/src/rawls/core/target/scala-2.12/test-classes ...
[success] Total time: 42 s, completed Oct 26, 2021, 12:42:53 PM
➜  rawls git:(develop) 
```