### PR TITLE
AJ-355 add rename entity type end point

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1416,7 +1416,7 @@ paths:
           description: Successful Request
           content: { }
         404:
-          description: Workspace or Entity not found
+          description: Workspace or Entity Type not found
           content:
             'application/json':
               schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1460,7 +1460,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         404:
-          description: Workspace or Entity not found
+          description: Workspace or Entity Type not found
           content:
             'application/json':
               schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1394,7 +1394,7 @@ paths:
         500:
           $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: newEntityNameJson
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/entityType/rename:
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/renameEntityType:
     post:
       tags:
         - entities
@@ -1405,7 +1405,7 @@ paths:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
       requestBody:
-        description: Old entity type name and what you want to rename it
+        description: Old entity type name and the name you'd like to change it to
         content:
           'application/json':
             schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1394,6 +1394,42 @@ paths:
         500:
           $ref: '#/components/responses/RawlsInternalError'
       x-codegen-request-body-name: newEntityNameJson
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/entityType/rename:
+    post:
+      tags:
+        - entities
+      summary: rename entity type in a workspace
+      description: Rename an entity type
+      operationId: renameEntityType
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+      requestBody:
+        description: Old entity type name and what you want to rename it
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/EntityTypeRename'
+        required: true
+      responses:
+        204:
+          description: Successful Request
+          content: { }
+        404:
+          description: Workspace or Entity not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        409:
+          description: New name for entity type already exists in workspace
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+      x-codegen-request-body-name: entityTypeRenameJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/{entityName}/evaluate:
     post:
       tags:
@@ -4191,6 +4227,18 @@ components:
           type: string
           description: The name of the entity
       description: ""
+    EntityTypeRename:
+      required:
+        - oldName
+        - newName
+      type: object
+      properties:
+        oldName:
+          type: string
+          description: the entity type name to change
+        newName:
+          type: string
+          description: the new entity type name
     EntityCopyDefinition:
       required:
         - destinationWorkspace

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -816,7 +816,8 @@ trait EntityComponent {
     }
 
     def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): ReadWriteAction[Int] = {
-      ChangeEntityTypeNameQuery.changeEntityTypeName(workspaceContext, oldName, newName)
+      ChangeEntityTypeNameQuery.changeEntityTypeName(workspaceContext, oldName, newName) andThen
+        workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
     }
 
     def rename(workspaceContext: Workspace, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -475,7 +475,7 @@ trait EntityComponent {
       def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Seq[Boolean]] = {
 
         sql"""select exists (select name from ENTITY
-               where workspace_id=${workspaceContext.workspaceIdAsUUID} and entity_type = $entityType)
+               where workspace_id=${workspaceContext.workspaceIdAsUUID} and entity_type = $entityType and deleted = 0)
           """.as[Boolean]
       }
     }
@@ -487,7 +487,7 @@ trait EntityComponent {
       def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): WriteAction[Int] = {
 
         sqlu"""update ENTITY set entity_type = $newName
-              where workspace_id=${workspaceContext.workspaceIdAsUUID} and entity_type = $oldName
+              where workspace_id=${workspaceContext.workspaceIdAsUUID} and entity_type = $oldName and deleted = 0
           """
       }
     }
@@ -811,8 +811,8 @@ trait EntityComponent {
       }
     }
 
-    def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Seq[Boolean]] = {
-      CheckForExistingEntityTypeQuery.doesEntityTypeAlreadyExist(workspaceContext, entityType)
+    def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Option[Boolean]] = {
+      uniqueResult(CheckForExistingEntityTypeQuery.doesEntityTypeAlreadyExist(workspaceContext, entityType))
     }
 
     def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): ReadWriteAction[Int] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -816,8 +816,12 @@ trait EntityComponent {
     }
 
     def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): ReadWriteAction[Int] = {
-      ChangeEntityTypeNameQuery.changeEntityTypeName(workspaceContext, oldName, newName) andThen
-        workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
+      for {
+        numRowsRenamed <- ChangeEntityTypeNameQuery.changeEntityTypeName(workspaceContext, oldName, newName)
+        _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
+      } yield {
+        numRowsRenamed
+      }
     }
 
     def rename(workspaceContext: Workspace, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -124,24 +124,40 @@ class EntityService(protected val userInfo: UserInfo, val dataSource: SlickDataS
       }
     }
 
