### PR TITLE
automatically label Scala Steward PRs [AJ-489]

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,1 @@
+Scala_Steward: '/update\/.+/'

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,1 +1,1 @@
-Scala_Steward: '/update\/.+/'
+Scala_Steward: 'update/*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses https://github.com/TimonVS/pr-labeler-action to automatically label Scala Steward PRs with the "Scala_Steward" label.

See #1912 as an example of this in action.