### PR TITLE
upgrade swagger-ui [AJ-318]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val jodaConvert: ModuleID =     "org.joda"                      % "joda-convert"          % "1.8"
   val typesafeConfig: ModuleID =  "com.typesafe"                  % "config"                % "1.4.1"
   val sentryLogback: ModuleID =   "io.sentry"                     % "sentry-logback"        % "1.7.30"
-  val swaggerUI: ModuleID =       "org.webjars.npm"               % "swagger-ui-dist"       % "3.37.2"
+  val swaggerUI: ModuleID =       "org.webjars.npm"               % "swagger-ui-dist"       % "4.6.1"
   val webjarsLocator: ModuleID =  "org.webjars"                   % "webjars-locator"       % "0.40"
   val commonsJEXL: ModuleID =     "org.apache.commons"            % "commons-jexl"          % "2.1.1"
   val commonsCodec: ModuleID =    "commons-codec"                 % "commons-codec"         % "1.15"   // upgrading a transitive dependency to avoid security warnings


### PR DESCRIPTION
Upgrades swagger-ui to latest. This inherits a change in swagger-ui that now correctly displays the example payload for the `update_entity` API.

See also https://github.com/broadinstitute/firecloud-orchestration/pull/920

Before this PR:
![swagger-example-before](https://user-images.githubusercontent.com/6041577/156582280-570460f2-6936-4cf9-b9b8-290bf4a5c643.png)

After this PR:
![swagger-example-after](https://user-images.githubusercontent.com/6041577/156582309-01c2636a-a3b3-40a9-b0e2-7cf7127c5cb4.png)

