### PR TITLE
list-all-entities now streams [AJ-242]

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -57,6 +57,15 @@ data-source {
   }
 }
 
+slick {
+  # batchSize is used for writes, to group inserts/updates
+  # this must be explicitly utilized via custom business logic
+  batchSize = 2000
+  # fetchSize is used during Slick streaming to set the size of pages
+  # this must be explicitly set via withStatementParameters
+  fetchSize = 5000
+}
+
 wdl-parsing {
   # number of parsed WDLs to cache
   cache-max-size = 7500

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -24,7 +24,10 @@ object AttributeTempTableType extends Enumeration {
 }
 
 class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit executionContext: ExecutionContext) extends LazyLogging {
-  val dataAccess = new DataAccessComponent(databaseConfig.profile, databaseConfig.config.getInt("batchSize"))
+  val batchSize = databaseConfig.config.getInt("batchSize")
+  val fetchSize = databaseConfig.config.getInt("fetchSize")
+
+  val dataAccess = new DataAccessComponent(databaseConfig.profile, batchSize, fetchSize)
 
   val database = databaseConfig.db
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -30,7 +30,8 @@ trait DataAccess
   this: DriverComponent =>
 
   val driver: JdbcProfile
-  val batchSize: Int
+  val batchSize: Int // used for writes to group inserts/updates; must be explicitly utilized via custom business logic
+  val fetchSize: Int // used during Slick streaming to set the size of pages; must be explicitly set via withStatementParameters
 
   import driver.api._
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -4,5 +4,5 @@ import slick.jdbc.JdbcProfile
 
 import scala.concurrent.ExecutionContext
 
-class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int)(implicit val executionContext: ExecutionContext)
+class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int, val fetchSize: Int)(implicit val executionContext: ExecutionContext)
 extends DriverComponent with DataAccess

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
@@ -13,7 +13,8 @@ import scala.concurrent.ExecutionContext
 
 trait DriverComponent extends StringValidationUtils {
   val driver: JdbcProfile
-  val batchSize: Int
+  val batchSize: Int // used for writes to group inserts/updates; must be explicitly utilized via custom business logic
+  val fetchSize: Int // used during Slick streaming to set the size of pages; must be explicitly set via withStatementParameters
   implicit val executionContext: ExecutionContext
   override implicit val errorReportSource = ErrorReportSource("rawls")
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -2,6 +2,9 @@ package org.broadinstitute.dsde.rawls.entities
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.scaladsl.Source
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
@@ -17,6 +20,7 @@ import org.broadinstitute.dsde.rawls.util.OpenCensusDBIOUtils.traceDBIOWithParen
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.AttributeUpdateOperationException
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -166,25 +170,114 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       metadataFuture.recover(bigQueryRecover)
     }
 
