### PR TITLE
[CA-1119] Migrate Workspace Bucket to New Google Project

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -103,4 +103,5 @@
     <include file="changesets/20220107_update_shard_procedures.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211208_storage_transfer_service_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20211217_v1_migration_buckets_deleted.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220112_add_updated_and_transfer_job_timestamps_to_workspace_migration.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220112_add_updated_and_transfer_job_timestamps_to_workspace_migration.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220112_add_updated_and_transfer_job_timestamps_to_workspace_migration.xml
@@ -6,9 +6,9 @@
     <changeSet logicalFilePath="dummy" author="ehigham" id="add_UPDATED_TIMESTAMP_TO_WORKSPACE_MIGRATION">
         <addColumn tableName="V1_WORKSPACE_MIGRATION_HISTORY">
             <column name="UPDATED"
-                    type="DATETIME"
-                    defaultValueComputed="CURRENT_TIMESTAMP"
-                    remarks="When the system scheduled migrating the WORKSPACE.">
+                    type="DATETIME(6)"
+                    defaultValueComputed="NOW(6)"
+                    remarks="When the system updated the migration attempt.">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
@@ -17,26 +17,26 @@
                 BEFORE UPDATE ON V1_WORKSPACE_MIGRATION_HISTORY
                 FOR EACH ROW
             BEGIN
-                SET NEW.UPDATED = CURRENT_TIMESTAMP();
+                SET NEW.UPDATED = NOW(6);
             END ~
         </sql>
     </changeSet>
     <changeSet logicalFilePath="dummy" author="ehigham" id="add_WORKSPACE_BUCKET_TRANSFER_TIMESTAMPS">
         <addColumn tableName="V1_WORKSPACE_MIGRATION_HISTORY">
-            <column name="WORKSPACE_BUCKET_TRANSFER_JOB_ISSUED" type="DATETIME">
+            <column name="WORKSPACE_BUCKET_TRANSFER_JOB_ISSUED" type="DATETIME(6)">
                 <constraints nullable="true"/>
             </column>
-            <column name="WORKSPACE_BUCKET_TRANSFERRED" type="DATETIME">
+            <column name="WORKSPACE_BUCKET_TRANSFERRED" type="DATETIME(6)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>
     </changeSet>
     <changeSet logicalFilePath="dummy" author="ehigham" id="add_TMP_BUCKET_TRANSFER_TIMESTAMPS">
         <addColumn tableName="V1_WORKSPACE_MIGRATION_HISTORY">
-            <column name="TMP_BUCKET_TRANSFER_JOB_ISSUED" type="DATETIME">
+            <column name="TMP_BUCKET_TRANSFER_JOB_ISSUED" type="DATETIME(6)">
                 <constraints nullable="true"/>
             </column>
-            <column name="TMP_BUCKET_TRANSFERRED" type="DATETIME">
+            <column name="TMP_BUCKET_TRANSFERRED" type="DATETIME(6)">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220112_add_updated_and_transfer_job_timestamps_to_workspace_migration.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220112_add_updated_and_transfer_job_timestamps_to_workspace_migration.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="ehigham" id="add_UPDATED_TIMESTAMP_TO_WORKSPACE_MIGRATION">
+        <addColumn tableName="V1_WORKSPACE_MIGRATION_HISTORY">
+            <column name="UPDATED"
+                    type="DATETIME"
+                    defaultValueComputed="CURRENT_TIMESTAMP"
+                    remarks="When the system scheduled migrating the WORKSPACE.">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <sql endDelimiter="~">
+            CREATE TRIGGER bump_migration_timestamp_on_update
+                BEFORE UPDATE ON V1_WORKSPACE_MIGRATION_HISTORY
+                FOR EACH ROW
+            BEGIN
+                SET NEW.UPDATED = CURRENT_TIMESTAMP();
+            END ~
+        </sql>
+    </changeSet>
+    <changeSet logicalFilePath="dummy" author="ehigham" id="add_WORKSPACE_BUCKET_TRANSFER_TIMESTAMPS">
+        <addColumn tableName="V1_WORKSPACE_MIGRATION_HISTORY">
+            <column name="WORKSPACE_BUCKET_TRANSFER_JOB_ISSUED" type="DATETIME">
+                <constraints nullable="true"/>
+            </column>
+            <column name="WORKSPACE_BUCKET_TRANSFERRED" type="DATETIME">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet logicalFilePath="dummy" author="ehigham" id="add_TMP_BUCKET_TRANSFER_TIMESTAMPS">
+        <addColumn tableName="V1_WORKSPACE_MIGRATION_HISTORY">
+            <column name="TMP_BUCKET_TRANSFER_JOB_ISSUED" type="DATETIME">
+                <constraints nullable="true"/>
+            </column>
+            <column name="TMP_BUCKET_TRANSFERRED" type="DATETIME">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -231,6 +231,10 @@ trait WorkspaceComponent {
       loadWorkspace(findByIdQuery(UUID.fromString(workspaceId)))
     }
 
+    def findByIdOrFail(workspaceId: String): ReadAction[Workspace] = findById(workspaceId) map {
+      _.getOrElse(throw new RawlsException(s"""No workspace found matching id "$workspaceId"."""))
+    }
+
     def listByIds(workspaceIds: Seq[UUID], attributeSpecs: Option[WorkspaceAttributeSpecs] = None): ReadAction[Seq[Workspace]] = {
       loadWorkspaces(findByIdsQuery(workspaceIds), attributeSpecs)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigration.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.monitor.migration
 
 import cats.implicits._
 import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, GoogleProjectNumber}
