### PR TITLE
use supported codecov uploader [AJ-500]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Codecov upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         if: ${{ always() }}
 
       - name: Stop MySQL


### PR DESCRIPTION
From https://github.com/codecov/codecov-action:

> As of February 1, 2022, v1 has been fully sunset and no longer functions

Which doesn't seem to be true; the v1 action was succeeding at uploading our coverage reports. Nonetheless, let's update to their recommended version.

Codecov still works with the changes in this PR: https://app.codecov.io/gh/broadinstitute/rawls/pull/1936; see also the "Codecov upload" output for one of the GHA build/test actions.