### PR TITLE
always use entity metadata cache [AJ-310]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -63,14 +63,5 @@ trait EntityCacheComponent {
 
       uniqueResult[Int](baseQuery)
     }
-
-    // TODO: update the tests that call this method to call entityCacheStaleness instead, then delete this method
-    /** does an up-to-date entity cache exist? currently unused except in tests */
-    def isEntityCacheCurrent(workspaceId: UUID): ReadAction[Boolean] = {
-      // staleness of 0 means the cache is current
-      entityCacheStaleness(workspaceId).map (_.getOrElse(Integer.MAX_VALUE) == 0)
-    }
-
   }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -63,24 +63,10 @@ trait EntityCacheComponent {
       uniqueResult[Int](baseQuery)
     }
 
-    /** does an up-to-date entity cache exist? */
-    // currently unused except in tests
+    /** does an up-to-date entity cache exist? currently unused except in tests */
     def isEntityCacheCurrent(workspaceId: UUID): ReadAction[Boolean] = {
       // staleness of 0 means the cache is current
       entityCacheStaleness(workspaceId).map (_.getOrElse(Integer.MAX_VALUE) == 0)
-
-//      val baseQuery = sql"""SELECT EXISTS(
-//              SELECT 1
-//                FROM WORKSPACE w, WORKSPACE_ENTITY_CACHE c
-//                WHERE
-//                  w.id = $workspaceId
-//                  and w.id = c.workspace_id
-//                  and w.last_modified = c.entity_cache_last_updated
-//                LIMIT 1);""".as[Int]
-//
-//      uniqueResult[Int](baseQuery).map { existsResult =>
-//        existsResult.contains(1)
-//      }
     }
 
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -47,6 +47,7 @@ trait EntityCacheComponent {
       entityCacheQuery.insertOrUpdate(EntityCacheRecord(workspaceId, timestamp, errorMessage))
     }
 
