### PR TITLE
swagger yaml cleanup/consolidation [AJ-366]

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -128,12 +128,7 @@ paths:
       description: list members of billing project the caller owns
       operationId: listBillingProjectMembers
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         200:
           description: Success
@@ -163,12 +158,7 @@ paths:
       description: add user or group to billing project the caller owns
       operationId: addUserToBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -213,12 +203,7 @@ paths:
       description: remove user or group from billing project the caller owns
       operationId: removeUserFromBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -303,12 +288,7 @@ paths:
       description: get billing project
       operationId: getBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         200:
           description: OK
@@ -335,12 +315,7 @@ paths:
       description: delete billing project
       operationId: deleteBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         204:
           description: OK
@@ -364,12 +339,7 @@ paths:
       description: update billing account on billing project
       operationId: updateBillingProjectBillingAccount
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       requestBody:
         description: update billing account request
         content:
@@ -409,12 +379,7 @@ paths:
       description: removes the billing account from the billing project
       operationId: removeBillingProjectBillingAccount
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         200:
           description: OK
@@ -442,12 +407,7 @@ paths:
       description: list members of billing project the caller owns
       operationId: listBillingProjectMembers
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         200:
           description: Success
@@ -477,12 +437,7 @@ paths:
       description: get spend report for the billing project
       operationId: getSpendReport
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
         - name: startDate
           in: query
           description: start date of report (YYYY-MM-DD). Data included in report will start at 12 AM UTC on this date.
@@ -546,12 +501,7 @@ paths:
       description: get the spend report configuration for the billing project
       operationId: getSpendReportConfiguration
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         200:
           description: Successfully retrieved spend report configuration
@@ -586,12 +536,7 @@ paths:
       description: set the spend configuration for the billing project
       operationId: setSpendReportConfiguration
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       requestBody:
         description: billing project spend configuration information
         content:
@@ -632,12 +577,7 @@ paths:
       description: clear the spend configuration for the billing project
       operationId: clearSpendReportConfiguration
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
         204:
           description: Successfully cleared spend configuration
@@ -661,12 +601,7 @@ paths:
       description: add user or group to billing project the caller owns
       operationId: addUserToBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -710,12 +645,7 @@ paths:
       description: remove user or group from billing project the caller owns
       operationId: removeUserFromBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -6239,6 +6169,13 @@ components:
             type: string
       description: status of a subsystem Rawls depends on
   parameters:
+    billingProjectIdPathParam:
+      name: projectId
+      in: path
+      description: Billing Project ID
+      required: true
+      schema:
+        type: string
     billingProjectQueryParam:
       name: billingProject
       in: query

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5270,7 +5270,6 @@ components:
           default: false
         bucketLocation:
           type: string
-          required: false
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
       description: ""
     WorkspaceRequestClone:
@@ -5304,7 +5303,6 @@ components:
           default: false
         bucketLocation:
           type: string
-          required: false
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
       description: ""
     BucketUsageResponse:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -866,18 +866,8 @@ paths:
       description: Administratively abort an active submission
       operationId: adminAbortSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: workspaceNamespace of the submission
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: workspaceName of the submission
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: id of the submission
@@ -1186,18 +1176,8 @@ paths:
       description: List all submissions run in this workspace
       operationId: listSubmissions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -1287,18 +1267,8 @@ paths:
         Returns a map of status:count.
       operationId: countSubmissions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -1327,18 +1297,8 @@ paths:
       description: Validate expression syntax for a submission
       operationId: validateSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Description of a submission.
         content:
@@ -1387,18 +1347,8 @@ paths:
       description: Monitor submission status
       operationId: getSubmissionStatus
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -1526,18 +1476,8 @@ paths:
       description: Retrieve workflow cost, if available
       operationId: getWorkflowCost
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -1577,18 +1517,8 @@ paths:
       description: Retrieve outputs for a workflow
       operationId: getWorkflowOutputs
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -1634,18 +1564,8 @@ paths:
       description: Get call-level metadata for workflow
       operationId: workflowMetadata
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -1798,18 +1718,8 @@ paths:
       description: Rename an entity
       operationId: renameEntity
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -1860,18 +1770,8 @@ paths:
       description: Evaluates an attribute expression taking the given entity as root
       operationId: evaluateExpression
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -2023,18 +1923,8 @@ paths:
       description: List all entities of a given type
       operationId: list_entities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -2312,18 +2202,8 @@ paths:
         a workspace
       operationId: batch_upsert_entities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Entity update definitions
         content:
