### PR TITLE
EntityStatisticsCacheMonitor resiliency for timeouts/troublesome workspaces [AS-1003]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -61,9 +61,13 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
         // calculate now - workspaceCooldown as the upper bound for workspace last_modified
         val maxModifiedTime = nowMinus(workspaceCooldown)
 
-        dataAccess.entityCacheQuery.findMostOutdatedEntityCacheAfter(MIN_CACHE_TIME, maxModifiedTime).flatMap {
-          case Some((workspaceId, lastModified, cacheLastUpdated)) =>
+        dataAccess.entityCacheQuery.findMostOutdatedEntityCachesAfter(MIN_CACHE_TIME, maxModifiedTime) flatMap { candidates =>
+          if (candidates.nonEmpty) {
+            // pick one of the candidates at random. This randomness ensures that we don't get stuck constantly trying
+            // and failing to update the same workspace - until all we have left as candidates are un-updatable workspaces
+            val (workspaceId, lastModified, cacheLastUpdated) = candidates.toArray.apply(scala.util.Random.nextInt(candidates.size))
             rootSpan.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId.toString))
+            logger.info(s"EntityStatisticsCacheMonitor starting update attempt for workspace $workspaceId.")
             traceDBIOWithParent("updateStatisticsCache", rootSpan) { _ =>
               DBIO.from(updateStatisticsCache(workspaceId, lastModified).map { _ =>
                 val outDated = lastModified.getTime - cacheLastUpdated.getOrElse(MIN_CACHE_TIME).getTime
@@ -71,11 +75,12 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
                 Sweep
               })
             }
-          case None =>
+          } else {
             traceDBIOWithParent("nothing-to-update", rootSpan) { _ =>
               logger.info(s"All workspace entity caches are up to date. Sleeping for $standardPollInterval")
               DBIO.successful(ScheduleDelayedSweep)
             }
+          }
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -44,6 +44,10 @@ class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val tim
   override def receive = {
     case Sweep => sweep() pipeTo self
     case ScheduleDelayedSweep => context.system.scheduler.scheduleOnce(standardPollInterval, self, Sweep)
+    case akka.actor.ReceiveTimeout =>
+      val pauseLength = standardPollInterval*2
+      logger.warn(s"EntityStatisticsCacheMonitor attempt timed out. Pausing for ${pauseLength}.")
+      context.system.scheduler.scheduleOnce(pauseLength, self, Sweep)
   }
 
 }


### PR DESCRIPTION
part of AS-1003, does not complete that ticket.

EntityStatisticsCacheMonitor now:
* handles `akka.actor.ReceiveTimeout` messages, by pausing operations for a cooldown period and then starting another sweep
* on each sweep, samples the next 10 workspaces that are candidates for cache updates, and updates one of them at random. This will hopefully prevent a single - or a few - problematic workspaces from blocking other cache updates.