### PR TITLE
Filter out "pet service account not found" error before sending events to Sentry [BW-1125]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryFilteredClientFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryFilteredClientFactory.scala
@@ -7,14 +7,19 @@ import io.sentry.{DefaultSentryClientFactory, SentryClient}
 
 import scala.util.{Failure, Success, Try}
 
-/* Filter for Sentry, which will ignore exceptions from https://github.com/slick/slick/issues/1856
-   here at the source, without attempting to send to Sentry.
+/* Filter for Sentry, which will ignore below exceptions from here at the source, without attempting to send to Sentry.
+    - https://github.com/slick/slick/issues/1856 (https://broadworkbench.atlassian.net/browse/AS-217)
+    - "pet service account not found" error: We are ignoring this exception because SubmissionMonitor actor is sending
+      about 150-200 messages per minute to Sentry and this is depleting most of the error capacity in Sentry and
+      putting us over quota (https://broadworkbench.atlassian.net/browse/BW-1125).
  */
 class RawlsSentryEventFilter extends ShouldSendEventCallback {
   override def shouldSend(event: Event): Boolean = {
     // earlier versions of sentry-logback could pass nulls, so we wrap everything in a Try to be defensive.
     // by default this will run in a separate async thread so failures aren't a problem, but still.
-    Try(!event.getMessage.contains("requirement failed: count cannot be decreased")) match {
+    Try(!event.getMessage.contains("requirement failed: count cannot be decreased") &&
+      !event.getMessage.contains("pet service account not found")
+    ) match {
       case Success(send) => send
       case Failure(_) => true
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/util/RawlsSentryEventFilterSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/util/RawlsSentryEventFilterSpec.scala
@@ -20,6 +20,17 @@ class RawlsSentryEventFilterSpec extends AnyFreeSpec {
       }
     }
 
+    // https://broadworkbench.atlassian.net/browse/BW-1125
+    "should filter out 'pet service account not found' errors" in {
+      val e = evt("org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport: ErrorReport(rawls,HTTP error calling URI " +
+        "https://sam/api/google/petServiceAccount/abc@terra.iam.gserviceaccount.com. Response: {\"causes\":[]," +
+        "\"message\":\"pet service account not found\",\"source\":\"sam\",\"stackTrace\":[],\"statusCode\":404}," +
+        "Some(404 Not Found),List(),List(),None)")
+      assertResult(false) {
+        new RawlsSentryEventFilter().shouldSend(e)
+      }
+    }
+
     "should NOT filter any other messages" in {
       val e = evt("This is some other error message that should be sent to Sentry")
       assertResult(true) {


### PR DESCRIPTION
This PR filters out the error at source and doesn't send it to Sentry. This way the user will still see/receive the error but Sentry won't receive it.

Closes https://broadworkbench.atlassian.net/browse/BW-1125