@@ -2371,18 +2251,8 @@ paths:
         must already exist.
       operationId: batch_update_entities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Entity update definitions
         content:
@@ -2451,18 +2321,8 @@ paths:
         If you are only working with Agora methods, the fields `"sourceRepo"` and `"methodUri"` can be considered informational and do not need to be round-tripped (see the corresponding `POST /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs` for more details).
       operationId: list_method_configurations
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: allRepos
           in: query
           description: Configs for all repos, not just Agora
@@ -2593,18 +2453,8 @@ paths:
       description: Validate a method configuration
       operationId: validate_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -2644,18 +2494,8 @@ paths:
       description: Get a method configuration
       operationId: get_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -2887,18 +2727,8 @@ paths:
         409 may be returned if there's already a method configuration at the target location.
       operationId: rename_method_config
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -3167,18 +2997,8 @@ paths:
       description: Read a workspace bucket
       operationId: readBucket
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -3210,18 +3030,8 @@ paths:
         Sam. Takes into account if the workspace is locked too.
       operationId: checkIamActionWithLock
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: samActionName
           in: path
           description: Sam action
@@ -3250,18 +3060,8 @@ paths:
       description: List incoming file transfers that are pending for this workspace
       operationId: listPendingFileTransfers
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -3285,18 +3085,8 @@ paths:
       description: Lock a workspace
       operationId: lockWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         204:
           description: Successful Request
@@ -3333,18 +3123,8 @@ paths:
       description: Unlock a workspace
       operationId: unlockWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         204:
           description: Successful Request
@@ -3375,18 +3155,8 @@ paths:
       description: Get access control list for a workspace
       operationId: getACL
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -3488,18 +3258,8 @@ paths:
       description: Returns metadata about the workspace bucket.
       operationId: getWorkspaceBucketOptions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -3528,18 +3288,8 @@ paths:
         the permission for the workspace
       operationId: getCatalog
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -3759,18 +3509,8 @@ paths:
         Get a single workspace's details, optionally filtered to only the specified fields. See additional GET methods in this section to retrieve additional details about the workspace. For instance, this API only returns the workspace's owners; use the GET .../acl method to retrieve the full list of all users at all permission levels.
       operationId: listWorkspaceDetails
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: fields
           in: query
           description: |
@@ -3914,18 +3654,8 @@ paths:
       description: Clone a workspace
       operationId: clone
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Request for new workspace
         content:
@@ -3992,18 +3722,8 @@ paths:
       description: Get the storage bucket usage
       operationId: getBucketUsage
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -4055,18 +3775,8 @@ paths:
         Enable Requester Pays for the user's linked service accounts in a workspace. Grants the serviceusage.services.use permission in the project associated to the workspace to each service account linked in the account linking service (Bond).
       operationId: enableRequesterPaysForLinkedServiceAccounts
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         204:
           description: Successful Request
@@ -4099,18 +3809,8 @@ paths:
         a workspace
       operationId: disableRequesterPaysForLinkedServiceAccounts
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         204:
           description: |
@@ -4589,18 +4289,8 @@ paths:
       summary: Gets the notifications available for a workspace
       operationId: workspaceNotifications
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: workspace namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: workspace name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Success
@@ -4617,18 +4307,8 @@ paths:
       summary: Get access instructions for the workspace
       operationId: getWorkspaceAccessInstructions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: workspace namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: workspace name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Success
@@ -4645,18 +4325,8 @@ paths:
       summary: Send Notification of data added to Workspace
       operationId: sendChangeNotification
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: workspace namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: workspace name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         200:
           description: Success

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1206,18 +1206,8 @@ paths:
       description: Submit a new job
       operationId: createSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Description of a submission.
         content:
