### PR TITLE
Finite retries for workflow termination errors [BW-694]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.WorkspaceShardStates.{Sharded, Unsharded, WorkspaceShardState}
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsFatalExceptionWithErrorReport}
 import slick.ast.{BaseTypedType, TypedType}
 import slick.dbio.Effect.Write
 import slick.jdbc.JdbcProfile
@@ -577,7 +577,7 @@ trait AttributeComponent {
           val errMsg = s"inconsistent attributes for list: attribute lists must consist of a single data type. For attribute " +
             s"'${toDelimitedName(attributeName)}', found types: [${typeNames.mkString(", ")}]. " +
             s"Sample values for these types: [${exampleValues.map(_.take(100)).mkString(", ")}]"
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, errMsg))
+          throw new RawlsFatalExceptionWithErrorReport(ErrorReport(errMsg))
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -194,7 +194,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     this.globalWorkflowStatusCounts = workflowStatus
   }
 
-  // restart the actor on failure (e.g. a DB deadlock or failed transaction) up to a maximum of 100 times
+  // restart the actor on failure (e.g. a DB deadlock or failed transaction) up to a maximum of 10 times
   override val supervisorStrategy = {
     val alwaysRestart: SupervisorStrategy.Decider = {
       case _ => Restart
@@ -209,7 +209,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
         logger.error(s"error monitoring submission after $count times", throwable)
     }
 
-    new ThresholdOneForOneStrategy(thresholdLimit = 0, maxNrOfRetries = Option(100))(alwaysRestart)(thresholdFunc)
+    new ThresholdOneForOneStrategy(thresholdLimit = 0, maxNrOfRetries = Option(10))(alwaysRestart)(thresholdFunc)
   }
 
   private def registerGlobalJobExecGauges(): Unit = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -194,8 +194,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     this.globalWorkflowStatusCounts = workflowStatus
   }
 
-  // restart the actor on failure (e.g. a DB deadlock or failed transaction)
-  // if this actor has failed more than 3 times, log each new failure
+  // restart the actor on failure (e.g. a DB deadlock or failed transaction) up to a maximum of 100 times
   override val supervisorStrategy = {
     val alwaysRestart: SupervisorStrategy.Decider = {
       case _ => Restart
@@ -210,7 +209,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
         logger.error(s"error monitoring submission after $count times", throwable)
     }
 
-    new ThresholdOneForOneStrategy(thresholdLimit = 3)(alwaysRestart)(thresholdFunc)
+    new ThresholdOneForOneStrategy(thresholdLimit = 0, maxNrOfRetries = Option(100))(alwaysRestart)(thresholdFunc)
   }
 
   private def registerGlobalJobExecGauges(): Unit = {


### PR DESCRIPTION
Tested with a specially crafted WDL [0] on dev, with `out` assigned to `this.array_with_null` in the UI.

**Before**

Workflow `Succeeded`, submission stuck in `Submitted`, infinitely recurring `inconsistent attributes for list` errors in logs

**After**

Workflow `Failed` with `inconsistent attributes for list` message in UI, submission `Done`, no recurring log messages

<img width="656" alt="Screen Shot 2021-12-07 at 3 20 46 PM" src="https://user-images.githubusercontent.com/1087943/145104528-587c6015-7386-49eb-a43e-8d028a6e1ff7.png">

**Additional effect**

Workflow errors that are not explicitly converted to the non-retried `RawlsFatalExceptionWithErrorReport` form will only be retried 10 times per Rawls JVM lifetime, down from infinite retries with the previous implementation. This does still mean we will get 10 retries every time we deploy but it's a lot better than infinite and we can't fix everything at once.

[0]
```
version development

workflow null_item_in_output_array {

  input {
    Int? int_in = None
  }

  output {
    Array[String?] out = ["asdf", "wasd", "qwerty", int_in]
  }

}
```