### PR TITLE
improve error messages from Sam [QA-1500]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -72,7 +72,7 @@ class HttpSamDAO(baseSamServiceURL: String, serviceAccountCreds: Credential)(imp
                     case Success(stringErr) => stringErr
                     case Failure(_) => response.entity.toString
                   }
-                  throw new RawlsExceptionWithErrorReport(ErrorReport(f, s"Sam call to ${request.method} ${request.uri.path} failed with error $stringErrMsg"))
+                  throw new RawlsExceptionWithErrorReport(ErrorReport(f, s"Sam call to ${request.method} ${request.uri.path} failed with error '$stringErrMsg'"))
                 }
             }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -61,12 +61,19 @@ class HttpSamDAO(baseSamServiceURL: String, serviceAccountCreds: Credential)(imp
             // attempt to propagate an ErrorReport from Sam. If we can't understand Sam's response as an ErrorReport,
             // create our own error message.
             import WorkspaceJsonSupport.ErrorReportFormat
-            toFutureTry(Unmarshal(response.entity).to[ErrorReport]) map {
+            toFutureTry(Unmarshal(response.entity).to[ErrorReport]) flatMap {
               case Success(err) =>
                 logger.error(s"Sam call to ${request.method} ${request.uri.path} failed with error $err")
                 throw new RawlsExceptionWithErrorReport(err)
               case Failure(_) =>
-                throw new RawlsExceptionWithErrorReport(ErrorReport(f, s"Sam call to ${request.method} ${request.uri.path} failed with error ${response.entity}"))
+                // attempt to extract something useful from the response entity, even though it's not an ErrorReport
+                toFutureTry(Unmarshal(response.entity).to[String]) map { maybeString =>
+                  val stringErrMsg = maybeString match {
+                    case Success(stringErr) => stringErr
+                    case Failure(_) => response.entity.toString
+                  }
+                  throw new RawlsExceptionWithErrorReport(ErrorReport(f, s"Sam call to ${request.method} ${request.uri.path} failed with error $stringErrMsg"))
+                }
             }
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAOSpec.scala
@@ -1,13 +1,17 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.mock.RemoteServicesMockServer
-import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
 import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -52,5 +56,50 @@ class HttpSamDAOSpec extends TestKit(ActorSystem("HttpSamDAOSpec"))
     assertResult(SamDAO.NotFound) {
       Await.result(dao.getUserIdInfo("dne@example.com", UserInfo(RawlsUserEmail(""), OAuth2BearerToken(""), 0, RawlsUserSubjectId(""))), Duration.Inf)
     }
+  }
+
+  it should "bubble up non-ErrorReport Sam errors to Rawls' response" in {
+    // this tests the error handling in HttpSamDAO.doSuccessOrFailureRequest, which is used by
+    // multiple of HttpSamDAO's methods. We'll test two of them here.
+
+    // inviteUser
+    mockServer.mockServer.when(
+      request()
+        .withMethod("POST")
+        .withPath("/api/users/v1/invite/fake-email")
+    ).respond(
+      response().withStatusCode(StatusCodes.InternalServerError.intValue).withBody("not an ErrorReport")
+    )
+
+    // deleteUserPetServiceAccount
+    mockServer.mockServer.when(
+      request()
+        .withMethod("DELETE")
+        .withPath("/api/google/v1/user/petServiceAccount/fake-project")
+    ).respond(
+      response().withStatusCode(StatusCodes.InternalServerError.intValue).withBody("also not an ErrorReport")
+    )
+
+    val fakeUserInfo = UserInfo(RawlsUserEmail(""), OAuth2BearerToken(""), 0, RawlsUserSubjectId(""))
+
+    val dao = new HttpSamDAO(mockServer.mockServerBaseUrl, new MockGoogleCredential.Builder().build())
+
+    val inviteErr = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(dao.inviteUser("fake-email", fakeUserInfo), Duration.Inf)
+    }
+
+    inviteErr.errorReport.message should startWith ("Sam call to")
+    inviteErr.errorReport.message should endWith ("failed with error not an ErrorReport")
+
+    val deletePetError = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(dao.deleteUserPetServiceAccount(GoogleProjectId("fake-project"), fakeUserInfo), Duration.Inf)
+    }
+
+    deletePetError.errorReport.message should startWith ("Sam call to")
+    // note the "also" in the error string below
+    deletePetError.errorReport.message should endWith ("failed with error also not an ErrorReport")
+
+    mockServer.mockServer.clear(request().withMethod("POST").withPath("/api/users/v1/invite/fake-email"))
+    mockServer.mockServer.clear(request().withMethod("DELETE").withPath("/api/google/v1/user/petServiceAccount/fake-project"))
   }
 }


### PR DESCRIPTION
found during QA-1500, does not complete that ticket. QA-1500 had some pain to debug because Rawls was obscuring the actual error message fro mSam.

For any calls from Rawls -> Sam that use `doSuccessOrFailureRequest`, improve the error messages in cases where Sam does not return an `ErrorReport`.

Previous to this PR, those failures would result in an error message similar to
```
Sam call to HttpMethod(POST) /api/users/v1/invite/fake-email failed with error HttpEntity.Strict(application/octet-stream,18 bytes total)
```
which wasn't helpful. Now they will say
```
Sam call to HttpMethod(POST) /api/users/v1/invite/fake-email failed with error 'the-actual-error-from-Sam'
```