@@ -1381,18 +1371,8 @@ paths:
       description: Update user comment for a submission
       operationId: updateSubmissionUserComment
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -1428,18 +1408,8 @@ paths:
       description: Abort a currently running submission
       operationId: abortSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -1859,18 +1829,8 @@ paths:
       description: Create entity
       operationId: create_entity
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Entity data
         content:
@@ -2028,18 +1988,8 @@ paths:
       description: Update an entity
       operationId: update_entity
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -2389,18 +2339,8 @@ paths:
         The system is specified to check for a URI first before falling back to the legacy fields. Unsupported repos will return a 400 Bad Request.
       operationId: create_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Method Configuration contents
         content:
@@ -2536,18 +2476,8 @@ paths:
         The method configuration name and namespace in the URI must match the values in the JSON.
       operationId: overwrite_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -2606,18 +2536,8 @@ paths:
         If the location in the request body is different to the location in the URI, and there is a method config already at that location, 409 is returned.
       operationId: update_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -2676,18 +2596,8 @@ paths:
       description: Delete a method configuration
       operationId: delete_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -3189,18 +3099,8 @@ paths:
       description: Edit access control list for a workspace
       operationId: updateACL
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
         - name: inviteUsersNotFound
           in: query
           description: true to invite unregistered users, false to ignore
@@ -3318,18 +3218,8 @@ paths:
       description: Edit catalog permissions for a workspace
       operationId: updateCatalog
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Series of Catalog updates for workspace
         content:
@@ -3553,18 +3443,8 @@ paths:
       description: Delete a workspace
       operationId: delete_workspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       responses:
         202:
           description: Delete request accepted. Workspace bucket will be deleted within
@@ -3595,18 +3475,8 @@ paths:
       description: Update workspace attributes
       operationId: update_workspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
         description: Update operations
         content:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -798,12 +798,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: id of the submission
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
       responses:
         204:
           description: Successful Request
@@ -1269,12 +1264,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
       responses:
         200:
           description: Successful Request
@@ -1303,12 +1293,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
       requestBody:
         description: User comment to be updated
         content:
@@ -1340,12 +1325,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
       responses:
         204:
           description: Submission successfully aborted
@@ -1378,12 +1358,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
         - name: workflowId
           in: path
           description: Workflow Id
@@ -1419,12 +1394,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
         - name: workflowId
           in: path
           description: Workflow Id
@@ -1466,12 +1436,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdPathParam'
         - name: workflowId
           in: path
           description: Workflow Id
@@ -6213,6 +6178,13 @@ components:
       name: referenceName
       in: path
       description: The snapshot reference's name
+      required: true
+      schema:
+        type: string
+    submissionIdPathParam:
+      name: submissionId
+      in: path
+      description: Submission Id
       required: true
       schema:
         type: string

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -108,11 +108,7 @@ paths:
           description: project already exists in rawls or google
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       security:
         - authorization:
             - openid
@@ -145,11 +141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/{projectId}/{workbenchRole}/{email}:
     put:
       tags:
@@ -183,11 +175,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - billing
@@ -220,11 +208,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2:
     post:
       tags:
@@ -252,11 +236,7 @@ paths:
           description: project already exists in rawls
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       security:
         - authorization:
             - openid
@@ -408,11 +388,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}/spendReport:
     get:
       tags:
@@ -470,13 +446,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-
-
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}/spendReportConfiguration:
     get:
       tags:
@@ -508,11 +478,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     put:
       tags:
         - billing_v2
@@ -549,11 +515,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - billing_v2
@@ -572,11 +534,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}/members/{workbenchRole}/{email}:
     put:
       tags:
@@ -609,11 +567,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - billing_v2
@@ -645,11 +599,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/project/registration:
     post:
       tags:
@@ -744,11 +694,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
         502:
           description: Trouble talking to Google
           content:
@@ -778,11 +724,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
         502:
           description: Trouble talking to Google or Cromwell
           content:
