### PR TITLE
Revert "[WOR-379] Update jersey-hk2 to 2.35"

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
 
   val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.264-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
-  val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.35"
+  val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,7 +131,7 @@ object Dependencies {
 
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.274-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
-  val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.35"
+  val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32"
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"


### PR DESCRIPTION
Reverts broadinstitute/rawls#1818

This should be the library version used by the TDR client.