+    // TODO: probably rename this method, I expect an "exists" method to return a boolean
     /** does an entity cache exist at all, regardless of how current it is?
       *  returns None if no cache exists
       *  returns Some[Int] if a cache exists. The integer is the number of seconds
@@ -54,7 +55,7 @@ trait EntityCacheComponent {
       * */
     def entityCacheExists(workspaceId: UUID): ReadAction[Option[Int]] = {
       val baseQuery = sql"""
-                      select TIMESTAMPDIFF(SECOND, w.last_modified, c.entity_cache_last_updated) as staleness
+                      select TIMESTAMPDIFF(SECOND, c.entity_cache_last_updated, w.last_modified) as staleness
                         from WORKSPACE w, WORKSPACE_ENTITY_CACHE c
                         where c.workspace_id = w.id
                         and c.workspace_id = $workspaceId;""".as[Int]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityCacheComponent.scala
@@ -50,8 +50,9 @@ trait EntityCacheComponent {
     /**
       * Describes the staleness of the entity cache for a given workspace.
       *  - returns None if no cache exists
-      *  - returns Some[Int] if a cache exists. The integer is the number of seconds
-      *   by which the cache is stale; this will be zero if the cache is up-to-date
+      *  - returns Some(0) if a cache exists and is up-to-date
+      *  - returns Some(n) if a cache exists but is out of date, where n is a positive integer representing
+      *     the number of seconds by which the cache is stale.
       * */
     def entityCacheStaleness(workspaceId: UUID): ReadAction[Option[Int]] = {
       val baseQuery = sql"""
@@ -63,6 +64,7 @@ trait EntityCacheComponent {
       uniqueResult[Int](baseQuery)
     }
 
+    // TODO: update the tests that call this method to call entityCacheStaleness instead, then delete this method
     /** does an up-to-date entity cache exist? currently unused except in tests */
     def isEntityCacheCurrent(workspaceId: UUID): ReadAction[Boolean] = {
       // staleness of 0 means the cache is current

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -548,20 +548,6 @@ trait EntityComponent {
       EntityAndAttributesRawSqlQuery.activeActionForType(workspaceContext, entityType) map(query => unmarshalEntities(query, workspaceContext.shardState))
     }
 
-    // get entity types, counts, and attribute names to populate UI tables.  Active entities and attributes only.
-    /* currently unused except in tests */
-    // TODO: update the tests that call this method, then delete this method
-    def getEntityTypeMetadata(workspaceContext: Workspace, outerSpan: Span = null): ReadAction[Map[String, EntityTypeMetadata]] = {
-      val typesAndCountsQ = traceReadOnlyDBIOWithParent("getEntityTypesWithCounts", outerSpan) { _ =>
-        getEntityTypesWithCounts(workspaceContext.workspaceIdAsUUID)
-      }
-      val typesAndAttrsQ = traceReadOnlyDBIOWithParent("getAttrNamesAndEntityTypes", outerSpan) { _ =>
-        getAttrNamesAndEntityTypes(workspaceContext.workspaceIdAsUUID, workspaceContext.shardState)
-      }
-
-      generateEntityMetadataMap(typesAndCountsQ, typesAndAttrsQ)
-    }
-
     def getEntityTypesWithCounts(workspaceId: UUID): ReadAction[Map[String, Int]] = {
       findActiveEntityByWorkspace(workspaceId).groupBy(e => e.entityType).map { case (entityType, entities) =>
         (entityType, entities.length)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceShardStates.WorkspaceShardState
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
-import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.traceDBIOWithParent
+import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.{traceDBIOWithParent, traceReadOnlyDBIOWithParent}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsFatalExceptionWithErrorReport, model}
 import slick.jdbc.{GetResult, JdbcProfile}
 
@@ -550,9 +550,13 @@ trait EntityComponent {
 
     // get entity types, counts, and attribute names to populate UI tables.  Active entities and attributes only.
 
-    def getEntityTypeMetadata(workspaceContext: Workspace): ReadAction[Map[String, EntityTypeMetadata]] = {
-      val typesAndCountsQ = getEntityTypesWithCounts(workspaceContext.workspaceIdAsUUID)
-      val typesAndAttrsQ = getAttrNamesAndEntityTypes(workspaceContext.workspaceIdAsUUID, workspaceContext.shardState)
+    def getEntityTypeMetadata(workspaceContext: Workspace, outerSpan: Span = null): ReadAction[Map[String, EntityTypeMetadata]] = {
+      val typesAndCountsQ = traceReadOnlyDBIOWithParent("getEntityTypesWithCounts", outerSpan) { _ =>
+        getEntityTypesWithCounts(workspaceContext.workspaceIdAsUUID)
+      }
+      val typesAndAttrsQ = traceReadOnlyDBIOWithParent("getAttrNamesAndEntityTypes", outerSpan) { _ =>
+        getAttrNamesAndEntityTypes(workspaceContext.workspaceIdAsUUID, workspaceContext.shardState)
+      }
 
       generateEntityMetadataMap(typesAndCountsQ, typesAndAttrsQ)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -549,7 +549,8 @@ trait EntityComponent {
     }
 
     // get entity types, counts, and attribute names to populate UI tables.  Active entities and attributes only.
-
+    /* currently unused except in tests */
+    // TODO: update the tests that call this method, then delete this method
     def getEntityTypeMetadata(workspaceContext: Workspace, outerSpan: Span = null): ReadAction[Map[String, EntityTypeMetadata]] = {
       val typesAndCountsQ = traceReadOnlyDBIOWithParent("getEntityTypesWithCounts", outerSpan) { _ =>
         getEntityTypesWithCounts(workspaceContext.workspaceIdAsUUID)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
@@ -11,18 +11,23 @@ import java.sql.Timestamp
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
+/**
+  * helper methods that deal with entity type metadata and its cache
+  */
 trait EntityStatisticsCacheSupport extends LazyLogging {
 
   implicit protected val executionContext: ExecutionContext
-
-  val workspaceContext: Workspace
   protected val dataSource: SlickDataSource
+  val workspaceContext: Workspace
 
   import dataSource.dataAccess.driver.api._
 
-  /** convenience method for querying and then assembling an entity type metadata response
-    *
-    * see also getEntityTypeMetadata() in EntityComponent
+  private val FEATURE_ALWAYS_CACHE_TYPE_COUNTS = "alwaysCacheTypeCounts"
+  private val FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES = "alwaysCacheAttributes"
+
+  /** convenience method for querying and then assembling an entity type metadata response.
+    * if this method retrieves metadata directly from entities and attributes (i.e. not from cache),
+    * it will update the cache with the results it found.
     * */
   def calculateMetadataResponse(dataAccess: DataAccess,
                                         countsFromCache: Boolean,
@@ -88,11 +93,11 @@ trait EntityStatisticsCacheSupport extends LazyLogging {
       // TODO: use actual feature flag methods once that PR merges. Will look something like:
       /*
       dataAccess.workspaceFeatureFlagQuery.listFlagsForWorkspace(workspaceContext.workspaceIdAsUUID,
-        List("alwaysCacheTypeCounts", "alwaysCacheAttributes")).flatMap { foundFlags =>
+        List(FEATURE_ALWAYS_CACHE_TYPE_COUNTS, FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES)).flatMap { foundFlags =>
 
         val flagMap: Map[String, Boolean] = foundFlags.map { flag => (flag.flagname -> flag.enabled)}
-        val alwaysCacheTypeCounts = flagMap.getOrElse("alwaysCacheTypeCounts", false)
-        val alwaysCacheAttributes = flagMap.getOrElse("alwaysCacheAttributes", false)
+        val alwaysCacheTypeCounts = flagMap.getOrElse(FEATURE_ALWAYS_CACHE_TYPE_COUNTS, false)
+        val alwaysCacheAttributes = flagMap.getOrElse(FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES, false)
         CacheFeatureFlags(alwaysCacheTypeCounts = alwaysCacheTypeCounts, alwaysCacheAttributes = alwaysCacheAttributes)
       }
       */

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
@@ -101,7 +101,7 @@ trait EntityStatisticsCacheSupport extends LazyLogging {
         CacheFeatureFlags(alwaysCacheTypeCounts = alwaysCacheTypeCounts, alwaysCacheAttributes = alwaysCacheAttributes)
       }
       */
-      DBIO.successful(CacheFeatureFlags(alwaysCacheTypeCounts = false, alwaysCacheAttributes = true))
+      DBIO.successful(CacheFeatureFlags(alwaysCacheTypeCounts = false, alwaysCacheAttributes = false))
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
@@ -1,0 +1,147 @@
+package org.broadinstitute.dsde.rawls.entities.local
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opencensus.trace.Span
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, EntityTypeMetadata, Workspace}
+import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.{traceDBIOWithParent, traceReadOnlyDBIOWithParent}
+
+import java.sql.Timestamp
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+trait EntityStatisticsCacheSupport extends LazyLogging {
+
+  implicit protected val executionContext: ExecutionContext
+
+  val workspaceContext: Workspace
+  protected val dataSource: SlickDataSource
+
+  import dataSource.dataAccess.driver.api._
+
+  /** convenience method for querying and then assembling an entity type metadata response
+    *
+    * see also getEntityTypeMetadata() in EntityComponent
+    * */
+  def calculateMetadataResponse(dataAccess: DataAccess,
+                                        countsFromCache: Boolean,
+                                        attributesFromCache: Boolean,
+                                        outerSpan: Span = null): ReadWriteAction[Map[String, EntityTypeMetadata]] = {
+    val typesAndCountsQ = typeCounts(dataAccess, countsFromCache, outerSpan)
+    val typesAndAttrsQ = typeAttributes(dataAccess, attributesFromCache, outerSpan)
+    traceDBIOWithParent[Map[String, EntityTypeMetadata]]("generateEntityMetadataMap", outerSpan) { innerSpan =>
+      dataAccess.entityQuery.generateEntityMetadataMap(typesAndCountsQ, typesAndAttrsQ).flatMap { metadata =>
+        // and opportunistically save, if we have bypassed cache for all components
+        val saveCacheAction = if (countsFromCache || attributesFromCache) {
+          DBIO.successful(())
+        } else {
+          opportunisticSaveEntityCache(metadata, dataAccess, outerSpan)
+        }
+        saveCacheAction.map(_ => metadata)
+      }
+    }
+  }
+
+  /** convenience method for writing back to cache, if we have already calculated a response from outside the cache */
+  def opportunisticSaveEntityCache(metadata: Map[String, EntityTypeMetadata], dataAccess: DataAccess, outerSpan: Span = null) = {
+    val entityTypesWithCounts: Map[String, Int] = metadata.map {
+      case (typeName, typeMetadata) => typeName -> typeMetadata.count
+    }
+    val entityTypesWithAttrNames: Map[String, Seq[AttributeName]] = metadata.map {
+      case (typeName, typeMetadata) => typeName -> typeMetadata.attributeNames.map(AttributeName.fromDelimitedName)
+    }
+    val timestamp: Timestamp = new Timestamp(workspaceContext.lastModified.getMillis)
+
+    traceDBIOWithParent("generateEntityMetadataMap", outerSpan) { _ =>
+      dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceContext.workspaceIdAsUUID,
+        entityTypesWithCounts, entityTypesWithAttrNames, timestamp).asTry.map {
+        case Success(_) => // noop
+        case Failure(ex) =>
+          logger.warn(s"failed to opportunistically update the entity statistics cache: ${ex.getMessage}. " +
+            s"The user's request was not impacted.")
+      }
+    }
+  }
+
+  /** wrapper for cache staleness lookup, includes performance tracing */
+  def cacheStaleness(dataAccess: DataAccess, outerSpan: Span = null): ReadAction[Option[Int]] = {
+    traceReadOnlyDBIOWithParent("entityCacheStaleness", outerSpan) { _ =>
+      dataAccess.entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID).map { stalenessOpt =>
+        // record the cache-staleness for this request
+        // TODO: send to a metrics service that allows these values to be graphed/analyzed, instead of just logging
+        stalenessOpt match {
+          case Some(staleness) => logger.info(s"entity statistics cache staleness: $staleness")
+          case None => logger.info(s"entity statistics cache staleness: n/a (cache does not exist)")
+        }
+        stalenessOpt
+      }
+    }
+  }
+
+  // TODO: move case class somewhere more central
+  case class CacheFeatureFlags(alwaysCacheTypeCounts: Boolean, alwaysCacheAttributes: Boolean)
+
+  /** wrapper for workspace feature flag lookup, includes performance tracing */
+  def cacheFeatureFlags(dataAccess: DataAccess, outerSpan: Span = null): ReadAction[CacheFeatureFlags] = {
+    traceReadOnlyDBIOWithParent("getWorkspaceFeatureFlags", outerSpan) { _ =>
+      // TODO: use actual feature flag methods once that PR merges. Will look something like:
+      /*
+      dataAccess.workspaceFeatureFlagQuery.listFlagsForWorkspace(workspaceContext.workspaceIdAsUUID,
+        List("alwaysCacheTypeCounts", "alwaysCacheAttributes")).flatMap { foundFlags =>
+
+        val flagMap: Map[String, Boolean] = foundFlags.map { flag => (flag.flagname -> flag.enabled)}
+        val alwaysCacheTypeCounts = flagMap.getOrElse("alwaysCacheTypeCounts", false)
+        val alwaysCacheAttributes = flagMap.getOrElse("alwaysCacheAttributes", false)
+        CacheFeatureFlags(alwaysCacheTypeCounts = alwaysCacheTypeCounts, alwaysCacheAttributes = alwaysCacheAttributes)
+      }
+      */
+      DBIO.successful(CacheFeatureFlags(alwaysCacheTypeCounts = false, alwaysCacheAttributes = true))
+    }
+  }
+
+  /** convenience method for retrieving type-counts, either from cache or from raw entities */
+  def typeCounts(dataAccess: DataAccess, fromCache: Boolean, outerSpan: Span = null): ReadAction[Map[String, Int]] = {
+    if (fromCache)
+      cachedTypeCounts(dataAccess, outerSpan)
+    else
+      uncachedTypeCounts(dataAccess, outerSpan)
+  }
+
+  /** convenience method for retrieving type-attributes, either from cache or from raw attributes */
+  def typeAttributes(dataAccess: DataAccess, fromCache: Boolean, outerSpan: Span = null): ReadAction[Map[String, Seq[AttributeName]]] = {
+    if (fromCache)
+      cachedTypeAttributes(dataAccess, outerSpan)
+    else
+      uncachedTypeAttributes(dataAccess, outerSpan)
+  }
+
+  /** wrapper for cached type-counts lookup, includes performance tracing */
+  def cachedTypeCounts(dataAccess: DataAccess, outerSpan: Span = null): ReadAction[Map[String, Int]] = {
+    traceReadOnlyDBIOWithParent("entityTypeStatisticsQuery.getAll", outerSpan) { _ =>
+      dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID)
+    }
+  }
+
+  /** wrapper for uncached type-counts lookup, includes performance tracing */
+  def uncachedTypeCounts(dataAccess: DataAccess, outerSpan: Span = null): ReadAction[Map[String, Int]] = {
+    traceReadOnlyDBIOWithParent("getEntityTypesWithCounts", outerSpan) { _ =>
+      dataAccess.entityQuery.getEntityTypesWithCounts(workspaceContext.workspaceIdAsUUID)
+    }
+  }
+
+  /** wrapper for cached type-attributes lookup, includes performance tracing */
+  def cachedTypeAttributes(dataAccess: DataAccess, outerSpan: Span = null): ReadAction[Map[String, Seq[AttributeName]]] = {
+    traceReadOnlyDBIOWithParent("entityAttributeStatisticsQuery.getAll", outerSpan) { _ =>
+      dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID)
+    }
+  }
+
+  /** wrapper for uncached type-attributes lookup, includes performance tracing */
+  def uncachedTypeAttributes(dataAccess: DataAccess, outerSpan: Span = null): ReadAction[Map[String, Seq[AttributeName]]] = {
+    traceReadOnlyDBIOWithParent("getAttrNamesAndEntityTypes", outerSpan) { _ =>
+      dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceContext.workspaceIdAsUUID, workspaceContext.shardState)
+    }
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
@@ -43,7 +43,7 @@ trait EntityStatisticsCacheSupport extends LazyLogging {
         val saveCacheAction = if (countsFromCache || attributesFromCache) {
           DBIO.successful(())
         } else {
-          opportunisticSaveEntityCache(metadata, dataAccess, outerSpan)
+          opportunisticSaveEntityCache(metadata, dataAccess, innerSpan)
         }
         saveCacheAction.map(_ => metadata)
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -52,6 +52,9 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
                 val typesAndCountsQ = dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID)
                 val typesAndAttrsQ = dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID)
 
+                // TODO: if cache is out of date, fire off an async/non-blocking cache update.
+                // TODO: re-enable the "opportunistically update cache if user requests metadata while cache is out of date" test
+
                 dataAccess.entityQuery.generateEntityMetadataMap(typesAndCountsQ, typesAndAttrsQ)
               }
             }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -66,17 +66,15 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
             case Some(staleness) =>
               // cache exists, but is out of date - check if this workspace has any always-cache feature flags set
               cacheFeatureFlags(dataAccess, rootSpan).flatMap { flags =>
-                val alwaysCacheCounts = flags.alwaysCacheTypeCounts
-                val alwaysCacheAttributes = flags.alwaysCacheAttributes
-                if (alwaysCacheCounts || alwaysCacheAttributes) {
-                  rootSpan.putAttribute("alwaysCacheCountsFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(alwaysCacheCounts))
-                  rootSpan.putAttribute("alwaysCacheAttributesFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(alwaysCacheAttributes))
-                  logger.info(s"entity statistics cache: partial hit (alwaysCacheCounts=$alwaysCacheCounts, alwaysCacheAttributes=$alwaysCacheAttributes) [${workspaceContext.workspaceIdAsUUID}]")
+                if (flags.alwaysCacheTypeCounts || flags.alwaysCacheAttributes) {
+                  rootSpan.putAttribute("alwaysCacheCountsFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheTypeCounts))
+                  rootSpan.putAttribute("alwaysCacheAttributesFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheAttributes))
+                  logger.info(s"entity statistics cache: partial hit (alwaysCacheCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}) [${workspaceContext.workspaceIdAsUUID}]")
                 } else {
                   logger.info(s"entity statistics cache: miss (cache is out of date) [${workspaceContext.workspaceIdAsUUID}]")
                   // and opportunistically save
                 }
-                calculateMetadataResponse(dataAccess, countsFromCache = alwaysCacheCounts, attributesFromCache = alwaysCacheAttributes, rootSpan)
+                calculateMetadataResponse(dataAccess, countsFromCache = flags.alwaysCacheTypeCounts, attributesFromCache = flags.alwaysCacheAttributes, rootSpan)
               } // end feature-flags lookup
           } // end staleness lookup
         } // end if useCache/cacheEnabled check

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -70,7 +70,7 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
                   rootSpan.putAttribute("alwaysCacheAttributesFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheAttributes))
                   logger.info(s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]")
                 } else {
-                  logger.info(s"entity statistics cache: miss (cache is out of date) [${workspaceContext.workspaceIdAsUUID}]")
+                  logger.info(s"entity statistics cache: miss (cache is out of date, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]")
                   // and opportunistically save
                 }
                 calculateMetadataResponse(dataAccess, countsFromCache = flags.alwaysCacheTypeCounts, attributesFromCache = flags.alwaysCacheAttributes, rootSpan)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -62,13 +62,13 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
               // cache is up to date - return cached
               logger.info(s"entity statistics cache: hit [${workspaceContext.workspaceIdAsUUID}]")
               calculateMetadataResponse(dataAccess, countsFromCache = true, attributesFromCache = true, rootSpan)
-            case Some(_) =>
+            case Some(stalenessSeconds) =>
               // cache exists, but is out of date - check if this workspace has any always-cache feature flags set
               cacheFeatureFlags(dataAccess, rootSpan).flatMap { flags =>
                 if (flags.alwaysCacheTypeCounts || flags.alwaysCacheAttributes) {
                   rootSpan.putAttribute("alwaysCacheTypeCountsFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheTypeCounts))
                   rootSpan.putAttribute("alwaysCacheAttributesFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheAttributes))
-                  logger.info(s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}) [${workspaceContext.workspaceIdAsUUID}]")
+                  logger.info(s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]")
                 } else {
                   logger.info(s"entity statistics cache: miss (cache is out of date) [${workspaceContext.workspaceIdAsUUID}]")
                   // and opportunistically save

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/OpenCensusDBIOUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/OpenCensusDBIOUtils.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.util
 
 import io.opencensus.scala.Tracing._
 import io.opencensus.trace.{Span, Status}
-import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadAction, ReadWriteAction}
 import slick.dbio.DBIO
 
 import scala.concurrent.ExecutionContext
@@ -15,6 +15,18 @@ object OpenCensusDBIOUtils {
     traceDBIOSpan(startSpan(name), failureStatus)(f)
 
   private def traceDBIOSpan[T](span: Span, failureStatus: Throwable => Status)(f: Span => ReadWriteAction[T])(implicit executor: ExecutionContext): ReadWriteAction[T] =
+    f(span).cleanUp { _ =>
+      endSpan(span, Status.OK)
+      DBIO.successful(0)
+    }
+
+  def traceReadOnlyDBIOWithParent[T](name: String, parentSpan: Span, failureStatus: Throwable => Status = (_: Throwable) => Status.UNKNOWN)(f: Span => ReadAction[T])(implicit executor: ExecutionContext): ReadAction[T] =
+    traceReadOnlyDBIOSpan(startSpanWithParent(name, parentSpan), failureStatus)(f)
+
+  def traceReadOnlyDBIO[T](name: String, failureStatus: Throwable => Status = (_: Throwable) => Status.UNKNOWN)(f: Span => ReadAction[T])(implicit executor: ExecutionContext): ReadAction[T] =
+    traceReadOnlyDBIOSpan(startSpan(name), failureStatus)(f)
+
+  private def traceReadOnlyDBIOSpan[T](span: Span, failureStatus: Throwable => Status)(f: Span => ReadAction[T])(implicit executor: ExecutionContext): ReadAction[T] =
     f(span).cleanUp { _ =>
       endSpan(span, Status.OK)
       DBIO.successful(0)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -401,66 +401,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-  it should "list all entity type metadata" in withDefaultTestDatabase {
-    withWorkspaceContext(testData.workspace) { context =>
 
-      val desiredTypeMetadata = Map[String, EntityTypeMetadata](
-        "Sample" -> EntityTypeMetadata(8, "sample_id", Seq("type", "whatsit", "thingies", "quot", "somefoo", "tumortype", "confused", "cycle", "foo_id")),
-        "Aliquot" -> EntityTypeMetadata(2, "aliquot_id", Seq()),
-        "Pair" -> EntityTypeMetadata(2, "pair_id", Seq("case", "control", "whatsit")),
-        "SampleSet" -> EntityTypeMetadata(5, "sampleset_id", Seq("samples", "hasSamples")),
-        "PairSet" -> EntityTypeMetadata(1, "pairset_id", Seq("pairs")),
-        "Individual" -> EntityTypeMetadata(2, "individual_id", Seq("sset"))
-      )
-
-      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
-      //so we test the existence of all keys correctly here...
-      val testTypeMetadata = runAndWait(entityQuery.getEntityTypeMetadata(context))
-      assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
-
-      testTypeMetadata foreach { case (eType, testMetadata) =>
-        val desiredMetadata = desiredTypeMetadata(eType)
-
-        //...and test that count and the list of attribute names are correct here.
-        assert(testMetadata.count == desiredMetadata.count)
-        assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
-      }
-    }
-  }
-
-  // GAWB-870
   val testWorkspace = new EmptyWorkspace
-  it should "list all entity type metadata when all_attribute_values is null" in withCustomTestDatabase(testWorkspace) { dataSource =>
-    withWorkspaceContext(testWorkspace.workspace) { context =>
-
-      val id1 = 1
-      val id2 = 2   // arbitrary
-
-      // count distinct misses rows with null columns, like this one
-      runAndWait(entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id1, "test1", "null_attrs_type", context.workspaceIdAsUUID, 0, None, deleted = false, None))
-
-      runAndWait(entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id2, "test2", "blank_attrs_type", context.workspaceIdAsUUID, 0, Some(""), deleted = false, None))
-
-      val desiredTypeMetadata = Map[String, EntityTypeMetadata](
-        "null_attrs_type" -> EntityTypeMetadata(1, "null_attrs_type_id", Seq()),
-        "blank_attrs_type" -> EntityTypeMetadata(1, "blank_attrs_type", Seq())
-      )
-
-      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
-      //so we test the existence of all keys correctly here...
-      val testTypeMetadata = runAndWait(entityQuery.getEntityTypeMetadata(context))
-      assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
-
-      testTypeMetadata foreach { case (eType, testMetadata) =>
-        val desiredMetadata = desiredTypeMetadata(eType)
-
-        //...and test that count and the list of attribute names are correct here.
-        assert(testMetadata.count == desiredMetadata.count)
-        assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
-      }
-    }
-  }
-
 
   it should "trim giant all_attribute_values strings so they don't overflow" in withCustomTestDatabase(testWorkspace) { dataSource =>
     //it'll be longer than this (and thus will need trimming) because it'll get the entity name too

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupportSpec.scala
@@ -1,0 +1,87 @@
+package org.broadinstitute.dsde.rawls.entities.local
+
+import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{EntityRecordWithInlineAttributes, TestDriverComponentWithFlatSpecAndMatchers}
+import org.broadinstitute.dsde.rawls.model.{EntityTypeMetadata, Workspace}
+
+import scala.concurrent.ExecutionContext
+
+class CacheSupport(val dataSource: SlickDataSource, val workspaceContext: Workspace) extends EntityStatisticsCacheSupport {
+  override implicit protected val executionContext: ExecutionContext = ExecutionContext.global
+}
+
+
+class EntityStatisticsCacheSupportSpec extends TestDriverComponentWithFlatSpecAndMatchers with RawlsTestUtils {
+
+  import driver.api._
+
+  behavior of "EntityStatisticsCacheSupport"
+
+  it should "list all entity type metadata" in withDefaultTestDatabase {
+    withWorkspaceContext(testData.workspace) { context =>
+
+      val cacheSupport = new CacheSupport(slickDataSource, context)
+
+      val desiredTypeMetadata = Map[String, EntityTypeMetadata](
+        "Sample" -> EntityTypeMetadata(8, "sample_id", Seq("type", "whatsit", "thingies", "quot", "somefoo", "tumortype", "confused", "cycle", "foo_id")),
+        "Aliquot" -> EntityTypeMetadata(2, "aliquot_id", Seq()),
+        "Pair" -> EntityTypeMetadata(2, "pair_id", Seq("case", "control", "whatsit")),
+        "SampleSet" -> EntityTypeMetadata(5, "sampleset_id", Seq("samples", "hasSamples")),
+        "PairSet" -> EntityTypeMetadata(1, "pairset_id", Seq("pairs")),
+        "Individual" -> EntityTypeMetadata(2, "individual_id", Seq("sset"))
+      )
+
+      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
+      //so we test the existence of all keys correctly here...
+      val testTypeMetadata = runAndWait(cacheSupport.calculateMetadataResponse(slickDataSource.dataAccess,
+        countsFromCache = false, attributesFromCache = false, outerSpan = null))
+      assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
+
+      testTypeMetadata foreach { case (eType, testMetadata) =>
+        val desiredMetadata = desiredTypeMetadata(eType)
+
+        //...and test that count and the list of attribute names are correct here.
+        assert(testMetadata.count == desiredMetadata.count)
+        assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
+      }
+    }
+  }
+
+  // GAWB-870
+  val testWorkspace = new EmptyWorkspace
+  it should "list all entity type metadata when all_attribute_values is null" in withCustomTestDatabase(testWorkspace) { dataSource =>
+    withWorkspaceContext(testWorkspace.workspace) { context =>
+
+      val cacheSupport = new CacheSupport(slickDataSource, context)
+
+      val id1 = 1
+      val id2 = 2   // arbitrary
+
+      // count distinct misses rows with null columns, like this one
+      runAndWait(entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id1, "test1", "null_attrs_type", context.workspaceIdAsUUID, 0, None, deleted = false, None))
+
+      runAndWait(entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id2, "test2", "blank_attrs_type", context.workspaceIdAsUUID, 0, Some(""), deleted = false, None))
+
+      val desiredTypeMetadata = Map[String, EntityTypeMetadata](
+        "null_attrs_type" -> EntityTypeMetadata(1, "null_attrs_type_id", Seq()),
+        "blank_attrs_type" -> EntityTypeMetadata(1, "blank_attrs_type", Seq())
+      )
+
+      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
+      //so we test the existence of all keys correctly here...
+      val testTypeMetadata = runAndWait(cacheSupport.calculateMetadataResponse(dataSource.dataAccess,
+        countsFromCache = false, attributesFromCache = false, outerSpan = null))
+      assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
+
+      testTypeMetadata foreach { case (eType, testMetadata) =>
+        val desiredMetadata = desiredTypeMetadata(eType)
+
+        //...and test that count and the list of attribute names are correct here.
+        assert(testMetadata.count == desiredMetadata.count)
+        assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -505,95 +505,97 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     }
   }
 
-  "return helpful error message when upserting case-divergent entity names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
-    val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-    val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
+  "LocalEntityProvider case-sensitivity" should {
+    "return helpful error message when upserting case-divergent entity names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
+      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
+      val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
-    // create the first entity with name "myname"
-    val entity1 = Entity("myname", "casetest", Map())
-    val created1 = localEntityProvider.createEntity(entity1).futureValue
-    created1 shouldBe entity1
+      // create the first entity with name "myname"
+      val entity1 = Entity("myname", "casetest", Map())
+      val created1 = localEntityProvider.createEntity(entity1).futureValue
+      created1 shouldBe entity1
 
-    // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
-    val entity2 = Entity("MyName", "casetest", Map())
-    val ex = recoverToExceptionIf[Exception] {
-      localEntityProvider.createEntity(entity2)
-    }.futureValue
+      // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
+      val entity2 = Entity("MyName", "casetest", Map())
+      val ex = recoverToExceptionIf[Exception] {
+        localEntityProvider.createEntity(entity2)
+      }.futureValue
 
-    ex match {
-      case er:RawlsExceptionWithErrorReport =>
-        val expectedMessage = s"${entity2.entityType} ${entity2.name} already exists in ${workspaceContext.toWorkspaceName}"
-        er.errorReport.message shouldBe expectedMessage
-      case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      ex match {
+        case er: RawlsExceptionWithErrorReport =>
+          val expectedMessage = s"${entity2.entityType} ${entity2.name} already exists in ${workspaceContext.toWorkspaceName}"
+          er.errorReport.message shouldBe expectedMessage
+        case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      }
     }
-  }
 
-  "return helpful error message when upserting case-divergent entity names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
-    val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-    val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
+    "return helpful error message when upserting case-divergent entity names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
+      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
+      val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
-    // create the first entity with name "myname"
-    val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
-    val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
-    created1.size shouldBe 1
+      // create the first entity with name "myname"
+      val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
+      val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
+      created1.size shouldBe 1
 
-    // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
-    val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))
-    val ex = recoverToExceptionIf[Exception] {
-      localEntityProvider.batchUpsertEntities(upsert2)
-    }.futureValue
+      // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
+      val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))
+      val ex = recoverToExceptionIf[Exception] {
+        localEntityProvider.batchUpsertEntities(upsert2)
+      }.futureValue
 
-    ex match {
-      case er:RawlsExceptionWithErrorReport =>
-        val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities."
-        er.errorReport.message shouldBe expectedMessage
-      case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      ex match {
+        case er: RawlsExceptionWithErrorReport =>
+          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities."
+          er.errorReport.message shouldBe expectedMessage
+        case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      }
     }
-  }
 
-  "return helpful error message when upserting case-divergent type names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
-    val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-    val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
+    "return helpful error message when upserting case-divergent type names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
+      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
+      val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
-    // create the first entity with type "casetest"
-    val entity1 = Entity("myname", "casetest", Map())
-    val created1 = localEntityProvider.createEntity(entity1).futureValue
-    created1 shouldBe entity1
+      // create the first entity with type "casetest"
+      val entity1 = Entity("myname", "casetest", Map())
+      val created1 = localEntityProvider.createEntity(entity1).futureValue
+      created1 shouldBe entity1
 
-    // attempt to create the second entity with type "CaseTest" - differing from entity1's type only in case
-    val entity2 = Entity("myname", "CaseTest", Map())
-    val ex = recoverToExceptionIf[Exception] {
-      localEntityProvider.createEntity(entity2)
-    }.futureValue
+      // attempt to create the second entity with type "CaseTest" - differing from entity1's type only in case
+      val entity2 = Entity("myname", "CaseTest", Map())
+      val ex = recoverToExceptionIf[Exception] {
+        localEntityProvider.createEntity(entity2)
+      }.futureValue
 
-    ex match {
-      case er:RawlsExceptionWithErrorReport =>
-        val expectedMessage = s"${entity2.entityType} ${entity2.name} already exists in ${workspaceContext.toWorkspaceName}"
-        er.errorReport.message shouldBe expectedMessage
-      case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      ex match {
+        case er: RawlsExceptionWithErrorReport =>
+          val expectedMessage = s"${entity2.entityType} ${entity2.name} already exists in ${workspaceContext.toWorkspaceName}"
+          er.errorReport.message shouldBe expectedMessage
+        case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      }
     }
-  }
 
-  "return helpful error message when upserting case-divergent type names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
-    val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-    val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
+    "return helpful error message when upserting case-divergent type names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
+      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
+      val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
-    // create the first entity with type "casetest"
-    val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
-    val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
-    created1.size shouldBe 1
+      // create the first entity with type "casetest"
+      val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
+      val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
+      created1.size shouldBe 1
 
-    // attempt to create the second entity with type "CaseTest" - differing from entity1's type only in case
-    val upsert2 = Seq(EntityUpdateDefinition("myname", "CaseTest", Seq()))
-    val ex = recoverToExceptionIf[Exception] {
-      localEntityProvider.batchUpsertEntities(upsert2)
-    }.futureValue
+      // attempt to create the second entity with type "CaseTest" - differing from entity1's type only in case
+      val upsert2 = Seq(EntityUpdateDefinition("myname", "CaseTest", Seq()))
+      val ex = recoverToExceptionIf[Exception] {
+        localEntityProvider.batchUpsertEntities(upsert2)
+      }.futureValue
 
-    ex match {
-      case er:RawlsExceptionWithErrorReport =>
-        val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities."
-        er.errorReport.message shouldBe expectedMessage
-      case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      ex match {
+        case er: RawlsExceptionWithErrorReport =>
+          val expectedMessage = "Database error occurred. Check if you are uploading entity names or entity types that differ only in case from pre-existing entities."
+          er.errorReport.message shouldBe expectedMessage
+        case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
+      }
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -289,6 +289,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
     }
 
+    // TODO: start isEntityCacheCurrent() tests; these are obsolete
     "consider cache out of date if no cache record" in withLocalEntityProviderTestDatabase { _ =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
       val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
@@ -341,6 +342,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         assert(isCurrent)
       }
     }
+    // TODO: end isEntityCacheCurrent() tests; these are obsolete
 
     "insert cache record when updating if non-existent" in withLocalEntityProviderTestDatabase { _ =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -232,7 +232,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingCache
     }
 
-    "not use cache for entityTypeMetadata when useCache=true, cache is not up to date, and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
+    "use cache for entityTypeMetadata when useCache=true, cache is not up to date, and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
@@ -248,7 +248,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       typeCountCache should not be Map.empty
       attrNamesCache should not be Map.empty
 
-      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
+      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingCache
     }
 
     "not use cache for entityTypeMetadata when useCache=false even if cache is up to date and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
@@ -416,7 +416,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       secondMessage shouldBe empty
     }
 
-    "opportunistically update cache if user requests metadata while cache is out of date" in withLocalEntityProviderTestDatabase { dataSource =>
+    // temporarily disabled until we
+    "opportunistically update cache if user requests metadata while cache is out of date" ignore withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
       val wsid = workspaceContext.workspaceIdAsUUID

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -235,7 +235,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingCache
     }
 
-    "use cache for entityTypeMetadata when useCache=true, cache is not up to date, and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
+    "not use cache for entityTypeMetadata when useCache=true, cache is not up to date, and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
@@ -251,7 +251,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       typeCountCache should not be Map.empty
       attrNamesCache should not be Map.empty
 
-      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingCache
+      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
     }
 
     "not use cache for entityTypeMetadata when useCache=false even if cache is up to date and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
@@ -291,6 +291,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
 
       entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
     }
+
+    "use cache for entityTypeMetadata when cache is not up to date but feature flags are enabled" is pending
 
     // =========== START isEntityCacheCurrent() tests; these are obsolete
     "consider cache out of date if no cache record" in withLocalEntityProviderTestDatabase { _ =>
@@ -360,6 +362,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         staleness shouldBe empty
       }
     }
+
     "return Some(positive integer) from entityCacheStaleness if cache exists but is stale" in withLocalEntityProviderTestDatabase { _ =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
       val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
@@ -380,6 +383,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         }
       }
     }
+
     "return Some(0) from entityCacheStaleness if cache is up-to-date" in withLocalEntityProviderTestDatabase { da =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
       val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
@@ -475,7 +479,6 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       secondMessage shouldBe empty
     }
 
-    // temporarily disabled until we re-implement opportunistic cache update
     "opportunistically update cache if user requests metadata while cache is out of date" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
@@ -503,6 +506,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         assert(isCurrentAfter)
       }
     }
+
+
   }
 
   "LocalEntityProvider case-sensitivity" should {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -419,7 +419,6 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    // =========== START isEntityCacheCurrent() tests; these are obsolete
     "consider cache out of date if no cache record" in withLocalEntityProviderTestDatabase { _ =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
       val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
@@ -428,7 +427,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         assert(!runAndWait(workspaceFilter.exists.result))
       }
 
-      val isCurrent = runAndWait(entityCacheQuery.isEntityCacheCurrent(wsid))
+      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
       withClue("cache should be out of date") {
         assert(!isCurrent)
       }
@@ -446,7 +445,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       // update cache timestamp
       runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, wsLastModifiedTimestamp))
 
-      val isCurrent = runAndWait(entityCacheQuery.isEntityCacheCurrent(wsid))
+      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
       withClue("cache should be out of date") {
         assert(!isCurrent)
       }
@@ -467,12 +466,11 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       // update cache timestamp
       runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, wsLastModifiedTimestamp))
 
-      val isCurrent = runAndWait(entityCacheQuery.isEntityCacheCurrent(wsid))
+      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
       withClue("cache should be current") {
         assert(isCurrent)
       }
     }
-    // =========== END isEntityCacheCurrent() tests; these are obsolete
 
     "return None from entityCacheStaleness if cache is non-existent" in withLocalEntityProviderTestDatabase { _ =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
@@ -614,7 +612,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         assert(!runAndWait(workspaceFilter.exists.result))
       }
 
-      val isCurrentBefore = runAndWait(entityCacheQuery.isEntityCacheCurrent(wsid))
+      val isCurrentBefore = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
       withClue("cache should be not-current before requesting metadata") {
         assert(!isCurrentBefore)
       }
@@ -626,7 +624,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         assert(runAndWait(workspaceFilter.exists.result))
       }
 
-      val isCurrentAfter = runAndWait(entityCacheQuery.isEntityCacheCurrent(wsid))
+      val isCurrentAfter = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
       withClue("cache should be current after requesting metadata") {
         assert(isCurrentAfter)
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -476,7 +476,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     }
 
     // temporarily disabled until we re-implement opportunistic cache update
-    "opportunistically update cache if user requests metadata while cache is out of date" ignore withLocalEntityProviderTestDatabase { dataSource =>
+    "opportunistically update cache if user requests metadata while cache is out of date" in withLocalEntityProviderTestDatabase { dataSource =>
       val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
       val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
       val wsid = workspaceContext.workspaceIdAsUUID

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -158,10 +158,10 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
     //Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache
-    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 1)))
+    // runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 1)))
 
     //Load the current entityMetadata (which should not use the cache)
-    val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+    val originalResult = Await.result(localEntityProvider.entityTypeMetadata(false), Duration.Inf)
 
     //Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
     //Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -157,14 +157,10 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
     val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
-    //Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache
-    // runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 1)))
-
-    //Load the current entityMetadata (which should not use the cache)
+    //Load the current entityMetadata, explicitly bypassing the cache
     val originalResult = Await.result(localEntityProvider.entityTypeMetadata(false), Duration.Inf)
 
-    //Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
-    //Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so
+    //Update the entityCacheLastUpdated field to be older than lastModified, so
     //the monitor will update it using its internal code path
     runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 2)))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -240,7 +240,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
 
     // this first monitor should, eventually, update the workspace's cache
     eventually(timeout = timeout(timeoutPerWorkspace*3)) {
-      val isCurrent = runAndWait(entityCacheQuery.isEntityCacheCurrent(workspaceContext.workspaceIdAsUUID))
+      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)).contains(0)
       isCurrent shouldBe true
     }
 
@@ -258,13 +258,13 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     // remove the cache record for our test workspace, and wait for the the monitor to sweep and update its cache.
     val killCacheFuture = for {
       _ <- entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).delete
-      isCurrent <- entityCacheQuery.isEntityCacheCurrent(workspaceContext.workspaceIdAsUUID)
-    } yield isCurrent
+      staleness <- entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)
+    } yield staleness.contains(0)
 
     runAndWait(killCacheFuture) shouldBe false
 
     eventually(timeout = timeout(timeoutPerWorkspace*3)) {
-      val isCurrent = runAndWait(entityCacheQuery.isEntityCacheCurrent(workspaceContext.workspaceIdAsUUID))
+      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)).contains(0)
       isCurrent shouldBe true
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -157,10 +157,14 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
     val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
-    //Load the current entityMetadata, explicitly bypassing the cache
-    val originalResult = Await.result(localEntityProvider.entityTypeMetadata(false), Duration.Inf)
+    //Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache
+    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 1)))
 
-    //Update the entityCacheLastUpdated field to be older than lastModified, so
+    //Load the current entityMetadata (which should not use the cache)
+    val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+
+    //Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
+    //Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so
     //the monitor will update it using its internal code path
     runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 2)))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -158,7 +158,8 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     val localEntityProvider = new LocalEntityProvider(workspaceContext, slickDataSource, cacheEnabled = true)
 
     //Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache
-    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 1)))
+    // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
 
     //Load the current entityMetadata (which should not use the cache)
     val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -1152,7 +1152,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
         assertMetadataMapsEqual(expectedMetadataMap, responseAs[Map[String, EntityTypeMetadata]])
-        assertMetadataMapsEqual(expectedMetadataMap, runAndWait(entityQuery.getEntityTypeMetadata(constantData.workspace)))
       }
   }
 
@@ -1183,7 +1182,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
         assertMetadataMapsEqual(expectedMetadataMap, responseAs[Map[String, EntityTypeMetadata]])
-        assertMetadataMapsEqual(expectedMetadataMap, runAndWait(entityQuery.getEntityTypeMetadata(constantData.workspace)))
       }
   }
 


### PR DESCRIPTION
PR summary:
* define two workspace feature flags "alwaysCacheTypeCounts" and "alwaysCacheAttributes".
* if "alwaysCacheTypeCounts" is set for a workspace, we will always read the **_list of distinct types and their counts_** from cache when returning entity type statistics in metadata, even if the cache is out of date.
* if "alwaysCacheAttributes" is set for a workspace, we will always read the **_list of distinct attribute names for each type_** from cache when returning entity type statistics in metadata, even if the cache is out of date. This is the one that I expect to have the most benefit to end-user latency.
* additional tracing throughout the metadata API to assist with future performance debugging

This PR has one functional change above and beyond the feature-flagged "always cache" functionality: if cache is disabled at the system level via https://github.com/broadinstitute/rawls/blob/a5bb0ae387c54d40ae29c72680f4304dec01023d/core/src/main/resources/reference.conf#L83, we previously would _not_ opportunistically save metadata results to the cache. After this PR, we do. I'm fine with this change because I expect that we will never have cache disabled at the system level, and in fact we should probably just remove that setting in a future PR.

See also broadinstitute/firecloud-develop#2815

TODOs:
- [x] deal with the two now-unused methods (only used in unit tests). This could wait for a future PR if they are troublesome but let's not forget about them!
- [x] validate the new unit tests: are they asserting the right things? are they passing? do we need any more coverage?
- [x] test test test test, stand up the branch and set some flags and see how it's working

thoughts for later:
- [ ] maybe, add config to reference.conf to control default caching behavior in addition to the per-workspace flags
- [ ] if a metrics sink is easily available, use it instead of logging staleness