@@ -808,11 +750,7 @@ paths:
           description: Successful Request
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - admin
@@ -831,11 +769,7 @@ paths:
           description: Successful Request
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/workspaces:
     get:
       tags:
@@ -881,11 +815,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/workspaces/{workspaceNamespace}/{workspaceName}/flags:
     get:
       tags:
@@ -913,11 +843,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     put:
       tags:
         - admin
@@ -953,11 +879,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/refreshToken/{userSubjectId}:
     delete:
       deprecated: true
@@ -978,11 +900,7 @@ paths:
           description: user's refresh token revoked and removed
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/submissions/queueStatusByUser:
     get:
       tags:
@@ -1005,11 +923,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/servicePerimeters/{servicePerimeterName}/projects/{projectName}:
     put:
       tags:
@@ -1056,11 +970,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions:
     get:
       tags:
@@ -1087,11 +997,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     post:
       tags:
         - submissions
@@ -1129,11 +1035,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
         502:
           description: Trouble talking to Agora
           content:
@@ -1167,11 +1069,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/validate:
     post:
       tags:
@@ -1210,11 +1108,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
         502:
           description: Trouble talking to Agora
           content:
@@ -1247,11 +1141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     patch:
       tags:
         - submissions
@@ -1279,11 +1169,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - submissions
@@ -1305,11 +1191,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
         502:
           description: Unable to abort all workflows in this submission
           content:
@@ -1342,11 +1224,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/{submissionId}/workflows/{workflowId}/outputs:
     get:
       tags:
@@ -1373,11 +1251,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
         502:
           description: Unable to retrieve outputs or logs from Cromwell
           content:
@@ -1434,11 +1308,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/submissions/queueStatus:
     get:
       tags:
@@ -1454,11 +1324,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkflowQueueStatusResponse'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entityQuery/{entityType}:
     get:
       tags:
@@ -1564,11 +1430,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: newEntityNameJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/{entityName}/evaluate:
     post:
@@ -1606,11 +1468,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: expression
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities:
     get:
@@ -1645,11 +1503,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     post:
       tags:
         - entities
@@ -1697,11 +1551,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: entityJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}:
     get:
@@ -1730,11 +1580,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - entities
@@ -1766,11 +1612,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/{entityName}:
     get:
       tags:
@@ -1799,11 +1641,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     patch:
       tags:
         - entities
@@ -1848,11 +1686,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: attributeUpdateJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/delete:
     post:
@@ -1893,11 +1727,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/AttributeEntityReference'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: entities
   /api/workspaces/entities/copy:
     post:
@@ -1950,11 +1780,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: entityCopyDefinition
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/batchUpsert:
     post:
@@ -1999,11 +1825,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: batchUpsertJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/batchUpdate:
     post:
@@ -2046,11 +1868,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: batchUpdateJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs:
     get:
@@ -2108,11 +1926,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     post:
       tags:
         - methodconfigs
@@ -2192,11 +2006,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: methodConfigJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs/{configNamespace}/{configName}/validate:
     get:
@@ -2224,11 +2034,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs/{configNamespace}/{configName}:
     get:
       tags:
@@ -2255,11 +2061,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     put:
       tags:
         - methodconfigs
@@ -2301,11 +2103,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: newMethodConfigJson
     post:
       tags:
@@ -2356,11 +2154,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: newMethodConfigJson
     delete:
       tags:
@@ -2384,11 +2178,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs/{configNamespace}/{configName}/rename:
     post:
       tags:
@@ -2434,11 +2224,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: newMethodConfigurationName
   /api/methodconfigs/copy:
     post:
@@ -2485,11 +2271,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: methodConfigurationNamePair
   /api/methodconfigs/copyFromMethodRepo:
     post:
@@ -2542,11 +2324,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: methodRepoImport
   /api/methodconfigs/copyToMethodRepo:
     post:
@@ -2576,11 +2354,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: methodRepoExport
   /api/methodconfigs/template:
     post:
