### PR TITLE
Aj 433 by-reference snapshots do not show datarepo_row_id columns, if the snapshot has a primary key

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -54,9 +54,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
     // TODO: AS-321 auto-switch to see if the ref supplied in argument is a UUID or a name?? Use separate query params? Never allow ID?
 
-    // reformat TDR's response into the expected response structure
+    // reformat TDR's response into the expected response structure - all snapshots should have a datarepo_row_id
     val entityTypesResponse: Map[String, EntityTypeMetadata] = snapshotModel.getTables.asScala.map { table =>
-      val attrs: Seq[String] = table.getColumns.asScala.map(_.getName).toList
+      val attrs: Seq[String] = table.getColumns.asScala.map(_.getName).toList :+ "datarepo_row_id"
       val primaryKey = pkFromSnapshotTable(table)
       (table.getName, EntityTypeMetadata(table.getRowCount, primaryKey, attrs))
     }.toMap

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -56,8 +56,11 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
     // reformat TDR's response into the expected response structure - all snapshots should have a datarepo_row_id
     val entityTypesResponse: Map[String, EntityTypeMetadata] = snapshotModel.getTables.asScala.map { table =>
-      val attrs: Seq[String] = table.getColumns.asScala.map(_.getName).toList :+ "datarepo_row_id"
       val primaryKey = pkFromSnapshotTable(table)
+      var attrs: Seq[String] = table.getColumns.asScala.map(_.getName).toList
+      if (primaryKey != datarepoRowIdColumn && !attrs.contains(datarepoRowIdColumn)){
+        attrs = attrs :+ datarepoRowIdColumn
+      }
       (table.getName, EntityTypeMetadata(table.getRowCount, primaryKey, attrs))
     }.toMap
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -73,6 +73,7 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     // - compound PK returned for table, defaults to datarepo_row_id
     // - single PK returned for table is honored
     // - row counts returned for table are honored
+    // - datarepo_row_id is added to columns if not included and not pk
 
     val provider = createTestProvider()
 
@@ -80,7 +81,7 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
       // this is the default expected value, should it move to the support trait?
       val expected = Map(
         ("table1", EntityTypeMetadata(10, "datarepo_row_id", Seq("integer-field", "boolean-field", "timestamp-field"))),
-        ("table2", EntityTypeMetadata(123, "table2PK", Seq("col2a", "col2b"))),
+        ("table2", EntityTypeMetadata(123, "table2PK", Seq("col2a", "col2b", "datarepo_row_id"))),
         ("table3", EntityTypeMetadata(456, "datarepo_row_id", Seq("col3.1", "col3.2"))))
       assertResult(expected) { metadata }
     }


### PR DESCRIPTION
AJ-433
Although all snapshots have a `datarepo_row_id`, if it is not named the primary key for a by-reference snapshot, then the entity metadata is unaware of it without making a call to BigQuery.  This adds `datarepo_row_id` to the attributes in the case that it is neither the primary key nor otherwise listed with the attributes.  Test is updated to reflect this.

Note that the second half of AJ-433, duplicate id columns, is treated in the front end.  

Question: since this issue is mainly driven by displays in terra-ui, will this break anything for anyone using firecloud or API only?  Where else does this show up?  Reviewers, please alert me to these concerns!
