### PR TITLE
[AJ-465] Implement new round of Rawls metrics

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -389,7 +389,8 @@ object Boot extends IOApp with LazyLogging {
         slickDataSource,
         workspaceManagerDAO,
         samDAO,
-        multiCloudWorkspaceConfig
+        multiCloudWorkspaceConfig,
+        metricsPrefix
       )
 
       val workspaceServiceConstructor: (UserInfo) => WorkspaceService = WorkspaceService.constructor(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -5,4 +5,4 @@ import slick.jdbc.JdbcProfile
 import scala.concurrent.ExecutionContext
 
 class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int)(implicit val executionContext: ExecutionContext)
-extends DriverComponent with DataAccess
+extends DriverComponent with DataAccess // TODO: resolve metric base name

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -5,4 +5,4 @@ import slick.jdbc.JdbcProfile
 import scala.concurrent.ExecutionContext
 
 class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int)(implicit val executionContext: ExecutionContext)
-extends DriverComponent with DataAccess // TODO: resolve metric base name
+extends DriverComponent with DataAccess

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
 import io.opencensus.trace.{Span, AttributeValue => OpenCensusAttributeValue}
+import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
@@ -77,7 +78,7 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 }
 
 //noinspection TypeAnnotation
-trait EntityComponent {
+trait EntityComponent extends RawlsInstrumented {
   this: DriverComponent
     with WorkspaceComponent
     with AttributeComponent
@@ -1147,6 +1148,8 @@ trait EntityComponent {
                         entityTypesWithCounts: Map[String, Int],
                         entityTypesWithAttrNames: Map[String, Seq[AttributeName]],
                         timestamp: Timestamp) = {
+      entityCacheSaveCounter.inc()
+
       // TODO: beware contention on the approach of delete-all and batch-insert all below
       // if we see contention we could move to encoding the entire metadata object as json
       // and storing in a single column on WORKSPACE_ENTITY_CACHE

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
 import io.opencensus.trace.{Span, AttributeValue => OpenCensusAttributeValue}
-import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
@@ -78,7 +77,7 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 }
 
 //noinspection TypeAnnotation
-trait EntityComponent extends RawlsInstrumented {
+trait EntityComponent {
   this: DriverComponent
     with WorkspaceComponent
     with AttributeComponent
@@ -906,9 +905,6 @@ trait EntityComponent extends RawlsInstrumented {
         entitiesCopiedCount <- CopyEntitiesQuery.copyEntities(sourceWs, destWs)
         attributesCopiedCount <- CopyEntityAttributesQuery.copyAllAttributes(sourceWs, destWs)
       } yield {
-        clonedWorkspaceEntityHistogram += entitiesCopiedCount
-        clonedWorkspaceAttributeHistogram += attributesCopiedCount
-
         (entitiesCopiedCount, attributesCopiedCount)
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
 import io.opencensus.trace.{Span, AttributeValue => OpenCensusAttributeValue}
-import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -78,7 +78,7 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 }
 
 //noinspection TypeAnnotation
-trait EntityComponent extends RawlsInstrumented {
+trait EntityComponent {
   this: DriverComponent
     with WorkspaceComponent
     with AttributeComponent
@@ -1148,7 +1148,6 @@ trait EntityComponent extends RawlsInstrumented {
                         entityTypesWithCounts: Map[String, Int],
                         entityTypesWithAttrNames: Map[String, Seq[AttributeName]],
                         timestamp: Timestamp) = {
-      entityCacheSaveCounter.inc()
 
       // TODO: beware contention on the approach of delete-all and batch-insert all below
       // if we see contention we could move to encoding the entire metadata object as json

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -80,7 +80,7 @@ class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRe
 }
 
 //noinspection TypeAnnotation
-trait EntityComponent extends RawlsInstrumented with WorkspaceComponent {
+trait EntityComponent extends RawlsInstrumented {
   this: DriverComponent
     with WorkspaceComponent
     with AttributeComponent
@@ -539,14 +539,9 @@ trait EntityComponent extends RawlsInstrumented with WorkspaceComponent {
         val sourceShardId = determineShard(clonedWorkspaceId)
         val destShardId = determineShard(newWorkspaceId)
 
-        var entityCount = 0
-        workspaceQuery.findByIdOrFail(clonedWorkspaceId.toString).map(w => {
-          listEntities(w).map(e => {
-            entityCount += 1
-            e
-          })
-          clonedWorkspaceEntityHistogram += entityCount
-          clonedWorkspaceAttributeHistogram += w.attributes.size
+        cloneEntitiesToNewWorkspace(clonedWorkspaceId, newWorkspaceId).map({p =>
+          clonedWorkspaceEntityHistogram += p._1
+          clonedWorkspaceAttributeHistogram += p._2
         })
 
         sqlu"""insert into ENTITY_ATTRIBUTE_#$destShardId (name, value_string, value_number, value_boolean, value_entity_ref,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
@@ -61,6 +61,7 @@ trait EntityStatisticsCacheSupport extends LazyLogging with RawlsInstrumented {
       case (typeName, typeMetadata) => typeName -> typeMetadata.attributeNames.map(AttributeName.fromDelimitedName)
     }
     val timestamp: Timestamp = new Timestamp(workspaceContext.lastModified.getMillis)
+    opportunisticEntityCacheSaveCounter.inc()
 
     traceDBIOWithParent("generateEntityMetadataMap", outerSpan) { _ =>
       dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceContext.workspaceIdAsUUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.metrics
 
-import nl.grons.metrics4.scala.{Counter, Gauge, Histogram, Timer}
+import nl.grons.metrics4.scala.{Counter, Histogram, Timer}
 import org.broadinstitute.dsde.rawls.metrics.RawlsExpansion._
 import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
@@ -73,19 +73,19 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
       .asTimer("staleness")
 
   /**
-    * A gauge to track the number of entities in each cloned workspace.
+    * A histogram to track the number of entities in each cloned workspace.
     */
   protected def clonedWorkspaceEntityHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(WorkflowStatusMetricKey, "cloned_ws_entities")
+      .expand(WorkspaceMetricKey, "cloned_ws_entities")
       .asHistogram("count")
 
   /**
-    * A gauge to track the number of attributes in each cloned workspace.
+    * A histogram to track the number of attributes in each cloned workspace.
     */
   protected def clonedWorkspaceAttributeHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(WorkflowStatusMetricKey, "cloned_ws_attributes")
+      .expand(WorkspaceMetricKey, "cloned_ws_attributes")
       .asHistogram("count")
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -65,12 +65,58 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
       .asTimer("latency")
 
   /**
+    * A counter to track the total number of times that the entity cache was manually updated, as opposed to automatically.
+    */
+  protected def opportunisticEntityCacheSaveCounter: Counter =
+    ExpandedMetricBuilder
+      .expand(WorkspaceMetricKey, "opportunistic_entity_cache_save")
+      .transient()
+      .asCounter("count")
+
+  /**
+    * A counter to track the total number of entity cache saves, regardless of type.
+    */
+  protected def entityCacheSaveCounter: Counter =
+    ExpandedMetricBuilder
+      .expand(WorkspaceMetricKey, "entity_cache_save")
+      .transient()
+      .asCounter("count")
+
+  /**
     * A timer for capturing cache staleness for Rawls entities.
     */
   protected def entityCacheStaleness: Timer =
     ExpandedMetricBuilder
       .expand(WorkspaceMetricKey, "entity_cache")
       .asTimer("staleness")
+
+  /**
+    * A counter to track the total number of created workspaces.
+    */
+  protected def createdWorkspaceCounter: Counter =
+    ExpandedMetricBuilder
+      .expand(WorkspaceMetricKey, "created_workspaces")
+      .transient()
+      .asCounter("count")
+
+  /**
+    * A counter to track the total number of created multi-cloud workspaces from Azure billing projects.
+    */
+  protected def createdMultiCloudWorkspaceCounter: Counter =
+    ExpandedMetricBuilder
+      .expand(WorkspaceMetricKey, "created_mc_workspaces")
+      .transient()
+      .asCounter("count")
+
+  /**
+    * A counter to track the total number of cloned workspaces.
+    * @return
+    */
+  protected def clonedWorkspaceCounter: Counter =
+    ExpandedMetricBuilder
+      .expand(WorkspaceMetricKey, "cloned_workspaces")
+      .transient()
+      .asCounter("count")
 
   /**
     * A histogram to track the number of entities in each cloned workspace.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.metrics
 
-import nl.grons.metrics4.scala.{Counter, Timer}
+import nl.grons.metrics4.scala.{Counter, Gauge, Histogram, Timer}
 import org.broadinstitute.dsde.rawls.metrics.RawlsExpansion._
 import org.broadinstitute.dsde.rawls.model.SubmissionStatuses.SubmissionStatus
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
@@ -71,6 +71,22 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     ExpandedMetricBuilder
       .expand(WorkspaceMetricKey, "entity_cache")
       .asTimer("staleness")
+
+  /**
+    * A gauge to track the number of entities in each cloned workspace.
+    */
+  protected def clonedWorkspaceEntityHistogram: Histogram =
+    ExpandedMetricBuilder
+      .expand(WorkflowStatusMetricKey, "cloned_ws_entities")
+      .asHistogram("count")
+
+  /**
+    * A gauge to track the number of attributes in each cloned workspace.
+    */
+  protected def clonedWorkspaceAttributeHistogram: Histogram =
+    ExpandedMetricBuilder
+      .expand(WorkflowStatusMetricKey, "cloned_ws_attributes")
+      .asHistogram("count")
 }
 
 object RawlsInstrumented {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -91,7 +91,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
       .asTimer("staleness")
 
   /**
-    * A counter to track the total number of created workspaces.
+    * A counter to track the total number of created non-multi-cloud workspaces.
     */
   protected def createdWorkspaceCounter: Counter =
     ExpandedMetricBuilder

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -88,6 +88,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
   protected def entityCacheStaleness: Timer =
     ExpandedMetricBuilder
       .expand(WorkspaceMetricKey, "entity_cache")
+      .transient()
       .asTimer("staleness")
 
   /**
@@ -124,6 +125,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
   protected def clonedWorkspaceEntityHistogram: Histogram =
     ExpandedMetricBuilder
       .expand(WorkspaceMetricKey, "cloned_ws_entities")
+      .transient()
       .asHistogram("count")
 
   /**
@@ -132,6 +134,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
   protected def clonedWorkspaceAttributeHistogram: Histogram =
     ExpandedMetricBuilder
       .expand(WorkspaceMetricKey, "cloned_ws_attributes")
+      .transient()
       .asHistogram("count")
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -105,6 +105,7 @@ object BootMonitors extends LazyLogging {
         util.toScalaDuration(conf.getDuration("entityStatisticsCache.timeoutPerWorkspace")),
         util.toScalaDuration(conf.getDuration("entityStatisticsCache.standardPollInterval")),
         util.toScalaDuration(conf.getDuration("entityStatisticsCache.workspaceCooldown")),
+        metricsPrefix
       )
     }
 
@@ -231,8 +232,8 @@ object BootMonitors extends LazyLogging {
     system.actorOf(CloneWorkspaceFileTransferMonitor.props(slickDataSource, gcsDAO, cloneWorkspaceFileTransferMonitorConfig.initialDelay, cloneWorkspaceFileTransferMonitorConfig.pollInterval))
   }
 
-  private def startEntityStatisticsCacheMonitor(system: ActorSystem, slickDataSource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration, workspaceCooldown: FiniteDuration) = {
-    system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown))
+  private def startEntityStatisticsCacheMonitor(system: ActorSystem, slickDataSource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration, workspaceCooldown: FiniteDuration, workbenchMetricBaseName: String) = {
+    system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
   }
 
   private def startAvroUpsertMonitor(system: ActorSystem, entityService: UserInfo => EntityService, googleServicesDAO: GoogleServicesDAO, samDAO: SamDAO, googleStorage: GoogleStorageService[IO], googlePubSubDAO: GooglePubSubDAO, importServicePubSubDAO: GooglePubSubDAO, importServiceDAO: HttpImportServiceDAO, avroUpsertMonitorConfig: AvroUpsertMonitorConfig, dataSource: SlickDataSource) = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -24,6 +24,7 @@ import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
+import scala.util.Success
 
 object MultiCloudWorkspaceService {
   def constructor(dataSource: SlickDataSource,
@@ -104,7 +105,9 @@ class MultiCloudWorkspaceService(userInfo: UserInfo,
 
     createdMultiCloudWorkspaceCounter.inc()
     traceWithParent("createMultiCloudWorkspace", parentSpan)(s1 =>
-        createWorkspace(workspaceRequest, s1)
+        createWorkspace(workspaceRequest, s1) andThen {
+          case Success(_) => createdMultiCloudWorkspaceCounter.inc()
+        }
     )
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -68,7 +68,7 @@ class MultiCloudWorkspaceService(userInfo: UserInfo,
    */
   def createMultiCloudOrRawlsWorkspace(workspaceRequest: WorkspaceRequest,
                                        workspaceService: WorkspaceService,
-                                       parentSpan: Span = null): Future[Workspace]= {
+                                       parentSpan: Span = null): Future[Workspace] = {
     val azureConfig = multiCloudWorkspaceConfig.azureConfig match {
       // no azure config, just create the workspace using the legacy codepath
       case None => return workspaceService.createWorkspace(workspaceRequest, parentSpan)
@@ -77,7 +77,6 @@ class MultiCloudWorkspaceService(userInfo: UserInfo,
 
     // for now, the only supported azure billing project is the hardcoded one from the config
     if (workspaceRequest.namespace == azureConfig.billingProjectName) {
-      createdMultiCloudWorkspaceCounter.inc()
       createMultiCloudWorkspace(
         MultiCloudWorkspaceRequest(
           workspaceRequest.namespace,
@@ -88,7 +87,6 @@ class MultiCloudWorkspaceService(userInfo: UserInfo,
         )
       )
     } else {
-      createdWorkspaceCounter.inc()
       workspaceService.createWorkspace(workspaceRequest, parentSpan)
     }
   }
@@ -104,6 +102,7 @@ class MultiCloudWorkspaceService(userInfo: UserInfo,
       throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotImplemented, "MC workspaces are not enabled"))
     }
 
+    createdMultiCloudWorkspaceCounter.inc()
     traceWithParent("createMultiCloudWorkspace", parentSpan)(s1 =>
         createWorkspace(workspaceRequest, s1)
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -792,6 +792,7 @@ class WorkspaceService(protected val userInfo: UserInfo,
   // NOTE: Orchestration has its own implementation of cloneWorkspace. When changing something here, you may also need to update orchestration's implementation (maybe helpful search term: `Post(workspacePath + "/clone"`).
   def cloneWorkspace(sourceWorkspaceName: WorkspaceName, destWorkspaceRequest: WorkspaceRequest, parentSpan: Span = null): Future[Workspace] = {
     destWorkspaceRequest.copyFilesWithPrefix.foreach(prefix => validateFileCopyPrefix(prefix))
+    clonedWorkspaceCounter.inc()
 
     val (libraryAttributeNames, workspaceAttributeNames) = destWorkspaceRequest.attributes.keys.partition(name => name.namespace == AttributeName.libraryNamespace)
     withAttributeNamespaceCheck(workspaceAttributeNames) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -824,7 +824,7 @@ class WorkspaceService(protected val userInfo: UserInfo,
                             dataAccess.entityQuery.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID).map { counts: (Int, Int) =>
                               clonedWorkspaceEntityHistogram += counts._1
                               clonedWorkspaceAttributeHistogram += counts._2
-                            } andThen
+                            } andThen {
                               dataAccess.methodConfigurationQuery.listActive(sourceWorkspaceContext).flatMap { methodConfigShorts =>
                                 val inserts = methodConfigShorts.map { methodConfigShort =>
                                   dataAccess.methodConfigurationQuery.get(sourceWorkspaceContext, methodConfigShort.namespace, methodConfigShort.name).flatMap { methodConfig =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -821,7 +821,10 @@ class WorkspaceService(protected val userInfo: UserInfo,
                         val newAttrs = sourceWorkspaceContext.attributes ++ destWorkspaceRequest.attributes
                         traceDBIOWithParent("withNewWorkspaceContext (cloneWorkspace)", parentSpan) { s1 =>
                           withNewWorkspaceContext(destWorkspaceRequest.copy(authorizationDomain = Option(newAuthDomain), attributes = newAttrs), destBillingProject, sourceBucketNameOption, dataAccess, s1) { destWorkspaceContext =>
-                            dataAccess.entityQuery.cloneEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID) andThen
+                            dataAccess.entityQuery.cloneEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID).map { counts: (Int, Int) =>
+                              clonedWorkspaceEntityHistogram += counts._1
+                              clonedWorkspaceAttributeHistogram += counts._2
+                            } andThen {
                               dataAccess.methodConfigurationQuery.listActive(sourceWorkspaceContext).flatMap { methodConfigShorts =>
                                 val inserts = methodConfigShorts.map { methodConfigShort =>
                                   dataAccess.methodConfigurationQuery.get(sourceWorkspaceContext, methodConfigShort.namespace, methodConfigShort.name).flatMap { methodConfig =>
@@ -830,7 +833,8 @@ class WorkspaceService(protected val userInfo: UserInfo,
                                 }
                                 DBIO.seq(inserts: _*)
                               } andThen {
-                              DBIO.successful((sourceWorkspaceContext, destWorkspaceContext))
+                                DBIO.successful((sourceWorkspaceContext, destWorkspaceContext))
+                              }
                             }
                           }
                         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -46,6 +46,8 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
 
   val testConf = ConfigFactory.load()
 
+  val metricsPrefix = "test"
+
   def this() = this(ActorSystem("EntityStatisticsCacheMonitorSpec"))
 
   override def beforeAll(): Unit = {
@@ -65,7 +67,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricBaseName.name
+      override val workbenchMetricBaseName: String = metricsPrefix
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first sweep should return Sweep,
@@ -86,7 +88,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricBaseName.name
+      override val workbenchMetricBaseName: String = metricsPrefix
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first time we sweep,
@@ -105,7 +107,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricBaseName.name
+      override val workbenchMetricBaseName: String = metricsPrefix
     }
 
     //Scenario: there is one workspace in the test data set used for this test. Because it was saved to the db
@@ -123,7 +125,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricBaseName.name
+      override val workbenchMetricBaseName: String = metricsPrefix
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -160,7 +162,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricBaseName.name
+      override val workbenchMetricBaseName: String = metricsPrefix
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -286,7 +288,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
         override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
         override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
         override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-        override val workbenchMetricBaseName: String = metricBaseName.name
+        override val workbenchMetricBaseName: String = metricsPrefix
       }
 
       val duration = Duration(mins, TimeUnit.MINUTES)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -65,6 +65,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+      override val workbenchMetricBaseName: String = metricBaseName.name
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first sweep should return Sweep,
@@ -85,6 +86,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+      override val workbenchMetricBaseName: String = metricBaseName.name
     }
 
     //Scenario: there is one workspace in the test data set used for this test. The first time we sweep,
@@ -103,6 +105,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+      override val workbenchMetricBaseName: String = metricBaseName.name
     }
 
     //Scenario: there is one workspace in the test data set used for this test. Because it was saved to the db
@@ -120,6 +123,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+      override val workbenchMetricBaseName: String = metricBaseName.name
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -156,6 +160,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
       override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
       override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+      override val workbenchMetricBaseName: String = metricBaseName.name
     }
 
     val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
@@ -208,7 +213,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
 
     // start a monitor actor, and return its ActorRef.
-    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown))
+    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
 
     // set up a TestKit probe for DeathWatch on the monitor
     val probe1 = TestProbe()
@@ -240,7 +245,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
     implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
 
     // start a monitor actor, and return its ActorRef.
-    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown))
+    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
 
     // this first monitor should, eventually, update the workspace's cache
     eventually(timeout = timeout(timeoutPerWorkspace*3)) {
@@ -281,6 +286,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
         override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
         override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
         override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        override val workbenchMetricBaseName: String = metricBaseName.name
       }
 
       val duration = Duration(mins, TimeUnit.MINUTES)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -257,7 +257,8 @@ trait ApiServiceSpec extends TestDriverComponentWithFlatSpecAndMatchers with Raw
       slickDataSource,
       workspaceManagerDAO,
       samDAO,
-      MultiCloudWorkspaceConfig(testConf)
+      MultiCloudWorkspaceConfig(testConf),
+      workbenchMetricBaseName
     )
 
     override val entityServiceConstructor = EntityService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -23,6 +23,7 @@ import scala.language.postfixOps
 class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with TestDriverComponent {
 
   implicit val actorSystem: ActorSystem = ActorSystem("MultiCloudWorkspaceServiceSpec")
+  implicit val workbenchMetricBaseName = "test"
 
   def activeMcWorkspaceConfig = MultiCloudWorkspaceConfig(
     multiCloudWorkspacesEnabled = true,
@@ -35,7 +36,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val config = MultiCloudWorkspaceConfig(ConfigFactory.load())
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config
+      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
     )(userInfo)
     val workspaceRequest = WorkspaceRequest(
       "fake_billing_project",
@@ -65,7 +66,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val config = MultiCloudWorkspaceConfig(ConfigFactory.load())
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config
+      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
     )(userInfo)
     val workspaceRequest = WorkspaceRequest(
       "fake_mc_billing_project_name",
@@ -98,7 +99,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
         userInfo)
     ).thenReturn(Future.successful(false))
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config
+      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
     )(userInfo)
     val workspaceRequest = WorkspaceRequest(
       "fake_mc_billing_project_name",
@@ -126,7 +127,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val config = MultiCloudWorkspaceConfig(multiCloudWorkspacesEnabled = false, None, None)
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config
+      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
     )(userInfo)
     val request = MultiCloudWorkspaceRequest("fake", "fake_name", Map.empty, cloudPlatform = WorkspaceCloudPlatform.Azure, "fake_region")
 
@@ -143,7 +144,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val workspaceManagerDAO = new MockWorkspaceManagerDAO()
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig
+      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig, workbenchMetricBaseName
     )(userInfo)
     val request = MultiCloudWorkspaceRequest(
       namespace, name, Map.empty, cloudPlatform = WorkspaceCloudPlatform.Azure, "fake_region")
@@ -160,7 +161,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig
+      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig, workbenchMetricBaseName
     )(userInfo)
     val namespace = "fake_ns" + UUID.randomUUID().toString
     val request = new MultiCloudWorkspaceRequest(
@@ -202,7 +203,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val workspaceManagerDAO = MockWorkspaceManagerDAO.buildWithAsyncResults(createCloudContestStatus, createAzureRelayStatus)
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig
+      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig, workbenchMetricBaseName
     )(userInfo)
     val namespace = "fake_ns" + UUID.randomUUID().toString
     val request = new MultiCloudWorkspaceRequest(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -157,7 +157,7 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     )
     val multiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(testConf)
     override val multiCloudWorkspaceServiceConstructor: UserInfo => MultiCloudWorkspaceService = MultiCloudWorkspaceService.constructor(
-      dataSource, workspaceManagerDAO, samDAO, multiCloudWorkspaceConfig
+      dataSource, workspaceManagerDAO, samDAO, multiCloudWorkspaceConfig, workbenchMetricBaseName
     )
     lazy val mcWorkspaceService: MultiCloudWorkspaceService = multiCloudWorkspaceServiceConstructor(userInfo1)
 


### PR DESCRIPTION
This branch adds instrumentation to the Rawls codebase for tracking the umber of workspaces created, number of cloned workspaces, and cache writing types (on demand vs. auto). Will coincide with a PR for the [terra-helmfile](https://github.com/broadinstitute/terra-helmfile) repository.