### PR TITLE
get workspace by id [AJ-337]

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3657,7 +3657,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       x-codegen-request-body-name: workspaceJson
-  /api/workspaces/{workspaceId}:
+  /api/workspaces/id/{workspaceId}:
     get:
       tags:
         - workspaces

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3657,6 +3657,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       x-codegen-request-body-name: workspaceJson
+  /api/workspaces/{workspaceId}:
+    get:
+      tags:
+        - workspaces
+      summary: Get workspace details by id
+      description: |
+        Get a single workspace's details, optionally filtered to only the specified fields. See additional GET methods in this section to retrieve additional details about the workspace. For instance, this API only returns the workspace's owners; use the GET .../acl method to retrieve the full list of all users at all permission levels.
+      operationId: getWorkspaceById
+      parameters:
+        - name: workspaceId
+          in: path
+          description: Workspace Id
+          required: true
+          schema:
+            type: string
+        - name: fields
+          in: query
+          description: |
+            When specified, include only these keys in the response payload and exclude other keys. Accepts a comma-delimited list of values. To include a nested key, specify the key's path using a dot delimiter; for example, to include {"workspace": {"attributes": {}}}, specify "workspace.attributes". Legal values are any first-level key in the response, any first-level key inside the {"workspace": {}} object, and any first-level key inside the {"workspace": {"attributes": {}}} object. If omitted, will return the full response payload.
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceResponse'
+        400:
+          description: Unrecognized query parameters
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/workspaces/{workspaceNamespace}/{workspaceName}:
     get:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, SamBillingProjectActions, SamBillingProjectRoles, SamResourceAction, SamResourceTypeNames, SamWorkspaceActions, UserInfo, Workspace, WorkspaceAttributeSpecs, WorkspaceName, WorkspaceRequest}
 import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.traceDBIOWithParent
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 trait WorkspaceSupport {
@@ -153,5 +154,6 @@ trait WorkspaceSupport {
   }
 
   def noSuchWorkspaceMessage(workspaceName: WorkspaceName) = s"${workspaceName} does not exist or you do not have permission to use it"
+  def noSuchWorkspaceMessage(workspaceId: UUID) = s"workspace ${workspaceId} does not exist or you do not have permission to use it"
   def accessDeniedMessage(workspaceName: WorkspaceName) = s"insufficient permissions to perform operation on ${workspaceName}"
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -65,6 +65,15 @@ trait WorkspaceApiService extends UserInfoDirectives {
           }
         }
     } ~