-  def listEntities(workspaceName: WorkspaceName, entityType: String, parentSpan: Span = null): Future[Seq[Entity]] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        traceDBIOWithParent("countActiveEntitiesOfType", parentSpan) { countSpan =>
-          dataAccess.entityQuery.findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result.flatMap { entityCount =>
-            if (entityCount > pageSizeLimit) {
-              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest,
-                s"Result set size of $entityCount cannot exceed $pageSizeLimit. Use the paginated entityQuery API instead."))
-            } else {
-              traceDBIOWithParent("listActiveEntitiesOfType", countSpan) { _ =>
-                dataAccess.entityQuery.listActiveEntitiesOfType(workspaceContext, entityType)
-              }.map { r =>
-                r.toSeq
-              }
-            }
-          }
+  def listEntities(workspaceName: WorkspaceName, entityType: String) = {
+
+    import dataSource.dataAccess.entityQuery.EntityAndAttributesResult
+
+    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) map { workspaceContext =>
+      // note ReadCommitted transaction isolation level
+      val allAttrsStream = dataSource.dataAccess.entityQuery.streamActiveEntityAttributesOfType(workspaceContext, entityType)
+        .transactionally.withTransactionIsolation(TransactionIsolation.ReadCommitted)
+        .withStatementParameters(
+          rsType = ResultSetType.ForwardOnly,
+          rsConcurrency = ResultSetConcurrency.ReadOnly,
+          fetchSize = dataSource.dataAccess.fetchSize)
+
+      // database source stream
+      val dbSource = Source.fromPublisher(dataSource.database.stream(allAttrsStream)) // this REQUIRES an order by ENTITY.id
+
+      // interim class used while iterating through the stream, allows us to accumulate attributes
+      // until ready to emit an entity
+      trait AttributeStreamElement
+      case class AttrAccum(accum: Seq[EntityAndAttributesResult], entity: Option[Entity]) extends AttributeStreamElement
+      case object EmptyElement extends AttributeStreamElement
+
+      def gatherOrOutput(previous: AttributeStreamElement, current: AttributeStreamElement): AttrAccum = {
+        // utility function called when an entity is finished or when the stream is finished
+        def entityFinished(prevAttrs: Seq[EntityAndAttributesResult], nextAttrs: Seq[EntityAndAttributesResult]) = {
+          val unmarshalled = dataSource.dataAccess.entityQuery.unmarshalEntities(prevAttrs)
+          // safety check - did the attributes we gathered all marshal into a single entity?
+          if (unmarshalled.size != 1)
+            throw new DataEntityException(s"gatherOrOutput expected only one entity, found ${unmarshalled.size}")
+          AttrAccum(nextAttrs, Some(unmarshalled.head))
+        }
+
+        (previous, current) match {
+          // the first element
+          case (EmptyElement, curr: AttrAccum) =>
+            curr
+
+          // midstream, we notice that the current entity is the same as the previous entity.
+          // keep gathering attributes for this entity, and don't emit an entity yet.
+          case (prev: AttrAccum, curr: AttrAccum) if prev.accum.head.entityRecord.id == curr.accum.head.entityRecord.id =>
+            val newAccum = prev.accum ++ curr.accum
+            AttrAccum(newAccum, None)
+
+          // midstream, we notice that the current entity is DIFFERENT from the previous entity.
+          // take all the attributes we have gathered for the previous entity,
+          // marshal them into an Entity object, emit that Entity, and start a new accumulator
+          // for the new/current entity
+          case (prev: AttrAccum, curr: AttrAccum) if prev.accum.head.entityRecord.id != curr.accum.head.entityRecord.id =>
+            entityFinished(prev.accum, curr.accum)
+
+          // the stream has finished (curr == EmptyElement). marshal and output the final Entity.
+          case (prev: AttrAccum, EmptyElement) =>
+            entityFinished(prev.accum, Seq())
+
+          // relief valve, this should not happen
+          case _ =>
+            throw new Exception(s"gatherOrOutput encountered unexpected input, cannot continue. Prev: $previous :: Curr: $current")
         }
       }
+
+      /* custom stream stage that allows us to compare the current stream element
+         to the previous stream element. In turn, this allows us to accumulate attributes
+         until we notice that the current element is from a different entity than the previous attribute;
+         when that happens, we marshal and emit an entity.
+       */
+      class EntityCollector extends GraphStage[FlowShape[AttrAccum, AttrAccum]] {
+        val in = Inlet[AttrAccum]("EntityCollector.in")
+        val out = Outlet[AttrAccum]("EntityCollector.out")
+        override val shape = FlowShape(in, out)
+
+        override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+          private var prev: AttributeStreamElement = EmptyElement // note: var!
+
+          // if our downstream pulls on us, propagate that pull to our upstream
+          setHandler(out, new OutHandler {
+            override def onPull(): Unit = pull(in)
+          })
+
+          setHandler(in, new InHandler {
+            // when a new element arrives ...
+            override def onPush(): Unit = {
+              // send it to gatherOrOutput which has most of the logic
+              val next = gatherOrOutput(prev, grab(in))
+              // save the current element to "prev" to prepare for the next iteration
+              prev = next
+              // emit whatever gatherOrOutput returned
+              emit(out, next)
+            }
+            // when the upstream finishes ...
+            override def onUpstreamFinish(): Unit = {
+              // ensure we marshal and emit the last entity
+              emit(out, gatherOrOutput(prev, EmptyElement))
+              completeStage()
+            }
+          })
+        }
+      }
+
+      val pipeline = dbSource
+        .map(x => AttrAccum(Seq(x), None)) // transform EntityAndAttributesResult to AttrAccum
+        .via(new EntityCollector())        // execute the business logic to accumulate attributes and emit entities
+        .collect {                         // "flatten" the stream to only emit entities
+          case x if x.entity.isDefined => x.entity.get
+        }
+
+      Source.fromGraph(pipeline) // return a Source, which akka-http natively knows how to stream to the caller
     }
