### PR TITLE
CA-1669 Do not update Billing Account information if the current value on Google does not match what Rawls thinks it should be

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -130,7 +130,10 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
     */
   def listBillingAccountsUsingServiceCredential(implicit executionContext: ExecutionContext): Future[Seq[RawlsBillingAccount]]
 
-  def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId, newBillingAccount: Option[RawlsBillingAccountName], oldBillingAccount: Option[RawlsBillingAccountName]): Future[ProjectBillingInfo]
+  def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId,
+                                        newBillingAccount: Option[RawlsBillingAccountName],
+                                        oldBillingAccount: Option[RawlsBillingAccountName],
+                                        force: Boolean = false): Future[ProjectBillingInfo]
 
   def getBillingAccountIdForGoogleProject(googleProject: GoogleProject, userInfo: UserInfo)(implicit executionContext: ExecutionContext): Future[Option[String]]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -130,7 +130,7 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
     */
   def listBillingAccountsUsingServiceCredential(implicit executionContext: ExecutionContext): Future[Seq[RawlsBillingAccount]]
 
-  def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId, newBillingAccount: Option[RawlsBillingAccountName]): Future[ProjectBillingInfo]
+  def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId, newBillingAccount: Option[RawlsBillingAccountName], oldBillingAccount: Option[RawlsBillingAccountName]): Future[ProjectBillingInfo]
 
   def getBillingAccountIdForGoogleProject(googleProject: GoogleProject, userInfo: UserInfo)(implicit executionContext: ExecutionContext): Future[Option[String]]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -725,7 +725,7 @@ class HttpGoogleServicesDAO(
           Option(RawlsBillingAccountName(projectBillingInfo.getBillingAccountName))
 
         // Check actual Billing Account value from google against the value that Rawls thinks it should be before the update
-        if (oldBillingAccount != currentBillingAccountFromGoogle) {
+        if (!force && (oldBillingAccount != currentBillingAccountFromGoogle)) {
           throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.PreconditionFailed,
             s"Could not update Billing Account on Google Project ID ${googleProjectId} to Billing Account ${newBillingAccount} because Billing Account in Rawls ${oldBillingAccount} did not equal current Billing Account in Google ${projectBillingInfo.getBillingAccountName}"))
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -688,7 +688,7 @@ class HttpGoogleServicesDAO(
     * Terra users should not have IAM permissions to change the Billing Account on their Terra managed Google Projects
     * directly on Google.  However, Billing Account Admins (who may know nothing about Terra) _can_ at least remove
     * their Billing Account from Terra managed Google Projects as a means of disabling billing.  See https://broadworkbench.atlassian.net/browse/CA-1585
-    * TODO: Refactor method.  A decent amount of business logic has crept into this method and is currently untested as a result.
+    * TODO: Refactor method: https://broadworkbench.atlassian.net/browse/CA-1673.  A decent amount of business logic has crept into this method and is currently untested as a result.
     *
     * @param googleProjectId - Google Project ID that the Billing Account will be changed on
     * @param newBillingAccount - The new value we want to set on the project

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -312,17 +312,17 @@ trait WorkspaceComponent {
       loadWorkspaces(workspaces)
     }
 
-    def listWorkspaceGoogleProjectsToUpdateWithNewBillingAccount(): ReadAction[Set[(GoogleProjectId, Option[RawlsBillingAccountName])]] = {
+    def listWorkspaceGoogleProjectsToUpdateWithNewBillingAccount(): ReadAction[Set[(GoogleProjectId, Option[RawlsBillingAccountName], Option[RawlsBillingAccountName])]] = {
       val query = for {
         billingProject <- rawlsBillingProjectQuery if !billingProject.invalidBillingAccount
         workspace <- workspaceQuery if workspace.namespace === billingProject.projectName &&
           workspace.billingAccountErrorMessage.isEmpty &&
           (workspace.currentBillingAccountOnGoogleProject =!= billingProject.billingAccount ||
             workspace.currentBillingAccountOnGoogleProject.isEmpty =!= billingProject.billingAccount.isEmpty)
-      } yield (workspace.googleProjectId, billingProject.billingAccount)
+      } yield (workspace.googleProjectId, billingProject.billingAccount, workspace.currentBillingAccountOnGoogleProject)
       query.result.map(results => results.map {
-        case (googleProjectId, newBillingAccount) =>
-          (GoogleProjectId(googleProjectId), newBillingAccount.map(RawlsBillingAccountName))
+        case (googleProjectId, newBillingAccount, fromWorkspaceBillingAccount) =>
+          (GoogleProjectId(googleProjectId), newBillingAccount.map(RawlsBillingAccountName), fromWorkspaceBillingAccount.map(RawlsBillingAccountName))
       }.toSet)
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceBillingAccountMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceBillingAccountMonitor.scala
@@ -44,7 +44,7 @@ class WorkspaceBillingAccountMonitor(dataSource: SlickDataSource, gcsDAO: Google
               // We do not want to throw e here. traverse stops executing as soon as it encounters a Failure, but we
               // want to continue traversing the list to update the rest of the google project billing accounts even
               // if one of the update operations fails.
-              logger.warn(s"Failed to update billing account on $googleProjectId to $newBillingAccount", e)
+              logger.warn(s"Failed to update billing account from ${oldBillingAccount}to ${newBillingAccount} on project $googleProjectId", e)
               ()
             }
             case Right(res) => res
@@ -69,12 +69,12 @@ class WorkspaceBillingAccountMonitor(dataSource: SlickDataSource, gcsDAO: Google
           dataSource.inTransaction { dataAccess =>
             dataAccess.workspaceQuery.updateWorkspaceBillingAccountErrorMessages(googleProjectId, e.getMessage)
           }.map { _ =>
-            logger.error(s"Failure to set the billing account on ${googleProjectId} to ${newBillingAccount.get}", e)
+            logger.error(s"Failure while trying to update Billing Account from ${oldBillingAccount} to ${newBillingAccount} on Google Project ${googleProjectId}", e)
             throw e
           }
       }
       dbResult <- dataSource.inTransaction( { dataAccess =>
-        logger.info(s"Updating billing account on ${googleProjectId} to ${newBillingAccount}")
+        logger.info(s"Updating Billing Account from ${oldBillingAccount} to ${newBillingAccount} on all Workspaces in Google Project ${googleProjectId}")
         dataAccess.workspaceQuery.updateWorkspaceBillingAccount(googleProjectId, newBillingAccount)
       })
     } yield dbResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1984,7 +1984,8 @@ class WorkspaceService(protected val userInfo: UserInfo,
 
       _ = logger.info(s"Setting up billing account for ${googleProjectId}.")
       _ <- traceWithParent("updateGoogleProjectBillingAccount", span) { _ =>
-        gcsDAO.updateGoogleProjectBillingAccount(googleProjectId, Option(billingAccount))
+        // TODO: CA-1669 Either we implement a "force BA update" option, or we need to know the BA that is used for all RBS projects at creation time
+        gcsDAO.updateGoogleProjectBillingAccount(googleProjectId, Option(billingAccount), ???)
       }
 
       _ = logger.info(s"Creating labels for ${googleProjectId}.")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1982,10 +1982,11 @@ class WorkspaceService(protected val userInfo: UserInfo,
         maybeMoveGoogleProjectToFolder(billingProject.servicePerimeter, googleProjectId)
       }
 
-      _ = logger.info(s"Setting up billing account for ${googleProjectId}.")
+      _ = logger.info(s"Setting billing account for ${googleProjectId} to ${billingAccount} replacing the RBS billing account.")
       _ <- traceWithParent("updateGoogleProjectBillingAccount", span) { _ =>
-        // TODO: CA-1669 Either we implement a "force BA update" option, or we need to know the BA that is used for all RBS projects at creation time
-        gcsDAO.updateGoogleProjectBillingAccount(googleProjectId, Option(billingAccount), ???)
+        // Since we don't necessarily know what the RBS Billing Account is, we need to bypass the "oldBillingAccount"
+        // check when updating the Billing Account on the project
+        gcsDAO.updateGoogleProjectBillingAccount(googleProjectId, Option(billingAccount), None, force = true)
       }
 
       _ = logger.info(s"Creating labels for ${googleProjectId}.")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -250,7 +250,10 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(billingAccount == accessibleBillingAccountName)
   }
 
-  override def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId, newBillingAccount: Option[RawlsBillingAccountName], oldBillingAccount: Option[RawlsBillingAccountName]): Future[ProjectBillingInfo] = {
+  override def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId,
+                                                 newBillingAccount: Option[RawlsBillingAccountName],
+                                                 oldBillingAccount: Option[RawlsBillingAccountName],
+                                                 force: Boolean = false): Future[ProjectBillingInfo] = {
     Future.successful(new ProjectBillingInfo().setBillingAccountName(newBillingAccount.map(_.value).getOrElse("")).setProjectId(googleProjectId.value))
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -250,7 +250,7 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(billingAccount == accessibleBillingAccountName)
   }
 
-  override def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId, newBillingAccount: Option[RawlsBillingAccountName]): Future[ProjectBillingInfo] = {
+  override def updateGoogleProjectBillingAccount(googleProjectId: GoogleProjectId, newBillingAccount: Option[RawlsBillingAccountName], oldBillingAccount: Option[RawlsBillingAccountName]): Future[ProjectBillingInfo] = {
     Future.successful(new ProjectBillingInfo().setBillingAccountName(newBillingAccount.map(_.value).getOrElse("")).setProjectId(googleProjectId.value))
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceBillingAccountMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceBillingAccountMonitorSpec.scala
@@ -74,8 +74,8 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
 
   it should "not endlessly retry when it fails to update a billing account" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, Option(defaultBillingAccountName), None, googleProjectNumber = Option(defaultGoogleProjectNumber))
-      val originalBillingAccount: Option[RawlsBillingAccountName] = billingProject.billingAccount
+      val originalBillingAccount = Option(defaultBillingAccountName)
+      val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, originalBillingAccount, None, googleProjectNumber = Option(defaultGoogleProjectNumber))
       val v1Workspace = Workspace(billingProject.projectName.value, "v1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val v2Workspace = Workspace(billingProject.projectName.value, "v2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val badWorkspaceGoogleProjectId = GoogleProjectId("very bad")
@@ -111,8 +111,8 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
   // TODO: CA-1235 Remove during cleanup once all workspaces have their own Google project
   it should "propagate error messages to all workspaces in a Google project" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, Option(defaultBillingAccountName), None, googleProjectNumber = Option(defaultGoogleProjectNumber))
