### PR TITLE
remove already-migrated rows from archived table

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -100,4 +100,5 @@
     <include file="changesets/20211129_v1_migration_temporary_bucket.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211206_v1_migration_google_project.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211209_v1_migration_final_bucket.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220106_delete_already_migrated_shards.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220106_delete_already_migrated_shards.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220106_delete_already_migrated_shards.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="davidan" id="delete_already_migrated_shards">
+        <!--
+            rows in ENTITY_ATTRIBUTE_archived that were already copied to shards in
+            20210924_populate_sharded_entity_tables.xml should now be deleted.
+            This migration is expected to take some time to run.
+        -->
+        <sql stripComments="true">
+            delete ea from ENTITY_ATTRIBUTE_archived ea, ENTITY e, WORKSPACE w
+            WHERE e.workspace_id = w.id
+            AND ea.owner_id = e.id
+            AND w.shard_state = 'Sharded';
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
do not merge yet, if we migrate all shards we don't need this. It's here as a fallback in case we need more time to roll out the all-shard migration.