-  def renameEntityType(workspaceName: WorkspaceName, oldName: String, newName: String): Future[Int] =
+  def renameEntityType(workspaceName: WorkspaceName, renameInfo: EntityTypeRename): Future[Int] = {
+    import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
+
+    def validateExistingType(dataAccess: DataAccess, workspaceContext: Workspace, oldName: String): ReadAction[Boolean] = {
+      dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, oldName) map {
+        case Some(true) => true
+        case Some(false) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound,
+          s"Can't find entity type ${oldName}"))
+        case None => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError,
+          s"Unexpected error; could not determine existence of entity type ${oldName}"))
+      }
+    }
+
+    def validateNewType(dataAccess: DataAccess, workspaceContext: Workspace, newName: String): ReadAction[Boolean] = {
+      dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, newName) map {
+        case Some(true) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"${newName} already exists as an entity type"))
+        case Some(false) => false
+        case None => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError,
+          s"Unexpected error; could not determine existence of entity type ${newName}"))
+      }
+    }
+
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
-        dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, newName) flatMap {
-          _.head match {
-            case false =>
-              dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, oldName) flatMap {
-                _.head match {
-                  case false => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound,
-                    s"Can't find entity type ${oldName}"))
-                  case true => dataAccess.entityQuery.changeEntityTypeName(workspaceContext, oldName, newName)
-                }
-              }
-            case true => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"${newName} already exists as an entity type"))
-          }
+        for {
+          _ <- validateNewType(dataAccess, workspaceContext, renameInfo.newName)
+          _ <- validateExistingType(dataAccess, workspaceContext, renameInfo.oldName)
+          renameResult <- dataAccess.entityQuery.changeEntityTypeName(workspaceContext, renameInfo.oldName, renameInfo.newName)
+        } yield {
+          renameResult
         }
       }
     }
+  }
 
   def evaluateExpression(workspaceName: WorkspaceName, entityType: String, entityName: String, expression: String): Future[Seq[AttributeValue]] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -135,6 +135,13 @@ trait EntityApiService extends UserInfoDirectives {
             }
           }
         } ~
+        path("workspaces" / Segment / Segment / "entityType" / "rename") { (workspaceNamespace, workspaceName) =>
+          post {
+            entity(as[EntityTypeRename]) { rename =>
+              complete { entityServiceConstructor(userInfo).renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), rename.oldName, rename.newName).map(_ => StatusCodes.NoContent) }
+            }
+          }
+        } ~
         path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "evaluate") { (workspaceNamespace, workspaceName, entityType, entityName) =>
           post {
             entity(as[String]) { expression =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -135,10 +135,10 @@ trait EntityApiService extends UserInfoDirectives {
             }
           }
         } ~
-        path("workspaces" / Segment / Segment / "entityType" / "rename") { (workspaceNamespace, workspaceName) =>
+        path("workspaces" / Segment / Segment / "entities" / "renameEntityType") { (workspaceNamespace, workspaceName) =>
           post {
             entity(as[EntityTypeRename]) { rename =>
-              complete { entityServiceConstructor(userInfo).renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), rename.oldName, rename.newName).map(_ => StatusCodes.NoContent) }
+              complete { entityServiceConstructor(userInfo).renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), rename).map(_ => StatusCodes.NoContent) }
             }
           }
         } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -159,6 +159,27 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
