### PR TITLE
opportunistically update entity stats cache [AS-1003]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -13,10 +13,11 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, D
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeValue, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, ErrorReport, SubmissionValidationEntityInputs, SubmissionValidationValue, Workspace}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, AttributeValue, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, ErrorReport, SubmissionValidationEntityInputs, SubmissionValidationValue, Workspace}
 import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.{traceDBIO, traceDBIOWithParent}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, CollectionUtils, EntitySupport}
 
+import java.sql.Timestamp
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -65,13 +66,39 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
               logger.info(s"entity statistics cache: miss ($missReason) [${workspaceContext.workspaceIdAsUUID}]")
 
               traceDBIOWithParent("retrieve-uncached-results", outerSpan) { _ =>
-                dataAccess.entityQuery.getEntityTypeMetadata(workspaceContext)
+                dataAccess.entityQuery.getEntityTypeMetadata(workspaceContext) map { metadata =>
+                  if (!isEntityCacheCurrent) {
+                    // if the entity cache is not current, AND we have the metadata result, save it to the cache!
+                    // the user has done us the favor of waiting for the result, let's take advantage of that result.
+                    // if saving the cache here fails, ignore the failure and still get the metadata to the user
+                    opportunisticSaveEntityCache(metadata, dataAccess).asTry.map {
+                      case Success(_) => //
+                      case Failure(ex) =>
+                        logger.warn(s"failed to opportunistically update the entity statistics cache: ${ex.getMessage}. " +
+                          s"The user's request was not impacted.")
+                    }
+                  }
+                  metadata
+                }
               }
             }
           }
         }
       }
     }
+  }
+
+  private def opportunisticSaveEntityCache(metadata: Map[String, EntityTypeMetadata], dataAccess: DataAccess) = {
+    val entityTypesWithCounts: Map[String, Int] = metadata.map {
+      case (typeName, typeMetadata) => typeName -> typeMetadata.count
+    }
+    val entityTypesWithAttrNames: Map[String, Seq[AttributeName]] = metadata.map {
+      case (typeName, typeMetadata) => typeName -> typeMetadata.attributeNames.map(AttributeName.fromDelimitedName)
+    }
+    val timestamp: Timestamp = new Timestamp(workspaceContext.lastModified.getMillis)
+
+    dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceContext.workspaceIdAsUUID,
+      entityTypesWithCounts, entityTypesWithAttrNames, timestamp)
   }
 
   override def createEntity(entity: Entity): Future[Entity] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -96,17 +96,12 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
       // if we see contention we could move to encoding the entire metadata object as json
       // and storing in a single column on WORKSPACE_ENTITY_CACHE
       for {
-        //update entity statistics
+        // calculate entity statistics
         entityTypesWithCounts <- dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)
-        _ <- dataAccess.entityTypeStatisticsQuery.deleteAllForWorkspace(workspaceId)
-        _ <- dataAccess.entityTypeStatisticsQuery.batchInsert(workspaceId, entityTypesWithCounts)
-        //update entity attribute statistics
+        // calculate entity attribute statistics
         workspaceShardState <- dataAccess.workspaceQuery.getWorkspaceShardState(workspaceId)
         entityTypesWithAttrNames <- dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceId, workspaceShardState)
-        _ <- dataAccess.entityAttributeStatisticsQuery.deleteAllForWorkspace(workspaceId)
-        _ <- dataAccess.entityAttributeStatisticsQuery.batchInsert(workspaceId, entityTypesWithAttrNames)
-        //update cache update date
-        _ <- dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, timestamp)
+        _ <- dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId, entityTypesWithCounts, entityTypesWithAttrNames, timestamp)
       } yield ()
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -145,6 +145,11 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
     //Load the current entityMetadata (which should not use the cache)
     val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
 
+    //Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
+    //Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so
+    //the monitor will update it using its internal code path
+    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 2)))
+
     //Make sure that the timestamps do not match
     val lastModifiedOriginal = runAndWait(workspaceQuery.findByIdQuery(workspaceContext.workspaceIdAsUUID).result).head.lastModified
     val entityCacheLastUpdatedOriginal = runAndWait(entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).result).head.entityCacheLastUpdated


### PR DESCRIPTION
If a workspace's cache is out of date, and a user requests entity metadata, then save that metadata to the cache once it's been calculated!

This aims to address workspaces whose cache is invalid. If a user has waited through the metadata calculation then let's not just throw away that metadata.