### PR TITLE
update shard procedures [AS-1053]

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -100,4 +100,5 @@
     <include file="changesets/20211129_v1_migration_temporary_bucket.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211206_v1_migration_google_project.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211209_v1_migration_final_bucket.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220107_update_shard_procedures.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220107_update_shard_procedures.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220107_update_shard_procedures.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <!-- create db functions and stored procedures that will help with the db migration -->
+    <changeSet logicalFilePath="dummy" author="davidan" id="update_shard_functions_and_procedures">
+        <sql stripComments="true" endDelimiter="~">
+            -- procedure to copy rows from ENTITY_ATTRIBUTE_archived to the appropriate shard table,
+            -- based on the attributes' owning workspace
+            DROP PROCEDURE IF EXISTS copyRowsToAttributeShard ~
+            CREATE PROCEDURE copyRowsToAttributeShard(IN shardIdentifier CHAR(5))
+            BEGIN
+                SET @tableSuffix := shardIdentifier;
+
+                SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+                SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+                SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
+
+                SET @sql_text:=CONCAT('INSERT INTO ENTITY_ATTRIBUTE_',@tableSuffix,'(name, value_string, value_number, value_boolean,'
+                    ' value_entity_ref, list_index, owner_id, list_length, namespace, VALUE_JSON, deleted, deleted_date)'
+                    'SELECT ea.name, ea.value_string, ea.value_number, ea.value_boolean,'
+                    ' ea.value_entity_ref, ea.list_index, ea.owner_id, ea.list_length, ea.namespace, ea.VALUE_JSON, ea.deleted, ea.deleted_date'
+                    ' FROM ENTITY_ATTRIBUTE_archived ea, ENTITY e, WORKSPACE w'
+                    ' WHERE e.workspace_id = w.id'
+                    ' AND ea.owner_id = e.id'
+                    ' AND w.shard_state = ''unsharded'''
+                    ' AND shardIdentifier(hex(w.id)) = ''',@tableSuffix,''''
+                    ' ORDER BY ea.id;');
+                PREPARE stmt from @sql_text;
+                EXECUTE stmt;
+
+                SET SQL_MODE=@OLD_SQL_MODE;
+                SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+                SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+
+            END ~
+        </sql>
+        <rollback>
+            DROP PROCEDURE IF EXISTS copyRowsToAttributeShard;
+        </rollback>
+    </changeSet>
+
+
+</databaseChangeLog>


### PR DESCRIPTION
compared to the previous iteration of the `copyRowsToAttributeShard` stored procedure ([link](https://github.com/broadinstitute/rawls/blob/a4bdc468fad3ffb166c7e7291d01e5ba0e94ba2e/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210924_sharded_entity_tables.xml#L59-L86)), this PR changes:
1. only copy rows for workspaces that are currently unsharded; this avoids duplication for the workspaces we previously migrated
2. don't attempt to reuse the primary keys for attribute rows. These PKs are not user-facing and it doesn't matter if they change. If we try to reuse them, we run the (real) risk of id conflicts between rows we're migrating and rows already created inside shards.

I wish there was a good way to diff this PR against the previous liquibase changeset, I can't think of a way to do that in github web UI.

This change is a prereq to rolling out all workspaces to a sharded state.