+  it should "checkForEntityTypes" in withDefaultTestDatabase {
+    withWorkspaceContext(testData.workspace) { context =>
+      val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
+      assert(!pair2EntityTypeExists)
+      val pairEntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair")).head
+      assert(pairEntityTypeExists)
+    }
+  }
+
+  it should "changeEntityTypeName" in withDefaultTestDatabase {
+    withWorkspaceContext(testData.workspace) { context =>
+      val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
+      assert(!pair2EntityTypeExists)
+      val rowsChanged = runAndWait(entityQuery.changeEntityTypeName(context, "Pair", "Pair2"))
+      assert(rowsChanged == 2)
+      val pair2EntityTypeExistsAfterUpdate = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
+      assert(pair2EntityTypeExistsAfterUpdate)
+
+    }
+  }
+
   it should "saveEntityPatch" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -159,21 +159,17 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-  it should "properly check For existing entity types" in withDefaultTestDatabase {
+  it should "return false if the entity type does not exist" in withMinimalTestDatabase { _ =>
     withWorkspaceContext(testData.workspace) { context =>
-      val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
+      val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).get
       assert(!pair2EntityTypeExists)
-      val pairEntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair")).head
-      assert(pairEntityTypeExists)
     }
   }
 
   it should "change entity type name" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
-      assert(!pair2EntityTypeExists)
       runAndWait(entityQuery.changeEntityTypeName(context, "Pair", "Pair2"))
-      val pair2EntityTypeExistsAfterUpdate = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
+      val pair2EntityTypeExistsAfterUpdate = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).get
       assert(pair2EntityTypeExistsAfterUpdate)
 
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -159,7 +159,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-  it should "checkForEntityTypes" in withDefaultTestDatabase {
+  it should "properly check For existing entity types" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
       assert(!pair2EntityTypeExists)
@@ -168,7 +168,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-  it should "changeEntityTypeName" in withDefaultTestDatabase {
+  it should "change entity type name" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
       assert(!pair2EntityTypeExists)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -168,7 +168,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "change entity type name" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      runAndWait(entityQuery.changeEntityTypeName(context, "Pair", "Pair2"))
+      val rowsUpdated = runAndWait(entityQuery.changeEntityTypeName(context, "Pair", "Pair2"))
+      assert(rowsUpdated == 2)
       val pair2EntityTypeExistsAfterUpdate = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).get
       assert(pair2EntityTypeExistsAfterUpdate)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -172,8 +172,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     withWorkspaceContext(testData.workspace) { context =>
       val pair2EntityTypeExists = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
       assert(!pair2EntityTypeExists)
-      val rowsChanged = runAndWait(entityQuery.changeEntityTypeName(context, "Pair", "Pair2"))
-      assert(rowsChanged == 2)
+      runAndWait(entityQuery.changeEntityTypeName(context, "Pair", "Pair2"))
       val pair2EntityTypeExistsAfterUpdate = runAndWait(entityQuery.doesEntityTypeAlreadyExist(context, "Pair2")).head
       assert(pair2EntityTypeExistsAfterUpdate)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -200,7 +200,7 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
 
   it should "rename an entity type as long as the selected name is not in use"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
-    assertResult(1) {Await.result(services.entityService.renameEntityType(testData.wsName, EntityTypeRename(testData.pair1.entityType, "newPair")), waitDuration)}
+    assertResult(2) {Await.result(services.entityService.renameEntityType(testData.wsName, EntityTypeRename(testData.pair1.entityType, "newPair")), waitDuration)}
     // verify there are no longer any entities under the old entity name
     val queryResult = Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
     assert(queryResult.isEmpty)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -189,6 +189,21 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
     }
   }
 
