### PR TITLE
AJ 394

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -276,7 +276,8 @@ class AvroUpsertMonitorActor(
 
     //Make sure message is acknowledged in the case of any failure while trying to construct importFuture
     importFuture.map(_ => ImportComplete)  recover {
-      case _ =>
+      case t =>
+        logger.error(s"unexpected error in importFuture for ${attributes.importId}: ${t.getMessage}", t)
         acknowledgeMessage(message.ackId)
     } pipeTo self
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -274,7 +274,12 @@ class AvroUpsertMonitorActor(
       }
     } yield ()
 
-    importFuture.map(_ => ImportComplete) pipeTo self
+    //Make sure message is acknowledged in the case of any failure while trying to construct importFuture
+    importFuture.map(_ => ImportComplete)  recover {
+      case Throwable =>
+        acknowledgeMessage(message.ackId)
+    } pipeTo self
+
   }
 
   private def publishMessageToUpdateImportStatus(importId: UUID, currentImportStatus: Option[ImportStatus], newImportStatus: ImportStatus, errorMessage: Option[String]) = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -276,7 +276,7 @@ class AvroUpsertMonitorActor(
 
     //Make sure message is acknowledged in the case of any failure while trying to construct importFuture
     importFuture.map(_ => ImportComplete)  recover {
-      case Throwable =>
+      case _ =>
         acknowledgeMessage(message.ackId)
     } pipeTo self
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -143,7 +143,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     setUpPubSub(services)
 
     val mockImportServiceDAO =  mock[ImportServiceDAO]
-    when(mockImportServiceDAO.getImportStatus(failImportStatusUUID, importStatusFailingWorkspace, userInfo)).thenReturn(Future.failed(new Exception("USer not found")))
+    when(mockImportServiceDAO.getImportStatus(failImportStatusUUID, workspaceName, userInfo)).thenReturn(Future.failed(new Exception("User not found")))
 
     // Start the monitor
     system.actorOf(AvroUpsertMonitorSupervisor.props(
@@ -588,8 +588,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     }
 
     // Publish message on the request topic
-    val messageAttributes = testAttributes(failImportStatusUUID) ++ Map("workspaceName" -> importStatusFailingWorkspace.toString)
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(failImportStatusUUID.toString, messageAttributes)))
+    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(failImportStatusUUID.toString, testAttributes(failImportStatusUUID))))
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -525,7 +525,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
     // upsert will fail; check that a pubsub message was acked.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      services.gpsDAO.acks shouldBe empty
+      services.gpsDAO.acks should not be empty
     }
 
   }
@@ -562,7 +562,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
     // upsert will fail; check that a pubsub message was acked.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      services.gpsDAO.acks shouldBe empty
+      services.gpsDAO.acks should not be empty
     }
 
   }
@@ -597,7 +597,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
     // upsert will fail; check that a pubsub message was acked.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      services.gpsDAO.acks shouldBe empty
+      services.gpsDAO.acks should not be empty
     }
 
   }


### PR DESCRIPTION
See AJ-394 for description of how to reproduce issue.  Unacked messages can be seen on google cloud console by going to Pub/Sub -> Subscriptions -> rawls-async-import-topic-sub-[ENV] (or rather, hopefully won't be seen).  

This PR adds a recover after creating `importFuture` to acknowledge the pubsub message in case anything fails.  Note that this does not cover the situation where `parseMessage` throws an error.  

Tests are added to check failure when finding the workspace, getting the pet user info, and fetching the import status.   To do this I added some mocked objects, which resulted in somewhat duplicated code (`setUpMockImportService/setUpMockSamDAO/setUpMockEntityManager` (pre-existing method, used as a model).  Would love input on whether refactoring this is necessary or desirable, or really anything else.