### PR TITLE
discard/subscribe entity on ok status checks [QA-1558]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ServiceDAOWithStatus.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ServiceDAOWithStatus.scala
@@ -15,7 +15,12 @@ trait ServiceDAOWithStatus {
     for {
       response <- http.singleRequest(Get(statusUrl))
       ok = response.status.isSuccess
-      message <- if (ok) Future.successful(None) else Unmarshal(response.entity).to[String].map(Option(_))
+      message <- if (ok) {
+        response.discardEntityBytes() // ensure the entity is subscribed!
+        Future.successful(None)
+      } else {
+        Unmarshal(response.entity).to[String].map(Option(_))
+      }
     } yield {
       SubsystemStatus(ok, message.map(List(_)))
     }


### PR DESCRIPTION
When checking `/status` on an external service, always consume/discard the response entity body. In theory, this should avoid `Response entity was not subscribed after 1 second.` errors from akka. Note that I do not expect this to solve the pervasive timeout errors we have seen in fiab tests, but this does address one single known sore spot.

Found during QA-1558, does not resolve that ticket.