### PR TITLE
update WSM client to latest; deal with removed model classes - take 2 [AJ-326]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions :+ rawlsModelExclusion:_*)
 
-  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.5-SNAPSHOT"
+  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.195-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.entities.datarepo
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.datarepo.client.{ApiException => DatarepoApiException}
 import bio.terra.workspace.client.{ApiException => WorkspaceApiException}
-import bio.terra.workspace.model.{DataRepoSnapshotResource, ReferenceTypeEnum, ResourceType}
+import bio.terra.workspace.model.{DataRepoSnapshotResource, ResourceType}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -79,7 +79,7 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
     // verify it's a TDR snapshot. should be a noop, since getDataReferenceByName enforces this.
     if (ResourceType.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
-      throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}")
+      throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}")
     }
 
     val dataReference = dataRef.getAttributes

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -146,12 +146,15 @@ class SnapshotService(protected val userInfo: UserInfo, val dataSource: SlickDat
     SnapshotListResponse(refs)
   }
 
-  def updateSnapshot(workspaceName: WorkspaceName, snapshotId: String, updateInfo: UpdateDataReferenceRequestBody): Future[Unit] = {
+  def updateSnapshot(workspaceName: WorkspaceName, snapshotId: String, updateInfo: UpdateDataRepoSnapshotReferenceRequestBody): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
       // check that snapshot exists before updating it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, userInfo.accessToken)
-      // build the update request body
+      // build the update request body, ignoring any changes to instanceName and snapshot, and requiring either name or description
+      if (Option(updateInfo.getName).isEmpty && Option(updateInfo.getDescription).isEmpty) {
+        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Either name or description is required."))
+      }
       val updateBody = new UpdateDataRepoSnapshotReferenceRequestBody()
       updateBody.setName(updateInfo.getName)
       updateBody.setDescription(updateInfo.getDescription)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -45,9 +45,9 @@ trait SnapshotApiService extends UserInfoDirectives {
         }
       } ~
       patch {
-        entity(as[UpdateDataReferenceRequestBody]) { updateDataReferenceRequestBody =>
+        entity(as[UpdateDataRepoSnapshotReferenceRequestBody]) { updateDataRepoSnapshotReferenceRequestBody =>
           complete {
-            snapshotServiceConstructor(userInfo).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataReferenceRequestBody).map(_ => StatusCodes.NoContent)
+            snapshotServiceConstructor(userInfo).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataRepoSnapshotReferenceRequestBody).map(_ => StatusCodes.NoContent)
           }
         }
       } ~
@@ -61,25 +61,6 @@ trait SnapshotApiService extends UserInfoDirectives {
       get {
         complete {
           snapshotServiceConstructor(userInfo).getSnapshotByName(WorkspaceName(workspaceNamespace, workspaceName), referenceName)
-        }
-      }
-    } ~
-    path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
-      get {
-        complete {
-          snapshotServiceConstructor(userInfo).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId)
-        }
-      } ~
-      patch {
-        entity(as[UpdateDataReferenceRequestBody]) { updateDataReferenceRequestBody =>
-          complete {
-            snapshotServiceConstructor(userInfo).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataReferenceRequestBody).map(_ => StatusCodes.NoContent)
-          }
-        }
-      } ~
-      delete {
-        complete {
-          snapshotServiceConstructor(userInfo).deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(_ => StatusCodes.NoContent)
         }
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
 import akka.http.scaladsl.model.StatusCodes
-import bio.terra.workspace.model.ReferenceTypeEnum
+import bio.terra.workspace.model.ResourceType
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
@@ -61,7 +61,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     )
 
     val ex = intercept[DataEntityException] { builder.build(defaultEntityRequestArguments).get }
-    assertResult( s"Reference type value for referenceName is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
+    assertResult( s"Reference type value for referenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
   }
 
   behavior of "DataRepoEntityProviderBuilder.lookupSnapshotForName()"
@@ -99,7 +99,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     )
 
     val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
-    assertResult( s"Reference type value for foo is not of type ${ReferenceTypeEnum.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
+    assertResult( s"Reference type value for foo is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
   }
 
   it should "error if workspace manager reference json `instanceName` value does not match DataRepoDAO's base url" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -25,7 +25,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
     description = Option(DataReferenceDescriptionField("bar")),
     snapshotId = UUID.randomUUID()
   ))
