### PR TITLE
dont override google2 deps [AJ-490]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,12 +54,6 @@ object Dependencies {
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
-//  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.33.1"
-//  val googleRpcNettyShaded: ModuleID =    "io.grpc" % "grpc-netty-shaded" % "1.33.1"
-//  val googleCloudCoreGrpc: ModuleID =     "com.google.cloud" % "google-cloud-core-grpc" % "2.8.1"
-
-//  val googleAutoValue: ModuleID =         "com.google.auto.value" % "auto-value-annotations" % "1.7.4"
-
   val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
@@ -190,11 +184,7 @@ object Dependencies {
   // google2 lib requires specific versions of rpc libs:
   val google2Dependencies = Seq(
     workbenchGoogle2,
-//    googleCloudCoreGrpc,
-//    googleRpc,
-//    googleRpcNettyShaded,
     workbenchGoogle2Tests,
-//    googleAutoValue // workbench-libs/google2 fails to correctly pull this as a dependency, so we do it manually
   )
 
   val utilDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,11 +54,11 @@ object Dependencies {
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.33.1"
-  val googleRpcNettyShaded: ModuleID =    "io.grpc" % "grpc-netty-shaded" % "1.33.1"
-  val googleCloudCoreGrpc: ModuleID =     "com.google.cloud" % "google-cloud-core-grpc" % "2.8.1"
+//  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.33.1"
+//  val googleRpcNettyShaded: ModuleID =    "io.grpc" % "grpc-netty-shaded" % "1.33.1"
+//  val googleCloudCoreGrpc: ModuleID =     "com.google.cloud" % "google-cloud-core-grpc" % "2.8.1"
 
-  val googleAutoValue: ModuleID =         "com.google.auto.value" % "auto-value-annotations" % "1.7.4"
+//  val googleAutoValue: ModuleID =         "com.google.auto.value" % "auto-value-annotations" % "1.7.4"
 
   val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1"
 
@@ -190,11 +190,11 @@ object Dependencies {
   // google2 lib requires specific versions of rpc libs:
   val google2Dependencies = Seq(
     workbenchGoogle2,
-    googleCloudCoreGrpc,
-    googleRpc,
-    googleRpcNettyShaded,
+//    googleCloudCoreGrpc,
+//    googleRpc,
+//    googleRpcNettyShaded,
     workbenchGoogle2Tests,
-    googleAutoValue // workbench-libs/google2 fails to correctly pull this as a dependency, so we do it manually
+//    googleAutoValue // workbench-libs/google2 fails to correctly pull this as a dependency, so we do it manually
   )
 
   val utilDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -181,7 +181,6 @@ object Dependencies {
     googleGuava
   )
 
-  // google2 lib requires specific versions of rpc libs:
   val google2Dependencies = Seq(
     workbenchGoogle2,
     workbenchGoogle2Tests,


### PR DESCRIPTION
We have explicit dependencies for `io.grpc:grpc-core`, `io.grpc:grpc-netty-shaded`, `com.google.cloud:google-cloud-core-grpc`, and `com.google.auto.value:auto-value-annotations` configured as part of our `google2Dependencies `. Why do we need these listed explicitly? Everything seems to work without them, as workbench-libs already specifies what it needs. Perhaps an earlier version of workbench-libs didn't specify them correctly?

Looks like this was added in #1235 and #1259 - both by me!! So now let's pull them out.

The changes in this PR make other Scala Steward PRs irrelevant:
* obsoletes #1863
* supersedes #1900