### PR TITLE
[SUP-449] Add an optional limit parameter to the get tags endpoint

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3990,6 +3990,11 @@ paths:
           description: Query string
           schema:
             type: string
+        - name: limit
+          in: query
+          description: Maximum number of tags to return
+          schema:
+            type: integer
       responses:
         200:
           description: Successful Request

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -161,8 +161,8 @@ trait WorkspaceComponent {
       }
     }
 
-    def getTags(queryString: Option[String]): ReadAction[Seq[WorkspaceTag]] = {
-      val tags = workspaceAttributeQuery.findUniqueStringsByNameQuery(AttributeName.withTagsNS, queryString).result
+    def getTags(queryString: Option[String], limit: Option[Int] = None): ReadAction[Seq[WorkspaceTag]] = {
+      val tags = workspaceAttributeQuery.findUniqueStringsByNameQuery(AttributeName.withTagsNS, queryString, limit).result
       tags map(_.map { rec =>
           WorkspaceTag(rec._1, rec._2)
         })

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -67,10 +67,10 @@ trait WorkspaceApiService extends UserInfoDirectives {
         }
     } ~
       path("workspaces" / "tags") {
-        parameter('q.?) { queryString =>
+        parameters('q.?, "limit".as[Int].optional) { (queryString, limit) =>
           get {
             complete {
-              workspaceServiceConstructor(userInfo).getTags(queryString)
+              workspaceServiceConstructor(userInfo).getTags(queryString, limit)
             }
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -597,9 +597,9 @@ class WorkspaceService(protected val userInfo: UserInfo,
     }
   }
 
-  def getTags(query: Option[String]): Future[Seq[WorkspaceTag]] =
+  def getTags(query: Option[String], limit: Option[Int] = None): Future[Seq[WorkspaceTag]] =
     dataSource.inTransaction { dataAccess =>
-      dataAccess.workspaceQuery.getTags(query)
+      dataAccess.workspaceQuery.getTags(query, limit)
     }
 
   def listWorkspaces(params: WorkspaceFieldSpecs, parentSpan: Span): Future[JsValue] = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -518,6 +518,9 @@ class AttributeComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers 
     assertResult(Vector(("cancer", 2), ("buffalo", 1), ("cantaloupe", 1))) {
       runAndWait(workspaceAttributeQuery.findUniqueStringsByNameQuery(AttributeName.withTagsNS, None).result)
     }
+    assertResult(Vector(("cancer", 2), ("buffalo", 1))) {
+      runAndWait(workspaceAttributeQuery.findUniqueStringsByNameQuery(AttributeName.withTagsNS, None, Some(2)).result)
+    }
     assertResult(Vector(("cant", 1))) {
       runAndWait(workspaceAttributeQuery.findUniqueStringsByNameQuery(AttributeName.withDefaultNS("testString"), Some("can")).result)
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -825,15 +825,21 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       res6
     }
 
+    // setting a limit should limit the number of tags returned
+    val res7 = Await.result(services.workspaceService.getTags(None, Some(2)), Duration.Inf)
+    assertResult(Vector(WorkspaceTag("cantaloupe", 2), WorkspaceTag("buffalo", 1))) {
+      res7
+    }
+
     // remove tags
     Await.result(services.workspaceService.updateWorkspace(testData.wsName, Seq(RemoveAttribute(AttributeName.withTagsNS))), Duration.Inf)
     Await.result(services.workspaceService.updateWorkspace(testData.wsName7, Seq(RemoveAttribute(AttributeName.withTagsNS))), Duration.Inf)
 
 
     // make sure that tags no longer exists
-    val res7 = Await.result(services.workspaceService.getTags(Some("aNc")), Duration.Inf)
+    val res8 = Await.result(services.workspaceService.getTags(Some("aNc")), Duration.Inf)
     assertResult(Vector.empty[WorkspaceTag]) {
-      res7
+      res8
     }
 
   }


### PR DESCRIPTION
Currently, users have to enter 3 characters for anything to show up in the tags menu on the workspaces list or workspace dashboard. We'd like to remove that restriction and show the most frequently used tags when the user focuses on the menu.  Currently, the only way to do that is to load all the tags in Terra and filter them client side. This adds an optional `limit` parameter to the get tags endpoint so that the UI can request only the top few tags.