### PR TITLE
preselect scopes in swagger [AJ-352]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SwaggerRoutes.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SwaggerRoutes.scala
@@ -60,6 +60,7 @@ trait SwaggerRoutes extends LazyLogging {
                                         |        clientSecret: "${swaggerConfig.realm}",
                                         |        realm: "${swaggerConfig.realm}",
                                         |        appName: "rawls",
+                                        |        scopes: ["openid", "email", "profile"],
                                         |        scopeSeparator: " ",
                                         |        additionalQueryStringParams: {}
                                         |      })


### PR DESCRIPTION
in swagger-ui, preselect the "openid", "email", and "profile" scopes - these are the required/default scopes for most APIs.

This only affects swagger-ui, it does not affect behavior of the app itself.