@@ -2679,11 +2453,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/checkIamActionWithLock/{samActionName}:
     get:
       tags:
@@ -2710,11 +2480,7 @@ paths:
             if it doesn't exist)
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/fileTransfers:
     get:
       tags:
@@ -2773,11 +2539,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/unlock:
     put:
       tags:
@@ -2805,11 +2567,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/acl:
     get:
       tags:
@@ -2840,11 +2598,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     patch:
       tags:
         - workspaces
@@ -2897,11 +2651,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: aclUpdates
   /api/workspaces/{workspaceNamespace}/{workspaceName}/bucketOptions:
     get:
@@ -2927,11 +2677,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/catalog:
     get:
       tags:
@@ -2959,11 +2705,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     patch:
       tags:
         - workspaces
@@ -2996,11 +2738,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: catalogUpdates
   /api/workspaces:
     get:
@@ -3037,11 +2775,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     post:
       tags:
         - workspaces
@@ -3087,11 +2821,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: workspaceJson
   /api/workspaces/id/{workspaceId}:
     get:
@@ -3138,11 +2868,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}:
     get:
       tags:
@@ -3184,11 +2910,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - workspaces
@@ -3216,11 +2938,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     patch:
       tags:
         - workspaces
@@ -3263,11 +2981,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: entityUpdateJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/clone:
     post:
@@ -3331,11 +3045,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: workspaceRequest
   /api/workspaces/{workspaceNamespace}/{workspaceName}/bucketUsage:
     get:
@@ -3384,11 +3094,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/WorkspaceTag'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/enableRequesterPaysForLinkedServiceAccounts:
     put:
       tags:
@@ -3418,11 +3124,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/disableRequesterPaysForLinkedServiceAccounts:
     put:
       tags:
@@ -3440,11 +3142,7 @@ paths:
             In all cases whether or not the workspace exists or user has access. If there were linked service accounts they were removed from the workspace but this api does not indicate that anything was done (for security reasons).
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workflows/{workflowId}/genomics/{operationId}:
     get:
       tags:
@@ -3472,11 +3170,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/user/refreshToken:
     put:
       deprecated: true
@@ -3497,11 +3191,7 @@ paths:
           description: Successful Request
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: refreshToken
   /api/user/refreshTokenDate:
     get:
@@ -3531,11 +3221,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/user/role/admin:
     get:
       tags:
@@ -3551,11 +3237,7 @@ paths:
           description: User is not an admin
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/user/role/curator:
     get:
       tags:
@@ -3571,11 +3253,7 @@ paths:
           description: User is not a curator
           content: {}
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/user/billing:
     get:
       tags:
@@ -3601,11 +3279,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/user/billing/{projectName}:
     get:
       tags:
@@ -3664,11 +3338,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/user/billingAccounts:
     get:
       tags:
@@ -3695,11 +3365,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
       security:
         - authorization:
             - openid
@@ -3752,11 +3418,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     post:
       tags:
         - snapshots_v2
@@ -3784,11 +3446,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/{snapshotId}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
@@ -3814,11 +3472,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     patch:
       summary: Update name or description of a reference to a snapshot in the Terra Data Repo.
       operationId: updateDataRepoSnapshot_v2
@@ -3840,11 +3494,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - snapshots_v2
@@ -3862,11 +3512,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/snapshots/v2/name/{referenceName}:
     parameters:
       - $ref: '#/components/parameters/workspaceNamespacePathParam'
@@ -3892,14 +3538,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-
-
-
+          $ref: '#/components/responses/RawlsInternalError'
   /api/notifications/workspace/{workspaceNamespace}/{workspaceName}:
     get:
       tags:
@@ -6084,6 +5723,13 @@ components:
       required: true
       schema:
         type: string
+  responses:
+    RawlsInternalError:
+      description: Rawls Internal Error
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/ErrorReport'
   securitySchemes:
     authorization:
       type: oauth2

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -297,7 +297,7 @@ paths:
         - billing_v2
       summary: delete billing project
       description: delete billing project
