### PR TITLE
update data repo client [AJ-476]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/datarepo/HttpDataRepoDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/datarepo/HttpDataRepoDAO.scala
@@ -24,6 +24,7 @@ class HttpDataRepoDAO(dataRepoInstanceName: String, dataRepoInstanceBasePath: St
   override def getInstanceName: String = dataRepoInstanceName
 
   override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = {
-    getRepositoryApi(accessToken).retrieveSnapshot(snapshotId.toString)
+    // future enhancement: allow callers to specify the list of SnapshotRetrieveIncludeModel to retrieve
+    getRepositoryApi(accessToken).retrieveSnapshot(snapshotId, java.util.Collections.emptyList())
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -37,7 +37,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
                             (implicit protected val executionContext: ExecutionContext)
   extends EntityProvider with DataRepoBigQuerySupport with LazyLogging with ExpressionEvaluationSupport {
 
-  override val entityStoreId: Option[String] = Option(snapshotModel.getId)
+  override val entityStoreId: Option[String] = Option(snapshotModel.getId.toString)
 
   private[datarepo] lazy val googleProject: GoogleProjectId = {
     /* Determine project to be billed for the BQ job:

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -826,7 +826,7 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val snapshotResponse = dataRepoDAO.getSnapshot(mockSnapshotId, userInfo.accessToken)
     mockServer.stopAsync()
 
-    snapshotResponse.getId shouldBe mockSnapshotId.toString
+    snapshotResponse.getId shouldBe mockSnapshotId
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -102,6 +102,7 @@ trait DataRepoEntityProviderSpecSupport {
    */
   def createSnapshotModel( tables: List[TableModel] = defaultTables, relationships: List[RelationshipModel] = List.empty): SnapshotModel =
     new SnapshotModel()
+      .id(UUID.randomUUID())
       .tables(tables.asJava)
       .relationships(relationships.asJava)
       .dataProject("unittest-dataproject")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -25,7 +25,8 @@ trait DataRepoEntityProviderSpecSupport {
   val wsId: UUID = UUID.randomUUID()
   val refId: UUID = UUID.randomUUID()
   val dataRepoInstanceName: String = "mock-instance-name"
-  val snapshot: String = UUID.randomUUID().toString
+  val snapshotUUID: UUID = UUID.randomUUID()
+  val snapshot: String = snapshotUUID.toString
 
   // default Workspace object, mostly irrelevant for DataRepoEntityProviderSpec but necessary to exist
   val workspace = Workspace("namespace", "name", wsId.toString, "bucketName", None,
@@ -102,7 +103,7 @@ trait DataRepoEntityProviderSpecSupport {
    */
   def createSnapshotModel( tables: List[TableModel] = defaultTables, relationships: List[RelationshipModel] = List.empty): SnapshotModel =
     new SnapshotModel()
-      .id(UUID.randomUUID())
+      .id(snapshotUUID)
       .tables(tables.asJava)
       .relationships(relationships.asJava)
       .dataProject("unittest-dataproject")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -1081,7 +1081,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
 
     when(dataRepoDAO.getSnapshot(snapshotUUID, userInfo.accessToken)).thenReturn(createSnapshotModel(List(
       new TableModel().name(tableName).primaryKey(null).rowCount(0)
-        .columns(List(columnName).map(new ColumnModel().name(_)).asJava))).id(snapshotUUID.toString)
+        .columns(List(columnName).map(new ColumnModel().name(_)).asJava))).id(snapshotUUID)
     )
     when(dataRepoDAO.getInstanceName).thenReturn("dataRepoInstance")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
@@ -11,7 +11,7 @@ class MockDataRepoDAO(instanceName: String) extends DataRepoDAO {
 
   override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = {
     val snap = new SnapshotModel()
-    snap.id(snapshotId.toString)
+    snap.id(snapshotId)
     snap.name("snapshotName")
     snap.description("snapshotDescription")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -119,7 +119,6 @@ object Dependencies {
 
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.295-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
-  val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32" // scala-steward:off (must match TDR)
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"
@@ -245,7 +244,6 @@ object Dependencies {
     apacheCommonsIO,
     workspaceManager,
     dataRepo,
-    dataRepoJersey,
     antlrParser,
     resourceBufferService,
     kindProjector,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -135,7 +135,6 @@ object Dependencies {
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides = Seq(
     "commons-codec"                 % "commons-codec"         % "1.15",
-    "org.apache.httpcomponents"     % "httpclient"            % "4.5.13",
     "org.glassfish.jersey.core"     % "jersey-client"         % "2.36"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -135,7 +135,7 @@ object Dependencies {
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides = Seq(
     "commons-codec"                 % "commons-codec"         % "1.15",
-    "org.glassfish.jersey.core"     % "jersey-client"         % "2.36"
+    "org.glassfish.jersey.core"     % "jersey-client"         % "2.36" // scala-steward:off (must match TDR)
   )
 
   val openCensusDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -118,7 +118,7 @@ object Dependencies {
   def excludeJakarta(m: ModuleID): ModuleID = m.excludeAll(excludeJakartaActivationApi, excludeJakartaXmlBindApi)
 
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.295-SNAPSHOT")
-  val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT")
+  val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val dataRepoJersey = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32" // scala-steward:off (must match TDR)
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
 


### PR DESCRIPTION
We were woefully out of date on our `datarepo-client` dependency. This PR updates it to the latest version.

This update:
* requires a few small syntax compatibility changes
* allows us to remove the explicit `jersey-hk2` dependency, since that is now properly pulled in transitively from `datarepo-client`

Note that #1393, from a ways back, created a unit test to validate that the proper libraries are in place for data repo client connectivity.