### PR TITLE
output unit test durations [no ticket, test code only, no prod impact]

### DIFF
--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -50,6 +50,7 @@ object Testing {
         .invoke(null, "ROOT")
     ),
     Test / testOptions ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
+    Test / testOptions += Tests.Argument("-oD"), // prints individual test durations
     IntegrationTest / testOptions := Seq(Tests.Filter(s => isIntegrationTest(s))),
 
     validMySqlHostSetting,

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -50,7 +50,7 @@ object Testing {
         .invoke(null, "ROOT")
     ),
     Test / testOptions ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
-    Test / testOptions += Tests.Argument("-oD"), // prints individual test durations
+    Test / testOptions += Tests.Argument("-oDG"), // D = individual test durations, G = stack trace reminders at end
     IntegrationTest / testOptions := Seq(Tests.Filter(s => isIntegrationTest(s))),
 
     validMySqlHostSetting,


### PR DESCRIPTION
outputs durations for individual unit tests; we can use these to identify slow tests. See unit test output from the various actions; they'll look something like this:
```
[info] DataAccessSpec:
[info] DataAccess
[info] - should not deadlock due to too few threads (8 seconds, 358 milliseconds)
[info] - should use utf8 for MySQL's character_set_server (346 milliseconds)
[info] Run completed in 13 seconds, 729 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```