### PR TITLE
remove google oauth dependencies [AJ-490]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -7,7 +7,7 @@ import cats.effect._
 import cats.implicits._
 import com.codahale.metrics.SharedMetricRegistries
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.readytalk.metrics.{StatsDReporter, WorkbenchStatsD}
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
@@ -126,7 +126,7 @@ object Boot extends IOApp with LazyLogging {
       logger.info("Metrics reporting is disabled.")
     }
 
-    val jsonFactory = JacksonFactory.getDefaultInstance
+    val jsonFactory = GsonFactory.getDefaultInstance
     val clientSecrets = GoogleClientSecrets.load(jsonFactory, new StringReader(gcsConfig.getString("secrets")))
     val clientEmail = gcsConfig.getString("serviceClientEmail")
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -16,7 +16,7 @@ import com.google.api.client.googleapis.auth.oauth2.{GoogleClientSecrets, Google
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException, InputStreamContent}
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.admin.directory.model._
 import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
 import com.google.api.services.cloudbilling.Cloudbilling
@@ -139,7 +139,7 @@ class HttpGoogleServicesDAO(
   val billingScopes = Seq("https://www.googleapis.com/auth/cloud-billing")
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = GsonFactory.getDefaultInstance
   val BILLING_ACCOUNT_PERMISSION = "billing.resourceAssociations.create"
 
   val SingleRegionLocationType: String = "region"

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/HttpGoogleAccessContextManagerDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/HttpGoogleAccessContextManagerDAO.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.accesscontextmanager.v1.model.{Operation, ServicePerimeter, ServicePerimeterConfig}
 import com.google.api.services.accesscontextmanager.v1.{AccessContextManager, AccessContextManagerScopes}
 import org.broadinstitute.dsde.rawls.metrics.GoogleInstrumentedService
@@ -20,7 +20,7 @@ class HttpGoogleAccessContextManagerDAO(clientEmail: String, pemFile: String, ap
 
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = GsonFactory.getDefaultInstance
 
   val accessContextScopes = Seq(AccessContextManagerScopes.CLOUD_PLATFORM)
 

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/HttpGooglePubSubDAO.scala
@@ -6,7 +6,7 @@ import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.HttpResponseException
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.pubsub.model._
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO._
@@ -29,7 +29,7 @@ class HttpGooglePubSubDAO(clientEmail: String,
   val pubSubScopes = Seq(PubsubScopes.PUBSUB)
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = GsonFactory.getDefaultInstance
 
   private val characterEncoding = "UTF-8"
   implicit val service = GoogleInstrumentedService.PubSub

--- a/google/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGooglePubSubDAOSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGooglePubSubDAOSpec.scala
@@ -6,7 +6,7 @@ package org.broadinstitute.dsde.rawls.integrationtest
 
 import akka.actor.ActorSystem
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.MessageRequest
@@ -32,7 +32,7 @@ class HttpGooglePubSubDAOSpec extends AnyFlatSpec with Matchers with BeforeAndAf
   import scala.concurrent.ExecutionContext.Implicits.global
   val gpsDAO = new HttpGooglePubSubDAO(
     GoogleClientSecrets.load(
-      JacksonFactory.getDefaultInstance, new StringReader(gcsConfig.getString("secrets"))).getDetails.get("client_email").toString,
+      GsonFactory.getDefaultInstance, new StringReader(gcsConfig.getString("secrets"))).getDetails.get("client_email").toString,
     gcsConfig.getString("pathToPem"),
     gcsConfig.getString("appName"),
     gcsConfig.getString("serviceProject"),

--- a/google/src/test/scala/org/broadinstitute/dsde/rawls/metrics/GoogleInstrumentedSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/rawls/metrics/GoogleInstrumentedSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.metrics
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException}
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.json.gson.GsonFactory
 import com.google.api.client.testing.http.{HttpTesting, MockHttpTransport}
 import com.google.api.services.storage.Storage
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
@@ -22,7 +22,7 @@ class GoogleInstrumentedSpec extends GoogleInstrumented with AnyFlatSpecLike wit
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val mockTransport = new MockHttpTransport()
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = GsonFactory.getDefaultInstance
   val credential = new HttpRequestInitializer {
     override def initialize(request: HttpRequest): Unit = ()
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -210,7 +210,7 @@ object Dependencies {
     scalatest
   )
 
-  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
+  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
     typesafeConfig,
     sentryLogback,
     slick,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,13 +48,13 @@ object Dependencies {
   val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev72-" + olderGoogleV)
   val googleAdminDirectory: ModuleID =    "com.google.apis"   % "google-api-services-admin-directory"   % ("directory_v1-rev53-" + olderGoogleV)
   val googlePlus: ModuleID =              "com.google.apis"   % "google-api-services-plus"              % ("v1-rev381-" + olderGoogleV)
-  val googleOAuth2: ModuleID =            "com.google.apis"   % "google-api-services-oauth2"            % ("v1-rev112-" + olderGoogleV)
+//  val googleOAuth2: ModuleID =            "com.google.apis"   % "google-api-services-oauth2"            % ("v1-rev112-" + olderGoogleV)
   val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20210322-" + googleV)
   val googleServicemanagement: ModuleID = "com.google.apis"   % "google-api-services-servicemanagement" % ("v1-rev20210604-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
-  val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1"
+//  val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =       "nl.grons"              %% "metrics4-scala"    % "4.1.19"
@@ -173,8 +173,8 @@ object Dependencies {
     googleCompute,
     googleAdminDirectory,
     googlePlus,
-    googleOAuth2,
-    googleOAuth2too,
+//    googleOAuth2,
+//    googleOAuth2too,
     googlePubSub,
     googleServicemanagement,
     googleDeploymentManager,
@@ -215,7 +215,8 @@ object Dependencies {
     scalatest
   )
 
-  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
+//  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
+  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
     typesafeConfig,
     sentryLogback,
     slick,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,13 +48,10 @@ object Dependencies {
   val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev72-" + olderGoogleV)
   val googleAdminDirectory: ModuleID =    "com.google.apis"   % "google-api-services-admin-directory"   % ("directory_v1-rev53-" + olderGoogleV)
   val googlePlus: ModuleID =              "com.google.apis"   % "google-api-services-plus"              % ("v1-rev381-" + olderGoogleV)
-//  val googleOAuth2: ModuleID =            "com.google.apis"   % "google-api-services-oauth2"            % ("v1-rev112-" + olderGoogleV)
   val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20210322-" + googleV)
   val googleServicemanagement: ModuleID = "com.google.apis"   % "google-api-services-servicemanagement" % ("v1-rev20210604-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
-
-//  val googleOAuth2too: ModuleID = "com.google.auth" % "google-auth-library-oauth2-http" % "0.9.1"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =       "nl.grons"              %% "metrics4-scala"    % "4.1.19"
@@ -173,8 +170,6 @@ object Dependencies {
     googleCompute,
     googleAdminDirectory,
     googlePlus,
-//    googleOAuth2,
-//    googleOAuth2too,
     googlePubSub,
     googleServicemanagement,
     googleDeploymentManager,
@@ -215,7 +210,6 @@ object Dependencies {
     scalatest
   )
 
-//  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
   val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
     typesafeConfig,
     sentryLogback,


### PR DESCRIPTION

* switch `JacksonFactory` to `GsonFactory`, since `JacksonFactory` [is deprecated](https://cloud.google.com/java/docs/reference/google-http-client/latest/com.google.api.client.json.jackson2.JacksonFactory).
* remove the unnecessary `google-api-services-oauth2` and `google-auth-library-oauth2-http` libraries. The only functionality these offered was pulling in `JacksonFactory`, which we no longer need. This supersedes #1842 .

NOT in this PR, considering for a future PR: align the direct `com.google.apis` dependencies in Rawls and the same libraries pulled in as transitive dependencies from workbench-libs' workbench-google.