### PR TITLE
specify timeout for cache monitor calculating attribute names [AS-1003]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -564,7 +564,15 @@ trait EntityComponent {
       }
     }
 
-    def getAttrNamesAndEntityTypes(workspaceId: UUID, shardState: WorkspaceShardState): ReadAction[Map[String, Seq[AttributeName]]] = {
+    /**
+      * Find the distinct attribute names associated with each entity type in the workspace.
+      * @param workspaceId the workspace to query
+      * @param shardState the workspace's sharding status
+      * @param queryTimeout the current query timeout limit in seconds; zero means there is
+      *                     no limit
+      * @return result set containing entity types -> seq of attribute names
+      */
+    def getAttrNamesAndEntityTypes(workspaceId: UUID, shardState: WorkspaceShardState, queryTimeout: Int = 0): ReadAction[Map[String, Seq[AttributeName]]] = {
       val typesAndAttrNames = for {
         entityRec <- findActiveEntityByWorkspace(workspaceId)
         attrib <- findActiveAttributesByEntityId(workspaceId, shardState, entityRec.id)
@@ -572,7 +580,7 @@ trait EntityComponent {
         (entityRec.entityType, (attrib.namespace, attrib.name))
       }
 
-      typesAndAttrNames.distinct.result map { result =>
+      typesAndAttrNames.distinct.result.withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout)) map { result =>
         CollectionUtils.groupByTuples (result.map {
           case (entityType:String, (ns:String, n:String)) => (entityType, AttributeName(ns, n))
         })

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -92,7 +92,8 @@ trait EntityStatisticsCacheMonitor extends LazyLogging {
   }
 
   def updateStatisticsCache(workspaceId: UUID, timestamp: Timestamp): Future[Unit] = {
-    // allow 80% of the per-workspace timeout to be spent calculating the attribute names
+    // allow 80% of the per-workspace timeout to be spent calculating the attribute names.
+    // note that other statements do not have timeouts and are unbounded.
     val attrNamesTimeout = (timeoutPerWorkspace * .8).toSeconds.toInt
 
     val updateFuture = dataSource.inTransaction { dataAccess =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -375,8 +375,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   it should "time out when listing all entity types with their attribute names, if a timeout is specified" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       // insert a whole lot of entities with a lot of unique attribute names
-      val numEntities = 1000
-      val numAttrsPerEntity = 100
+      val numEntities = 10000
+      val numAttrsPerEntity = 1000
       (1 to numEntities) foreach { entityIdx =>
         val attrs = (1 to numAttrsPerEntity) map { _ =>
           val attrName = RandomStringUtils.randomAlphanumeric(12)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -47,6 +47,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first sweep should return Sweep,
@@ -66,6 +67,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first time we sweep,
@@ -83,6 +85,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
+      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
     }
 
     //Scenario: there is one workspace in the test data set used for this test. Because it was saved to the db
@@ -99,6 +102,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -134,6 +138,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
       override implicit val executionContext: ExecutionContext = defaultExecutionContext
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -177,6 +182,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
         override implicit val executionContext: ExecutionContext = defaultExecutionContext
         override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
         override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+        override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
       }
 
       val duration = Duration(mins, TimeUnit.MINUTES)


### PR DESCRIPTION
Changes in this PR:
* give `EntityComponent.getAttrNamesAndEntityTypes` the ability to time out its SQL statement, plus an argument to control the timeout length. This defaults to "0" which means no timeout. See `java.sql.Statement.setQueryTimeout` for implementation info.
* in `EntityStatisticsCacheMonitor`, allocate 80% of the per-workspace actor timeout to be spent in `EntityComponent.getAttrNamesAndEntityTypes`.

The end result of these changes is that - hopefully - when `EntityStatisticsCacheMonitor` is processing a workspace, it will hit a SQL timeout exception before the actor times out. In turn, this will mark the workspace as un-updatable. If the SQL statement didn't have a timeout, then when the actor times out we never mark the workspace as invalid.

This still has a case where if > 20% of the per-workspace timeout is already spent before  `EntityComponent.getAttrNamesAndEntityTypes` fires, the SQL timeout will be too long. Handling this case feels like a complexity:benefit loss, so I'm ignoring it.
