### PR TITLE
update mysqlconnector [AJ-273]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -258,7 +258,7 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
 
           traceDBIOWithParent("saveAction", rootSpan)(_ => saveAction)
         } recover {
-          case icve:com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException =>
+          case icve:java.sql.SQLIntegrityConstraintViolationException =>
             val userMessage =
               s"Database error occurred. Check if you are uploading entity names or entity types that differ only in case " +
                 s"from pre-existing entities."

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.server.{Directive0, ExceptionHandler, RejectionHandler
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import bio.terra.workspace.client.ApiException
-import com.mysql.jdbc.exceptions.jdbc4.MySQLTransactionRollbackException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.SwaggerConfig
@@ -28,6 +27,7 @@ import org.broadinstitute.dsde.rawls.status.StatusService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 
+import java.sql.SQLTransactionRollbackException
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -38,7 +38,7 @@ object RawlsApiService extends LazyLogging {
     ExceptionHandler {
       case withErrorReport: RawlsExceptionWithErrorReport =>
         complete(withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError) -> withErrorReport.errorReport)
-      case rollback:MySQLTransactionRollbackException =>
+      case rollback:SQLTransactionRollbackException =>
         logger.error(s"ROLLBACK EXCEPTION, PROBABLE DEADLOCK: ${rollback.getMessage} [${rollback.getErrorCode} ${rollback.getSQLState}] ${rollback.getNextException}", rollback)
         complete(StatusCodes.InternalServerError -> ErrorReport(rollback))
       case wsmApiException: ApiException =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -2,12 +2,12 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import _root_.slick.dbio.DBIOAction
+import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils, model}
 import slick.jdbc.TransactionIsolation
 
-import java.sql.SQLTransactionRollbackException
 import java.util.UUID
 
 /**
@@ -394,7 +394,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // now attempt to calculate attr names and types, with a timeout of 1 second
       withClue("This test is potentially flaky, failures should be reviewed: ") {
-        intercept[SQLTransactionRollbackException] {
+        intercept[MySQLTimeoutException] {
           runAndWait(entityQuery.getAttrNamesAndEntityTypes(context.workspaceIdAsUUID, WorkspaceShardStates.Sharded, 1))
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -2,12 +2,12 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import _root_.slick.dbio.DBIOAction
-import com.mysql.jdbc.exceptions.MySQLTimeoutException
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils, model}
 import slick.jdbc.TransactionIsolation
 
+import java.sql.SQLTransactionRollbackException
 import java.util.UUID
 
 /**
@@ -394,7 +394,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // now attempt to calculate attr names and types, with a timeout of 1 second
       withClue("This test is potentially flaky, failures should be reviewed: ") {
-        intercept[MySQLTimeoutException] {
+        intercept[SQLTransactionRollbackException] {
           runAndWait(entityQuery.getAttrNamesAndEntityTypes(context.workspaceIdAsUUID, WorkspaceShardStates.Sharded, 1))
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, DefaultInstrumented, MetricName}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.config.WDLParserConfig
@@ -32,7 +33,7 @@ import scala.concurrent.{Await, Future}
 import scala.language.{implicitConversions, postfixOps}
 
 // initialize database tables and connection pool only once
-object DbResource {
+object DbResource extends LazyLogging {
   // to override, e.g. to run against mysql:
   // $ sbt -Dtestdb=mysql test
   private val testdb = ConfigFactory.load.getStringOr("testdb", "mysql")
@@ -44,6 +45,9 @@ object DbResource {
 
   val dataSource = new SlickDataSource(dataConfig)(TestExecutionContext.testExecutionContext)
   dataSource.initWithLiquibase(liquibaseChangeLog, Map.empty)
+  logger.info("executing liquibase a second time to verify changesets work on an already-initialized database ...")
+  dataSource.initWithLiquibase(liquibaseChangeLog, Map.empty)
+
 }
 
 /**

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import com.mysql.jdbc.exceptions.jdbc4.MySQLTransactionRollbackException
 import com.typesafe.config.ConfigFactory
 import nl.grons.metrics4.scala.{Counter, DefaultInstrumented, MetricName}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
@@ -26,6 +25,7 @@ import org.scalatest.Suite
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.sql.SQLTransactionRollbackException
 import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -97,7 +97,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
     DbResource.dataSource.database.run(chain).recoverWith {
       case e: RawlsConcurrentModificationException => retryConcurrentModificationException(action)
-      case rollbackException: MySQLTransactionRollbackException if rollbackException.getMessage.contains("try restarting transaction") => retryConcurrentModificationException(action)
+      case rollbackException: SQLTransactionRollbackException if rollbackException.getMessage.contains("try restarting transaction") => retryConcurrentModificationException(action)
     }
   }
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -108,7 +108,7 @@ function make_jar()
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:graalvm-ce-21.3.0-java11_1.5.5_2.12.15 /working/docker/install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-11.0.13_1.5.5_2.12.15 /working/docker/install.sh /working"
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -108,7 +108,7 @@ function make_jar()
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-11.0.13_1.5.5_2.12.15 /working/docker/install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:graalvm-ce-21.3.0-java11_1.5.5_2.12.15 /working/docker/install.sh /working"
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val jerseyClient: ModuleID =    "org.glassfish.jersey.core"     % "jersey-client"         % "2.35"   // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.11"
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.28"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.2.10"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,8 +79,6 @@ object Dependencies {
   val jerseyClient: ModuleID =    "org.glassfish.jersey.core"     % "jersey-client"         % "2.35"   // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.28"
-  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.2.10"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"
   val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.2.2" % "test"
@@ -91,6 +89,20 @@ object Dependencies {
   val scalaCache: ModuleID =      "com.github.cb372"              %% "scalacache-caffeine"  % "0.24.2"
   val apacheCommonsIO: ModuleID = "commons-io"                    % "commons-io"            % "2.6"
   val antlrParser: ModuleID =     "org.antlr"                     % "antlr4-runtime"        % "4.8-1"
+
+  /* mysql-connector-java > 8.0.22 is incompatible with liquibase-core < 4.3.1. See:
+      - https://github.com/liquibase/liquibase/issues/1639
+      - https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-23.html
+     the end result of this incompatibility is that attempting to run Rawls' liquibase on an already-initialized database
+     will throw an error "java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.lang.String".
+     This only occurs on already-initialized databases; it does not happen when liquibase is run the first time on an
+     empty DB. This is important:
+     >> the bug does not show up in unit tests, because unit tests start with an empty database <<
+     The behavior change in mysql-connector-java between 8.0.22 and 8.0.23 needs to be assessed to see if it will cause
+     any issues elsewhere in Rawls before upgrading.
+   */
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.22"
+  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
 
   val workbenchLibsHash = "7ddf186"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val jerseyClient: ModuleID =    "org.glassfish.jersey.core"     % "jersey-client"         % "2.35"   // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "5.1.42"
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.28"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.2.10"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -96,8 +96,8 @@ object Dependencies {
      the end result of this incompatibility is that attempting to run Rawls' liquibase on an already-initialized database
      will throw an error "java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.lang.String".
      This only occurs on already-initialized databases; it does not happen when liquibase is run the first time on an
-     empty DB. This is important:
-     >> the bug does not show up in unit tests, because unit tests start with an empty database <<
+     empty DB.
+
      The behavior change in mysql-connector-java between 8.0.22 and 8.0.23 needs to be assessed to see if it will cause
      any issues elsewhere in Rawls before upgrading.
    */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val jerseyClient: ModuleID =    "org.glassfish.jersey.core"     % "jersey-client"         % "2.35"   // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.16"
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.11"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.2.10"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val jerseyClient: ModuleID =    "org.glassfish.jersey.core"     % "jersey-client"         % "2.35"   // upgrading a transitive dependency to avoid security warnings
   val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.6.1"
   val parserCombinators =         "org.scala-lang.modules"        %% "scala-parser-combinators" % "1.1.1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.28"
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.16"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.2.10"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"


### PR DESCRIPTION
See also: #1625 , #1633. The original PR #1625 to update `mysql-connector-java` passed all tests, including fiab/swatomation tests, but failed when deploying in argo/k8s. I reverted those changes in #1633 to unblock deploys.

The failure deploying in argo/k8s was due to a bug that happened while processing liquibase changesets. This bug only happens when processing changesets on top of an already-initialized database; it does not occur when processing changesets from scratch on an empty db. Thus, the bug did not previously appear in unit tests or fiabs, because those start from an empty db.

This PR:
* updates `mysql-connector-java` to a liquibase-compatible version
* updates the unit test framework to catch the bug in question