### PR TITLE
list-entity and entity-query safety limits [AJ-244]

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -86,6 +86,10 @@ entityStatisticsCache {
   workspaceCooldown = 4 minutes
 }
 
+entities {
+  pageSizeLimit = 300000
+}
+
 akka.http.host-connection-pool.max-open-requests = 16384
 akka.http.host-connection-pool.max-connections = 20
 akka.http.server.idle-timeout = 210 s

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -416,7 +416,8 @@ object Boot extends IOApp with LazyLogging {
         slickDataSource,
         samDAO,
         workbenchMetricBaseName = metricsPrefix,
-        entityManager
+        entityManager,
+        conf.getInt("entities.pageSizeLimit")
       )
 
       val snapshotServiceConstructor: (UserInfo) => SnapshotService = SnapshotService.constructor(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -166,7 +166,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       metadataFuture.recover(bigQueryRecover)
     }
 
-  def listEntities(workspaceName: WorkspaceName, entityType: String, parentSpan: Span = null): Future[Seq[Entity]] = {
+  def listEntities(workspaceName: WorkspaceName, entityType: String, parentSpan: Span = null): Future[Seq[Entity]] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         traceDBIOWithParent("countActiveEntitiesOfType", parentSpan) { countSpan =>
@@ -185,7 +185,6 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
         }
       }
     }
-  }
 
   def queryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId], parentSpan: Span = null): Future[EntityQueryResponse] = {
     if (query.pageSize > pageSizeLimit) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -192,6 +192,13 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   }
 
   def queryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId], parentSpan: Span = null): Future[EntityQueryResponse] = {
+    // TODO: AJ-244 retrieve hardLimit from config, not hardcoded heres
+    // TODO: AJ-244 add unit tests that assert we throw an error when page size is too large
+    val hardLimit = 400000
+    if (query.pageSize > hardLimit) {
+      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $hardLimit"))
+    }
+
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
 
       val entityRequestArguments = EntityRequestArguments(workspaceContext, userInfo, dataReference, billingProject)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -166,7 +166,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       metadataFuture.recover(bigQueryRecover)
     }
 
-  def listEntities(workspaceName: WorkspaceName, entityType: String, parentSpan: Span = null): Future[Seq[Entity]] =
+  def listEntities(workspaceName: WorkspaceName, entityType: String, parentSpan: Span = null): Future[Seq[Entity]] = {
     // TODO: AJ-244 add unit tests that assert we throw an error when result set is too large
     // TODO: AJ-244 retrieve hardLimit from config, not hardcoded here
     val hardLimit = 400000
@@ -189,6 +189,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
         }
       }
     }