-import org.broadinstitute.dsde.rawls.monitor.migration.MigrationStatus._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
@@ -29,42 +28,7 @@ final case class WorkspaceMigration(id: Long,
                                     tmpBucketTransferJobIssued: Option[Timestamp],
                                     tmpBucketTransferred: Option[Timestamp],
                                     tmpBucketDeleted: Option[Timestamp]
-                                   ) {
-
-  def getStatus: MigrationStatus = (
-    ((finished fmap Finished.curried) <*> outcome).widen[MigrationStatus]
-      <+> (tmpBucketDeleted fmap TmpBucketDeleted)
-      <+> (tmpBucketTransferred fmap TmpBucketTransferred)
-      <+> (tmpBucketTransferJobIssued fmap TmpBucketTransferJobIssued)
-      <+> (finalBucketCreated fmap FinalWorkspaceBucketCreated)
-      <+> (workspaceBucketDeleted fmap WorkspaceBucketDeleted)
-      <+> (workspaceBucketTransferred fmap WorkspaceBucketTransferred)
-      <+> (workspaceBucketTransferJobIssued fmap WorkspaceBucketTransferJobIssued)
-      <+> ((tmpBucketCreated fmap TmpBucketCreated.curried) <*> tmpBucketName)
-      <+> ((newGoogleProjectConfigured fmap GoogleProjectConfigured.curried) <*> newGoogleProjectId)
-      <+> (started fmap Started)
-    )
-    .getOrElse(Created(created))
-}
-
-sealed trait MigrationStatus
-
-object MigrationStatus {
-
-  final case class Created(time: Timestamp) extends MigrationStatus
-  final case class Started(time: Timestamp) extends MigrationStatus
-  final case class GoogleProjectConfigured(time: Timestamp, googleProjectId: GoogleProjectId) extends MigrationStatus
-  final case class TmpBucketCreated(time: Timestamp, bucketName: GcsBucketName) extends MigrationStatus
-  final case class WorkspaceBucketTransferJobIssued(time: Timestamp) extends MigrationStatus
-  final case class WorkspaceBucketTransferred(time: Timestamp) extends MigrationStatus
-  final case class WorkspaceBucketDeleted(time: Timestamp) extends MigrationStatus
-  final case class FinalWorkspaceBucketCreated(time: Timestamp) extends MigrationStatus
-  final case class TmpBucketTransferJobIssued(time: Timestamp) extends MigrationStatus
-  final case class TmpBucketTransferred(time: Timestamp) extends MigrationStatus
-  final case class TmpBucketDeleted(time: Timestamp) extends MigrationStatus
-  final case class Finished(time: Timestamp, outcome: Outcome) extends MigrationStatus
-
-}
+                                   )
 
 private[migration]
 object WorkspaceMigration {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigration.scala
@@ -14,6 +14,7 @@ final case class WorkspaceMigration(id: Long,
                                     workspaceId: UUID,
                                     created: Timestamp,
                                     started: Option[Timestamp],
+                                    updated: Timestamp,
                                     finished: Option[Timestamp],
                                     outcome: Option[Outcome],
                                     newGoogleProjectId: Option[GoogleProjectId],
@@ -21,16 +22,24 @@ final case class WorkspaceMigration(id: Long,
                                     newGoogleProjectConfigured: Option[Timestamp],
                                     tmpBucketName: Option[GcsBucketName],
                                     tmpBucketCreated: Option[Timestamp],
+                                    workspaceBucketTransferJobIssued: Option[Timestamp],
+                                    workspaceBucketTransferred: Option[Timestamp],
                                     workspaceBucketDeleted: Option[Timestamp],
                                     finalBucketCreated: Option[Timestamp],
+                                    tmpBucketTransferJobIssued: Option[Timestamp],
+                                    tmpBucketTransferred: Option[Timestamp],
                                     tmpBucketDeleted: Option[Timestamp]
                                    ) {
 
   def getStatus: MigrationStatus = (
     ((finished fmap Finished.curried) <*> outcome).widen[MigrationStatus]
       <+> (tmpBucketDeleted fmap TmpBucketDeleted)
+      <+> (tmpBucketTransferred fmap TmpBucketTransferred)
+      <+> (tmpBucketTransferJobIssued fmap TmpBucketTransferJobIssued)
       <+> (finalBucketCreated fmap FinalWorkspaceBucketCreated)
       <+> (workspaceBucketDeleted fmap WorkspaceBucketDeleted)
+      <+> (workspaceBucketTransferred fmap WorkspaceBucketTransferred)
+      <+> (workspaceBucketTransferJobIssued fmap WorkspaceBucketTransferJobIssued)
       <+> ((tmpBucketCreated fmap TmpBucketCreated.curried) <*> tmpBucketName)
       <+> ((newGoogleProjectConfigured fmap GoogleProjectConfigured.curried) <*> newGoogleProjectId)
       <+> (started fmap Started)
@@ -46,9 +55,11 @@ object MigrationStatus {
   final case class Started(time: Timestamp) extends MigrationStatus
   final case class GoogleProjectConfigured(time: Timestamp, googleProjectId: GoogleProjectId) extends MigrationStatus
   final case class TmpBucketCreated(time: Timestamp, bucketName: GcsBucketName) extends MigrationStatus
+  final case class WorkspaceBucketTransferJobIssued(time: Timestamp) extends MigrationStatus
   final case class WorkspaceBucketTransferred(time: Timestamp) extends MigrationStatus
   final case class WorkspaceBucketDeleted(time: Timestamp) extends MigrationStatus
   final case class FinalWorkspaceBucketCreated(time: Timestamp) extends MigrationStatus
+  final case class TmpBucketTransferJobIssued(time: Timestamp) extends MigrationStatus
   final case class TmpBucketTransferred(time: Timestamp) extends MigrationStatus
   final case class TmpBucketDeleted(time: Timestamp) extends MigrationStatus
   final case class Finished(time: Timestamp, outcome: Outcome) extends MigrationStatus
@@ -59,25 +70,44 @@ private[migration]
 object WorkspaceMigration {
 
   type RecordType = (
-    Long, UUID, Timestamp, Option[Timestamp], Option[Timestamp], Option[String], Option[String],
-      Option[String], Option[String], Option[Timestamp],
-      Option[String], Option[Timestamp],
-      Option[Timestamp], Option[Timestamp], Option[Timestamp]
+    Long,                 // id
+      UUID,               // workspace uuid
+      Timestamp,          // created
+      Option[Timestamp],  // started
+      Timestamp,          // updated
+      Option[Timestamp],  // finished
+      Option[String],     // outcome
+      Option[String],     // message
+      Option[String],     // newGoogleProjectId
+      Option[String],     // newGoogleProjectNumber
+      Option[Timestamp],  // newGoogleProjectConfigured
+      Option[String],     // tmpBucketName
+      Option[Timestamp],  // tmpBucketCreated
+      Option[Timestamp],  // workspaceBucketTransferJobIssued
+      Option[Timestamp],  // workspaceBucketTransferred
+      Option[Timestamp],  // workspaceBucketDeleted
+      Option[Timestamp],  // finalBucketCreated
+      Option[Timestamp],  // tmpBucketTransferJobIssued
+      Option[Timestamp],  // tmpBucketTransferred
+      Option[Timestamp]   // tmpBucketDeleted
     )
 
 
   def fromRecord(record: RecordType): Either[String, WorkspaceMigration] = record match {
-    case (id, workspaceId, created, started, finished, outcome, message,
-    newGoogleProjectId, newGoogleProjectNumber, newGoogleProjectConfigured,
-    tmpBucketName, tmpBucketCreated,
-    workspaceBucketDeleted,
-    finalBucketCreated,
-      tmpBucketDeleted) => Outcome.fromFields(outcome, message).map { outcome =>
+    case (
+      id, workspaceId, created, started, updated, finished, outcome, message,
+      newGoogleProjectId, newGoogleProjectNumber, newGoogleProjectConfigured,
+      tmpBucketName, tmpBucketCreated,
+      workspaceBucketTransferJobIssued, workspaceBucketTransferred, workspaceBucketDeleted,
+      finalBucketCreated,
+      tmpBucketTransferJobIssued, tmpBucketTransferred, tmpBucketDeleted
+      ) => Outcome.fromFields(outcome, message).map { outcome =>
       WorkspaceMigration(
         id,
         workspaceId,
         created,
         started,
+        updated,
         finished,
         outcome,
         newGoogleProjectId.map(GoogleProjectId),
@@ -85,8 +115,12 @@ object WorkspaceMigration {
         newGoogleProjectConfigured,
         tmpBucketName.map(GcsBucketName),
         tmpBucketCreated,
+        workspaceBucketTransferJobIssued,
+        workspaceBucketTransferred,
         workspaceBucketDeleted,
         finalBucketCreated,
+        tmpBucketTransferJobIssued,
+        tmpBucketTransferred,
         tmpBucketDeleted
       )
     }
@@ -100,6 +134,7 @@ object WorkspaceMigration {
       migration.workspaceId,
       migration.created,
       migration.started,
+      migration.updated,
       migration.finished,
       outcome,
       message,
@@ -108,8 +143,12 @@ object WorkspaceMigration {
       migration.newGoogleProjectConfigured,
       migration.tmpBucketName.map(_.value),
       migration.tmpBucketCreated,
+      migration.workspaceBucketTransferJobIssued,
+      migration.workspaceBucketTransferred,
       migration.workspaceBucketDeleted,
       migration.finalBucketCreated,
+      migration.tmpBucketTransferJobIssued,
+      migration.tmpBucketTransferred,
       migration.tmpBucketDeleted
     )
   }
@@ -127,6 +166,7 @@ object WorkspaceMigrationHistory {
     def workspaceId = column[UUID]("WORKSPACE_ID", O.SqlType("BINARY(16)"))
     def created = column[Timestamp]("CREATED")
     def started = column[Option[Timestamp]]("STARTED")
+    def updated = column[Timestamp]("UPDATED")
     def finished = column[Option[Timestamp]]("FINISHED")
     def outcome = column[Option[String]]("OUTCOME")
     def message = column[Option[String]]("MESSAGE")
@@ -135,17 +175,22 @@ object WorkspaceMigrationHistory {
     def newGoogleProjectConfigured = column[Option[Timestamp]]("NEW_GOOGLE_PROJECT_CONFIGURED")
     def tmpBucket = column[Option[String]]("TMP_BUCKET")
     def tmpBucketCreated = column[Option[Timestamp]]("TMP_BUCKET_CREATED")
+    def workspaceBucketTransferJobIssued = column[Option[Timestamp]]("WORKSPACE_BUCKET_TRANSFER_JOB_ISSUED")
+    def workspaceBucketTransferred = column[Option[Timestamp]]("WORKSPACE_BUCKET_TRANSFERRED")
     def workspaceBucketDeleted = column[Option[Timestamp]]("WORKSPACE_BUCKET_DELETED")
     def finalBucketCreated = column[Option[Timestamp]]("FINAL_BUCKET_CREATED")
+    def tmpBucketTransferJobIssued = column[Option[Timestamp]]("TMP_BUCKET_TRANSFER_JOB_ISSUED")
+    def tmpBucketTransferred = column[Option[Timestamp]]("TMP_BUCKET_TRANSFERRED")
     def tmpBucketDeleted = column[Option[Timestamp]]("TMP_BUCKET_DELETED")
 
     override def * =
-      (id, workspaceId, created, started, finished, outcome, message,
+      (
+        id, workspaceId, created, started, updated, finished, outcome, message,
         newGoogleProjectId, newGoogleProjectNumber, newGoogleProjectConfigured,
         tmpBucket, tmpBucketCreated,
-        workspaceBucketDeleted,
+        workspaceBucketTransferJobIssued, workspaceBucketTransferred, workspaceBucketDeleted,
         finalBucketCreated,
-        tmpBucketDeleted
+        tmpBucketTransferJobIssued, tmpBucketTransferred, tmpBucketDeleted
       ) <>
         (MigrationUtils.unsafeFromEither(WorkspaceMigration.fromRecord, _),
           WorkspaceMigration.toRecord(_: WorkspaceMigration).some)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationMonitor.scala
@@ -74,14 +74,15 @@ object WorkspaceMigrationMonitor {
   type MigrateAction[T] = ReaderT[OptionT[IO, *], MigrationDeps, T]
 
   object MigrateAction {
+    // lookup a value in the environment
     final def asks[T](f: MigrationDeps => T): MigrateAction[T] =
       ReaderT.ask[OptionT[IO, *], MigrationDeps].map(f)
 
-
+    // lift an IO action into the context of a MigrateAction
     final def liftIO[A](ioa: IO[A]): MigrateAction[A] =
       ReaderT.liftF(OptionT.liftF(ioa))
 
-
+    // empty action
     final def unit: MigrateAction[Unit] =
       ReaderT.pure()
   }
@@ -95,7 +96,8 @@ object WorkspaceMigrationMonitor {
         .result
     }
 
-
+  // Read workspace migrations in various states, attempt to advance their state forward by one
+  // step and write the outcome of each step to the database.
   final def migrate: MigrateAction[Unit] =
     startMigration >>
       claimAndConfigureGoogleProject >>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationMonitor.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.monitor.migration
 
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
-import cats.Traverse
 import cats.data.{OptionT, ReaderT}
 import cats.effect.IO
 import cats.implicits._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationMonitor.scala
@@ -74,9 +74,9 @@ object WorkspaceMigrationMonitor {
   type MigrateAction[T] = ReaderT[OptionT[IO, *], MigrationDeps, T]
 
   object MigrateAction {
-    // lookup a value in the environment
-    final def asks[T](f: MigrationDeps => T): MigrateAction[T] =
-      ReaderT.ask[OptionT[IO, *], MigrationDeps].map(f)
+    // lookup a value in the environment using `selector`
+    final def asks[T](selector: MigrationDeps => T): MigrateAction[T] =
+      ReaderT.ask[OptionT[IO, *], MigrationDeps].map(selector)
 
     // lift an IO action into the context of a MigrateAction
     final def liftIO[A](ioa: IO[A]): MigrateAction[A] =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
@@ -1,15 +1,17 @@
 package org.broadinstitute.dsde.rawls.monitor
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import cats.data.{NonEmptyList, ReaderT}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.implicits.catsSyntaxOptionId
-import com.google.cloud.storage.Storage
+import com.google.cloud.storage.{Acl, Storage}
 import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
-import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.mock.{MockGoogleStorageService, MockGoogleStorageTransferService}
 import org.broadinstitute.dsde.rawls.model.GoogleProjectId
-import org.broadinstitute.dsde.rawls.monitor.migration.WorkspaceMigrationMonitor
+import org.broadinstitute.dsde.rawls.monitor.migration.MigrationStatus._
+import org.broadinstitute.dsde.rawls.monitor.migration.WorkspaceMigrationMonitor.MigrationDeps
+import org.broadinstitute.dsde.rawls.monitor.migration.{WorkspaceMigration, WorkspaceMigrationMonitor}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceServiceSpec
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
@@ -20,11 +22,11 @@ import org.broadinstitute.dsde.workbench.util2.{ConsoleLogger, LogLevel}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{BeforeAndAfterAll, OptionValues}
-import slick.dbio.DBIO
+import org.scalatest.{Assertion, BeforeAndAfterAll, OptionValues}
 import slick.jdbc.MySQLProfile.api._
 
-import java.sql.SQLException
+import java.sql.{SQLException, Timestamp}
+import java.time.LocalDateTime
 import java.util.UUID
 import scala.language.postfixOps
 
@@ -32,204 +34,31 @@ class WorkspaceMigrationMonitorSpec
   extends AnyFlatSpecLike
     with BeforeAndAfterAll
     with Matchers
-    with TestDriverComponent
     with Eventually
     with OptionValues {
 
   val testKit: ActorTestKit = ActorTestKit()
   implicit val logger = new ConsoleLogger("unit_test", LogLevel(false, false, true, true))
 
-  override def afterAll(): Unit = testKit.shutdownTestKit()
+  // This is a horrible hack to avoid refactoring the tangled mess in the WorkspaceServiceSpec.
+  val spec = new WorkspaceServiceSpec()
 
-  "isMigrating" should "return false when a workspace is not being migrated" in {
-    withMinimalTestDatabase { _ =>
-      runAndWait(WorkspaceMigrationMonitor.isMigrating(minimalTestData.v1Workspace)) shouldBe false
-    }
-  }
 
-  "schedule" should "error when a workspace is scheduled concurrently" in {
-    withMinimalTestDatabase { _ =>
-      runAndWait(WorkspaceMigrationMonitor.schedule(minimalTestData.v1Workspace)) shouldBe()
-      assertThrows[SQLException] {
-        runAndWait(WorkspaceMigrationMonitor.schedule(minimalTestData.v1Workspace))
-      }
-    }
-  }
-
-  "claimAndConfigureGoogleProject" should "return a valid database operation" in {
-    val spec = new WorkspaceServiceSpec()
+  def runMigrationTest(test: ReaderT[IO, MigrationDeps, Assertion]): Assertion =
     spec.withTestDataServices { services =>
-      spec.runAndWait {
-        DBIO.seq(
-          spec.workspaceQuery.createOrUpdate(spec.testData.v1Workspace),
-          WorkspaceMigrationMonitor.schedule(spec.testData.v1Workspace)
+      test.run {
+        WorkspaceMigrationMonitor.MigrationDeps(
+          services.slickDataSource,
+          spec.testData.billingProject,
+          services.workspaceService,
+          mockStorageService,
+          mockStorageTransferService
         )
-      }
-
-      val (_, _, dbOp) = IO.fromFuture(IO {
-        services.slickDataSource.database
-          .run {
-            WorkspaceMigrationMonitor.workspaceMigrations
-              .filter(_.workspaceId === spec.testData.v1Workspace.workspaceIdAsUUID)
-              .result
-          }
-      })
-        .map(_.head)
-        .flatMap { attempt =>
-          WorkspaceMigrationMonitor.claimAndConfigureNewGoogleProject(
-            attempt,
-            services.workspaceService,
-            spec.testData.v1Workspace,
-            spec.testData.billingProject
-          )
-        }
-        .unsafeRunSync
-
-      spec.runAndWait(dbOp) shouldBe()
-
-      val (projectId, projectNumber, projectConfigured) = IO.fromFuture(IO {
-        services.slickDataSource.database
-          .run {
-            WorkspaceMigrationMonitor.workspaceMigrations
-              .filter(_.workspaceId === spec.testData.v1Workspace.workspaceIdAsUUID)
-              .map(r => (r.newGoogleProjectId, r.newGoogleProjectNumber, r.newGoogleProjectConfigured))
-              .result
-          }
-      })
-        .map(_.head)
-        .unsafeRunSync
-
-      projectId shouldBe defined
-      projectNumber shouldBe defined
-      projectConfigured shouldBe defined
-    }
-  }
-
-  // use an existing test project (broad-dsde-dev)
-  "createTempBucket" should "create a new bucket in the same region as the workspace bucket" ignore {
-    val sourceProject = "general-dev-billing-account"
-    val sourceBucket = "az-leotest"
-    val destProject = "terra-dev-7af423b8"
-    val serviceProject = GoogleProject(sourceProject)
-    val pathToCredentialJson = "config/rawls-account.json"
-    val v1WorkspaceCopy = minimalTestData.v1Workspace.copy(
-      namespace = sourceProject,
-      googleProjectId = GoogleProjectId(sourceProject),
-      bucketName = sourceBucket
-    )
-
-    withMinimalTestDatabase { _ =>
-      runAndWait {
-        DBIO.seq(
-          workspaceQuery.createOrUpdate(v1WorkspaceCopy),
-          WorkspaceMigrationMonitor.schedule(v1WorkspaceCopy)
-        )
-      }
-
-      // Creating the temp bucket requires that the new google project has been created
-      val attempt = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.workspaceId === v1WorkspaceCopy.workspaceIdAsUUID).result
-      )
-        .head
-        .copy(newGoogleProjectId = GoogleProjectId(destProject).some)
-
-      val writeAction = GoogleStorageService.resource[IO](pathToCredentialJson, None, Option(serviceProject)).use { googleStorageService =>
-        for {
-          res <- WorkspaceMigrationMonitor.createTempBucket(attempt, v1WorkspaceCopy, googleStorageService)
-          (bucketName, writeAction) = res
-          loadedBucket <- googleStorageService.getBucket(GoogleProject(destProject), bucketName)
-          _ <- googleStorageService.deleteBucket(GoogleProject(destProject), bucketName).compile.drain
-        } yield {
-          loadedBucket shouldBe defined
-          writeAction
-        }
       }.unsafeRunSync
-
-      runAndWait(writeAction) shouldBe()
-    }
-  }
-
-  "deleteWorkspaceBucket" should "delete the workspace bucket and record when it was deleted" in {
-    withMinimalTestDatabase { _ =>
-      runAndWait {
-        DBIO.seq(
-          workspaceQuery.createOrUpdate(minimalTestData.v1Workspace),
-          WorkspaceMigrationMonitor.schedule(minimalTestData.v1Workspace)
-        )
-      }
-
-      val migration = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.workspaceId === minimalTestData.v1Workspace.workspaceIdAsUUID).result
-      )
-        .head
-
-      val writeAction = WorkspaceMigrationMonitor.deleteWorkspaceBucket(
-        migration,
-        minimalTestData.v1Workspace,
-        new MockGoogleStorageService[IO] {
-          override def deleteBucket(googleProject: GoogleProject, bucketName: GcsBucketName, isRecursive: Boolean, bucketSourceOptions: List[Storage.BucketSourceOption], traceId: Option[TraceId], retryConfig: RetryConfig): fs2.Stream[IO, Boolean] =
-            fs2.Stream.emit(true)
-        }
-      ).unsafeRunSync
-
-      runAndWait(writeAction) shouldBe()
-
-      val workspaceBucketDeleted = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.id === migration.id)
-          .map(_.workspaceBucketDeleted)
-          .result
-          .map(_.head)
-      )
-
-      workspaceBucketDeleted shouldBe defined
-    }
-  }
-
-  "deleteTemporaryBucket" should "delete the temporary bucket and record when it was deleted" in
-    withMinimalTestDatabase { _ =>
-      runAndWait {
-        DBIO.seq(
-          workspaceQuery.createOrUpdate(minimalTestData.v1Workspace),
-          WorkspaceMigrationMonitor.schedule(minimalTestData.v1Workspace)
-        )
-      }
-
-      // We need a temp bucket to transfer the workspace bucket contents into
-      val migration = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.workspaceId === minimalTestData.v1Workspace.workspaceIdAsUUID).result
-      )
-        .head
-        .copy(
-          newGoogleProjectId = GoogleProjectId("google-project-").some,
-          tmpBucketName = GcsBucketName("temp-bucket-name").some
-        )
-
-      val writeAction = WorkspaceMigrationMonitor.deleteTemporaryBucket(
-        migration,
-        new MockGoogleStorageService[IO] {
-          override def deleteBucket(googleProject: GoogleProject, bucketName: GcsBucketName, isRecursive: Boolean, bucketSourceOptions: List[Storage.BucketSourceOption], traceId: Option[TraceId], retryConfig: RetryConfig): fs2.Stream[IO, Boolean] =
-            fs2.Stream.emit(true)
-        }
-      ).unsafeRunSync
-
-      runAndWait(writeAction) shouldBe()
-
-      val tmpBucketDeleted = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.id === migration.id)
-          .map(_.tmpBucketDeleted)
-          .result
-          .map(_.head)
-      )
-
-      tmpBucketDeleted shouldBe defined
     }
 
-  val mockStsService = new MockGoogleStorageTransferService[IO] {
+
+  val mockStorageTransferService = new MockGoogleStorageTransferService[IO] {
     override def createTransferJob(jobName: JobName, jobDescription: String, projectToBill: GoogleProject, originBucket: GcsBucketName, destinationBucket: GcsBucketName, schedule: JobTransferSchedule): IO[TransferJob] =
       IO.pure {
         TransferJob.newBuilder()
@@ -240,150 +69,282 @@ class WorkspaceMigrationMonitorSpec
       }
   }
 
-  "startStorageTransferJobToTmpBucket" should "create and start a storage transfer job from the workspace bucket to the temp bucket" in {
-    withMinimalTestDatabase { _ =>
-      runAndWait {
-        DBIO.seq(
-          workspaceQuery.createOrUpdate(minimalTestData.v1Workspace),
-          WorkspaceMigrationMonitor.schedule(minimalTestData.v1Workspace)
-        )
-      }
 
-      // We need a temp bucket to transfer the workspace bucket contents into
-      val migration = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.workspaceId === minimalTestData.v1Workspace.workspaceIdAsUUID)
-          .result
-      )
-        .head
-        .copy(
-          tmpBucketName = GcsBucketName("tmp-bucket-name").some
-        )
+  val mockStorageService = new MockGoogleStorageService[IO] {
+    override def deleteBucket(googleProject: GoogleProject, bucketName: GcsBucketName, isRecursive: Boolean, bucketSourceOptions: List[Storage.BucketSourceOption], traceId: Option[TraceId], retryConfig: RetryConfig): fs2.Stream[IO, Boolean] =
+      fs2.Stream.emit(true)
 
-      val (job, writeAction) = WorkspaceMigrationMonitor.startStorageTransferJobToTmpBucket(
-        migration,
-        minimalTestData.v1Workspace,
-        GoogleProject("to-be-determined"),
-        mockStsService
-      ).unsafeRunSync
-
-      runAndWait(writeAction) shouldBe()
-
-      val transferJobs = runAndWait(
-        WorkspaceMigrationMonitor.storageTransferJobs
-          .filter(_.migrationId === migration.id)
-          .result
-      )
-
-      transferJobs.length shouldBe 1
-      transferJobs.head.jobName.value shouldBe job.getName
-      transferJobs.head.originBucket.value shouldBe minimalTestData.v1Workspace.bucketName
-      transferJobs.head.destBucket shouldBe migration.tmpBucketName.get
-    }
+    override def insertBucket(googleProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]], labels: Map[String, String], traceId: Option[TraceId], bucketPolicyOnlyEnabled: Boolean, logBucket: Option[GcsBucketName], retryConfig: RetryConfig, location: Option[String]): fs2.Stream[IO, Unit] =
+      fs2.Stream.emit(())
   }
 
-  "startStorageTransferJobToFinalBucket" should "create and start a storage transfer job from the tmp bucket to the new workspace bucket" in {
-    withMinimalTestDatabase { _ =>
-      runAndWait {
-        DBIO.seq(
-          workspaceQuery.createOrUpdate(minimalTestData.v1Workspace),
-          WorkspaceMigrationMonitor.schedule(minimalTestData.v1Workspace)
-        )
+
+  def getAttempt(workspaceUuid: UUID): ReaderT[IO, MigrationDeps, WorkspaceMigration] =
+    WorkspaceMigrationMonitor.inTransaction { _ =>
+      WorkspaceMigrationMonitor.workspaceMigrations
+        .filter(_.workspaceId === workspaceUuid)
+        .result
+    }
+      .map(_.head)
+
+
+  override def afterAll(): Unit = testKit.shutdownTestKit()
+
+  "isMigrating" should "return false when a workspace is not being migrated" in
+    spec.withMinimalTestDatabase { _ =>
+      spec.runAndWait(WorkspaceMigrationMonitor.isMigrating(spec.minimalTestData.v1Workspace)) shouldBe false
+    }
+
+
+  "schedule" should "error when a workspace is scheduled concurrently" in
+    spec.withMinimalTestDatabase { _ =>
+      spec.runAndWait(WorkspaceMigrationMonitor.schedule(spec.minimalTestData.v1Workspace)) shouldBe()
+      assertThrows[SQLException] {
+        spec.runAndWait(WorkspaceMigrationMonitor.schedule(spec.minimalTestData.v1Workspace))
+      }
+    }
+
+
+  "claimAndConfigureGoogleProject" should "return a valid database operation" in
+    runMigrationTest {
+      for {
+        _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+          spec.workspaceQuery.createOrUpdate(spec.testData.v1Workspace) >>
+            WorkspaceMigrationMonitor.schedule(spec.testData.v1Workspace)
+        }
+
+        _ <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID).flatMap {
+          WorkspaceMigrationMonitor.claimAndConfigureNewGoogleProject(_, spec.testData.v1Workspace)
+        }
+
+        attempt <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID)
+
+      } yield {
+        attempt.newGoogleProjectId shouldBe defined
+        attempt.newGoogleProjectNumber shouldBe defined
+        attempt.newGoogleProjectConfigured shouldBe defined
+      }
+    }
+
+
+  // use an existing test project (broad-dsde-dev)
+  "createTempBucket" should "create a new bucket in the same region as the workspace bucket" ignore {
+    val sourceProject = "general-dev-billing-account"
+    val sourceBucket = "az-leotest"
+    val destProject = "terra-dev-7af423b8"
+    val pathToCredentialJson = "config/rawls-account.json"
+    val v1Workspace = spec.testData.v1Workspace.copy(
+      namespace = sourceProject,
+      googleProjectId = GoogleProjectId(sourceProject),
+      bucketName = sourceBucket
+    )
+
+    val test = for {
+      _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+        spec.workspaceQuery.createOrUpdate(v1Workspace) >>
+          WorkspaceMigrationMonitor.schedule(v1Workspace)
       }
 
-      // We need a temp bucket to transfer the workspace bucket contents into
-      val migration = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.workspaceId === minimalTestData.v1Workspace.workspaceIdAsUUID)
-          .result
-      )
-        .head
-        .copy(
-          tmpBucketName = GcsBucketName("tmp-bucket-name").some
-        )
+      bucketName <- getAttempt(v1Workspace.workspaceIdAsUUID).flatMap { migration =>
+        WorkspaceMigrationMonitor.createTempBucket(migration, v1Workspace, GoogleProjectId(destProject))
+      }
 
-      val (job, writeAction) = WorkspaceMigrationMonitor.startStorageTransferJobToFinalBucket(
-        migration,
-        minimalTestData.v1Workspace,
-        GoogleProject("to-be-determined"),
-        mockStsService
-      ).unsafeRunSync
+      bucket <- ReaderT { env: MigrationDeps =>
+        env.storageService.getBucket(GoogleProject(destProject), bucketName) <*
+          env.storageService.deleteBucket(GoogleProject(destProject), bucketName, isRecursive = true).compile.drain
+      }
 
-      runAndWait(writeAction) shouldBe()
+      attempt <- getAttempt(v1Workspace.workspaceIdAsUUID)
 
-      val transferJobs = runAndWait(
-        WorkspaceMigrationMonitor.storageTransferJobs
-          .filter(_.migrationId === migration.id)
-          .result
-      )
-
-      transferJobs.length shouldBe 1
-      transferJobs.head.jobName.value shouldBe job.getName
-      transferJobs.head.originBucket.value shouldBe migration.tmpBucketName.get.value
-      transferJobs.head.destBucket.value shouldBe minimalTestData.v1Workspace.bucketName
+    } yield {
+      bucket shouldBe defined
+      attempt.tmpBucketName shouldBe bucketName.some
+      attempt.tmpBucketCreated shouldBe defined
     }
+
+    runMigrationTest(ReaderT { env =>
+      GoogleStorageService.resource[IO](pathToCredentialJson).use { googleStorageService =>
+        test.run(env.copy(storageService = googleStorageService))
+      }
+    })
   }
+
+
+  "deleteWorkspaceBucket" should "delete the workspace bucket and record when it was deleted" in
+    runMigrationTest {
+      for {
+        _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+          spec.workspaceQuery.createOrUpdate(spec.testData.v1Workspace) >>
+            WorkspaceMigrationMonitor.schedule(spec.testData.v1Workspace)
+        }
+
+        _ <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID).flatMap {
+          WorkspaceMigrationMonitor.deleteWorkspaceBucket(_, spec.testData.v1Workspace)
+        }
+
+        migration <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID)
+      } yield migration.workspaceBucketDeleted shouldBe defined
+    }
+
+
+  "deleteTemporaryBucket" should "delete the temporary bucket and record when it was deleted" in
+    runMigrationTest {
+      for {
+        _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+          spec.workspaceQuery.createOrUpdate(spec.testData.v1Workspace) >>
+            WorkspaceMigrationMonitor.schedule(spec.testData.v1Workspace)
+        }
+
+        _ <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID).flatMap { attempt =>
+          WorkspaceMigrationMonitor.deleteTemporaryBucket(
+            attempt.copy(
+              newGoogleProjectId = GoogleProjectId("new-google-project-id").some,
+              tmpBucketName = GcsBucketName("tmp-bucket-name").some
+            )
+          )
+        }
+
+        migration <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID)
+      } yield migration.tmpBucketDeleted shouldBe defined
+    }
+
+
+  "startBucketStorageTransferJob" should "create and start a storage transfer job between the specified buckets" in
+    runMigrationTest {
+      for {
+        _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+          spec.workspaceQuery.createOrUpdate(spec.testData.v1Workspace) >>
+            WorkspaceMigrationMonitor.schedule(spec.testData.v1Workspace)
+        }
+
+        job <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID).flatMap { attempt =>
+          WorkspaceMigrationMonitor.startBucketStorageTransferJob(
+            attempt,
+            GcsBucketName(spec.testData.v1Workspace.bucketName),
+            GcsBucketName("tmp-bucket-name")
+          )
+        }
+
+        transferJob <- WorkspaceMigrationMonitor.inTransaction { _ =>
+          WorkspaceMigrationMonitor.storageTransferJobs
+            .filter(_.jobName === job.getName)
+            .result
+        }
+          .map(_.head)
+
+        attempt <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID)
+
+      } yield {
+        transferJob.jobName.value shouldBe job.getName
+        transferJob.migrationId shouldBe attempt.id
+        transferJob.originBucket.value shouldBe spec.testData.v1Workspace.bucketName
+        transferJob.destBucket shouldBe GcsBucketName("tmp-bucket-name")
+      }
+    }
+
 
   "createFinalBucket" should "create a new bucket in the same region as the tmp workspace bucket" ignore {
     val sourceProject = "general-dev-billing-account"
     val sourceBucket = "az-leotest"
     val destProject = "terra-dev-7af423b8"
     val destBucket = "v1-migration-test-" + UUID.randomUUID.toString.replace("-", "")
-    val serviceProject = GoogleProject(sourceProject)
     val pathToCredentialJson = "config/rawls-account.json"
 
-    val v1Workspace = minimalTestData.v1Workspace.copy(
+    val v1Workspace = spec.testData.v1Workspace.copy(
       namespace = sourceProject,
       googleProjectId = GoogleProjectId(sourceProject),
       bucketName = destBucket
     )
 
-    withMinimalTestDatabase { _ =>
-      runAndWait {
-        DBIO.seq(
-          workspaceQuery.createOrUpdate(v1Workspace),
+    val test = for {
+      _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+        spec.workspaceQuery.createOrUpdate(v1Workspace) >>
           WorkspaceMigrationMonitor.schedule(v1Workspace)
+      }
+
+      bucketName <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID).flatMap { attempt =>
+        WorkspaceMigrationMonitor.createFinalBucket(
+          attempt.copy(
+            newGoogleProjectId = GoogleProjectId(destProject).some,
+            tmpBucketName = GcsBucketName(sourceBucket).some
+          ),
+          v1Workspace
         )
       }
 
-      // Creating the bucket requires that the new google project and tmp bucket have been created
-      val migration = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.workspaceId === v1Workspace.workspaceIdAsUUID)
-          .result
-      )
-        .head
-        .copy(
-          newGoogleProjectId = GoogleProjectId(destProject).some,
-          tmpBucketName = GcsBucketName(sourceBucket).some
-        )
+      bucket <- ReaderT { env: MigrationDeps =>
+        env.storageService.getBucket(GoogleProject(destProject), bucketName) <*
+          env.storageService.deleteBucket(GoogleProject(destProject), bucketName, isRecursive = true).compile.drain
+      }
 
-      val writeAction = GoogleStorageService.resource[IO](pathToCredentialJson, None, Option(serviceProject)).use { googleStorageService =>
-        for {
-          res <- WorkspaceMigrationMonitor.createFinalBucket(migration, v1Workspace, googleStorageService)
-          (bucketName, writeAction) = res
-          loadedBucket <- googleStorageService.getBucket(GoogleProject(destProject), bucketName)
-          _ <- googleStorageService.deleteBucket(GoogleProject(destProject), bucketName).compile.drain
-        } yield {
-          loadedBucket shouldBe defined
-          loadedBucket.get.getName shouldBe destBucket
-          writeAction
-        }
-      }.unsafeRunSync
-
-      runAndWait(writeAction) shouldBe()
-
-      val finalBucketCreated = runAndWait(
-        WorkspaceMigrationMonitor.workspaceMigrations
-          .filter(_.id === migration.id)
-          .map(_.finalBucketCreated)
-          .result
-          .map(_.head)
-      )
-
-      finalBucketCreated shouldBe defined
+      attempt <- getAttempt(v1Workspace.workspaceIdAsUUID)
+    } yield {
+      bucket shouldBe defined
+      attempt.finalBucketCreated shouldBe defined
     }
+
+    runMigrationTest(ReaderT { env =>
+      GoogleStorageService.resource[IO](pathToCredentialJson).use { googleStorageService =>
+        test.run(env.copy(storageService = googleStorageService))
+      }
+    })
   }