-      val originalBillingAccount = billingProject.billingAccount
+      val originalBillingAccount = Option(defaultBillingAccountName)
+      val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, originalBillingAccount, None, googleProjectNumber = Option(defaultGoogleProjectNumber))
       val v1Workspace = Workspace(billingProject.projectName.value, "v1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val v2Workspace = Workspace(billingProject.projectName.value, "v2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val secondV1Workspace = Workspace(billingProject.projectName.value, "second", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
@@ -150,8 +150,8 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
 
   it should "mark a billing project's billing account as invalid if Google returns a 403" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, Option(defaultBillingAccountName), None, googleProjectNumber = Option(defaultGoogleProjectNumber))
-      val originalBillingAccount = billingProject.billingAccount
+      val originalBillingAccount = Option(defaultBillingAccountName)
+      val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, originalBillingAccount, None, googleProjectNumber = Option(defaultGoogleProjectNumber))
       val v1Workspace = Workspace(billingProject.projectName.value, "v1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val v2Workspace = Workspace(billingProject.projectName.value, "v2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val newBillingAccount = RawlsBillingAccountName("new-ba")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceBillingAccountMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceBillingAccountMonitorSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.monitor
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.testkit.TestKit
+import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.model._
@@ -85,7 +86,11 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
       val failingGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val failureMessage = "because I feel like it"
       val exception = new RawlsException(failureMessage)
-      when(failingGcsDAO.updateGoogleProjectBillingAccount(ArgumentMatchers.eq(badWorkspace.googleProjectId), ArgumentMatchers.eq(Option(newBillingAccount)), any[Option[RawlsBillingAccountName]], any[Boolean]))
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        ArgumentMatchers.eq(badWorkspace.googleProjectId),
+        ArgumentMatchers.eq(Option(newBillingAccount)),
+        any[Option[RawlsBillingAccountName]],
+        any[Boolean]))
         .thenReturn(Future.failed(exception))
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
@@ -108,32 +113,49 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Option(defaultBillingAccountName)
       val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, originalBillingAccount, None, googleProjectNumber = Option(defaultGoogleProjectNumber))
