### PR TITLE
cache monitor double processing [AS-1003]

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -1,18 +1,21 @@
 package org.broadinstitute.dsde.rawls.monitor
 
-import akka.actor.ActorSystem
-import akka.testkit.TestKit
+import akka.actor.{ActorRef, ActorSystem}
+import akka.pattern.ask
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.model.Entity
-import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor.{ScheduleDelayedSweep, Sweep}
+import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor.{DieAndRestart, ScheduleDelayedSweep, Start, Sweep}
 import org.broadinstitute.dsde.rawls.util
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.sql.Timestamp
@@ -21,8 +24,19 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 import scala.language.postfixOps
+import scala.reflect.classTag
 
-class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_system) with MockitoSugar with AnyFlatSpecLike with Matchers with TestDriverComponent with BeforeAndAfterAll with Eventually with ScalaFutures {
+class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with ImplicitSender
+    with MockitoSugar
+    with AnyFlatSpecLike
+    with Matchers
+    with TestDriverComponent
+    with BeforeAndAfterAll
+    with Eventually
+    with ScalaFutures {
+
   import driver.api._
 
   val defaultExecutionContext: ExecutionContext = executionContext
@@ -173,6 +187,35 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem) extends TestKit(_sy
     val entityCacheLastUpdated = runAndWait(entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).result).head.entityCacheLastUpdated
 
     lastModified shouldBe entityCacheLastUpdated
+  }
+
+  it should "die and restart properly upon request" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
+    // timings for the monitor(s)
+    val timeoutPerWorkspace: FiniteDuration = FiniteDuration(3, TimeUnit.SECONDS)
+    val standardPollInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS)
+    val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
+
+    // timing for TestKit, waiting for actor responses
+    implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
+
+    // start a monitor actor, and return its ActorRef.
+    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown))
+
+    // set up a TestKit probe for DeathWatch on the monitor
+    val probe1 = TestProbe()
+    probe1.watch(monitor1)
+
+    // send DieAndRestart to the monitor. It should return an ActorRef to a newly-created monitor, then terminate.
+    val monitor2Any = (monitor1 ? DieAndRestart).futureValue
+    monitor2Any shouldBe a [ActorRef]
+
+    // assert that the monitor shut itself down
+    probe1.expectTerminated(monitor1, timeoutPerWorkspace * 3) // EntityStatisticsCacheMonitor waits timeoutPerWorkspace * 2 before terminating
+
+    // we want to know if the newly-created monitor is responsive
+    val monitor2 = monitor2Any.asInstanceOf[ActorRef]
+    monitor2 ! Start
+    expectMsg(Sweep)
   }
 
   List(0, 1, 10, 180) foreach { mins =>


### PR DESCRIPTION
followup to #1566. That other PR was incomplete - because my understanding was incomplete - in its handling of `ReceiveTimeout` messages. There are two cases of `ReceiveTimeout`:
1. The actor is hung/the query died and will never finish
2. The actor is just plain slow, it received a timeout but the query it's currently running will eventually finish

In the latter case, with #1566 alone, we can end up with the monitor sweeping twice/multiple times simultaneously. Because the `ReceiveTimeout` triggers a new sweep, AND the current long-running sweep will finish, both threads will result in new `Sweep` messages.

In this PR, we make sure to kill the current actor before starting a new sweep upon timeout.