### PR TITLE
enable new attribute namespaces [AS-1040]

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -85,8 +85,14 @@ object AttributeName {
   val libraryNamespace = "library"
   val tagsNamespace = "tag"
   val pfbNamespace = "pfb"
+  val importNamespace = "import"
+  val systemNamespace = "system"
+  val sysNamespace = "sys"
+  val tdrNamespace = "tdr"
+
   // removed library from the set because these attributes should no longer be set with updateWorkspace
-  val validNamespaces = Set(AttributeName.defaultNamespace, AttributeName.tagsNamespace, AttributeName.pfbNamespace)
+  val validNamespaces = Set(AttributeName.defaultNamespace, AttributeName.tagsNamespace, AttributeName.pfbNamespace,
+    AttributeName.importNamespace, AttributeName.systemNamespace, AttributeName.sysNamespace, AttributeName.tdrNamespace)
 
   val delimiter = ':'
 


### PR DESCRIPTION
This enables new namespace options for attributes: `import`, `system`, `sys`, and `tdr`.

As of this writing we are still discussing which of these will actually be used by TDR import-by-copy. Once that decision is made, I can either update this PR or leave it as-is and keep the additional namespaces for future use.