### PR TITLE
add entity_type_id to ENTITY table [AJ-540]

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -118,4 +118,5 @@
     <include file="changesets/20220627_add_submission_root.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220722_v1_workspace_migration_retries.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220728_add_billing_profile_id.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20220802_add_entity_type_normalization.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220802_add_entity_type_normalization.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220802_add_entity_type_normalization.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="add_entity_type_normalization" author="davidan" logicalFilePath="dummy">
+        <addColumn tableName="ENTITY">
+            <column name="entity_type_id" type="BINARY(16)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Do not merge until after the scheduled manual db-migration downtime.

Is there any drawback to proactively adding a `entity_type_id` column to the `ENTITY` table, without updating any of the Slick/Scala code that uses the table? Tests on this PR say no.

We added this column in the prod db during the scheduled case-sensitivity downtime, but have not added it anywhere else; let’s do that to keep lower envs (and local envs) in sync with prod.