### PR TITLE
liquibase full sharding migration [AJ-19]

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210924_populate_sharded_entity_tables.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20210924_populate_sharded_entity_tables.xml
@@ -4,264 +4,267 @@
     <!-- START populate each shard in its own changeset. If we hit an error with an
             individual shard, we can restart the liquibase migration at that point,
             and don't have to rollback any progress up to that changeset. -->
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_00_03">-->
-<!--        <sql>call populateShardAndMarkAsSharded('00_03');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_00_03">
+        <sql>call populateShardAndMarkAsSharded('00_03');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_04_07">-->
-<!--        <sql>call populateShardAndMarkAsSharded('04_07');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_04_07">
+        <sql>call populateShardAndMarkAsSharded('04_07');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_08_0b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('08_0b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_08_0b">
+        <sql>call populateShardAndMarkAsSharded('08_0b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_0c_0f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('0c_0f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_0c_0f">
+        <sql>call populateShardAndMarkAsSharded('0c_0f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_10_13">-->
-<!--        <sql>call populateShardAndMarkAsSharded('10_13');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_10_13">
+        <sql>call populateShardAndMarkAsSharded('10_13');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_14_17">-->
-<!--        <sql>call populateShardAndMarkAsSharded('14_17');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_14_17">
+        <sql>call populateShardAndMarkAsSharded('14_17');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_18_1b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('18_1b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_18_1b">
+        <sql>call populateShardAndMarkAsSharded('18_1b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_1c_1f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('1c_1f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_1c_1f">
+        <sql>call populateShardAndMarkAsSharded('1c_1f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_20_23">-->
-<!--        <sql>call populateShardAndMarkAsSharded('20_23');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_20_23">
+        <sql>call populateShardAndMarkAsSharded('20_23');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_24_27">-->
-<!--        <sql>call populateShardAndMarkAsSharded('24_27');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_24_27">
+        <sql>call populateShardAndMarkAsSharded('24_27');</sql>
+    </changeSet>
 
     <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_28_2b">
         <sql>call populateShardAndMarkAsSharded('28_2b');</sql>
     </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_2c_2f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('2c_2f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_2c_2f">
+        <sql>call populateShardAndMarkAsSharded('2c_2f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_30_33">-->
-<!--        <sql>call populateShardAndMarkAsSharded('30_33');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_30_33">
+        <sql>call populateShardAndMarkAsSharded('30_33');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_34_37">-->
-<!--        <sql>call populateShardAndMarkAsSharded('34_37');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_34_37">
+        <sql>call populateShardAndMarkAsSharded('34_37');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_38_3b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('38_3b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_38_3b">
+        <sql>call populateShardAndMarkAsSharded('38_3b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_3c_3f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('3c_3f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_3c_3f">
+        <sql>call populateShardAndMarkAsSharded('3c_3f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_40_43">-->
-<!--        <sql>call populateShardAndMarkAsSharded('40_43');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_40_43">
+        <sql>call populateShardAndMarkAsSharded('40_43');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_44_47">-->
-<!--        <sql>call populateShardAndMarkAsSharded('44_47');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_44_47">
+        <sql>call populateShardAndMarkAsSharded('44_47');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_48_4b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('48_4b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_48_4b">
+        <sql>call populateShardAndMarkAsSharded('48_4b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_4c_4f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('4c_4f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_4c_4f">
+        <sql>call populateShardAndMarkAsSharded('4c_4f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_50_53">-->
-<!--        <sql>call populateShardAndMarkAsSharded('50_53');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_50_53">
+        <sql>call populateShardAndMarkAsSharded('50_53');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_54_57">-->
-<!--        <sql>call populateShardAndMarkAsSharded('54_57');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_54_57">
+        <sql>call populateShardAndMarkAsSharded('54_57');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_58_5b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('58_5b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_58_5b">
+        <sql>call populateShardAndMarkAsSharded('58_5b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_5c_5f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('5c_5f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_5c_5f">
+        <sql>call populateShardAndMarkAsSharded('5c_5f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_60_63">-->
-<!--        <sql>call populateShardAndMarkAsSharded('60_63');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_60_63">
+        <sql>call populateShardAndMarkAsSharded('60_63');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_64_67">-->
-<!--        <sql>call populateShardAndMarkAsSharded('64_67');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_64_67">
+        <sql>call populateShardAndMarkAsSharded('64_67');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_68_6b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('68_6b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_68_6b">
+        <sql>call populateShardAndMarkAsSharded('68_6b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_6c_6f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('6c_6f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_6c_6f">
+        <sql>call populateShardAndMarkAsSharded('6c_6f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_70_73">-->
-<!--        <sql>call populateShardAndMarkAsSharded('70_73');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_70_73">
+        <sql>call populateShardAndMarkAsSharded('70_73');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_74_77">-->
-<!--        <sql>call populateShardAndMarkAsSharded('74_77');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_74_77">
+        <sql>call populateShardAndMarkAsSharded('74_77');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_78_7b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('78_7b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_78_7b">
+        <sql>call populateShardAndMarkAsSharded('78_7b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_7c_7f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('7c_7f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_7c_7f">
+        <sql>call populateShardAndMarkAsSharded('7c_7f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_80_83">-->
-<!--        <sql>call populateShardAndMarkAsSharded('80_83');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_80_83">
+        <sql>call populateShardAndMarkAsSharded('80_83');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_84_87">-->
-<!--        <sql>call populateShardAndMarkAsSharded('84_87');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_84_87">
+        <sql>call populateShardAndMarkAsSharded('84_87');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_88_8b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('88_8b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_88_8b">
+        <sql>call populateShardAndMarkAsSharded('88_8b');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_8c_8f">-->
-<!--        <sql>call populateShardAndMarkAsSharded('8c_8f');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_8c_8f">
+        <sql>call populateShardAndMarkAsSharded('8c_8f');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_90_93">-->
-<!--        <sql>call populateShardAndMarkAsSharded('90_93');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_90_93">
+        <sql>call populateShardAndMarkAsSharded('90_93');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_94_97">-->
-<!--        <sql>call populateShardAndMarkAsSharded('94_97');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_94_97">
+        <sql>call populateShardAndMarkAsSharded('94_97');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_98_9b">-->
-<!--        <sql>call populateShardAndMarkAsSharded('98_9b');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_98_9b">
+        <sql>call populateShardAndMarkAsSharded('98_9b');</sql>
+    </changeSet>
 
     <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_9c_9f">
         <sql>call populateShardAndMarkAsSharded('9c_9f');</sql>
     </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_a0_a3">-->
-<!--        <sql>call populateShardAndMarkAsSharded('a0_a3');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_a0_a3">
+        <sql>call populateShardAndMarkAsSharded('a0_a3');</sql>
+    </changeSet>
 
     <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_a4_a7">
         <sql>call populateShardAndMarkAsSharded('a4_a7');</sql>
     </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_a8_ab">-->
-<!--        <sql>call populateShardAndMarkAsSharded('a8_ab');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_a8_ab">
+        <sql>call populateShardAndMarkAsSharded('a8_ab');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_ac_af">-->
-<!--        <sql>call populateShardAndMarkAsSharded('ac_af');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_ac_af">
+        <sql>call populateShardAndMarkAsSharded('ac_af');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_b0_b3">-->
-<!--        <sql>call populateShardAndMarkAsSharded('b0_b3');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_b0_b3">
+        <sql>call populateShardAndMarkAsSharded('b0_b3');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_b4_b7">-->
-<!--        <sql>call populateShardAndMarkAsSharded('b4_b7');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_b4_b7">
+        <sql>call populateShardAndMarkAsSharded('b4_b7');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_b8_bb">-->
-<!--        <sql>call populateShardAndMarkAsSharded('b8_bb');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_b8_bb">
+        <sql>call populateShardAndMarkAsSharded('b8_bb');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_bc_bf">-->
-<!--        <sql>call populateShardAndMarkAsSharded('bc_bf');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_bc_bf">
+        <sql>call populateShardAndMarkAsSharded('bc_bf');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_c0_c3">-->
-<!--        <sql>call populateShardAndMarkAsSharded('c0_c3');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_c0_c3">
+        <sql>call populateShardAndMarkAsSharded('c0_c3');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_c4_c7">-->
-<!--        <sql>call populateShardAndMarkAsSharded('c4_c7');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_c4_c7">
+        <sql>call populateShardAndMarkAsSharded('c4_c7');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_c8_cb">-->
-<!--        <sql>call populateShardAndMarkAsSharded('c8_cb');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_c8_cb">
+        <sql>call populateShardAndMarkAsSharded('c8_cb');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_cc_cf">-->
-<!--        <sql>call populateShardAndMarkAsSharded('cc_cf');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_cc_cf">
+        <sql>call populateShardAndMarkAsSharded('cc_cf');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_d0_d3">-->
-<!--        <sql>call populateShardAndMarkAsSharded('d0_d3');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_d0_d3">
+        <sql>call populateShardAndMarkAsSharded('d0_d3');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_d4_d7">-->
-<!--        <sql>call populateShardAndMarkAsSharded('d4_d7');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_d4_d7">
+        <sql>call populateShardAndMarkAsSharded('d4_d7');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_d8_db">-->
-<!--        <sql>call populateShardAndMarkAsSharded('d8_db');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_d8_db">
+        <sql>call populateShardAndMarkAsSharded('d8_db');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_dc_df">-->
-<!--        <sql>call populateShardAndMarkAsSharded('dc_df');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_dc_df">
+        <sql>call populateShardAndMarkAsSharded('dc_df');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_e0_e3">-->
-<!--        <sql>call populateShardAndMarkAsSharded('e0_e3');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_e0_e3">
+        <sql>call populateShardAndMarkAsSharded('e0_e3');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_e4_e7">-->
-<!--        <sql>call populateShardAndMarkAsSharded('e4_e7');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_e4_e7">
+        <sql>call populateShardAndMarkAsSharded('e4_e7');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_e8_eb">-->
-<!--        <sql>call populateShardAndMarkAsSharded('e8_eb');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_e8_eb">
+        <sql>call populateShardAndMarkAsSharded('e8_eb');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_ec_ef">-->
-<!--        <sql>call populateShardAndMarkAsSharded('ec_ef');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_ec_ef">
+        <sql>call populateShardAndMarkAsSharded('ec_ef');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_f0_f3">-->
-<!--        <sql>call populateShardAndMarkAsSharded('f0_f3');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_f0_f3">
+        <sql>call populateShardAndMarkAsSharded('f0_f3');</sql>
+    </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_f4_f7">-->
-<!--        <sql>call populateShardAndMarkAsSharded('f4_f7');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_f4_f7">
+        <sql>call populateShardAndMarkAsSharded('f4_f7');</sql>
+    </changeSet>
 
     <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_f8_fb">
         <sql>call populateShardAndMarkAsSharded('f8_fb');</sql>
     </changeSet>
 
-<!--    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_fc_ff">-->
-<!--        <sql>call populateShardAndMarkAsSharded('fc_ff');</sql>-->
-<!--    </changeSet>-->
+    <changeSet logicalFilePath="dummy" author="davidan" id="populate_shard_fc_ff">
+        <sql>call populateShardAndMarkAsSharded('fc_ff');</sql>
+    </changeSet>
     <!-- END populate each shard in its own changeset. If we hit an error with an
             individual shard, we can restart the liquibase migration at that point,
             and don't have to rollback any progress up to that changeset. -->
 
+    <changeSet id="drop_entity_attribute_archived" author="davidan" logicalFilePath="dummy">
+        <dropTable tableName="ENTITY_ATTRIBUTE_archived" />
+    </changeSet>
 
 </databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -43,7 +43,7 @@ trait DataAccess
       val second = secondLong.toHexString
       determineShard(java.util.UUID.fromString(s"$first${second}000000-0000-0000-0000-000000000000"), shardState = WorkspaceShardStates.Sharded).toString
     }
-  }).toSet + determineShard(java.util.UUID.fromString(s"00000000-0000-0000-0000-000000000000"), shardState = WorkspaceShardStates.Unsharded).toString
+  }).toSet
 
   // only called from TestDriverComponent
   def truncateAll: WriteAction[Int] = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
@@ -72,7 +72,7 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
   // checks row counts for each shard, plus the _archived table
   def checkShardCounts(expected: Map[ShardId, Int] = Map()): Unit = {
     // default to 0 for all shards plus the archive table
-    val default: Map[ShardId, Int] = (allShards + "archived").map(_ -> 0).toMap
+    val default: Map[ShardId, Int] = (allShards).map(_ -> 0).toMap
     val combined = default ++ expected
     combined.foreach {
       case (shardId, expectedCount) =>


### PR DESCRIPTION
I am marking this PR as a draft to ensure it does not merge, but I would like code review on it.

We do not want to let this code reach production until *after* we have manually run the parallelized migration code. If this reaches production it will cause a ~7 hr liquibase migration, while the parallel code cuts that down significantly.

Once the parallel code has run, the migrations in this PR will be noops and fast. It is here for completeness, to ensure that any environment can be created/managed in a fully automated fashion and we don't _require_ the parallel code; we only _prefer_ the parallel code because it is faster.

We will need a future PR, sometime after all the migration completes, to remove the sharded vs. unsharded code paths in `AttributeComponent.determineShard()` and elsewhere.