### PR TITLE
clean up metrics dependencies [AJ-501]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,8 +53,12 @@ object Dependencies {
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
+  // metrics4-scala and metrics3-statsd are pulled in by workbench-metrics, which is pulled in by
+  // workbench-google (workbenchGoogle variable in this file). Thus, anything that depends on workbench-google, such as
+  // rawlsCoreDependencies, does not need these. As of this writing, metrics4-scala and metrics3-statsd are only
+  // needed by the metrics subproject of Rawls.
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
-  val metricsScala: ModuleID =       "nl.grons"              %% "metrics4-scala"    % "4.1.19"
+  val metricsScala: ModuleID =       "nl.grons"              %% "metrics4-scala"    % "4.2.9"
   val metricsStatsd: ModuleID =      "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
 
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"    %% "scala-logging"        % "3.9.5"
@@ -156,7 +160,7 @@ object Dependencies {
     mockito
   )
 
-  val googleDependencies = metricsDependencies ++ Seq(
+  val googleDependencies = Seq(
 
     accessContextManager,
 
@@ -214,7 +218,7 @@ object Dependencies {
     scalatest
   )
 
-  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ metricsDependencies ++ openCensusDependencies ++ Seq(
+  val rawlsCoreDependencies: Seq[ModuleID] = modelDependencies ++ googleDependencies ++ google2Dependencies ++ openCensusDependencies ++ Seq(
     typesafeConfig,
     sentryLogback,
     slick,


### PR DESCRIPTION
Supersedes #1902. While looking at #1902, I questioned how the metrics libraries were being used, and saw that we could clean up a little bit.