### PR TITLE
align on Temurin for JVM distro [AJ-273]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,9 @@ jobs:
           sh docker/run-mysql.sh start
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 11
 
       - name: Git secrets setup

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -108,7 +108,7 @@ function make_jar()
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:graalvm-ce-21.2.0-java11_1.5.5_2.12.15 /working/docker/install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-11.0.13_1.5.5_2.12.15 /working/docker/install.sh /working"
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
 


### PR DESCRIPTION
This PR aligns all Rawls build/test onto the Temurin distro for JVM.

_**Before this PR:**_
* **Production Rawls ran on Temurin.** The Rawls Dockerfile uses the appsec blessed image `jre:11-debian`, which in turn is based on Temurin: https://github.com/broadinstitute/dsp-appsec-blessed-images/blob/9cc6026ee85930365653ce5d79ec8f718eedeaab/jre/Dockerfile.11-debian#L1
* **Github Actions build/test ran on Zulu OpenJDK**, because that's the default for `actions/setup-java@v1`
* **Jenkins build/test/assembly ran on GraalVM**, as specified in build.sh.

_**After this PR:**_
* Production, Github Actions, and Jenkins all use Temurin.

This is driven by a mysterious bug that arose in #1625, in which our liquibase changesets applied correctly in Github Actions and when run locally, but hung without error in Jenkins. Switching off GraalVM for Jenkins eliminates the hang.