+
+
+  def runStep(configureBefore: WorkspaceMigration => WorkspaceMigration,
+              assertAfter: WorkspaceMigration => Assertion) =
+    runMigrationTest {
+      for {
+        _ <- WorkspaceMigrationMonitor.inTransaction { _ =>
+          spec.workspaceQuery.createOrUpdate(spec.testData.v1Workspace) >>
+            WorkspaceMigrationMonitor.schedule(spec.testData.v1Workspace)
+        }
+
+        _ <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID)
+          .map(configureBefore)
+          .flatMap(WorkspaceMigrationMonitor.step)
+
+        migration <- getAttempt(spec.testData.v1Workspace.workspaceIdAsUUID)
+      } yield assertAfter(migration)
+    }
+
+
+  "step" should "advance the migration from Created -> Started" in
+    runStep(identity, _.getStatus.isInstanceOf[Started] shouldBe true)
+
+
+  def now: Timestamp = Timestamp.valueOf(LocalDateTime.now())
+
+  it should "advance the migration from Started -> GoogleProjectConfigured" in
+    runStep(
+      _.copy(started = now.some),
+      _.getStatus.isInstanceOf[GoogleProjectConfigured] shouldBe true
+    )
+
+
+  // cant mock out creating a Bucket - thanks google.
+  it should "advance the migration from GoogleProjectConfigured -> TmpBucketCreated" ignore
+    runStep(
+      _.copy(
+        started = now.some,
+        newGoogleProjectConfigured = now.some,
+        newGoogleProjectId = GoogleProjectId(UUID.randomUUID.toString).some
+      ),
+      _.getStatus.isInstanceOf[TmpBucketCreated] shouldBe true
+    )
+
+
+  it should "advance the migration from TmpBucketCreated -> TmpBucketCreated" ignore
+    runStep(
+      _.copy(
+        started = now.some,
+        newGoogleProjectConfigured = now.some,
+        newGoogleProjectId = GoogleProjectId(UUID.randomUUID.toString).some,
+        tmpBucketCreated = now.some,
+        tmpBucketName = GcsBucketName("tmp-bucket").some
+      ),
+      m => m.getStatus.isInstanceOf[TmpBucketCreated] shouldBe true
+    )
 
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
@@ -128,7 +128,7 @@ class WorkspaceMigrationMonitorSpec
     val sourceProject = "general-dev-billing-account"
     val sourceBucket = "az-leotest"
     val destProject = "terra-dev-7af423b8"