-      operationId: deleteBillingProject
+      operationId: deleteBillingProjectV2
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
@@ -389,7 +389,7 @@ paths:
         - billing_v2
       summary: list members of billing project the caller owns
       description: list members of billing project the caller owns
-      operationId: listBillingProjectMembers
+      operationId: listBillingProjectMembersV2
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
       responses:
@@ -583,7 +583,7 @@ paths:
         - billing_v2
       summary: add user or group to billing project the caller owns
       description: add user or group to billing project the caller owns
-      operationId: addUserToBillingProject
+      operationId: addUserToBillingProjectV2
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
         - $ref: '#/components/parameters/workbenchRolePathParam'
@@ -619,7 +619,7 @@ paths:
         - billing_v2
       summary: remove user or group from billing project the caller owns
       description: remove user or group from billing project the caller owns
-      operationId: removeUserFromBillingProject
+      operationId: removeUserFromBillingProjectV2
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
         - $ref: '#/components/parameters/workbenchRolePathParam'

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -159,15 +159,7 @@ paths:
       operationId: addUserToBillingProject
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
-        - name: workbenchRole
-          in: path
-          description: role of user for project
-          required: true
-          schema:
-            type: string
-            enum:
-              - user
-              - owner
+        - $ref: '#/components/parameters/workbenchRolePathParam'
         - name: email
           in: path
           description: email of user or group to add
@@ -204,15 +196,7 @@ paths:
       operationId: removeUserFromBillingProject
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
-        - name: workbenchRole
-          in: path
-          description: role of user for project
-          required: true
-          schema:
-            type: string
-            enum:
-              - user
-              - owner
+        - $ref: '#/components/parameters/workbenchRolePathParam'
         - name: email
           in: path
           description: email of user or group to remove
@@ -602,15 +586,7 @@ paths:
       operationId: addUserToBillingProject
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
-        - name: workbenchRole
-          in: path
-          description: role of user for project
-          required: true
-          schema:
-            type: string
-            enum:
-              - user
-              - owner
+        - $ref: '#/components/parameters/workbenchRolePathParam'
         - name: email
           in: path
           description: email of user or group to add
@@ -646,15 +622,7 @@ paths:
       operationId: removeUserFromBillingProject
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'
-        - name: workbenchRole
-          in: path
-          description: role of user for project
-          required: true
-          schema:
-            type: string
-            enum:
-              - user
-              - owner
+        - $ref: '#/components/parameters/workbenchRolePathParam'
         - name: email
           in: path
           description: email of user or group to remove
@@ -1359,12 +1327,7 @@ paths:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
         - $ref: '#/components/parameters/submissionIdPathParam'
-        - name: workflowId
-          in: path
-          description: Workflow Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workflowIdPathParam'
       responses:
         200:
           description: Successful Request
@@ -1395,12 +1358,7 @@ paths:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
         - $ref: '#/components/parameters/submissionIdPathParam'
-        - name: workflowId
-          in: path
-          description: Workflow Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workflowIdPathParam'
       responses:
         200:
           description: Successful Request
@@ -1437,12 +1395,7 @@ paths:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
         - $ref: '#/components/parameters/submissionIdPathParam'
-        - name: workflowId
-          in: path
-          description: Workflow Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workflowIdPathParam'
         - name: includeKey
           in: query
           description: |
@@ -3500,12 +3453,7 @@ paths:
       description: retrieve operations info from Google Genomics API
       operationId: genomics_operations_get
       parameters:
-        - name: workflowId
-          in: path
-          description: Workflow Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/workflowIdPathParam'
         - name: operationId
           in: path
           description: operations job id; for PAPIv1 in the form of "operations/{id}",
@@ -6104,6 +6052,23 @@ components:
       name: submissionId
       in: path
       description: Submission Id
+      required: true
+      schema:
+        type: string
+    workbenchRolePathParam:
+      name: workbenchRole
+      in: path
+      description: role of user for project
+      required: true
+      schema:
+        type: string
+        enum:
+          - user
+          - owner
+    workflowIdPathParam:
+      name: workflowId
+      in: path
+      description: Workflow Id
       required: true
       schema:
         type: string

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -267,11 +267,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Internal Server Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - billing_v2
@@ -290,11 +286,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Internal Server Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}/billingAccount:
     put:
       tags:
