### PR TITLE
update WSM client to latest; deal with removed model classes [AJ-326]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions :+ rawlsModelExclusion:_*)
 
-  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.5-SNAPSHOT"
+  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.195-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.client.{ApiException => DatarepoApiException}
 import bio.terra.workspace.client.{ApiException => WorkspaceApiException}
-import bio.terra.workspace.model.{DataRepoSnapshotResource, ReferenceTypeEnum, ResourceType}
+import bio.terra.workspace.model.{DataRepoSnapshotResource, ResourceType}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -79,7 +79,7 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
     // verify it's a TDR snapshot. should be a noop, since getDataReferenceByName enforces this.
     if (ResourceType.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
-      throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}")
+      throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}")
     }
 
     val dataReference = dataRef.getAttributes

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import akka.http.scaladsl.model.StatusCodes
-import bio.terra.workspace.model.ReferenceTypeEnum
+import bio.terra.workspace.model.ResourceType
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -61,7 +61,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     )
 
     val ex = intercept[DataEntityException] { builder.build(defaultEntityRequestArguments).get }
-    assertResult( s"Reference type value for referenceName is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
+    assertResult( s"Reference type value for referenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
   }
 
   behavior of "DataRepoEntityProviderBuilder.lookupSnapshotForName()"
@@ -99,7 +99,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     )
 
     val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
-    assertResult( s"Reference type value for foo is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
+    assertResult( s"Reference type value for foo is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
   }
 
   it should "error if workspace manager reference json `instanceName` value does not match DataRepoDAO's base url" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -26,7 +26,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     description = Option(DataReferenceDescriptionField("bar")),
     snapshotId = UUID.randomUUID()
   ))
-  val defaultSnapshotUpdateBodyJson = httpJson(new UpdateDataReferenceRequestBody().name("foo2").description("bar2"))
+  val defaultSnapshotUpdateBodyJson = httpJson(new UpdateDataRepoSnapshotReferenceRequestBody().name("foo2").description("bar2"))
 
   // base MockWorkspaceManagerDAO always returns a value for enumerateDataReferences.
   // this version, used inside this spec, throws errors on specific workspaces,
@@ -537,7 +537,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
           status
         }
 
-        Get(s"${baseSnapshotsPath}/${response.getReferenceId}") ~>
+        Get(s"${baseSnapshotsPath}/${response.referenceId}") ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
             assertResult(StatusCodes.OK) {
@@ -639,9 +639,9 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
                 }
                 // Our mock doesn't guarantee order, so we just check that there are two
                 // elements, that one is named "foo", and that one is named "bar"
-                assert(response.getResources.size == 2)
+                assert(response.resources.size == 2)
                 assertResult(Set("foo", "bar")) {
-                  response.getResources.asScala.map(_.getName).toSet
+                  response.resources.map(_.name).toSet
                 }
               }
           }
@@ -679,7 +679,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.OK) {
           status
         }
-        assert(response.getResources.isEmpty)
+        assert(response.resources.isEmpty)
       }
   }
 
@@ -703,7 +703,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.Created, "Unexpected snapshot creation status") {
           status
         }
-        Patch(s"${baseSnapshotsPath}/${response.getReferenceId}", defaultSnapshotUpdateBodyJson) ~>
+        Patch(s"${baseSnapshotsPath}/${response.referenceId}", defaultSnapshotUpdateBodyJson) ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
             assertResult(StatusCodes.NoContent, "Unexpected snapshot update response") {
@@ -712,15 +712,15 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
           }
 
         //verify that it was updated
-        Get(s"${baseSnapshotsPath}/${response.getReferenceId}") ~>
+        Get(s"${baseSnapshotsPath}/${response.referenceId}") ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
             val response = responseAs[DataReferenceDescription]
             assertResult(StatusCodes.OK, "Unexpected return code getting updated snapshot") {
               status
             }
-            assert(response.getName == "foo2", "Unexpected result of updating snapshot name")
-            assert(response.getDescription == "bar2", "Unexpected result of updating snapshot description")
+            assert(response.name == "foo2", "Unexpected result of updating snapshot name")
+            assert(response.description == "bar2", "Unexpected result of updating snapshot description")
           }
       }
   }
@@ -774,7 +774,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.Created) {
           status
         }
-        Delete(s"${baseSnapshotsPath}/${response.getReferenceId}") ~>
+        Delete(s"${baseSnapshotsPath}/${response.referenceId}") ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
             assertResult(StatusCodes.NoContent) {
@@ -783,7 +783,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
           }
 
         //verify that it was deleted
