### PR TITLE
latest 5.x version of mysql-connector [AJ-273]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,7 +78,7 @@ object Dependencies {
   val httpClient: ModuleID =      "org.apache.httpcomponents"     % "httpclient"            % "4.5.13" // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "5.1.42"
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "5.1.49"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.2.10"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"


### PR DESCRIPTION
alternate version of #1625 that stays on the 5.x release of `mysql-connector-java`, let's see how this one does in tests