+  it should "fail to rename an entity type to a name already taken"  in withTestDataServices { services =>
+    val waitDuration = Duration(10, SECONDS)
+    val ex = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, testData.pair1.entityType), waitDuration)
+    }
+    ex.errorReport.message shouldBe "Pair already exists as an entity type"
+  }
+
+  it should "rename an entity type as long as the selected name is not in use"  in withTestDataServices { services =>
+    val waitDuration = Duration(10, SECONDS)
+    val result = Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, "newPair"), waitDuration)
+    assert(result == 2) // should update the two entities belonging to the original Pair type
+  }
+
+
   it should "respect page size limits for listEntities"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities
 
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
@@ -10,7 +11,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, M
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO, RemoteServicesMockServer}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, CreateAttributeEntityReferenceList, CreateAttributeValueList, RemoveAttribute, RemoveListMember}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeNumber, AttributeString, AttributeValueEmptyList, AttributeValueList, Entity, EntityQuery, RawlsUser, SortDirections, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeNumber, AttributeString, AttributeValueEmptyList, AttributeValueList, Entity, EntityQuery, EntityTypeRename, RawlsUser, SortDirections, UserInfo, Workspace}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
@@ -192,17 +193,26 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
   it should "fail to rename an entity type to a name already in use"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     val ex = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, testData.pair1.entityType), waitDuration)
+      Await.result(services.entityService.renameEntityType(testData.wsName, EntityTypeRename(testData.pair1.entityType, testData.pair1.entityType)), waitDuration)
     }
     ex.errorReport.message shouldBe "Pair already exists as an entity type"
   }
 
   it should "rename an entity type as long as the selected name is not in use"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
-    assertResult(1) {Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, "newPair"), waitDuration)}
+    assertResult(1) {Await.result(services.entityService.renameEntityType(testData.wsName, EntityTypeRename(testData.pair1.entityType, "newPair")), waitDuration)}
     // verify there are no longer any entities under the old entity name
     val queryResult = Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
     assert(queryResult.isEmpty)
+  }
+
+  it should "throw an error when trying to rename entity that does not exist" in withTestDataServices { services =>
+    val waitDuration = Duration(10, SECONDS)
+    val ex = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(services.entityService.renameEntityType(testData.wsName, EntityTypeRename("non-existent-type", "new-name")), waitDuration)
+    }
+    ex.errorReport.message shouldBe "Can't find entity type non-existent-type"
+    ex.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
   }
 
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -199,8 +199,9 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
 
   it should "rename an entity type as long as the selected name is not in use"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
-    val result = Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, "newPair"), waitDuration)
-    assert(result == 2) // should update the two entities belonging to the original Pair type
+    assertResult(1) {Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, "newPair"), waitDuration)}
+    val queryResult = Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
+    assert(queryResult.isEmpty)
   }
 
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -189,7 +189,7 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
     }
   }
 
-  it should "fail to rename an entity type to a name already taken"  in withTestDataServices { services =>
+  it should "fail to rename an entity type to a name already in use"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     val ex = intercept[RawlsExceptionWithErrorReport] {
       Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, testData.pair1.entityType), waitDuration)
@@ -200,6 +200,7 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
   it should "rename an entity type as long as the selected name is not in use"  in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     assertResult(1) {Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, "newPair"), waitDuration)}
+    // verify there are no longer any entities under the old entity name
     val queryResult = Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
     assert(queryResult.isEmpty)
   }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -250,6 +250,8 @@ case class WorkspaceSubmissionStats(lastSuccessDate: Option[DateTime],
 
 case class WorkspaceBucketOptions(requesterPays: Boolean)
 
+case class EntityTypeRename(oldName: String, newName: String)
+
 case class EntityName(
                    name: String)
 
@@ -1023,6 +1025,8 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val MethodInputsOutputsFormat = jsonFormat2(MethodInputsOutputs)
 
   implicit val WorkspaceTagFormat = jsonFormat2(WorkspaceTag)
+
+  implicit val EntityTypeRenameFormat = jsonFormat2(EntityTypeRename)
 
   implicit object WorkspaceFeatureFlagFormat extends JsonFormat[WorkspaceFeatureFlag] {
     override def write(flag: WorkspaceFeatureFlag): JsValue = JsString(flag.name)


### PR DESCRIPTION
My `EntityService` and test code could likely use a more refined scala touch.  