### PR TITLE
upgrade workbench-libs serviceTest [AS-1018]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val workbenchLibsHash = "808590d"
   val serviceTestV = s"0.21-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.22-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.23-${workbenchLibsHash}"
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.5-${workbenchLibsHash}"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,11 +7,11 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.12.3"
 
-  val workbenchLibsHash = "ae11b9f"
-  val serviceTestV = s"0.20-${workbenchLibsHash}"
+  val workbenchLibsHash = "5ba81aa"
+  val serviceTestV = s"0.21-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.22-${workbenchLibsHash}"
-  val workbenchModelV  = s"0.14-${workbenchLibsHash}"
+  val workbenchModelV  = s"0.15-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.5-${workbenchLibsHash}"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.12.3"
 
-  val workbenchLibsHash = "5ba81aa"
+  val workbenchLibsHash = "808590d"
   val serviceTestV = s"0.21-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.22-${workbenchLibsHash}"


### PR DESCRIPTION
updates the workbench-libs service-test library, to gain new test logging. See broadinstitute/workbench-libs#793 and broadinstitute/workbench-libs#801 for details on the logging changes. You should be able to see the logging changes in effect in the Jenkins Automation Tests for this PR.

Also updates the workbench-model and google2 libraries to stay in sync with service-test.
