### PR TITLE
update jersey-client, which updates jersey-common [AJ-273]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,6 +76,7 @@ object Dependencies {
   val commonsJEXL: ModuleID =     "org.apache.commons"            % "commons-jexl"          % "2.1.1"
   val commonsCodec: ModuleID =    "commons-codec"                 % "commons-codec"         % "1.15"   // upgrading a transitive dependency to avoid security warnings
   val httpClient: ModuleID =      "org.apache.httpcomponents"     % "httpclient"            % "4.5.13" // upgrading a transitive dependency to avoid security warnings
+  val jerseyClient: ModuleID =    "org.glassfish.jersey.core"     % "jersey-client"         % "2.35"   // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "5.1.42"
@@ -208,6 +209,7 @@ object Dependencies {
     googleApiClient,
     scalaUri,
     workspaceManager,
+    jerseyClient,
     scalatest
   )
 
@@ -245,6 +247,7 @@ object Dependencies {
     scalaCache,
     apacheCommonsIO,
     workspaceManager,
+    jerseyClient,
     dataRepo,
     dataRepoJersey,
     antlrParser,


### PR DESCRIPTION
Updates the version of `jersey-client`, which carries with it an update to `jersey-common`, which is mentioned in AJ-273. Updating `jersey-common` on its own caused method-not-found errors, so I'm updating the whole client.

The previous version of jersey-client (and jersey-common) that was in use was 2.32. This was pulled in as a transitive dependency in workspace mananger client. If/when workspace manager client updates its jersey dependency, we could remove this.

See also #1625, which is the other half of AJ-273.