-  val defaultSnapshotUpdateBodyJson = httpJson(new UpdateDataReferenceRequestBody().name("foo2").description("bar2"))
+  val defaultSnapshotUpdateBodyJson = httpJson(new UpdateDataRepoSnapshotReferenceRequestBody().name("foo2").description("bar2"))
 
   // base MockWorkspaceManagerDAO always returns a value for enumerateDataReferences.
   // this version, used inside this spec, throws errors on specific workspaces,

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.model
 
-import bio.terra.workspace.model.CloningInstructionsEnum.NOTHING
-import bio.terra.workspace.model.ReferenceTypeEnum.DATA_REPO_SNAPSHOT
+import bio.terra.workspace.model.ResourceType.DATA_REPO_SNAPSHOT
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import org.scalatest.freespec.AnyFreeSpec
@@ -10,7 +9,6 @@ import spray.json._
 
 import java.util.UUID
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
 class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
 
@@ -28,31 +26,6 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
     }
 
     "JSON logic" - {
-
-      "DataReferenceDescriptionList, which contains DataReferenceDescription, which contains DataRepoSnapshot" in {
-        val referenceId = UUID.randomUUID()
-        val workspaceId = UUID.randomUUID()
-        assertResult {
-          s"""{"resources":[{"referenceId": "$referenceId","name":"test-ref","workspaceId":"$workspaceId","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"description":"test description","cloningInstructions":"$NOTHING"}]}""".parseJson
-        } {
-          new DataReferenceList().resources(ArrayBuffer(
-            new DataReferenceDescription()
-              .referenceId(referenceId)
-              .name("test-ref")
-              .description("test description")
-              .workspaceId(workspaceId)
-              .referenceType(DATA_REPO_SNAPSHOT)
-              .reference(new DataRepoSnapshot().instanceName("test-instance").snapshot("test-snapshot"))
-              .cloningInstructions(NOTHING)
-          ).asJava).toJson
-        }
-      }
-
-      "DataReferenceDescription with bad UUID's should fail" in {
-        assertThrows[DeserializationException] {
-          s"""{"referenceId": "abcd","name":"test-ref","workspaceId":"abcd","referenceType":"$DATA_REPO_SNAPSHOT","reference":{"instanceName":"test-instance","snapshot":"test-snapshot"},"cloningInstructions":"$NOTHING"}""".parseJson.convertTo[DataReferenceDescription]
-        }
-      }
 
       "DataRepoSnapshotResource, ResourceMetadata, DataRepoSnapshotAttributes" in {
         val resourceId = UUID.randomUUID()
@@ -235,20 +208,20 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
       }
 
       "UpdateDataReferenceRequestBody should work when updating name and description" in {
-        assertResult { s"""{"name":"foo","description":"bar"}""".parseJson } {
-          new UpdateDataReferenceRequestBody().name("foo").description("bar").toJson
+        assertResult { s"""{"name":"foo","description":"bar","instanceName":null,"snapshot":null}""".parseJson } {
+          new UpdateDataRepoSnapshotReferenceRequestBody().name("foo").description("bar").toJson
         }
       }
 
       "UpdateDataReferenceRequestBody should work with only one parameter" in {
-        assertResult { s"""{"name":null,"description":"foo"}""".parseJson } {
-          new UpdateDataReferenceRequestBody().description("foo").toJson
+        assertResult { s"""{"name":null,"description":"foo","instanceName":null,"snapshot":null}""".parseJson } {
+          new UpdateDataRepoSnapshotReferenceRequestBody().description("foo").toJson
         }
       }
 
       "UpdateDataReferenceRequestBody with no parameters should fail" in {
         assertThrows[DeserializationException] {
-          s"""{}""".parseJson.convertTo[UpdateDataReferenceRequestBody]
+          s"""{}""".parseJson.convertTo[UpdateDataRepoSnapshotReferenceRequestBody]
         }
       }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,7 +128,7 @@ object Dependencies {
   def excludeJakartaXmlBindApi = ExclusionRule("jakarta.xml.bind", "jakarta.xml.bind-api")
   def excludeJakarta(m: ModuleID): ModuleID = m.excludeAll(excludeJakartaActivationApi, excludeJakartaXmlBindApi)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.173-SNAPSHOT")
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.195-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
   val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")


### PR DESCRIPTION
https://github.com/DataBiosphere/terra-workspace-manager/pull/570 removed deprecated APIs from Workspace Manager. Along with those removals came removal of model classes inside the WSM client. Rawls was using those now-removed model classes in a bunch of places.

This PR:
* updates to the latest version of WSM client in both runtime and automation
* changes some code away from the removed model classes and onto supported model classes