-    val pathToCredentialJson = "config/rawls-account.json"
+
     val v1Workspace = spec.testData.v1Workspace.copy(
       namespace = sourceProject,
       googleProjectId = GoogleProjectId(sourceProject),
@@ -158,9 +158,12 @@ class WorkspaceMigrationMonitorSpec
       attempt.tmpBucketCreated shouldBe defined
     }
 
+    val serviceProject = GoogleProject(sourceProject)
+    val pathToCredentialJson = "config/rawls-account.json"
+
     runMigrationTest(ReaderT { env =>
-      GoogleStorageService.resource[IO](pathToCredentialJson).use { googleStorageService =>
-        test.run(env.copy(storageService = googleStorageService))
+      GoogleStorageService.resource[IO](pathToCredentialJson, None, serviceProject.some).use {
+        googleStorageService => test.run(env.copy(storageService = googleStorageService))
       }
     })
   }
@@ -244,7 +247,6 @@ class WorkspaceMigrationMonitorSpec
     val sourceBucket = "az-leotest"
     val destProject = "terra-dev-7af423b8"
     val destBucket = "v1-migration-test-" + UUID.randomUUID.toString.replace("-", "")
-    val pathToCredentialJson = "config/rawls-account.json"
 
     val v1Workspace = spec.testData.v1Workspace.copy(
       namespace = sourceProject,
@@ -279,9 +281,12 @@ class WorkspaceMigrationMonitorSpec
       attempt.finalBucketCreated shouldBe defined
     }
 
