### PR TITLE
improve error message for inconsistent attribute types [SUP-549]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -567,10 +567,16 @@ trait AttributeComponent {
       if(!attributes.isEmpty) {
         val headAttribute = attributes.head
         if (!attributes.forall(_.getClass == headAttribute.getClass)) {
-          // generate a helpful error message
+          // determine the different attribute types
           val typeNames = attributes.map(_.getClass.getSimpleName).distinct
+          // generate example values for those types
+          val exampleValues = typeNames.flatMap { typeName =>
+            attributes.find(x => x.getClass.getSimpleName == typeName).map(_.toString)
+          }
+          // generate a helpful error message
           val errMsg = s"inconsistent attributes for list: attribute lists must consist of a single data type. For attribute " +
-            s"'${toDelimitedName(attributeName)}', found types: [${typeNames.mkString(", ")}]"
+            s"'${toDelimitedName(attributeName)}', found types: [${typeNames.mkString(", ")}]. " +
+            s"Sample values for these types: [${exampleValues.mkString(", ")}]"
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, errMsg))
         }
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -576,7 +576,7 @@ trait AttributeComponent {
           // generate a helpful error message
           val errMsg = s"inconsistent attributes for list: attribute lists must consist of a single data type. For attribute " +
             s"'${toDelimitedName(attributeName)}', found types: [${typeNames.mkString(", ")}]. " +
-            s"Sample values for these types: [${exampleValues.mkString(", ")}]"
+            s"Sample values for these types: [${exampleValues.map(_.take(100)).mkString(", ")}]"
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, errMsg))
         }
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.WorkspaceShardStates.{Sharded, Unsharded, WorkspaceShardState}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
@@ -265,7 +266,7 @@ trait AttributeComponent {
           refs.zipWithIndex.map { case (ref, index) => marshalAttributeEntityReference(ownerId, attributeName, Option(index), ref, entityIdsByRef, Option(refs.length))}
 
         case AttributeValueList(values) =>
-          assertConsistentValueListMembers(values)
+          assertConsistentValueListMembers(values, attributeName)
           values.zipWithIndex.map { case (value, index) => marshalAttributeValue(ownerId, attributeName, value, Option(index), Option(values.length))}
         case value: AttributeValue => Seq(marshalAttributeValue(ownerId, attributeName, value, None, None))
         case ref: AttributeEntityReference => Seq(marshalAttributeEntityReference(ownerId, attributeName, None, ref, entityIdsByRef, None))
@@ -562,11 +563,15 @@ trait AttributeComponent {
       }
     }
 
-    private def assertConsistentValueListMembers(attributes: Seq[AttributeValue]): Unit = {
+    private def assertConsistentValueListMembers(attributes: Seq[AttributeValue], attributeName: AttributeName): Unit = {
       if(!attributes.isEmpty) {
         val headAttribute = attributes.head
         if (!attributes.forall(_.getClass == headAttribute.getClass)) {
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"inconsistent attributes for list: $attributes"))
+          // generate a helpful error message
+          val typeNames = attributes.map(_.getClass.getSimpleName).distinct
+          val errMsg = s"inconsistent attributes for list: attribute lists must consist of a single data type. For attribute " +
+            s"'${toDelimitedName(attributeName)}', found types: [${typeNames.mkString(", ")}]"
+          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, errMsg))
         }
       }
     }


### PR DESCRIPTION
related to SUP-549 but does not complete that ticket.

This PR improves the error message that results when something tries to insert/update an entity, and that entity contains an attribute value list, and that list contains disparate data types.

old error message:

> inconsistent attributes for list: List(AttributeNumber(9), AttributeString(oops), AttributeNumber(7), AttributeNumber(6))

new error message:

> inconsistent attributes for list: attribute lists must consist of a single data type. For attribute 'test', found types: [AttributeNumber, AttributeString]. Sample values for these types: [AttributeNumber(9), AttributeString(oops)]

(I left the "inconsistent attributes for list" verbiage in place to preserve history - you can search e.g. Slack for previous instances of this error)

Note that this PR *only* changes the error message. If this error condition occurs because a workflow is trying to write outputs, I have made no changes to how that workflow will retry forever.