+  }
 
   def queryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId], parentSpan: Span = null): Future[EntityQueryResponse] = {
     if (query.pageSize > pageSizeLimit) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.webservice
 
+import akka.http.scaladsl.common.{EntityStreamingSupport, JsonEntityStreamingSupport}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.BadRequest
@@ -144,9 +145,11 @@ trait EntityApiService extends UserInfoDirectives {
         } ~
         path("workspaces" / Segment / Segment / "entities" / Segment) { (workspaceNamespace, workspaceName, entityType) =>
           get {
-            traceRequest { span =>
+            // if any other APIs adopt streaming, move this implicit val higher up in the EntityApiService trait
+            implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+            traceRequest { _ =>
               complete {
-                entityServiceConstructor(userInfo).listEntities(WorkspaceName(workspaceNamespace, workspaceName), entityType, span)
+                entityServiceConstructor(userInfo).listEntities(WorkspaceName(workspaceNamespace, workspaceName), entityType)
               }
             }
           } ~

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -34,7 +34,12 @@ backRawls = true
 
 mysql {
   driver = "slick.driver.MySQLDriver$"
+  # batchSize is used for writes, to group inserts/updates
+  # this must be explicitly utilized via custom business logic
   batchSize = 5000
+  # fetchSize is used during Slick streaming to set the size of pages
+  # this must be explicitly set via withStatementParameters
+  fetchSize = 5000
   host = "localhost"
   port = 3310
   db {
@@ -49,7 +54,12 @@ mysql {
 // TODO: programatically modify the above DB Config object instead?
 mysql-low-thread-count {
   driver = "slick.driver.MySQLDriver$"
+  # batchSize is used for writes, to group inserts/updates
+  # this must be explicitly utilized via custom business logic
   batchSize = 5000
+  # fetchSize is used during Slick streaming to set the size of pages
+  # this must be explicitly set via withStatementParameters
+  fetchSize = 5000
   host = "localhost"
   port = 3310
   db {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -66,6 +66,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
   override val driver: JdbcProfile = DbResource.dataConfig.profile
   override val batchSize: Int = DbResource.dataConfig.config.getInt("batchSize")
+  override val fetchSize: Int = DbResource.dataConfig.config.getInt("fetchSize")
   val slickDataSource = DbResource.dataSource
 
   val userInfo = UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345"))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -189,28 +189,6 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
     }
   }
 
-  it should "respect page size limits for listEntities"  in withTestDataServices { services =>
-    val waitDuration = Duration(10, SECONDS)
-
-    // the entityServiceConstructor inside TestApiService sets a pageSizeLimit of 7, so:
-    // these should pass
-    List(testData.aliquot1.entityType, testData.pair1.entityType) foreach { entityType =>
-      withClue(s"for entity type '$entityType':") {
-        val queryResult = Await.result(services.entityService.listEntities(testData.wsName, entityType), waitDuration)
-        queryResult.size should be < 7
-      }
-    }
-    // this should fail
-    List(testData.sample1.entityType).foreach { entityType =>
-      withClue(s"for entity type '$entityType':") {
-        val ex = intercept[RawlsExceptionWithErrorReport] {
-          Await.result(services.entityService.listEntities(testData.wsName, entityType), waitDuration)
-        }
-        ex.errorReport.message shouldBe "Result set size of 8 cannot exceed 7. Use the paginated entityQuery API instead."
-      }
-    }
-  }
-
   it should "respect page size limits for queryEntities"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
 


### PR DESCRIPTION
#1536 was too far out of date to comfortably rebase, so I recreated it here in this PR. From the original description:

---

this changes the list-all-entities API to use streams, all the way from the db to the json response.

We should see much improved memory usage and object allocation, though I haven't quantified that.

We should also see much improved [time-to-first-byte](https://developer.mozilla.org/en-US/docs/Glossary/time_to_first_byte) (TTFB). This will help especially with proxy timeouts, which are sometimes caused because the TTFB exceeds the timeout; the server is so busy calculating stuff that it hasn't yet even sent a byte in response. By lowering the TTFB and streaming bytes as they're ready, we keep the proxy connection alive.

Measurement using curl against a **_2504-entity/7-attribute dataset_** running Rawls on my local machine:

  | Streaming (this PR) |   | Materializing (dev branch) |  
-- | -- | -- | -- | --
  | TTFB | Total | TTFB | Total
run 1 | 0.854295 | 8.258964 | 5.503287 | 5.517296
run 2 | 0.857463 | 6.071911 | 7.147478 | 7.164272
run 3 | 0.986192 | 7.673797 | 6.814422 | 6.831227
run 4 | 1.852225 | 8.882299 | 4.975124 | 4.994485
  |   |   |   |  
average | 1.13754375 | 7.72174275 | 6.11007775 | 6.12682

Measurement using curl against a **_32,865-entity/60-attribute dataset_** running Rawls on my local machine:

  | Streaming (this PR) |   | Materializing (dev branch) |  
-- | -- | -- | -- | --
  | TTFB | Total | TTFB | Total
run 1 | 2.318231 | 138.972411 | 91.426873 | 93.138935
run 2 | 2.243682 | 168.240942 | 89.526169 | 91.260541
run 3 | 1.919636 | 228.454679 | 88.052662 | 89.706733
run 4 | 2.246611 | 174.422509 | 118.243408 | 119.984261
  |   |   |   |  
average | 2.18204 | 177.5226353 | 96.812278 | 98.5226175



the TTFB is _much_ better, though it looks as if total request time increased. This could use some more perf tests (I wonder if our perf tests capture TTFB at all?)

EDIT 11/15/21: I ran curl against a **_32,865-entity/60-attribute dataset_** running Rawls on my local machine, comparing a batch size of 1000 to a batch size of 5000. The larger batch size performed much better in terms of the total request time:


   | batch size 1000 |   | batch size 5000 |  
-- | -- | -- | -- | --
   | TTFB | Total | TTFB | Total
run 1 | 1.106258 | 211.857628 | 2.104846 | 114.173619
run 2 | 2.381596 | 213.056431 | 1.754114 | 75.178991
run 3 | 2.129985 | 212.905949 | 1.936276 | 143.929869
run 4 | 2.439934 | 212.906833 | 1.737956 | 82.278875
run 5 | 2.329623 | 226.098492 | 1.765553 | 104.955654
   |   |   |   |  
avg | 2.0774792 | 215.3650666 | 1.883298 | 103.8903385

The total request time for batch size 5000 is in line with the materializing approach.