-      val v1Workspace = Workspace(billingProject.projectName.value, "v1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
-      val v2Workspace = Workspace(billingProject.projectName.value, "v2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
+      val workspace1 = Workspace(billingProject.projectName.value, "workspace1", UUID.randomUUID().toString, "bucketName1", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
+      val workspace2 = Workspace(billingProject.projectName.value, "workspace2", UUID.randomUUID().toString, "bucketName2", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
       val badWorkspaceGoogleProjectId = GoogleProjectId("very bad")
       val badWorkspace = Workspace(billingProject.projectName.value, "bad", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, badWorkspaceGoogleProjectId, Option(GoogleProjectNumber("44")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
 
       val newBillingAccount = RawlsBillingAccountName("new-ba")
 
 
+      // Going to set up some mocking.  In this case, we need to make sure that there is a mock that will catch each of
+      // the different param combinations we might pass to it.  Per Mockito docs, the last last match is the one that
+      // will be used which is why we have the "generic" case first.
       val failingGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+
+      // "generic" matcher will catch all calls to this method that don't match the "exception" case below
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        any[GoogleProjectId],
+        any[Option[RawlsBillingAccountName]],
+        any[Option[RawlsBillingAccountName]],
+        any[Boolean]
+      )).thenReturn(Future.successful(new ProjectBillingInfo()))
+
       val failureMessage = "because I feel like it"
       val exception = new RawlsException(failureMessage)
-      when(failingGcsDAO.updateGoogleProjectBillingAccount(ArgumentMatchers.eq(badWorkspace.googleProjectId), ArgumentMatchers.eq(Option(newBillingAccount)), any[Option[RawlsBillingAccountName]], any[Boolean]))
+      // the "exception" case.  When method is called with these specific params, we want to Fail the Future.
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        ArgumentMatchers.eq(badWorkspace.googleProjectId),
+        ArgumentMatchers.eq(Option(newBillingAccount)),
+        any[Option[RawlsBillingAccountName]],
+        any[Boolean]))
         .thenReturn(Future.failed(exception))
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
-      runAndWait(workspaceQuery.createOrUpdate(v1Workspace))
-      runAndWait(workspaceQuery.createOrUpdate(v2Workspace))
+      runAndWait(workspaceQuery.createOrUpdate(workspace1))
+      runAndWait(workspaceQuery.createOrUpdate(workspace2))
       runAndWait(workspaceQuery.createOrUpdate(badWorkspace))
       runAndWait(rawlsBillingProjectQuery.updateBillingAccount(billingProject.projectName, Option(newBillingAccount)))
 
       val actor = createWorkspaceBillingAccountMonitor(dataSource, failingGcsDAO)
 
       eventually (timeout = timeout(Span(10, Seconds))) {
-        runAndWait(workspaceQuery.findByName(v1Workspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
+        runAndWait(workspaceQuery.findByName(workspace1.toWorkspaceName)).getOrElse(fail("workspace not found"))
           .currentBillingAccountOnGoogleProject shouldBe Option(newBillingAccount)
-        runAndWait(workspaceQuery.findByName(v2Workspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
+        runAndWait(workspaceQuery.findByName(workspace2.toWorkspaceName)).getOrElse(fail("workspace not found"))
           .currentBillingAccountOnGoogleProject shouldBe Option(newBillingAccount)
         runAndWait(workspaceQuery.findByName(badWorkspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
           .billingAccountErrorMessage shouldBe Option(failureMessage)
@@ -148,21 +170,35 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Option(defaultBillingAccountName)
       val billingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, originalBillingAccount, None, googleProjectNumber = Option(defaultGoogleProjectNumber))
-      val v1Workspace = Workspace(billingProject.projectName.value, "v1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
-      val v2Workspace = Workspace(billingProject.projectName.value, "v2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
-      val secondV1Workspace = Workspace(billingProject.projectName.value, "second", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
+      val firstV1Workspace  = Workspace(billingProject.projectName.value, "first-v1-workspace",  UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
+      val secondV1Workspace = Workspace(billingProject.projectName.value, "second-v1-workspace", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V1, GoogleProjectId(billingProject.projectName.value), billingProject.googleProjectNumber, originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
+      val v2Workspace = Workspace(billingProject.projectName.value, "v2 workspace", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator@example.com", Map.empty, false, WorkspaceVersions.V2, GoogleProjectId("differentId"), Option(GoogleProjectNumber("43")), originalBillingAccount, None, Option(DateTime.now), WorkspaceShardStates.Sharded)
 
       val newBillingAccount = RawlsBillingAccountName("new-ba")
 
-
       val failingGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+
+      // We are going to mock this method that will get called multiple times with different params.  Need to implement
+      // a "catch-all" mock first before implementing a specific param matcher that will change the behavior.  Last
+      // matching param list wins per Mockito docs
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        any[GoogleProjectId],
+        any[Option[RawlsBillingAccountName]],
+        any[Option[RawlsBillingAccountName]],
+        any[Boolean]
+      )).thenReturn(Future.successful(new ProjectBillingInfo()))
+
       val failureMessage = "because I feel like it"
       val exception = new RawlsException(failureMessage)
-      when(failingGcsDAO.updateGoogleProjectBillingAccount(secondV1Workspace.googleProjectId, Option(newBillingAccount), Option(any[RawlsBillingAccountName])))
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        secondV1Workspace.googleProjectId,
+        Option(newBillingAccount),
+        originalBillingAccount,
+        false))
         .thenReturn(Future.failed(exception))
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
-      runAndWait(workspaceQuery.createOrUpdate(v1Workspace))
+      runAndWait(workspaceQuery.createOrUpdate(firstV1Workspace))
       runAndWait(workspaceQuery.createOrUpdate(v2Workspace))
       runAndWait(workspaceQuery.createOrUpdate(secondV1Workspace))
       runAndWait(rawlsBillingProjectQuery.updateBillingAccount(billingProject.projectName, Option(newBillingAccount)))
@@ -172,12 +208,16 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
       eventually (timeout = timeout(Span(10, Seconds))) {
         runAndWait(workspaceQuery.findByName(secondV1Workspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
           .billingAccountErrorMessage shouldBe Option(failureMessage)
-        runAndWait(workspaceQuery.findByName(v1Workspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
+        runAndWait(workspaceQuery.findByName(firstV1Workspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
           .billingAccountErrorMessage shouldBe Option(failureMessage)
         runAndWait(workspaceQuery.findByName(v2Workspace.toWorkspaceName)).getOrElse(fail("workspace not found"))
           .billingAccountErrorMessage shouldBe None
       }
-      verify(failingGcsDAO, times(1)).updateGoogleProjectBillingAccount(secondV1Workspace.googleProjectId, Option(newBillingAccount), originalBillingAccount)
+      // Note the final boolean on this "verify".  That is important because during initial workspace creation, the
+      // "force" boolean will be true and we do not want to count those calls during this assertion.  We only want to
+      // count the number of times this was called from the WorkspaceBillingAccountMonitor spec, and in that case, the
+      // "force" boolean will be false.
+      verify(failingGcsDAO, times(1)).updateGoogleProjectBillingAccount(secondV1Workspace.googleProjectId, Option(newBillingAccount), originalBillingAccount, false)
 
       system.stop(actor)
     }
@@ -192,9 +232,24 @@ class WorkspaceBillingAccountMonitorSpec(_system: ActorSystem) extends TestKit(_
       val newBillingAccount = RawlsBillingAccountName("new-ba")
 
       val failingGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+
+      // We are going to mock this method that will get called multiple times with different params.  Need to implement
+      // a "catch-all" mock first before implementing a specific param matcher that will change the behavior.  Last
+      // matching param list wins per Mockito docs
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        any[GoogleProjectId],
+        any[Option[RawlsBillingAccountName]],
+        any[Option[RawlsBillingAccountName]],
+        any[Boolean]
+      )).thenReturn(Future.successful(new ProjectBillingInfo()))
+
       val failureMessage = "because I feel like it"
       val exception = new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, failureMessage))
-      when(failingGcsDAO.updateGoogleProjectBillingAccount(any[GoogleProjectId], any[Option[RawlsBillingAccountName]], any[Option[RawlsBillingAccountName]]))
+      when(failingGcsDAO.updateGoogleProjectBillingAccount(
+        any[GoogleProjectId],
+        ArgumentMatchers.eq(Option(newBillingAccount)),
+        ArgumentMatchers.eq(originalBillingAccount),
+        ArgumentMatchers.eq(false)))
         .thenReturn(Future.failed(exception))
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1250,7 +1250,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
     // mock(ito) out the workspace creation
     when(services.gcsDAO.testDMBillingAccountAccess(any[RawlsBillingAccountName])).thenReturn(Future.successful(true))
-    when(services.gcsDAO.updateGoogleProjectBillingAccount(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), Option(any[RawlsBillingAccountName]), Option(any[RawlsBillingAccountName])))
+    when(services.gcsDAO.updateGoogleProjectBillingAccount(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), any[Some[RawlsBillingAccountName]], any[Option[RawlsBillingAccountName]], any[Boolean]))
       .thenReturn(Future.successful(new ProjectBillingInfo().setBillingAccountName(testData.workspace.currentBillingAccountOnGoogleProject.map(_.value).getOrElse("")).setProjectId(testData.workspace.googleProjectId.value)))
     when(services.gcsDAO.getGoogleProject(any[GoogleProjectId])).thenReturn(Future.successful(new Project().setProjectNumber(null)))
     when(services.gcsDAO.labelSafeMap(any[Map[String, String]], any[String])).thenReturn(Map.empty[String, String])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1250,7 +1250,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
     // mock(ito) out the workspace creation
     when(services.gcsDAO.testDMBillingAccountAccess(any[RawlsBillingAccountName])).thenReturn(Future.successful(true))
-    when(services.gcsDAO.updateGoogleProjectBillingAccount(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), Option(any[RawlsBillingAccountName])))
+    when(services.gcsDAO.updateGoogleProjectBillingAccount(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), Option(any[RawlsBillingAccountName]), Option(any[RawlsBillingAccountName])))
       .thenReturn(Future.successful(new ProjectBillingInfo().setBillingAccountName(testData.workspace.currentBillingAccountOnGoogleProject.map(_.value).getOrElse("")).setProjectId(testData.workspace.googleProjectId.value)))
     when(services.gcsDAO.getGoogleProject(any[GoogleProjectId])).thenReturn(Future.successful(new Project().setProjectNumber(null)))
     when(services.gcsDAO.labelSafeMap(any[Map[String, String]], any[String])).thenReturn(Map.empty[String, String])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1310,11 +1310,14 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
     // Project ID gets allocated when creating the Workspace, so we don't care what it is here.  We do care that
     // whatever that Google Project is, we set the right Billing Account on it, which is the Billing Account specified
-    // in the Billing Project
-    val billingAccountNameCaptor = captor[RawlsBillingAccountName]
-    // TODO: CA-1669 See TODO from WorkspaceService.scala:1987
-    verify(services.gcsDAO).updateGoogleProjectBillingAccount(any[GoogleProjectId], Option(billingAccountNameCaptor.capture), ???)
-    billingAccountNameCaptor.getValue shouldEqual Option(billingProject.billingAccount.get)
+    // in the Billing Project.  Additionally, only when creating a new Workspace, we can `force` the update (and ignore
+    // the "oldBillingAccount" value
+    verify(services.gcsDAO).updateGoogleProjectBillingAccount(
+      any[GoogleProjectId],
+      ArgumentMatchers.eq(billingProject.billingAccount),
+      any[Option[RawlsBillingAccountName]],
+      ArgumentMatchers.eq(true)
+    )
   }
 
   it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1312,12 +1312,13 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     // whatever that Google Project is, we set the right Billing Account on it, which is the Billing Account specified
     // in the Billing Project
     val billingAccountNameCaptor = captor[RawlsBillingAccountName]
-    verify(services.gcsDAO).updateGoogleProjectBillingAccount(any[GoogleProjectId], Option(billingAccountNameCaptor.capture))
+    // TODO: CA-1669 See TODO from WorkspaceService.scala:1987
+    verify(services.gcsDAO).updateGoogleProjectBillingAccount(any[GoogleProjectId], Option(billingAccountNameCaptor.capture), ???)
     billingAccountNameCaptor.getValue shouldEqual Option(billingProject.billingAccount.get)
   }
 
   it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>
-    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct"))))
+    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct")), Option(any[RawlsBillingAccountName])))
       .thenReturn(Future.failed(new Exception("Fake error from Google")))
 
     val workspaceName = WorkspaceName(testData.testProject1Name.value, "sad_workspace")
@@ -1564,12 +1565,12 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     // whatever that Google Project is, we set the right Billing Account on it, which is the Billing Account specified
     // in the Billing Project
     val billingAccountNameCaptor = captor[RawlsBillingAccountName]
-    verify(services.gcsDAO).updateGoogleProjectBillingAccount(any[GoogleProjectId], Option(billingAccountNameCaptor.capture))
+    verify(services.gcsDAO).updateGoogleProjectBillingAccount(any[GoogleProjectId], Option(billingAccountNameCaptor.capture), testData.testProject1.billingAccount)
     billingAccountNameCaptor.getValue shouldEqual Option(billingProject.billingAccount.get)
   }
 
   it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>
-    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct"))))
+    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct")), Option(any[RawlsBillingAccountName])))
       .thenReturn(Future.failed(new Exception("Fake error from Google")))
 
     val baseWorkspace = testData.workspace

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1321,7 +1321,7 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   }
 
   it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>
-    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct")), Option(any[RawlsBillingAccountName])))
+    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct")), None, true))
       .thenReturn(Future.failed(new Exception("Fake error from Google")))
 
     val workspaceName = WorkspaceName(testData.testProject1Name.value, "sad_workspace")
@@ -1557,34 +1557,38 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   }
 
   it should "set the Billing Account on the Workspace's Google Project to match the Billing Project's Billing Account" in withTestDataServices { services =>
-    val billingProject = testData.testProject1
-    val workspaceName = WorkspaceName(billingProject.projectName.value, "cool_workspace")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
+    val destBillingProject = testData.testProject1
+    val destWorkspaceName = WorkspaceName(destBillingProject.projectName.value, "cool_workspace")
+    val workspaceRequest = WorkspaceRequest(destWorkspaceName.namespace, destWorkspaceName.name, Map.empty)
 
     val baseWorkspace = testData.workspace
     Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
 
     // Project ID gets allocated when creating the Workspace, so we don't care what it is here.  We do care that
-    // whatever that Google Project is, we set the right Billing Account on it, which is the Billing Account specified
-    // in the Billing Project
-    val billingAccountNameCaptor = captor[RawlsBillingAccountName]
-    verify(services.gcsDAO).updateGoogleProjectBillingAccount(any[GoogleProjectId], Option(billingAccountNameCaptor.capture), testData.testProject1.billingAccount)
-    billingAccountNameCaptor.getValue shouldEqual Option(billingProject.billingAccount.get)
+    // we set the right Billing Account on it, which is the Billing Account specified by the Billing Project in the
+    // clone Workspace Request
+    verify(services.gcsDAO, times(1)).updateGoogleProjectBillingAccount(
+      any[GoogleProjectId],
+      ArgumentMatchers.eq(destBillingProject.billingAccount),
+      ArgumentMatchers.eq(None),
+      ArgumentMatchers.eq(true))
   }
 
   it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>
-    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct")), Option(any[RawlsBillingAccountName])))
+    val baseWorkspace = testData.workspace
+    val destBillingProject = testData.testProject1
+    val clonedWorkspaceName = WorkspaceName(destBillingProject.projectName.value, "sad_workspace")
+    val cloneWorkspaceRequest = WorkspaceRequest(clonedWorkspaceName.namespace, clonedWorkspaceName.name, Map.empty)
+
+    // Note: It seems that trying to use ArgumentMatchers when stubbing this method on a Spy results in NPE.  I do not know why.
+    when(services.gcsDAO.updateGoogleProjectBillingAccount(GoogleProjectId("project-from-buffer"), Option(RawlsBillingAccountName("fakeBillingAcct")), None, true))
       .thenReturn(Future.failed(new Exception("Fake error from Google")))
 
-    val baseWorkspace = testData.workspace
-    val workspaceName = WorkspaceName(testData.testProject1Name.value, "sad_workspace")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
-
     intercept[Exception] {
-      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, cloneWorkspaceRequest), Duration.Inf)
     }
 
-    val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
+    val maybeWorkspace = runAndWait(workspaceQuery.findByName(clonedWorkspaceName))
     maybeWorkspace shouldBe None
   }
 


