### PR TITLE
DO NOT MERGE: parallel sharding migration [AJ-21]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -98,9 +98,10 @@ object Boot extends IOApp with LazyLogging {
              this codebase simply issues small SQL statements ('call storedProc()') and all the
              actual data processing happens in the db
         7. manually verify that all shards migrated properly
-        8. drop and re-create the ENTITY_ATTRIBUTE_archived table; this is equivalent to deleting all its rows.
+        8. back up the db again
+        9. drop and re-create the ENTITY_ATTRIBUTE_archived table; this is equivalent to deleting all its rows.
              This step is necessary, else the liquibase migration will fail because the table is not found.
-        9. shut down your local Rawls, and re-comment the "parallelShardingMigration.migrate()" line for safety
+        10. shut down your local Rawls, and re-comment the "parallelShardingMigration.migrate()" line for safety
      */
     val parallelShardingMigration = new ParallelShardingMigration(slickDataSource)
     // parallelShardingMigration.migrate()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -91,7 +91,8 @@ object Boot extends IOApp with LazyLogging {
         2. Render configs for the environment you want to migrate (prod, alpha, dev, etc)
         3. back up the db in that env
         4. uncomment the "parallelShardingMigration.migrate()" line below
-        5. manually increase the slick.db.connectionTimeout value to avoid db connection issues
+        5. manually increase the slick.db.connectionTimeout value to avoid db connection issues, and
+          manually set slick.db.leakDetectionThreshold to 0 to avoid spurious leak warnings
         6. run this branch locally, connecting to the db. It's ok to run locally; this codebase simply issues
           small SQL statements ('call storedProc()') and all the actual data processing happens in the db
         7. manually verify that all shards migrated properly

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -90,16 +90,17 @@ object Boot extends IOApp with LazyLogging {
         1. Check out this branch locally
         2. Render configs for the environment you want to migrate (prod, alpha, dev, etc)
         3. back up the db in that env
-        4. uncomment the "parallelShardingMigration.migrate()" line below
-        5. manually increase the slick.db.connectionTimeout value to avoid db connection issues, and
-          manually set slick.db.leakDetectionThreshold to 0 to avoid spurious leak warnings
-        6. run this branch locally, connecting to the db. It's ok to run locally; this codebase simply issues
-          small SQL statements ('call storedProc()') and all the actual data processing happens in the db
+        4. change the nThreads val in ParallelShardingMigration to an appropriate value for your env
+        5. uncomment the "parallelShardingMigration.migrate()" line below
+        6. manually increase the slick.db.connectionTimeout value to avoid db connection issues, and
+             manually set slick.db.leakDetectionThreshold to 0 to avoid spurious leak warnings
+        6. run this branch locally, connecting to the db. You don't have to run on a beefy server;
+             this codebase simply issues small SQL statements ('call storedProc()') and all the
+             actual data processing happens in the db
         7. manually verify that all shards migrated properly
         8. drop and re-create the ENTITY_ATTRIBUTE_archived table; this is equivalent to deleting all its rows.
-          This step is necessary, else the liquibase migration will fail because the table is not found.
+             This step is necessary, else the liquibase migration will fail because the table is not found.
         9. shut down your local Rawls, and re-comment the "parallelShardingMigration.migrate()" line for safety
-        TODO: validate the SQL in ParallelShardingMigration.migrateShardImpl
      */
     val parallelShardingMigration = new ParallelShardingMigration(slickDataSource)
     // parallelShardingMigration.migrate()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -91,12 +91,13 @@ object Boot extends IOApp with LazyLogging {
         2. Render configs for the environment you want to migrate (prod, alpha, dev, etc)
         3. back up the db in that env
         4. uncomment the "parallelShardingMigration.migrate()" line below
-        5. run this branch locally, connecting to the db. It's ok to run locally; this codebase simply issues
+        5. manually increase the slick.db.connectionTimeout value to avoid db connection issues
+        6. run this branch locally, connecting to the db. It's ok to run locally; this codebase simply issues
           small SQL statements ('call storedProc()') and all the actual data processing happens in the db
-        6. manually verify that all shards migrated properly
-        7. drop and re-create the ENTITY_ATTRIBUTE_archived table; this is equivalent to deleting all its rows.
+        7. manually verify that all shards migrated properly
+        8. drop and re-create the ENTITY_ATTRIBUTE_archived table; this is equivalent to deleting all its rows.
           This step is necessary, else the liquibase migration will fail because the table is not found.
-        8. shut down your local Rawls, and re-comment the "parallelShardingMigration.migrate()" line for safety
+        9. shut down your local Rawls, and re-comment the "parallelShardingMigration.migrate()" line for safety
         TODO: validate the SQL in ParallelShardingMigration.migrateShardImpl
      */
     val parallelShardingMigration = new ParallelShardingMigration(slickDataSource)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/ParallelShardingMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/ParallelShardingMigration.scala
@@ -1,0 +1,68 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import slick.jdbc.TransactionIsolation
+
+import java.util.concurrent.Executors
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
+
+
+class ParallelShardingMigration(slickDataSource: SlickDataSource) extends LazyLogging {
+
+  import slickDataSource.dataAccess.driver.api._
+
+  // thread pool with 24 threads to match the 24 CPUs in the prod db
+  val threadPool = Executors.newFixedThreadPool(24)
+  implicit val fixedThreadPool: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(threadPool)
+
+  def migrate() = {
+    // migrate all shards - except for "_archived". This will include the 4 shards we already migrated, but
+    // those will be quick no-ops.
+    val shardsToMigrate = (slickDataSource.dataAccess.allShards - "archived").toSeq.sorted
+
+    val migrationResults = Future.traverse(shardsToMigrate) { shardId => migrateShard(shardId) }
+
+    val res = Await.result(migrationResults, Duration.Inf)
+    logger.warn(s"******* res: $res")
+
+    // now that all shards have migrated - and ONLY if they all succeeded - drop and recreate the _archived table
+    // That should be a manual step to ensure a human is looking at the results and we don't
+    // have any risk of losing data
+  }
+
+  // this shenanigans around futures and blocking makes it easy to use the Future.traverse above
+  private def migrateShard(shardId: String): Future[String] = {
+    Future(migrateShardImpl(shardId))
+  }
+
+  private def migrateShardImpl(shardId: String): String = {
+    val tick = System.currentTimeMillis()
+    logger.warn(s"migration for shard $shardId starting ...")
+
+    // TODO: swap from the 'select count' sql to the 'call stored proc' sql ONLY when ready to actually migrate
+    // TODO: verify that the call to populateShardAndMarkAsSharded($shardId); works as intended here in Scala (we
+    //        know it works in the db)
+    val sql = sql"""select count(1) from ENTITY_ATTRIBUTE_#$shardId;""".as[String]
+    // val sql = sql"""call populateShardAndMarkAsSharded($shardId);""".as[String]
+
+    // ReadCommitted here? Since we intend this to run while Rawls as a whole is down, and no other db activity,
+    // it really shouldn't matter
+    val transaction = sql
+      .transactionally
+      .withTransactionIsolation(TransactionIsolation.ReadCommitted)
+
+    val transactionRun = slickDataSource.database.run(transaction)
+
+    // block for the result, helps with concurrency
+    val procResult = Await.result(transactionRun, Duration.Inf).head
+
+    val elapsed = System.currentTimeMillis() - tick
+
+    logger.warn(s"migration for shard $shardId done in $elapsed ms: $procResult")
+    s"$shardId: $procResult"
+  }
+
+}
+

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/ParallelShardingMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/ParallelShardingMigration.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import slick.jdbc.TransactionIsolation
 
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutorService, Future}
 
@@ -13,14 +14,24 @@ class ParallelShardingMigration(slickDataSource: SlickDataSource) extends LazyLo
 
   import slickDataSource.dataAccess.driver.api._
 
-  // thread pool with 24 threads to match the 24 CPUs in the prod db
-  val threadPool = Executors.newFixedThreadPool(24)
+  // prod db has 24 CPUs, that's the ideal for number of threads
+  // NB increase slick.db.connectionTimeout setting to avoid "Connection is not available" errors
+  val nThreads = 24
+  val threadPool = Executors.newFixedThreadPool(nThreads)
   implicit val fixedThreadPool: ExecutionContextExecutorService = ExecutionContext.fromExecutorService(threadPool)
+
+  // note: var!
+  var migrationsRunning: AtomicInteger = new AtomicInteger(0)
+  var shardsStarted: AtomicInteger = new AtomicInteger(0)
+  var shardsFinished: AtomicInteger = new AtomicInteger(0)
+
+  val shardsToMigrate = (slickDataSource.dataAccess.allShards - "archived").toSeq.sorted
+  val nShards = shardsToMigrate.size
 
   def migrate() = {
     // migrate all shards - except for "_archived". This will include the 4 shards we already migrated, but
     // those will be quick no-ops.
-    val shardsToMigrate = (slickDataSource.dataAccess.allShards - "archived").toSeq.sorted
+    logger.warn(s"migration of $nShards shards starting.")
 
     val migrationResults = Future.traverse(shardsToMigrate) { shardId => migrateShard(shardId) }
 
@@ -39,7 +50,19 @@ class ParallelShardingMigration(slickDataSource: SlickDataSource) extends LazyLo
 
   private def migrateShardImpl(shardId: String): String = {
     val tick = System.currentTimeMillis()
-    logger.warn(s"migration for shard $shardId starting ...")
+
+    shardsStarted.incrementAndGet()
+    migrationsRunning.incrementAndGet()
+
+    // this is expensive, just for logging. Remove the counts?
+    val countSql =
+      sql"""select count(1) from ENTITY_ATTRIBUTE_archived ea, ENTITY e, WORKSPACE w
+              WHERE e.workspace_id = w.id
+              AND ea.owner_id = e.id
+              AND shardIdentifier(hex(w.id)) = $shardId;""".as[Int]
+    val countResult = Await.result(runSql(countSql), Duration.Inf).head
+
+    logger.warn(s"[$shardId] migration for shard $shardId starting ($shardsStarted/$nShards started, $shardsFinished/$nShards finished, $migrationsRunning/$nThreads threads in use). $countResult rows to migrate ...")
 
     // TODO: swap from the 'select count' sql to the 'call stored proc' sql ONLY when ready to actually migrate
     // TODO: verify that the call to populateShardAndMarkAsSharded($shardId); works as intended here in Scala (we
@@ -47,21 +70,27 @@ class ParallelShardingMigration(slickDataSource: SlickDataSource) extends LazyLo
     val sql = sql"""select count(1) from ENTITY_ATTRIBUTE_#$shardId;""".as[String]
     // val sql = sql"""call populateShardAndMarkAsSharded($shardId);""".as[String]
 
+    // block for the result, helps with concurrency
+    val procResult = Await.result(runSql(sql), Duration.Inf).head
+
+    val elapsed = System.currentTimeMillis() - tick
+
+    shardsFinished.incrementAndGet()
+    migrationsRunning.decrementAndGet()
+
+    logger.warn(s"[$shardId] migration for shard $shardId done     ($shardsStarted/$nShards started, $shardsFinished/$nShards finished, $migrationsRunning/$nThreads threads in use) in $elapsed ms: $procResult")
+    s"$shardId: $procResult"
+
+  }
+
+  private def runSql[T](sql: ReadWriteAction[T]) = {
     // ReadCommitted here? Since we intend this to run while Rawls as a whole is down, and no other db activity,
     // it really shouldn't matter
     val transaction = sql
       .transactionally
       .withTransactionIsolation(TransactionIsolation.ReadCommitted)
 
-    val transactionRun = slickDataSource.database.run(transaction)
-
-    // block for the result, helps with concurrency
-    val procResult = Await.result(transactionRun, Duration.Inf).head
-
-    val elapsed = System.currentTimeMillis() - tick
-
-    logger.warn(s"migration for shard $shardId done in $elapsed ms: $procResult")
-    s"$shardId: $procResult"
+    slickDataSource.database.run(transaction)
   }
 
 }


### PR DESCRIPTION
DO NOT RUN THIS BRANCH WITHOUT UNDERSTANDING IT

DO NOT MERGE THIS BRANCH. It is intended to be run manually, not merged into the main codestream. I am leaving this PR as draft to prevent merging.

This branch migrates entity attribute data for all unsharded workspaces to shards. It migrates N shards in parallel via a Scala ExecutionContext. We do this parallel migration because it is significantly faster than a liquibase migration; liquibase is purely serial. See the parent ticket AJ-21 for context.

The settings (number of threads, order of shards) is configured for the dev environment. Next up is testing against a prod clone, after which some settings may change but I do not expect (I hope!) that the code will not change in any significant way.

There is a lot of `Await.result` and blocking in this PR. I am prioritizing easy-to-understand code over concurrency and thread-optimization; this branch should only be run by a single developer, and the code in question runs before Rawls even opens itself up for requests. Since we are not merging this code I am ok with "bad practice" patterns like `Await`.

If you want to see what a migration looks like using this branch, here is an example rawls log:
[migration2.log](https://github.com/broadinstitute/rawls/files/7842413/migration2.log)

