### PR TITLE
resolve slash-syntax deprecation warnings [AJ-383]

### DIFF
--- a/project/CodeGeneration.scala
+++ b/project/CodeGeneration.scala
@@ -18,16 +18,16 @@ object CodeGeneration {
     The sbt plugin doesn't behave like the maven plugin, so we have to specify the package...
     https://github.com/ihji/sbt-antlr4/issues/3
      */
-    antlr4PackageName in Antlr4 := Option("org.broadinstitute.dsde.rawls.expressions.parser.antlr"),
-    antlr4Version in Antlr4 := "4.8-1",
-    antlr4GenVisitor in Antlr4 := true,
-    antlr4GenListener in Antlr4 := false,
-    antlr4TreatWarningsAsErrors in Antlr4 := true,
+    Antlr4 / antlr4PackageName := Option("org.broadinstitute.dsde.rawls.expressions.parser.antlr"),
+    Antlr4 / antlr4Version := "4.8-1",
+    Antlr4 / antlr4GenVisitor := true,
+    Antlr4 / antlr4GenListener := false,
+    Antlr4 / antlr4TreatWarningsAsErrors := true,
     /*
     Put the generated code in a sibling to `main`. Otherwise the default, a nested directory `main/antlr4`, trips up
     IntelliJ. It will try to compile the generated source code twice, once under `main`, and again under `main/antlr4`,
     resulting in cryptic errors like "TerraExpressionBaseVisitor is already defined as class TerraExpressionBaseVisitor"
      */
-    javaSource in Antlr4 := new File((sourceManaged in Compile).value + "_antlr4")
+    Antlr4 / javaSource := new File((Compile / sourceManaged).value + "_antlr4")
   )
 }

--- a/project/Compiling.scala
+++ b/project/Compiling.scala
@@ -4,7 +4,7 @@ import sbt._
 object Compiling {
   // generate version.conf
   val writeVersionConf = Def.task {
-    val file = (resourceManaged in Compile).value / "version.conf"
+    val file = (Compile / resourceManaged).value / "version.conf"
     // jenkins sets BUILD_NUMBER and GIT_COMMIT environment variables
     val buildNumber = sys.env.getOrElse("BUILD_NUMBER", default = "None")
     val gitHash = sys.env.getOrElse("GIT_COMMIT", default = "None")
@@ -14,6 +14,6 @@ object Compiling {
   }
 
   val rawlsCompileSettings = List(
-    resourceGenerators in Compile += writeVersionConf
+    Compile / resourceGenerators += writeVersionConf
   )
 }

--- a/project/MinnieKenny.scala
+++ b/project/MinnieKenny.scala
@@ -38,9 +38,9 @@ object MinnieKenny {
       val args = spaceDelimited("<arg>").parsed
       minnieKennySingleRunner.runOnce(log, args)
     },
-    test in Test := {
+    Test / test := {
       minnieKenny.toTask("").value
-      (test in Test).value
+      (Test / test).value
     }
   )
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -54,23 +54,23 @@ object Settings {
 
   //sbt assembly settings common to rawlsCore and rawlsModel
   val commonAssemblySettings = Seq(
-    assemblyMergeStrategy in assembly := customMergeStrategy((assemblyMergeStrategy in assembly).value),
+    assembly / assemblyMergeStrategy := customMergeStrategy((assembly / assemblyMergeStrategy).value),
     //  Try to fix the following error. We're not using akka-stream, so it should be safe to exclude `akka-protobuf`
     //  [error] /Users/qi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.4/protobuf-java-3.11.4.jar:google/protobuf/field_mask.proto
     //  [error] /Users/qi/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/typesafe/akka/akka-protobuf-v3_2.12/2.6.1/akka-protobuf-v3_2.12-2.6.1.jar:google/protobuf/field_mask.proto
-    assemblyExcludedJars in assembly := {
-      val cp = (fullClasspath in assembly).value
+    assembly / assemblyExcludedJars := {
+      val cp = (assembly / fullClasspath).value
       cp filter {_.data.getName == "akka-protobuf-v3_2.13-2.6.3.jar"}
     },
-    test in assembly := {}
+    assembly / test := {}
   )
 
   //sbt assembly settings for rawls proper needs to include a main class to launch the jar
   val rawlsAssemblySettings = Seq(
-    mainClass in assembly := Some("org.broadinstitute.dsde.rawls.Boot"),
+    assembly / mainClass := Some("org.broadinstitute.dsde.rawls.Boot"),
     // we never want guava-jdk5
-    assemblyExcludedJars in assembly := {
-      val cp = (fullClasspath in assembly).value
+    assembly / assemblyExcludedJars := {
+      val cp = (assembly / fullClasspath).value
       cp filter {_.data.getName.startsWith("guava-jdk5")}
     }
   )


### PR DESCRIPTION
Since I was looking at compile-time warnings as part of moving Rawls to Java 17, I cleaned up these warnings. They are not technically related to the Java 17 upgrade, but that's where they stood out as needing attention.

See https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash for explanation of the changes.