+    val serviceProject = GoogleProject(sourceProject)
+    val pathToCredentialJson = "config/rawls-account.json"
+
     runMigrationTest(ReaderT { env =>
-      GoogleStorageService.resource[IO](pathToCredentialJson).use { googleStorageService =>
-        test.run(env.copy(storageService = googleStorageService))
+      GoogleStorageService.resource[IO](pathToCredentialJson, None, serviceProject.some).use {
+        googleStorageService => test.run(env.copy(storageService = googleStorageService))
       }
     })
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.workbench.util2.{ConsoleLogger, LogLevel}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 import org.scalatest.{Assertion, BeforeAndAfterAll, OptionValues}
 import slick.jdbc.MySQLProfile.api._
 
@@ -121,9 +120,6 @@ class WorkspaceMigrationMonitorSpec
         before <- WorkspaceMigrationMonitor
           .getMigrations(spec.testData.v1Workspace.workspaceIdAsUUID)
           .map(_.last)
-
-        // sleep needed due to Timestamp imprecision
-        _ <- MigrateAction.liftIO(IO.sleep(1.second))
 
         after <- WorkspaceMigrationMonitor.inTransaction { _ =>
           val migration = WorkspaceMigrationMonitor.workspaceMigrations

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationMonitorSpec.scala
@@ -80,15 +80,11 @@ class WorkspaceMigrationMonitorSpec
 
 
   def getAttempt(workspaceUuid: UUID): ReaderT[IO, MigrationDeps, WorkspaceMigration] =
-    WorkspaceMigrationMonitor.inTransaction { _ =>
-      WorkspaceMigrationMonitor.workspaceMigrations
-        .filter(_.workspaceId === workspaceUuid)
-        .result
-    }
-      .map(_.head)
+    WorkspaceMigrationMonitor.getMigrations(workspaceUuid).map(_.last)
 
 
   override def afterAll(): Unit = testKit.shutdownTestKit()
+
 
   "isMigrating" should "return false when a workspace is not being migrated" in
     spec.withMinimalTestDatabase { _ =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.{compilerPlugin, _}
 
 object Dependencies {
   val akkaV = "2.6.17"
@@ -121,6 +121,8 @@ object Dependencies {
   val opencensusStackDriverExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-stackdriver" % "0.28.3" excludeAll(excludeProtobufJavalite)
   val opencensusLoggingExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging"     % "0.28.3"
 
+  val kindProjector = compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full))
+
   val openCensusDependencies = Seq(
     opencensusScalaCode,
     opencensusAkkaHttp,
@@ -239,6 +241,7 @@ object Dependencies {
     dataRepo,
     dataRepoJersey,
     antlrParser,
-    resourceBufferService
+    resourceBufferService,
+    kindProjector
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -122,6 +122,7 @@ object Dependencies {
   val opencensusLoggingExporter: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging"     % "0.28.3"
 
   val kindProjector = compilerPlugin(("org.typelevel" %% "kind-projector" % "0.13.2").cross(CrossVersion.full))
+  val betterMonadicFor = compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
   val openCensusDependencies = Seq(
     opencensusScalaCode,
@@ -242,6 +243,7 @@ object Dependencies {
     dataRepoJersey,
     antlrParser,
     resourceBufferService,
-    kindProjector
+    kindProjector,
+    betterMonadicFor
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt.{compilerPlugin, _}
+import sbt._
 
 object Dependencies {
   val akkaV = "2.6.17"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,7 +6,7 @@ import Merging._
 import Publishing._
 import Testing._
 import Version._
-import sbt.Keys.{crossScalaVersions, _}
+import sbt.Keys._
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -37,7 +37,9 @@ object Settings {
     "-encoding", "utf8",
 //    "-Ywarn-unused-import", bad option for 2.13
     "-deprecation:false", // This is tricky to enable as of 03/2020 [AEN]
-    "-Xfatal-warnings"
+    "-Xfatal-warnings",
+    "-language:higherKinds",
+    "-Ypartial-unification"
   )
 
   //sbt assembly settings common to rawlsCore and rawlsModel

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,12 +33,14 @@ object Settings {
 
   def scalacOptionsVersion(scalaVersion: String) = {
     val commonCompilerSettings = Seq(
-      "-unchecked",
-      "-feature",
-      "-encoding", "utf8",
       "-deprecation:false", // This is tricky to enable as of 03/2020 [AEN]
-      "-Xfatal-warnings",
-      "-language:higherKinds"
+      "-encoding", "utf8",
+      "-feature",
+      "-language:higherKinds",
+      "-opt:l:inline",
+      "-opt-inline-from:org.broadinstitute.dsde.rawls.**",
+      "-unchecked",
+      "-Xfatal-warnings"
     )
 
     val scala212CompilerSettings = Seq(


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1119
Add functionality to incrementally advance the state of a migration via
composiong together actions that read migrations of a specified state,
perform some action, then write the updated state to the database.
Use ReaderT to inject depedencies into each step/handler.
Use OptionT to encode that there might not be a migration in the right
state to be handled by that handler.
Enable higher-kinded types, type-projection and better-monadic-for.

For anyone unfamiliar with monad transformers:

`ReaderT` and `OptionT` are what's called "Monad Transformers" - they wrap an inner monad and extend its effects with its own. We can "stack" monad transformers to build new, more capable monads with more interesting effects. Let's make this idea clear with an example that's motivated in this PR. Consider a system that fires nuclear weapons at designated targets when an order is given. In such a system, we'll read a command then fire the nuclear weapons and update the command if a command exists.

```scala
def getCommand: IO[Option[Command]] = ???

// https://youtu.be/t8xliaDUPwg?t=37
def fireTheNuclearWeapons(command: Command): IO[Outcome] = ???

def updateCommand(command: Command, outcome: Outcome): IO[Unit] = ???
```

Let's put this system to use:

```scala
def doomsdayMachine: IO[Unit] =
  for {
    commandOpt <- getCommand
    _ <- if (commandOpt.isEmpty) IO.unit else
     for {
       outcome <- fireTheNuclearWeapons(commandOpt.get)
       _ <- updateCommand(outcome, commandOpt.get)    
     } yield ()
  } yield ()
```
What's the problem? Well most of the logic in this function is nested an extra later down leading to clutter. We might need to perform more complicated logic involving optional values which would make this mess worse. Well, we could just write another function. But what about if we have other missiles that need to be fired other than nuclear ones? Then we'd just end up writing tons of functions and we'd end up with a mess.

In this particular case, we can simplify our code by noticing that our whole system conditionally executes if an order exists. This is what the `OptionT` monad transformer enables - it transforms the `IO` `bind` (or `flatMap`) operation from 
`IO[Option[A]] => (Option[A] => IO[Option[B]]) => IO[Option[B] `
 to 
`OptionT[IO, A] => (A => OptionT[IO, B]) => OptionT[IO, B]`
. What does that mean? In `IO`, the argument to `flatMap` (called a "Kleisli arrow") is always called regardless of the state of the `Option`. With `OptionT`, the arrow is only called if the optional value is Some(a). Modifying our function signatures:

```scala
def getCommand: OptionT[IO, Command] = ???

def fireTheNuclearWeapons(command: Command): OptionT[IO, Outcome] = ???

def updateCommand(command: Command, outcome: Outcome): OptionT[IO, Unit] = ???
```
Our system becomes:

```scala
def doomsdayMachine: OptionT[IO, Unit] =
  for {
    command <- getCommand
    outcome <- fireTheNuclearWeapons(command)
    _ <- updateCommand(outcome, command)    
  } yield ()
```

Beautiful.

Now let's say that our commands come from a cloud pubsub queue and `getCommand` and `updateCommand` need access to that pubsub queue. Well, we'll just pass them along as arguments:

```scala
def doomsdayMachine(messageQueue: PubSubQueue): OptionT[IO, Unit] =
  for {
    command <- getCommand(messageQueue)
    outcome <- fireTheNuclearWeapons(command)
    _ <- updateCommand(messageQueue, outcome, command)    
  } yield ()
```

Ok simple enough. But what about if we have other dependencies? Can we just pass these in too? Well yes, but then we get lots of noise from forwarding dependencies to functions, which may need to forward dependencies to the functions they call etc etc etc. Yuck. We can do one better. Enter the `ReaderT` monad transformer!!

The `ReaderT` provides a means of threading dependencies through your application without explicit handling. You can `ask` what the environment is and you can modify the environment locally (`local`) to update a dependency for an inner funciton call. `ReaderT[F[_], Env, A]` is simply a wrapper for the function `Env => F[A]`. We can "stack" the reader onto our existing monad stack to add dependency injection to our system:

```scala
def doomsdayMachine: ReaderT[OptionT[IO, *], PubSubQueue, Unit] =
  for {
    command <- getCommand
    outcome <- fireTheNuclearWeapons(command)
    _ <- updateCommand(outcome, command)    
  } yield ()
```
And we have returned to our original simple program. Monad transformers are awesome.

`ReaderT`: https://typelevel.org/cats/datatypes/kleisli.html

 `OptionT`: https://typelevel.org/cats/datatypes/optiont.html

This is all inspired by monad transformers in Haskell. If you're up to it, the following articles do a great job at explaining things:
https://wiki.haskell.org/IO_inside -- really helpful for understanding IO (and monads in general) in a pure functional language.
https://wiki.haskell.org/Monad_Transformers_Explained
https://wiki.haskell.org/All_About_Monads#The_Reader_monad


- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Check that the **Product Owner** has signed off on any user-facing changes
- [ ] **Submitter**: Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Database checks:
  * If PR includes new or changed db queries, include the explain plans in the description
  * Make sure liquibase is updated if appropriate
  * If doing a migration, take a backup of the
  [dev](https://console.cloud.google.com/sql/instances/terraform-qfarbdq3lrexxck5htofjs5z6m/backups?project=broad-dsde-dev&organizationId=548622027621)
  and
  [alpha](https://console.cloud.google.com/sql/instances/terraform-r4caezzc35c4tb7pgdhwkmme4y/backups?project=broad-dsde-alpha&organizationId=548622027621)
  DBs in Google Cloud Console
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell your tech lead (TL) that the PR exists if they want to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