+  }
 
   def queryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId], parentSpan: Span = null): Future[EntityQueryResponse] = {
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -167,7 +167,6 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
     }
 
   def listEntities(workspaceName: WorkspaceName, entityType: String, parentSpan: Span = null): Future[Seq[Entity]] = {
-    // TODO: AJ-244 add unit tests that assert we throw an error when result set is too large
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         traceDBIOWithParent("countActiveEntitiesOfType", parentSpan) { countSpan =>
@@ -189,7 +188,6 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
   }
 
   def queryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId], parentSpan: Span = null): Future[EntityQueryResponse] = {
-    // TODO: AJ-244 retrieve hardLimit from config, not hardcoded heres
     if (query.pageSize > pageSizeLimit) {
       throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $pageSizeLimit"))
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -171,7 +171,7 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         traceDBIOWithParent("countActiveEntitiesOfType", parentSpan) { countSpan =>
-          dataAccess.entityQuery.findActiveEntityByWorkspace(workspaceContext.workspaceIdAsUUID).length.result.flatMap { entityCount =>
+          dataAccess.entityQuery.findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result.flatMap { entityCount =>
             if (entityCount > pageSizeLimit) {
               throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest,
                 s"Result set size of $entityCount cannot exceed $pageSizeLimit. Use the paginated entityQuery API instead."))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -167,13 +167,6 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   }
 
   override def queryEntities(entityType: String, query: EntityQuery, parentSpan: Span = null): Future[EntityQueryResponse] = {
-    // TODO: AJ-244 retrieve hardLimit from config, not hardcoded heres
-    // TODO: AJ-244 add unit tests that assert we throw an error when page size is too large
-    val hardLimit = 400000
-    if (query.pageSize > hardLimit) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $hardLimit"))
-    }
-
     dataSource.inTransaction { dataAccess =>
       traceDBIOWithParent("loadEntityPage", parentSpan) { s1 =>
         s1.putAttribute("pageSize", OpenCensusAttributeValue.longAttributeValue(query.pageSize))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -167,6 +167,13 @@ class LocalEntityProvider(workspace: Workspace, implicit protected val dataSourc
   }
 
   override def queryEntities(entityType: String, query: EntityQuery, parentSpan: Span = null): Future[EntityQueryResponse] = {
+    // TODO: AJ-244 retrieve hardLimit from config, not hardcoded heres
+    // TODO: AJ-244 add unit tests that assert we throw an error when page size is too large
+    val hardLimit = 400000
+    if (query.pageSize > hardLimit) {
+      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $hardLimit"))
+    }
+
     dataSource.inTransaction { dataAccess =>
       traceDBIOWithParent("loadEntityPage", parentSpan) { s1 =>
         s1.putAttribute("pageSize", OpenCensusAttributeValue.longAttributeValue(query.pageSize))

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -78,6 +78,10 @@ entityStatisticsCache {
   workspaceCooldown = 0 minutes
 }
 
+entities {
+  pageSizeLimit = 300000
+}
+
 gcs {
   bucketLogsMaxAge = "180"
   pathToCredentialJson = "fakePathToCredential"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -72,7 +72,8 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled")),
+     1000
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -3,14 +3,14 @@ package org.broadinstitute.dsde.rawls.entities
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
-import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO, RemoteServicesMockServer}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, CreateAttributeEntityReferenceList, CreateAttributeValueList, RemoveAttribute, RemoveListMember}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeNumber, AttributeString, AttributeValueEmptyList, AttributeValueList, Entity, RawlsUser, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeNumber, AttributeString, AttributeValueEmptyList, AttributeValueList, Entity, EntityQuery, RawlsUser, SortDirections, UserInfo, Workspace}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
@@ -20,7 +20,8 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{Await, ExecutionContext}
 
 class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with TestDriverComponent with RawlsTestUtils with Eventually with MockitoTestUtils with RawlsStatsDTestUtils with BeforeAndAfterAll {
 
@@ -73,7 +74,7 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
       samDAO,
       workbenchMetricBaseName,
       EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled")),
-     1000
+      7 // <-- specifically chosen to be lower than the number of samples in "workspace" within testData
     )_
   }
 
@@ -187,6 +188,53 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
       )).attributes.get(AttributeName.withDefaultNS("newAttribute"))
     }
   }
+
+  it should "respect page size limits for listEntities"  in withTestDataServices { services =>
+    val waitDuration = Duration(10, SECONDS)
+
+    // the entityServiceConstructor inside TestApiService sets a pageSizeLimit of 7, so:
+    // these should pass
+    List(testData.aliquot1.entityType, testData.pair1.entityType) foreach { entityType =>
+      withClue(s"for entity type '$entityType':") {
+        val queryResult = Await.result(services.entityService.listEntities(testData.wsName, entityType), waitDuration)
+        queryResult.size should be < 7
+      }
+    }
+    // this should fail
+    List(testData.sample1.entityType).foreach { entityType =>
+      withClue(s"for entity type '$entityType':") {
+        val ex = intercept[RawlsExceptionWithErrorReport] {
+          Await.result(services.entityService.listEntities(testData.wsName, entityType), waitDuration)
+        }
+        ex.errorReport.message shouldBe "Result set size of 8 cannot exceed 7. Use the paginated entityQuery API instead."
+      }
+    }
+  }
+
+  it should "respect page size limits for queryEntities"  in withTestDataServices { services =>
+    val waitDuration = Duration(10, SECONDS)
+
+    // the entityServiceConstructor inside TestApiService sets a pageSizeLimit of 7, so:
+    // these should pass
+    List(1, 5, 6, 7) foreach { pageSize =>
+      withClue(s"for page size '$pageSize':") {
+        val entityQuery = EntityQuery(1, pageSize, "name", SortDirections.Ascending, None)
+        val queryResult = Await.result(services.entityService.queryEntities(testData.wsName, None, testData.sample1.entityType, entityQuery, None), waitDuration)
+        queryResult.results should not be (empty)
+      }
+    }
+    // these should fail
+    List(8, 100, 250000, Int.MaxValue) foreach { pageSize =>
+      withClue(s"for page size '$pageSize':") {
+        val entityQuery = EntityQuery(1, pageSize, "name", SortDirections.Ascending, None)
+        val ex = intercept[RawlsExceptionWithErrorReport] {
+          Await.result(services.entityService.queryEntities(testData.wsName, None, testData.sample1.entityType, entityQuery, None), waitDuration)
+        }
+        ex.errorReport.message shouldBe "Page size cannot exceed 7"
+      }
+    }
+  }
+
 
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
@@ -43,7 +43,8 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
       slickDataSource,
       samDAO,
       workbenchMetricBaseName = "test",
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO("mockrepo"), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO("mockrepo"), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled")),
+     1000
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -76,7 +76,8 @@ class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Ma
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"))
+      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled")),
+     1000
     )_
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -245,7 +245,8 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      entityManager
+      entityManager,
+     1000
     )_
 
     def cleanupSupervisor = {


### PR DESCRIPTION
Changes in this PR:
* enforce a hard cap on number of entities returned by the list-entities and entity-query APIs
* set the cap to 300,000. I specifically chose this number to not cause any errors to current users, after looking at the entity counts in our top workspaces and who is using the list-entities API.
* read the cap from configuration, so we could easily update it later by adding/updating a stanza in rawls.conf

the entity-query API simply looks at the pageSize parameter for the request and rejects if the pageSize is too high. This requires no database queries.

the list-entities API adds a `select count()` db query. If the result of this query is too high, it throws an error, else it continues on to the "real" query it already had in place. I verified by running Rawls locally that Slick generates this new query correctly. An example:
```sql
select count(1) from `ENTITY` where ((`entity_type` = 'mfjqsybnzsvcbtvozps') and (`workspace_id` = ?)) and (not `deleted`)
```

Since we increased the heap size for Rawls, we have been less in danger of OOMs (see graph below). So, it feels safe to set a high cap of 300,000 to protect us against pathological future cases, while still not interrupting current behaviors.

![Screenshot (37)](https://user-images.githubusercontent.com/6041577/156578203-7d44a825-c0ca-4b1e-9f69-8e29ff3085d9.png)

