### PR TITLE
[AJ-450] Implement metrics for entity/attribute count in cloned workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -5,4 +5,4 @@ import slick.jdbc.JdbcProfile
 import scala.concurrent.ExecutionContext
 
 class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int)(implicit val executionContext: ExecutionContext)
-extends DriverComponent with DataAccess
+extends DriverComponent with DataAccess // TODO: resolve metric base name

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -5,4 +5,4 @@ import slick.jdbc.JdbcProfile
 import scala.concurrent.ExecutionContext
 
 class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int)(implicit val executionContext: ExecutionContext)
-extends DriverComponent with DataAccess // TODO: resolve metric base name
+extends DriverComponent with DataAccess

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
 import io.opencensus.trace.{Span, AttributeValue => OpenCensusAttributeValue}
-import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
@@ -78,7 +77,7 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 }
 
 //noinspection TypeAnnotation
-trait EntityComponent extends RawlsInstrumented {
+trait EntityComponent {
   this: DriverComponent
     with WorkspaceComponent
     with AttributeComponent
@@ -906,9 +905,6 @@ trait EntityComponent extends RawlsInstrumented {
         entitiesCopiedCount <- CopyEntitiesQuery.copyEntities(sourceWs, destWs)
         attributesCopiedCount <- CopyEntityAttributesQuery.copyAllAttributes(sourceWs, destWs)
       } yield {
-        clonedWorkspaceEntityHistogram += entitiesCopiedCount
-        clonedWorkspaceAttributeHistogram += attributesCopiedCount
-
         (entitiesCopiedCount, attributesCopiedCount)
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -80,7 +80,7 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 }
 
 //noinspection TypeAnnotation
-trait EntityComponent extends RawlsInstrumented with WorkspaceComponent {
+trait EntityComponent extends RawlsInstrumented {
   this: DriverComponent
     with WorkspaceComponent
     with AttributeComponent
@@ -539,14 +539,9 @@ trait EntityComponent extends RawlsInstrumented with WorkspaceComponent {
         val sourceShardId = determineShard(clonedWorkspaceId)
         val destShardId = determineShard(newWorkspaceId)
 
-        var entityCount = 0
-        workspaceQuery.findByIdOrFail(clonedWorkspaceId.toString).map(w => {
-          listEntities(w).map(e => {
-            entityCount += 1
-            e
-          })
-          clonedWorkspaceEntityHistogram += entityCount
-          clonedWorkspaceAttributeHistogram += w.attributes.size
+        cloneEntitiesToNewWorkspace(clonedWorkspaceId, newWorkspaceId).map({p =>
+          clonedWorkspaceEntityHistogram += p._1
+          clonedWorkspaceAttributeHistogram += p._2
         })
 
         sqlu"""insert into ENTITY_ATTRIBUTE_#$destShardId (name, value_string, value_number, value_boolean, value_entity_ref,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.metrics
 
-import nl.grons.metrics4.scala.{Counter, Gauge, Histogram, Timer}
+import nl.grons.metrics4.scala.{Counter, Histogram, Timer}
 import org.broadinstitute.dsde.rawls.metrics.RawlsExpansion._
 import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
@@ -73,19 +73,19 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
       .asTimer("staleness")
 
   /**
-    * A gauge to track the number of entities in each cloned workspace.
+    * A histogram to track the number of entities in each cloned workspace.
     */
   protected def clonedWorkspaceEntityHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(WorkflowStatusMetricKey, "cloned_ws_entities")
+      .expand(WorkspaceMetricKey, "cloned_ws_entities")
       .asHistogram("count")
 
   /**
-    * A gauge to track the number of attributes in each cloned workspace.
+    * A histogram to track the number of attributes in each cloned workspace.
     */
   protected def clonedWorkspaceAttributeHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(WorkflowStatusMetricKey, "cloned_ws_attributes")
+      .expand(WorkspaceMetricKey, "cloned_ws_attributes")
       .asHistogram("count")
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.metrics
 
-import nl.grons.metrics4.scala.{Counter, Timer}
+import nl.grons.metrics4.scala.{Counter, Gauge, Histogram, Timer}
 import org.broadinstitute.dsde.rawls.metrics.RawlsExpansion._
 import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
@@ -71,6 +71,22 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     ExpandedMetricBuilder
       .expand(WorkspaceMetricKey, "entity_cache")
       .asTimer("staleness")
+
+  /**
+    * A gauge to track the number of entities in each cloned workspace.
+    */
+  protected def clonedWorkspaceEntityHistogram: Histogram =
+    ExpandedMetricBuilder
+      .expand(WorkflowStatusMetricKey, "cloned_ws_entities")
+      .asHistogram("count")
+
+  /**
+    * A gauge to track the number of attributes in each cloned workspace.
+    */
+  protected def clonedWorkspaceAttributeHistogram: Histogram =
+    ExpandedMetricBuilder
+      .expand(WorkflowStatusMetricKey, "cloned_ws_attributes")
+      .asHistogram("count")
 }
 
 object RawlsInstrumented {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -821,7 +821,10 @@ class WorkspaceService(protected val userInfo: UserInfo,
                         val newAttrs = sourceWorkspaceContext.attributes ++ destWorkspaceRequest.attributes
                         traceDBIOWithParent("withNewWorkspaceContext (cloneWorkspace)", parentSpan) { s1 =>
                           withNewWorkspaceContext(destWorkspaceRequest.copy(authorizationDomain = Option(newAuthDomain), attributes = newAttrs), destBillingProject, sourceBucketNameOption, dataAccess, s1) { destWorkspaceContext =>
-                            dataAccess.entityQuery.cloneEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID) andThen
+                            dataAccess.entityQuery.cloneEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID).map { counts: (Int, Int) =>
+                              clonedWorkspaceEntityHistogram += counts._1
+                              clonedWorkspaceAttributeHistogram += counts._2
+                            } andThen {
                               dataAccess.methodConfigurationQuery.listActive(sourceWorkspaceContext).flatMap { methodConfigShorts =>
                                 val inserts = methodConfigShorts.map { methodConfigShort =>
                                   dataAccess.methodConfigurationQuery.get(sourceWorkspaceContext, methodConfigShort.namespace, methodConfigShort.name).flatMap { methodConfig =>
@@ -830,7 +833,8 @@ class WorkspaceService(protected val userInfo: UserInfo,
                                 }
                                 DBIO.seq(inserts: _*)
                               } andThen {
-                              DBIO.successful((sourceWorkspaceContext, destWorkspaceContext))
+                                DBIO.successful((sourceWorkspaceContext, destWorkspaceContext))
+                              }
                             }
                           }
                         }


### PR DESCRIPTION
This PR sends data regarding cloned workspaces to a histogram to be viewed in Grafana. Possible uses of the data include average, max, and percentile-based entity/attribute count for the cloned workspaces.