+      path("workspaces" / "tags") {
+        parameter('q.?) { queryString =>
+          get {
+            complete {
+              workspaceServiceConstructor(userInfo).getTags(queryString)
+            }
+          }
+        }
+      } ~
       path("workspaces" / Segment / Segment) { (workspaceNamespace, workspaceName) =>
         patch {
           entity(as[Array[AttributeUpdateOperation]]) { operations =>
@@ -207,15 +216,6 @@ trait WorkspaceApiService extends UserInfoDirectives {
         get {
           complete {
             workspaceServiceConstructor(userInfo).getBucketUsage(WorkspaceName(workspaceNamespace, workspaceName))
-          }
-        }
-      } ~
-      path("workspaces" / "tags") {
-        parameter('q.?) { queryString =>
-          get {
-            complete {
-              workspaceServiceConstructor(userInfo).getTags(queryString)
-            }
           }
         }
       } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -75,7 +75,7 @@ trait WorkspaceApiService extends UserInfoDirectives {
           }
         }
       } ~
-      path("workspaces" / Segment ) { workspaceId =>
+      path("workspaces" / "id" / Segment ) { workspaceId =>
         get {
           parameterSeq { allParams =>
             traceRequest { span =>
@@ -88,6 +88,13 @@ trait WorkspaceApiService extends UserInfoDirectives {
         }
       } ~
       path("workspaces" / Segment / Segment) { (workspaceNamespace, workspaceName) =>
+        /* we enforce a 6-character minimum for workspaceNamespace, as part of billing project creation.
+           the previous "mc", "tags", and "id" paths rely on this convention to avoid path-matching conflicts.
+           we might want to change the first Segment above to a regex a la """[^/.]{6,}""".r
+           but note that would be a behavior change: if a user entered fewer than 6 chars it would result in an
+           unmatched path rejection instead of the custom error handling inside WorkspaceService.
+        */
+
         patch {
           entity(as[Array[AttributeUpdateOperation]]) { operations =>
             complete {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.rawls.webservice.CustomDirectives._
 import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceService, WorkspaceService}
 import spray.json.DefaultJsonProtocol._
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext
 
 /**
@@ -70,6 +71,18 @@ trait WorkspaceApiService extends UserInfoDirectives {
           get {
             complete {
               workspaceServiceConstructor(userInfo).getTags(queryString)
+            }
+          }
+        }
+      } ~
+      path("workspaces" / Segment ) { workspaceId =>
+        get {
+          parameterSeq { allParams =>
+            traceRequest { span =>
+              complete {
+                workspaceServiceConstructor(userInfo).getWorkspaceById(workspaceId,
+                  WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"), span)
+              }
             }
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -313,7 +313,7 @@ class WorkspaceService(protected val userInfo: UserInfo,
     // retrieve the namespace/name for this workspace and then delegate to getWorkspace(WorkspaceName).
     // note that this id -> namespace/name lookup does not enforce security; that's enforced in getWorkspace(WorkspaceName).
     val workspaceRecords = dataSource.inTransaction { dataAccess =>
-      dataAccess.workspaceQuery.findByIdQuery(workspaceUuid).map(r => (r.namespace, r.name)).result
+      dataAccess.workspaceQuery.findByIdQuery(workspaceUuid).map(r => (r.namespace, r.name)).take(1).result
     }
     workspaceRecords.flatMap { recsFound =>
       if (recsFound.size == 1) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -397,5 +397,24 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
       }
   }
 
+  // get-workspace-by-id delegates to get-workspace-by-name, so we test its option handling briefly, enough
+  // to know we are passing the WorkspaceFieldSpecs along.
+  it should "include multiple keys simultaneously when getting a workspace by id" in withTestWorkspacesApiServices { services =>
+    Get(s"/workspaces/${testWorkspaces.workspace.workspaceId}" + "?fields=canShare,workspace.attributes,accessLevel") ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) { status }
+        val actual = responseAs[String].parseJson.asJsObject
+        val expected = JsObject(
+          "accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString),
+          "canShare" -> JsBoolean(fullWorkspaceResponse.canShare.get),
+          "workspace" -> JsObject(
+            "attributes" -> JsObject("a" -> JsString("x"), "description" -> JsString("my description"))
+          )
+        )
+        assertResult(expected) { actual }
+      }
+  }
+
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -400,7 +400,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   // get-workspace-by-id delegates to get-workspace-by-name, so we test its option handling briefly, enough
   // to know we are passing the WorkspaceFieldSpecs along.
   it should "include multiple keys simultaneously when getting a workspace by id" in withTestWorkspacesApiServices { services =>
-    Get(s"/workspaces/${testWorkspaces.workspace.workspaceId}" + "?fields=canShare,workspace.attributes,accessLevel") ~>
+    Get(s"/workspaces/id/${testWorkspaces.workspace.workspaceId}" + "?fields=canShare,workspace.attributes,accessLevel") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) { status }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -485,6 +485,23 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "get a workspace by id" in withTestWorkspacesApiServices { services =>
+    Get(s"/workspaces/${testWorkspaces.workspace.workspaceId}") ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        val dateTime = currentTime()
+        assertResult(
+          WorkspaceResponse(Option(WorkspaceAccessLevels.Owner), Option(true), Option(true), Option(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), Option(WorkspaceBucketOptions(false)), Option(Set.empty))
+        ){
+          val response = responseAs[WorkspaceResponse]
+          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners)
+        }
+      }
+  }
+
   // see also WorkspaceApiGetOptionsSpec for additional tests related to get-workspace
 
   it should "return 404 getting a non-existent workspace" in withTestDataApiServices { services =>
@@ -492,6 +509,26 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
+  it should "return 404 getting a non-existent workspace by id" in withTestDataApiServices { services =>
+    Get(s"/workspaces/${UUID.randomUUID()}") ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
+  it should "return 400 getting a workspace by id with an invalid UUID" in withTestDataApiServices { services =>
+    Get("/workspaces/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
           status
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -486,7 +486,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "get a workspace by id" in withTestWorkspacesApiServices { services =>
-    Get(s"/workspaces/${testWorkspaces.workspace.workspaceId}") ~>
+    Get(s"/workspaces/id/${testWorkspaces.workspace.workspaceId}") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -515,7 +515,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 404 getting a non-existent workspace by id" in withTestDataApiServices { services =>
-    Get(s"/workspaces/${UUID.randomUUID()}") ~>
+    Get(s"/workspaces/id/${UUID.randomUUID()}") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -525,7 +525,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 400 getting a workspace by id with an invalid UUID" in withTestDataApiServices { services =>
-    Get("/workspaces/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") ~>
+    Get("/workspaces/id/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
@@ -1530,7 +1530,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "not allow a no-access user to get a workspace by id" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
-    Get(s"/workspaces/${testWorkspaces.workspace.workspaceId}") ~>
+    Get(s"/workspaces/id/${testWorkspaces.workspace.workspaceId}") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1529,6 +1529,16 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "not allow a no-access user to get a workspace by id" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
+    Get(s"/workspaces/${testWorkspaces.workspace.workspaceId}") ~>
+      sealRoute(services.workspaceRoutes) ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
   // Update Workspace requires WRITE access.  Accept if OWNER or WRITE; Reject if READ or NO ACCESS
 
   it should "allow an project-owner-access user to update a workspace" in withTestDataApiServicesAndUser(testData.userProjectOwner.userEmail.value) { services =>


### PR DESCRIPTION
Adds a new API to retrieve a workspace by its id. This API has the same features as - and at the implementation level, delegates to - the API to retrieve a workspace by its name.