-        Delete(s"${baseSnapshotsPath}/${response.getReferenceId}") ~>
+        Delete(s"${baseSnapshotsPath}/${response.referenceId}") ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
             assertResult(StatusCodes.NotFound) {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModel.scala
@@ -13,83 +13,29 @@ case class DataReferenceDescriptionField(value: String = "") extends ValueObject
 case class NamedDataRepoSnapshot(name: DataReferenceName, description: Option[DataReferenceDescriptionField], snapshotId: UUID)
 case class SnapshotListResponse(gcpDataRepoSnapshots: Seq[DataRepoSnapshotResource])
 
+// model classes that previously existed in WSM's client library, but now we have a local copy.
+// these are used to support Rawls' deprecated v1 snapshot APIs.
+// when those APIs are no longer needed, delete these classes.
+case class DataRepoSnapshot(snapshot: String, instanceName: String)
+
+case class DataReferenceDescription(referenceId: UUID,
+                                    name: String,
+                                    description: String,
+                                    workspaceId: UUID,
+                                    referenceType: String,
+                                    reference: DataRepoSnapshot,
+                                    cloningInstructions: String)
+
+
+case class DataReferenceList(resources: Seq[DataReferenceDescription])
+// END v1-specific classes
+
 object DataReferenceModelJsonSupport extends JsonSupport {
   def stringOrNull(in: Any): JsValue = Option(in) match {
     case None => JsNull
     case Some(str: String) => JsString(str)
     case Some(notStr) => JsString(notStr.toString)
   }
-
-  implicit object DataRepoSnapshotFormat extends RootJsonFormat[DataRepoSnapshot] {
-    val INSTANCE_NAME = "instanceName"
-    val SNAPSHOT = "snapshot"
-
-    override def write(snap: DataRepoSnapshot) = JsObject(
-      INSTANCE_NAME -> stringOrNull(snap.getInstanceName),
-      SNAPSHOT -> stringOrNull(snap.getSnapshot)
-    )
-
-    override def read(json: JsValue) = {
-      json.asJsObject.getFields(INSTANCE_NAME, SNAPSHOT) match {
-        case Seq(JsString(instanceName), JsString(snapshot)) =>
-          new DataRepoSnapshot().instanceName(instanceName).snapshot(snapshot)
-        case _ => throw DeserializationException("DataRepoSnapshot expected")
-      }
-    }
-  }
-
-  // Only handling supported fields for now, resourceDescription and credentialId aren't used currently
-  implicit object DataReferenceDescriptionFormat extends RootJsonFormat[DataReferenceDescription] {
-    val REFERENCE_ID = "referenceId"
-    val NAME = "name"
-    val DESCRIPTION = "description"
-    val WORKSPACE_ID = "workspaceId"
-    val REFERENCE_TYPE = "referenceType"
-    val REFERENCE = "reference"
-    val CLONING_INSTRUCTIONS = "cloningInstructions"
-
-    override def write(description: DataReferenceDescription) = JsObject(
-      REFERENCE_ID -> stringOrNull(description.getReferenceId),
-      NAME -> stringOrNull(description.getName),
-      DESCRIPTION -> stringOrNull(description.getDescription),
-      WORKSPACE_ID -> stringOrNull(description.getWorkspaceId),
-      REFERENCE_TYPE -> stringOrNull(description.getReferenceType),
-      REFERENCE -> description.getReference.toJson,
-      CLONING_INSTRUCTIONS -> stringOrNull(description.getCloningInstructions)
-    )
-
-    override def read(json: JsValue): DataReferenceDescription = {
-      json.asJsObject.getFields(REFERENCE_ID, NAME, DESCRIPTION, WORKSPACE_ID, REFERENCE_TYPE, REFERENCE, CLONING_INSTRUCTIONS) match {
-        case Seq(referenceId, JsString(name), JsString(description), workspaceId, JsString(referenceType), reference, JsString(cloningInstructions)) =>
-          new DataReferenceDescription()
-            .referenceId(referenceId.convertTo[UUID])
-            .name(name)
-            .description(description)
-            .workspaceId(workspaceId.convertTo[UUID])
-            .referenceType(ReferenceTypeEnum.fromValue(referenceType))
-            .reference(reference.convertTo[DataRepoSnapshot])
-            .cloningInstructions(CloningInstructionsEnum.fromValue(cloningInstructions))
-        case _ => throw DeserializationException("DataReferenceDescription expected")
-      }
-    }
-  }
-
-  implicit object DataReferenceListFormat extends RootJsonFormat[DataReferenceList] {
-    val RESOURCES = "resources"
-
-    override def write(refList: DataReferenceList) = JsObject(
-      RESOURCES -> refList.getResources.asScala.toList.toJson
-    )
-
-    override def read(json: JsValue): DataReferenceList = {
-      json.asJsObject.getFields(RESOURCES) match {
-        case Seq(JsArray(resources)) =>
-          new DataReferenceList().resources(resources.map(_.convertTo[DataReferenceDescription]).asJava)
-        case _ => throw DeserializationException("DataReferenceList expected")
-      }
-    }
-  }
-
 
   implicit object ResourceMetadataFormat extends RootJsonFormat[ResourceMetadata] {
     val WORKSPACE_ID = "workspaceId"
@@ -168,16 +114,20 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     }
   }
 
-  implicit object UpdateDataReferenceRequestFormat extends RootJsonFormat[UpdateDataReferenceRequestBody] {
+  implicit object UpdateDataReferenceRequestFormat extends RootJsonFormat[UpdateDataRepoSnapshotReferenceRequestBody] {
     val NAME = "name"
     val DESCRIPTION = "description"
+    val INSTANCE_NAME = "instanceName"
+    val SNAPSHOT = "snapshot"
 
-    override def write(request: UpdateDataReferenceRequestBody) = JsObject(
+    override def write(request: UpdateDataRepoSnapshotReferenceRequestBody) = JsObject(
       NAME -> stringOrNull(request.getName),
       DESCRIPTION -> stringOrNull(request.getDescription),
+      INSTANCE_NAME -> stringOrNull(request.getInstanceName),
+      SNAPSHOT -> stringOrNull(request.getSnapshot),
     )
 
-    override def read(json: JsValue): UpdateDataReferenceRequestBody = {
+    override def read(json: JsValue): UpdateDataRepoSnapshotReferenceRequestBody = {
       val jsObject = json.asJsObject
 
       def getOptionalStringField(fieldName: String): Option[String] = {
@@ -187,13 +137,15 @@ object DataReferenceModelJsonSupport extends JsonSupport {
         }
       }
 
-      jsObject.getFields(NAME, DESCRIPTION) match {
-        case Seq() => throw DeserializationException("UpdateDataReferenceRequestBody expected")
-        case _ => // both fields are optional, as long as one is present we can proceed
-          val updateRequest = new UpdateDataReferenceRequestBody()
+      jsObject.getFields(NAME, DESCRIPTION, INSTANCE_NAME, SNAPSHOT) match {
+        case Seq() => throw DeserializationException("UpdateDataRepoSnapshotReferenceRequestBody expected")
+        case _ => // all fields are optional, as long as one is present we can proceed
+          val updateRequest = new UpdateDataRepoSnapshotReferenceRequestBody()
 
           getOptionalStringField(NAME).map(updateRequest.name)
           getOptionalStringField(DESCRIPTION).map(updateRequest.description)
+          getOptionalStringField(INSTANCE_NAME).map(updateRequest.instanceName)
+          getOptionalStringField(SNAPSHOT).map(updateRequest.snapshot)
 
           updateRequest
       }
@@ -252,12 +204,13 @@ object DataReferenceModelJsonSupport extends JsonSupport {
     }
   }
 
-
-
-
-
   implicit val DataReferenceNameFormat = ValueObjectFormat(DataReferenceName)
   implicit val dataReferenceDescriptionFieldFormat = ValueObjectFormat(DataReferenceDescriptionField)
   implicit val NamedDataRepoSnapshotFormat = jsonFormat3(NamedDataRepoSnapshot)
   implicit val SnapshotListResponseFormat = jsonFormat1(SnapshotListResponse)
+
+  // formats for v1-specific classes
+  implicit val dataRepoSnapshotFormat = jsonFormat2(DataRepoSnapshot)
+  implicit val dataReferenceDescriptionFormat = jsonFormat7(DataReferenceDescription)
+  implicit val dataReferenceListFormat = jsonFormat1(DataReferenceList)
 }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.model
 
 import bio.terra.workspace.model.CloningInstructionsEnum.NOTHING
-import bio.terra.workspace.model.ReferenceTypeEnum.DATA_REPO_SNAPSHOT
+import bio.terra.workspace.model.ResourceType.DATA_REPO_SNAPSHOT
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import org.scalatest.freespec.AnyFreeSpec
@@ -29,25 +29,28 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
 
     "JSON logic" - {
 
+      // TODO: obsolete test, these are now simple classes
       "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
         val referenceId = UUID.randomUUID()
         val workspaceId = UUID.randomUUID()
         assertResult {
           s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
         } {
-          new DataReferenceList().resources(ArrayBuffer(
-            new DataReferenceDescription()
-              .referenceId(referenceId)
-              .name("test-ref")
-              .description("test description")
-              .workspaceId(workspaceId)
-              .referenceType(DATA_REPO_SNAPSHOT)
-              .reference(new DataRepoSnapshot().instanceName("test-instance").snapshot("test-snapshot"))
-              .cloningInstructions(NOTHING)
-          ).asJava).toJson
+          DataReferenceList(resources = Seq(
+            DataReferenceDescription(
+              referenceId = referenceId,
+              name = "test-ref",
+              description = "test description",
+              workspaceId = workspaceId,
+              referenceType = DATA_REPO_SNAPSHOT.getValue,
+              reference = new DataRepoSnapshot(instanceName = "test-instance", snapshot = "test-snapshot"),
+              cloningInstructions = NOTHING.getValue
+            )
+          )).toJson
         }
       }
 
+      // TODO: obsolete test, this now tests spray-json UUID deserialization
       "DataReferenceDescription with bad UUID's should fail" in {
         assertThrows[DeserializationException] {
           s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
@@ -235,20 +238,20 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
       }
 
       "UpdateDataReferenceRequestBody should work when updating name and description" in {
-        assertResult { s"""{"name":"foo","description":"bar"}""".parseJson } {
-          new UpdateDataReferenceRequestBody().name("foo").description("bar").toJson
+        assertResult { s"""{"name":"foo","description":"bar", "instanceName":null, "snapshot":null}""".parseJson } {
+          new UpdateDataRepoSnapshotReferenceRequestBody().name("foo").description("bar").toJson
         }
       }
 
       "UpdateDataReferenceRequestBody should work with only one parameter" in {
-        assertResult { s"""{"name":null,"description":"foo"}""".parseJson } {
-          new UpdateDataReferenceRequestBody().description("foo").toJson
+        assertResult { s"""{"name":null,"description":"foo", "instanceName":null, "snapshot":null}""".parseJson } {
+          new UpdateDataRepoSnapshotReferenceRequestBody().description("foo").toJson
         }
       }
 
       "UpdateDataReferenceRequestBody with no parameters should fail" in {
         assertThrows[DeserializationException] {
-          s"""{}""".parseJson.convertTo[UpdateDataReferenceRequestBody]
+          s"""{}""".parseJson.convertTo[UpdateDataRepoSnapshotReferenceRequestBody]
         }
       }
     }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -29,34 +29,6 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
 
     "JSON logic" - {
 
-      // TODO: obsolete test, these are now simple classes
-      "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
-        val referenceId = UUID.randomUUID()
-        val workspaceId = UUID.randomUUID()
-        assertResult {
-          s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
-        } {
-          DataReferenceList(resources = Seq(
-            DataReferenceDescription(
-              referenceId = referenceId,
-              name = "test-ref",
-              description = "test description",
-              workspaceId = workspaceId,
-              referenceType = DATA_REPO_SNAPSHOT.getValue,
-              reference = new DataRepoSnapshot(instanceName = "test-instance", snapshot = "test-snapshot"),
-              cloningInstructions = NOTHING.getValue
-            )
-          )).toJson
-        }
-      }
-
-      // TODO: obsolete test, this now tests spray-json UUID deserialization
-      "DataReferenceDescription with bad UUID's should fail" in {
-        assertThrows[DeserializationException] {
-          s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
-        }
-      }
-
       "DataRepoSnapshotResource, ResourceMetadata, DataRepoSnapshotAttributes" in {
         val resourceId = UUID.randomUUID()
         val workspaceId = UUID.randomUUID()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,7 +128,7 @@ object Dependencies {
   def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")
   def excludeJakarta(m: ModuleID): ModuleID = m.excludeAll(excludeJakartaActivationApi, excludeJakartaXmlBindApi)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.173-SNAPSHOT")
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.195-SNAPSHOT") // 0.254.173-SNAPSHOT --> 0.254.195-SNAPSHOT
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
   val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,7 +128,7 @@ object Dependencies {
   def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")
   def excludeJakarta(m: ModuleID): ModuleID = m.excludeAll(excludeJakartaActivationApi, excludeJakartaXmlBindApi)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.195-SNAPSHOT") // 0.254.173-SNAPSHOT --> 0.254.195-SNAPSHOT
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.195-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
   val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-manager/pull/570 removed deprecated APIs from Workspace Manager. Along with those removals came removal of model classes inside the WSM client. Rawls was using those now-removed model classes in a bunch of places.

This PR:
* updates to the latest version of WSM client in both runtime and automation
* changes some code away from the removed model classes and onto supported model classes
* creates new, local to Rawls, case classes to represent some of the now-removed WSM models. These are necessary because while WSM dropped their deprecated APIs, Rawls still supports its "v1" snapshot APIs. In order to not change request/response payloads for those APIs, I have created replacement classes.

We should absolutely consider just removing those v1 APIs from Rawls, but we need to verify they are not used.

**EDIT:** I just checked, and it looks like the v1 APIs haven't been called in the last 90 days. I am going to work towards removing them, which should simplify this PR a lot.