@@ -331,11 +323,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Internal Server Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
     delete:
       tags:
         - billing_v2
@@ -358,11 +346,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Internal Server Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}/members:
     get:
       tags:
@@ -1392,8 +1376,7 @@ paths:
           description: Workspace or entity type does not exist
           content: {}
         500:
-          description: Internal Server Error
-          content: {}
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/{entityName}/rename:
     post:
       tags:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -2290,18 +2290,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: configNamespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: configName
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespacePathParam'
+        - $ref: '#/components/parameters/configNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -2331,18 +2321,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: configNamespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: configName
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespacePathParam'
+        - $ref: '#/components/parameters/configNamePathParam'
       responses:
         200:
           description: Successful Request
@@ -2373,18 +2353,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: configNamespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: configName
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespacePathParam'
+        - $ref: '#/components/parameters/configNamePathParam'
       requestBody:
         description: New Method Configuration contents
         content:
@@ -2433,18 +2403,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: configNamespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: configName
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespacePathParam'
+        - $ref: '#/components/parameters/configNamePathParam'
       requestBody:
         description: New Method Configuration contents
         content:
@@ -2493,18 +2453,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: configNamespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: configName
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespacePathParam'
+        - $ref: '#/components/parameters/configNamePathParam'
       responses:
         204:
           description: Successful Request
@@ -2534,18 +2484,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: configNamespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: configName
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespacePathParam'
+        - $ref: '#/components/parameters/configNamePathParam'
       requestBody:
         description: New Method Configuration Name
         content:
@@ -6145,6 +6085,20 @@ components:
       name: billingProject
       in: query
       description: Billing project to use for queries to the data reference
+      schema:
+        type: string
+    configNamespacePathParam:
+      name: configNamespace
+      in: path
+      description: Method Configuration Namespace
+      required: true
+      schema:
+        type: string
+    configNamePathParam:
+      name: configName
+      in: path
+      description: Method Configuration Name
+      required: true
       schema:
         type: string
     dataReferenceQueryParam:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1585,18 +1585,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
-        - name: entityName
-          in: path
-          description: Entity Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/entityTypePathParam'
+        - $ref: '#/components/parameters/entityNamePathParam'
       requestBody:
         description: New entity name
         content:
@@ -1637,18 +1627,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
-        - name: entityName
-          in: path
-          description: Entity Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/entityTypePathParam'
+        - $ref: '#/components/parameters/entityNamePathParam'
       requestBody:
         description: Expression
         content:
@@ -1780,12 +1760,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/entityTypePathParam'
       responses:
         200:
           description: Successful Request
@@ -1885,18 +1860,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
-        - name: entityName
-          in: path
-          description: Entity Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/entityTypePathParam'
+        - $ref: '#/components/parameters/entityNamePathParam'
       requestBody:
         description: Update operations for attributes
         content:


### PR DESCRIPTION
In which I delete over 1,000 lines (~15%) of the Rawls swagger yaml file, by:

* using centralized `parameter` refs where possible (I've updated most instances, there are some low-ROI stragglers left)
* using a centralized `responses` ref for 500 Rawls Internal Server Error
    * there remain a few ISEs that claim to respond with `{}`, which I doubt, but I haven't updated those because I would need to research those APIs. I updated one that I am certain was wrong.

Additionally, I eliminated all but one validation error. The remaining error would require an API rewrite, which is far out of scope.

REVIEWER: you may have an easier time going commit-by-commit - or review as a chunk, up to you

Errors before this PR, according to https://editor.swagger.io/:
![Screenshot (1)](https://user-images.githubusercontent.com/6041577/160696854-17e2cc43-94ec-4ee4-a3cc-4307cb3add97.png)

Errors after this PR:
![Screenshot](https://user-images.githubusercontent.com/6041577/160696876-f5c8fd5d-d286-4b30-9775-b1fae425cd0d.png)