### PR DESCRIPTION
As part of fixing PROD-625, we are going to manually update some Billing Account information in the Rawls db.  These changes will then be picked up by the `WorkspaceBillingAccountMonitor` which will actually try to call Google to set the desired Billing Accounts on the right Google Projects.  

One of the problems we caused before with the PPW release was that we overwrote a bunch of Billing Account information to the whatever value Rawls thought should be set.  However, users have historically been able to change the Billing Account on their Terra managed Google Projects.  This means that users could change the Billing Account to exactly what they want, but Rawls would not know about this change.  Similarly, Billing Account owners could disable billing on Terra managed projects and Rawls would not know about this change.

In an effort to avoid overwriting user's changes to their Google Projects Billing Account, this PR adds an additional check when Rawls is trying to update the Billing Account on a Terra managed Google Project.  This check compares the current Billing Account that is actually set on the Google Project to the Billing Account value that Rawls _thinks_ should be set on that Project.  If those values match, then Rawls can proceed with the update.  If those values don't match, then we have to assume that the user (or Billing Account owner) modified the Billing Account directly on Google and Rawls _should not_ change that value.   This check _can_ be overridden by providing a `force` flag.  This should be used with caution, but it was needed when creating new v2 Workspaces which use Google Projects allocated from RBS.  We `force` the overwrite at this time so that Rawls does not need to know the Billing Account set on RBS projects in its pool. 

Unfortunately, since the business logic for this change is buried in `HttpGoogleServicesDAO`, it is not unit testable because that class relies on real interactions with GCP.  Ideally, we would refactor that method and extract that logic someplace where it would be testable, but that effort would significantly expand the scope of this change and it sounds like we cannot afford to do that right now.

Additionally, we also modified a bunch of log statements to try and capture the `oldBillingAccount` value that is being overwritten in the `updateBillingAccount` request(s).  

- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
