### PR TITLE
[AJ-483] Fix potential faults in RawlsInstrumented objects

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -21,6 +21,8 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
   final val SubsystemMetricKey         = "subsystem"
   final val WorkflowStatusMetricKey    = "workflowStatus"
   final val WorkspaceMetricKey         = "workspace"
+  final val StatsBoardMetricKey        = "statsBoard"
+  final val RawlsBoardMetricValue      = "rawlsBoard"
 
   /**
     * An ExpandedMetricBuilder for a WorkspaceName.
@@ -69,6 +71,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def opportunisticEntityCacheSaveCounter: Counter =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "opportunistic_entity_cache_save")
       .transient()
       .asCounter("count")
@@ -78,6 +81,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def entityCacheSaveCounter: Counter =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "entity_cache_save")
       .transient()
       .asCounter("count")
@@ -87,6 +91,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def entityCacheStaleness: Timer =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "entity_cache")
       .transient()
       .asTimer("staleness")
@@ -96,6 +101,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def createdWorkspaceCounter: Counter =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "created_workspaces")
       .transient()
       .asCounter("count")
@@ -105,6 +111,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def createdMultiCloudWorkspaceCounter: Counter =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "created_mc_workspaces")
       .transient()
       .asCounter("count")
@@ -115,6 +122,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceCounter: Counter =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "cloned_workspaces")
       .transient()
       .asCounter("count")
@@ -124,6 +132,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceEntityHistogram: Histogram =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "cloned_ws_entities")
       .transient()
       .asHistogram("count")
@@ -133,6 +142,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceAttributeHistogram: Histogram =
     ExpandedMetricBuilder
+      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
       .expand(WorkspaceMetricKey, "cloned_ws_attributes")
       .transient()
       .asHistogram("count")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -16,13 +16,14 @@ import scala.concurrent.ExecutionContext
 trait RawlsInstrumented extends WorkbenchInstrumented {
 
   // Keys for expanded metric fragments
-  final val SubmissionMetricKey        = "submission"
-  final val SubmissionStatusMetricKey  = "submissionStatus"
-  final val SubsystemMetricKey         = "subsystem"
-  final val WorkflowStatusMetricKey    = "workflowStatus"
-  final val WorkspaceMetricKey         = "workspace"
-  final val StatsBoardMetricKey        = "statsBoard"
-  final val RawlsBoardMetricValue      = "rawlsBoard"
+  final val SubmissionMetricKey             = "submission"
+  final val SubmissionStatusMetricKey       = "submissionStatus"
+  final val SubsystemMetricKey              = "subsystem"
+  final val WorkflowStatusMetricKey         = "workflowStatus"
+  final val WorkspaceMetricKey              = "workspace"
+  final val WorkspaceDataMetricKey          = "workspaceData"
+  final val AggregationMetricKey            = "aggregation"
+  final val WorkspaceAggregationMetricValue = "workspaceAggregates"
 
   /**
     * An ExpandedMetricBuilder for a WorkspaceName.
@@ -71,8 +72,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def opportunisticEntityCacheSaveCounter: Counter =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
-      .expand(WorkspaceMetricKey, "opportunistic_entity_cache_save")
+      .expand(WorkspaceDataMetricKey, "opportunistic_entity_cache_save")
       .transient()
       .asCounter("count")
 
@@ -81,8 +81,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def entityCacheSaveCounter: Counter =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
-      .expand(WorkspaceMetricKey, "entity_cache_save")
+      .expand(WorkspaceDataMetricKey, "entity_cache_save")
       .transient()
       .asCounter("count")
 
@@ -91,7 +90,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def entityCacheStaleness: Timer =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
+      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
       .expand(WorkspaceMetricKey, "entity_cache")
       .transient()
       .asTimer("staleness")
@@ -101,7 +100,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def createdWorkspaceCounter: Counter =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
+      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
       .expand(WorkspaceMetricKey, "created_workspaces")
       .transient()
       .asCounter("count")
@@ -111,7 +110,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def createdMultiCloudWorkspaceCounter: Counter =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
+      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
       .expand(WorkspaceMetricKey, "created_mc_workspaces")
       .transient()
       .asCounter("count")
@@ -121,7 +120,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceCounter: Counter =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
+      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
       .expand(WorkspaceMetricKey, "cloned_workspaces")
       .transient()
       .asCounter("count")
@@ -131,7 +130,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceEntityHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
+      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
       .expand(WorkspaceMetricKey, "cloned_ws_entities")
       .transient()
       .asHistogram("count")
@@ -141,7 +140,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceAttributeHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(StatsBoardMetricKey, RawlsBoardMetricValue)
+      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
       .expand(WorkspaceMetricKey, "cloned_ws_attributes")
       .transient()
       .asHistogram("count")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -23,7 +23,6 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
   final val WorkspaceMetricKey              = "workspace"
   final val WorkspaceDataMetricKey          = "workspaceData"
   final val AggregationMetricKey            = "aggregation"
-  final val WorkspaceAggregationMetricValue = "workspaceAggregates"
 
   /**
     * An ExpandedMetricBuilder for a WorkspaceName.
@@ -90,8 +89,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def entityCacheStaleness: Timer =
     ExpandedMetricBuilder
-      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
-      .expand(WorkspaceMetricKey, "entity_cache")
+      .expand(AggregationMetricKey, "entity_cache")
       .transient()
       .asTimer("staleness")
 
@@ -100,8 +98,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def createdWorkspaceCounter: Counter =
     ExpandedMetricBuilder
-      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
-      .expand(WorkspaceMetricKey, "created_workspaces")
+      .expand(AggregationMetricKey, "created_workspaces")
       .transient()
       .asCounter("count")
 
@@ -110,8 +107,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def createdMultiCloudWorkspaceCounter: Counter =
     ExpandedMetricBuilder
-      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
-      .expand(WorkspaceMetricKey, "created_mc_workspaces")
+      .expand(AggregationMetricKey, "created_mc_workspaces")
       .transient()
       .asCounter("count")
 
@@ -120,8 +116,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceCounter: Counter =
     ExpandedMetricBuilder
-      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
-      .expand(WorkspaceMetricKey, "cloned_workspaces")
+      .expand(AggregationMetricKey, "cloned_workspaces")
       .transient()
       .asCounter("count")
 
@@ -130,8 +125,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceEntityHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
-      .expand(WorkspaceMetricKey, "cloned_ws_entities")
+      .expand(AggregationMetricKey, "cloned_ws_entities")
       .transient()
       .asHistogram("count")
 
@@ -140,8 +134,7 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
     */
   protected def clonedWorkspaceAttributeHistogram: Histogram =
     ExpandedMetricBuilder
-      .expand(AggregationMetricKey, WorkspaceAggregationMetricValue)
-      .expand(WorkspaceMetricKey, "cloned_ws_attributes")
+      .expand(AggregationMetricKey, "cloned_ws_attributes")
       .transient()
       .asHistogram("count")
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -118,7 +118,6 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
 
   /**
     * A counter to track the total number of cloned workspaces.
-    * @return
     */
   protected def clonedWorkspaceCounter: Counter =
     ExpandedMetricBuilder


### PR DESCRIPTION
Adds new key/value pair to metrics currently in the "Workspaces" section of Grafana to avoid potential conflicts with the naming. Also separates histogram metrics into three different transmitted values.