### PR TITLE
result of scalafmtAll [WOR-180]

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -14,12 +14,22 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
 import com.typesafe.scalalogging.LazyLogging
 import io.sentry.{Hint, Sentry, SentryEvent, SentryOptions}
 import net.ceedubs.ficus.Ficus._
-import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAOImpl, BillingProjectOrchestrator, BillingRepository, BpmBillingProjectCreator, GoogleBillingProjectCreator, HttpBillingProfileManagerClientProvider}
+import org.broadinstitute.dsde.rawls.billing.{
+  BillingProfileManagerDAOImpl,
+  BillingProjectOrchestrator,
+  BillingRepository,
+  BpmBillingProjectCreator,
+  GoogleBillingProjectCreator,
+  HttpBillingProfileManagerClientProvider
+}
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.HttpDataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.martha.MarthaResolver
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.{HttpResourceBufferDAO, ResourceBufferDAO}
-import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.{HttpWorkspaceManagerClientProvider, HttpWorkspaceManagerDAO}
+import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.{
+  HttpWorkspaceManagerClientProvider,
+  HttpWorkspaceManagerDAO
+}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.log4cats.{Logger, StructuredLogger}
 import slick.basic.DatabaseConfig
@@ -63,8 +73,8 @@ import scala.language.{higherKinds, postfixOps}
 
 object Boot extends IOApp with LazyLogging {
   override def run(
-                    args: List[String]
-                  ): IO[ExitCode] =
+    args: List[String]
+  ): IO[ExitCode] =
     startup() *> ExitCode.Success.pure[IO]
 
   private def startup(): IO[Unit] = {
@@ -88,7 +98,7 @@ object Boot extends IOApp with LazyLogging {
 
     val changelogParams = Map("gcs:appsDomain" -> gcsConfig.getString("appsDomain"))
 
-    if(initWithLiquibase) {
+    if (initWithLiquibase) {
       slickDataSource.initWithLiquibase(liquibaseChangeLog, changelogParams)
     }
 
@@ -109,18 +119,18 @@ object Boot extends IOApp with LazyLogging {
           configObject.entrySet.asScala.map(_.toTuple).foreach {
             case ("statsd", conf: ConfigObject) =>
               val statsDConf = conf.toConfig
-              startStatsDReporter(
-                statsDConf.getString("host"),
-                statsDConf.getInt("port"),
-                statsDConf.getDuration("period"),
-                apiKey = statsDConf.getStringOption("apiKey"))
+              startStatsDReporter(statsDConf.getString("host"),
+                                  statsDConf.getInt("port"),
+                                  statsDConf.getDuration("period"),
+                                  apiKey = statsDConf.getStringOption("apiKey")
+              )
             case ("statsd-sidecar", conf: ConfigObject) =>
               // Capability for apiKey-less additional statsd target, intended for statsd-exporter sidecar
               val statsDConf = conf.toConfig
-              startStatsDReporter(
-                statsDConf.getString("host"),
-                statsDConf.getInt("port"),
-                statsDConf.getDuration("period"))
+              startStatsDReporter(statsDConf.getString("host"),
+                                  statsDConf.getInt("port"),
+                                  statsDConf.getDuration("period")
+              )
             case (other, _) =>
               logger.warn(s"Unknown metrics backend: $other")
           }
@@ -138,7 +148,7 @@ object Boot extends IOApp with LazyLogging {
     val appName = gcsConfig.getString("appName")
     val pathToPem = gcsConfig.getString("pathToPem")
 
-    //Sanity check deployment manager template path.
+    // Sanity check deployment manager template path.
     val dmConfig = DeploymentManagerConfig(gcsConfig.getConfig("deploymentManager"))
 
     val accessContextManagerDAO = new HttpGoogleAccessContextManagerDAO(
@@ -176,7 +186,6 @@ object Boot extends IOApp with LazyLogging {
         resourceBufferJsonFile = gcsConfig.getString("pathToResourceBufferJson")
       )
 
-
       val pubSubDAO = new HttpGooglePubSubDAO(
         clientEmail,
         pathToPem,
@@ -198,7 +207,9 @@ object Boot extends IOApp with LazyLogging {
 
       val pathToBqJson = gcsConfig.getString("pathToBigQueryJson")
       val bqJsonFileSource = scala.io.Source.fromFile(pathToBqJson)
-      val bqJsonCreds = try bqJsonFileSource.mkString finally bqJsonFileSource.close()
+      val bqJsonCreds =
+        try bqJsonFileSource.mkString
+        finally bqJsonFileSource.close()
 
       val bigQueryDAO = new HttpGoogleBigQueryDAO(
         appName,
@@ -256,7 +267,8 @@ object Boot extends IOApp with LazyLogging {
           }
           .toSet
 
-      val cromiamDAO: ExecutionServiceDAO = new HttpExecutionServiceDAO(executionServiceConfig.getString("cromiamUrl"), metricsPrefix)
+      val cromiamDAO: ExecutionServiceDAO =
+        new HttpExecutionServiceDAO(executionServiceConfig.getString("cromiamUrl"), metricsPrefix)
       val shardedExecutionServiceCluster: ExecutionServiceCluster =
         new ShardedHttpExecutionServiceCluster(
           executionServiceServers,
@@ -328,9 +340,11 @@ object Boot extends IOApp with LazyLogging {
         metricsPrefix
       )
 
-      val workspaceManagerDAO = new HttpWorkspaceManagerDAO(new HttpWorkspaceManagerClientProvider(conf.getString("workspaceManager.baseUrl")))
+      val workspaceManagerDAO =
+        new HttpWorkspaceManagerDAO(new HttpWorkspaceManagerClientProvider(conf.getString("workspaceManager.baseUrl")))
 
-      val dataRepoDAO = new HttpDataRepoDAO(conf.getString("dataRepo.terraInstanceName"), conf.getString("dataRepo.terraInstance"))
+      val dataRepoDAO =
+        new HttpDataRepoDAO(conf.getString("dataRepo.terraInstanceName"), conf.getString("dataRepo.terraInstance"))
 
       val maxActiveWorkflowsTotal =
         conf.getInt("executionservice.maxActiveWorkflowsPerServer")
@@ -341,8 +355,10 @@ object Boot extends IOApp with LazyLogging {
         conf.getBoolean("executionservice.useWorkflowCollectionField")
       val useWorkflowCollectionLabel =
         conf.getBoolean("executionservice.useWorkflowCollectionLabel")
-      val defaultNetworkCromwellBackend: CromwellBackend = CromwellBackend(conf.getString("executionservice.defaultNetworkBackend"))
-      val highSecurityNetworkCromwellBackend: CromwellBackend = CromwellBackend(conf.getString("executionservice.highSecurityNetworkBackend"))
+      val defaultNetworkCromwellBackend: CromwellBackend =
+        CromwellBackend(conf.getString("executionservice.defaultNetworkBackend"))
+      val highSecurityNetworkCromwellBackend: CromwellBackend =
+        CromwellBackend(conf.getString("executionservice.highSecurityNetworkBackend"))
 
       val wdlParsingConfig = WDLParserConfig(conf.getConfig("wdl-parsing"))
       def cromwellSwaggerClient = new CromwellSwaggerClient(wdlParsingConfig.serverBasePath)
@@ -352,7 +368,7 @@ object Boot extends IOApp with LazyLogging {
           new CachingWDLParser(wdlParsingConfig, cromwellSwaggerClient)
         else new NonCachingWDLParser(wdlParsingConfig, cromwellSwaggerClient)
 
-      val methodConfigResolver  = new MethodConfigResolver(wdlParser)
+      val methodConfigResolver = new MethodConfigResolver(wdlParser)
 
       val healthMonitor = system.actorOf(
         HealthMonitor
@@ -378,34 +394,41 @@ object Boot extends IOApp with LazyLogging {
         HealthMonitor.CheckAll
       )
 
-      val statusServiceConstructor: () => StatusService = () =>
-        StatusService.constructor(healthMonitor)
+      val statusServiceConstructor: () => StatusService = () => StatusService.constructor(healthMonitor)
 
       val workspaceServiceConfig = WorkspaceServiceConfig.apply(conf)
 
       val bondConfig = conf.getConfig("bond")
       val bondApiDAO: BondApiDAO = new HttpBondApiDAO(bondConfig.getString("baseUrl"))
-      val requesterPaysSetupService: RequesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole)
+      val requesterPaysSetupService: RequesterPaysSetupService =
+        new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole)
 
       // create the entity manager.
-      val entityManager = EntityManager.defaultEntityManager(slickDataSource, workspaceManagerDAO, dataRepoDAO, samDAO,
+      val entityManager = EntityManager.defaultEntityManager(
+        slickDataSource,
+        workspaceManagerDAO,
+        dataRepoDAO,
+        samDAO,
         appDependencies.bigQueryServiceFactory,
         DataRepoEntityProviderConfig(conf.getConfig("dataRepoEntityProvider")),
         conf.getBoolean("entityStatisticsCache.enabled"),
-        metricsPrefix)
+        metricsPrefix
+      )
 
       val resourceBufferConfig = ResourceBufferConfig(conf.getConfig("resourceBuffer"))
-      val resourceBufferDAO: ResourceBufferDAO = new HttpResourceBufferDAO(resourceBufferConfig, gcsDAO.getResourceBufferServiceAccountCredential)
+      val resourceBufferDAO: ResourceBufferDAO =
+        new HttpResourceBufferDAO(resourceBufferConfig, gcsDAO.getResourceBufferServiceAccountCredential)
       val resourceBufferService = new ResourceBufferService(resourceBufferDAO, resourceBufferConfig)
       val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
-      val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService = MultiCloudWorkspaceService.constructor(
-        slickDataSource,
-        workspaceManagerDAO,
-        samDAO,
-        multiCloudWorkspaceConfig,
-        metricsPrefix
-      )
+      val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService =
+        MultiCloudWorkspaceService.constructor(
+          slickDataSource,
+          workspaceManagerDAO,
+          samDAO,
+          multiCloudWorkspaceConfig,
+          metricsPrefix
+        )
 
       val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService = WorkspaceService.constructor(
         slickDataSource,
@@ -451,27 +474,31 @@ object Boot extends IOApp with LazyLogging {
         conf.getString("dataRepo.terraInstanceName")
       )
 
-      val spendReportingBigQueryService = appDependencies.bigQueryServiceFactory.getServiceFromJson(bqJsonCreds, GoogleProject(gcsConfig.getString("serviceProject")))
+      val spendReportingBigQueryService =
+        appDependencies.bigQueryServiceFactory.getServiceFromJson(bqJsonCreds,
+                                                                  GoogleProject(gcsConfig.getString("serviceProject"))
+        )
       val spendReportingServiceConfig = SpendReportingServiceConfig(
         gcsConfig.getString("billingExportTableName"),
         gcsConfig.getString("billingExportTimePartitionColumn"),
         gcsConfig.getConfig("spendReporting").getInt("maxDateRange")
       )
 
-      val spendReportingServiceConstructor: RawlsRequestContext => SpendReportingService = SpendReportingService.constructor(
-        slickDataSource,
-        spendReportingBigQueryService,
-        samDAO,
-        spendReportingServiceConfig
-      )
+      val spendReportingServiceConstructor: RawlsRequestContext => SpendReportingService =
+        SpendReportingService.constructor(
+          slickDataSource,
+          spendReportingBigQueryService,
+          samDAO,
+          spendReportingServiceConfig
+        )
 
       val billingRepository = new BillingRepository(slickDataSource)
       val billingProjectOrchestratorConstructor: RawlsRequestContext => BillingProjectOrchestrator =
-        BillingProjectOrchestrator.constructor(
-          samDAO,
-          billingRepository,
-          new GoogleBillingProjectCreator(samDAO, gcsDAO),
-          new BpmBillingProjectCreator(billingRepository, billingProfileManagerDAO))
+        BillingProjectOrchestrator.constructor(samDAO,
+                                               billingRepository,
+                                               new GoogleBillingProjectCreator(samDAO, gcsDAO),
+                                               new BpmBillingProjectCreator(billingRepository, billingProfileManagerDAO)
+        )
 
       val service = new RawlsApiServiceImpl(
         multiCloudWorkspaceServiceConstructor,
@@ -548,9 +575,7 @@ object Boot extends IOApp with LazyLogging {
   private def setupSentry(options: SentryOptions): Unit = {
     def setupOptions(options: SentryOptions): Unit = {
       options.setEnableExternalConfiguration(true)
-      options.setBeforeSend((event: SentryEvent, hint: Hint) =>
-        SentryEventFilter.filterEvent(event)
-      )
+      options.setBeforeSend((event: SentryEvent, hint: Hint) => SentryEventFilter.filterEvent(event))
     }
 
     setupOptions(options)
@@ -573,9 +598,15 @@ object Boot extends IOApp with LazyLogging {
     }
   }
 
-  def startStatsDReporter(host: String, port: Int, period: java.time.Duration, registryName: String = "default", apiKey: Option[String] = None): Unit = {
+  def startStatsDReporter(host: String,
+                          port: Int,
+                          period: java.time.Duration,
+                          registryName: String = "default",
+                          apiKey: Option[String] = None
+  ): Unit = {
     logger.info(s"Starting statsd reporter writing to [$host:$port] with period [${period.toMillis} ms]")
-    val reporter = StatsDReporter.forRegistry(SharedMetricRegistries.getOrCreate(registryName))
+    val reporter = StatsDReporter
+      .forRegistry(SharedMetricRegistries.getOrCreate(registryName))
       .prefixedWith(apiKey.orNull)
       .convertRatesTo(TimeUnit.SECONDS)
       .convertDurationsTo(TimeUnit.MILLISECONDS)
@@ -583,7 +614,10 @@ object Boot extends IOApp with LazyLogging {
     reporter.start(period.toMillis, period.toMillis, TimeUnit.MILLISECONDS)
   }
 
-  def initAppDependencies[F[_]: Logger: Async](config: Config, appName: String, metricsPrefix: String)(implicit executionContext: ExecutionContext, system: ActorSystem): cats.effect.Resource[F, AppDependencies[F]] = {
+  def initAppDependencies[F[_]: Logger: Async](config: Config, appName: String, metricsPrefix: String)(implicit
+    executionContext: ExecutionContext,
+    system: ActorSystem
+  ): cats.effect.Resource[F, AppDependencies[F]] = {
     val gcsConfig = config.getConfig("gcs")
     val serviceProject = GoogleProject(gcsConfig.getString("serviceProject"))
     val oidcConfig = config.getConfig("oidc")
@@ -591,7 +625,9 @@ object Boot extends IOApp with LazyLogging {
     // todo: load these credentials once [CA-1806]
     val pathToCredentialJson = gcsConfig.getString("pathToCredentialJson")
     val jsonFileSource = scala.io.Source.fromFile(pathToCredentialJson)
-    val jsonCreds = try jsonFileSource.mkString finally jsonFileSource.close()
+    val jsonCreds =
+      try jsonFileSource.mkString
+      finally jsonFileSource.close()
     val saCredentials = ServiceAccountCredentials.fromStream(
       new ByteArrayInputStream(jsonCreds.getBytes(StandardCharsets.UTF_8))
     )
@@ -608,7 +644,10 @@ object Boot extends IOApp with LazyLogging {
       googleServiceHttp <- GoogleServiceHttp.withRetryAndLogging(httpClient, metadataNotificationConfig)
       topicAdmin <- GoogleTopicAdmin.fromCredentialPath(pathToCredentialJson)
       bqServiceFactory = new GoogleBigQueryServiceFactory(pathToCredentialJson)(executionContext)
-      httpGoogleIamDAO = new HttpGoogleIamDAO(appName, GoogleCredentialModes.Json(jsonCreds), metricsPrefix)(system, executionContext)
+      httpGoogleIamDAO = new HttpGoogleIamDAO(appName, GoogleCredentialModes.Json(jsonCreds), metricsPrefix)(
+        system,
+        executionContext
+      )
 
       openIdConnect <- cats.effect.Resource.eval(
         OpenIDConnectConfiguration[F](
@@ -616,9 +655,17 @@ object Boot extends IOApp with LazyLogging {
           ClientId(oidcConfig.getString("oidcClientId")),
           oidcClientSecret = oidcConfig.getAs[String]("oidcClientSecret").map(ClientSecret),
           extraGoogleClientId = oidcConfig.getAs[String]("legacyGoogleClientId").map(ClientId),
-          extraAuthParams = Some("prompt=login"))
+          extraAuthParams = Some("prompt=login")
+        )
       )
-    } yield AppDependencies[F](googleStorage, googleStorageTransferService, googleServiceHttp, topicAdmin, bqServiceFactory, httpGoogleIamDAO, openIdConnect)
+    } yield AppDependencies[F](googleStorage,
+                               googleStorageTransferService,
+                               googleServiceHttp,
+                               topicAdmin,
+                               bqServiceFactory,
+                               httpGoogleIamDAO,
+                               openIdConnect
+    )
   }
 }
 
@@ -630,4 +677,4 @@ final case class AppDependencies[F[_]](googleStorageService: GoogleStorageServic
                                        bigQueryServiceFactory: GoogleBigQueryServiceFactory,
                                        httpGoogleIamDAO: HttpGoogleIamDAO,
                                        oidcConfiguration: OpenIDConnectConfiguration
-                                      )
+)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
@@ -20,7 +20,6 @@ trait BillingProfileManagerClientProvider {
   def getProfileApi(ctx: RawlsRequestContext): ProfileApi
 }
 
-
 class HttpBillingProfileManagerClientProvider(baseBpmUrl: Option[String]) extends BillingProfileManagerClientProvider {
   def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient() {
@@ -38,15 +37,12 @@ class HttpBillingProfileManagerClientProvider(baseBpmUrl: Option[String]) extend
     client
   }
 
-  override def getAzureApi(ctx: RawlsRequestContext): AzureApi = {
+  override def getAzureApi(ctx: RawlsRequestContext): AzureApi =
     new AzureApi(getApiClient(ctx))
-  }
 
-  override def getProfileApi(ctx: RawlsRequestContext): ProfileApi = {
+  override def getProfileApi(ctx: RawlsRequestContext): ProfileApi =
     new ProfileApi(getApiClient(ctx))
-  }
 
-  private def basePath = {
+  private def basePath =
     baseBpmUrl.getOrElse(throw new NotImplementedError("Billing profile manager path not configured"))
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -5,7 +5,19 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, CreationStatuses, ErrorReport, RawlsBillingAccountName, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamResourceAction, SamResourceTypeNames, SamUserResource, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  CreationStatuses,
+  ErrorReport,
+  RawlsBillingAccountName,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamResourceAction,
+  SamResourceTypeNames,
+  SamUserResource,
+  UserInfo
+}
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -15,13 +27,17 @@ import scala.jdk.CollectionConverters._
  * Common interface for Billing Profile Manager operations
  */
 trait BillingProfileManagerDAO {
-  def createBillingProfile(displayName: String, billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates], ctx: RawlsRequestContext): Future[ProfileModel]
+  def createBillingProfile(displayName: String,
+                           billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates],
+                           ctx: RawlsRequestContext
+  ): Future[ProfileModel]
 
-  def listBillingProfiles(samUserResources: Seq[SamUserResource], ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[RawlsBillingProject]]
+  def listBillingProfiles(samUserResources: Seq[SamUserResource], ctx: RawlsRequestContext)(implicit
+    ec: ExecutionContext
+  ): Future[Seq[RawlsBillingProject]]
 
   def listManagedApps(subscriptionId: UUID, ctx: RawlsRequestContext): Future[Seq[AzureManagedAppModel]]
 }
-
 
 class ManagedAppNotFoundException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
 
@@ -32,8 +48,9 @@ class ManagedAppNotFoundException(errorReport: ErrorReport) extends RawlsExcepti
  */
 class BillingProfileManagerDAOImpl(samDAO: SamDAO,
                                    apiClientProvider: BillingProfileManagerClientProvider,
-                                   config: MultiCloudWorkspaceConfig) extends BillingProfileManagerDAO with LazyLogging {
-
+                                   config: MultiCloudWorkspaceConfig
+) extends BillingProfileManagerDAO
+    with LazyLogging {
 
   override def listManagedApps(subscriptionId: UUID, ctx: RawlsRequestContext): Future[Seq[AzureManagedAppModel]] = {
     val azureApi = apiClientProvider.getAzureApi(ctx)
@@ -44,9 +61,10 @@ class BillingProfileManagerDAOImpl(samDAO: SamDAO,
 
   override def createBillingProfile(displayName: String,
                                     billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates],
-                                    ctx: RawlsRequestContext): Future[ProfileModel] = {
+                                    ctx: RawlsRequestContext
+  ): Future[ProfileModel] = {
     val azureManagedAppCoordinates = billingInfo match {
-      case Left(_) => throw new NotImplementedError("Google billing accounts not supported in billing profiles")
+      case Left(_)       => throw new NotImplementedError("Google billing accounts not supported in billing profiles")
       case Right(coords) => coords
     }
 
@@ -67,13 +85,14 @@ class BillingProfileManagerDAOImpl(samDAO: SamDAO,
     Future.successful(createdProfile)
   }
 
-
   /**
    * Fetches the billing profiles to which the user has access.
    *
    * This method only returns Azure billing profiles for now
    */
-  def listBillingProfiles(samUserResources: Seq[SamUserResource], ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[RawlsBillingProject]] = {
+  def listBillingProfiles(samUserResources: Seq[SamUserResource], ctx: RawlsRequestContext)(implicit
+    ec: ExecutionContext
+  ): Future[Seq[RawlsBillingProject]] = {
     if (!config.multiCloudWorkspacesEnabled) {
       return Future.successful(Seq())
     }
@@ -87,42 +106,43 @@ class BillingProfileManagerDAOImpl(samDAO: SamDAO,
 
     for {
       billingProfiles <- getAllBillingProfiles(azureConfig, ctx)
-    } yield {
-      billingProfiles.filter {
-        bp => samUserResources.map(_.resourceId).contains(bp.projectName.value)
-      }
+    } yield billingProfiles.filter { bp =>
+      samUserResources.map(_.resourceId).contains(bp.projectName.value)
     }
   }
 
-  private def getAllBillingProfiles(azureConfig: AzureConfig, ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[RawlsBillingProject]] = {
+  private def getAllBillingProfiles(azureConfig: AzureConfig, ctx: RawlsRequestContext)(implicit
+    ec: ExecutionContext
+  ): Future[Seq[RawlsBillingProject]] =
     // NB until the BPM is live, we are returning a hardcoded
     // Azure billing profile, with access enforced by SAM
-    samDAO.userHasAction(
-      SamResourceTypeNames.managedGroup,
-      azureConfig.alphaFeatureGroup,
-      SamResourceAction("use"),
-      ctx.userInfo
-    ).flatMap {
-      case true =>
-        Future.successful(
-          Seq(
-            RawlsBillingProject(
-              RawlsBillingProjectName(azureConfig.billingProjectName),
-              CreationStatuses.Ready,
-              None,
-              None,
-              azureManagedAppCoordinates = Some(
-                AzureManagedAppCoordinates(
-                  UUID.fromString(azureConfig.azureTenantId),
-                  UUID.fromString(azureConfig.azureSubscriptionId),
-                  azureConfig.azureResourceGroupId
+    samDAO
+      .userHasAction(
+        SamResourceTypeNames.managedGroup,
+        azureConfig.alphaFeatureGroup,
+        SamResourceAction("use"),
+        ctx.userInfo
+      )
+      .flatMap {
+        case true =>
+          Future.successful(
+            Seq(
+              RawlsBillingProject(
+                RawlsBillingProjectName(azureConfig.billingProjectName),
+                CreationStatuses.Ready,
+                None,
+                None,
+                azureManagedAppCoordinates = Some(
+                  AzureManagedAppCoordinates(
+                    UUID.fromString(azureConfig.azureTenantId),
+                    UUID.fromString(azureConfig.azureSubscriptionId),
+                    azureConfig.azureResourceGroupId
+                  )
                 )
               )
             )
           )
-        )
-      case false =>
-        Future.successful(Seq.empty)
-    }
-  }
+        case false =>
+          Future.successful(Seq.empty)
+      }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectCreator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectCreator.scala
@@ -11,6 +11,10 @@ import scala.concurrent.Future
  * b) external state is valid after rawls internal state is updated (i.e, syncing groups, etc.)
  */
 trait BillingProjectCreator {
-  def validateBillingProjectCreationRequest(createProjectRequest: CreateRawlsV2BillingProjectFullRequest, ctx: RawlsRequestContext): Future[Unit]
-  def postCreationSteps(createProjectRequest: CreateRawlsV2BillingProjectFullRequest, ctx: RawlsRequestContext): Future[Unit]
+  def validateBillingProjectCreationRequest(createProjectRequest: CreateRawlsV2BillingProjectFullRequest,
+                                            ctx: RawlsRequestContext
+  ): Future[Unit]
+  def postCreationSteps(createProjectRequest: CreateRawlsV2BillingProjectFullRequest,
+                        ctx: RawlsRequestContext
+  ): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -3,12 +3,24 @@ package org.broadinstitute.dsde.rawls.billing
 import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
-import org.broadinstitute.dsde.rawls.model.{CreateRawlsV2BillingProjectFullRequest, CreationStatuses, ErrorReport, ErrorReportSource, RawlsBillingProject, RawlsRequestContext, SamBillingProjectPolicyNames, SamBillingProjectRoles, SamPolicy, SamResourcePolicyName, SamResourceTypeNames, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  CreateRawlsV2BillingProjectFullRequest,
+  CreationStatuses,
+  ErrorReport,
+  ErrorReportSource,
+  RawlsBillingProject,
+  RawlsRequestContext,
+  SamBillingProjectPolicyNames,
+  SamBillingProjectRoles,
+  SamPolicy,
+  SamResourcePolicyName,
+  SamResourceTypeNames,
+  UserInfo
+}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import scala.concurrent.{ExecutionContext, Future}
-
 
 /**
  * Knows how to provision billing projects with external cloud providers (that is, implementors of the
@@ -25,8 +37,10 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
                                  samDAO: SamDAO,
                                  billingRepository: BillingRepository,
                                  googleBillingProjectCreator: BillingProjectCreator,
-                                 bpmBillingProjectCreator: BillingProjectCreator)
-                                (implicit val executionContext: ExecutionContext) extends StringValidationUtils with LazyLogging {
+                                 bpmBillingProjectCreator: BillingProjectCreator
+)(implicit val executionContext: ExecutionContext)
+    extends StringValidationUtils
+    with LazyLogging {
   implicit val errorReportSource = ErrorReportSource("rawls")
 
   /**
@@ -34,7 +48,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
    */
   def createBillingProjectV2(createProjectRequest: CreateRawlsV2BillingProjectFullRequest): Future[Unit] = {
     val billingProjectCreator = createProjectRequest.billingInfo match {
-      case Left(_) => googleBillingProjectCreator
+      case Left(_)  => googleBillingProjectCreator
       case Right(_) => bpmBillingProjectCreator
     }
     val billingProjectName = createProjectRequest.projectName
@@ -49,66 +63,91 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
       _ <- createV2BillingProjectInternal(createProjectRequest, ctx)
 
       _ = logger.info(s"Created billing project record, running post-creation steps [name=${billingProjectName.value}]")
-      result <- billingProjectCreator.postCreationSteps(createProjectRequest, ctx).recoverWith {
-        case t: Throwable =>
-          logger.error(s"Error in post-creation steps for billing project [name=${billingProjectName.value}]")
-          rollbackCreateV2BillingProjectInternal(createProjectRequest).map(throw t)
+      result <- billingProjectCreator.postCreationSteps(createProjectRequest, ctx).recoverWith { case t: Throwable =>
+        logger.error(s"Error in post-creation steps for billing project [name=${billingProjectName.value}]")
+        rollbackCreateV2BillingProjectInternal(createProjectRequest).map(throw t)
       }
-    } yield {
-      result
-    }
+    } yield result
   }
 
-  private def rollbackCreateV2BillingProjectInternal(createProjectRequest: CreateRawlsV2BillingProjectFullRequest): Future[Unit] = {
+  private def rollbackCreateV2BillingProjectInternal(
+    createProjectRequest: CreateRawlsV2BillingProjectFullRequest
+  ): Future[Unit] =
     for {
-      _ <- billingRepository.deleteBillingProject(createProjectRequest.projectName).recover {
-        case e => logger.error(s"Failure deleting billing project from DB during error recovery [name=${createProjectRequest.projectName.value}]", e)
+      _ <- billingRepository.deleteBillingProject(createProjectRequest.projectName).recover { case e =>
+        logger.error(
+          s"Failure deleting billing project from DB during error recovery [name=${createProjectRequest.projectName.value}]",
+          e
+        )
       }
-      _ <- samDAO.deleteResource(SamResourceTypeNames.billingProject, createProjectRequest.projectName.value, ctx.userInfo).recover {
-        case e => logger.error(s"Failure deleting billing project resource in SAM during error recovery [name=${createProjectRequest.projectName.value}]", e)
-      }
-    } yield {
-    }
-  }
+      _ <- samDAO
+        .deleteResource(SamResourceTypeNames.billingProject, createProjectRequest.projectName.value, ctx.userInfo)
+        .recover { case e =>
+          logger.error(
+            s"Failure deleting billing project resource in SAM during error recovery [name=${createProjectRequest.projectName.value}]",
+            e
+          )
+        }
+    } yield {}
 
-  private def createV2BillingProjectInternal(createProjectRequest: CreateRawlsV2BillingProjectFullRequest, ctx: RawlsRequestContext): Future[Unit] = {
+  private def createV2BillingProjectInternal(createProjectRequest: CreateRawlsV2BillingProjectFullRequest,
+                                             ctx: RawlsRequestContext
+  ): Future[Unit] =
     for {
       maybeProject <- billingRepository.getBillingProject(createProjectRequest.projectName)
       _ <- maybeProject match {
-        case Some(_) => Future.failed(new DuplicateBillingProjectException(ErrorReport(StatusCodes.Conflict, "project by that name already exists")))
+        case Some(_) =>
+          Future.failed(
+            new DuplicateBillingProjectException(
+              ErrorReport(StatusCodes.Conflict, "project by that name already exists")
+            )
+          )
         case None => Future.successful(())
       }
-      _ <- samDAO.createResourceFull(SamResourceTypeNames.billingProject,
+      _ <- samDAO.createResourceFull(
+        SamResourceTypeNames.billingProject,
         createProjectRequest.projectName.value,
         BillingProjectOrchestrator.defaultBillingProjectPolicies(ctx),
         Set.empty,
         ctx.userInfo,
-        None)
+        None
+      )
       _ <- billingRepository.createBillingProject(
         RawlsBillingProject(createProjectRequest.projectName,
-          CreationStatuses.Ready,
-          createProjectRequest.billingAccount,
-          None,
-          None,
-          createProjectRequest.servicePerimeter))
+                            CreationStatuses.Ready,
+                            createProjectRequest.billingAccount,
+                            None,
+                            None,
+                            createProjectRequest.servicePerimeter
+        )
+      )
     } yield {}
-  }
 }
 
 object BillingProjectOrchestrator {
   def constructor(samDAO: SamDAO,
                   billingRepository: BillingRepository,
                   googleBillingProjectCreator: GoogleBillingProjectCreator,
-                  bpmBillingProjectCreator: BpmBillingProjectCreator)(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): BillingProjectOrchestrator = {
-    new BillingProjectOrchestrator(ctx, samDAO, billingRepository, googleBillingProjectCreator, bpmBillingProjectCreator)
-  }
-
-  def defaultBillingProjectPolicies(ctx: RawlsRequestContext): Map[SamResourcePolicyName, SamPolicy] = {
-    Map(
-      SamBillingProjectPolicyNames.owner -> SamPolicy(Set(WorkbenchEmail(ctx.userInfo.userEmail.value)), Set.empty, Set(SamBillingProjectRoles.owner)),
-      SamBillingProjectPolicyNames.workspaceCreator -> SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.workspaceCreator))
+                  bpmBillingProjectCreator: BpmBillingProjectCreator
+  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): BillingProjectOrchestrator =
+    new BillingProjectOrchestrator(ctx,
+                                   samDAO,
+                                   billingRepository,
+                                   googleBillingProjectCreator,
+                                   bpmBillingProjectCreator
     )
-  }
+
+  def defaultBillingProjectPolicies(ctx: RawlsRequestContext): Map[SamResourcePolicyName, SamPolicy] =
+    Map(
+      SamBillingProjectPolicyNames.owner -> SamPolicy(Set(WorkbenchEmail(ctx.userInfo.userEmail.value)),
+                                                      Set.empty,
+                                                      Set(SamBillingProjectRoles.owner)
+      ),
+      SamBillingProjectPolicyNames.workspaceCreator -> SamPolicy(Set.empty,
+                                                                 Set.empty,
+                                                                 Set(SamBillingProjectRoles.workspaceCreator)
+      )
+    )
 }
 
 class DuplicateBillingProjectException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectCreator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectCreator.scala
@@ -2,7 +2,16 @@ package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
-import org.broadinstitute.dsde.rawls.model.{CreateRawlsV2BillingProjectFullRequest, ErrorReport, ErrorReportSource, RawlsRequestContext, SamResourceTypeNames, SamServicePerimeterActions, ServicePerimeterName, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  CreateRawlsV2BillingProjectFullRequest,
+  ErrorReport,
+  ErrorReportSource,
+  RawlsRequestContext,
+  SamResourceTypeNames,
+  SamServicePerimeterActions,
+  ServicePerimeterName,
+  UserInfo
+}
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService.syncBillingProjectOwnerPolicyToGoogleAndGetEmail
 
@@ -10,7 +19,9 @@ import java.net.URLEncoder
 import scala.concurrent.{ExecutionContext, Future}
 import java.nio.charset.StandardCharsets.UTF_8
 
-class GoogleBillingProjectCreator(samDAO: SamDAO, gcsDAO: GoogleServicesDAO)(implicit executionContext: ExecutionContext) extends BillingProjectCreator {
+class GoogleBillingProjectCreator(samDAO: SamDAO, gcsDAO: GoogleServicesDAO)(implicit
+  executionContext: ExecutionContext
+) extends BillingProjectCreator {
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
 
   /**
@@ -19,20 +30,25 @@ class GoogleBillingProjectCreator(samDAO: SamDAO, gcsDAO: GoogleServicesDAO)(imp
    * @return A successful future in the event of a passed validation, a failed future with an Exception in the event of
    *         validation failure.
    */
-  override def validateBillingProjectCreationRequest(createProjectRequest: CreateRawlsV2BillingProjectFullRequest, ctx: RawlsRequestContext): Future[Unit] = {
+  override def validateBillingProjectCreationRequest(createProjectRequest: CreateRawlsV2BillingProjectFullRequest,
+                                                     ctx: RawlsRequestContext
+  ): Future[Unit] =
     for {
       _ <- ServicePerimeterService.checkServicePerimeterAccess(samDAO, createProjectRequest.servicePerimeter, ctx)
       hasAccess <- gcsDAO.testBillingAccountAccess(createProjectRequest.billingAccount.get, ctx.userInfo)
       _ = if (!hasAccess) {
-        throw new GoogleBillingAccountAccessException(ErrorReport(StatusCodes.BadRequest, "Billing account does not exist, user does not have access, or Terra does not have access"))
+        throw new GoogleBillingAccountAccessException(
+          ErrorReport(StatusCodes.BadRequest,
+                      "Billing account does not exist, user does not have access, or Terra does not have access"
+          )
+        )
       }
     } yield {}
-  }
 
-
-  override def postCreationSteps(createProjectRequest: CreateRawlsV2BillingProjectFullRequest, ctx: RawlsRequestContext): Future[Unit] = {
+  override def postCreationSteps(createProjectRequest: CreateRawlsV2BillingProjectFullRequest,
+                                 ctx: RawlsRequestContext
+  ): Future[Unit] =
     for {
       _ <- syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO, createProjectRequest.projectName)
     } yield {}
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1,12 +1,17 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
-import io.opencensus.trace.{Span, AttributeValue => OpenCensusAttributeValue}
+import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsFatalExceptionWithErrorReport, model}
+import org.broadinstitute.dsde.rawls.{
+  model,
+  RawlsException,
+  RawlsExceptionWithErrorReport,
+  RawlsFatalExceptionWithErrorReport
+}
 import slick.jdbc.{GetResult, JdbcProfile, SQLActionBuilder}
 
 import java.sql.Timestamp
@@ -26,7 +31,15 @@ sealed trait EntityRecordBase {
 
   def toReference = AttributeEntityReference(entityType, name)
   def withoutAllAttributeValues = EntityRecord(id, name, entityType, workspaceId, recordVersion, deleted, deletedDate)
-  def withAllAttributeValues(allAttributeValues: Option[String]) = EntityRecordWithInlineAttributes(id, name, entityType, workspaceId, recordVersion, allAttributeValues, deleted, deletedDate)
+  def withAllAttributeValues(allAttributeValues: Option[String]) = EntityRecordWithInlineAttributes(id,
+                                                                                                    name,
+                                                                                                    entityType,
+                                                                                                    workspaceId,
+                                                                                                    recordVersion,
+                                                                                                    allAttributeValues,
+                                                                                                    deleted,
+                                                                                                    deletedDate
+  )
 }
 
 case class EntityRecord(id: Long,
@@ -35,7 +48,8 @@ case class EntityRecord(id: Long,
                         workspaceId: UUID,
                         recordVersion: Long,
                         deleted: Boolean,
-                        deletedDate: Option[Timestamp]) extends EntityRecordBase
+                        deletedDate: Option[Timestamp]
+) extends EntityRecordBase
 
 case class EntityRecordWithInlineAttributes(id: Long,
                                             name: String,
@@ -44,16 +58,18 @@ case class EntityRecordWithInlineAttributes(id: Long,
                                             recordVersion: Long,
                                             allAttributeValues: Option[String],
                                             deleted: Boolean,
-                                            deletedDate: Option[Timestamp]) extends EntityRecordBase
+                                            deletedDate: Option[Timestamp]
+) extends EntityRecordBase
 
 object EntityComponent {
-  //the length of the all_attribute_values column, which is TEXT, -1 becaue i'm nervous
+  // the length of the all_attribute_values column, which is TEXT, -1 becaue i'm nervous
   val allAttributeValuesColumnSize = 65534
 }
 
 import slick.jdbc.MySQLProfile.api._
 
-sealed abstract class EntityTableBase[RECORD_TYPE <: EntityRecordBase](tag: Tag) extends Table[RECORD_TYPE](tag, "ENTITY") {
+sealed abstract class EntityTableBase[RECORD_TYPE <: EntityRecordBase](tag: Tag)
+    extends Table[RECORD_TYPE](tag, "ENTITY") {
   def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
   def name = column[String]("name", O.Length(254))
   def entityType = column[String]("entity_type", O.Length(254))
@@ -67,13 +83,22 @@ sealed abstract class EntityTableBase[RECORD_TYPE <: EntityRecordBase](tag: Tag)
 }
 
 class EntityTable(tag: Tag) extends EntityTableBase[EntityRecord](tag) {
-  def * = (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (EntityRecord.tupled, EntityRecord.unapply)
+  def * =
+    (id, name, entityType, workspaceId, version, deleted, deletedDate) <> (EntityRecord.tupled, EntityRecord.unapply)
 }
 
 class EntityTableWithInlineAttributes(tag: Tag) extends EntityTableBase[EntityRecordWithInlineAttributes](tag) {
   def allAttributeValues = column[Option[String]]("all_attribute_values")
 
-  def * = (id, name, entityType, workspaceId, version, allAttributeValues, deleted, deletedDate) <> (EntityRecordWithInlineAttributes.tupled, EntityRecordWithInlineAttributes.unapply)
+  def * = (id,
+           name,
+           entityType,
+           workspaceId,
+           version,
+           allAttributeValues,
+           deleted,
+           deletedDate
+  ) <> (EntityRecordWithInlineAttributes.tupled, EntityRecordWithInlineAttributes.unapply)
 }
 
 //noinspection TypeAnnotation
@@ -89,63 +114,90 @@ trait EntityComponent {
     type EntityQueryWithInlineAttributes = Query[EntityTableWithInlineAttributes, EntityRecordWithInlineAttributes, Seq]
 
     // only used by tests
-    def findEntityByName(workspaceId: UUID, entityType: String, entityName: String): EntityQueryWithInlineAttributes = {
-      filter(entRec => entRec.name === entityName && entRec.entityType === entityType && entRec.workspaceId === workspaceId)
-    }
+    def findEntityByName(workspaceId: UUID, entityType: String, entityName: String): EntityQueryWithInlineAttributes =
+      filter(entRec =>
+        entRec.name === entityName && entRec.entityType === entityType && entRec.workspaceId === workspaceId
+      )
 
     @tailrec
-    def collectAttributeStrings(toProcess: Iterable[Attribute], processed: List[String], charsRemaining: Int): String = {
+    def collectAttributeStrings(toProcess: Iterable[Attribute], processed: List[String], charsRemaining: Int): String =
       if (toProcess.isEmpty || charsRemaining <= 0)
         processed.mkString(" ")
       else {
         val nextAttr = AttributeStringifier(toProcess.head)
         collectAttributeStrings(toProcess.tail, processed :+ nextAttr, charsRemaining - nextAttr.length - 1)
       }
-    }
 
     private def createAllAttributesString(entity: Entity): Option[String] = {
       val maxLength = EntityComponent.allAttributeValuesColumnSize
-      Option(s"${entity.name} ${collectAttributeStrings(entity.attributes.values.filterNot(_.isInstanceOf[AttributeList[_]]), List(), maxLength)}".toLowerCase.take(maxLength))
+      Option(
+        s"${entity.name} ${collectAttributeStrings(entity.attributes.values.filterNot(_.isInstanceOf[AttributeList[_]]), List(), maxLength)}".toLowerCase
+          .take(maxLength)
+      )
     }
 
-    def batchInsertEntities(workspaceContext: Workspace, entities: TraversableOnce[Entity]): ReadWriteAction[Seq[EntityRecord]] = {
-      def marshalNewEntity(entity: Entity, workspaceId: UUID): EntityRecordWithInlineAttributes = {
-        EntityRecordWithInlineAttributes(0, entity.name, entity.entityType, workspaceId, 0, createAllAttributesString(entity), deleted = false, deletedDate = None)
-      }
+    def batchInsertEntities(workspaceContext: Workspace,
+                            entities: TraversableOnce[Entity]
+    ): ReadWriteAction[Seq[EntityRecord]] = {
+      def marshalNewEntity(entity: Entity, workspaceId: UUID): EntityRecordWithInlineAttributes =
+        EntityRecordWithInlineAttributes(0,
+                                         entity.name,
+                                         entity.entityType,
+                                         workspaceId,
+                                         0,
+                                         createAllAttributesString(entity),
+                                         deleted = false,
+                                         deletedDate = None
+        )
 
       if (entities.nonEmpty) {
         val entityRecs = entities.toSeq.map(e => marshalNewEntity(e, workspaceContext.workspaceIdAsUUID))
 
         workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
-          DBIO.sequence(entityRecs.grouped(batchSize).map(entityQueryWithInlineAttributes ++= _)).map(_.flatten.sum).andThen(
-            entityQuery.getEntityRecords(workspaceContext.workspaceIdAsUUID, entityRecs.map(_.toReference).toSet))
-      }
-      else {
+          DBIO
+            .sequence(entityRecs.grouped(batchSize).map(entityQueryWithInlineAttributes ++= _))
+            .map(_.flatten.sum)
+            .andThen(
+              entityQuery.getEntityRecords(workspaceContext.workspaceIdAsUUID, entityRecs.map(_.toReference).toSet)
+            )
+      } else {
         DBIO.successful(Seq.empty[EntityRecord])
       }
     }
 
-    def insertNewEntities(workspaceContext: Workspace, entities: Traversable[Entity], existingEntityRefs: Seq[AttributeEntityReference]): ReadWriteAction[Seq[EntityRecord]] = {
-      val newEntities = entities.filterNot { e => existingEntityRefs.contains(e.toReference) }
+    def insertNewEntities(workspaceContext: Workspace,
+                          entities: Traversable[Entity],
+                          existingEntityRefs: Seq[AttributeEntityReference]
+    ): ReadWriteAction[Seq[EntityRecord]] = {
+      val newEntities = entities.filterNot(e => existingEntityRefs.contains(e.toReference))
       batchInsertEntities(workspaceContext, newEntities)
     }
 
-    def optimisticLockUpdate(entityRecs: Seq[EntityRecord], entities: Traversable[Entity]): ReadWriteAction[Seq[Int]] = {
-      def populateAllAttributeValues(entityRecsFromDb: Seq[EntityRecord], entitiesToSave: Traversable[Entity]): Seq[EntityRecordWithInlineAttributes] = {
+    def optimisticLockUpdate(entityRecs: Seq[EntityRecord],
+                             entities: Traversable[Entity]
+    ): ReadWriteAction[Seq[Int]] = {
+      def populateAllAttributeValues(entityRecsFromDb: Seq[EntityRecord],
+                                     entitiesToSave: Traversable[Entity]
+      ): Seq[EntityRecordWithInlineAttributes] = {
         val entitiesByRef = entitiesToSave.map(e => e.toReference -> e).toMap
-        entityRecsFromDb map { rec => rec.withAllAttributeValues(createAllAttributesString(entitiesByRef(rec.toReference))) }
-      }
-
-      def findEntityByIdAndVersion(id: Long, version: Long): EntityQueryWithInlineAttributes = {
-        filter(rec => rec.id === id && rec.version === version)
-      }
-
-      def optimisticLockUpdateOne(originalRec: EntityRecordWithInlineAttributes): ReadWriteAction[Int] = {
-        findEntityByIdAndVersion(originalRec.id, originalRec.recordVersion) update originalRec.copy(recordVersion = originalRec.recordVersion + 1) map {
-          case 0 => throw new RawlsConcurrentModificationException(s"could not update $originalRec because its record version has changed")
-          case success => success
+        entityRecsFromDb map { rec =>
+          rec.withAllAttributeValues(createAllAttributesString(entitiesByRef(rec.toReference)))
         }
       }
+
+      def findEntityByIdAndVersion(id: Long, version: Long): EntityQueryWithInlineAttributes =
+        filter(rec => rec.id === id && rec.version === version)
+
+      def optimisticLockUpdateOne(originalRec: EntityRecordWithInlineAttributes): ReadWriteAction[Int] =
+        findEntityByIdAndVersion(originalRec.id, originalRec.recordVersion) update originalRec.copy(recordVersion =
+          originalRec.recordVersion + 1
+        ) map {
+          case 0 =>
+            throw new RawlsConcurrentModificationException(
+              s"could not update $originalRec because its record version has changed"
+            )
+          case success => success
+        }
 
       DBIO.sequence(populateAllAttributeValues(entityRecs, entities) map optimisticLockUpdateOne)
     }
@@ -158,28 +210,34 @@ trait EntityComponent {
 
     // Raw queries - used when querying for multiple AttributeEntityReferences
 
-    //noinspection SqlDialectInspection,DuplicatedCode
+    // noinspection SqlDialectInspection,DuplicatedCode
     private object EntityRecordRawSqlQuery extends RawSqlQuery {
       val driver: JdbcProfile = EntityComponent.this.driver
-      implicit val getEntityRecord = GetResult { r => EntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<) }
+      implicit val getEntityRecord = GetResult(r => EntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
 
-      def action(workspaceId: UUID, entities: Set[AttributeEntityReference]): ReadAction[Seq[EntityRecord]] = {
-        if( entities.isEmpty ) {
+      def action(workspaceId: UUID, entities: Set[AttributeEntityReference]): ReadAction[Seq[EntityRecord]] =
+        if (entities.isEmpty) {
           DBIO.successful(Seq.empty[EntityRecord])
         } else {
-          val baseSelect = sql"select id, name, entity_type, workspace_id, record_version, deleted, deleted_date from ENTITY where workspace_id = $workspaceId and ("
-          val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { entity => sql"(entity_type = ${entity.entityType} and name = ${entity.entityName})" }.toSeq, sql" OR ")
+          val baseSelect =
+            sql"select id, name, entity_type, workspace_id, record_version, deleted, deleted_date from ENTITY where workspace_id = $workspaceId and ("
+          val entityTypeNameTuples = reduceSqlActionsWithDelim(
+            entities.map(entity => sql"(entity_type = ${entity.entityType} and name = ${entity.entityName})").toSeq,
+            sql" OR "
+          )
           concatSqlActions(baseSelect, entityTypeNameTuples, sql")").as[EntityRecord]
         }
-      }
 
       def batchHide(workspaceId: UUID, entities: Seq[AttributeEntityReference]): ReadWriteAction[Seq[Int]] = {
         // get unique suffix for renaming
         val renameSuffix = "_" + getSufficientlyRandomSuffix(1000000000) // 1 billion
         val deletedDate = new Timestamp(new Date().getTime)
         // issue bulk rename/hide for all entities
-        val baseUpdate = sql"""update ENTITY set deleted=1, deleted_date=$deletedDate, name=CONCAT(name, $renameSuffix) where deleted=0 AND workspace_id=$workspaceId and (entity_type, name) in ("""
-        val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref => sql"(${ref.entityType}, ${ref.entityName})" })
+        val baseUpdate =
+          sql"""update ENTITY set deleted=1, deleted_date=$deletedDate, name=CONCAT(name, $renameSuffix) where deleted=0 AND workspace_id=$workspaceId and (entity_type, name) in ("""
+        val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref =>
+          sql"(${ref.entityType}, ${ref.entityName})"
+        })
         concatSqlActions(baseUpdate, entityTypeNameTuples, sql")").as[Int]
       }
 
@@ -187,28 +245,38 @@ trait EntityComponent {
         val renameSuffix = "_" + getSufficientlyRandomSuffix(1000000000) // 1 billion
         val deletedDate = new Timestamp(new Date().getTime)
         // issue bulk rename/hide for all entities of the specified type
-        val typeUpdate = sql"""update ENTITY set deleted=1, deleted_date=$deletedDate, name=CONCAT(name, $renameSuffix) where deleted=0 AND workspace_id=$workspaceId and entity_type=$entityType"""
+        val typeUpdate =
+          sql"""update ENTITY set deleted=1, deleted_date=$deletedDate, name=CONCAT(name, $renameSuffix) where deleted=0 AND workspace_id=$workspaceId and entity_type=$entityType"""
         typeUpdate.as[Int]
       }
 
-      def activeActionForRefs(workspaceId: UUID, entities: Set[AttributeEntityReference]): ReadAction[Seq[AttributeEntityReference]] = {
-        if( entities.isEmpty ) {
+      def activeActionForRefs(workspaceId: UUID,
+                              entities: Set[AttributeEntityReference]
+      ): ReadAction[Seq[AttributeEntityReference]] =
+        if (entities.isEmpty) {
           DBIO.successful(Seq.empty[AttributeEntityReference])
         } else {
           val baseSelect = sql"select entity_type, name from ENTITY where workspace_id = $workspaceId and ("
-          val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { entity => sql"(entity_type = ${entity.entityType} and name = ${entity.entityName})" }.toSeq, sql" OR ")
-          concatSqlActions(baseSelect, entityTypeNameTuples, sql") and deleted = 0").as[(String, String)].map { vect => vect.map { pair => AttributeEntityReference(pair._1, pair._2) } }
+          val entityTypeNameTuples = reduceSqlActionsWithDelim(
+            entities.map(entity => sql"(entity_type = ${entity.entityType} and name = ${entity.entityName})").toSeq,
+            sql" OR "
+          )
+          concatSqlActions(baseSelect, entityTypeNameTuples, sql") and deleted = 0").as[(String, String)].map { vect =>
+            vect.map(pair => AttributeEntityReference(pair._1, pair._2))
+          }
         }
-      }
 
     }
 
-    //noinspection ScalaDocMissingParameterDescription,SqlDialectInspection,RedundantBlock,DuplicatedCode
+    // noinspection ScalaDocMissingParameterDescription,SqlDialectInspection,RedundantBlock,DuplicatedCode
     private object EntityAndAttributesRawSqlQuery extends RawSqlQuery {
       val driver: JdbcProfile = EntityComponent.this.driver
 
       // result structure from entity and attribute list raw sql
-      case class EntityAndAttributesResult(entityRecord: EntityRecord, attributeRecord: Option[EntityAttributeRecord], refEntityRecord: Option[EntityRecord])
+      case class EntityAndAttributesResult(entityRecord: EntityRecord,
+                                           attributeRecord: Option[EntityAttributeRecord],
+                                           refEntityRecord: Option[EntityRecord]
+      )
 
       // tells slick how to convert a result row from a raw sql query to an instance of EntityAndAttributesResult
       implicit val getEntityAndAttributesResult = GetResult { r =>
@@ -216,52 +284,63 @@ trait EntityComponent {
         val entityRec = EntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
 
         val attributeIdOption: Option[Long] = r.<<
-        val attributeRecOption = attributeIdOption.map(id => EntityAttributeRecord(id, entityRec.id, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<))
+        val attributeRecOption = attributeIdOption.map(id =>
+          EntityAttributeRecord(id, entityRec.id, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
+        )
 
         val refEntityRecOption = for {
           attributeRec <- attributeRecOption
           _ <- attributeRec.valueEntityRef
-        } yield {
-          EntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
-        }
+        } yield EntityRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
 
         EntityAndAttributesResult(entityRec, attributeRecOption, refEntityRecOption)
       }
 
       // the where clause for this query is filled in specific to the use case
-      def baseEntityAndAttributeSql(workspace: Workspace): String = baseEntityAndAttributeSql(workspace.workspaceIdAsUUID)
+      def baseEntityAndAttributeSql(workspace: Workspace): String = baseEntityAndAttributeSql(
+        workspace.workspaceIdAsUUID
+      )
 
       def baseEntityAndAttributeSql(workspaceId: UUID): String = baseEntityAndAttributeSql(determineShard(workspaceId))
 
-      private def baseEntityAndAttributeSql(shardId: ShardId): String = {
+      private def baseEntityAndAttributeSql(shardId: ShardId): String =
         s"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
           a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
           e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
           from ENTITY e
           left outer join ENTITY_ATTRIBUTE_$shardId a on a.owner_id = e.id and a.deleted = e.deleted
           left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id"""
-      }
 
       // Active actions: only return entities and attributes with their deleted flag set to false
 
-      def activeActionForType(workspaceContext: Workspace, entityType: String): ReadAction[Seq[EntityAndAttributesResult]] = {
-        sql"""#${baseEntityAndAttributeSql(workspaceContext)} where e.deleted = false and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""".as[EntityAndAttributesResult]
-      }
+      def activeActionForType(workspaceContext: Workspace,
+                              entityType: String
+      ): ReadAction[Seq[EntityAndAttributesResult]] =
+        sql"""#${baseEntityAndAttributeSql(
+            workspaceContext
+          )} where e.deleted = false and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
+          .as[EntityAndAttributesResult]
 
-      def activeActionForRefs(workspaceContext: Workspace, entityRefs: Set[AttributeEntityReference]): ReadAction[Seq[EntityAndAttributesResult]] = {
-        if( entityRefs.isEmpty ) {
+      def activeActionForRefs(workspaceContext: Workspace,
+                              entityRefs: Set[AttributeEntityReference]
+      ): ReadAction[Seq[EntityAndAttributesResult]] =
+        if (entityRefs.isEmpty) {
           DBIO.successful(Seq.empty[EntityAndAttributesResult])
         } else {
-          val baseSelect = sql"""#${baseEntityAndAttributeSql(workspaceContext)} where e.deleted = false and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} and (e.entity_type, e.name) in ("""
-          val entityTypeNameTuples = reduceSqlActionsWithDelim(entityRefs.map { ref => sql"(${ref.entityType}, ${ref.entityName})" }.toSeq)
+          val baseSelect = sql"""#${baseEntityAndAttributeSql(
+              workspaceContext
+            )} where e.deleted = false and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} and (e.entity_type, e.name) in ("""
+          val entityTypeNameTuples = reduceSqlActionsWithDelim(entityRefs.map { ref =>
+            sql"(${ref.entityType}, ${ref.entityName})"
+          }.toSeq)
           concatSqlActions(baseSelect, entityTypeNameTuples, sql")").as[EntityAndAttributesResult]
         }
 
-      }
-
-      def activeActionForWorkspace(workspaceContext: Workspace): ReadAction[Seq[EntityAndAttributesResult]] = {
-        sql"""#${baseEntityAndAttributeSql(workspaceContext)} where e.deleted = false and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""".as[EntityAndAttributesResult]
-      }
+      def activeActionForWorkspace(workspaceContext: Workspace): ReadAction[Seq[EntityAndAttributesResult]] =
+        sql"""#${baseEntityAndAttributeSql(
+            workspaceContext
+          )} where e.deleted = false and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
+          .as[EntityAndAttributesResult]
 
       /**
         * Generates a sub query that can be filtered, sorted, sliced
@@ -274,25 +353,36 @@ trait EntityComponent {
         val shardId = determineShard(workspaceId)
 
         val (sortColumns, sortJoin) = sortFieldName match {
-          case "name" => (
-            // no additional sort columns
-            "",
-            // no additional join required
-            sql"")
+          case "name" =>
+            (
+              // no additional sort columns
+              "",
+              // no additional join required
+              sql""
+            )
           case _ =>
             // sortFieldName may be a namespace:name delimited string
             val sortAttr = AttributeName.fromDelimitedName(sortFieldName)
             (
-            // select each attribute column and the referenced entity name
-            """, sort_a.list_length as sort_list_length, sort_a.value_string as sort_field_string, sort_a.value_number as sort_field_number, sort_a.value_boolean as sort_field_boolean, sort_a.value_json as sort_field_json, sort_e_ref.name as sort_field_ref""",
-            // join to attribute and entity (for references) table, grab only the named sort attribute and only the first element of a list
-            sql"""left outer join ENTITY_ATTRIBUTE_#$shardId sort_a on sort_a.owner_id = e.id and sort_a.namespace = ${sortAttr.namespace} and sort_a.name = ${sortAttr.name} and ifnull(sort_a.list_index, 0) = 0 left outer join ENTITY sort_e_ref on sort_a.value_entity_ref = sort_e_ref.id """)
+              // select each attribute column and the referenced entity name
+              """, sort_a.list_length as sort_list_length, sort_a.value_string as sort_field_string, sort_a.value_number as sort_field_number, sort_a.value_boolean as sort_field_boolean, sort_a.value_json as sort_field_json, sort_e_ref.name as sort_field_ref""",
+              // join to attribute and entity (for references) table, grab only the named sort attribute and only the first element of a list
+              sql"""left outer join ENTITY_ATTRIBUTE_#$shardId sort_a on sort_a.owner_id = e.id and sort_a.namespace = ${sortAttr.namespace} and sort_a.name = ${sortAttr.name} and ifnull(sort_a.list_index, 0) = 0 left outer join ENTITY sort_e_ref on sort_a.value_entity_ref = sort_e_ref.id """
+            )
         }
 
-        concatSqlActions(sql"""select e.id, e.name #$sortColumns from ENTITY e """, sortJoin, sql""" where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId """)
+        concatSqlActions(
+          sql"""select e.id, e.name #$sortColumns from ENTITY e """,
+          sortJoin,
+          sql""" where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = $workspaceId """
+        )
       }
 
-      def activeActionForPagination(workspaceContext: Workspace, entityType: String, entityQuery: model.EntityQuery, parentContext: RawlsRequestContext): ReadWriteAction[(Int, Int, Seq[EntityAndAttributesResult])] = {
+      def activeActionForPagination(workspaceContext: Workspace,
+                                    entityType: String,
+                                    entityQuery: model.EntityQuery,
+                                    parentContext: RawlsRequestContext
+      ): ReadWriteAction[(Int, Int, Seq[EntityAndAttributesResult])] = {
         /*
           Lots of conditionals in here, to achieve the optimal SQL query for any given request. Pseudocode:
 
@@ -312,14 +402,20 @@ trait EntityComponent {
 
         // generate the clause to filter based on user search terms
         def filterSql(prefix: String, alias: String) = {
-          val filtersOption = entityQuery.filterTerms.map { _.split(" ").toSeq.map { term =>
-            sql"concat(#$alias.name, ' ', #$alias.all_attribute_values) like ${'%' + term.toLowerCase + '%'}"
-          }}
+          val filtersOption = entityQuery.filterTerms.map {
+            _.split(" ").toSeq.map { term =>
+              sql"concat(#$alias.name, ' ', #$alias.all_attribute_values) like ${'%' + term.toLowerCase + '%'}"
+            }
+          }
 
           filtersOption match {
             case None => sql""
             case Some(filters) =>
-              concatSqlActions(sql"#$prefix (", reduceSqlActionsWithDelim(filters, sql" #${FilterOperators.toSql(entityQuery.filterOperator)} "), sql") ")
+              concatSqlActions(
+                sql"#$prefix (",
+                reduceSqlActionsWithDelim(filters, sql" #${FilterOperators.toSql(entityQuery.filterOperator)} "),
+                sql") "
+              )
           }
         }
 
@@ -345,7 +441,12 @@ trait EntityComponent {
           }
           entityQuery.sortField match {
             case "name" => sql" order by #${prefix}name #${SortDirections.toSql(entityQuery.sortDirection)} "
-            case _ => sql" order by #${prefix}sort_list_length #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}sort_field_string #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}sort_field_number #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}sort_field_boolean #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}sort_field_ref #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}name #${SortDirections.toSql(entityQuery.sortDirection)} "
+            case _ =>
+              sql" order by #${prefix}sort_list_length #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}sort_field_string #${SortDirections
+                  .toSql(entityQuery.sortDirection)}, #${prefix}sort_field_number #${SortDirections.toSql(
+                  entityQuery.sortDirection
+                )}, #${prefix}sort_field_boolean #${SortDirections.toSql(entityQuery.sortDirection)}, #${prefix}sort_field_ref #${SortDirections
+                  .toSql(entityQuery.sortDirection)}, #${prefix}name #${SortDirections.toSql(entityQuery.sortDirection)} "
           }
         }
 
@@ -355,7 +456,7 @@ trait EntityComponent {
           paginationSubquery(workspaceContext.workspaceIdAsUUID, entityType, entityQuery.sortField),
           filterSql("and", "e"),
           order(""),
-          sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page-1) * entityQuery.pageSize} ) p on p.id = e.id "
+          sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page - 1) * entityQuery.pageSize} ) p on p.id = e.id "
         )
 
         // standalone query to calculate the count of results that match our filter
@@ -389,7 +490,8 @@ trait EntityComponent {
                              where e.deleted = 'false' and e.entity_type = $entityType and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """,
               filterSql("and", "e"),
               order("e"),
-              sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page-1) * entityQuery.pageSize}").as[EntityAndAttributesResult]
+              sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page - 1) * entityQuery.pageSize}"
+            ).as[EntityAndAttributesResult]
           } else {
             // user is sorting by an attribute value, so we need the largest number of joins
             // this query is very similar to baseEntityAndAttributeSql
@@ -407,18 +509,23 @@ trait EntityComponent {
                              left outer join ENTITY_ATTRIBUTE_#$shardId a on a.owner_id = e.id and a.deleted = e.deleted """,
               attrSelectionSql(" and "),
               sql""" left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id """,
-              paginationJoin, order("p")).as[EntityAndAttributesResult]
+              paginationJoin,
+              order("p")
+            ).as[EntityAndAttributesResult]
           }
         }
 
         for {
-          unfilteredCount <- traceDBIOWithParent("findActiveEntityByType", parentContext)(_ => findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result)
-          filteredCount <- if (entityQuery.filterTerms.isEmpty) {
-                              // if the query has no filter, then "filteredCount" and "unfilteredCount" will always be the same; no need to make another query
-                              DBIO.successful(Vector(unfilteredCount))
-                            } else {
-                              traceDBIOWithParent("filteredCountQuery", parentContext)(_ => filteredCountQuery)
-                            }
+          unfilteredCount <- traceDBIOWithParent("findActiveEntityByType", parentContext)(_ =>
+            findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
+          )
+          filteredCount <-
+            if (entityQuery.filterTerms.isEmpty) {
+              // if the query has no filter, then "filteredCount" and "unfilteredCount" will always be the same; no need to make another query
+              DBIO.successful(Vector(unfilteredCount))
+            } else {
+              traceDBIOWithParent("filteredCountQuery", parentContext)(_ => filteredCountQuery)
+            }
           page <- traceDBIOWithParent("pageQuery", parentContext)(_ => pageQuery)
         } yield (unfilteredCount, filteredCount.head, page)
       }
@@ -426,23 +533,28 @@ trait EntityComponent {
 
       // actions which may include "deleted" hidden entities
 
-      def actionForTypeName(workspaceContext: Workspace, entityType: String, entityName: String): ReadAction[Seq[EntityAndAttributesResult]] = {
-        sql"""#${baseEntityAndAttributeSql(workspaceContext)} where e.name = ${entityName} and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""".as[EntityAndAttributesResult]
-      }
+      def actionForTypeName(workspaceContext: Workspace,
+                            entityType: String,
+                            entityName: String
+      ): ReadAction[Seq[EntityAndAttributesResult]] =
+        sql"""#${baseEntityAndAttributeSql(
+            workspaceContext
+          )} where e.name = ${entityName} and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
+          .as[EntityAndAttributesResult]
 
-      def actionForIds(workspaceId: UUID, entityIds: Set[Long]): ReadAction[Seq[EntityAndAttributesResult]] = {
-        if( entityIds.isEmpty ) {
+      def actionForIds(workspaceId: UUID, entityIds: Set[Long]): ReadAction[Seq[EntityAndAttributesResult]] =
+        if (entityIds.isEmpty) {
           DBIO.successful(Seq.empty[EntityAndAttributesResult])
         } else {
           val baseSelect = sql"""#${baseEntityAndAttributeSql(workspaceId)} where e.id in ("""
-          val entityIdSql = reduceSqlActionsWithDelim(entityIds.map { id => sql"$id" }.toSeq)
+          val entityIdSql = reduceSqlActionsWithDelim(entityIds.map(id => sql"$id").toSeq)
           concatSqlActions(baseSelect, entityIdSql, sql")").as[EntityAndAttributesResult]
         }
-      }
 
-      def actionForWorkspace(workspaceContext: Workspace): ReadAction[Seq[EntityAndAttributesResult]] = {
-        sql"""#${baseEntityAndAttributeSql(workspaceContext)} where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""".as[EntityAndAttributesResult]
-      }
+      def actionForWorkspace(workspaceContext: Workspace): ReadAction[Seq[EntityAndAttributesResult]] =
+        sql"""#${baseEntityAndAttributeSql(
+            workspaceContext
+          )} where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""".as[EntityAndAttributesResult]
 
       def batchHide(workspaceContext: Workspace, entities: Seq[AttributeEntityReference]): ReadWriteAction[Seq[Int]] = {
         val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
@@ -454,7 +566,9 @@ trait EntityComponent {
           sql"""update ENTITY_ATTRIBUTE_#$shardId ea join ENTITY e on ea.owner_id = e.id
                 set ea.deleted=1, ea.deleted_date=$deletedDate, ea.name=CONCAT(ea.name, $renameSuffix)
                 where e.workspace_id=${workspaceContext.workspaceIdAsUUID} and ea.deleted=0 and (e.entity_type, e.name) in ("""
-        val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref => sql"(${ref.entityType}, ${ref.entityName})" })
+        val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref =>
+          sql"(${ref.entityType}, ${ref.entityName})"
+        })
         concatSqlActions(baseUpdate, entityTypeNameTuples, sql")").as[Int]
       }
 
@@ -474,21 +588,22 @@ trait EntityComponent {
       def countReferencesToType(workspaceContext: Workspace, entityType: String): ReadAction[Vector[Int]] = {
         val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
 
-        val countQuery = sql"""select count(ea.id) from ENTITY doing_reference, ENTITY being_referenced, ENTITY_ATTRIBUTE_#$shardId ea where ea.value_entity_ref = being_referenced.id
-             |and ea.owner_id = doing_reference.id
-             |and being_referenced.entity_type=$entityType
-             |and doing_reference.entity_type!=$entityType
-             |and ea.deleted = 0
-             |and doing_reference.deleted = 0
-             |and being_referenced.workspace_id=${workspaceContext.workspaceIdAsUUID}""".stripMargin
+        val countQuery =
+          sql"""select count(ea.id) from ENTITY doing_reference, ENTITY being_referenced, ENTITY_ATTRIBUTE_#$shardId ea where ea.value_entity_ref = being_referenced.id
+               |and ea.owner_id = doing_reference.id
+               |and being_referenced.entity_type=$entityType
+               |and doing_reference.entity_type!=$entityType
+               |and ea.deleted = 0
+               |and doing_reference.deleted = 0
+               |and being_referenced.workspace_id=${workspaceContext.workspaceIdAsUUID}""".stripMargin
 
-          countQuery.as[Int]
+        countQuery.as[Int]
       }
     }
 
     // Raw query for performing actual deletion (not hiding) of everything that depends on an entity
 
-    //noinspection SqlDialectInspection
+    // noinspection SqlDialectInspection
     private object EntityDependenciesDeletionQuery extends RawSqlQuery {
       val driver: JdbcProfile = EntityComponent.this.driver
 
@@ -503,31 +618,36 @@ trait EntityComponent {
       }
     }
 
-    //noinspection SqlDialectInspection
+    // noinspection SqlDialectInspection
     private object CheckForExistingEntityTypeQuery extends RawSqlQuery {
       val driver: JdbcProfile = EntityComponent.this.driver
 
-      def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Seq[Boolean]] = {
-
+      def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Seq[Boolean]] =
         sql"""select exists (select name from ENTITY
                where workspace_id=${workspaceContext.workspaceIdAsUUID} and entity_type = $entityType and deleted = 0)
           """.as[Boolean]
-      }
     }
 
-    //noinspection SqlDialectInspection
+    // noinspection SqlDialectInspection
     private object CopyEntitiesQuery extends RawSqlQuery {
       val driver: JdbcProfile = EntityComponent.this.driver
 
-      def copyEntities(clonedWorkspaceId: UUID, newWorkspaceId: UUID, entityRefs: Set[AttributeEntityReference] = Set()): WriteAction[Int] = {
+      def copyEntities(clonedWorkspaceId: UUID,
+                       newWorkspaceId: UUID,
+                       entityRefs: Set[AttributeEntityReference] = Set()
+      ): WriteAction[Int] = {
 
-        val baseInsert = sql"""insert into ENTITY (name, entity_type, workspace_id, record_version, all_attribute_values, deleted, deleted_date)
+        val baseInsert =
+          sql"""insert into ENTITY (name, entity_type, workspace_id, record_version, all_attribute_values, deleted, deleted_date)
                 select name, entity_type, $newWorkspaceId, record_version, all_attribute_values, 0, null from ENTITY e where workspace_id = $clonedWorkspaceId and deleted = 0
           """
         addEntitiesToWhereIfNeeded(entityRefs, baseInsert).head
       }
 
-      def copyAttributes(clonedWorkspaceId: UUID, newWorkspaceId: UUID, entityRefs: Set[AttributeEntityReference] = Set()): WriteAction[Int] = {
+      def copyAttributes(clonedWorkspaceId: UUID,
+                         newWorkspaceId: UUID,
+                         entityRefs: Set[AttributeEntityReference] = Set()
+      ): WriteAction[Int] = {
 
         val sourceShardId = determineShard(clonedWorkspaceId)
         val destShardId = determineShard(newWorkspaceId)
@@ -555,39 +675,39 @@ trait EntityComponent {
         addEntitiesToWhereIfNeeded(entityRefs, baseInsert).head
       }
 
-      private def addEntitiesToWhereIfNeeded(entityRefs: Set[AttributeEntityReference], baseInsert: SQLActionBuilder) = {
+      private def addEntitiesToWhereIfNeeded(entityRefs: Set[AttributeEntityReference], baseInsert: SQLActionBuilder) =
         if (entityRefs.nonEmpty) {
-          val entityTypeNameTuples = reduceSqlActionsWithDelim(entityRefs.map { entity => sql"(e.entity_type = ${entity.entityType} and e.name = ${entity.entityName})" }.toSeq, sql" OR ")
+          val entityTypeNameTuples = reduceSqlActionsWithDelim(
+            entityRefs.map { entity =>
+              sql"(e.entity_type = ${entity.entityType} and e.name = ${entity.entityName})"
+            }.toSeq,
+            sql" OR "
+          )
           concatSqlActions(baseInsert, sql" and (", entityTypeNameTuples, sql")").as[Int]
         } else {
           baseInsert.as[Int]
         }
-      }
     }
 
-    //noinspection SqlDialectInspection
+    // noinspection SqlDialectInspection
     private object ChangeEntityTypeNameQuery extends RawSqlQuery {
       val driver: JdbcProfile = EntityComponent.this.driver
 
-      def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): WriteAction[Int] = {
-
+      def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): WriteAction[Int] =
         sqlu"""update ENTITY set entity_type = $newName
               where workspace_id=${workspaceContext.workspaceIdAsUUID} and entity_type = $oldName and deleted = 0
           """
-      }
     }
 
     // Slick queries
 
     // Active queries: only return entities and attributes with their deleted flag set to false
 
-    def findActiveEntityByType(workspaceId: UUID, entityType: String): EntityQuery = {
-      filter(entRec => entRec.entityType === entityType && entRec.workspaceId === workspaceId && ! entRec.deleted)
-    }
+    def findActiveEntityByType(workspaceId: UUID, entityType: String): EntityQuery =
+      filter(entRec => entRec.entityType === entityType && entRec.workspaceId === workspaceId && !entRec.deleted)
 
-    def findActiveEntityByWorkspace(workspaceId: UUID): EntityQuery = {
-      filter(entRec => entRec.workspaceId === workspaceId && ! entRec.deleted)
-    }
+    def findActiveEntityByWorkspace(workspaceId: UUID): EntityQuery =
+      filter(entRec => entRec.workspaceId === workspaceId && !entRec.deleted)
 
     /**
       * given a set of AttributeEntityReference, query the db and return those refs that
@@ -598,71 +718,81 @@ trait EntityComponent {
       * @param entities the refs for which to query
       * @return the subset of refs that are active and found in the workspace
       */
-    def getActiveRefs(workspaceId: UUID, entities: Set[AttributeEntityReference]): ReadAction[Seq[AttributeEntityReference]] = {
+    def getActiveRefs(workspaceId: UUID,
+                      entities: Set[AttributeEntityReference]
+    ): ReadAction[Seq[AttributeEntityReference]] =
       EntityRecordRawSqlQuery.activeActionForRefs(workspaceId, entities)
-    }
 
     private def findActiveAttributesByEntityId(workspaceId: UUID, entityId: Rep[Long]): EntityAttributeQuery = for {
-      entityAttrRec <- entityAttributeShardQuery(workspaceId) if entityAttrRec.ownerId === entityId && ! entityAttrRec.deleted
+      entityAttrRec <- entityAttributeShardQuery(workspaceId)
+      if entityAttrRec.ownerId === entityId && !entityAttrRec.deleted
     } yield entityAttrRec
 
     // queries which may include "deleted" hidden entities
 
-    def findEntityByName(workspaceId: UUID, entityType: String, entityName: String): EntityQuery = {
-      filter(entRec => entRec.name === entityName && entRec.entityType === entityType && entRec.workspaceId === workspaceId)
-    }
+    def findEntityByName(workspaceId: UUID, entityType: String, entityName: String): EntityQuery =
+      filter(entRec =>
+        entRec.name === entityName && entRec.entityType === entityType && entRec.workspaceId === workspaceId
+      )
 
-    def findEntityById(id: Long): EntityQuery = {
+    def findEntityById(id: Long): EntityQuery =
       filter(_.id === id)
-    }
 
     // Actions
 
     // get a specific entity or set of entities: may include "hidden" deleted entities if not named "active"
 
-    def get(workspaceContext: Workspace, entityType: String, entityName: String): ReadAction[Option[Entity]] = {
-      EntityAndAttributesRawSqlQuery.actionForTypeName(workspaceContext, entityType, entityName) map(query => unmarshalEntities(query)) map(_.headOption)
-    }
+    def get(workspaceContext: Workspace, entityType: String, entityName: String): ReadAction[Option[Entity]] =
+      EntityAndAttributesRawSqlQuery.actionForTypeName(workspaceContext, entityType, entityName) map (query =>
+        unmarshalEntities(query)
+      ) map (_.headOption)
 
-    def getEntities(workspaceId: UUID, entityIds: Traversable[Long]): ReadAction[Seq[(Long, Entity)]] = {
-      EntityAndAttributesRawSqlQuery.actionForIds(workspaceId, entityIds.toSet) map(query => unmarshalEntitiesWithIds(query))
-    }
+    def getEntities(workspaceId: UUID, entityIds: Traversable[Long]): ReadAction[Seq[(Long, Entity)]] =
+      EntityAndAttributesRawSqlQuery.actionForIds(workspaceId, entityIds.toSet) map (query =>
+        unmarshalEntitiesWithIds(query)
+      )
 
     def getEntityRecords(workspaceId: UUID, entities: Set[AttributeEntityReference]): ReadAction[Seq[EntityRecord]] = {
       val entitiesGrouped = entities.grouped(batchSize).toSeq
 
-      DBIO.sequence(entitiesGrouped map { batch =>
-        EntityRecordRawSqlQuery.action(workspaceId, batch)
-      }).map(_.flatten)
+      DBIO
+        .sequence(entitiesGrouped map { batch =>
+          EntityRecordRawSqlQuery.action(workspaceId, batch)
+        })
+        .map(_.flatten)
     }
 
-    def getActiveEntities(workspaceContext: Workspace, entityRefs: Traversable[AttributeEntityReference]): ReadAction[TraversableOnce[Entity]] = {
-      EntityAndAttributesRawSqlQuery.activeActionForRefs(workspaceContext, entityRefs.toSet) map(query => unmarshalEntities(query))
-    }
+    def getActiveEntities(workspaceContext: Workspace,
+                          entityRefs: Traversable[AttributeEntityReference]
+    ): ReadAction[TraversableOnce[Entity]] =
+      EntityAndAttributesRawSqlQuery.activeActionForRefs(workspaceContext, entityRefs.toSet) map (query =>
+        unmarshalEntities(query)
+      )
 
     // list all entities or those in a category
 
-    def listActiveEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] = {
-      EntityAndAttributesRawSqlQuery.activeActionForWorkspace(workspaceContext) map(query => unmarshalEntities(query))
-    }
+    def listActiveEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
+      EntityAndAttributesRawSqlQuery.activeActionForWorkspace(workspaceContext) map (query => unmarshalEntities(query))
 
     // includes "deleted" hidden entities
-    //Note: currently only used by tests?
-    def listEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] = {
-      EntityAndAttributesRawSqlQuery.actionForWorkspace(workspaceContext) map(query => unmarshalEntities(query))
-    }
+    // Note: currently only used by tests?
+    def listEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
+      EntityAndAttributesRawSqlQuery.actionForWorkspace(workspaceContext) map (query => unmarshalEntities(query))
 
-    def listActiveEntitiesOfType(workspaceContext: Workspace, entityType: String): ReadAction[TraversableOnce[Entity]] = {
-      EntityAndAttributesRawSqlQuery.activeActionForType(workspaceContext, entityType) map(query => unmarshalEntities(query))
-    }
+    def listActiveEntitiesOfType(workspaceContext: Workspace, entityType: String): ReadAction[TraversableOnce[Entity]] =
+      EntityAndAttributesRawSqlQuery.activeActionForType(workspaceContext, entityType) map (query =>
+        unmarshalEntities(query)
+      )
 
-    def getEntityTypesWithCounts(workspaceId: UUID): ReadAction[Map[String, Int]] = {
-      findActiveEntityByWorkspace(workspaceId).groupBy(e => e.entityType).map { case (entityType, entities) =>
-        (entityType, entities.length)
-      }.result map { result =>
+    def getEntityTypesWithCounts(workspaceId: UUID): ReadAction[Map[String, Int]] =
+      findActiveEntityByWorkspace(workspaceId)
+        .groupBy(e => e.entityType)
+        .map { case (entityType, entities) =>
+          (entityType, entities.length)
+        }
+        .result map { result =>
         result.toMap
       }
-    }
 
     /**
       * Find the distinct attribute names associated with each entity type in the workspace.
@@ -671,36 +801,43 @@ trait EntityComponent {
       *                     no limit
       * @return result set containing entity types -> seq of attribute names
       */
-    def getAttrNamesAndEntityTypes(workspaceId: UUID, queryTimeout: Int = 0): ReadAction[Map[String, Seq[AttributeName]]] = {
+    def getAttrNamesAndEntityTypes(workspaceId: UUID,
+                                   queryTimeout: Int = 0
+    ): ReadAction[Map[String, Seq[AttributeName]]] = {
       val typesAndAttrNames = for {
         entityRec <- findActiveEntityByWorkspace(workspaceId)
         attrib <- findActiveAttributesByEntityId(workspaceId, entityRec.id)
-      } yield {
-        (entityRec.entityType, (attrib.namespace, attrib.name))
-      }
+      } yield (entityRec.entityType, (attrib.namespace, attrib.name))
 
-      typesAndAttrNames.distinct.result.withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout)) map { result =>
-        CollectionUtils.groupByTuples (result.map {
-          case (entityType:String, (ns:String, n:String)) => (entityType, AttributeName(ns, n))
-        })
+      typesAndAttrNames.distinct.result.withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout)) map {
+        result =>
+          CollectionUtils.groupByTuples(result.map { case (entityType: String, (ns: String, n: String)) =>
+            (entityType, AttributeName(ns, n))
+          })
       }
     }
 
     // get paginated entities for UI display, as a result of executing a query
-    def loadEntityPage(workspaceContext: Workspace, entityType: String, entityQuery: model.EntityQuery, parentContext: RawlsRequestContext): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
-      EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext, entityType, entityQuery, parentContext) map { case (unfilteredCount, filteredCount, pagination) =>
+    def loadEntityPage(workspaceContext: Workspace,
+                       entityType: String,
+                       entityQuery: model.EntityQuery,
+                       parentContext: RawlsRequestContext
+    ): ReadWriteAction[(Int, Int, Iterable[Entity])] =
+      EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
+                                                               entityType,
+                                                               entityQuery,
+                                                               parentContext
+      ) map { case (unfilteredCount, filteredCount, pagination) =>
         (unfilteredCount, filteredCount, unmarshalEntities(pagination))
       }
-    }
 
     // create or replace entities
 
     // TODO: can this be optimized? It nicely reuses the save(..., entities) method, but that method
     // does a lot of work. This single-entity save could, for instance, look for simple cases e.g. no references,
     // and take an easier code path.
-    def save(workspaceContext: Workspace, entity: Entity): ReadWriteAction[Entity] = {
+    def save(workspaceContext: Workspace, entity: Entity): ReadWriteAction[Entity] =
       save(workspaceContext, Seq(entity)).map(_.head)
-    }
 
     def save(workspaceContext: Workspace, entities: Traversable[Entity]): ReadWriteAction[Traversable[Entity]] = {
       entities.foreach(validateEntity)
@@ -708,24 +845,46 @@ trait EntityComponent {
       for {
         _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
         preExistingEntityRecs <- getEntityRecords(workspaceContext.workspaceIdAsUUID, entities.map(_.toReference).toSet)
-        savingEntityRecs <- entityQueryWithInlineAttributes.insertNewEntities(workspaceContext, entities, preExistingEntityRecs.map(_.toReference)).map(_ ++ preExistingEntityRecs)
-        referencedAndSavingEntityRecs <- lookupNotYetLoadedReferences(workspaceContext, entities, savingEntityRecs.map(_.toReference)).map(_ ++ savingEntityRecs)
-        actuallyUpdatedEntityIds <- rewriteAttributes(workspaceContext.workspaceIdAsUUID, entities, savingEntityRecs.map(_.id), referencedAndSavingEntityRecs.map(e => e.toReference -> e.id).toMap)
-        actuallyUpdatedPreExistingEntityRecs = preExistingEntityRecs.filter(e => actuallyUpdatedEntityIds.contains(e.id))
+        savingEntityRecs <- entityQueryWithInlineAttributes
+          .insertNewEntities(workspaceContext, entities, preExistingEntityRecs.map(_.toReference))
+          .map(_ ++ preExistingEntityRecs)
+        referencedAndSavingEntityRecs <- lookupNotYetLoadedReferences(workspaceContext,
+                                                                      entities,
+                                                                      savingEntityRecs.map(_.toReference)
+        ).map(_ ++ savingEntityRecs)
+        actuallyUpdatedEntityIds <- rewriteAttributes(
+          workspaceContext.workspaceIdAsUUID,
+          entities,
+          savingEntityRecs.map(_.id),
+          referencedAndSavingEntityRecs.map(e => e.toReference -> e.id).toMap
+        )
+        actuallyUpdatedPreExistingEntityRecs = preExistingEntityRecs.filter(e =>
+          actuallyUpdatedEntityIds.contains(e.id)
+        )
         _ <- entityQueryWithInlineAttributes.optimisticLockUpdate(actuallyUpdatedPreExistingEntityRecs, entities)
       } yield entities
     }
 
-    private def applyEntityPatch(workspaceContext: Workspace, entityRecord: EntityRecord, upserts: AttributeMap, deletes: Traversable[AttributeName]) = {
-      //yank the attribute list for this entity to determine what to do with upserts
-      entityAttributeShardQuery(workspaceContext).findByOwnerQuery(Seq(entityRecord.id)).map(attr => (attr.namespace, attr.name, attr.id)).result flatMap { attrCols =>
-
+    private def applyEntityPatch(workspaceContext: Workspace,
+                                 entityRecord: EntityRecord,
+                                 upserts: AttributeMap,
+                                 deletes: Traversable[AttributeName]
+    ) =
+      // yank the attribute list for this entity to determine what to do with upserts
+      entityAttributeShardQuery(workspaceContext)
+        .findByOwnerQuery(Seq(entityRecord.id))
+        .map(attr => (attr.namespace, attr.name, attr.id))
+        .result flatMap { attrCols =>
         val existingAttrsToRecordIds: Map[AttributeName, Set[Long]] =
-          attrCols.groupBy { case (namespace, name, _) =>
-            (namespace, name)
-          }.map { case ((namespace, name), ids) =>
-            AttributeName(namespace, name) -> ids.map(_._3).toSet //maintain the full list of attribute ids since list members are stored as individual attributes
-          }
+          attrCols
+            .groupBy { case (namespace, name, _) =>
+              (namespace, name)
+            }
+            .map { case ((namespace, name), ids) =>
+              AttributeName(namespace, name) -> ids
+                .map(_._3)
+                .toSet // maintain the full list of attribute ids since list members are stored as individual attributes
+            }
 
         val entityRefsToLookup = upserts.valuesIterator.collect { case e: AttributeEntityReference => e }.toSet
 
@@ -740,7 +899,7 @@ trait EntityComponent {
           or delete extra records from the entity table respectively.
 
           NOTE: Attributes that are not lists are treated as a list of size one.
-        */
+         */
 
         // Tuple of
         // insertRecs: Seq[EntityAttributeRecord]
@@ -749,9 +908,10 @@ trait EntityComponent {
         type AttributeModifications = (Seq[EntityAttributeRecord], Seq[EntityAttributeRecord], Seq[Long])
 
         def checkAndUpdateRecSize(name: AttributeName,
-                               existingAttrSize: Int,
-                               updateAttrSize: Int,
-                               attrRecords: Seq[EntityAttributeRecord]): AttributeModifications = {
+                                  existingAttrSize: Int,
+                                  updateAttrSize: Int,
+                                  attrRecords: Seq[EntityAttributeRecord]
+        ): AttributeModifications =
           if (updateAttrSize > existingAttrSize) {
             // since the size of the "list" has increased, move these new records to insertRecs
             val (newInsertRecs, newUpdateRecs) = attrRecords.partition {
@@ -763,56 +923,80 @@ trait EntityComponent {
             // since the size of the list has decreased, delete the extra rows from table
             val deleteIds = existingAttrsToRecordIds(name).toSeq.takeRight(existingAttrSize - updateAttrSize)
             (Seq.empty[EntityAttributeRecord], attrRecords, deleteIds)
-          }
-          else (Seq.empty[EntityAttributeRecord], attrRecords, Seq.empty[Long]) // the list size hasn't changed
-        }
+          } else (Seq.empty[EntityAttributeRecord], attrRecords, Seq.empty[Long]) // the list size hasn't changed
 
         def recordsForUpdateAttribute(name: AttributeName,
                                       attribute: Attribute,
-                                      attrRecords: Seq[EntityAttributeRecord]): AttributeModifications = {
+                                      attrRecords: Seq[EntityAttributeRecord]
+        ): AttributeModifications = {
           val existingAttrSize = existingAttrsToRecordIds.get(name).map(_.size).getOrElse(0)
           attribute match {
             case list: AttributeList[_] => checkAndUpdateRecSize(name, existingAttrSize, list.list.size, attrRecords)
-            case _ => checkAndUpdateRecSize(name, existingAttrSize, 1, attrRecords)
+            case _                      => checkAndUpdateRecSize(name, existingAttrSize, 1, attrRecords)
           }
         }
 
-        lookupNotYetLoadedReferences(workspaceContext, entityRefsToLookup, Seq(entityRecord.toReference)) flatMap { entityRefRecs =>
-          val allTheEntityRefs = entityRefRecs ++ Seq(entityRecord) //re-add the current entity
-          val refsToIds = allTheEntityRefs.map(e => e.toReference -> e.id).toMap
+        lookupNotYetLoadedReferences(workspaceContext, entityRefsToLookup, Seq(entityRecord.toReference)) flatMap {
+          entityRefRecs =>
+            val allTheEntityRefs = entityRefRecs ++ Seq(entityRecord) // re-add the current entity
+            val refsToIds = allTheEntityRefs.map(e => e.toReference -> e.id).toMap
 
-          //get ids that need to be deleted from db
-          val deleteIds = (for {
-            attributeName <- deletes
-          } yield existingAttrsToRecordIds.get(attributeName)).flatten.flatten
+            // get ids that need to be deleted from db
+            val deleteIds = (for {
+              attributeName <- deletes
+            } yield existingAttrsToRecordIds.get(attributeName)).flatten.flatten
 
-          val (insertRecs: Seq[EntityAttributeRecord], updateRecs: Seq[EntityAttributeRecord], extraDeleteIds: Seq[Long]) = upserts.map {
-            case (name, attribute) =>
-              val attrRecords = entityAttributeShardQuery(workspaceContext).marshalAttribute(refsToIds(entityRecord.toReference), name, attribute, refsToIds)
+            val (insertRecs: Seq[EntityAttributeRecord],
+                 updateRecs: Seq[EntityAttributeRecord],
+                 extraDeleteIds: Seq[Long]
+            ) = upserts
+              .map { case (name, attribute) =>
+                val attrRecords =
+                  entityAttributeShardQuery(workspaceContext).marshalAttribute(refsToIds(entityRecord.toReference),
+                                                                               name,
+                                                                               attribute,
+                                                                               refsToIds
+                  )
 
-              recordsForUpdateAttribute(name, attribute, attrRecords)
-          }.foldLeft((Seq.empty[EntityAttributeRecord], Seq.empty[EntityAttributeRecord], Seq.empty[Long])) {
-              case ((insert1, update1, delete1), (insert2, update2, delete2)) => (insert1 ++ insert2, update1 ++ update2, delete1 ++ delete2)
-          }
+                recordsForUpdateAttribute(name, attribute, attrRecords)
+              }
+              .foldLeft((Seq.empty[EntityAttributeRecord], Seq.empty[EntityAttributeRecord], Seq.empty[Long])) {
+                case ((insert1, update1, delete1), (insert2, update2, delete2)) =>
+                  (insert1 ++ insert2, update1 ++ update2, delete1 ++ delete2)
+              }
 
-          val totalDeleteIds = deleteIds ++ extraDeleteIds
+            val totalDeleteIds = deleteIds ++ extraDeleteIds
 
-          entityAttributeShardQuery(workspaceContext).patchAttributesAction(insertRecs, updateRecs, totalDeleteIds, entityAttributeTempQuery.insertScratchAttributes)
+            entityAttributeShardQuery(workspaceContext).patchAttributesAction(
+              insertRecs,
+              updateRecs,
+              totalDeleteIds,
+              entityAttributeTempQuery.insertScratchAttributes
+            )
         }
       }
-    }
 
-    //"patch" this entity by applying the upserts and the deletes to its attributes, then save. a little more database efficient than a "full" save, but requires the entity already exist.
-    def saveEntityPatch(workspaceContext: Workspace, entityRef: AttributeEntityReference, upserts: AttributeMap, deletes: Traversable[AttributeName]) = {
+    // "patch" this entity by applying the upserts and the deletes to its attributes, then save. a little more database efficient than a "full" save, but requires the entity already exist.
+    def saveEntityPatch(workspaceContext: Workspace,
+                        entityRef: AttributeEntityReference,
+                        upserts: AttributeMap,
+                        deletes: Traversable[AttributeName]
+    ) = {
       val deleteIntersectUpsert = deletes.toSet intersect upserts.keySet
       if (upserts.isEmpty && deletes.isEmpty) {
-        DBIO.successful(()) //no-op
+        DBIO.successful(()) // no-op
       } else if (deleteIntersectUpsert.nonEmpty) {
-        DBIO.failed(new RawlsException(s"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"))
+        DBIO.failed(
+          new RawlsException(
+            s"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"
+          )
+        )
       } else {
         getEntityRecords(workspaceContext.workspaceIdAsUUID, Set(entityRef)) flatMap { entityRecs =>
           if (entityRecs.length != 1) {
-            throw new RawlsException(s"saveEntityPatch looked up $entityRef expecting 1 record, got ${entityRecs.length} instead")
+            throw new RawlsException(
+              s"saveEntityPatch looked up $entityRef expecting 1 record, got ${entityRecs.length} instead"
+            )
           }
 
           val entityRecord = entityRecs.head
@@ -830,50 +1014,73 @@ trait EntityComponent {
       }
     }
 
-    private def lookupNotYetLoadedReferences(workspaceContext: Workspace, entities: Traversable[Entity], alreadyLoadedEntityRefs: Seq[AttributeEntityReference]): ReadAction[Seq[EntityRecord]] = {
+    private def lookupNotYetLoadedReferences(workspaceContext: Workspace,
+                                             entities: Traversable[Entity],
+                                             alreadyLoadedEntityRefs: Seq[AttributeEntityReference]
+    ): ReadAction[Seq[EntityRecord]] = {
       val allRefAttributes = (for {
         entity <- entities
         (_, attribute) <- entity.attributes
         ref <- attribute match {
           case AttributeEntityReferenceList(l) => l
-          case r: AttributeEntityReference => Seq(r)
-          case _ => Seq.empty
+          case r: AttributeEntityReference     => Seq(r)
+          case _                               => Seq.empty
         }
       } yield ref).toSet
 
       lookupNotYetLoadedReferences(workspaceContext, allRefAttributes, alreadyLoadedEntityRefs)
     }
 
-    private def lookupNotYetLoadedReferences(workspaceContext: Workspace, attrReferences: Set[AttributeEntityReference], alreadyLoadedEntityRefs: Seq[AttributeEntityReference]): ReadAction[Seq[EntityRecord]] = {
+    private def lookupNotYetLoadedReferences(workspaceContext: Workspace,
+                                             attrReferences: Set[AttributeEntityReference],
+                                             alreadyLoadedEntityRefs: Seq[AttributeEntityReference]
+    ): ReadAction[Seq[EntityRecord]] = {
       val notYetLoadedEntityRecs = attrReferences -- alreadyLoadedEntityRefs
 
       getEntityRecords(workspaceContext.workspaceIdAsUUID, notYetLoadedEntityRecs) map { foundEntities =>
         if (foundEntities.size != notYetLoadedEntityRecs.size) {
           val notFoundRefs = notYetLoadedEntityRecs -- foundEntities.map(_.toReference)
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Could not resolve some entity references", notFoundRefs.map { missingRef =>
-            ErrorReport(s"${missingRef.entityType} ${missingRef.entityName} not found", Seq.empty)
-          }.toSeq))
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              "Could not resolve some entity references",
+              notFoundRefs.map { missingRef =>
+                ErrorReport(s"${missingRef.entityType} ${missingRef.entityName} not found", Seq.empty)
+              }.toSeq
+            )
+          )
         } else {
           foundEntities
         }
       }
     }
 
-    private def rewriteAttributes(workspaceId: UUID, entitiesToSave: Traversable[Entity], entityIds: Seq[Long], entityIdsByRef: Map[AttributeEntityReference, Long]) = {
+    private def rewriteAttributes(workspaceId: UUID,
+                                  entitiesToSave: Traversable[Entity],
+                                  entityIds: Seq[Long],
+                                  entityIdsByRef: Map[AttributeEntityReference, Long]
+    ) = {
       val attributesToSave = for {
         entity <- entitiesToSave
         (attributeName, attribute) <- entity.attributes
-        attributeRec <- entityAttributeShardQuery(workspaceId).marshalAttribute(entityIdsByRef(entity.toReference), attributeName, attribute, entityIdsByRef)
+        attributeRec <- entityAttributeShardQuery(workspaceId).marshalAttribute(entityIdsByRef(entity.toReference),
+                                                                                attributeName,
+                                                                                attribute,
+                                                                                entityIdsByRef
+        )
       } yield attributeRec
 
       entityAttributeShardQuery(workspaceId).findByOwnerQuery(entityIds).result flatMap { existingAttributes =>
-        entityAttributeShardQuery(workspaceId).rewriteAttrsAction(attributesToSave, existingAttributes, entityAttributeTempQuery.insertScratchAttributes)
+        entityAttributeShardQuery(workspaceId).rewriteAttrsAction(attributesToSave,
+                                                                  existingAttributes,
+                                                                  entityAttributeTempQuery.insertScratchAttributes
+        )
       }
     }
 
     // "delete" entities by hiding and renaming. we must rename the entity to avoid future name collisions if the user
     // attempts to create a new entity of the same name.
-    def hide(workspaceContext: Workspace, entRefs: Seq[AttributeEntityReference]): ReadWriteAction[Int] = {
+    def hide(workspaceContext: Workspace, entRefs: Seq[AttributeEntityReference]): ReadWriteAction[Int] =
       // N.B. we must hide both the entity attributes and the entity itself. Other queries, such
       // as baseEntityAndAttributeSql, use "where ENTITY.deleted = ENTITY_ATTRIBUTE.deleted" during joins.
       // Thus, we need to keep the "deleted" value for attributes in sync with their parent entity,
@@ -881,41 +1088,35 @@ trait EntityComponent {
       workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
         EntityAndAttributesRawSqlQuery.batchHide(workspaceContext, entRefs) andThen
         EntityRecordRawSqlQuery.batchHide(workspaceContext.workspaceIdAsUUID, entRefs).map(res => res.sum)
-    }
 
     // "deletes" entities of a certain type by hiding and renaming them
-    def hideType(workspaceContext: Workspace, entityType: String): ReadWriteAction[Int] = {
+    def hideType(workspaceContext: Workspace, entityType: String): ReadWriteAction[Int] =
       for {
         _ <- EntityAndAttributesRawSqlQuery.batchHideAttributesOfType(workspaceContext, entityType)
         numEntitiesHidden <- EntityRecordRawSqlQuery.batchHideType(workspaceContext.workspaceIdAsUUID, entityType)
         _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
-      } yield {
-        numEntitiesHidden.sum
-      }
-    }
+      } yield numEntitiesHidden.sum
 
     // perform actual deletion (not hiding) of all entities in a workspace
 
-    def deleteFromDb(workspaceContext: Workspace): WriteAction[Int] = {
+    def deleteFromDb(workspaceContext: Workspace): WriteAction[Int] =
       EntityDependenciesDeletionQuery.deleteAction(workspaceContext) andThen {
         filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).delete
       }
-    }
 
-    def countReferringEntitiesForType(workspaceContext: Workspace, entityType: String): ReadAction[Int] = {
+    def countReferringEntitiesForType(workspaceContext: Workspace, entityType: String): ReadAction[Int] =
       EntityAndAttributesRawSqlQuery.countReferencesToType(workspaceContext, entityType).map(_.sum)
-    }
 
-    def copyEntitiesToNewWorkspace(sourceWs: UUID, destWs: UUID, entityRefs: Set[AttributeEntityReference] = Set()): WriteAction[(Int, Int)] = {
+    def copyEntitiesToNewWorkspace(sourceWs: UUID,
+                                   destWs: UUID,
+                                   entityRefs: Set[AttributeEntityReference] = Set()
+    ): WriteAction[(Int, Int)] = {
 
-      def copyChunkOfEntitiesOrAllEntities(chunk: Set[AttributeEntityReference] = Set()) = {
+      def copyChunkOfEntitiesOrAllEntities(chunk: Set[AttributeEntityReference] = Set()) =
         for {
           entitiesCopiedCount <- CopyEntitiesQuery.copyEntities(sourceWs, destWs, chunk)
           attributesCopiedCount <- CopyEntitiesQuery.copyAttributes(sourceWs, destWs, chunk)
-        } yield {
-          (entitiesCopiedCount, attributesCopiedCount)
-        }
-      }
+        } yield (entitiesCopiedCount, attributesCopiedCount)
 
       val chunks: Iterator[Set[AttributeEntityReference]] = if (entityRefs.size > batchSize) {
         entityRefs.grouped(batchSize)
@@ -930,20 +1131,20 @@ trait EntityComponent {
       }
     }
 
-    def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Option[Boolean]] = {
+    def doesEntityTypeAlreadyExist(workspaceContext: Workspace, entityType: String): ReadAction[Option[Boolean]] =
       uniqueResult(CheckForExistingEntityTypeQuery.doesEntityTypeAlreadyExist(workspaceContext, entityType))
-    }
 
-    def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): ReadWriteAction[Int] = {
+    def changeEntityTypeName(workspaceContext: Workspace, oldName: String, newName: String): ReadWriteAction[Int] =
       for {
         numRowsRenamed <- ChangeEntityTypeNameQuery.changeEntityTypeName(workspaceContext, oldName, newName)
         _ <- workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID)
-      } yield {
-        numRowsRenamed
-      }
-    }
+      } yield numRowsRenamed
 
-    def rename(workspaceContext: Workspace, entityType: String, oldName: String, newName: String): ReadWriteAction[Int] = {
+    def rename(workspaceContext: Workspace,
+               entityType: String,
+               oldName: String,
+               newName: String
+    ): ReadWriteAction[Int] = {
       validateEntityName(newName)
       workspaceQuery.updateLastModified(workspaceContext.workspaceIdAsUUID) andThen
         findEntityByName(workspaceContext.workspaceIdAsUUID, entityType, oldName).map(_.name).update(newName)
@@ -951,62 +1152,101 @@ trait EntityComponent {
 
     // copy entities from one workspace to another, checking for conflicts first
 
-    def checkAndCopyEntities(sourceWorkspaceContext: Workspace, destWorkspaceContext: Workspace, entityType: String, entityNames: Seq[String], linkExistingEntities: Boolean, parentContext: RawlsRequestContext): ReadWriteAction[EntityCopyResponse] = {
+    def checkAndCopyEntities(sourceWorkspaceContext: Workspace,
+                             destWorkspaceContext: Workspace,
+                             entityType: String,
+                             entityNames: Seq[String],
+                             linkExistingEntities: Boolean,
+                             parentContext: RawlsRequestContext
+    ): ReadWriteAction[EntityCopyResponse] = {
 
-      def getSoftConflicts(paths: Seq[EntityPath]) = {
+      def getSoftConflicts(paths: Seq[EntityPath]) =
         getCopyConflicts(destWorkspaceContext, paths.map(_.path.last)).map { conflicts =>
           val conflictsAsRefs = conflicts.toSeq.map(_.toReference)
           paths.filter(p => conflictsAsRefs.contains(p.path.last))
         }
-      }
 
-      def buildSoftConflictTree(pathsRemaining: EntityPath): Seq[EntitySoftConflict] = {
-        if(pathsRemaining.path.isEmpty) Seq.empty
-        else Seq(EntitySoftConflict(pathsRemaining.path.head.entityType, pathsRemaining.path.head.entityName, buildSoftConflictTree(EntityPath(pathsRemaining.path.tail))))
-      }
+      def buildSoftConflictTree(pathsRemaining: EntityPath): Seq[EntitySoftConflict] =
+        if (pathsRemaining.path.isEmpty) Seq.empty
+        else
+          Seq(
+            EntitySoftConflict(pathsRemaining.path.head.entityType,
+                               pathsRemaining.path.head.entityName,
+                               buildSoftConflictTree(EntityPath(pathsRemaining.path.tail))
+            )
+          )
 
       val entitiesToCopyRefs = entityNames.map(name => AttributeEntityReference(entityType, name))
 
       traceDBIOWithParent("EntityComponent.checkAndCopyEntities", parentContext) { childContext =>
         childContext.tracingSpan.foreach { s =>
-          s.putAttribute("destWorkspaceId", OpenCensusAttributeValue.stringAttributeValue(destWorkspaceContext.workspaceId))
-          s.putAttribute("sourceWorkspaceId", OpenCensusAttributeValue.stringAttributeValue(sourceWorkspaceContext.workspaceId))
+          s.putAttribute("destWorkspaceId",
+                         OpenCensusAttributeValue.stringAttributeValue(destWorkspaceContext.workspaceId)
+          )
+          s.putAttribute("sourceWorkspaceId",
+                         OpenCensusAttributeValue.stringAttributeValue(sourceWorkspaceContext.workspaceId)
+          )
           s.putAttribute("numEntities", OpenCensusAttributeValue.longAttributeValue(entityNames.length))
         }
-        traceDBIOWithParent("getHardConflicts", childContext)(s2 => getActiveRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet).flatMap {
-          case Seq() =>
-            val pathsAndConflicts = for {
-              entityPaths <- traceDBIOWithParent("getEntitySubtrees", s2)(_ => getEntitySubtrees(sourceWorkspaceContext, entityType, entityNames.toSet))
-              softConflicts <- traceDBIOWithParent("getSoftConflicts", s2)(_ => getSoftConflicts(entityPaths))
-            } yield (entityPaths, softConflicts)
+        traceDBIOWithParent("getHardConflicts", childContext)(s2 =>
+          getActiveRefs(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopyRefs.toSet).flatMap {
+            case Seq() =>
+              val pathsAndConflicts = for {
+                entityPaths <- traceDBIOWithParent("getEntitySubtrees", s2)(_ =>
+                  getEntitySubtrees(sourceWorkspaceContext, entityType, entityNames.toSet)
+                )
+                softConflicts <- traceDBIOWithParent("getSoftConflicts", s2)(_ => getSoftConflicts(entityPaths))
+              } yield (entityPaths, softConflicts)
 
-            pathsAndConflicts.flatMap { case (entityPaths, softConflicts) =>
-              if (softConflicts.isEmpty || linkExistingEntities) {
-                val allEntityRefs = entityPaths.flatMap(_.path)
-                val allConflictRefs = softConflicts.flatMap(_.path)
-                val entitiesToCopy = allEntityRefs diff allConflictRefs toSet
+              pathsAndConflicts.flatMap { case (entityPaths, softConflicts) =>
+                if (softConflicts.isEmpty || linkExistingEntities) {
+                  val allEntityRefs = entityPaths.flatMap(_.path)
+                  val allConflictRefs = softConflicts.flatMap(_.path)
+                  val entitiesToCopy = allEntityRefs diff allConflictRefs toSet
 
-                for {
-                  _ <- traceDBIOWithParent("copyEntities", s2)(_ => copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
-                    destWorkspaceContext.workspaceIdAsUUID, entitiesToCopy))
-                  _ <- workspaceQuery.updateLastModified(destWorkspaceContext.workspaceIdAsUUID)
-                } yield EntityCopyResponse(entitiesToCopy.toSeq, Seq.empty, Seq.empty)
-              } else {
-                val unmergedSoftConflicts = softConflicts.flatMap(buildSoftConflictTree).groupBy(c => (c.entityType, c.entityName)).map {
-                  case ((conflictType, conflictName), conflicts) => EntitySoftConflict(conflictType, conflictName, conflicts.flatMap(_.conflicts))
-                }.toSeq
-                DBIO.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
+                  for {
+                    _ <- traceDBIOWithParent("copyEntities", s2)(_ =>
+                      copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
+                                                 destWorkspaceContext.workspaceIdAsUUID,
+                                                 entitiesToCopy
+                      )
+                    )
+                    _ <- workspaceQuery.updateLastModified(destWorkspaceContext.workspaceIdAsUUID)
+                  } yield EntityCopyResponse(entitiesToCopy.toSeq, Seq.empty, Seq.empty)
+                } else {
+                  val unmergedSoftConflicts = softConflicts
+                    .flatMap(buildSoftConflictTree)
+                    .groupBy(c => (c.entityType, c.entityName))
+                    .map { case ((conflictType, conflictName), conflicts) =>
+                      EntitySoftConflict(conflictType, conflictName, conflicts.flatMap(_.conflicts))
+                    }
+                    .toSeq
+                  DBIO.successful(EntityCopyResponse(Seq.empty, Seq.empty, unmergedSoftConflicts))
+                }
               }
-            }
-          case hardConflicts => DBIO.successful(EntityCopyResponse(Seq.empty, hardConflicts.map(c => EntityHardConflict(c.entityType, c.entityName)), Seq.empty))
-        })
+            case hardConflicts =>
+              DBIO.successful(
+                EntityCopyResponse(Seq.empty,
+                                   hardConflicts.map(c => EntityHardConflict(c.entityType, c.entityName)),
+                                   Seq.empty
+                )
+              )
+          }
+        )
       }
     }
 
     // retrieve all paths from these entities, for checkAndCopyEntities
 
-    private[slick] def getEntitySubtrees(workspaceContext: Workspace, entityType: String, entityNames: Set[String]): ReadAction[Seq[EntityPath]] = {
-      val startingEntityRecsAction = filter(rec => rec.workspaceId === workspaceContext.workspaceIdAsUUID && rec.entityType === entityType && rec.name.inSetBind(entityNames))
+    private[slick] def getEntitySubtrees(workspaceContext: Workspace,
+                                         entityType: String,
+                                         entityNames: Set[String]
+    ): ReadAction[Seq[EntityPath]] = {
+      val startingEntityRecsAction = filter(rec =>
+        rec.workspaceId === workspaceContext.workspaceIdAsUUID && rec.entityType === entityType && rec.name.inSetBind(
+          entityNames
+        )
+      )
 
       startingEntityRecsAction.result.flatMap { startingEntityRecs =>
         val refsToId = startingEntityRecs.map(rec => EntityPath(Seq(rec.toReference)) -> rec.id).toMap
@@ -1016,22 +1256,27 @@ trait EntityComponent {
 
     // return the entities already present in the destination workspace
 
-    private[slick] def getCopyConflicts(destWorkspaceContext: Workspace, entitiesToCopy: TraversableOnce[AttributeEntityReference]): ReadAction[TraversableOnce[EntityRecord]] = {
+    private[slick] def getCopyConflicts(destWorkspaceContext: Workspace,
+                                        entitiesToCopy: TraversableOnce[AttributeEntityReference]
+    ): ReadAction[TraversableOnce[EntityRecord]] =
       getEntityRecords(destWorkspaceContext.workspaceIdAsUUID, entitiesToCopy.toSet)
-    }
 
     // the opposite of getEntitySubtrees: traverse the graph to retrieve all entities which ultimately refer to these
 
-    def getAllReferringEntities(context: Workspace, entities: Set[AttributeEntityReference]): ReadAction[Set[AttributeEntityReference]] = {
+    def getAllReferringEntities(context: Workspace,
+                                entities: Set[AttributeEntityReference]
+    ): ReadAction[Set[AttributeEntityReference]] =
       getEntityRecords(context.workspaceIdAsUUID, entities) flatMap { entityRecs =>
         val refsToId = entityRecs.map(rec => EntityPath(Seq(rec.toReference)) -> rec.id).toMap
         recursiveGetEntityReferences(context, Up, entityRecs.map(_.id).toSet, refsToId)
       } flatMap { refs =>
-        val entityAction = EntityAndAttributesRawSqlQuery.activeActionForRefs(context, refs.flatMap(_.path).toSet) map(query => unmarshalEntities(query))
+        val entityAction =
+          EntityAndAttributesRawSqlQuery.activeActionForRefs(context, refs.flatMap(_.path).toSet) map (query =>
+            unmarshalEntities(query)
+          )
         entityAction map { _.toSet map { e: Entity => e.toReference } }
       }
-    }
-    
+
     sealed trait RecursionDirection
     case object Up extends RecursionDirection
     case object Down extends RecursionDirection
@@ -1045,16 +1290,24 @@ trait EntityComponent {
       *                       that if there is a cycle some of entityIds may be in the result anyway
       * @return the ids of all the entities referred to by entityIds
       */
-    private def recursiveGetEntityReferences(workspace: Workspace, direction: RecursionDirection, entityIds: Set[Long], accumulatedPathsWithLastId: Map[EntityPath, Long]): ReadAction[Seq[EntityPath]] = {
+    private def recursiveGetEntityReferences(workspace: Workspace,
+                                             direction: RecursionDirection,
+                                             entityIds: Set[Long],
+                                             accumulatedPathsWithLastId: Map[EntityPath, Long]
+    ): ReadAction[Seq[EntityPath]] = {
       def oneLevelDown(idBatch: Set[Long]): ReadAction[Set[(Long, EntityRecord)]] = {
         val query = entityAttributeShardQuery(workspace) filter (_.ownerId inSetBind idBatch) join
-          this on { (attr, ent) => attr.valueEntityRef === ent.id && ! attr.deleted } map { case (attr, entity) => (attr.ownerId, entity)}
+          this on { (attr, ent) => attr.valueEntityRef === ent.id && !attr.deleted } map { case (attr, entity) =>
+            (attr.ownerId, entity)
+          }
         query.result.map(_.toSet)
       }
 
       def oneLevelUp(idBatch: Set[Long]): ReadAction[Set[(Long, EntityRecord)]] = {
         val query = entityAttributeShardQuery(workspace) filter (_.valueEntityRef inSetBind idBatch) join
-          this on { (attr, ent) => attr.ownerId === ent.id && ! ent.deleted } map { case (attr, entity) => (attr.valueEntityRef.get, entity)}
+          this on { (attr, ent) => attr.ownerId === ent.id && !ent.deleted } map { case (attr, entity) =>
+            (attr.valueEntityRef.get, entity)
+          }
         query.result.map(_.toSet)
       }
 
@@ -1063,13 +1316,15 @@ trait EntityComponent {
 
       val batchActions: Iterator[ReadAction[Set[(Long, EntityRecord)]]] = direction match {
         case Down => batchedEntityIds map oneLevelDown
-        case Up => batchedEntityIds map oneLevelUp
+        case Up   => batchedEntityIds map oneLevelUp
       }
 
       DBIO.sequence(batchActions).map(_.flatten.toSet).flatMap { priorIdWithCurrentRec =>
         val currentPaths = priorIdWithCurrentRec.flatMap { case (priorId, currentRec) =>
           val pathsThatEndWithPrior = accumulatedPathsWithLastId.filter { case (_, id) => id == priorId }
-          pathsThatEndWithPrior.keys.map(_.path).map { path => (EntityPath(path :+ currentRec.toReference), currentRec.id)}
+          pathsThatEndWithPrior.keys.map(_.path).map { path =>
+            (EntityPath(path :+ currentRec.toReference), currentRec.id)
+          }
         }.toMap
 
         val untraversedIds = priorIdWithCurrentRec.map(_._2.id) -- accumulatedPathsWithLastId.values
@@ -1085,10 +1340,12 @@ trait EntityComponent {
 
     private def validateEntity(entity: Entity): Unit = {
       if (entity.entityType.equalsIgnoreCase(Attributable.workspaceEntityType)) {
-        throw new RawlsFatalExceptionWithErrorReport(errorReport = ErrorReport(
-          message = s"Entity type ${Attributable.workspaceEntityType} is reserved and cannot be overwritten",
-          statusCode = StatusCodes.BadRequest
-        ))
+        throw new RawlsFatalExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            message = s"Entity type ${Attributable.workspaceEntityType} is reserved and cannot be overwritten",
+            statusCode = StatusCodes.BadRequest
+          )
+        )
       }
       validateUserDefinedString(entity.entityType)
       validateEntityName(entity.name)
@@ -1098,40 +1355,51 @@ trait EntityComponent {
       }
     }
 
-    def generateEntityMetadataMap(typesAndCountsQ: ReadAction[Map[String, Int]], typesAndAttrsQ: ReadAction[Map[String, Seq[AttributeName]]]) = {
+    def generateEntityMetadataMap(typesAndCountsQ: ReadAction[Map[String, Int]],
+                                  typesAndAttrsQ: ReadAction[Map[String, Seq[AttributeName]]]
+    ) =
       typesAndCountsQ flatMap { typesAndCounts =>
         typesAndAttrsQ map { typesAndAttrs =>
           (typesAndCounts.keySet ++ typesAndAttrs.keySet) map { entityType =>
-            (entityType, EntityTypeMetadata(
-              typesAndCounts.getOrElse(entityType, 0),
-              entityType + Attributable.entityIdAttributeSuffix,
-              typesAndAttrs.getOrElse(entityType, Seq()).map(AttributeName.toDelimitedName).sortBy(_.toLowerCase)))
+            (entityType,
+             EntityTypeMetadata(
+               typesAndCounts.getOrElse(entityType, 0),
+               entityType + Attributable.entityIdAttributeSuffix,
+               typesAndAttrs.getOrElse(entityType, Seq()).map(AttributeName.toDelimitedName).sortBy(_.toLowerCase)
+             )
+            )
           } toMap
         }
       }
-    }
 
     // Unmarshal methods
 
     // NOTE: marshalNewEntity is in entityQueryWithInlineAttributes because it helps save the inline attributes to DB
 
-    private def unmarshalEntity(entityRecord: EntityRecord, attributes: AttributeMap): Entity = {
+    private def unmarshalEntity(entityRecord: EntityRecord, attributes: AttributeMap): Entity =
       Entity(entityRecord.name, entityRecord.entityType, attributes)
-    }
 
-    private def unmarshalEntities(entityAttributeRecords: Seq[entityQuery.EntityAndAttributesRawSqlQuery.EntityAndAttributesResult]): Seq[Entity] = {
+    private def unmarshalEntities(
+      entityAttributeRecords: Seq[entityQuery.EntityAndAttributesRawSqlQuery.EntityAndAttributesResult]
+    ): Seq[Entity] =
       unmarshalEntitiesWithIds(entityAttributeRecords).map { case (_, entity) => entity }
-    }
 
-    private def unmarshalEntitiesWithIds(entityAttributeRecords: Seq[entityQuery.EntityAndAttributesRawSqlQuery.EntityAndAttributesResult]): Seq[(Long, Entity)] = {
+    private def unmarshalEntitiesWithIds(
+      entityAttributeRecords: Seq[entityQuery.EntityAndAttributesRawSqlQuery.EntityAndAttributesResult]
+    ): Seq[(Long, Entity)] = {
       val allEntityRecords = entityAttributeRecords.map(_.entityRecord).distinct
 
       // note that not all entities have attributes, thus the collect below
       val entitiesWithAttributes = entityAttributeRecords.collect {
-        case EntityAndAttributesRawSqlQuery.EntityAndAttributesResult(entityRec, Some(attributeRec), refEntityRecOption) => ((entityRec.id, attributeRec), refEntityRecOption)
+        case EntityAndAttributesRawSqlQuery.EntityAndAttributesResult(entityRec,
+                                                                      Some(attributeRec),
+                                                                      refEntityRecOption
+            ) =>
+          ((entityRec.id, attributeRec), refEntityRecOption)
       }
 
-      val attributesByEntityId = entityAttributeShardQuery(UUID.randomUUID()).unmarshalAttributes(entitiesWithAttributes)
+      val attributesByEntityId =
+        entityAttributeShardQuery(UUID.randomUUID()).unmarshalAttributes(entitiesWithAttributes)
 
       allEntityRecords.map { entityRec =>
         entityRec.id -> unmarshalEntity(entityRec, attributesByEntityId.getOrElse(entityRec.id, Map.empty))
@@ -1145,22 +1413,21 @@ trait EntityComponent {
     def saveEntityCache(workspaceId: UUID,
                         entityTypesWithCounts: Map[String, Int],
                         entityTypesWithAttrNames: Map[String, Seq[AttributeName]],
-                        timestamp: Timestamp) = {
-
+                        timestamp: Timestamp
+    ) =
       // TODO: beware contention on the approach of delete-all and batch-insert all below
       // if we see contention we could move to encoding the entire metadata object as json
       // and storing in a single column on WORKSPACE_ENTITY_CACHE
       for {
-        //update entity statistics
+        // update entity statistics
         _ <- entityTypeStatisticsQuery.deleteAllForWorkspace(workspaceId)
         _ <- entityTypeStatisticsQuery.batchInsert(workspaceId, entityTypesWithCounts)
-        //update entity attribute statistics
+        // update entity attribute statistics
         _ <- entityAttributeStatisticsQuery.deleteAllForWorkspace(workspaceId)
         _ <- entityAttributeStatisticsQuery.batchInsert(workspaceId, entityTypesWithAttrNames)
-        //update cache update date
+        // update cache update date
         numCachesUpdated <- entityCacheQuery.updateCacheLastUpdated(workspaceId, timestamp)
       } yield numCachesUpdated
-    }
 
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -11,152 +11,194 @@ import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataR
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 
-class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvider)(implicit val system: ActorSystem, val materializer: Materializer, val executionContext: ExecutionContext) extends WorkspaceManagerDAO {
+class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvider)(implicit
+  val system: ActorSystem,
+  val materializer: Materializer,
+  val executionContext: ExecutionContext
+) extends WorkspaceManagerDAO {
 
-  private def getApiClient(ctx: RawlsRequestContext): ApiClient = {
+  private def getApiClient(ctx: RawlsRequestContext): ApiClient =
     apiClientProvider.getApiClient(ctx)
-  }
 
-  private def getWorkspaceApi(ctx: RawlsRequestContext): WorkspaceApi = {
+  private def getWorkspaceApi(ctx: RawlsRequestContext): WorkspaceApi =
     new WorkspaceApi(getApiClient(ctx))
-  }
 
-  private def getReferencedGcpResourceApi(ctx: RawlsRequestContext): ReferencedGcpResourceApi = {
+  private def getReferencedGcpResourceApi(ctx: RawlsRequestContext): ReferencedGcpResourceApi =
     new ReferencedGcpResourceApi(getApiClient(ctx))
-  }
 
-  private def getResourceApi(ctx: RawlsRequestContext): ResourceApi = {
+  private def getResourceApi(ctx: RawlsRequestContext): ResourceApi =
     new ResourceApi(getApiClient(ctx))
-  }
 
-  private def getWorkspaceApplicationApi(ctx: RawlsRequestContext) = {
+  private def getWorkspaceApplicationApi(ctx: RawlsRequestContext) =
     apiClientProvider.getWorkspaceApplicationApi(ctx)
-  }
 
-  private def getControlledAzureResourceApi(ctx: RawlsRequestContext) = {
+  private def getControlledAzureResourceApi(ctx: RawlsRequestContext) =
     apiClientProvider.getControlledAzureResourceApi(ctx)
-  }
 
-  private def createCommonFields(name: String) = {
-      new ControlledResourceCommonFields().name(name).
-        cloningInstructions(CloningInstructionsEnum.NOTHING).
-        accessScope(AccessScope.SHARED_ACCESS).
-        managedBy(ManagedBy.USER)
-  }
+  private def createCommonFields(name: String) =
+    new ControlledResourceCommonFields()
+      .name(name)
+      .cloningInstructions(CloningInstructionsEnum.NOTHING)
+      .accessScope(AccessScope.SHARED_ACCESS)
+      .managedBy(ManagedBy.USER)
 
-  override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription = {
+  override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription =
     getWorkspaceApi(ctx).getWorkspace(workspaceId)
-  }
 
-  override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace = {
+  override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace =
     getWorkspaceApi(ctx).createWorkspace(new CreateWorkspaceRequestBody().id(workspaceId))
-  }
 
   override def createWorkspaceWithSpendProfile(workspaceId: UUID,
                                                displayName: String,
                                                spendProfileId: String,
-                                               ctx: RawlsRequestContext): CreatedWorkspace = {
-    getWorkspaceApi(ctx).createWorkspace(new CreateWorkspaceRequestBody()
-      .id(workspaceId)
-      .displayName(displayName)
-      .spendProfile(spendProfileId)
-      .stage(WorkspaceStageModel.MC_WORKSPACE))
-  }
+                                               ctx: RawlsRequestContext
+  ): CreatedWorkspace =
+    getWorkspaceApi(ctx).createWorkspace(
+      new CreateWorkspaceRequestBody()
+        .id(workspaceId)
+        .displayName(displayName)
+        .spendProfile(spendProfileId)
+        .stage(WorkspaceStageModel.MC_WORKSPACE)
+    )
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                                 azureTenantId: String,
                                                 azureResourceGroupId: String,
                                                 azureSubscriptionId: String,
-                                                ctx: RawlsRequestContext): CreateCloudContextResult = {
+                                                ctx: RawlsRequestContext
+  ): CreateCloudContextResult = {
     val jobControlId = UUID.randomUUID().toString
-    val azureContext = new AzureContext().tenantId(azureTenantId).subscriptionId(azureSubscriptionId).resourceGroupId(azureResourceGroupId)
-    getWorkspaceApi(ctx).createCloudContext(
-      new CreateCloudContextRequest()
-        .cloudPlatform(CloudPlatform.AZURE)
-        .jobControl(new JobControl().id(jobControlId))
-        .azureContext(azureContext), workspaceId)
+    val azureContext = new AzureContext()
+      .tenantId(azureTenantId)
+      .subscriptionId(azureSubscriptionId)
+      .resourceGroupId(azureResourceGroupId)
+    getWorkspaceApi(ctx).createCloudContext(new CreateCloudContextRequest()
+                                              .cloudPlatform(CloudPlatform.AZURE)
+                                              .jobControl(new JobControl().id(jobControlId))
+                                              .azureContext(azureContext),
+                                            workspaceId
+    )
   }
 
-  override def getWorkspaceCreateCloudContextResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CreateCloudContextResult = {
+  override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
+                                                    jobControlId: String,
+                                                    ctx: RawlsRequestContext
+  ): CreateCloudContextResult =
     getWorkspaceApi(ctx).getCreateCloudContextResult(workspaceId, jobControlId)
-  }
 
-  override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit = {
+  override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit =
     getWorkspaceApi(ctx).deleteWorkspace(workspaceId)
-  }
 
-  override def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, ctx: RawlsRequestContext): DataRepoSnapshotResource = {
+  override def createDataRepoSnapshotReference(workspaceId: UUID,
+                                               snapshotId: UUID,
+                                               name: DataReferenceName,
+                                               description: Option[DataReferenceDescriptionField],
+                                               instanceName: String,
+                                               cloningInstructions: CloningInstructionsEnum,
+                                               ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource = {
     val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId.toString)
-    val commonFields = new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
+    val commonFields =
+      new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
     description.map(d => commonFields.description(d.value))
     val request = new CreateDataRepoSnapshotReferenceRequestBody().snapshot(snapshot).metadata(commonFields)
     getReferencedGcpResourceApi(ctx).createDataRepoSnapshotReference(request, workspaceId)
   }
 
-  override def updateDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataRepoSnapshotReferenceRequestBody, ctx: RawlsRequestContext): Unit = {
+  override def updateDataRepoSnapshotReference(workspaceId: UUID,
+                                               referenceId: UUID,
+                                               updateInfo: UpdateDataRepoSnapshotReferenceRequestBody,
+                                               ctx: RawlsRequestContext
+  ): Unit =
     getReferencedGcpResourceApi(ctx).updateDataRepoSnapshotReferenceResource(updateInfo, workspaceId, referenceId)
-  }
 
-  override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit = {
+  override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit =
     getReferencedGcpResourceApi(ctx).deleteDataRepoSnapshotReference(workspaceId, referenceId)
-  }
 
-  override def getDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): DataRepoSnapshotResource = {
+  override def getDataRepoSnapshotReference(workspaceId: UUID,
+                                            referenceId: UUID,
+                                            ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource =
     getReferencedGcpResourceApi(ctx).getDataRepoSnapshotReference(workspaceId, referenceId)
-  }
 
-  override def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, ctx: RawlsRequestContext): DataRepoSnapshotResource = {
+  override def getDataRepoSnapshotReferenceByName(workspaceId: UUID,
+                                                  refName: DataReferenceName,
+                                                  ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource =
     getReferencedGcpResourceApi(ctx).getDataRepoSnapshotReferenceByName(workspaceId, refName.value)
-  }
 
-  override def enumerateDataRepoSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList = {
-    getResourceApi(ctx).enumerateResources(workspaceId, offset, limit, ResourceType.DATA_REPO_SNAPSHOT, StewardshipType.REFERENCED)
-  }
-
-  def enableApplication(workspaceId: UUID, applicationId: String, ctx: RawlsRequestContext): WorkspaceApplicationDescription = {
-    getWorkspaceApplicationApi(ctx).enableWorkspaceApplication(
-      workspaceId, applicationId
+  override def enumerateDataRepoSnapshotReferences(workspaceId: UUID,
+                                                   offset: Int,
+                                                   limit: Int,
+                                                   ctx: RawlsRequestContext
+  ): ResourceList =
+    getResourceApi(ctx).enumerateResources(workspaceId,
+                                           offset,
+                                           limit,
+                                           ResourceType.DATA_REPO_SNAPSHOT,
+                                           StewardshipType.REFERENCED
     )
-  }
 
-  def createAzureRelay(workspaceId: UUID, region: String, ctx: RawlsRequestContext): CreateControlledAzureRelayNamespaceResult = {
+  def enableApplication(workspaceId: UUID,
+                        applicationId: String,
+                        ctx: RawlsRequestContext
+  ): WorkspaceApplicationDescription =
+    getWorkspaceApplicationApi(ctx).enableWorkspaceApplication(
+      workspaceId,
+      applicationId
+    )
+
+  def createAzureRelay(workspaceId: UUID,
+                       region: String,
+                       ctx: RawlsRequestContext
+  ): CreateControlledAzureRelayNamespaceResult = {
     val jobControlId = UUID.randomUUID().toString
     getControlledAzureResourceApi(ctx).createAzureRelayNamespace(
-      new CreateControlledAzureRelayNamespaceRequestBody().common(
-        createCommonFields(s"relay-${workspaceId}")
-      ).azureRelayNamespace(
-        new AzureRelayNamespaceCreationParameters().namespaceName(s"relay-ns-${workspaceId}").region(region)
-      ).jobControl(new JobControl().id(jobControlId)),
+      new CreateControlledAzureRelayNamespaceRequestBody()
+        .common(
+          createCommonFields(s"relay-${workspaceId}")
+        )
+        .azureRelayNamespace(
+          new AzureRelayNamespaceCreationParameters().namespaceName(s"relay-ns-${workspaceId}").region(region)
+        )
+        .jobControl(new JobControl().id(jobControlId)),
       workspaceId
     )
   }
 
-  def getCreateAzureRelayResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CreateControlledAzureRelayNamespaceResult = {
+  def getCreateAzureRelayResult(workspaceId: UUID,
+                                jobControlId: String,
+                                ctx: RawlsRequestContext
+  ): CreateControlledAzureRelayNamespaceResult =
     getControlledAzureResourceApi(ctx).getCreateAzureRelayNamespaceResult(workspaceId, jobControlId)
-  }
 
   def createAzureStorageAccount(workspaceId: UUID, region: String, ctx: RawlsRequestContext) = {
     // Storage account names must be unique and 3-24 characters in length, numbers and lowercase letters only.
     val prefix = workspaceId.toString.substring(0, workspaceId.toString.indexOf("-"))
     val suffix = workspaceId.toString.substring(workspaceId.toString.lastIndexOf("-") + 1)
     getControlledAzureResourceApi(ctx).createAzureStorage(
-      new CreateControlledAzureStorageRequestBody().common(
-        createCommonFields(s"sa-${workspaceId}")
-      ).azureStorage(
-        new AzureStorageCreationParameters().storageAccountName(s"sa${prefix}${suffix}").region(region)
-      ),
+      new CreateControlledAzureStorageRequestBody()
+        .common(
+          createCommonFields(s"sa-${workspaceId}")
+        )
+        .azureStorage(
+          new AzureStorageCreationParameters().storageAccountName(s"sa${prefix}${suffix}").region(region)
+        ),
       workspaceId
     )
   }
 
-  def createAzureStorageContainer(workspaceId: UUID, storageAccountId: UUID, ctx: RawlsRequestContext) = {
+  def createAzureStorageContainer(workspaceId: UUID, storageAccountId: UUID, ctx: RawlsRequestContext) =
     getControlledAzureResourceApi(ctx).createAzureStorageContainer(
-      new CreateControlledAzureStorageContainerRequestBody().common(
-        createCommonFields(s"sc-${workspaceId}")
-      ).azureStorageContainer(
-        new AzureStorageContainerCreationParameters().storageContainerName(s"sc-${workspaceId}").storageAccountId(storageAccountId)
-      ),
+      new CreateControlledAzureStorageContainerRequestBody()
+        .common(
+          createCommonFields(s"sc-${workspaceId}")
+        )
+        .azureStorageContainer(
+          new AzureStorageContainerCreationParameters()
+            .storageContainerName(s"sc-${workspaceId}")
+            .storageAccountId(storageAccountId)
+        ),
       workspaceId
     )
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
@@ -40,12 +40,9 @@ class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: String) extend
     client
   }
 
-  def getControlledAzureResourceApi(ctx: RawlsRequestContext): ControlledAzureResourceApi = {
+  def getControlledAzureResourceApi(ctx: RawlsRequestContext): ControlledAzureResourceApi =
     new ControlledAzureResourceApi(getApiClient(ctx))
-  }
 
-  def getWorkspaceApplicationApi(ctx: RawlsRequestContext): WorkspaceApplicationApi = {
+  def getWorkspaceApplicationApi(ctx: RawlsRequestContext): WorkspaceApplicationApi =
     new WorkspaceApplicationApi(getApiClient(ctx))
-  }
 }
-

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -12,19 +12,67 @@ trait WorkspaceManagerDAO {
 
   def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription
   def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace
-  def createWorkspaceWithSpendProfile(workspaceId: UUID, displayName: String, spendProfileId: String, ctx: RawlsRequestContext): CreatedWorkspace
-  def createAzureWorkspaceCloudContext(workspaceId: UUID, azureTenantId: String, azureResourceGroupId: String, azureSubscriptionId: String, ctx: RawlsRequestContext): CreateCloudContextResult
-  def getWorkspaceCreateCloudContextResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CreateCloudContextResult
+  def createWorkspaceWithSpendProfile(workspaceId: UUID,
+                                      displayName: String,
+                                      spendProfileId: String,
+                                      ctx: RawlsRequestContext
+  ): CreatedWorkspace
+  def createAzureWorkspaceCloudContext(workspaceId: UUID,
+                                       azureTenantId: String,
+                                       azureResourceGroupId: String,
+                                       azureSubscriptionId: String,
+                                       ctx: RawlsRequestContext
+  ): CreateCloudContextResult
+  def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
+                                           jobControlId: String,
+                                           ctx: RawlsRequestContext
+  ): CreateCloudContextResult
   def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit
-  def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, ctx: RawlsRequestContext): DataRepoSnapshotResource
-  def updateDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataRepoSnapshotReferenceRequestBody, ctx: RawlsRequestContext): Unit
+  def createDataRepoSnapshotReference(workspaceId: UUID,
+                                      snapshotId: UUID,
+                                      name: DataReferenceName,
+                                      description: Option[DataReferenceDescriptionField],
+                                      instanceName: String,
+                                      cloningInstructions: CloningInstructionsEnum,
+                                      ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource
+  def updateDataRepoSnapshotReference(workspaceId: UUID,
+                                      referenceId: UUID,
+                                      updateInfo: UpdateDataRepoSnapshotReferenceRequestBody,
+                                      ctx: RawlsRequestContext
+  ): Unit
   def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit
-  def getDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): DataRepoSnapshotResource
-  def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, ctx: RawlsRequestContext): DataRepoSnapshotResource
-  def enumerateDataRepoSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList
-  def enableApplication(workspaceId: UUID, applicationId: String, ctx: RawlsRequestContext): WorkspaceApplicationDescription
-  def createAzureRelay(workspaceId: UUID, region: String, ctx: RawlsRequestContext): CreateControlledAzureRelayNamespaceResult
-  def getCreateAzureRelayResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CreateControlledAzureRelayNamespaceResult
-  def createAzureStorageAccount(workspaceId: UUID, region: String, ctx: RawlsRequestContext): CreatedControlledAzureStorage
-  def createAzureStorageContainer(workspaceId: UUID, storageAccountId: UUID, ctx: RawlsRequestContext): CreatedControlledAzureStorageContainer
+  def getDataRepoSnapshotReference(workspaceId: UUID,
+                                   referenceId: UUID,
+                                   ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource
+  def getDataRepoSnapshotReferenceByName(workspaceId: UUID,
+                                         refName: DataReferenceName,
+                                         ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource
+  def enumerateDataRepoSnapshotReferences(workspaceId: UUID,
+                                          offset: Int,
+                                          limit: Int,
+                                          ctx: RawlsRequestContext
+  ): ResourceList
+  def enableApplication(workspaceId: UUID,
+                        applicationId: String,
+                        ctx: RawlsRequestContext
+  ): WorkspaceApplicationDescription
+  def createAzureRelay(workspaceId: UUID,
+                       region: String,
+                       ctx: RawlsRequestContext
+  ): CreateControlledAzureRelayNamespaceResult
+  def getCreateAzureRelayResult(workspaceId: UUID,
+                                jobControlId: String,
+                                ctx: RawlsRequestContext
+  ): CreateControlledAzureRelayNamespaceResult
+  def createAzureStorageAccount(workspaceId: UUID,
+                                region: String,
+                                ctx: RawlsRequestContext
+  ): CreatedControlledAzureStorage
+  def createAzureStorageContainer(workspaceId: UUID,
+                                  storageAccountId: UUID,
+                                  ctx: RawlsRequestContext
+  ): CreatedControlledAzureStorageContainer
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityRequestArguments.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityRequestArguments.scala
@@ -5,4 +5,5 @@ import org.broadinstitute.dsde.rawls.model.{DataReferenceName, GoogleProjectId, 
 case class EntityRequestArguments(workspace: Workspace,
                                   ctx: RawlsRequestContext,
                                   dataReference: Option[DataReferenceName] = None,
-                                  billingProject: Option[GoogleProjectId] = None)
+                                  billingProject: Option[GoogleProjectId] = None
+)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -8,12 +8,28 @@ import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException
+}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityCopyDefinition, EntityQuery, ErrorReport, SamResourceTypeNames, SamWorkspaceActions, UserInfo, WorkspaceName, _}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  Entity,
+  EntityCopyDefinition,
+  EntityQuery,
+  ErrorReport,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  UserInfo,
+  WorkspaceName,
+  _
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.AttributeUpdateOperationException
@@ -24,51 +40,80 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object EntityService {
-  def constructor(dataSource: SlickDataSource, samDAO: SamDAO, workbenchMetricBaseName: String, entityManager: EntityManager, pageSizeLimit: Int)
-                 (ctx: RawlsRequestContext)
-                 (implicit executionContext: ExecutionContext): EntityService = {
-
+  def constructor(dataSource: SlickDataSource,
+                  samDAO: SamDAO,
+                  workbenchMetricBaseName: String,
+                  entityManager: EntityManager,
+                  pageSizeLimit: Int
+  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): EntityService =
     new EntityService(ctx, dataSource, samDAO, entityManager, workbenchMetricBaseName, pageSizeLimit)
-  }
 }
 
-class EntityService(protected val ctx: RawlsRequestContext, val dataSource: SlickDataSource, val samDAO: SamDAO, entityManager: EntityManager, override val workbenchMetricBaseName: String, pageSizeLimit: Int)(implicit protected val executionContext: ExecutionContext)
-  extends WorkspaceSupport with EntitySupport with AttributeSupport with LazyLogging with RawlsInstrumented with JsonFilterUtils {
+class EntityService(protected val ctx: RawlsRequestContext,
+                    val dataSource: SlickDataSource,
+                    val samDAO: SamDAO,
+                    entityManager: EntityManager,
+                    override val workbenchMetricBaseName: String,
+                    pageSizeLimit: Int
+)(implicit protected val executionContext: ExecutionContext)
+    extends WorkspaceSupport
+    with EntitySupport
+    with AttributeSupport
+    with LazyLogging
+    with RawlsInstrumented
+    with JsonFilterUtils {
 
   import dataSource.dataAccess.driver.api._
 
-  def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[Entity] = {
+  def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[Entity] =
     withAttributeNamespaceCheck(entity) {
       for {
-        workspaceContext <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false)))
+        workspaceContext <- getWorkspaceContextAndPermissions(workspaceName,
+                                                              SamWorkspaceActions.write,
+                                                              Some(WorkspaceAttributeSpecs(all = false))
+        )
         entityManager <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
         result <- entityManager.createEntity(entity)
       } yield result
     }
-  }
 
-  def getEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[Entity] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-
+  def getEntity(workspaceName: WorkspaceName,
+                entityType: String,
+                entityName: String,
+                dataReference: Option[DataReferenceName],
+                billingProject: Option[GoogleProjectId]
+  ): Future[Entity] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
       val entityFuture = for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
         entity <- entityProvider.getEntity(entityType, entityName)
-      } yield {
-        entity
-      }
+      } yield entity
 
-      entityFuture.recover {
-        case _: EntityNotFoundException =>
+      entityFuture
+        .recover { case _: EntityNotFoundException =>
           // could move this error message into EntityNotFoundException and allow it to bubble up
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in $workspaceName"))
-      }.recover(bigQueryRecover)
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in $workspaceName")
+          )
+        }
+        .recover(bigQueryRecover)
     }
 
-  def updateEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation]): Future[Entity] =
+  def updateEntity(workspaceName: WorkspaceName,
+                   entityType: String,
+                   entityName: String,
+                   operations: Seq[AttributeUpdateOperation]
+  ): Future[Entity] =
     withAttributeNamespaceCheck(operations.map(_.name)) {
-      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+      getWorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
+      ) flatMap { workspaceContext =>
         dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
           withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
             val updateAction = Try {
@@ -77,7 +122,15 @@ class EntityService(protected val ctx: RawlsRequestContext, val dataSource: Slic
             } match {
               case Success(result) => result
               case Failure(e: AttributeUpdateOperationException) =>
-                DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Unable to update entity ${entityType}/${entityName} in ${workspaceName}", ErrorReport(e))))
+                DBIO.failed(
+                  new RawlsExceptionWithErrorReport(
+                    errorReport =
+                      ErrorReport(StatusCodes.BadRequest,
+                                  s"Unable to update entity ${entityType}/${entityName} in ${workspaceName}",
+                                  ErrorReport(e)
+                      )
+                  )
+                )
               case Failure(regrets) => DBIO.failed(regrets)
             }
             updateAction
@@ -86,60 +139,93 @@ class EntityService(protected val ctx: RawlsRequestContext, val dataSource: Slic
       }
     }
 
-  def deleteEntities(workspaceName: WorkspaceName, entRefs: Seq[AttributeEntityReference], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[Set[AttributeEntityReference]] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-
+  def deleteEntities(workspaceName: WorkspaceName,
+                     entRefs: Seq[AttributeEntityReference],
+                     dataReference: Option[DataReferenceName],
+                     billingProject: Option[GoogleProjectId]
+  ): Future[Set[AttributeEntityReference]] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
       val deleteFuture = for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
         _ <- entityProvider.deleteEntities(entRefs)
-      } yield {
-        Set[AttributeEntityReference]()
-      }
+      } yield Set[AttributeEntityReference]()
 
-      deleteFuture.recover {
-        case delEx: DeleteEntitiesConflictException => delEx.referringEntities
-      }.recover(bigQueryRecover)
+      deleteFuture
+        .recover { case delEx: DeleteEntitiesConflictException =>
+          delEx.referringEntities
+        }
+        .recover(bigQueryRecover)
     }
 
-
-  def deleteEntitiesOfType(workspaceName: WorkspaceName, entityType: String, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]) = {
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-
+  def deleteEntitiesOfType(workspaceName: WorkspaceName,
+                           entityType: String,
+                           dataReference: Option[DataReferenceName],
+                           billingProject: Option[GoogleProjectId]
+  ) =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
       val deleteFuture = for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
         numberOfEntitiesDeleted <- entityProvider.deleteEntitiesOfType(entityType)
-      } yield { numberOfEntitiesDeleted }
+      } yield numberOfEntitiesDeleted
 
-      deleteFuture.recover {
-        case delEx: DeleteEntitiesOfTypeConflictException =>
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict,
-            s"Entity type [$entityType] cannot be deleted because there are ${delEx.conflictCount} references " +
-              s"to this entity type. All references must be removed before deleting a type."))
-      }.recover(bigQueryRecover)
+      deleteFuture
+        .recover { case delEx: DeleteEntitiesOfTypeConflictException =>
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.Conflict,
+              s"Entity type [$entityType] cannot be deleted because there are ${delEx.conflictCount} references " +
+                s"to this entity type. All references must be removed before deleting a type."
+            )
+          )
+        }
+        .recover(bigQueryRecover)
     }
-  }
 
-  def deleteEntityAttributes(workspaceName: WorkspaceName, entityType: String, attributeNames: Set[AttributeName]): Future[Unit] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+  def deleteEntityAttributes(workspaceName: WorkspaceName,
+                             entityType: String,
+                             attributeNames: Set[AttributeName]
+  ): Future[Unit] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
-        dataAccess.entityAttributeShardQuery(workspaceContext).deleteAttributes(workspaceContext, entityType, attributeNames) flatMap {
-          case Vector(0) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Could not find any of the given attribute names."))
+        dataAccess
+          .entityAttributeShardQuery(workspaceContext)
+          .deleteAttributes(workspaceContext, entityType, attributeNames) flatMap {
+          case Vector(0) =>
+            throw new RawlsExceptionWithErrorReport(
+              errorReport = ErrorReport(StatusCodes.BadRequest, s"Could not find any of the given attribute names.")
+            )
           case _ => DBIO.successful(())
         }
       }
     }
 
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
           dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName) flatMap {
             case None => dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName)
-            case Some(_) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"Destination ${entity.entityType} ${newName} already exists"))
+            case Some(_) =>
+              throw new RawlsExceptionWithErrorReport(
+                errorReport =
+                  ErrorReport(StatusCodes.Conflict, s"Destination ${entity.entityType} ${newName} already exists")
+              )
           }
         }
       }
@@ -148,93 +234,90 @@ class EntityService(protected val ctx: RawlsRequestContext, val dataSource: Slic
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
     import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 
-    def validateExistingType(dataAccess: DataAccess, workspaceContext: Workspace, oldName: String): ReadAction[Boolean] = {
+    def validateExistingType(dataAccess: DataAccess,
+                             workspaceContext: Workspace,
+                             oldName: String
+    ): ReadAction[Boolean] =
       dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, oldName) map {
         case Some(true) => true
-        case Some(false) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound,
-          s"Can't find entity type ${oldName}"))
-        case None => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError,
-          s"Unexpected error; could not determine existence of entity type ${oldName}"))
+        case Some(false) =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.NotFound, s"Can't find entity type ${oldName}")
+          )
+        case None =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.InternalServerError,
+                                      s"Unexpected error; could not determine existence of entity type ${oldName}"
+            )
+          )
       }
-    }
 
-    def validateNewType(dataAccess: DataAccess, workspaceContext: Workspace, newName: String): ReadAction[Boolean] = {
+    def validateNewType(dataAccess: DataAccess, workspaceContext: Workspace, newName: String): ReadAction[Boolean] =
       dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, newName) map {
-        case Some(true) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"${newName} already exists as an entity type"))
+        case Some(true) =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.Conflict, s"${newName} already exists as an entity type")
+          )
         case Some(false) => false
-        case None => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError,
-          s"Unexpected error; could not determine existence of entity type ${newName}"))
+        case None =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.InternalServerError,
+                                      s"Unexpected error; could not determine existence of entity type ${newName}"
+            )
+          )
       }
-    }
 
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         for {
           _ <- validateNewType(dataAccess, workspaceContext, renameInfo.newName)
           _ <- validateExistingType(dataAccess, workspaceContext, oldName)
           renameResult <- dataAccess.entityQuery.changeEntityTypeName(workspaceContext, oldName, renameInfo.newName)
-        } yield {
-          renameResult
-        }
+        } yield renameResult
       }
     }
   }
 
-  def evaluateExpression(workspaceName: WorkspaceName, entityType: String, entityName: String, expression: String): Future[Seq[AttributeValue]] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+  def evaluateExpression(workspaceName: WorkspaceName,
+                         entityType: String,
+                         entityName: String,
+                         expression: String
+  ): Future[Seq[AttributeValue]] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
           ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
-            evaluator.evalFinalAttribute(workspaceContext, expression).asTry map { tryValuesByEntity => tryValuesByEntity match {
-              //parsing failure
-              case Failure(regret) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
-              case Success(valuesByEntity) =>
-                if (valuesByEntity.size != 1) {
-                  //wrong number of entities?!
-                  throw new RawlsException(s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead")
-                } else {
-                  assert(valuesByEntity.head._1 == entityName)
-                  valuesByEntity.head match {
-                    case (_, Success(result)) => result.toSeq
-                    case (_, Failure(regret)) =>
-                      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}", ErrorReport(regret)))
+            evaluator.evalFinalAttribute(workspaceContext, expression).asTry map { tryValuesByEntity =>
+              tryValuesByEntity match {
+                // parsing failure
+                case Failure(regret) =>
+                  throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
+                case Success(valuesByEntity) =>
+                  if (valuesByEntity.size != 1) {
+                    // wrong number of entities?!
+                    throw new RawlsException(
+                      s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
+                    )
+                  } else {
+                    assert(valuesByEntity.head._1 == entityName)
+                    valuesByEntity.head match {
+                      case (_, Success(result)) => result.toSeq
+                      case (_, Failure(regret)) =>
+                        throw new RawlsExceptionWithErrorReport(
+                          errorReport = ErrorReport(
+                            StatusCodes.BadRequest,
+                            "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
+                            ErrorReport(regret)
+                          )
+                        )
+                    }
                   }
-                }
-            }
-            }
-          }
-        }
-      }
-    }
-
-  def entityTypeMetadata(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId], useCache: Boolean): Future[Map[String, EntityTypeMetadata]] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
-
-      val metadataFuture = for {
-        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        metadata <- entityProvider.entityTypeMetadata(useCache)
-      } yield {
-        metadata
-      }
-
-      metadataFuture.recover(bigQueryRecover)
-    }
-
-  def listEntities(workspaceName: WorkspaceName, entityType: String): Future[Seq[Entity]] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        traceDBIOWithParent("countActiveEntitiesOfType", ctx) { countContext =>
-          dataAccess.entityQuery.findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result.flatMap { entityCount =>
-            if (entityCount > pageSizeLimit) {
-              throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest,
-                s"Result set size of $entityCount cannot exceed $pageSizeLimit. Use the paginated entityQuery API instead."))
-            } else {
-              traceDBIOWithParent("listActiveEntitiesOfType", countContext) { _ =>
-                dataAccess.entityQuery.listActiveEntitiesOfType(workspaceContext, entityType)
-              }.map { r =>
-                r.toSeq
               }
             }
           }
@@ -242,38 +325,121 @@ class EntityService(protected val ctx: RawlsRequestContext, val dataSource: Slic
       }
     }
 
-  def queryEntities(workspaceName: WorkspaceName, dataReference: Option[DataReferenceName], entityType: String, query: EntityQuery, billingProject: Option[GoogleProjectId]): Future[EntityQueryResponse] = {
-    if (query.pageSize > pageSizeLimit) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $pageSizeLimit"))
+  def entityTypeMetadata(workspaceName: WorkspaceName,
+                         dataReference: Option[DataReferenceName],
+                         billingProject: Option[GoogleProjectId],
+                         useCache: Boolean
+  ): Future[Map[String, EntityTypeMetadata]] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
+      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+
+      val metadataFuture = for {
+        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
+        metadata <- entityProvider.entityTypeMetadata(useCache)
+      } yield metadata
+
+      metadataFuture.recover(bigQueryRecover)
     }
 
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+  def listEntities(workspaceName: WorkspaceName, entityType: String): Future[Seq[Entity]] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
+      dataSource.inTransaction { dataAccess =>
+        traceDBIOWithParent("countActiveEntitiesOfType", ctx) { countContext =>
+          dataAccess.entityQuery
+            .findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType)
+            .length
+            .result
+            .flatMap { entityCount =>
+              if (entityCount > pageSizeLimit) {
+                throw new RawlsExceptionWithErrorReport(
+                  ErrorReport(
+                    StatusCodes.BadRequest,
+                    s"Result set size of $entityCount cannot exceed $pageSizeLimit. Use the paginated entityQuery API instead."
+                  )
+                )
+              } else {
+                traceDBIOWithParent("listActiveEntitiesOfType", countContext) { _ =>
+                  dataAccess.entityQuery.listActiveEntitiesOfType(workspaceContext, entityType)
+                }.map { r =>
+                  r.toSeq
+                }
+              }
+            }
+        }
+      }
+    }
 
+  def queryEntities(workspaceName: WorkspaceName,
+                    dataReference: Option[DataReferenceName],
+                    entityType: String,
+                    query: EntityQuery,
+                    billingProject: Option[GoogleProjectId]
+  ): Future[EntityQueryResponse] = {
+    if (query.pageSize > pageSizeLimit) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $pageSizeLimit")
+      )
+    }
+
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
       val queryFuture = for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
         entities <- entityProvider.queryEntities(entityType, query, ctx)
-      } yield {
-        entities
-      }
+      } yield entities
 
       queryFuture.recover(bigQueryRecover)
     }
   }
 
-  def copyEntities(entityCopyDef: EntityCopyDefinition, uri: Uri, linkExistingEntities: Boolean): Future[EntityCopyResponse] =
-
-    getWorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { destWorkspaceContext =>
-      getWorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))) flatMap { sourceWorkspaceContext =>
+  def copyEntities(entityCopyDef: EntityCopyDefinition,
+                   uri: Uri,
+                   linkExistingEntities: Boolean
+  ): Future[EntityCopyResponse] =
+    getWorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { destWorkspaceContext =>
+      getWorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
+      ) flatMap { sourceWorkspaceContext =>
         dataSource.inTransaction { dataAccess =>
           for {
-            sourceAD <- DBIO.from(samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, sourceWorkspaceContext.workspaceId, ctx.userInfo))
-            destAD <- DBIO.from(samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, destWorkspaceContext.workspaceId, ctx.userInfo))
+            sourceAD <- DBIO.from(
+              samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace,
+                                           sourceWorkspaceContext.workspaceId,
+                                           ctx.userInfo
+              )
+            )
+            destAD <- DBIO.from(
+              samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace,
+                                           destWorkspaceContext.workspaceId,
+                                           ctx.userInfo
+              )
+            )
             result <- authDomainCheck(sourceAD.toSet, destAD.toSet) flatMap { _ =>
               val entityNames = entityCopyDef.entityNames
               val entityType = entityCopyDef.entityType
-              val copyResults = traceDBIOWithParent("checkAndCopyEntities", ctx)( s1 => dataAccess.entityQuery.checkAndCopyEntities(sourceWorkspaceContext, destWorkspaceContext, entityType, entityNames, linkExistingEntities, s1))
+              val copyResults = traceDBIOWithParent("checkAndCopyEntities", ctx)(s1 =>
+                dataAccess.entityQuery.checkAndCopyEntities(sourceWorkspaceContext,
+                                                            destWorkspaceContext,
+                                                            entityType,
+                                                            entityNames,
+                                                            linkExistingEntities,
+                                                            s1
+                )
+              )
               copyResults
             }
           } yield result
@@ -281,79 +447,122 @@ class EntityService(protected val ctx: RawlsRequestContext, val dataSource: Slic
       }
     }
 
-  def batchUpdateEntitiesInternal(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean, dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[Traversable[Entity]] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
+  def batchUpdateEntitiesInternal(workspaceName: WorkspaceName,
+                                  entityUpdates: Seq[EntityUpdateDefinition],
+                                  upsert: Boolean,
+                                  dataReference: Option[DataReferenceName],
+                                  billingProject: Option[GoogleProjectId]
+  ): Future[Traversable[Entity]] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
-      (for {
+      for {
         entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        entities       <- if (upsert) {
-                            entityProvider.batchUpsertEntities(entityUpdates)
-                          } else {
-                            entityProvider.batchUpdateEntities(entityUpdates)
-                          }
-      } yield {
-        entities
-      })
+        entities <-
+          if (upsert) {
+            entityProvider.batchUpsertEntities(entityUpdates)
+          } else {
+            entityProvider.batchUpdateEntities(entityUpdates)
+          }
+      } yield entities
     }
 
-  def batchUpdateEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[Traversable[Entity]] =
+  def batchUpdateEntities(workspaceName: WorkspaceName,
+                          entityUpdates: Seq[EntityUpdateDefinition],
+                          dataReference: Option[DataReferenceName],
+                          billingProject: Option[GoogleProjectId]
+  ): Future[Traversable[Entity]] =
     batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject)
 
-  def batchUpsertEntities(workspaceName: WorkspaceName, entityUpdates: Seq[EntityUpdateDefinition], dataReference: Option[DataReferenceName], billingProject: Option[GoogleProjectId]): Future[Traversable[Entity]] =
+  def batchUpsertEntities(workspaceName: WorkspaceName,
+                          entityUpdates: Seq[EntityUpdateDefinition],
+                          dataReference: Option[DataReferenceName],
+                          billingProject: Option[GoogleProjectId]
+  ): Future[Traversable[Entity]] =
     batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject)
 
   def renameAttribute(workspaceName: WorkspaceName,
                       entityType: String,
                       oldAttributeName: AttributeName,
-                      attributeRenameRequest: AttributeRename): Future[Int] = {
+                      attributeRenameRequest: AttributeRename
+  ): Future[Int] =
     withAttributeNamespaceCheck(Seq(attributeRenameRequest.newAttributeName)) {
-      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))) flatMap { workspaceContext =>
-
+      getWorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
+      ) flatMap { workspaceContext =>
         def validateNewAttributeName(dataAccess: DataAccess,
                                      workspaceContext: Workspace,
                                      entityType: String,
-                                     attributeName: AttributeName): ReadAction[Boolean] = {
-          dataAccess.entityAttributeShardQuery(workspaceContext).doesAttributeNameAlreadyExist(workspaceContext, entityType, attributeName) map {
+                                     attributeName: AttributeName
+        ): ReadAction[Boolean] =
+          dataAccess
+            .entityAttributeShardQuery(workspaceContext)
+            .doesAttributeNameAlreadyExist(workspaceContext, entityType, attributeName) map {
             case Some(false) => false
-            case Some(true) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict,
-              s"${AttributeName.toDelimitedName(attributeName)} already exists as an attribute name"))
-            case None => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError,
-              s"Unexpected error; could not determine existence of attribute name ${AttributeName.toDelimitedName(attributeName)}"))
+            case Some(true) =>
+              throw new RawlsExceptionWithErrorReport(
+                errorReport =
+                  ErrorReport(StatusCodes.Conflict,
+                              s"${AttributeName.toDelimitedName(attributeName)} already exists as an attribute name"
+                  )
+              )
+            case None =>
+              throw new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.InternalServerError,
+                  s"Unexpected error; could not determine existence of attribute name ${AttributeName.toDelimitedName(attributeName)}"
+                )
+              )
           }
-        }
 
-        def validateRowsUpdated(rowsUpdated: Int, oldAttributeName: AttributeName): Boolean = {
+        def validateRowsUpdated(rowsUpdated: Int, oldAttributeName: AttributeName): Boolean =
           rowsUpdated match {
-            case 0 => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound,
-              s"Can't find attribute name ${AttributeName.toDelimitedName(oldAttributeName)}"))
+            case 0 =>
+              throw new RawlsExceptionWithErrorReport(
+                errorReport =
+                  ErrorReport(StatusCodes.NotFound,
+                              s"Can't find attribute name ${AttributeName.toDelimitedName(oldAttributeName)}"
+                  )
+              )
             case _ => true
           }
-        }
 
         dataSource.inTransaction { dataAccess =>
           val newAttributeName = attributeRenameRequest.newAttributeName
           for {
             _ <- validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName)
-            rowsUpdated <- dataAccess.entityAttributeShardQuery(workspaceContext).renameAttribute(workspaceContext, entityType, oldAttributeName, newAttributeName)
+            rowsUpdated <- dataAccess
+              .entityAttributeShardQuery(workspaceContext)
+              .renameAttribute(workspaceContext, entityType, oldAttributeName, newAttributeName)
             _ = validateRowsUpdated(rowsUpdated, oldAttributeName)
           } yield rowsUpdated
         }
       }
     }
-  }
 
   private def bigQueryRecover[U]: PartialFunction[Throwable, U] = {
-    case dee:DataEntityException =>
+    case dee: DataEntityException =>
       throw new RawlsExceptionWithErrorReport(ErrorReport(dee.code, dee.getMessage))
-    case bqe:BigQueryException =>
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.getForKey(bqe.getCode).getOrElse(StatusCodes.InternalServerError), bqe.getMessage))
-    case gjre:GoogleJsonResponseException =>
+    case bqe: BigQueryException =>
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.getForKey(bqe.getCode).getOrElse(StatusCodes.InternalServerError), bqe.getMessage)
+      )
+    case gjre: GoogleJsonResponseException =>
       // unlikely to hit this case; we should see BigQueryExceptions instead of GoogleJsonResponseExceptions
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.getForKey(gjre.getStatusCode).getOrElse(StatusCodes.InternalServerError), gjre.getMessage))
-    case report:RawlsExceptionWithErrorReport =>
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.getForKey(gjre.getStatusCode).getOrElse(StatusCodes.InternalServerError),
+                    gjre.getMessage
+        )
+      )
+    case report: RawlsExceptionWithErrorReport =>
       throw report // don't rewrap these, just rethrow
-    case ex:Exception =>
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Unexpected error: ${ex.getMessage}", ex))
+    case ex: Exception =>
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.InternalServerError, s"Unexpected error: ${ex.getMessage}", ex)
+      )
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -3,7 +3,16 @@ package org.broadinstitute.dsde.rawls.entities.base
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeValue, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, RawlsRequestContext, SubmissionValidationEntityInputs}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeValue,
+  Entity,
+  EntityQuery,
+  EntityQueryResponse,
+  EntityTypeMetadata,
+  RawlsRequestContext,
+  SubmissionValidationEntityInputs
+}
 
 import scala.concurrent.Future
 import scala.util.Try
@@ -44,13 +53,19 @@ trait EntityProvider {
 
     see core/src/main/antlr4/org/broadinstitute/dsde/rawls/expressions/parser/antlr/TerraExpression.g4
     */
-  def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext, gatherInputsResult: GatherInputsResult, workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]): Future[Stream[SubmissionValidationEntityInputs]]
+  def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
+                          gatherInputsResult: GatherInputsResult,
+                          workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]
+  ): Future[Stream[SubmissionValidationEntityInputs]]
 
   def expressionValidator: ExpressionValidator
 
   def getEntity(entityType: String, entityName: String): Future[Entity]
 
-  def queryEntities(entityType: String, query: EntityQuery, parentContext: RawlsRequestContext): Future[EntityQueryResponse]
+  def queryEntities(entityType: String,
+                    query: EntityQuery,
+                    parentContext: RawlsRequestContext
+  ): Future[EntityQueryResponse]
 
   def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -12,14 +12,40 @@ import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, SamDAO}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
-import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{EntityName, ExpressionAndResult, LookupExpression}
+import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{
+  EntityName,
+  ExpressionAndResult,
+  LookupExpression
+}
 import org.broadinstitute.dsde.rawls.entities.base._
 import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoBigQuerySupport._
 import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, UnsupportedEntityOperationException}
-import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{AntlrTerraExpressionParser, DataRepoEvaluateToAttributeVisitor, LookupExpressionExtractionVisitor, ParsedEntityLookupExpression}
+import org.broadinstitute.dsde.rawls.expressions.parser.antlr.{
+  AntlrTerraExpressionParser,
+  DataRepoEvaluateToAttributeVisitor,
+  LookupExpressionExtractionVisitor,
+  ParsedEntityLookupExpression
+}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeNull, AttributeNumber, AttributeString, AttributeValue, AttributeValueList, AttributeValueRawJson, Entity, EntityQuery, EntityQueryResponse, EntityTypeMetadata, ErrorReport, GoogleProjectId, RawlsRequestContext, SubmissionValidationEntityInputs}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
+  AttributeEntityReference,
+  AttributeNull,
+  AttributeNumber,
+  AttributeString,
+  AttributeValue,
+  AttributeValueList,
+  AttributeValueRawJson,
+  Entity,
+  EntityQuery,
+  EntityQueryResponse,
+  EntityTypeMetadata,
+  ErrorReport,
+  GoogleProjectId,
+  RawlsRequestContext,
+  SubmissionValidationEntityInputs
+}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -32,23 +58,26 @@ import scala.util.{Failure, Success, Try}
 
 class DataRepoEntityProvider(snapshotModel: SnapshotModel,
                              requestArguments: EntityRequestArguments,
-                             samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory,
-                             config: DataRepoEntityProviderConfig)
-                            (implicit protected val executionContext: ExecutionContext)
-  extends EntityProvider with DataRepoBigQuerySupport with LazyLogging with ExpressionEvaluationSupport {
+                             samDAO: SamDAO,
+                             bqServiceFactory: GoogleBigQueryServiceFactory,
+                             config: DataRepoEntityProviderConfig
+)(implicit protected val executionContext: ExecutionContext)
+    extends EntityProvider
+    with DataRepoBigQuerySupport
+    with LazyLogging
+    with ExpressionEvaluationSupport {
 
   override val entityStoreId: Option[String] = Option(snapshotModel.getId.toString)
 
-  private[datarepo] lazy val googleProject: GoogleProjectId = {
+  private[datarepo] lazy val googleProject: GoogleProjectId =
     /* Determine project to be billed for the BQ job:
         If a project was explicitly specified in the constructor arguments, use that.
         Else, use the workspace's project. This requires canCompute permissions on the workspace.
      */
     requestArguments.billingProject match {
       case Some(billing) => billing
-      case None => requestArguments.workspace.googleProjectId
+      case None          => requestArguments.workspace.googleProjectId
     }
-  }
 
   override def entityTypeMetadata(useCache: Boolean = false): Future[Map[String, EntityTypeMetadata]] = {
 
@@ -74,7 +103,6 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
   override def deleteEntitiesOfType(entityType: String): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities of type not supported by this provider.")
 
-
   override def getEntity(entityType: String, entityName: String): Future[Entity] = {
     // extract table definition, with PK, from snapshot schema
     val tableModel = getTableModel(snapshotModel, entityType)
@@ -87,9 +115,11 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
     val viewName = snapshotModel.getName
     // generate BQ SQL for this entity
     // they should be safe, but we should have layers of protection.
-    val query = s"SELECT * FROM `${validateSql(dataProject)}.${validateSql(viewName)}.${validateSql(entityType)}` WHERE $pk = @pkvalue;"
+    val query =
+      s"SELECT * FROM `${validateSql(dataProject)}.${validateSql(viewName)}.${validateSql(entityType)}` WHERE $pk = @pkvalue;"
     // generate query config, with named param for primary key
-    val queryConfigBuilder = QueryJobConfiguration.newBuilder(query)
+    val queryConfigBuilder = QueryJobConfiguration
+      .newBuilder(query)
       .addNamedParameter("pkvalue", QueryParameterValue.string(entityName))
 
     val resultIO = for {
@@ -97,14 +127,16 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       petKey <- getPetSAKey
       // execute the query against BQ
       queryResults <- runBigQuery(queryConfigBuilder, petKey, GoogleProject(googleProject.value))
-    } yield {
-      // translate the BQ results into a single Rawls Entity
-      queryResultsToEntity(queryResults, entityType, pk)
-    }
+    } yield
+    // translate the BQ results into a single Rawls Entity
+    queryResultsToEntity(queryResults, entityType, pk)
     resultIO.unsafeToFuture()
   }
 
-  override def queryEntities(entityType: String, incomingQuery: EntityQuery, parentContext: RawlsRequestContext = requestArguments.ctx): Future[EntityQueryResponse] = {
+  override def queryEntities(entityType: String,
+                             incomingQuery: EntityQuery,
+                             parentContext: RawlsRequestContext = requestArguments.ctx
+  ): Future[EntityQueryResponse] = {
     // throw immediate error if user supplied filterTerms
     if (incomingQuery.filterTerms.nonEmpty) {
       throw new UnsupportedEntityOperationException("term filtering not supported by this provider.")
@@ -115,27 +147,36 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
     // validate sort column exists in the snapshot's table description, or sort column is
     // one of the magic fields "datarepo_row_id" or "name"
-    if (datarepoRowIdColumn != incomingQuery.sortField &&
-        "name" != incomingQuery.sortField &&
-        !tableModel.getColumns.asScala.exists(_.getName == incomingQuery.sortField))
-      throw new DataEntityException(code = StatusCodes.BadRequest, message = s"sortField not valid for this entity type")
+    if (
+      datarepoRowIdColumn != incomingQuery.sortField &&
+      "name" != incomingQuery.sortField &&
+      !tableModel.getColumns.asScala.exists(_.getName == incomingQuery.sortField)
+    )
+      throw new DataEntityException(code = StatusCodes.BadRequest,
+                                    message = s"sortField not valid for this entity type"
+      )
 
     //  determine pk column
     val pk = pkFromSnapshotTable(tableModel)
 
     // allow sorting by magic "name" field, which is a derived field containing the pk
-    val finalQuery = if (incomingQuery.sortField == "name" && !tableModel.getColumns.asScala.exists(_.getName == "name")) {
-      incomingQuery.copy(sortField = pk)
-    } else {
-      incomingQuery
-    }
+    val finalQuery =
+      if (incomingQuery.sortField == "name" && !tableModel.getColumns.asScala.exists(_.getName == "name")) {
+        incomingQuery.copy(sortField = pk)
+      } else {
+        incomingQuery
+      }
 
     // calculate the pagination metadata
     val metadata = queryResultsMetadata(tableModel.getRowCount, finalQuery)
 
     // validate requested page against actual number of pages
     if (finalQuery.page > metadata.filteredPageCount) {
-      throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${incomingQuery.page} is greater than the number of pages ${metadata.filteredPageCount}")
+      throw new DataEntityException(
+        code = StatusCodes.BadRequest,
+        message =
+          s"requested page ${incomingQuery.page} is greater than the number of pages ${metadata.filteredPageCount}"
+      )
     }
 
     // if Data Repo indicates this table is empty, create an empty list and don't query BigQuery
@@ -154,10 +195,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
         petKey <- getPetSAKey
         // execute the query against BQ
         queryResults <- runBigQuery(queryConfigBuilder, petKey, GoogleProject(googleProject.value))
-      } yield {
-        // translate the BQ results into a Rawls query result
-        queryResultsToEntities(queryResults, entityType, pk)
-      }
+      } yield
+      // translate the BQ results into a Rawls query result
+      queryResultsToEntities(queryResults, entityType, pk)
       resultIO.unsafeToFuture()
     }
 
@@ -165,16 +205,17 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   }
 
-  def pkFromSnapshotTable(tableModel: TableModel): String = {
+  def pkFromSnapshotTable(tableModel: TableModel): String =
     // If data repo returns one and only one primary key, use it.
     // If data repo returns null or a compound PK, use the built-in rowid for pk instead.
     Option(tableModel.getPrimaryKey) match {
       case Some(pk) if pk.size() == 1 => pk.asScala.head
-      case _ => datarepoRowIdColumn // default data repo value
+      case _                          => datarepoRowIdColumn // default data repo value
     }
-  }
 
-  private[datarepo] def convertToListAndCheckSize(expressionResultsStream: Stream[ExpressionAndResult], expectedSize: Int): Seq[ExpressionAndResult] = {
+  private[datarepo] def convertToListAndCheckSize(expressionResultsStream: Stream[ExpressionAndResult],
+                                                  expectedSize: Int
+  ): Seq[ExpressionAndResult] = {
     // this size of stuff is not meant to be precise but just hopefully close enough
     // so that we can protect from OOMs
     val objectSize = 8
@@ -182,28 +223,26 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
     val booleanSize = objectSize + 1
     def stringSize(s: String) = objectSize + s.length * 1
 
-    def sizeOfJsValueBytes(jsValue: JsValue): Int = {
+    def sizeOfJsValueBytes(jsValue: JsValue): Int =
       jsValue match {
         case JsArray(elements) => objectSize + elements.map(sizeOfJsValueBytes).sum
-        case JsBoolean(_) => booleanSize
-        case JsNull => 0
-        case JsNumber(_) => bigDecimalSize
-        case JsObject(fields) => fields.map { case (k, v) => stringSize(k) + sizeOfJsValueBytes(v) }.sum
-        case JsString(value) => objectSize + stringSize(value)
-        case JsFalse => 1
-        case JsTrue => 1
+        case JsBoolean(_)      => booleanSize
+        case JsNull            => 0
+        case JsNumber(_)       => bigDecimalSize
+        case JsObject(fields)  => fields.map { case (k, v) => stringSize(k) + sizeOfJsValueBytes(v) }.sum
+        case JsString(value)   => objectSize + stringSize(value)
+        case JsFalse           => 1
+        case JsTrue            => 1
       }
-    }
 
-    def sizeOfAttributeValueBytes(attributeValue: AttributeValue): Int = {
+    def sizeOfAttributeValueBytes(attributeValue: AttributeValue): Int =
       attributeValue match {
-        case AttributeNull => 0
-        case AttributeBoolean(_) => booleanSize
-        case AttributeNumber(_) => bigDecimalSize
-        case AttributeString(value) => objectSize + stringSize(value)
+        case AttributeNull                => 0
+        case AttributeBoolean(_)          => booleanSize
+        case AttributeNumber(_)           => bigDecimalSize
+        case AttributeString(value)       => objectSize + stringSize(value)
         case AttributeValueRawJson(value) => objectSize + sizeOfJsValueBytes(value)
       }
-    }
 
     val buffer = new ArrayBuffer[ExpressionAndResult](expectedSize)
     var runningSizeEstimateBytes = 0
@@ -213,8 +252,10 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       val sizeEstimateBytes = result.values.map(_.map(_.map(sizeOfAttributeValueBytes).sum).getOrElse(0)).sum
       runningSizeEstimateBytes += sizeEstimateBytes
 
-      if(runningSizeEstimateBytes > config.maxBigQueryResponseSizeBytes) {
-        throw new DataEntityException(s"Query returned too many results likely due to either large one-to-many relationships or arrays. The limit on the total number bytes is ${config.maxBigQueryResponseSizeBytes}.")
+      if (runningSizeEstimateBytes > config.maxBigQueryResponseSizeBytes) {
+        throw new DataEntityException(
+          s"Query returned too many results likely due to either large one-to-many relationships or arrays. The limit on the total number bytes is ${config.maxBigQueryResponseSizeBytes}."
+        )
       }
 
       buffer += expressionAndResult
@@ -223,7 +264,10 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
     buffer.toList
   }
 
-  override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext, gatherInputsResult: GatherInputsResult, workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]): Future[Stream[SubmissionValidationEntityInputs]] = {
+  override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
+                                   gatherInputsResult: GatherInputsResult,
+                                   workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]
+  ): Future[Stream[SubmissionValidationEntityInputs]] =
     expressionEvaluationContext match {
       case ExpressionEvaluationContext(None, None, None, Some(rootEntityType)) =>
         /*
@@ -241,62 +285,95 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
           tableModel = getTableModel(snapshotModel, rootEntityType)
           _ <- checkSubmissionSize(parsedExpressions, tableModel)
           entityNameColumn = pkFromSnapshotTable(tableModel)
-          (selectAndFroms, bqQueryJobConfig) = queryConfigForExpressions(snapshotModel, parsedExpressions, tableModel, entityNameColumn)
-          _ = logger.debug(s"expressions [${parsedExpressions.map(_.expression).mkString(", ")}] for snapshot id [${snapshotModel.getId} produced sql query ${bqQueryJobConfig.build().getQuery}")
+          (selectAndFroms, bqQueryJobConfig) = queryConfigForExpressions(snapshotModel,
+                                                                         parsedExpressions,
+                                                                         tableModel,
+                                                                         entityNameColumn
+          )
+          _ = logger.debug(
+            s"expressions [${parsedExpressions.map(_.expression).mkString(", ")}] for snapshot id [${snapshotModel.getId} produced sql query ${bqQueryJobConfig.build().getQuery}"
+          )
           petKey <- getPetSAKey
           queryResults <- runBigQuery(bqQueryJobConfig, petKey, GoogleProject(googleProject.value))
         } yield {
-          val expressionResultsStream = transformQueryResultToExpressionAndResult(entityNameColumn, parsedExpressions, selectAndFroms, queryResults)
+          val expressionResultsStream =
+            transformQueryResultToExpressionAndResult(entityNameColumn, parsedExpressions, selectAndFroms, queryResults)
           val expressionResults = convertToListAndCheckSize(expressionResultsStream, tableModel.getRowCount)
           val rootEntityNames = getEntityNames(expressionResults)
-          val workspaceExpressionResultsPerEntity = populateWorkspaceLookupPerEntity(workspaceExpressionResults, rootEntityNames)
-          val groupedResults = groupResultsByExpressionAndEntityName(expressionResults ++ workspaceExpressionResultsPerEntity)
+          val workspaceExpressionResultsPerEntity =
+            populateWorkspaceLookupPerEntity(workspaceExpressionResults, rootEntityNames)
+          val groupedResults = groupResultsByExpressionAndEntityName(
+            expressionResults ++ workspaceExpressionResultsPerEntity
+          )
 
-          val entityNameAndInputValues = constructInputsForEachEntity(gatherInputsResult, groupedResults, rootEntityNames)
+          val entityNameAndInputValues =
+            constructInputsForEachEntity(gatherInputsResult, groupedResults, rootEntityNames)
 
           createSubmissionValidationEntityInputs(CollectionUtils.groupByTuples(entityNameAndInputValues))
         }
         resultIO.unsafeToFuture()
 
-      case _ => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Only root entity type supported for Data Repo workflows")))
+      case _ =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest, "Only root entity type supported for Data Repo workflows")
+          )
+        )
     }
-  }
 
   private def getPetSAKey: IO[String] = {
     logger.debug(s"getPetSAKey attempting against project ${googleProject.value}")
-    IO.fromFuture(IO(
-      samDAO.getPetServiceAccountKeyForUser(googleProject, requestArguments.ctx.userInfo.userEmail)
-        .recover {
-          case report:RawlsExceptionWithErrorReport =>
-            val errMessage = s"Error attempting to use project ${googleProject.value}. " +
-              s"The project does not exist or you do not have permission to use it: ${report.errorReport.message}"
-            throw new RawlsExceptionWithErrorReport(report.errorReport.copy(message = errMessage))
-          case err:Exception => throw new RawlsException(s"Error attempting to use project ${googleProject.value}. " +
-            s"The project does not exist or you do not have permission to use it: ${err.getMessage}")
-        }))
+    IO.fromFuture(
+      IO(
+        samDAO
+          .getPetServiceAccountKeyForUser(googleProject, requestArguments.ctx.userInfo.userEmail)
+          .recover {
+            case report: RawlsExceptionWithErrorReport =>
+              val errMessage = s"Error attempting to use project ${googleProject.value}. " +
+                s"The project does not exist or you do not have permission to use it: ${report.errorReport.message}"
+              throw new RawlsExceptionWithErrorReport(report.errorReport.copy(message = errMessage))
+            case err: Exception =>
+              throw new RawlsException(
+                s"Error attempting to use project ${googleProject.value}. " +
+                  s"The project does not exist or you do not have permission to use it: ${err.getMessage}"
+              )
+          }
+      )
+    )
   }
 
-  private def getEntityNames(bqExpressionResults: Seq[ExpressionAndResult]): Seq[EntityName] = {
-    bqExpressionResults.flatMap {
-      case (_, resultsMap) => resultsMap.keys
+  private def getEntityNames(bqExpressionResults: Seq[ExpressionAndResult]): Seq[EntityName] =
+    bqExpressionResults.flatMap { case (_, resultsMap) =>
+      resultsMap.keys
     }.distinct
-  }
 
-  private def populateWorkspaceLookupPerEntity(workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]], rootEntities: Seq[EntityName]): Seq[ExpressionAndResult] = {
-    workspaceExpressionResults.toSeq.map { case(lookup, result) =>
+  private def populateWorkspaceLookupPerEntity(
+    workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]],
+    rootEntities: Seq[EntityName]
+  ): Seq[ExpressionAndResult] =
+    workspaceExpressionResults.toSeq.map { case (lookup, result) =>
       (lookup, rootEntities.map(_ -> result).toMap)
     }
-  }
 
-  private def checkSubmissionSize(parsedExpressions: Set[ParsedEntityLookupExpression], tableModel: TableModel) = {
+  private def checkSubmissionSize(parsedExpressions: Set[ParsedEntityLookupExpression], tableModel: TableModel) =
     if (tableModel.getRowCount * parsedExpressions.size > config.maxInputsPerSubmission) {
-      IO.raiseError(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Too many results. Snapshot row count * number of entity expressions cannot exceed ${config.maxInputsPerSubmission}.")))
+      IO.raiseError(
+        new RawlsExceptionWithErrorReport(
+          ErrorReport(
+            StatusCodes.BadRequest,
+            s"Too many results. Snapshot row count * number of entity expressions cannot exceed ${config.maxInputsPerSubmission}."
+          )
+        )
+      )
     } else {
       IO.unit
     }
-  }
 
-  private def constructInputsForEachEntity(gatherInputsResult: GatherInputsResult, groupedResults: Seq[(LookupExpression, Map[EntityName, Try[Iterable[AttributeValue]]])], rootEntities: Seq[EntityName]) = {
+  private def constructInputsForEachEntity(
+    gatherInputsResult: GatherInputsResult,
+    groupedResults: Seq[(LookupExpression, Map[EntityName, Try[Iterable[AttributeValue]]])],
+    rootEntities: Seq[EntityName]
+  ) =
     // gatherInputsResult.processableInputs.toSeq so that the result is not a Set and does not worry about duplicates
     gatherInputsResult.processableInputs.toSeq.flatMap { input =>
       val parser = AntlrTerraExpressionParser.getParser(input.expression)
@@ -304,34 +381,52 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       val parsedTree = parser.root()
       val lookupExpressions = visitor.visit(parsedTree)
 
-      val expressionResultsByEntityName = InputExpressionReassembler.constructFinalInputValues(groupedResults.filter {
-        case (expression, _) => lookupExpressions.contains(expression)
-      }, parsedTree, Option(rootEntities), Option(input))
+      val expressionResultsByEntityName =
+        InputExpressionReassembler.constructFinalInputValues(groupedResults.filter { case (expression, _) =>
+                                                               lookupExpressions.contains(expression)
+                                                             },
+                                                             parsedTree,
+                                                             Option(rootEntities),
+                                                             Option(input)
+        )
 
       convertToSubmissionValidationValues(expressionResultsByEntityName, input)
     }
-  }
 
-  private def groupResultsByExpressionAndEntityName(expressionResults: Seq[ExpressionAndResult]) = {
-    expressionResults.groupBy {
-      case (expression, _) => expression
-    }.toSeq.map {
-      case (expression, groupedList) => (expression, groupedList.foldLeft(Map.empty[EntityName, Try[Iterable[AttributeValue]]]) {
-        case (aggregateResults, (_, individualResult)) => aggregateResults ++ individualResult
-      })
-    }
-  }
+  private def groupResultsByExpressionAndEntityName(expressionResults: Seq[ExpressionAndResult]) =
+    expressionResults
+      .groupBy { case (expression, _) =>
+        expression
+      }
+      .toSeq
+      .map { case (expression, groupedList) =>
+        (expression,
+         groupedList.foldLeft(Map.empty[EntityName, Try[Iterable[AttributeValue]]]) {
+           case (aggregateResults, (_, individualResult)) => aggregateResults ++ individualResult
+         }
+        )
+      }
 
-  private def runBigQuery(bqQueryJobConfigBuilder: QueryJobConfiguration.Builder, petKey: String, projectToBill: GoogleProject): IO[TableResult] = {
+  private def runBigQuery(bqQueryJobConfigBuilder: QueryJobConfiguration.Builder,
+                          petKey: String,
+                          projectToBill: GoogleProject
+  ): IO[TableResult] = {
     logger.debug(s"runBigQuery attempting against project  ${projectToBill.value}")
-    try {
-      bqServiceFactory.getServiceForPet(petKey, projectToBill).use(_.query(
-        bqQueryJobConfigBuilder
-          .setMaximumBytesBilled(config.bigQueryMaximumBytesBilled)
-          .build()))
-    } catch {
+    try
+      bqServiceFactory
+        .getServiceForPet(petKey, projectToBill)
+        .use(
+          _.query(
+            bqQueryJobConfigBuilder
+              .setMaximumBytesBilled(config.bigQueryMaximumBytesBilled)
+              .build()
+          )
+        )
+    catch {
       case ex: GoogleJsonResponseException if ex.getStatusCode == StatusCodes.Forbidden.intValue =>
-        throw new RawlsException(s"Billing project {googleProject.value} either does not exist or the user does not have access to it.")
+        throw new RawlsException(
+          s"Billing project {googleProject.value} either does not exist or the user does not have access to it."
+        )
     }
   }
 
@@ -347,9 +442,15 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
     * @param tableResult query results
     * @return Stream because it should not suck all the results from BigQuery into memory
     */
-  private[datarepo] def transformQueryResultToExpressionAndResult(entityNameColumn: String, parsedExpressions: Set[ParsedEntityLookupExpression], selectAndFroms: Seq[SelectAndFrom], tableResult: TableResult): Stream[ExpressionAndResult] = {
-    val selectAndFromByRelationshipPath = selectAndFroms.map(sf => sf.join.map(_.relationshipPath).getOrElse(Seq.empty) -> sf).toMap
-    val joinAliasesByRelationshipPath = selectAndFroms.flatMap(j => j.join.map(r => r.relationshipPath -> r.alias)).toMap
+  private[datarepo] def transformQueryResultToExpressionAndResult(entityNameColumn: String,
+                                                                  parsedExpressions: Set[ParsedEntityLookupExpression],
+                                                                  selectAndFroms: Seq[SelectAndFrom],
+                                                                  tableResult: TableResult
+  ): Stream[ExpressionAndResult] = {
+    val selectAndFromByRelationshipPath =
+      selectAndFroms.map(sf => sf.join.map(_.relationshipPath).getOrElse(Seq.empty) -> sf).toMap
+    val joinAliasesByRelationshipPath =
+      selectAndFroms.flatMap(j => j.join.map(r => r.relationshipPath -> r.alias)).toMap
     for {
       resultRow <- tableResult.iterateAll().asScala.toStream // this is the streaming goodness
       parsedExpression <- parsedExpressions
@@ -360,7 +461,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       // Using this information we can lookup the value for each parsedExpression in tableResult.
 
       // determine column index based on position of parsedExpression.columnName in SelectAndFrom.selectColumns
-      val columnIndex = selectAndFromByRelationshipPath(parsedExpression.relationshipPath).selectColumns.map(_.column).indexOf(parsedExpression.columnName)
+      val columnIndex = selectAndFromByRelationshipPath(parsedExpression.relationshipPath).selectColumns
+        .map(_.column)
+        .indexOf(parsedExpression.columnName)
       val attribute = joinAliasesByRelationshipPath.get(parsedExpression.relationshipPath) match {
         case None =>
           // this is a root level expression, e.g. this.foo, no alias required it should be at the top level of the row
@@ -374,22 +477,27 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
           assert(field.getMode == Mode.REPEATED, "expected result from relationship to be an array")
           assert(field.getType == LegacySQLTypeName.RECORD, "expected result from relationship to be a struct")
           val subField = field.getSubFields.get(columnIndex)
-          val attributeValues = resultRow.get(joinAlias).getRepeatedValue.asScala.map { struct =>
-            val subFieldValue = struct.getRecordValue.get(columnIndex)
-            fieldValueToAttribute(subField, subFieldValue)
-          }.flatMap {
-            case v: AttributeValue => Seq(v)
-            case AttributeValueList(l) => l
-            case unsupported => throw new RawlsException(s"unsupported attribute: $unsupported")
-          }
+          val attributeValues = resultRow
+            .get(joinAlias)
+            .getRepeatedValue
+            .asScala
+            .map { struct =>
+              val subFieldValue = struct.getRecordValue.get(columnIndex)
+              fieldValueToAttribute(subField, subFieldValue)
+            }
+            .flatMap {
+              case v: AttributeValue     => Seq(v)
+              case AttributeValueList(l) => l
+              case unsupported           => throw new RawlsException(s"unsupported attribute: $unsupported")
+            }
           AttributeValueList(attributeValues.toList)
       }
 
       val primaryKey: EntityName = resultRow.get(entityNameColumn).getStringValue
       val evaluationResult: Try[Iterable[AttributeValue]] = attribute match {
-        case v: AttributeValue => Success(Seq(v))
+        case v: AttributeValue     => Success(Seq(v))
         case AttributeValueList(l) => Success(l)
-        case unsupported => Failure(new RawlsException(s"unsupported attribute: $unsupported"))
+        case unsupported           => Failure(new RawlsException(s"unsupported attribute: $unsupported"))
       }
       (parsedExpression.expression, Map(primaryKey -> evaluationResult))
     }
@@ -414,7 +522,6 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
   override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] = {
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilder.scala
@@ -19,17 +19,22 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success, Try}
 
-class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, dataRepoDAO: DataRepoDAO,
-                                    samDAO: SamDAO, bqServiceFactory: GoogleBigQueryServiceFactory,
-                                    config: DataRepoEntityProviderConfig)
-                                   (implicit protected val executionContext: ExecutionContext)
-  extends EntityProviderBuilder[DataRepoEntityProvider] with LazyLogging {
+class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO,
+                                    dataRepoDAO: DataRepoDAO,
+                                    samDAO: SamDAO,
+                                    bqServiceFactory: GoogleBigQueryServiceFactory,
+                                    config: DataRepoEntityProviderConfig
+)(implicit protected val executionContext: ExecutionContext)
+    extends EntityProviderBuilder[DataRepoEntityProvider]
+    with LazyLogging {
 
   override def builds: TypeTag[DataRepoEntityProvider] = typeTag[DataRepoEntityProvider]
 
-  override def build(requestArguments: EntityRequestArguments): Try[DataRepoEntityProvider] = {
+  override def build(requestArguments: EntityRequestArguments): Try[DataRepoEntityProvider] =
     for {
-      dataReferenceName <- requestArguments.dataReference.toRight(new DataEntityException("data reference must be defined for this provider")).toTry
+      dataReferenceName <- requestArguments.dataReference
+        .toRight(new DataEntityException("data reference must be defined for this provider"))
+        .toTry
 
       // get snapshot UUID from data reference name
       dataReference <- Try(lookupSnapshotForName(dataReferenceName, requestArguments))
@@ -38,18 +43,22 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
       // contact TDR to describe the snapshot
       snapshotModel <- Try(dataRepoDAO.getSnapshot(snapshotId, requestArguments.ctx.userInfo.accessToken)).recoverWith {
         case notFound: DatarepoApiException if notFound.getCode == StatusCodes.NotFound.intValue =>
-          Failure(new DataEntityException(s"Snapshot id $snapshotId does not exist or you do not have access", notFound))
+          Failure(
+            new DataEntityException(s"Snapshot id $snapshotId does not exist or you do not have access", notFound)
+          )
 
         // Data Repo returns 401 Unauthorized if the user has a valid token but does not have the proper permission on the snapshot
-        case forbidden: DatarepoApiException if forbidden.getCode == StatusCodes.Forbidden.intValue || forbidden.getCode == StatusCodes.Unauthorized.intValue =>
+        case forbidden: DatarepoApiException
+            if forbidden.getCode == StatusCodes.Forbidden.intValue || forbidden.getCode == StatusCodes.Unauthorized.intValue =>
           // attempt to extract buried message
           // raw response looks like: {"message":"User 'davidan.dev2@gmail.com' does not have required action: read_data","errorDetail":[]}
           import spray.json._
-          val innerErrorMessage: String = Try(forbidden.getMessage.parseJson.asJsObject.fields.get("message"))
-            .toOption.flatten.collect {
-              case jss:JsString => jss.value
-            }
-            .getOrElse("[error could not be deserialized]")
+          val innerErrorMessage: String =
+            Try(forbidden.getMessage.parseJson.asJsObject.fields.get("message")).toOption.flatten
+              .collect { case jss: JsString =>
+                jss.value
+              }
+              .getOrElse("[error could not be deserialized]")
 
           val finalErrMessage = s"Snapshot id $snapshotId exists but access was denied: $innerErrorMessage"
 
@@ -58,18 +67,33 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
           Failure(new DataEntityException(code = StatusCodes.Forbidden, message = finalErrMessage))
       }
     } yield new DataRepoEntityProvider(snapshotModel, requestArguments, samDAO, bqServiceFactory, config)
-  }
 
-  private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName, requestArguments: EntityRequestArguments): DataRepoSnapshotResource = {
+  private[datarepo] def lookupSnapshotForName(dataReferenceName: DataReferenceName,
+                                              requestArguments: EntityRequestArguments
+  ): DataRepoSnapshotResource = {
     // contact WSM to retrieve the data reference specified in the request
-    val dataRefTry = Try(workspaceManagerDAO.getDataRepoSnapshotReferenceByName(UUID.fromString(requestArguments.workspace.workspaceId),
-      dataReferenceName,
-      requestArguments.ctx)).recoverWith {
+    val dataRefTry = Try(
+      workspaceManagerDAO.getDataRepoSnapshotReferenceByName(UUID.fromString(requestArguments.workspace.workspaceId),
+                                                             dataReferenceName,
+                                                             requestArguments.ctx
+      )
+    ).recoverWith {
 
       case notFound: WorkspaceApiException if notFound.getCode == StatusCodes.NotFound.intValue =>
-        Failure(new DataEntityException(s"Reference name ${dataReferenceName.value} does not exist in workspace ${requestArguments.workspace.toWorkspaceName}.", notFound, StatusCodes.NotFound))
+        Failure(
+          new DataEntityException(
+            s"Reference name ${dataReferenceName.value} does not exist in workspace ${requestArguments.workspace.toWorkspaceName}.",
+            notFound,
+            StatusCodes.NotFound
+          )
+        )
       case forbidden: WorkspaceApiException if forbidden.getCode == StatusCodes.Forbidden.intValue =>
-        Failure(new DataEntityException(s"Access denied for reference name ${dataReferenceName.value}.", forbidden, StatusCodes.Forbidden))
+        Failure(
+          new DataEntityException(s"Access denied for reference name ${dataReferenceName.value}.",
+                                  forbidden,
+                                  StatusCodes.Forbidden
+          )
+        )
     }
 
     // trigger any exceptions
@@ -79,7 +103,9 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
 
     // verify it's a TDR snapshot. should be a noop, since getDataReferenceByName enforces this.
     if (ResourceType.DATA_REPO_SNAPSHOT != dataRef.getMetadata.getResourceType) {
-      throw new DataEntityException(s"Reference type value for $dataReferenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}")
+      throw new DataEntityException(
+        s"Reference type value for $dataReferenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}"
+      )
     }
 
     val dataReference = dataRef.getAttributes
@@ -88,7 +114,9 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
     // TODO: AS-321 is this the right place to validate this? We could add a "validateInstanceURL" method to the DAO itself, for instance
     if (!dataReference.getInstanceName.equalsIgnoreCase(dataRepoDAO.getInstanceName)) {
       logger.error(s"expected instance name ${dataRepoDAO.getInstanceName}, got ${dataReference.getInstanceName}")
-      throw new DataEntityException(s"Reference value for $dataReferenceName contains an unexpected instance name value")
+      throw new DataEntityException(
+        s"Reference value for $dataReferenceName contains an unexpected instance name value"
+      )
     }
 
     // verify snapshotId value is a UUID
@@ -96,7 +124,9 @@ class DataRepoEntityProviderBuilder(workspaceManagerDAO: WorkspaceManagerDAO, da
       case Success(uuid) => // success; noop
       case Failure(ex) =>
         logger.error(s"invalid UUID for snapshotId in reference: ${dataReference.getSnapshot}")
-        throw new DataEntityException(s"Reference value for $dataReferenceName contains an unexpected snapshot value", ex)
+        throw new DataEntityException(s"Reference value for $dataReferenceName contains an unexpected snapshot value",
+                                      ex
+        )
     }
 
     dataRef

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupport.scala
@@ -4,7 +4,13 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
-import org.broadinstitute.dsde.rawls.model.{AttributeName, EntityTypeMetadata, RawlsRequestContext, Workspace, WorkspaceFeatureFlag}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeName,
+  EntityTypeMetadata,
+  RawlsRequestContext,
+  Workspace,
+  WorkspaceFeatureFlag
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 
 import java.sql.Timestamp
@@ -33,9 +39,10 @@ trait EntityStatisticsCacheSupport extends LazyLogging with RawlsInstrumented {
     * it will update the cache with the results it found.
     * */
   def calculateMetadataResponse(dataAccess: DataAccess,
-                                        countsFromCache: Boolean,
-                                        attributesFromCache: Boolean,
-                                        parentContext: RawlsRequestContext): ReadWriteAction[Map[String, EntityTypeMetadata]] = {
+                                countsFromCache: Boolean,
+                                attributesFromCache: Boolean,
+                                parentContext: RawlsRequestContext
+  ): ReadWriteAction[Map[String, EntityTypeMetadata]] = {
     val typesAndCountsQ = typeCounts(dataAccess, countsFromCache, parentContext)
     val typesAndAttrsQ = typeAttributes(dataAccess, attributesFromCache, parentContext)
     traceDBIOWithParent("generateEntityMetadataMap", parentContext) { innerSpan =>
@@ -52,96 +59,111 @@ trait EntityStatisticsCacheSupport extends LazyLogging with RawlsInstrumented {
   }
 
   /** convenience method for writing back to cache, if we have already calculated a response from outside the cache */
-  def opportunisticSaveEntityCache(metadata: Map[String, EntityTypeMetadata], dataAccess: DataAccess, parentContext: RawlsRequestContext) = {
-    val entityTypesWithCounts: Map[String, Int] = metadata.map {
-      case (typeName, typeMetadata) => typeName -> typeMetadata.count
+  def opportunisticSaveEntityCache(metadata: Map[String, EntityTypeMetadata],
+                                   dataAccess: DataAccess,
+                                   parentContext: RawlsRequestContext
+  ) = {
+    val entityTypesWithCounts: Map[String, Int] = metadata.map { case (typeName, typeMetadata) =>
+      typeName -> typeMetadata.count
     }
-    val entityTypesWithAttrNames: Map[String, Seq[AttributeName]] = metadata.map {
-      case (typeName, typeMetadata) => typeName -> typeMetadata.attributeNames.map(AttributeName.fromDelimitedName)
+    val entityTypesWithAttrNames: Map[String, Seq[AttributeName]] = metadata.map { case (typeName, typeMetadata) =>
+      typeName -> typeMetadata.attributeNames.map(AttributeName.fromDelimitedName)
     }
     val timestamp: Timestamp = new Timestamp(workspaceContext.lastModified.getMillis)
 
     traceDBIOWithParent("generateEntityMetadataMap", parentContext) { _ =>
-      dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceContext.workspaceIdAsUUID,
-        entityTypesWithCounts, entityTypesWithAttrNames, timestamp).asTry.map {
-        case Success(_) => opportunisticEntityCacheSaveCounter.inc()
-        case Failure(ex) =>
-          logger.warn(s"failed to opportunistically update the entity statistics cache: ${ex.getMessage}. " +
-            s"The user's request was not impacted.")
-      }
+      dataAccess.entityCacheManagementQuery
+        .saveEntityCache(workspaceContext.workspaceIdAsUUID, entityTypesWithCounts, entityTypesWithAttrNames, timestamp)
+        .asTry
+        .map {
+          case Success(_) => opportunisticEntityCacheSaveCounter.inc()
+          case Failure(ex) =>
+            logger.warn(
+              s"failed to opportunistically update the entity statistics cache: ${ex.getMessage}. " +
+                s"The user's request was not impacted."
+            )
+        }
     }
   }
 
   /** wrapper for cache staleness lookup, includes performance tracing */
-  def cacheStaleness(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Option[Int]] = {
+  def cacheStaleness(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Option[Int]] =
     traceDBIOWithParent("entityCacheStaleness", parentContext) { _ =>
       dataAccess.entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID).map { stalenessOpt =>
         // record the cache-staleness for this request
         stalenessOpt match {
           case Some(staleness) =>
-            logger.info(f"entity statistics cache staleness for workspaceId ${workspaceContext.workspaceId}: $staleness")
+            logger
+              .info(f"entity statistics cache staleness for workspaceId ${workspaceContext.workspaceId}: $staleness")
             entityCacheStaleness.update(staleness, TimeUnit.SECONDS)
           case None => logger.info(s"entity statistics cache staleness: n/a (cache does not exist)")
         }
         stalenessOpt
       }
     }
-  }
 
   /** wrapper for workspace feature flag lookup, includes performance tracing */
-  def cacheFeatureFlags(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[CacheFeatureFlags] = {
+  def cacheFeatureFlags(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[CacheFeatureFlags] =
     traceDBIOWithParent("getWorkspaceFeatureFlags", parentContext) { _ =>
-      dataAccess.workspaceFeatureFlagQuery.listFlagsForWorkspace(workspaceContext.workspaceIdAsUUID,
-        List(FEATURE_ALWAYS_CACHE_TYPE_COUNTS, FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES)).map { flags =>
-        val alwaysCacheTypeCounts = flags.contains(FEATURE_ALWAYS_CACHE_TYPE_COUNTS)
-        val alwaysCacheAttributes = flags.contains(FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES)
-        CacheFeatureFlags(alwaysCacheTypeCounts = alwaysCacheTypeCounts, alwaysCacheAttributes = alwaysCacheAttributes)
-      }
+      dataAccess.workspaceFeatureFlagQuery
+        .listFlagsForWorkspace(workspaceContext.workspaceIdAsUUID,
+                               List(FEATURE_ALWAYS_CACHE_TYPE_COUNTS, FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES)
+        )
+        .map { flags =>
+          val alwaysCacheTypeCounts = flags.contains(FEATURE_ALWAYS_CACHE_TYPE_COUNTS)
+          val alwaysCacheAttributes = flags.contains(FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES)
+          CacheFeatureFlags(alwaysCacheTypeCounts = alwaysCacheTypeCounts,
+                            alwaysCacheAttributes = alwaysCacheAttributes
+          )
+        }
     }
-  }
 
   /** convenience method for retrieving type-counts, either from cache or from raw entities */
-  def typeCounts(dataAccess: DataAccess, fromCache: Boolean, parentContext: RawlsRequestContext): ReadAction[Map[String, Int]] = {
+  def typeCounts(dataAccess: DataAccess,
+                 fromCache: Boolean,
+                 parentContext: RawlsRequestContext
+  ): ReadAction[Map[String, Int]] =
     if (fromCache)
       cachedTypeCounts(dataAccess, parentContext)
     else
       uncachedTypeCounts(dataAccess, parentContext)
-  }
 
   /** convenience method for retrieving type-attributes, either from cache or from raw attributes */
-  def typeAttributes(dataAccess: DataAccess, fromCache: Boolean, parentContext: RawlsRequestContext): ReadAction[Map[String, Seq[AttributeName]]] = {
+  def typeAttributes(dataAccess: DataAccess,
+                     fromCache: Boolean,
+                     parentContext: RawlsRequestContext
+  ): ReadAction[Map[String, Seq[AttributeName]]] =
     if (fromCache)
       cachedTypeAttributes(dataAccess, parentContext)
     else
       uncachedTypeAttributes(dataAccess, parentContext)
-  }
 
   /** wrapper for cached type-counts lookup, includes performance tracing */
-  def cachedTypeCounts(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Map[String, Int]] = {
+  def cachedTypeCounts(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Map[String, Int]] =
     traceDBIOWithParent("entityTypeStatisticsQuery.getAll", parentContext) { _ =>
       dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID)
     }
-  }
 
   /** wrapper for uncached type-counts lookup, includes performance tracing */
-  def uncachedTypeCounts(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Map[String, Int]] = {
+  def uncachedTypeCounts(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Map[String, Int]] =
     traceDBIOWithParent("getEntityTypesWithCounts", parentContext) { _ =>
       dataAccess.entityQuery.getEntityTypesWithCounts(workspaceContext.workspaceIdAsUUID)
     }
-  }
 
   /** wrapper for cached type-attributes lookup, includes performance tracing */
-  def cachedTypeAttributes(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Map[String, Seq[AttributeName]]] = {
+  def cachedTypeAttributes(dataAccess: DataAccess,
+                           parentContext: RawlsRequestContext
+  ): ReadAction[Map[String, Seq[AttributeName]]] =
     traceDBIOWithParent("entityAttributeStatisticsQuery.getAll", parentContext) { _ =>
       dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID)
     }
-  }
 
   /** wrapper for uncached type-attributes lookup, includes performance tracing */
-  def uncachedTypeAttributes(dataAccess: DataAccess, parentContext: RawlsRequestContext): ReadAction[Map[String, Seq[AttributeName]]] = {
+  def uncachedTypeAttributes(dataAccess: DataAccess,
+                             parentContext: RawlsRequestContext
+  ): ReadAction[Map[String, Seq[AttributeName]]] =
     traceDBIOWithParent("getAttrNamesAndEntityTypes", parentContext) { _ =>
       dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceContext.workspaceIdAsUUID)
     }
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -8,12 +8,34 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityRecord,
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.{EntityName, LookupExpression}
-import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, ExpressionEvaluationContext, ExpressionEvaluationSupport, ExpressionValidator}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException}
+import org.broadinstitute.dsde.rawls.entities.base.{
+  EntityProvider,
+  ExpressionEvaluationContext,
+  ExpressionEvaluationSupport,
+  ExpressionValidator
+}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException
+}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeValue, Entity, EntityQuery, EntityQueryResponse, EntityQueryResultMetadata, EntityTypeMetadata, ErrorReport, RawlsRequestContext, SubmissionValidationEntityInputs, SubmissionValidationValue, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeValue,
+  Entity,
+  EntityQuery,
+  EntityQueryResponse,
+  EntityQueryResultMetadata,
+  EntityTypeMetadata,
+  ErrorReport,
+  RawlsRequestContext,
+  SubmissionValidationEntityInputs,
+  SubmissionValidationValue,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, CollectionUtils, EntitySupport}
 
@@ -24,10 +46,17 @@ import scala.util.{Failure, Success, Try}
 /**
  * Terra default entity provider, powered by Rawls and Cloud SQL
  */
-class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit protected val dataSource: SlickDataSource, cacheEnabled: Boolean, override val workbenchMetricBaseName: String)
-                         (implicit protected val executionContext: ExecutionContext)
-  extends EntityProvider with LazyLogging
-    with EntitySupport with AttributeSupport with ExpressionEvaluationSupport with EntityStatisticsCacheSupport {
+class LocalEntityProvider(requestArguments: EntityRequestArguments,
+                          implicit protected val dataSource: SlickDataSource,
+                          cacheEnabled: Boolean,
+                          override val workbenchMetricBaseName: String
+)(implicit protected val executionContext: ExecutionContext)
+    extends EntityProvider
+    with LazyLogging
+    with EntitySupport
+    with AttributeSupport
+    with ExpressionEvaluationSupport
+    with EntityStatisticsCacheSupport {
 
   import dataSource.dataAccess.driver.api._
 
@@ -35,11 +64,13 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
 
   override val workspaceContext = requestArguments.workspace
 
-  override def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]] = {
+  override def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]] =
     // start performance tracing
     traceWithParent("LocalEntityProvider.entityTypeMetadata", requestArguments.ctx) { localContext =>
       localContext.tracingSpan.foreach { s =>
-        s.putAttribute("workspace", OpenCensusAttributeValue.stringAttributeValue(workspaceContext.toWorkspaceName.toString))
+        s.putAttribute("workspace",
+                       OpenCensusAttributeValue.stringAttributeValue(workspaceContext.toWorkspaceName.toString)
+        )
         s.putAttribute("useCache", OpenCensusAttributeValue.booleanAttributeValue(useCache))
         s.putAttribute("cacheEnabled", OpenCensusAttributeValue.booleanAttributeValue(cacheEnabled))
       }
@@ -47,9 +78,13 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
       dataSource.inTransaction { dataAccess =>
         if (!useCache || !cacheEnabled) {
           if (!cacheEnabled) {
-            logger.info(s"entity statistics cache: miss (cache disabled at system level) [${workspaceContext.workspaceIdAsUUID}]")
+            logger.info(
+              s"entity statistics cache: miss (cache disabled at system level) [${workspaceContext.workspaceIdAsUUID}]"
+            )
           } else if (!useCache) {
-            logger.info(s"entity statistics cache: miss (user request specified cache bypass) [${workspaceContext.workspaceIdAsUUID}]")
+            logger.info(
+              s"entity statistics cache: miss (user request specified cache bypass) [${workspaceContext.workspaceIdAsUUID}]"
+            )
           }
           // retrieve metadata, bypassing cache
           calculateMetadataResponse(dataAccess, countsFromCache = false, attributesFromCache = false, localContext)
@@ -58,7 +93,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
           cacheStaleness(dataAccess, localContext).flatMap {
             case None =>
               // cache does not exist - return uncached
-              logger.info(s"entity statistics cache: miss (cache does not exist) [${workspaceContext.workspaceIdAsUUID}]")
+              logger.info(
+                s"entity statistics cache: miss (cache does not exist) [${workspaceContext.workspaceIdAsUUID}]"
+              )
               calculateMetadataResponse(dataAccess, countsFromCache = false, attributesFromCache = false, localContext)
             case Some(0) =>
               // cache is up to date - return cached
@@ -69,33 +106,51 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
               cacheFeatureFlags(dataAccess, localContext).flatMap { flags =>
                 if (flags.alwaysCacheTypeCounts || flags.alwaysCacheAttributes) {
                   localContext.tracingSpan.foreach { s =>
-                    s.putAttribute("alwaysCacheTypeCountsFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheTypeCounts))
-                    s.putAttribute("alwaysCacheAttributesFeatureFlag", OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheAttributes))
+                    s.putAttribute("alwaysCacheTypeCountsFeatureFlag",
+                                   OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheTypeCounts)
+                    )
+                    s.putAttribute("alwaysCacheAttributesFeatureFlag",
+                                   OpenCensusAttributeValue.booleanAttributeValue(flags.alwaysCacheAttributes)
+                    )
                   }
-                  logger.info(s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]")
+                  logger.info(
+                    s"entity statistics cache: partial hit (alwaysCacheTypeCounts=${flags.alwaysCacheTypeCounts}, alwaysCacheAttributes=${flags.alwaysCacheAttributes}, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]"
+                  )
                 } else {
-                  logger.info(s"entity statistics cache: miss (cache is out of date, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]")
+                  logger.info(
+                    s"entity statistics cache: miss (cache is out of date, staleness=$stalenessSeconds) [${workspaceContext.workspaceIdAsUUID}]"
+                  )
                   // and opportunistically save
                 }
-                calculateMetadataResponse(dataAccess, countsFromCache = flags.alwaysCacheTypeCounts, attributesFromCache = flags.alwaysCacheAttributes, localContext)
+                calculateMetadataResponse(dataAccess,
+                                          countsFromCache = flags.alwaysCacheTypeCounts,
+                                          attributesFromCache = flags.alwaysCacheAttributes,
+                                          localContext
+                )
               } // end feature-flags lookup
           } // end staleness lookup
         } // end if useCache/cacheEnabled check
       } // end transaction
     } // end root trace
-  }
 
-  override def createEntity(entity: Entity): Future[Entity] = {
-    dataSource.inTransactionWithAttrTempTable (Set(AttributeTempTableType.Entity)) { dataAccess =>
+  override def createEntity(entity: Entity): Future[Entity] =
+    dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
       dataAccess.entityQuery.get(workspaceContext, entity.entityType, entity.name) flatMap {
-        case Some(_) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"${entity.entityType} ${entity.name} already exists in ${workspaceContext.toWorkspaceName}")))
+        case Some(_) =>
+          DBIO.failed(
+            new RawlsExceptionWithErrorReport(
+              errorReport =
+                ErrorReport(StatusCodes.Conflict,
+                            s"${entity.entityType} ${entity.name} already exists in ${workspaceContext.toWorkspaceName}"
+                )
+            )
+          )
         case None => dataAccess.entityQuery.save(workspaceContext, entity)
       }
     }
-  }
 
   // EntityApiServiceSpec has good test coverage for this api
-  override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] = {
+  override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] =
     dataSource.inTransaction { dataAccess =>
       // withAllEntityRefs throws exception if some entities not found; passes through if all ok
       traceDBIOWithParent("LocalEntityProvider.deleteEntities", requestArguments.ctx) { localContext =>
@@ -104,19 +159,23 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
           s.putAttribute("numEntities", OpenCensusAttributeValue.longAttributeValue(entRefs.length))
         }
         withAllEntityRefs(workspaceContext, dataAccess, entRefs, localContext) { _ =>
-          traceDBIOWithParent("entityQuery.getAllReferringEntities", localContext)(innerSpan => dataAccess.entityQuery.getAllReferringEntities(workspaceContext, entRefs.toSet) flatMap { referringEntities =>
-            if (referringEntities != entRefs.toSet)
-              throw new DeleteEntitiesConflictException(referringEntities)
-            else {
-              traceDBIOWithParent("entityQuery.hide", innerSpan)(_ => dataAccess.entityQuery.hide(workspaceContext, entRefs))
+          traceDBIOWithParent("entityQuery.getAllReferringEntities", localContext)(innerSpan =>
+            dataAccess.entityQuery.getAllReferringEntities(workspaceContext, entRefs.toSet) flatMap {
+              referringEntities =>
+                if (referringEntities != entRefs.toSet)
+                  throw new DeleteEntitiesConflictException(referringEntities)
+                else {
+                  traceDBIOWithParent("entityQuery.hide", innerSpan)(_ =>
+                    dataAccess.entityQuery.hide(workspaceContext, entRefs)
+                  )
+                }
             }
-          })
+          )
         }
       }
     }
-  }
 
-  override def deleteEntitiesOfType(entityType: String): Future[Int] = {
+  override def deleteEntitiesOfType(entityType: String): Future[Int] =
     dataSource.inTransaction { dataAccess =>
       traceDBIOWithParent("LocalEntityProvider.deleteEntitiesOfType", requestArguments.ctx) { localContext =>
         localContext.tracingSpan.foreach { s =>
@@ -124,58 +183,70 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
           s.putAttribute("entityType", OpenCensusAttributeValue.stringAttributeValue(entityType))
         }
 
-        dataAccess.entityQuery.countReferringEntitiesForType(workspaceContext, entityType) flatMap { referringEntitiesCount =>
-          if (referringEntitiesCount != 0)
-            throw new DeleteEntitiesOfTypeConflictException(referringEntitiesCount)
-          else {
-            dataAccess.entityQuery.hideType(workspaceContext, entityType)
-          }
+        dataAccess.entityQuery.countReferringEntitiesForType(workspaceContext, entityType) flatMap {
+          referringEntitiesCount =>
+            if (referringEntitiesCount != 0)
+              throw new DeleteEntitiesOfTypeConflictException(referringEntitiesCount)
+            else {
+              dataAccess.entityQuery.hideType(workspaceContext, entityType)
+            }
         }
       }
     }
-  }
 
-  override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext, gatherInputsResult: GatherInputsResult, workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]): Future[Stream[SubmissionValidationEntityInputs]] = {
+  override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
+                                   gatherInputsResult: GatherInputsResult,
+                                   workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]
+  ): Future[Stream[SubmissionValidationEntityInputs]] =
     dataSource.inTransaction { dataAccess =>
       withEntityRecsForExpressionEval(expressionEvaluationContext, workspaceContext, dataAccess) { jobEntityRecs =>
-        //Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
-        evaluateExpressionsInternal(workspaceContext, gatherInputsResult.processableInputs, jobEntityRecs, dataAccess) map { valuesByEntity =>
+        // Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
+        evaluateExpressionsInternal(workspaceContext,
+                                    gatherInputsResult.processableInputs,
+                                    jobEntityRecs,
+                                    dataAccess
+        ) map { valuesByEntity =>
           createSubmissionValidationEntityInputs(valuesByEntity)
         }
       }
     }
-  }
 
   override def expressionValidator: ExpressionValidator = new LocalEntityExpressionValidator
 
-  protected[local] def evaluateExpressionsInternal(workspaceContext: Workspace, inputs: Set[MethodInput], entities: Option[Seq[EntityRecord]], dataAccess: DataAccess)(implicit executionContext: ExecutionContext): ReadWriteAction[Map[String, Seq[SubmissionValidationValue]]] = {
+  protected[local] def evaluateExpressionsInternal(workspaceContext: Workspace,
+                                                   inputs: Set[MethodInput],
+                                                   entities: Option[Seq[EntityRecord]],
+                                                   dataAccess: DataAccess
+  )(implicit executionContext: ExecutionContext): ReadWriteAction[Map[String, Seq[SubmissionValidationValue]]] = {
     import dataAccess.driver.api._
 
     val entityNames = entities match {
       case Some(recs) => recs.map(_.name)
-      case None => Seq("")
+      case None       => Seq("")
     }
 
-    if( inputs.isEmpty ) {
-      //no inputs to evaluate = just return an empty map back!
-      DBIO.successful(entityNames.map( _ -> Seq.empty[SubmissionValidationValue] ).toMap)
+    if (inputs.isEmpty) {
+      // no inputs to evaluate = just return an empty map back!
+      DBIO.successful(entityNames.map(_ -> Seq.empty[SubmissionValidationValue]).toMap)
     } else {
       ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, entities) { evaluator =>
-        //Evaluate the results per input and return a seq of DBIO[ Map(entity -> value) ], one per input
+        // Evaluate the results per input and return a seq of DBIO[ Map(entity -> value) ], one per input
         val resultsByInput = inputs.toSeq.map { input =>
-          evaluator.evalFinalAttribute(workspaceContext, input.expression, Option(input)).asTry.map { tryAttribsByEntity =>
-            val validationValuesByEntity: Seq[(EntityName, SubmissionValidationValue)] = tryAttribsByEntity match {
-              case Failure(regret) =>
-                //The DBIOAction failed - this input expression was not evaluated. Make an error for each entity.
-                entityNames.map((_, SubmissionValidationValue(None, Some(regret.getMessage), input.workflowInput.getName)))
-              case Success(attributeMap) =>
-                convertToSubmissionValidationValues(attributeMap, input)
-            }
-            validationValuesByEntity
+          evaluator.evalFinalAttribute(workspaceContext, input.expression, Option(input)).asTry.map {
+            tryAttribsByEntity =>
+              val validationValuesByEntity: Seq[(EntityName, SubmissionValidationValue)] = tryAttribsByEntity match {
+                case Failure(regret) =>
+                  // The DBIOAction failed - this input expression was not evaluated. Make an error for each entity.
+                  entityNames
+                    .map((_, SubmissionValidationValue(None, Some(regret.getMessage), input.workflowInput.getName)))
+                case Success(attributeMap) =>
+                  convertToSubmissionValidationValues(attributeMap, input)
+              }
+              validationValuesByEntity
           }
         }
 
-        //Flip the list of DBIO monads into one on the outside that we can map across and then group by entity.
+        // Flip the list of DBIO monads into one on the outside that we can map across and then group by entity.
         DBIO.sequence(resultsByInput) map { results =>
           CollectionUtils.groupByTuples(results.flatten)
         }
@@ -183,15 +254,17 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
     }
   }
 
-  override def getEntity(entityType: String, entityName: String): Future[Entity] = {
+  override def getEntity(entityType: String, entityName: String): Future[Entity] =
     dataSource.inTransaction { dataAccess =>
-      withEntity(workspaceContext, entityType, entityName, dataAccess) {
-        entity => DBIO.successful(entity)
+      withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+        DBIO.successful(entity)
       }
     }
-  }
 
-  override def queryEntities(entityType: String, query: EntityQuery, parentContext: RawlsRequestContext = requestArguments.ctx): Future[EntityQueryResponse] = {
+  override def queryEntities(entityType: String,
+                             query: EntityQuery,
+                             parentContext: RawlsRequestContext = requestArguments.ctx
+  ): Future[EntityQueryResponse] =
     dataSource.inTransaction { dataAccess =>
       traceDBIOWithParent("loadEntityPage", parentContext) { childContext =>
         childContext.tracingSpan.foreach { s1 =>
@@ -207,18 +280,26 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
         createEntityQueryResponse(query, unfilteredCount, filteredCount, entities.toSeq)
       }
     }
-  }
 
-  def createEntityQueryResponse(query: EntityQuery, unfilteredCount: Int, filteredCount: Int, page: Seq[Entity]): EntityQueryResponse = {
+  def createEntityQueryResponse(query: EntityQuery,
+                                unfilteredCount: Int,
+                                filteredCount: Int,
+                                page: Seq[Entity]
+  ): EntityQueryResponse = {
     val pageCount = Math.ceil(filteredCount.toFloat / query.pageSize).toInt
     if (filteredCount > 0 && query.page > pageCount) {
-      throw new DataEntityException(code = StatusCodes.BadRequest, message = s"requested page ${query.page} is greater than the number of pages $pageCount")
+      throw new DataEntityException(code = StatusCodes.BadRequest,
+                                    message =
+                                      s"requested page ${query.page} is greater than the number of pages $pageCount"
+      )
     } else {
       EntityQueryResponse(query, EntityQueryResultMetadata(unfilteredCount, filteredCount, pageCount), page)
     }
   }
 
-  def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition], upsert: Boolean): Future[Traversable[Entity]] = {
+  def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition],
+                              upsert: Boolean
+  ): Future[Traversable[Entity]] = {
     val namesToCheck = for {
       update <- entityUpdates
       operation <- update.operations
@@ -229,12 +310,19 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
         s.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceContext.workspaceId))
         s.putAttribute("isUpsert", OpenCensusAttributeValue.booleanAttributeValue(upsert))
         s.putAttribute("entityUpdatesCount", OpenCensusAttributeValue.longAttributeValue(entityUpdates.length))
-        s.putAttribute("entityOperationsCount", OpenCensusAttributeValue.longAttributeValue(entityUpdates.map(_.operations.length).sum))
+        s.putAttribute("entityOperationsCount",
+                       OpenCensusAttributeValue.longAttributeValue(entityUpdates.map(_.operations.length).sum)
+        )
       }
 
       withAttributeNamespaceCheck(namesToCheck) {
         dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-          val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ => dataAccess.entityQuery.getActiveEntities(workspaceContext, entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name)))) map { entities =>
+          val updateTrialsAction = traceDBIOWithParent("getActiveEntities", localContext)(_ =>
+            dataAccess.entityQuery.getActiveEntities(
+              workspaceContext,
+              entityUpdates.map(eu => AttributeEntityReference(eu.entityType, eu.name))
+            )
+          ) map { entities =>
             val entitiesByName = entities.map(e => (e.entityType, e.name) -> e).toMap
             entityUpdates.map { entityUpdate =>
               entityUpdate -> (entitiesByName.get((entityUpdate.entityType, entityUpdate.name)) match {
@@ -242,7 +330,11 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
                   Try(applyOperationsToEntity(e, entityUpdate.operations))
                 case None =>
                   if (upsert) {
-                    Try(applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty), entityUpdate.operations))
+                    Try(
+                      applyOperationsToEntity(Entity(entityUpdate.name, entityUpdate.entityType, Map.empty),
+                                              entityUpdate.operations
+                      )
+                    )
                   } else {
                     Failure(new RuntimeException("Entity does not exist"))
                   }
@@ -255,7 +347,11 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
               ErrorReport(s"Could not update ${entityUpdate.entityType} ${entityUpdate.name}", ErrorReport(regrets))
             }
             if (errorReports.nonEmpty) {
-              DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)))
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  ErrorReport(StatusCodes.BadRequest, "Some entities could not be updated.", errorReports)
+                )
+              )
             } else {
               val t = updateTrials.collect { case (entityUpdate, Success(entity)) => entity }
 
@@ -265,12 +361,12 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments, implicit pro
 
           traceDBIOWithParent("saveAction", localContext)(_ => saveAction)
         } recover {
-          case icve:java.sql.SQLIntegrityConstraintViolationException =>
+          case icve: java.sql.SQLIntegrityConstraintViolationException =>
             val userMessage =
               s"Database error occurred. Check if you are uploading entity names that differ only in case " +
                 s"from pre-existing entities."
             throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, userMessage, icve))
-          case bue:java.sql.BatchUpdateException =>
+          case bue: java.sql.BatchUpdateException =>
             val maybeCaseIssue = bue.getMessage.startsWith("Duplicate entry")
             val userMessage = if (maybeCaseIssue) {
               s"Database error occurred. Check if you are uploading entity names that differ only in case " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
@@ -11,13 +11,12 @@ import scala.util.{Success, Try}
 /**
  * Builder for the Terra default entity provider
  */
-class LocalEntityProviderBuilder(dataSource: SlickDataSource, cacheEnabled: Boolean, metricsPrefix: String)
-                                (implicit protected val executionContext: ExecutionContext)
-  extends EntityProviderBuilder[LocalEntityProvider] {
+class LocalEntityProviderBuilder(dataSource: SlickDataSource, cacheEnabled: Boolean, metricsPrefix: String)(implicit
+  protected val executionContext: ExecutionContext
+) extends EntityProviderBuilder[LocalEntityProvider] {
 
   override def builds: TypeTag[LocalEntityProvider] = typeTag[LocalEntityProvider]
 
-  override def build(requestArguments: EntityRequestArguments): Try[LocalEntityProvider] = {
+  override def build(requestArguments: EntityRequestArguments): Try[LocalEntityProvider] =
     Success(new LocalEntityProvider(requestArguments, dataSource, cacheEnabled, metricsPrefix))
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/genomics/GenomicsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/genomics/GenomicsService.scala
@@ -11,15 +11,21 @@ import scala.concurrent.{ExecutionContext, Future}
  * Created by davidan on 06/12/16.
  */
 object GenomicsService {
-  def constructor(dataSource: SlickDataSource, googleServicesDAO: GoogleServicesDAO)(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext) =
+  def constructor(dataSource: SlickDataSource, googleServicesDAO: GoogleServicesDAO)(ctx: RawlsRequestContext)(implicit
+    executionContext: ExecutionContext
+  ) =
     new GenomicsService(ctx, dataSource, googleServicesDAO)
 
 }
 
-class GenomicsService(protected val ctx: RawlsRequestContext, val dataSource: SlickDataSource, protected val gcsDAO: GoogleServicesDAO)(implicit protected val executionContext: ExecutionContext) extends RoleSupport with FutureSupport with UserWiths {
+class GenomicsService(protected val ctx: RawlsRequestContext,
+                      val dataSource: SlickDataSource,
+                      protected val gcsDAO: GoogleServicesDAO
+)(implicit protected val executionContext: ExecutionContext)
+    extends RoleSupport
+    with FutureSupport
+    with UserWiths {
 
-  def getOperation(jobId: String): Future[Option[JsObject]] = {
+  def getOperation(jobId: String): Future[Option[JsObject]] =
     gcsDAO.getGenomicsOperation(jobId)
-  }
 }
-

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -15,8 +15,21 @@ import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ImportStatuses.ImportStatus
-import org.broadinstitute.dsde.rawls.model.{Entity, ImportStatuses, RawlsRequestContext, RawlsUserEmail, UserInfo, Workspace, WorkspaceName, ErrorReport => RawlsErrorReport}
-import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.{AvroUpsertMonitorConfig, KeepAlive, updateImportStatusFormat}
+import org.broadinstitute.dsde.rawls.model.{
+  Entity,
+  ErrorReport => RawlsErrorReport,
+  ImportStatuses,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  UserInfo,
+  Workspace,
+  WorkspaceName
+}
+import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.{
+  updateImportStatusFormat,
+  AvroUpsertMonitorConfig,
+  KeepAlive
+}
 import org.broadinstitute.dsde.rawls.util.AuthUtil
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
@@ -48,7 +61,8 @@ object AvroUpsertMonitorSupervisor {
                                            updateImportStatusPubSubTopic: String,
                                            ackDeadlineSeconds: Int,
                                            batchSize: Int,
-                                           workerCount: Int)
+                                           workerCount: Int
+  )
 
   def props(entityService: RawlsRequestContext => EntityService,
             googleServicesDAO: GoogleServicesDAO,
@@ -58,19 +72,20 @@ object AvroUpsertMonitorSupervisor {
             importServicePubSubDAO: GooglePubSubDAO,
             importServiceDAO: ImportServiceDAO,
             avroUpsertMonitorConfig: AvroUpsertMonitorConfig,
-            dataSource: SlickDataSource)(implicit executionContext: ExecutionContext): Props =
+            dataSource: SlickDataSource
+  )(implicit executionContext: ExecutionContext): Props =
     Props(
-      new AvroUpsertMonitorSupervisor(
-        entityService,
-        googleServicesDAO,
-        samDAO,
-        googleStorage,
-        pubSubDAO,
-        importServicePubSubDAO,
-        importServiceDAO,
-        avroUpsertMonitorConfig,
-        dataSource))
-
+      new AvroUpsertMonitorSupervisor(entityService,
+                                      googleServicesDAO,
+                                      samDAO,
+                                      googleStorage,
+                                      pubSubDAO,
+                                      importServicePubSubDAO,
+                                      importServiceDAO,
+                                      avroUpsertMonitorConfig,
+                                      dataSource
+      )
+    )
 
   import spray.json.DefaultJsonProtocol._
   implicit val updateImportStatusFormat = jsonFormat5(UpdateImportStatus)
@@ -80,10 +95,10 @@ case class UpdateImportStatus(importId: String,
                               newStatus: String,
                               currentStatus: Option[String] = None,
                               errorMessage: Option[String] = None,
-                              action: String = "status")
+                              action: String = "status"
+)
 
 case class ImportUpsertResults(successes: Int, failures: List[RawlsErrorReport])
-
 
 class AvroUpsertMonitorSupervisor(entityService: RawlsRequestContext => EntityService,
                                   googleServicesDAO: GoogleServicesDAO,
@@ -93,8 +108,8 @@ class AvroUpsertMonitorSupervisor(entityService: RawlsRequestContext => EntitySe
                                   importServicePubSubDAO: GooglePubSubDAO,
                                   importServiceDAO: ImportServiceDAO,
                                   avroUpsertMonitorConfig: AvroUpsertMonitorConfig,
-                                  dataSource: SlickDataSource)
-  extends Actor
+                                  dataSource: SlickDataSource
+) extends Actor
     with LazyLogging {
   import AvroUpsertMonitorSupervisor._
   import context._
@@ -102,30 +117,48 @@ class AvroUpsertMonitorSupervisor(entityService: RawlsRequestContext => EntitySe
   self ! Init
 
   override def receive = {
-    case Init => init pipeTo self
-    case Start => for (i <- 1 to avroUpsertMonitorConfig.workerCount) startOne()
+    case Init              => init pipeTo self
+    case Start             => for (i <- 1 to avroUpsertMonitorConfig.workerCount) startOne()
     case Status.Failure(t) => logger.error("error initializing avro upsert monitor", t)
   }
 
   def init =
     for {
       _ <- pubSubDAO.createTopic(avroUpsertMonitorConfig.importRequestPubSubTopic)
-      _ <- pubSubDAO.createSubscription(avroUpsertMonitorConfig.importRequestPubSubTopic, avroUpsertMonitorConfig.importRequestPubSubSubscription, Some(avroUpsertMonitorConfig.ackDeadlineSeconds))
+      _ <- pubSubDAO.createSubscription(
+        avroUpsertMonitorConfig.importRequestPubSubTopic,
+        avroUpsertMonitorConfig.importRequestPubSubSubscription,
+        Some(avroUpsertMonitorConfig.ackDeadlineSeconds)
+      )
     } yield Start
 
   def startOne(): Unit = {
     logger.info("starting AvroUpsertMonitorActor")
-    actorOf(AvroUpsertMonitor.props(avroUpsertMonitorConfig.pollInterval, avroUpsertMonitorConfig.pollIntervalJitter, entityService, googleServicesDAO, samDAO, googleStorage, pubSubDAO, importServicePubSubDAO, avroUpsertMonitorConfig.importRequestPubSubSubscription, avroUpsertMonitorConfig.updateImportStatusPubSubTopic, importServiceDAO, avroUpsertMonitorConfig.batchSize, dataSource))
+    actorOf(
+      AvroUpsertMonitor.props(
+        avroUpsertMonitorConfig.pollInterval,
+        avroUpsertMonitorConfig.pollIntervalJitter,
+        entityService,
+        googleServicesDAO,
+        samDAO,
+        googleStorage,
+        pubSubDAO,
+        importServicePubSubDAO,
+        avroUpsertMonitorConfig.importRequestPubSubSubscription,
+        avroUpsertMonitorConfig.updateImportStatusPubSubTopic,
+        importServiceDAO,
+        avroUpsertMonitorConfig.batchSize,
+        dataSource
+      )
+    )
   }
 
   override val supervisorStrategy =
-    OneForOneStrategy() {
-      case e => {
-        logger.error("unexpected error in avro upsert monitor", e)
-        // start one to replace the error, stop the errored child so that we also drop its mailbox (i.e. restart not good enough)
-        startOne()
-        Stop
-      }
+    OneForOneStrategy() { case e =>
+      logger.error("unexpected error in avro upsert monitor", e)
+      // start one to replace the error, stop the errored child so that we also drop its mailbox (i.e. restart not good enough)
+      startOne()
+      Stop
     }
 }
 
@@ -135,46 +168,66 @@ object AvroUpsertMonitor {
 
   val objectIdPattern = """"([^/]+)/([^/]+)"""".r
 
-  def props(
-             pollInterval: FiniteDuration,
-             pollIntervalJitter: FiniteDuration,
-             entityService: RawlsRequestContext => EntityService,
-             googleServicesDAO: GoogleServicesDAO,
-             samDAO: SamDAO,
-             googleStorage: GoogleStorageService[IO],
-             pubSubDao: GooglePubSubDAO,
-             importServicePubSubDAO: GooglePubSubDAO,
-             pubSubSubscriptionName: String,
-             importStatusPubSubTopic: String,
-             importServiceDAO: ImportServiceDAO,
-             batchSize: Int,
-             dataSource: SlickDataSource): Props =
-    Props(new AvroUpsertMonitorActor(pollInterval, pollIntervalJitter, entityService, googleServicesDAO, samDAO, googleStorage, pubSubDao, importServicePubSubDAO,
-      pubSubSubscriptionName, importStatusPubSubTopic, importServiceDAO, batchSize, dataSource))
+  def props(pollInterval: FiniteDuration,
+            pollIntervalJitter: FiniteDuration,
+            entityService: RawlsRequestContext => EntityService,
+            googleServicesDAO: GoogleServicesDAO,
+            samDAO: SamDAO,
+            googleStorage: GoogleStorageService[IO],
+            pubSubDao: GooglePubSubDAO,
+            importServicePubSubDAO: GooglePubSubDAO,
+            pubSubSubscriptionName: String,
+            importStatusPubSubTopic: String,
+            importServiceDAO: ImportServiceDAO,
+            batchSize: Int,
+            dataSource: SlickDataSource
+  ): Props =
+    Props(
+      new AvroUpsertMonitorActor(
+        pollInterval,
+        pollIntervalJitter,
+        entityService,
+        googleServicesDAO,
+        samDAO,
+        googleStorage,
+        pubSubDao,
+        importServicePubSubDAO,
+        pubSubSubscriptionName,
+        importStatusPubSubTopic,
+        importServiceDAO,
+        batchSize,
+        dataSource
+      )
+    )
 }
 
-class AvroUpsertMonitorActor(
-                              val pollInterval: FiniteDuration,
-                              pollIntervalJitter: FiniteDuration,
-                              entityService: RawlsRequestContext => EntityService,
-                              val googleServicesDAO: GoogleServicesDAO,
-                              val samDAO: SamDAO,
-                              googleStorage: GoogleStorageService[IO],
-                              pubSubDao: GooglePubSubDAO,
-                              importServicePubSubDAO: GooglePubSubDAO,
-                              pubSubSubscriptionName: String,
-                              importStatusPubSubTopic: String,
-                              importServiceDAO: ImportServiceDAO,
-                              batchSize: Int,
-                              dataSource: SlickDataSource)
-  extends Actor
+class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
+                             pollIntervalJitter: FiniteDuration,
+                             entityService: RawlsRequestContext => EntityService,
+                             val googleServicesDAO: GoogleServicesDAO,
+                             val samDAO: SamDAO,
+                             googleStorage: GoogleStorageService[IO],
+                             pubSubDao: GooglePubSubDAO,
+                             importServicePubSubDAO: GooglePubSubDAO,
+                             pubSubSubscriptionName: String,
+                             importStatusPubSubTopic: String,
+                             importServiceDAO: ImportServiceDAO,
+                             batchSize: Int,
+                             dataSource: SlickDataSource
+) extends Actor
     with LazyLogging
     with FutureSupport
     with AuthUtil {
   import AvroUpsertMonitor._
   import context._
 
-  case class AvroMetadataJson(namespace: String, name: String, userSubjectId: String, userEmail: String, jobId: String, startTime: String)
+  case class AvroMetadataJson(namespace: String,
+                              name: String,
+                              userSubjectId: String,
+                              userEmail: String,
+                              jobId: String,
+                              startTime: String
+  )
   implicit val avroMetadataJsonFormat = jsonFormat6(AvroMetadataJson)
 
   self ! StartMonitorPass
@@ -221,10 +274,9 @@ class AvroUpsertMonitorActor(
 
     case ImportComplete => self ! StartMonitorPass
 
-    case Status.Failure(t) => {
+    case Status.Failure(t) =>
       throw t
       self ! StartMonitorPass
-    }
 
     case ReceiveTimeout => throw new WorkbenchException("AvroUpsertMonitorActor has received no messages for too long")
 
@@ -250,54 +302,97 @@ class AvroUpsertMonitorActor(
         // Currently, there is only one upsert monitor thread - but if we decide to make more threads, we might
         // end up with a race condition where multiple threads are attempting the same import / updating the status
         // of the same import.
-        case Some(status) if status == ImportStatuses.ReadyForUpsert => {
+        case Some(status) if status == ImportStatuses.ReadyForUpsert =>
           publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Upserting, None)
-          toFutureTry(initUpsert(attributes.upsertFile, attributes.importId, message.ackId, workspace, attributes.userEmail, attributes.isUpsert)) map {
+          toFutureTry(
+            initUpsert(attributes.upsertFile,
+                       attributes.importId,
+                       message.ackId,
+                       workspace,
+                       attributes.userEmail,
+                       attributes.isUpsert
+            )
+          ) map {
             case Success(importUpsertResults) =>
               val failureMessages = stringMessageFromFailures(importUpsertResults.failures, 100)
-              val baseMsg = s"Successfully updated ${importUpsertResults.successes} entities; ${importUpsertResults.failures.size} updates failed."
+              val baseMsg =
+                s"Successfully updated ${importUpsertResults.successes} entities; ${importUpsertResults.failures.size} updates failed."
               if (importUpsertResults.failures.isEmpty)
-                publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Done, Option(baseMsg))
+                publishMessageToUpdateImportStatus(attributes.importId,
+                                                   Option(status),
+                                                   ImportStatuses.Done,
+                                                   Option(baseMsg)
+                )
               else {
                 val msg = baseMsg + s" First 100 failures are: $failureMessages"
-                publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Error, Option(msg))
+                publishMessageToUpdateImportStatus(attributes.importId,
+                                                   Option(status),
+                                                   ImportStatuses.Error,
+                                                   Option(msg)
+                )
               }
-            case Failure(t) => publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Error, Option(t.getMessage))
+            case Failure(t) =>
+              publishMessageToUpdateImportStatus(attributes.importId,
+                                                 Option(status),
+                                                 ImportStatuses.Error,
+                                                 Option(t.getMessage)
+              )
           }
-        }
-        case Some(_) => {
+        case Some(_) =>
           logger.warn(s"Received a double message delivery for import ID [${attributes.importId}]")
           Future.unit
-        }
-        case None => publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error, Option("Import status not found"))
+        case None =>
+          publishMessageToUpdateImportStatus(attributes.importId,
+                                             None,
+                                             ImportStatuses.Error,
+                                             Option("Import status not found")
+          )
       }
     } yield ()
 
-    //Make sure message is acknowledged in the case of any failure while trying to construct importFuture
-    importFuture.map(_ => ImportComplete)  recover {
-      case t =>
-        logger.error(s"unexpected error in importFuture for ${attributes.importId}: ${t.getMessage}", t)
-        publishMessageToUpdateImportStatus(attributes.importId, None, ImportStatuses.Error,
-          Option(s"Failed to import data. The underlying error message is: ${t.getMessage}"))
-        acknowledgeMessage(message.ackId)
+    // Make sure message is acknowledged in the case of any failure while trying to construct importFuture
+    importFuture.map(_ => ImportComplete) recover { case t =>
+      logger.error(s"unexpected error in importFuture for ${attributes.importId}: ${t.getMessage}", t)
+      publishMessageToUpdateImportStatus(
+        attributes.importId,
+        None,
+        ImportStatuses.Error,
+        Option(s"Failed to import data. The underlying error message is: ${t.getMessage}")
+      )
+      acknowledgeMessage(message.ackId)
     } pipeTo self
 
   }
 
-  private def publishMessageToUpdateImportStatus(importId: UUID, currentImportStatus: Option[ImportStatus], newImportStatus: ImportStatus, errorMessage: Option[String]) = {
-    logger.info(s"asking to change import job $importId from $currentImportStatus to $newImportStatus ${errorMessage.getOrElse("")}")
-    val updateImportStatus = UpdateImportStatus(importId.toString, newImportStatus.toString, currentImportStatus.map(_.toString), errorMessage)
+  private def publishMessageToUpdateImportStatus(importId: UUID,
+                                                 currentImportStatus: Option[ImportStatus],
+                                                 newImportStatus: ImportStatus,
+                                                 errorMessage: Option[String]
+  ) = {
+    logger.info(
+      s"asking to change import job $importId from $currentImportStatus to $newImportStatus ${errorMessage.getOrElse("")}"
+    )
+    val updateImportStatus =
+      UpdateImportStatus(importId.toString, newImportStatus.toString, currentImportStatus.map(_.toString), errorMessage)
     val attributes: Map[String, String] = updateImportStatus.toJson.asJsObject.fields.collect {
-      case (attName:String, attValue:JsString) =>
+      case (attName: String, attValue: JsString) =>
         // pubsub message attribute value limit is 1024 bytes, we'll use 1000 here to be safe
         val usableValue = if (attValue.value.length < 1000) attValue.value else attValue.value.take(1000) + " ..."
         (attName, usableValue)
     }
-    importServicePubSubDAO.publishMessages(importStatusPubSubTopic, scala.collection.immutable.Seq(GooglePubSubDAO.MessageRequest("", attributes)))
+    importServicePubSubDAO.publishMessages(
+      importStatusPubSubTopic,
+      scala.collection.immutable.Seq(GooglePubSubDAO.MessageRequest("", attributes))
+    )
   }
 
-
-  private def initUpsert(upsertFile: String, jobId: UUID, ackId: String, workspace: Workspace, userEmail: RawlsUserEmail, isUpsert: Boolean): Future[ImportUpsertResults] = {
+  private def initUpsert(upsertFile: String,
+                         jobId: UUID,
+                         ackId: String,
+                         workspace: Workspace,
+                         userEmail: RawlsUserEmail,
+                         isUpsert: Boolean
+  ): Future[ImportUpsertResults] = {
     val startTime = System.currentTimeMillis()
     logger.info(s"beginning upsert process for $jobId ...")
 
@@ -312,11 +407,14 @@ class AvroUpsertMonitorActor(
       // one valid byte in the stream.
       val nonEmptyStream = Try(upsertStream.exists(_.isValidByte).compile.toList.unsafeRunSync().head) match {
         case Success(true) => true
-        case _ => false
+        case _             => false
       }
       if (!nonEmptyStream) {
-        throw new RawlsExceptionWithErrorReport(RawlsErrorReport(StatusCodes.BadRequest,
-          s"Intermediate batch upsert file $upsertFile not found, or file was empty for jobId $jobId"))
+        throw new RawlsExceptionWithErrorReport(
+          RawlsErrorReport(StatusCodes.BadRequest,
+                           s"Intermediate batch upsert file $upsertFile not found, or file was empty for jobId $jobId"
+          )
+        )
       }
 
       // Ack the pubsub message as soon as we know we can read the file. pro: don't have to worry about ack timeouts for long operations, con: if someone restarts rawls here the upsert is lost
@@ -340,10 +438,14 @@ class AvroUpsertMonitorActor(
         logger.info(s"upserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
-          upsertResults <- entityService(RawlsRequestContext(petUserInfo)).batchUpdateEntitiesInternal(workspace.toWorkspaceName, upsertBatch, upsert = isUpsert, None, None)
-        } yield {
-          upsertResults
-        }
+          upsertResults <- entityService(RawlsRequestContext(petUserInfo)).batchUpdateEntitiesInternal(
+            workspace.toWorkspaceName,
+            upsertBatch,
+            upsert = isUpsert,
+            None,
+            None
+          )
+        } yield upsertResults
       }
 
       // create our pause signal. We use this to control when the stream should pause and resume.
@@ -359,8 +461,8 @@ class AvroUpsertMonitorActor(
       // TODO: I _think_ that by using evalMapChunk here, we can eliminate the pause/resume and trust the stream
       // to handle it natively. This will require more testing so I am leaving the pause/resume in place, as it does
       // no harm.
-      val upsertFuturesStream = batchStream.zipWithIndex.evalMapChunk {
-        case (chunk, idx) =>
+      val upsertFuturesStream = batchStream.zipWithIndex
+        .evalMapChunk { case (chunk, idx) =>
           for {
             _ <- sig.set(true)
             _ = self ! KeepAlive // keep actor alive during this loop
@@ -368,29 +470,33 @@ class AvroUpsertMonitorActor(
             _ <- sig.set(false)
           } yield {
             attempt match {
-              case Failure(regrets:RawlsExceptionWithErrorReport) =>
+              case Failure(regrets: RawlsExceptionWithErrorReport) =>
                 val loggedErrors = stringMessageFromFailures(regrets.errorReport.causes.toList, 100)
-                logger.warn(s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The first 100 errors are: $loggedErrors")
+                logger.warn(
+                  s"upsert batch #$idx for jobId ${jobId.toString} contained errors. The first 100 errors are: $loggedErrors"
+                )
               case _ => // noop; here for completeness of matching
             }
             logger.info(s"completed upsert batch #$idx for jobId ${jobId.toString}...")
             attempt
           }
-      }.pauseWhen(sig)
+        }
+        .pauseWhen(sig)
 
       // finally, after all the stream setup, tell the stream to execute
       val upsertResults = upsertFuturesStream.compile.toList.unsafeRunSync()
 
-      val numSuccesses:Int = upsertResults.collect {
-        case Success(entityList) => entityList.size
+      val numSuccesses: Int = upsertResults.collect { case Success(entityList) =>
+        entityList.size
       }.sum
 
       // if the failure has underlying causes, use those; else use the parent failure.
       // unresolved entity references only have useful error messages in the underlying causes, not the parent failure
       // therefore to deliver the best messages to the user we need to handle both cases
       val failureReports: List[RawlsErrorReport] = upsertResults collect {
-        case Failure(regrets:RawlsExceptionWithErrorReport) if regrets.errorReport.causes.nonEmpty => regrets.errorReport.causes
-        case Failure(regrets:RawlsExceptionWithErrorReport) => Seq(regrets.errorReport)
+        case Failure(regrets: RawlsExceptionWithErrorReport) if regrets.errorReport.causes.nonEmpty =>
+          regrets.errorReport.causes
+        case Failure(regrets: RawlsExceptionWithErrorReport) => Seq(regrets.errorReport)
       } flatten
 
       // this could be a LOT of error reports, we don't want to send an enormous packet back to the caller.
@@ -404,20 +510,26 @@ class AvroUpsertMonitorActor(
 
       // fail if nothing at all succeeded
       if (numSuccesses == 0) {
-        throw new RawlsExceptionWithErrorReport(RawlsErrorReport(StatusCodes.BadRequest,
-          s"All entities failed to update. There were ${failureReports.size} errors in total$additionalErrorString",
-          failureReportsForCaller))
+        throw new RawlsExceptionWithErrorReport(
+          RawlsErrorReport(
+            StatusCodes.BadRequest,
+            s"All entities failed to update. There were ${failureReports.size} errors in total$additionalErrorString",
+            failureReportsForCaller
+          )
+        )
       }
 
       val elapsed = System.currentTimeMillis() - startTime
-      logger.info(s"upsert process for $jobId succeeded after $elapsed ms: $numSuccesses upserted," +
-        s" ${failureReports.size} failed$additionalErrorString Errors: ${failureReportsForCaller.map(_.message).mkString(", ")}")
+      logger.info(
+        s"upsert process for $jobId succeeded after $elapsed ms: $numSuccesses upserted," +
+          s" ${failureReports.size} failed$additionalErrorString Errors: ${failureReportsForCaller.map(_.message).mkString(", ")}"
+      )
 
       Future.successful(ImportUpsertResults(numSuccesses, failureReports))
 
     } catch {
       // try/catch for any synchronous exceptions, not covered by a Future.recover(). Potential for retry here, in case of transient failures
-      case ex:Exception =>
+      case ex: Exception =>
         val elapsed = System.currentTimeMillis() - startTime
         logger.error(s"upsert process for $jobId FAILED after $elapsed ms: ${ex.getMessage}")
         acknowledgeMessage(ackId) // just in case
@@ -433,7 +545,12 @@ class AvroUpsertMonitorActor(
     pubSubDao.acknowledgeMessagesById(pubSubSubscriptionName, scala.collection.immutable.Seq(ackId))
   }
 
-  case class AvroUpsertAttributes(workspace: WorkspaceName, userEmail: RawlsUserEmail, importId: UUID, upsertFile: String, isUpsert: Boolean)
+  case class AvroUpsertAttributes(workspace: WorkspaceName,
+                                  userEmail: RawlsUserEmail,
+                                  importId: UUID,
+                                  upsertFile: String,
+                                  isUpsert: Boolean
+  )
 
   private def parseMessage(message: PubSubMessage) = {
     val workspaceNamespace = "workspaceNamespace"
@@ -443,11 +560,15 @@ class AvroUpsertMonitorActor(
     val upsertFile = "upsertFile"
     val isUpsert = "isUpsert"
 
-    def attributeNotFoundException(attribute: String) =  throw new Exception(s"unable to parse message - attribute $attribute not found in ${message.attributes}")
+    def attributeNotFoundException(attribute: String) = throw new Exception(
+      s"unable to parse message - attribute $attribute not found in ${message.attributes}"
+    )
 
     AvroUpsertAttributes(
-      WorkspaceName(message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
-        message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))),
+      WorkspaceName(
+        message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
+        message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))
+      ),
       RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
       UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
       message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
@@ -464,10 +585,8 @@ class AvroUpsertMonitorActor(
   }
 
   override val supervisorStrategy =
-    OneForOneStrategy() {
-      case e => {
-        Escalate
-      }
+    OneForOneStrategy() { case e =>
+      Escalate
     }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -19,9 +19,20 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 
 object EntityStatisticsCacheMonitor {
-  def props(datasource: SlickDataSource, timeoutPerWorkspace: Duration, standardPollInterval: FiniteDuration, workspaceCooldown: FiniteDuration, workbenchMetricBaseName: String)(implicit executionContext: ExecutionContext): Props = {
-    Props(new EntityStatisticsCacheMonitorActor(datasource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
-  }
+  def props(datasource: SlickDataSource,
+            timeoutPerWorkspace: Duration,
+            standardPollInterval: FiniteDuration,
+            workspaceCooldown: FiniteDuration,
+            workbenchMetricBaseName: String
+  )(implicit executionContext: ExecutionContext): Props =
+    Props(
+      new EntityStatisticsCacheMonitorActor(datasource,
+                                            timeoutPerWorkspace,
+                                            standardPollInterval,
+                                            workspaceCooldown,
+                                            workbenchMetricBaseName
+      )
+    )
 
   sealed trait EntityStatisticsCacheMessage
   case object Start extends EntityStatisticsCacheMessage
@@ -29,13 +40,20 @@ object EntityStatisticsCacheMonitor {
   case object ScheduleDelayedSweep extends EntityStatisticsCacheMessage
   case object DieAndRestart extends EntityStatisticsCacheMessage
 
-  //Note: Ignored workspaces have a cacheLastUpdated timestamp of 1000ms after epoch
+  // Note: Ignored workspaces have a cacheLastUpdated timestamp of 1000ms after epoch
   val MIN_CACHE_TIME = new Timestamp(1000)
 
 }
 
-class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val timeoutPerWorkspace: Duration, val standardPollInterval: FiniteDuration, val workspaceCooldown: FiniteDuration, override val workbenchMetricBaseName: String)(implicit val executionContext: ExecutionContext)
-  extends Actor with EntityStatisticsCacheMonitor with LazyLogging {
+class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource,
+                                        val timeoutPerWorkspace: Duration,
+                                        val standardPollInterval: FiniteDuration,
+                                        val workspaceCooldown: FiniteDuration,
+                                        override val workbenchMetricBaseName: String
+)(implicit val executionContext: ExecutionContext)
+    extends Actor
+    with EntityStatisticsCacheMonitor
+    with LazyLogging {
   import context.setReceiveTimeout
 
   setReceiveTimeout(timeoutPerWorkspace)
@@ -50,13 +68,20 @@ class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val tim
       // this Start case assists with unit testing, by providing a case where tests can send this Actor a message
       // and expect a consistent response
       sender ! Sweep
-    case Sweep => sweep() pipeTo self
+    case Sweep                => sweep() pipeTo self
     case ScheduleDelayedSweep => context.system.scheduler.scheduleOnce(standardPollInterval, self, Sweep)
-    case DieAndRestart =>
+    case DieAndRestart        =>
       // Kill this actor, and start a new one. This will drain this actor's mailbox to dead letters.
       // The new actor will take over processing caches.
       logger.warn(s"EntityStatisticsCacheMonitor restarting with a new Actor instance.")
-      val newActor = context.system.actorOf(EntityStatisticsCacheMonitor.props(dataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
+      val newActor = context.system.actorOf(
+        EntityStatisticsCacheMonitor.props(dataSource,
+                                           timeoutPerWorkspace,
+                                           standardPollInterval,
+                                           workspaceCooldown,
+                                           workbenchMetricBaseName
+        )
+      )
       if (sender != self) sender ! newActor // used by unit tests only
       context.stop(self)
     case akka.actor.ReceiveTimeout =>
@@ -64,7 +89,7 @@ class EntityStatisticsCacheMonitorActor(val dataSource: SlickDataSource, val tim
       // or if it is benignly just taking a while. Because we can't be sure of its state, kill this actor
       // and start up a new one using the same configuration. Pause before starting the new one
       // in case this one is actually still processing.
-      val pauseLength = FiniteDuration(timeoutPerWorkspace.toSeconds, TimeUnit.SECONDS)*2
+      val pauseLength = FiniteDuration(timeoutPerWorkspace.toSeconds, TimeUnit.SECONDS) * 2
       logger.warn(s"EntityStatisticsCacheMonitor attempt timed out. Pausing for ${pauseLength}.")
       context.system.scheduler.scheduleOnce(pauseLength, self, DieAndRestart)
   }
@@ -79,36 +104,39 @@ trait EntityStatisticsCacheMonitor extends LazyLogging with RawlsInstrumented {
   val workspaceCooldown: FiniteDuration
   val timeoutPerWorkspace: Duration
 
-  def sweep(): Future[EntityStatisticsCacheMessage] = {
+  def sweep(): Future[EntityStatisticsCacheMessage] =
     trace("EntityStatisticsCacheMonitor.sweep") { rootContext =>
       dataSource.inTransaction { dataAccess =>
         // calculate now - workspaceCooldown as the upper bound for workspace last_modified
         val maxModifiedTime = nowMinus(workspaceCooldown)
 
-        dataAccess.entityCacheQuery.findMostOutdatedEntityCachesAfter(MIN_CACHE_TIME, maxModifiedTime) flatMap { candidates =>
-          if (candidates.nonEmpty) {
-            // pick one of the candidates at random. This randomness ensures that we don't get stuck constantly trying
-            // and failing to update the same workspace - until all we have left as candidates are un-updatable workspaces
-            val (workspaceId, lastModified, cacheLastUpdated) = candidates.toArray.apply(scala.util.Random.nextInt(candidates.size))
-            rootContext.tracingSpan.foreach(_.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId.toString)))
-            logger.info(s"EntityStatisticsCacheMonitor starting update attempt for workspace $workspaceId.")
-            traceDBIOWithParent("updateStatisticsCache", rootContext) { _ =>
-              DBIO.from(updateStatisticsCache(workspaceId, lastModified).map { _ =>
-                val outDated = lastModified.getTime - cacheLastUpdated.getOrElse(MIN_CACHE_TIME).getTime
-                logger.info(s"Updated entity cache for workspace $workspaceId. Cache was ${outDated}ms out of date.")
-                Sweep
-              })
+        dataAccess.entityCacheQuery.findMostOutdatedEntityCachesAfter(MIN_CACHE_TIME, maxModifiedTime) flatMap {
+          candidates =>
+            if (candidates.nonEmpty) {
+              // pick one of the candidates at random. This randomness ensures that we don't get stuck constantly trying
+              // and failing to update the same workspace - until all we have left as candidates are un-updatable workspaces
+              val (workspaceId, lastModified, cacheLastUpdated) =
+                candidates.toArray.apply(scala.util.Random.nextInt(candidates.size))
+              rootContext.tracingSpan.foreach(
+                _.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId.toString))
+              )
+              logger.info(s"EntityStatisticsCacheMonitor starting update attempt for workspace $workspaceId.")
+              traceDBIOWithParent("updateStatisticsCache", rootContext) { _ =>
+                DBIO.from(updateStatisticsCache(workspaceId, lastModified).map { _ =>
+                  val outDated = lastModified.getTime - cacheLastUpdated.getOrElse(MIN_CACHE_TIME).getTime
+                  logger.info(s"Updated entity cache for workspace $workspaceId. Cache was ${outDated}ms out of date.")
+                  Sweep
+                })
+              }
+            } else {
+              traceDBIOWithParent("nothing-to-update", rootContext) { _ =>
+                logger.info(s"All workspace entity caches are up to date. Sleeping for $standardPollInterval")
+                DBIO.successful(ScheduleDelayedSweep)
+              }
             }
-          } else {
-            traceDBIOWithParent("nothing-to-update", rootContext) { _ =>
-              logger.info(s"All workspace entity caches are up to date. Sleeping for $standardPollInterval")
-              DBIO.successful(ScheduleDelayedSweep)
-            }
-          }
         }
       }
     }
-  }
 
   def updateStatisticsCache(workspaceId: UUID, timestamp: Timestamp): Future[Unit] = {
     // allow 80% of the per-workspace timeout to be spent calculating the attribute names.
@@ -124,23 +152,24 @@ trait EntityStatisticsCacheMonitor extends LazyLogging with RawlsInstrumented {
         entityTypesWithCounts <- dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)
         // calculate entity attribute statistics
         entityTypesWithAttrNames <- dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceId, attrNamesTimeout)
-        _ <- dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId, entityTypesWithCounts, entityTypesWithAttrNames, timestamp)
-      } yield {
-        entityCacheSaveCounter.inc()
-      }
+        _ <- dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId,
+                                                                   entityTypesWithCounts,
+                                                                   entityTypesWithAttrNames,
+                                                                   timestamp
+        )
+      } yield entityCacheSaveCounter.inc()
     }
 
-    updateFuture.recover {
-      case t: Throwable =>
-        logger.error(s"Error updating statistics cache for workspaceId $workspaceId: ${t.getMessage}", t)
-        dataSource.inTransaction { dataAccess =>
-          logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
-          //We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
-          // This is a "magic" value that allows the monitor to skip this problematic workspace
-          // so it does not get caught in a loop. These workspaces will require manual intervention.
-          val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
-          dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
-        }
+    updateFuture.recover { case t: Throwable =>
+      logger.error(s"Error updating statistics cache for workspaceId $workspaceId: ${t.getMessage}", t)
+      dataSource.inTransaction { dataAccess =>
+        logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
+        // We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
+        // This is a "magic" value that allows the monitor to skip this problematic workspace
+        // so it does not get caught in a loop. These workspaces will require manual intervention.
+        val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
+        dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
+      }
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/WorkspaceMigrationActor.scala
@@ -21,7 +21,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
-import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome.{Failure, Success, toTuple}
+import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome.{toTuple, Failure, Success}
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils._
 import org.broadinstitute.dsde.rawls.monitor.migration.WorkspaceMigrationActor.MigrateAction._
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
@@ -40,7 +40,6 @@ import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
-
 
 /**
  * The `WorkspaceMigrationActor` is an Akka Typed Actor [1] that migrates a v1 Workspace to a
@@ -73,8 +72,7 @@ import scala.jdk.CollectionConverters._
  */
 object WorkspaceMigrationActor {
 
-  final case class Config
-  (
+  final case class Config(
     /** The interval between pipeline invocations. */
     pollingInterval: FiniteDuration,
 
@@ -97,7 +95,6 @@ object WorkspaceMigrationActor {
     maxRetries: Int
   )
 
-
   implicit val configReader: ValueReader[Config] = ValueReader.relative { config =>
     Config(
       pollingInterval = config.as[FiniteDuration]("polling-interval"),
@@ -110,7 +107,6 @@ object WorkspaceMigrationActor {
     )
   }
 
-
   final case class MigrationDeps(dataSource: SlickDataSource,
                                  googleProjectToBill: GoogleProject,
                                  parentFolder: GoogleFolderId,
@@ -122,8 +118,7 @@ object WorkspaceMigrationActor {
                                  gcsDao: GoogleServicesDAO,
                                  googleIamDAO: GoogleIamDAO,
                                  samDao: SamDAO
-                                )
-
+  )
 
   type MigrateAction[A] = ReaderT[OptionT[IO, *], MigrationDeps, A]
 
@@ -162,8 +157,9 @@ object WorkspaceMigrationActor {
     final def pure[A](a: A): MigrateAction[A] =
       ReaderT.pure(a)
 
-    final def ifM[A](predicate: MigrateAction[Boolean])
-                    (ifTrue: => MigrateAction[A], ifFalse: => MigrateAction[A]): MigrateAction[A] =
+    final def ifM[A](
+      predicate: MigrateAction[Boolean]
+    )(ifTrue: => MigrateAction[A], ifFalse: => MigrateAction[A]): MigrateAction[A] =
       predicate.ifM(ifTrue, ifFalse)
 
     // Stop executing this Migrate Action
@@ -171,14 +167,12 @@ object WorkspaceMigrationActor {
       liftF(OptionT.none)
   }
 
-
   implicit class MigrateActionOps[A](action: MigrateAction[A]) {
     final def handleErrorWith(f: Throwable => MigrateAction[A]): MigrateAction[A] =
       MigrateAction { env =>
         OptionT(action.run(env).value.handleErrorWith(f(_).run(env).value))
       }
   }
-
 
   // Read workspace migrations in various states, attempt to advance their state forward by one
   // step and write the outcome of each step to the database.
@@ -200,11 +194,9 @@ object WorkspaceMigrationActor {
     )
       .parTraverse_(runStep)
 
-
   // Sequence the action and return an empty MigrateAction if the action succeeded
   def runStep(action: MigrateAction[Unit]): MigrateAction[Unit] =
     action.mapF(optionT => OptionT(optionT.value.as(().some)))
-
 
   implicit val ec: ExecutionContext = implicitly[IORuntime].compute
 
@@ -231,62 +223,73 @@ object WorkspaceMigrationActor {
             nextMigration(onlyChild = isBlocked || activeFullMigrations >= maxAttempts)
 
           _ <- OptionT.liftF[ReadWriteAction, Unit] {
-            orM[ReadWriteAction](workspaceQuery.withWorkspaceId(workspaceId).lock, wasLockedByPreviousMigration(workspaceId)).flatMap {
+            orM[ReadWriteAction](workspaceQuery.withWorkspaceId(workspaceId).lock,
+                                 wasLockedByPreviousMigration(workspaceId)
+            ).flatMap {
               update2(id, startedCol, Some(now), unlockOnCompletionCol, _).ignore
             }
           }
         } yield (id, workspaceName)
       }
-      _ <- getLogger[MigrateAction].info(stringify(
-        "migrationId" -> id,
-        "workspace" -> workspaceName,
-        "started" -> now
-      ))
+      _ <- getLogger[MigrateAction].info(
+        stringify(
+          "migrationId" -> id,
+          "workspace" -> workspaceName,
+          "started" -> now
+        )
+      )
     } yield ()
 
-
   final def removeWorkspaceBucketIam: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.removeWorkspaceBucketIamCondition) {
-      (migration, workspace) =>
-        for {
-          (storageService, gcsDao, googleProjectToBill) <- asks { d => (d.storageService, d.gcsDao, d.googleProjectToBill) }
-          _ <- liftIO {
-            for {
-              userInfo <- gcsDao.getServiceAccountUserInfo().io
-              actorSaIdentity = serviceAccount(userInfo.userEmail.value)
-              _ <- storageService.overrideIamPolicy(
+    withMigration(_.workspaceMigrationQuery.removeWorkspaceBucketIamCondition) { (migration, workspace) =>
+      for {
+        (storageService, gcsDao, googleProjectToBill) <- asks { d =>
+          (d.storageService, d.gcsDao, d.googleProjectToBill)
+        }
+        _ <- liftIO {
+          for {
+            userInfo <- gcsDao.getServiceAccountUserInfo().io
+            actorSaIdentity = serviceAccount(userInfo.userEmail.value)
+            _ <- storageService
+              .overrideIamPolicy(
                 GcsBucketName(workspace.bucketName),
                 Map(StorageRole.StorageAdmin -> NonEmptyList.one(actorSaIdentity)),
                 bucketSourceOptions = List(BucketSourceOption.userProject(googleProjectToBill.value))
-              ).compile.drain
-            } yield ()
-          }
-          now <- nowTimestamp
-          _ <- inTransaction { dataAccess =>
-            dataAccess.workspaceMigrationQuery.update(migration.id, dataAccess.workspaceMigrationQuery.workspaceBucketIamRemovedCol, now.some)
-          }
-          _ <- getLogger[MigrateAction].info(stringify(
+              )
+              .compile
+              .drain
+          } yield ()
+        }
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          dataAccess.workspaceMigrationQuery.update(migration.id,
+                                                    dataAccess.workspaceMigrationQuery.workspaceBucketIamRemovedCol,
+                                                    now.some
+          )
+        }
+        _ <- getLogger[MigrateAction].info(
+          stringify(
             "migrationId" -> migration.id,
             "workspace" -> workspace.toWorkspaceName,
             "workspaceBucketIamRemoved" -> now
-          ))
-        } yield ()
+          )
+        )
+      } yield ()
     }
 
   final def configureGoogleProject: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.configureGoogleProjectCondition) {
-      (migration, workspace) =>
+    withMigration(_.workspaceMigrationQuery.configureGoogleProjectCondition) { (migration, workspace) =>
+      val isSoleWorkspaceInBillingProjectGoogleProject: MigrateAction[Boolean] =
+        pure(Seq(workspace.workspaceIdAsUUID) == _) ap inTransaction { dataAccess =>
+          import dataAccess.{WorkspaceExtensions, workspaceQuery}
+          workspaceQuery
+            .withBillingProject(RawlsBillingProjectName(workspace.namespace))
+            .map(_.id)
+            .result
+        }
 
-        val isSoleWorkspaceInBillingProjectGoogleProject: MigrateAction[Boolean] =
-          pure(Seq(workspace.workspaceIdAsUUID) == _) ap inTransaction { dataAccess =>
-            import dataAccess.{WorkspaceExtensions, workspaceQuery}
-            workspaceQuery
-              .withBillingProject(RawlsBillingProjectName(workspace.namespace))
-              .map(_.id)
-              .result
-          }
-
-        val makeError = (message: String, data: Map[String, Any]) => WorkspaceMigrationException(
+      val makeError = (message: String, data: Map[String, Any]) =>
+        WorkspaceMigrationException(
           message = s"The workspace migration failed while configuring a new Google Project: $message.",
           data = Map(
             "migrationId" -> migration.id,
@@ -294,456 +297,510 @@ object WorkspaceMigrationActor {
           ) ++ data
         )
 
-        for {
-          _ <- raiseWhen(workspace.billingAccountErrorMessage.isDefined) {
-            makeError("a billing account error exists on workspace", Map(
-              "billingAccountErrorMessage" -> workspace.billingAccountErrorMessage.get
-            ))
-          }
-
-          workspaceBillingAccount = workspace.currentBillingAccountOnGoogleProject.getOrElse(
-            throw makeError("no billing account on workspace", Map.empty)
+      for {
+        _ <- raiseWhen(workspace.billingAccountErrorMessage.isDefined) {
+          makeError("a billing account error exists on workspace",
+                    Map(
+                      "billingAccountErrorMessage" -> workspace.billingAccountErrorMessage.get
+                    )
           )
+        }
 
-          // Safe to assume that this exists if the workspace exists
-          billingProject <- inTransactionT { dataAccess =>
-            OptionT {
-              dataAccess.rawlsBillingProjectQuery.load(RawlsBillingProjectName(workspace.namespace))
-            }
+        workspaceBillingAccount = workspace.currentBillingAccountOnGoogleProject.getOrElse(
+          throw makeError("no billing account on workspace", Map.empty)
+        )
+
+        // Safe to assume that this exists if the workspace exists
+        billingProject <- inTransactionT { dataAccess =>
+          OptionT {
+            dataAccess.rawlsBillingProjectQuery.load(RawlsBillingProjectName(workspace.namespace))
           }
+        }
 
-          billingProjectBillingAccount = billingProject.billingAccount.getOrElse(
-            throw makeError("no billing account on billing project", Map(
-              "billingProject" -> billingProject.projectName
-            ))
+        billingProjectBillingAccount = billingProject.billingAccount.getOrElse(
+          throw makeError("no billing account on billing project",
+                          Map(
+                            "billingProject" -> billingProject.projectName
+                          )
           )
+        )
 
-          _ <- raiseWhen(billingProject.invalidBillingAccount) {
-            makeError("invalid billing account on billing project", Map(
+        _ <- raiseWhen(billingProject.invalidBillingAccount) {
+          makeError(
+            "invalid billing account on billing project",
+            Map(
               "billingProject" -> billingProject.projectName,
               "billingProjectBillingAccount" -> billingProjectBillingAccount
-            ))
-          }
+            )
+          )
+        }
 
-          _ <- raiseWhen(workspaceBillingAccount != billingProjectBillingAccount) {
-            makeError("billing account on workspace differs from billing account on billing project", Map(
+        _ <- raiseWhen(workspaceBillingAccount != billingProjectBillingAccount) {
+          makeError(
+            "billing account on workspace differs from billing account on billing project",
+            Map(
               "workspaceBillingAccount" -> workspaceBillingAccount,
               "billingProject" -> billingProject.projectName,
               "billingProjectBillingAccount" -> billingProjectBillingAccount
-            ))
-          }
+            )
+          )
+        }
 
-          gcsDao <- asks(_.gcsDao)
-          userInfo <- fromFuture(gcsDao.getServiceAccountUserInfo())
-          workspaceService <- asks(_.workspaceService(RawlsRequestContext(userInfo)))
+        gcsDao <- asks(_.gcsDao)
+        userInfo <- fromFuture(gcsDao.getServiceAccountUserInfo())
+        workspaceService <- asks(_.workspaceService(RawlsRequestContext(userInfo)))
 
-          (googleProjectId, googleProjectNumber) <-
-            ifM(isSoleWorkspaceInBillingProjectGoogleProject)(
-              // when there's only one v1 workspace in a v1 billing project, we can re-use the
-              // google project associated with the billing project and forgo the need to transfer
-              // the workspace bucket to a new google project. Thus, the billing project will become
-              // a v2 billing project as its association with a google project will be removed.
-              for {
-                samDao <- asks(_.samDao)
-                // delete the google project resource in Sam while minimising length of time as admin
-                _ <- samDao.asResourceAdmin(SamResourceTypeNames.billingProject,
-                  billingProject.googleProjectId.value,
-                  SamBillingProjectPolicyNames.owner,
-                  userInfo
-                ) {
-                  fromFuture {
-                    samDao.deleteResource(SamResourceTypeNames.googleProject,
-                      billingProject.googleProjectId.value,
-                      userInfo
-                    )
-                  }
-                }
-
-                parentFolder <- asks(_.parentFolder)
-                _ <- Applicative[MigrateAction].unlessA(billingProject.servicePerimeter.isDefined) {
-                  fromFuture {
-                    gcsDao.addProjectToFolder(billingProject.googleProjectId, parentFolder.value)
-                  }
-                }
-
-                billingProjectPolicies <- fromFuture {
-                  samDao.admin.listPolicies(SamResourceTypeNames.billingProject,
-                    billingProject.projectName.value,
-                    userInfo
+        (googleProjectId, googleProjectNumber) <-
+          ifM(isSoleWorkspaceInBillingProjectGoogleProject)(
+            // when there's only one v1 workspace in a v1 billing project, we can re-use the
+            // google project associated with the billing project and forgo the need to transfer
+            // the workspace bucket to a new google project. Thus, the billing project will become
+            // a v2 billing project as its association with a google project will be removed.
+            for {
+              samDao <- asks(_.samDao)
+              // delete the google project resource in Sam while minimising length of time as admin
+              _ <- samDao.asResourceAdmin(SamResourceTypeNames.billingProject,
+                                          billingProject.googleProjectId.value,
+                                          SamBillingProjectPolicyNames.owner,
+                                          userInfo
+              ) {
+                fromFuture {
+                  samDao.deleteResource(SamResourceTypeNames.googleProject,
+                                        billingProject.googleProjectId.value,
+                                        userInfo
                   )
                 }
+              }
 
-                policiesAddedByDeploymentManager =
-                  Set(SamBillingProjectPolicyNames.owner, SamBillingProjectPolicyNames.canComputeUser)
+              parentFolder <- asks(_.parentFolder)
+              _ <- Applicative[MigrateAction].unlessA(billingProject.servicePerimeter.isDefined) {
+                fromFuture {
+                  gcsDao.addProjectToFolder(billingProject.googleProjectId, parentFolder.value)
+                }
+              }
 
-                _ <- removeIdentitiesFromGoogleProjectIam(
-                  GoogleProject(billingProject.googleProjectId.value),
-                  billingProjectPolicies
-                    .filter(p => policiesAddedByDeploymentManager.contains(p.policyName))
-                    .map(p => Identity.group(p.email.value))
+              billingProjectPolicies <- fromFuture {
+                samDao.admin.listPolicies(SamResourceTypeNames.billingProject,
+                                          billingProject.projectName.value,
+                                          userInfo
                 )
+              }
 
-                now <- nowTimestamp.map(_.some)
+              policiesAddedByDeploymentManager =
+                Set(SamBillingProjectPolicyNames.owner, SamBillingProjectPolicyNames.canComputeUser)
 
-                // short-circuit the bucket creation and transfer
-                _ <- inTransaction { dataAccess =>
-                  import dataAccess.workspaceMigrationQuery._
-                  update10(migration.id,
-                    tmpBucketCreatedCol, now,
-                    workspaceBucketTransferIamConfiguredCol, now,
-                    workspaceBucketTransferJobIssuedCol, now,
-                    workspaceBucketTransferredCol, now,
-                    workspaceBucketDeletedCol, now,
-                    finalBucketCreatedCol, now,
-                    tmpBucketTransferIamConfiguredCol, now,
-                    tmpBucketTransferJobIssuedCol, now,
-                    tmpBucketTransferredCol, now,
-                    tmpBucketDeletedCol, now
-                  )
-                }
+              _ <- removeIdentitiesFromGoogleProjectIam(
+                GoogleProject(billingProject.googleProjectId.value),
+                billingProjectPolicies
+                  .filter(p => policiesAddedByDeploymentManager.contains(p.policyName))
+                  .map(p => Identity.group(p.email.value))
+              )
 
-                googleProjectId = billingProject.googleProjectId
-                googleProjectNumber <- billingProject.googleProjectNumber.map(pure).getOrElse(
+              now <- nowTimestamp.map(_.some)
+
+              // short-circuit the bucket creation and transfer
+              _ <- inTransaction { dataAccess =>
+                import dataAccess.workspaceMigrationQuery._
+                update10(
+                  migration.id,
+                  tmpBucketCreatedCol,
+                  now,
+                  workspaceBucketTransferIamConfiguredCol,
+                  now,
+                  workspaceBucketTransferJobIssuedCol,
+                  now,
+                  workspaceBucketTransferredCol,
+                  now,
+                  workspaceBucketDeletedCol,
+                  now,
+                  finalBucketCreatedCol,
+                  now,
+                  tmpBucketTransferIamConfiguredCol,
+                  now,
+                  tmpBucketTransferJobIssuedCol,
+                  now,
+                  tmpBucketTransferredCol,
+                  now,
+                  tmpBucketDeletedCol,
+                  now
+                )
+              }
+
+              googleProjectId = billingProject.googleProjectId
+              googleProjectNumber <- billingProject.googleProjectNumber
+                .map(pure)
+                .getOrElse(
                   fromFuture(gcsDao.getGoogleProject(googleProjectId).map(gcsDao.getGoogleProjectNumber))
                 )
-              } yield (googleProjectId, googleProjectNumber),
-              fromFuture {
-                for {
-                  createResult@(googleProjectId, _) <- workspaceService.createGoogleProject(billingProject,
-                    rbsHandoutRequestId = workspace.workspaceId
-                  )
-                  _ <- workspaceService.setProjectBillingAccount(googleProjectId,
-                    billingProject,
-                    billingProjectBillingAccount,
-                    workspace.workspaceId
-                  )
-                } yield createResult
-              }
-            )
+            } yield (googleProjectId, googleProjectNumber),
+            fromFuture {
+              for {
+                createResult @ (googleProjectId, _) <- workspaceService.createGoogleProject(billingProject,
+                                                                                            rbsHandoutRequestId =
+                                                                                              workspace.workspaceId
+                )
+                _ <- workspaceService.setProjectBillingAccount(googleProjectId,
+                                                               billingProject,
+                                                               billingProjectBillingAccount,
+                                                               workspace.workspaceId
+                )
+              } yield createResult
+            }
+          )
 
-          _ <- fromFuture {
-            workspaceService.renameAndLabelProject(googleProjectId,
-              workspace.workspaceId,
-              workspace.toWorkspaceName
-            )
-          }
+        _ <- fromFuture {
+          workspaceService.renameAndLabelProject(googleProjectId, workspace.workspaceId, workspace.toWorkspaceName)
+        }
 
-          now <- nowTimestamp
-          _ <- inTransaction { dataAccess =>
-            import dataAccess.setOptionValueObject
-            import dataAccess.workspaceMigrationQuery._
-            update3(migration.id,
-              newGoogleProjectIdCol, googleProjectId.some,
-              newGoogleProjectNumberCol, googleProjectNumber.some,
-              newGoogleProjectConfiguredCol, Some(now)
-            )
-          }
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          import dataAccess.workspaceMigrationQuery._
+          update3(migration.id,
+                  newGoogleProjectIdCol,
+                  googleProjectId.some,
+                  newGoogleProjectNumberCol,
+                  googleProjectNumber.some,
+                  newGoogleProjectConfiguredCol,
+                  Some(now)
+          )
+        }
 
-          _ <- getLogger[MigrateAction].info(stringify(
+        _ <- getLogger[MigrateAction].info(
+          stringify(
             "migrationId" -> migration.id,
             "workspace" -> workspace.toWorkspaceName,
             "googleProjectConfigured" -> now
-          ))
-        } yield ()
+          )
+        )
+      } yield ()
     }
 
-
   final def createTempBucket: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.createTempBucketConditionCondition) {
-      (migration, workspace) =>
-        for {
-          tmpBucketName <-
-            liftIO(randomSuffix("terra-workspace-migration-").map(GcsBucketName))
+    withMigration(_.workspaceMigrationQuery.createTempBucketConditionCondition) { (migration, workspace) =>
+      for {
+        tmpBucketName <-
+          liftIO(randomSuffix("terra-workspace-migration-").map(GcsBucketName))
 
-          googleProjectId = migration.newGoogleProjectId.getOrElse(
-            throw noGoogleProjectError(migration, workspace)
+        googleProjectId = migration.newGoogleProjectId.getOrElse(
+          throw noGoogleProjectError(migration, workspace)
+        )
+        _ <- createBucketInSameRegion(
+          migration,
+          workspace,
+          sourceGoogleProject = GoogleProject(workspace.googleProjectId.value),
+          sourceBucketName = GcsBucketName(workspace.bucketName),
+          destGoogleProject = GoogleProject(googleProjectId.value),
+          destBucketName = tmpBucketName
+        )
+
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          dataAccess.workspaceMigrationQuery.update2(migration.id,
+                                                     dataAccess.workspaceMigrationQuery.tmpBucketCol,
+                                                     Some(tmpBucketName),
+                                                     dataAccess.workspaceMigrationQuery.tmpBucketCreatedCol,
+                                                     Some(now)
           )
-          _ <- createBucketInSameRegion(
-            migration,
-            workspace,
-            sourceGoogleProject = GoogleProject(workspace.googleProjectId.value),
-            sourceBucketName = GcsBucketName(workspace.bucketName),
-            destGoogleProject = GoogleProject(googleProjectId.value),
-            destBucketName = tmpBucketName
-          )
+        }
 
-          now <- nowTimestamp
-          _ <- inTransaction { dataAccess =>
-            import dataAccess.setOptionValueObject
-            dataAccess.workspaceMigrationQuery.update2(migration.id,
-              dataAccess.workspaceMigrationQuery.tmpBucketCol, Some(tmpBucketName),
-              dataAccess.workspaceMigrationQuery.tmpBucketCreatedCol, Some(now))
-          }
-
-          _ <- getLogger[MigrateAction].info(stringify(
+        _ <- getLogger[MigrateAction].info(
+          stringify(
             "migrationId" -> migration.id,
             "workspace" -> workspace.toWorkspaceName,
             "tmpBucketCreated" -> now
-          ))
-        } yield ()
+          )
+        )
+      } yield ()
     }
 
   final def configureTransferIamToTmpBucket: MigrateAction[Unit] =
-    configureBucketTransferIam(_.workspaceMigrationQuery.configureWorkspaceBucketTransferIam,
+    configureBucketTransferIam(
+      _.workspaceMigrationQuery.configureWorkspaceBucketTransferIam,
       getSrcBucket = (workspaceBucket, _) => workspaceBucket,
       getDstBucket = (_, tmpBucket) => tmpBucket,
       _.workspaceMigrationQuery.workspaceBucketTransferIamConfiguredCol
-  )
-
+    )
 
   final def issueTransferJobToTmpBucket: MigrateAction[Unit] =
-    issueBucketTransferJob(_.workspaceMigrationQuery.issueTransferJobToTmpBucketCondition,
+    issueBucketTransferJob(
+      _.workspaceMigrationQuery.issueTransferJobToTmpBucketCondition,
       getSrcBucket = (workspaceBucket, _) => workspaceBucket,
       getDstBucket = (_, tmpBucket) => tmpBucket,
       _.workspaceMigrationQuery.workspaceBucketTransferJobIssuedCol
     )
 
-
   final def deleteWorkspaceBucket: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.deleteWorkspaceBucketCondition) {
-      (migration, workspace) =>
-        for {
-          (storageService, googleProjectToBill) <- asks(s => (s.storageService, s.googleProjectToBill))
+    withMigration(_.workspaceMigrationQuery.deleteWorkspaceBucketCondition) { (migration, workspace) =>
+      for {
+        (storageService, googleProjectToBill) <- asks(s => (s.storageService, s.googleProjectToBill))
 
-          bucketInfo <- liftIO {
-            for {
-              bucketOpt <- storageService.getBucket(
-                GoogleProject(workspace.googleProjectId.value),
-                GcsBucketName(workspace.bucketName),
-                bucketGetOptions = List(
-                  Storage.BucketGetOption.fields(Storage.BucketField.BILLING),
-                  BucketGetOption.userProject(googleProjectToBill.value)),
+        bucketInfo <- liftIO {
+          for {
+            bucketOpt <- storageService.getBucket(
+              GoogleProject(workspace.googleProjectId.value),
+              GcsBucketName(workspace.bucketName),
+              bucketGetOptions = List(Storage.BucketGetOption.fields(Storage.BucketField.BILLING),
+                                      BucketGetOption.userProject(googleProjectToBill.value)
               )
-              bucketInfo <- IO.fromOption(bucketOpt)(noWorkspaceBucketError(migration, workspace))
-            } yield bucketInfo
-          }
+            )
+            bucketInfo <- IO.fromOption(bucketOpt)(noWorkspaceBucketError(migration, workspace))
+          } yield bucketInfo
+        }
 
-          // commit requester pays state before deleting bucket in case there is a failure
-          // and the bucket ends up being deleted and the not persisted which would be unrecoverable
-          _ <- inTransaction { dataAccess =>
-            val requesterPaysEnabled = Option(bucketInfo.requesterPays()).exists(_.booleanValue())
-            dataAccess.workspaceMigrationQuery.update(migration.id,
-              dataAccess.workspaceMigrationQuery.requesterPaysEnabledCol, requesterPaysEnabled)
-          }
+        // commit requester pays state before deleting bucket in case there is a failure
+        // and the bucket ends up being deleted and the not persisted which would be unrecoverable
+        _ <- inTransaction { dataAccess =>
+          val requesterPaysEnabled = Option(bucketInfo.requesterPays()).exists(_.booleanValue())
+          dataAccess.workspaceMigrationQuery.update(migration.id,
+                                                    dataAccess.workspaceMigrationQuery.requesterPaysEnabledCol,
+                                                    requesterPaysEnabled
+          )
+        }
 
-          _ <- liftIO {
-            storageService.deleteBucket(
+        _ <- liftIO {
+          storageService
+            .deleteBucket(
               GoogleProject(workspace.googleProjectId.value),
               GcsBucketName(workspace.bucketName),
               bucketSourceOptions = List(BucketSourceOption.userProject(googleProjectToBill.value))
-            ).compile.last
-          }
+            )
+            .compile
+            .last
+        }
 
-          now <- nowTimestamp
-          _ <- inTransaction { dataAccess =>
-            dataAccess.workspaceMigrationQuery.update(migration.id,
-              dataAccess.workspaceMigrationQuery.workspaceBucketDeletedCol, Some(now))
-          }
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          dataAccess.workspaceMigrationQuery.update(migration.id,
+                                                    dataAccess.workspaceMigrationQuery.workspaceBucketDeletedCol,
+                                                    Some(now)
+          )
+        }
 
-          _ <- getLogger[MigrateAction].info(stringify(
+        _ <- getLogger[MigrateAction].info(
+          stringify(
             "migrationId" -> migration.id,
             "workspace" -> workspace.toWorkspaceName,
             "workspaceBucketDeleted" -> now
-          ))
-        } yield ()
+          )
+        )
+      } yield ()
     }
 
   final def createFinalWorkspaceBucket: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.createFinalWorkspaceBucketCondition) {
-      (migration, workspace) =>
-        for {
-          (googleProjectId, tmpBucketName) <- getGoogleProjectAndTmpBucket(migration, workspace)
-          destGoogleProject = GoogleProject(googleProjectId.value)
-          _ <- createBucketInSameRegion(
-            migration,
-            workspace,
-            sourceGoogleProject = destGoogleProject,
-            sourceBucketName = tmpBucketName,
-            destGoogleProject = destGoogleProject,
-            destBucketName = GcsBucketName(workspace.bucketName)
+    withMigration(_.workspaceMigrationQuery.createFinalWorkspaceBucketCondition) { (migration, workspace) =>
+      for {
+        (googleProjectId, tmpBucketName) <- getGoogleProjectAndTmpBucket(migration, workspace)
+        destGoogleProject = GoogleProject(googleProjectId.value)
+        _ <- createBucketInSameRegion(
+          migration,
+          workspace,
+          sourceGoogleProject = destGoogleProject,
+          sourceBucketName = tmpBucketName,
+          destGoogleProject = destGoogleProject,
+          destBucketName = GcsBucketName(workspace.bucketName)
+        )
+
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          dataAccess.workspaceMigrationQuery.update(migration.id,
+                                                    dataAccess.workspaceMigrationQuery.finalBucketCreatedCol,
+                                                    Some(now)
           )
+        }
 
-          now <- nowTimestamp
-          _ <- inTransaction { dataAccess =>
-            dataAccess.workspaceMigrationQuery.update(migration.id,
-              dataAccess.workspaceMigrationQuery.finalBucketCreatedCol, Some(now))
-          }
-
-          _ <- getLogger[MigrateAction].info(stringify(
+        _ <- getLogger[MigrateAction].info(
+          stringify(
             "migrationId" -> migration.id,
             "workspace" -> workspace.toWorkspaceName,
             "finalWorkspaceBucketCreated" -> now
-          ))
-        } yield ()
+          )
+        )
+      } yield ()
     }
 
-
   final def configureTransferIamToFinalBucket: MigrateAction[Unit] =
-    configureBucketTransferIam(_.workspaceMigrationQuery.configureTmpBucketTransferIam,
+    configureBucketTransferIam(
+      _.workspaceMigrationQuery.configureTmpBucketTransferIam,
       getSrcBucket = (_, tmpBucket) => tmpBucket,
       getDstBucket = (workspaceBucket, _) => workspaceBucket,
       _.workspaceMigrationQuery.tmpBucketTransferIamConfiguredCol
     )
 
-
   final def issueTransferJobToFinalWorkspaceBucket: MigrateAction[Unit] =
-    issueBucketTransferJob(_.workspaceMigrationQuery.issueTransferJobToFinalWorkspaceBucketCondition,
+    issueBucketTransferJob(
+      _.workspaceMigrationQuery.issueTransferJobToFinalWorkspaceBucketCondition,
       getSrcBucket = (_, tmpBucket) => tmpBucket,
       getDstBucket = (workspaceBucket, _) => workspaceBucket,
       _.workspaceMigrationQuery.tmpBucketTransferJobIssuedCol
     )
 
-
   final def deleteTemporaryBucket: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.deleteTemporaryBucketCondition) {
-      (migration, workspace) =>
-        for {
-          (googleProjectId, tmpBucketName) <- getGoogleProjectAndTmpBucket(migration, workspace)
-          (storageService, googleProjectToBill) <- asks(s => (s.storageService, s.googleProjectToBill))
-          successOpt <- liftIO {
-            storageService.deleteBucket(
+    withMigration(_.workspaceMigrationQuery.deleteTemporaryBucketCondition) { (migration, workspace) =>
+      for {
+        (googleProjectId, tmpBucketName) <- getGoogleProjectAndTmpBucket(migration, workspace)
+        (storageService, googleProjectToBill) <- asks(s => (s.storageService, s.googleProjectToBill))
+        successOpt <- liftIO {
+          storageService
+            .deleteBucket(
               GoogleProject(googleProjectId.value),
               tmpBucketName,
               bucketSourceOptions = List(BucketSourceOption.userProject(googleProjectToBill.value))
-            ).compile.last
-          }
-
-          _ <- raiseWhen(!successOpt.contains(true)) {
-            noTmpBucketError(migration, workspace)
-          }
-
-          now <- nowTimestamp
-          _ <- inTransaction { dataAccess =>
-            dataAccess.workspaceMigrationQuery.update(migration.id,
-              dataAccess.workspaceMigrationQuery.tmpBucketDeletedCol,
-              Some(now)
             )
-          }
-          _ <- getLogger[MigrateAction].info(stringify(
+            .compile
+            .last
+        }
+
+        _ <- raiseWhen(!successOpt.contains(true)) {
+          noTmpBucketError(migration, workspace)
+        }
+
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          dataAccess.workspaceMigrationQuery.update(migration.id,
+                                                    dataAccess.workspaceMigrationQuery.tmpBucketDeletedCol,
+                                                    Some(now)
+          )
+        }
+        _ <- getLogger[MigrateAction].info(
+          stringify(
             "migrationId" -> migration.id,
             "workspace" -> workspace.toWorkspaceName,
             "tmpBucketDeleted" -> now
-          ))
-        } yield ()
-    }
-
-
-  final def restoreIamPoliciesAndUpdateWorkspaceRecord: MigrateAction[Unit] =
-    withMigration(_.workspaceMigrationQuery.restoreIamPoliciesAndUpdateWorkspaceRecordCondition) { (migration, workspace) =>
-      for {
-        MigrationDeps(_, googleProjectToBill, _, _, _, workspaceService, storageService, _, gcsDao, _, samDao) <-
-          asks(identity)
-
-        googleProjectId = migration.newGoogleProjectId.getOrElse(
-          throw noGoogleProjectError(migration, workspace)
+          )
         )
-
-        (userInfo, billingProjectOwnerPolicyGroup, workspacePolicies) <- fromFuture {
-          import SamBillingProjectPolicyNames.owner
-          for {
-            userInfo <- gcsDao.getServiceAccountUserInfo()
-
-            billingProjectPolicies <- samDao.admin.listPolicies(
-              SamResourceTypeNames.billingProject,
-              workspace.namespace,
-              userInfo
-            )
-
-            billingProjectOwnerPolicyGroup = billingProjectPolicies
-              .find(_.policyName == owner)
-              .getOrElse(throw WorkspaceMigrationException(
-                message = s"""Workspace migration failed: no "$owner" policy on billing project.""",
-                data = Map("migrationId" -> migration.id, "billingProject" -> workspace.namespace)
-              ))
-              .email
-
-            // The `can-compute` policy group is sync'ed for v2 workspaces. This
-            // was done at the billing project level only for v1 workspaces.
-            _ <- samDao.syncPolicyToGoogle(SamResourceTypeNames.workspace,
-              workspace.workspaceId,
-              SamWorkspacePolicyNames.canCompute
-            )
-
-            workspacePolicies <- samDao.admin.listPolicies(
-              SamResourceTypeNames.workspace,
-              workspace.workspaceId,
-              userInfo
-            )
-
-            workspacePoliciesByName = workspacePolicies.map(p => p.policyName -> p.email).toMap
-            _ <- workspaceService(RawlsRequestContext(userInfo)).setupGoogleProjectIam(
-              googleProjectId,
-              workspacePoliciesByName,
-              billingProjectOwnerPolicyGroup
-            )
-          } yield (userInfo, billingProjectOwnerPolicyGroup, workspacePoliciesByName)
-        }
-
-        // Now we'll update the workspace record with the new google project id.
-        // Why? Because the WorkspaceService does it in this order when creating the workspace.
-        _ <- inTransaction {
-          _.workspaceQuery
-            .filter(_.id === workspace.workspaceIdAsUUID)
-            .map(w => (w.googleProjectId, w.googleProjectNumber))
-            .update((googleProjectId.value, migration.newGoogleProjectNumber.map(_.toString)))
-        }
-
-        authDomains <- liftIO {
-          samDao.asResourceAdmin(SamResourceTypeNames.workspace,
-            workspace.workspaceId,
-            SamWorkspacePolicyNames.owner,
-            userInfo
-          ) {
-            samDao.createResourceFull(
-              SamResourceTypeNames.googleProject,
-              googleProjectId.value,
-              Map.empty,
-              Set.empty,
-              userInfo,
-              Some(SamFullyQualifiedResourceId(workspace.workspaceId, SamResourceTypeNames.workspace.value))
-            ).io *>
-              samDao.getResourceAuthDomain(
-                SamResourceTypeNames.workspace,
-                workspace.workspaceId,
-                userInfo
-              ).io
-          }
-        }
-
-        // when there isn't an auth domain, the billing project owners group is used in attempt
-        // to reduce an individual's google group membership below the limit of 2000.
-        _ <- liftIO {
-          val bucketPolices = (if (authDomains.isEmpty)
-            workspacePolicies.updated(SamWorkspacePolicyNames.projectOwner, billingProjectOwnerPolicyGroup) else
-            workspacePolicies)
-            .map { case (policyName, group) =>
-              WorkspaceAccessLevels.withPolicyName(policyName.value).map(_ -> group)
-            }
-            .flatten
-            .toMap
-
-          val bucket = GcsBucketName(workspace.bucketName)
-
-          gcsDao.updateBucketIam(bucket, bucketPolices, GoogleProjectId(googleProjectToBill.value).some).io *>
-            Applicative[IO].whenA(migration.requesterPaysEnabled) {
-              storageService.setRequesterPays(bucket,
-                migration.requesterPaysEnabled,
-                bucketTargetOptions = List(BucketTargetOption.userProject(googleProjectToBill.value))
-              ).compile.drain
-            }
-        }
-
-        _ <- inTransaction {
-          _.workspaceQuery
-            .filter(_.id === workspace.workspaceIdAsUUID)
-            .map(w => (w.isLocked, w.workspaceVersion))
-            .update((!migration.unlockOnCompletion, WorkspaceVersions.V2.value))
-        }
-
-        _ <- endMigration(migration.id, workspace.toWorkspaceName, Success)
       } yield ()
     }
 
+  final def restoreIamPoliciesAndUpdateWorkspaceRecord: MigrateAction[Unit] =
+    withMigration(_.workspaceMigrationQuery.restoreIamPoliciesAndUpdateWorkspaceRecordCondition) {
+      (migration, workspace) =>
+        for {
+          MigrationDeps(_, googleProjectToBill, _, _, _, workspaceService, storageService, _, gcsDao, _, samDao) <-
+            asks(identity)
+
+          googleProjectId = migration.newGoogleProjectId.getOrElse(
+            throw noGoogleProjectError(migration, workspace)
+          )
+
+          (userInfo, billingProjectOwnerPolicyGroup, workspacePolicies) <- fromFuture {
+            import SamBillingProjectPolicyNames.owner
+            for {
+              userInfo <- gcsDao.getServiceAccountUserInfo()
+
+              billingProjectPolicies <- samDao.admin.listPolicies(
+                SamResourceTypeNames.billingProject,
+                workspace.namespace,
+                userInfo
+              )
+
+              billingProjectOwnerPolicyGroup = billingProjectPolicies
+                .find(_.policyName == owner)
+                .getOrElse(
+                  throw WorkspaceMigrationException(
+                    message = s"""Workspace migration failed: no "$owner" policy on billing project.""",
+                    data = Map("migrationId" -> migration.id, "billingProject" -> workspace.namespace)
+                  )
+                )
+                .email
+
+              // The `can-compute` policy group is sync'ed for v2 workspaces. This
+              // was done at the billing project level only for v1 workspaces.
+              _ <- samDao.syncPolicyToGoogle(SamResourceTypeNames.workspace,
+                                             workspace.workspaceId,
+                                             SamWorkspacePolicyNames.canCompute
+              )
+
+              workspacePolicies <- samDao.admin.listPolicies(
+                SamResourceTypeNames.workspace,
+                workspace.workspaceId,
+                userInfo
+              )
+
+              workspacePoliciesByName = workspacePolicies.map(p => p.policyName -> p.email).toMap
+              _ <- workspaceService(RawlsRequestContext(userInfo)).setupGoogleProjectIam(
+                googleProjectId,
+                workspacePoliciesByName,
+                billingProjectOwnerPolicyGroup
+              )
+            } yield (userInfo, billingProjectOwnerPolicyGroup, workspacePoliciesByName)
+          }
+
+          // Now we'll update the workspace record with the new google project id.
+          // Why? Because the WorkspaceService does it in this order when creating the workspace.
+          _ <- inTransaction {
+            _.workspaceQuery
+              .filter(_.id === workspace.workspaceIdAsUUID)
+              .map(w => (w.googleProjectId, w.googleProjectNumber))
+              .update((googleProjectId.value, migration.newGoogleProjectNumber.map(_.toString)))
+          }
+
+          authDomains <- liftIO {
+            samDao.asResourceAdmin(SamResourceTypeNames.workspace,
+                                   workspace.workspaceId,
+                                   SamWorkspacePolicyNames.owner,
+                                   userInfo
+            ) {
+              samDao
+                .createResourceFull(
+                  SamResourceTypeNames.googleProject,
+                  googleProjectId.value,
+                  Map.empty,
+                  Set.empty,
+                  userInfo,
+                  Some(SamFullyQualifiedResourceId(workspace.workspaceId, SamResourceTypeNames.workspace.value))
+                )
+                .io *>
+                samDao
+                  .getResourceAuthDomain(
+                    SamResourceTypeNames.workspace,
+                    workspace.workspaceId,
+                    userInfo
+                  )
+                  .io
+            }
+          }
+
+          // when there isn't an auth domain, the billing project owners group is used in attempt
+          // to reduce an individual's google group membership below the limit of 2000.
+          _ <- liftIO {
+            val bucketPolices =
+              (if (authDomains.isEmpty)
+                 workspacePolicies.updated(SamWorkspacePolicyNames.projectOwner, billingProjectOwnerPolicyGroup)
+               else
+                 workspacePolicies)
+                .map { case (policyName, group) =>
+                  WorkspaceAccessLevels.withPolicyName(policyName.value).map(_ -> group)
+                }
+                .flatten
+                .toMap
+
+            val bucket = GcsBucketName(workspace.bucketName)
+
+            gcsDao.updateBucketIam(bucket, bucketPolices, GoogleProjectId(googleProjectToBill.value).some).io *>
+              Applicative[IO].whenA(migration.requesterPaysEnabled) {
+                storageService
+                  .setRequesterPays(bucket,
+                                    migration.requesterPaysEnabled,
+                                    bucketTargetOptions =
+                                      List(BucketTargetOption.userProject(googleProjectToBill.value))
+                  )
+                  .compile
+                  .drain
+              }
+          }
+
+          _ <- inTransaction {
+            _.workspaceQuery
+              .filter(_.id === workspace.workspaceIdAsUUID)
+              .map(w => (w.isLocked, w.workspaceVersion))
+              .update((!migration.unlockOnCompletion, WorkspaceVersions.V2.value))
+          }
+
+          _ <- endMigration(migration.id, workspace.toWorkspaceName, Success)
+        } yield ()
+    }
 
   def retryFailuresLike(failureMessage: String): MigrateAction[Unit] =
     for {
@@ -755,35 +812,39 @@ object WorkspaceMigrationActor {
         for {
           (migrationId, workspaceName) <- migrationRetryQuery.nextFailureLike(failureMessage, maxRetries)
           numAttempts <- OptionT.liftF(workspaceMigrationQuery.getNumActiveResourceLimitedMigrations)
-
           if numAttempts < maxAttempts
 
           retryCount <- OptionT.liftF[ReadWriteAction, Long] {
             for {
               MigrationRetry(id, _, numRetries) <- migrationRetryQuery.getOrCreate(migrationId)
               retryCount = numRetries + 1
-              _ <- workspaceMigrationQuery.update3(migrationId,
-                workspaceMigrationQuery.finishedCol, Option.empty[Timestamp],
-                workspaceMigrationQuery.outcomeCol, Option.empty[String],
-                workspaceMigrationQuery.messageCol, Option.empty[String]
+              _ <- workspaceMigrationQuery.update3(
+                migrationId,
+                workspaceMigrationQuery.finishedCol,
+                Option.empty[Timestamp],
+                workspaceMigrationQuery.outcomeCol,
+                Option.empty[String],
+                workspaceMigrationQuery.messageCol,
+                Option.empty[String]
               )
               _ <- migrationRetryQuery.update(id, migrationRetryQuery.retriesCol, retryCount)
             } yield retryCount
           }
         } yield (migrationId, workspaceName, retryCount)
       }
-      _ <- getLogger[MigrateAction].info(stringify(
-        "migrationId" -> migrationId,
-        "workspace" -> workspaceName,
-        "retry" -> retryCount,
-        "retried" -> now
-      ))
+      _ <- getLogger[MigrateAction].info(
+        stringify(
+          "migrationId" -> migrationId,
+          "workspace" -> workspaceName,
+          "retry" -> retryCount,
+          "retried" -> now
+        )
+      )
     } yield ()
-
 
   def removeIdentitiesFromGoogleProjectIam(googleProject: GoogleProject,
                                            identities: Set[Identity]
-                                          ): MigrateAction[Unit] =
+  ): MigrateAction[Unit] =
     asks(_.googleIamDAO).flatMap { googleIamDao =>
       fromFuture {
         for {
@@ -803,25 +864,23 @@ object WorkspaceMigrationActor {
           _ <- rolesToRemove.traverse_ { case (identity, roles) =>
             val Array(memberType, email) = identity.toString.split(":")
             googleIamDao.removeIamRoles(googleProject,
-              WorkbenchEmail(email),
-              GoogleIamDAO.MemberType.stringToMemberType(memberType),
-              roles
+                                        WorkbenchEmail(email),
+                                        GoogleIamDAO.MemberType.stringToMemberType(memberType),
+                                        roles
             )
           }
         } yield ()
       }
     }
 
-
   final def createBucketInSameRegion(migration: WorkspaceMigration,
                                      workspace: Workspace,
                                      sourceGoogleProject: GoogleProject,
                                      sourceBucketName: GcsBucketName,
                                      destGoogleProject: GoogleProject,
-                                     destBucketName: GcsBucketName)
-  : MigrateAction[Unit] =
+                                     destBucketName: GcsBucketName
+  ): MigrateAction[Unit] =
     MigrateAction { env =>
-
       def pollForBucketToBeCreated(interval: FiniteDuration, deadline: Deadline): IO[Unit] =
         IO.sleep(interval).whileM_ {
           for {
@@ -863,26 +922,30 @@ object WorkspaceMigrationActor {
             )
           )
 
-          _ <- env.storageService.insertBucket(
-            googleProject = destGoogleProject,
-            bucketName = destBucketName,
-            labels = Option(sourceBucket.getLabels).map(_.asScala.toMap).getOrElse(Map.empty),
-            bucketPolicyOnlyEnabled = true,
-            logBucket = GcsBucketName(GoogleServicesDAO.getStorageLogsBucketName(GoogleProjectId(destGoogleProject.value))).some,
-            location = Option(sourceBucket.getLocation)
-          ).compile.drain
+          _ <- env.storageService
+            .insertBucket(
+              googleProject = destGoogleProject,
+              bucketName = destBucketName,
+              labels = Option(sourceBucket.getLabels).map(_.asScala.toMap).getOrElse(Map.empty),
+              bucketPolicyOnlyEnabled = true,
+              logBucket = GcsBucketName(
+                GoogleServicesDAO.getStorageLogsBucketName(GoogleProjectId(destGoogleProject.value))
+              ).some,
+              location = Option(sourceBucket.getLocation)
+            )
+            .compile
+            .drain
 
           _ <- pollForBucketToBeCreated(interval = 100.milliseconds, deadline = 10.seconds.fromNow)
         } yield ()
       }
     }
 
-
   final def configureBucketTransferIam(readMigrations: DataAccess => ReadAction[Vector[WorkspaceMigration]],
                                        getSrcBucket: (GcsBucketName, GcsBucketName) => GcsBucketName,
                                        getDstBucket: (GcsBucketName, GcsBucketName) => GcsBucketName,
                                        getColumn: DataAccess => ColumnName[Option[Timestamp]]
-                                      ): MigrateAction[Unit] =
+  ): MigrateAction[Unit] =
     withMigration(readMigrations) { (migration, workspace) =>
       for {
         (srcBucket, dstBucket) <- getSrcAndDstBuckets(migration, workspace, getSrcBucket, getDstBucket)
@@ -896,20 +959,28 @@ object WorkspaceMigrationActor {
             serviceAccountList = NonEmptyList.one(Identity.serviceAccount(serviceAccount.email.value))
             // STS requires the following to read from the origin bucket and delete objects after
             // transfer
-            _ <- storageService.setIamPolicy(srcBucket,
-              Map(
-                StorageRole.LegacyBucketWriter -> serviceAccountList,
-                StorageRole.ObjectViewer -> serviceAccountList),
-              bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
-            ).compile.drain
+            _ <- storageService
+              .setIamPolicy(
+                srcBucket,
+                Map(StorageRole.LegacyBucketWriter -> serviceAccountList,
+                    StorageRole.ObjectViewer -> serviceAccountList
+                ),
+                bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
+              )
+              .compile
+              .drain
 
             // STS requires the following to write to the destination bucket
-            _ <- storageService.setIamPolicy(dstBucket,
-              Map(
-                StorageRole.LegacyBucketWriter -> serviceAccountList,
-                StorageRole.ObjectCreator -> serviceAccountList),
-              bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
-            ).compile.drain
+            _ <- storageService
+              .setIamPolicy(
+                dstBucket,
+                Map(StorageRole.LegacyBucketWriter -> serviceAccountList,
+                    StorageRole.ObjectCreator -> serviceAccountList
+                ),
+                bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
+              )
+              .compile
+              .drain
 
           } yield ()
         }
@@ -919,39 +990,39 @@ object WorkspaceMigrationActor {
           dataAccess.workspaceMigrationQuery.update(migration.id, getColumn(dataAccess), now.some)
         }
 
-        _ <- getLogger[MigrateAction].info(stringify(
-          "migrationId" -> migration.id,
-          "workspace" -> workspace.toWorkspaceName,
-          "srcBucket" -> srcBucket,
-          "dstBucket" -> dstBucket,
-          "iamConfigured" -> now
-        ))
+        _ <- getLogger[MigrateAction].info(
+          stringify(
+            "migrationId" -> migration.id,
+            "workspace" -> workspace.toWorkspaceName,
+            "srcBucket" -> srcBucket,
+            "dstBucket" -> dstBucket,
+            "iamConfigured" -> now
+          )
+        )
       } yield ()
     }
-
 
   final def issueBucketTransferJob(readMigrations: DataAccess => ReadAction[Vector[WorkspaceMigration]],
                                    getSrcBucket: (GcsBucketName, GcsBucketName) => GcsBucketName,
                                    getDstBucket: (GcsBucketName, GcsBucketName) => GcsBucketName,
                                    getColumn: DataAccess => ColumnName[Option[Timestamp]]
-                                   ): MigrateAction[Unit] =
+  ): MigrateAction[Unit] =
     withMigration(readMigrations) { (migration, workspace) =>
-    for {
-      (srcBucket, dstBucket) <- getSrcAndDstBuckets(migration, workspace, getSrcBucket, getDstBucket)
-      _ <- startBucketTransferJob(migration, workspace, srcBucket, dstBucket)
-      now <- nowTimestamp
-      _ <- inTransaction { dataAccess =>
-        dataAccess.workspaceMigrationQuery.update(migration.id, getColumn(dataAccess), now.some)
-      }
-    } yield ()
-  }
-
+      for {
+        (srcBucket, dstBucket) <- getSrcAndDstBuckets(migration, workspace, getSrcBucket, getDstBucket)
+        _ <- startBucketTransferJob(migration, workspace, srcBucket, dstBucket)
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          dataAccess.workspaceMigrationQuery.update(migration.id, getColumn(dataAccess), now.some)
+        }
+      } yield ()
+    }
 
   final def getSrcAndDstBuckets(migration: WorkspaceMigration,
                                 workspace: Workspace,
                                 getSrcBucket: (GcsBucketName, GcsBucketName) => GcsBucketName,
-                                getDstBucket: (GcsBucketName, GcsBucketName) => GcsBucketName,
-                               ): MigrateAction[(GcsBucketName, GcsBucketName)] =
+                                getDstBucket: (GcsBucketName, GcsBucketName) => GcsBucketName
+  ): MigrateAction[(GcsBucketName, GcsBucketName)] =
     liftIO {
       IO.fromOption(migration.tmpBucketName)(noTmpBucketError(migration, workspace)).map { tmpBucket =>
         val workspaceBucket = GcsBucketName(workspace.bucketName)
@@ -959,12 +1030,11 @@ object WorkspaceMigrationActor {
       }
     }
 
-
   final def startBucketTransferJob(migration: WorkspaceMigration,
                                    workspace: Workspace,
                                    srcBucket: GcsBucketName,
                                    dstBucket: GcsBucketName
-                                  ): MigrateAction[TransferJob] =
+  ): MigrateAction[TransferJob] =
     for {
       (storageTransferService, googleProject) <- asks { env =>
         (env.storageTransferService, env.googleProjectToBill)
@@ -987,14 +1057,16 @@ object WorkspaceMigrationActor {
         } yield transferJob
       }
 
-      _ <- getLogger[MigrateAction].info(stringify(
-        "migrationId" -> migration.id,
-        "workspace" -> workspace.toWorkspaceName,
-        "transferJob" -> transferJob.getName,
-        "srcBucket" -> srcBucket,
-        "dstBucket" -> dstBucket,
-        "issued" -> transferJob.getCreationTime
-      ))
+      _ <- getLogger[MigrateAction].info(
+        stringify(
+          "migrationId" -> migration.id,
+          "workspace" -> workspace.toWorkspaceName,
+          "transferJob" -> transferJob.getName,
+          "srcBucket" -> srcBucket,
+          "dstBucket" -> dstBucket,
+          "issued" -> transferJob.getCreationTime
+        )
+      )
 
       _ <- inTransaction { _ =>
         storageTransferJobs
@@ -1002,7 +1074,6 @@ object WorkspaceMigrationActor {
           .insert((transferJob.getName, migration.id, dstBucket.value, srcBucket.value))
       }
     } yield transferJob
-
 
   final def refreshTransferJobs: MigrateAction[PpwStorageTransferJob] =
     for {
@@ -1030,15 +1101,16 @@ object WorkspaceMigrationActor {
           .update(now.some, status.some, message)
       }
 
-      _ <- getLogger[MigrateAction].info(stringify(
-        "migrationId" -> transferJob.migrationId,
-        "transferJob" -> transferJob.jobName.value,
-        "finished" -> now,
-        "outcome" -> outcome.toJson.compactPrint
-      ))
+      _ <- getLogger[MigrateAction].info(
+        stringify(
+          "migrationId" -> transferJob.migrationId,
+          "transferJob" -> transferJob.jobName.value,
+          "finished" -> now,
+          "outcome" -> outcome.toJson.compactPrint
+        )
+      )
 
     } yield transferJob.copy(finished = now.some, outcome = outcome.some)
-
 
   final def getOperationOutcome(operation: Operation): Option[Outcome] =
     operation.getDone.some.collect { case true =>
@@ -1047,11 +1119,11 @@ object WorkspaceMigrationActor {
       else {
         val status = operation.getError
         if (status.getDetailsCount == 0)
-          Failure(status.getMessage) else
+          Failure(status.getMessage)
+        else
           Failure(status.getMessage ++ " : " ++ status.getDetailsList.toString)
       }
     }
-
 
   final def updateMigrationTransferJobStatus(transferJob: PpwStorageTransferJob): MigrateAction[Unit] =
     transferJob.outcome match {
@@ -1065,7 +1137,6 @@ object WorkspaceMigrationActor {
         pass
     }
 
-
   final def transferJobSucceeded(transferJob: PpwStorageTransferJob): MigrateAction[Unit] =
     withMigration(_.workspaceMigrationQuery.withMigrationId(transferJob.migrationId)) { (migration, _) =>
       for {
@@ -1078,19 +1149,27 @@ object WorkspaceMigrationActor {
             serviceAccount <- storageTransferService.getStsServiceAccount(googleProject)
             serviceAccountList = NonEmptyList.one(Identity.serviceAccount(serviceAccount.email.value))
 
-            _ <- storageService.removeIamPolicy(transferJob.originBucket,
-              Map(
-                StorageRole.LegacyBucketReader -> serviceAccountList,
-                StorageRole.ObjectViewer -> serviceAccountList),
-              bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
-            ).compile.drain
+            _ <- storageService
+              .removeIamPolicy(
+                transferJob.originBucket,
+                Map(StorageRole.LegacyBucketReader -> serviceAccountList,
+                    StorageRole.ObjectViewer -> serviceAccountList
+                ),
+                bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
+              )
+              .compile
+              .drain
 
-            _ <- storageService.removeIamPolicy(transferJob.destBucket,
-              Map(
-                StorageRole.LegacyBucketWriter -> serviceAccountList,
-                StorageRole.ObjectCreator -> serviceAccountList),
-              bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
-            ).compile.drain
+            _ <- storageService
+              .removeIamPolicy(
+                transferJob.destBucket,
+                Map(StorageRole.LegacyBucketWriter -> serviceAccountList,
+                    StorageRole.ObjectCreator -> serviceAccountList
+                ),
+                bucketSourceOptions = List(BucketSourceOption.userProject(googleProject.value))
+              )
+              .compile
+              .drain
 
           } yield ()
         }
@@ -1099,14 +1178,13 @@ object WorkspaceMigrationActor {
         _ <- inTransaction { dataAccess =>
           import dataAccess.workspaceMigrationQuery._
           update(migration.id,
-            if (migration.workspaceBucketTransferred.isEmpty) workspaceBucketTransferredCol
-            else tmpBucketTransferredCol,
-            transferred
+                 if (migration.workspaceBucketTransferred.isEmpty) workspaceBucketTransferredCol
+                 else tmpBucketTransferredCol,
+                 transferred
           )
         }
       } yield ()
     }
-
 
   final def endMigration(migrationId: Long, workspaceName: WorkspaceName, outcome: Outcome): MigrateAction[Unit] =
     for {
@@ -1114,26 +1192,26 @@ object WorkspaceMigrationActor {
       _ <- inTransaction {
         _.workspaceMigrationQuery.setMigrationFinished(migrationId, now, outcome)
       }
-      _ <- getLogger[MigrateAction].info(stringify(
-        "migrationId" -> migrationId,
-        "workspace" -> workspaceName,
-        "finished" -> now,
-        "outcome" -> outcome.toJson.compactPrint
-      ))
-  } yield ()
+      _ <- getLogger[MigrateAction].info(
+        stringify(
+          "migrationId" -> migrationId,
+          "workspace" -> workspaceName,
+          "finished" -> now,
+          "outcome" -> outcome.toJson.compactPrint
+        )
+      )
+    } yield ()
 
-
-  final def withMigration(selectMigrations: DataAccess => ReadAction[Seq[WorkspaceMigration]])
-                         (attempt: (WorkspaceMigration, Workspace) => MigrateAction[Unit])
-  : MigrateAction[Unit] =
+  final def withMigration(
+    selectMigrations: DataAccess => ReadAction[Seq[WorkspaceMigration]]
+  )(attempt: (WorkspaceMigration, Workspace) => MigrateAction[Unit]): MigrateAction[Unit] =
     for {
       (migration, workspace) <- inTransactionT { dataAccess =>
         OptionT[ReadWriteAction, (WorkspaceMigration, Workspace)] {
           for {
             migrations <- selectMigrations(dataAccess)
 
-            workspaces <- dataAccess
-              .workspaceQuery
+            workspaces <- dataAccess.workspaceQuery
               .listByIds(migrations.map(_.workspaceId))
 
           } yield migrations.zip(workspaces).headOption
@@ -1144,7 +1222,6 @@ object WorkspaceMigrationActor {
         endMigration(migration.id, workspace.toWorkspaceName, Failure(t.getMessage))
       }
     } yield ()
-
 
   final def peekTransferJob: MigrateAction[PpwStorageTransferJob] =
     nowTimestamp.flatMap { now =>
@@ -1169,9 +1246,9 @@ object WorkspaceMigrationActor {
       }
     }
 
-
-  final def getGoogleProjectAndTmpBucket(migration: WorkspaceMigration, workspace: Workspace)
-  : MigrateAction[(GoogleProjectId, GcsBucketName)] =
+  final def getGoogleProjectAndTmpBucket(migration: WorkspaceMigration,
+                                         workspace: Workspace
+  ): MigrateAction[(GoogleProjectId, GcsBucketName)] =
     liftIO {
       for {
         googleProjectId <- IO.fromOption(migration.newGoogleProjectId)(noGoogleProjectError(migration, workspace))
@@ -1179,13 +1256,11 @@ object WorkspaceMigrationActor {
       } yield (googleProjectId, bucketName)
     }
 
-
   final def inTransactionT[A](action: DataAccess => OptionT[ReadWriteAction, A]): MigrateAction[A] =
     for {
       dataSource <- asks(_.dataSource)
       result <- liftF(OptionT(dataSource.inTransaction(action(_).value).io))
     } yield result
-
 
   final def inTransaction[A](action: DataAccess => ReadWriteAction[A]): MigrateAction[A] =
     for {
@@ -1193,23 +1268,19 @@ object WorkspaceMigrationActor {
       result <- liftIO(dataSource.inTransaction(action).io)
     } yield result
 
-
   final def getWorkspace(workspaceId: UUID): MigrateAction[Workspace] =
     inTransaction {
       _.workspaceQuery.findByIdOrFail(workspaceId.toString)
     }
-
 
   final def nowTimestamp: MigrateAction[Timestamp] =
     liftIO(IO {
       Timestamp.valueOf(LocalDateTime.ofInstant(Instant.now, ZoneOffset.UTC))
     })
 
-
   final def randomSuffix(str: String): IO[String] = IO {
     str ++ UUID.randomUUID.toString.replace("-", "")
   }
-
 
   final def noGoogleProjectError(migration: WorkspaceMigration, workspace: Workspace): Throwable =
     WorkspaceMigrationException(
@@ -1221,7 +1292,6 @@ object WorkspaceMigrationActor {
       )
     )
 
-
   final def noWorkspaceBucketError(migration: WorkspaceMigration, workspace: Workspace): Throwable =
     WorkspaceMigrationException(
       message = "Workspace migration failed: Workspace cloud bucket not found.",
@@ -1232,7 +1302,6 @@ object WorkspaceMigrationActor {
       )
     )
 
-
   final def noTmpBucketError[A](migration: WorkspaceMigration, workspace: Workspace): Throwable =
     WorkspaceMigrationException(
       message = "Workspace migration failed: Temporary cloud storage bucket not found.",
@@ -1242,7 +1311,6 @@ object WorkspaceMigrationActor {
         "tmpBucket" -> migration.tmpBucketName
       )
     )
-
 
   sealed trait Message
   case object RunMigration extends Message
@@ -1256,12 +1324,11 @@ object WorkspaceMigrationActor {
             storageTransferService: GoogleStorageTransferService[IO],
             gcsDao: GoogleServicesDAO,
             iamDao: GoogleIamDAO,
-            samDao: SamDAO)
-  : Behavior[Message] =
+            samDao: SamDAO
+  ): Behavior[Message] =
     Behaviors.setup { context =>
-
       def unsafeRunMigrateAction[A](action: MigrateAction[A]): Behavior[Message] = {
-        try {
+        try
           action
             .run(
               MigrationDeps(
@@ -1281,7 +1348,7 @@ object WorkspaceMigrationActor {
             .value
             .void
             .unsafeRunSync
-        } catch {
+        catch {
           case failure: Throwable => context.executionContext.reportFailure(failure)
         }
         Behaviors.same
@@ -1316,4 +1383,3 @@ object WorkspaceMigrationActor {
     }
 
 }
-

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterService.scala
@@ -7,7 +7,18 @@ import org.broadinstitute.dsde.rawls.billing.ServicePerimeterAccessException
 import org.broadinstitute.dsde.rawls.config.ServicePerimeterServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
-import org.broadinstitute.dsde.rawls.model.{CreationStatuses, ErrorReport, GoogleProjectNumber, RawlsBillingProject, RawlsRequestContext, SamResourceTypeNames, SamServicePerimeterActions, ServicePerimeterName, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  CreationStatuses,
+  ErrorReport,
+  GoogleProjectNumber,
+  RawlsBillingProject,
+  RawlsRequestContext,
+  SamResourceTypeNames,
+  SamServicePerimeterActions,
+  ServicePerimeterName,
+  UserInfo,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.Retry
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 
@@ -15,10 +26,12 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 import scala.concurrent.{ExecutionContext, Future}
 
-
-class ServicePerimeterService(dataSource: SlickDataSource, gcsDAO: GoogleServicesDAO, config: ServicePerimeterServiceConfig)
-                             (implicit val system: ActorSystem, protected val executionContext: ExecutionContext)
-  extends LazyLogging with Retry {
+class ServicePerimeterService(dataSource: SlickDataSource,
+                              gcsDAO: GoogleServicesDAO,
+                              config: ServicePerimeterServiceConfig
+)(implicit val system: ActorSystem, protected val executionContext: ExecutionContext)
+    extends LazyLogging
+    with Retry {
 
   import dataSource.dataAccess.driver.api._
 
@@ -29,9 +42,10 @@ class ServicePerimeterService(dataSource: SlickDataSource, gcsDAO: GoogleService
     * @param servicePerimeterName
     * @return
     */
-  private def collectWorkspacesInPerimeter(servicePerimeterName: ServicePerimeterName, dataAccess: DataAccess): ReadAction[Seq[Workspace]] = {
+  private def collectWorkspacesInPerimeter(servicePerimeterName: ServicePerimeterName,
+                                           dataAccess: DataAccess
+  ): ReadAction[Seq[Workspace]] =
     dataAccess.workspaceQuery.getWorkspacesInPerimeter(servicePerimeterName)
-  }
 
   /**
     * Look up all of the Billing Projects that use the specified
@@ -40,9 +54,12 @@ class ServicePerimeterService(dataSource: SlickDataSource, gcsDAO: GoogleService
     * @param servicePerimeterName
     * @return
     */
-  private def collectBillingProjectsInPerimeter(servicePerimeterName: ServicePerimeterName, dataAccess: DataAccess): ReadAction[Seq[RawlsBillingProject]] = {
-    dataAccess.rawlsBillingProjectQuery.listProjectsWithServicePerimeterAndStatus(servicePerimeterName, CreationStatuses.Ready)
-  }
+  private def collectBillingProjectsInPerimeter(servicePerimeterName: ServicePerimeterName,
+                                                dataAccess: DataAccess
+  ): ReadAction[Seq[RawlsBillingProject]] =
+    dataAccess.rawlsBillingProjectQuery.listProjectsWithServicePerimeterAndStatus(servicePerimeterName,
+                                                                                  CreationStatuses.Ready
+    )
 
   /**
     * Some Service Perimeters may required that they have some additional non-Terra Google Projects that need to be in
@@ -53,9 +70,8 @@ class ServicePerimeterService(dataSource: SlickDataSource, gcsDAO: GoogleService
     * @param servicePerimeterName
     * @return
     */
-  private def loadStaticProjectsForPerimeter(servicePerimeterName: ServicePerimeterName): Seq[GoogleProjectNumber] = {
+  private def loadStaticProjectsForPerimeter(servicePerimeterName: ServicePerimeterName): Seq[GoogleProjectNumber] =
     config.staticProjectsInPerimeters.getOrElse(servicePerimeterName, Seq.empty)
-  }
 
   /**
     * Takes the the name of a Service Perimeter as the only parameter.  Since multiple Billing Projects can specify the
@@ -71,41 +87,83 @@ class ServicePerimeterService(dataSource: SlickDataSource, gcsDAO: GoogleService
     * @return Future[Unit] indicating whether we succeeded to update the Service Perimeter
     */
 
-  def overwriteGoogleProjectsInPerimeter(servicePerimeterName: ServicePerimeterName, dataAccess: DataAccess): ReadAction[Unit] = {
+  def overwriteGoogleProjectsInPerimeter(servicePerimeterName: ServicePerimeterName,
+                                         dataAccess: DataAccess
+  ): ReadAction[Unit] =
     for {
       workspacesInPerimeter <- collectWorkspacesInPerimeter(servicePerimeterName, dataAccess)
       billingProjectsInPerimeter <- collectBillingProjectsInPerimeter(servicePerimeterName, dataAccess)
-      googleProjectNumbers = workspacesInPerimeter.flatMap(_.googleProjectNumber) ++ billingProjectsInPerimeter.flatMap(_.googleProjectNumber) ++ loadStaticProjectsForPerimeter(servicePerimeterName)
+      googleProjectNumbers = workspacesInPerimeter.flatMap(_.googleProjectNumber) ++ billingProjectsInPerimeter.flatMap(
+        _.googleProjectNumber
+      ) ++ loadStaticProjectsForPerimeter(servicePerimeterName)
       googleProjectNumberStrings = googleProjectNumbers.map(_.value).toSet
-      operation <- DBIO.from(gcsDAO.accessContextManagerDAO.overwriteProjectsInServicePerimeter(servicePerimeterName, googleProjectNumberStrings))
-      result <- DBIO.from(retryUntilSuccessOrTimeout(failureLogMessage = s"Google Operation to update Service Perimeter: ${servicePerimeterName} was not successful")(config.pollInterval, config.pollTimeout) { () =>
-        gcsDAO.pollOperation(OperationId(GoogleApiTypes.AccessContextManagerApi, operation.getName)).map {
-          case OperationStatus(false, _) => Future.failed(new RawlsException(s"Google Operation to update Service Perimeter ${servicePerimeterName} is still in progress..."))
-          // TODO: If the operation to update the Service Perimeter failed, we need to consider the possibility that
-          // the list of Projects in the Perimeter may have been wiped or somehow modified in an undesirable way.  If
-          // this happened, it would be possible for Projects intended to be in the Perimeter are NOT in that
-          // Perimeter anymore, which is a problem.
-          case OperationStatus(true, errorMessage) if !errorMessage.isEmpty => Future.successful(throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, s"Google Operation to update Service Perimeter ${servicePerimeterName} failed with message: ${errorMessage}")))
-          case _ => Future.successful()
+      operation <- DBIO.from(
+        gcsDAO.accessContextManagerDAO.overwriteProjectsInServicePerimeter(servicePerimeterName,
+                                                                           googleProjectNumberStrings
+        )
+      )
+      result <- DBIO.from(
+        retryUntilSuccessOrTimeout(failureLogMessage =
+          s"Google Operation to update Service Perimeter: ${servicePerimeterName} was not successful"
+        )(config.pollInterval, config.pollTimeout) { () =>
+          gcsDAO.pollOperation(OperationId(GoogleApiTypes.AccessContextManagerApi, operation.getName)).map {
+            case OperationStatus(false, _) =>
+              Future.failed(
+                new RawlsException(
+                  s"Google Operation to update Service Perimeter ${servicePerimeterName} is still in progress..."
+                )
+              )
+            // TODO: If the operation to update the Service Perimeter failed, we need to consider the possibility that
+            // the list of Projects in the Perimeter may have been wiped or somehow modified in an undesirable way.  If
+            // this happened, it would be possible for Projects intended to be in the Perimeter are NOT in that
+            // Perimeter anymore, which is a problem.
+            case OperationStatus(true, errorMessage) if !errorMessage.isEmpty =>
+              Future.successful(
+                throw new RawlsExceptionWithErrorReport(
+                  ErrorReport(
+                    StatusCodes.InternalServerError,
+                    s"Google Operation to update Service Perimeter ${servicePerimeterName} failed with message: ${errorMessage}"
+                  )
+                )
+              )
+            case _ => Future.successful()
+          }
         }
-      })
-    } yield {
-      result match {
-        case Left(regrets) =>
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "Failed to update perimeter", regrets.map(ErrorReport(_)).toList))
-        case Right(_) => ()
-      }
+      )
+    } yield result match {
+      case Left(regrets) =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.InternalServerError, "Failed to update perimeter", regrets.map(ErrorReport(_)).toList)
+        )
+      case Right(_) => ()
     }
-  }
 }
 
 object ServicePerimeterService {
-  def checkServicePerimeterAccess(samDAO: SamDAO, servicePerimeterOption: Option[ServicePerimeterName], ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Unit] = {
-    servicePerimeterOption.map { servicePerimeter =>
-      samDAO.userHasAction(SamResourceTypeNames.servicePerimeter, URLEncoder.encode(servicePerimeter.value, UTF_8.name), SamServicePerimeterActions.addProject, ctx.userInfo).flatMap {
-        case true => Future.successful(())
-        case false => Future.failed(new ServicePerimeterAccessException(ErrorReport(StatusCodes.Forbidden, s"You do not have the action ${SamServicePerimeterActions.addProject.value} for $servicePerimeter")))
+  def checkServicePerimeterAccess(samDAO: SamDAO,
+                                  servicePerimeterOption: Option[ServicePerimeterName],
+                                  ctx: RawlsRequestContext
+  )(implicit ec: ExecutionContext): Future[Unit] =
+    servicePerimeterOption
+      .map { servicePerimeter =>
+        samDAO
+          .userHasAction(SamResourceTypeNames.servicePerimeter,
+                         URLEncoder.encode(servicePerimeter.value, UTF_8.name),
+                         SamServicePerimeterActions.addProject,
+                         ctx.userInfo
+          )
+          .flatMap {
+            case true => Future.successful(())
+            case false =>
+              Future.failed(
+                new ServicePerimeterAccessException(
+                  ErrorReport(
+                    StatusCodes.Forbidden,
+                    s"You do not have the action ${SamServicePerimeterActions.addProject.value} for $servicePerimeter"
+                  )
+                )
+              )
+          }
       }
-    }.getOrElse(Future.successful(()))
-  }
+      .getOrElse(Future.successful(()))
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -6,7 +6,17 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamWorkspaceActions, SnapshotListResponse, UserInfo, WorkspaceAttributeSpecs, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceName,
+  ErrorReport,
+  NamedDataRepoSnapshot,
+  RawlsRequestContext,
+  SamWorkspaceActions,
+  SnapshotListResponse,
+  UserInfo,
+  WorkspaceAttributeSpecs,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 
 import java.util.UUID
@@ -16,46 +26,70 @@ import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object SnapshotService {
-  def constructor(dataSource: SlickDataSource, samDAO: SamDAO, workspaceManagerDAO: WorkspaceManagerDAO, terraDataRepoUrl: String)(ctx: RawlsRequestContext)
-                 (implicit executionContext: ExecutionContext): SnapshotService = {
+  def constructor(dataSource: SlickDataSource,
+                  samDAO: SamDAO,
+                  workspaceManagerDAO: WorkspaceManagerDAO,
+                  terraDataRepoUrl: String
+  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SnapshotService =
     new SnapshotService(ctx, dataSource, samDAO, workspaceManagerDAO, terraDataRepoUrl)
-  }
 }
 
-class SnapshotService(protected val ctx: RawlsRequestContext, val dataSource: SlickDataSource, val samDAO: SamDAO, workspaceManagerDAO: WorkspaceManagerDAO, terraDataRepoInstanceName: String)
-                     (implicit protected val executionContext: ExecutionContext)
-  extends FutureSupport with WorkspaceSupport with LazyLogging {
+class SnapshotService(protected val ctx: RawlsRequestContext,
+                      val dataSource: SlickDataSource,
+                      val samDAO: SamDAO,
+                      workspaceManagerDAO: WorkspaceManagerDAO,
+                      terraDataRepoInstanceName: String
+)(implicit protected val executionContext: ExecutionContext)
+    extends FutureSupport
+    with WorkspaceSupport
+    with LazyLogging {
 
-  def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataRepoSnapshotResource] = {
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
+  def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataRepoSnapshotResource] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ).flatMap { workspaceContext =>
       val wsid = workspaceContext.workspaceIdAsUUID // to avoid UUID parsing multiple times
       // create the stub workspace in WSM if it does not already exist
-      if(!workspaceStubExists(wsid, ctx)) {
+      if (!workspaceStubExists(wsid, ctx)) {
         workspaceManagerDAO.createWorkspace(wsid, ctx)
       }
       // create the requested snapshot reference
-      val snapshotRef = workspaceManagerDAO.createDataRepoSnapshotReference(wsid, snapshot.snapshotId, snapshot.name,
-        snapshot.description, terraDataRepoInstanceName, CloningInstructionsEnum.NOTHING, ctx)
+      val snapshotRef = workspaceManagerDAO.createDataRepoSnapshotReference(wsid,
+                                                                            snapshot.snapshotId,
+                                                                            snapshot.name,
+                                                                            snapshot.description,
+                                                                            terraDataRepoInstanceName,
+                                                                            CloningInstructionsEnum.NOTHING,
+                                                                            ctx
+      )
       Future.successful(snapshotRef)
     }
-  }
 
   def getSnapshot(workspaceName: WorkspaceName, referenceId: String): Future[DataRepoSnapshotResource] = {
     val referenceUuid = validateSnapshotId(referenceId)
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceUuid, ctx)
       Future.successful(ref)
     }
   }
 
-  def getSnapshotByName(workspaceName: WorkspaceName, referenceName: String): Future[DataRepoSnapshotResource] = {
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).flatMap { workspaceContext =>
-      val ref = workspaceManagerDAO.getDataRepoSnapshotReferenceByName(workspaceContext.workspaceIdAsUUID, DataReferenceName(referenceName), ctx)
+  def getSnapshotByName(workspaceName: WorkspaceName, referenceName: String): Future[DataRepoSnapshotResource] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ).flatMap { workspaceContext =>
+      val ref = workspaceManagerDAO.getDataRepoSnapshotReferenceByName(workspaceContext.workspaceIdAsUUID,
+                                                                       DataReferenceName(referenceName),
+                                                                       ctx
+      )
       Future.successful(ref)
     }
-  }
 
-  //AS-787 - rework the data so that it's in the same place in the JSON with a list and get snapshot responses
+  // AS-787 - rework the data so that it's in the same place in the JSON with a list and get snapshot responses
   def massageSnapshots(references: ResourceList): SnapshotListResponse = {
     val snapshots = references.getResources.asScala.map { r =>
       val massaged = new DataRepoSnapshotResource
@@ -69,12 +103,13 @@ class SnapshotService(protected val ctx: RawlsRequestContext, val dataSource: Sl
   /*
     internal method to query WSM for a list of snapshot references; used by enumerateSnapshots and findBySnapshotId
    */
-  protected[snapshot] def retrieveSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int): SnapshotListResponse = {
+  protected[snapshot] def retrieveSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int): SnapshotListResponse =
     Try(workspaceManagerDAO.enumerateDataRepoSnapshotReferences(workspaceId, offset, limit, ctx)) match {
       case Success(references) => massageSnapshots(references)
       // if we fail with a 404, it means we have no stub in WSM yet. This is benign and functionally equivalent
       // to having no references, so return the empty list.
-      case Failure(ex: bio.terra.workspace.client.ApiException) if ex.getCode == 404 => new SnapshotListResponse(Seq.empty[DataRepoSnapshotResource])
+      case Failure(ex: bio.terra.workspace.client.ApiException) if ex.getCode == 404 =>
+        new SnapshotListResponse(Seq.empty[DataRepoSnapshotResource])
       // but if we hit a different error, it's a valid error; rethrow it
       case Failure(ex: bio.terra.workspace.client.ApiException) =>
         throw new RawlsExceptionWithErrorReport(ErrorReport(ex.getCode, ex))
@@ -82,7 +117,6 @@ class SnapshotService(protected val ctx: RawlsRequestContext, val dataSource: Sl
         logger.warn(s"Unexpected error when enumerating snapshots: ${other.getMessage}")
         throw new RawlsExceptionWithErrorReport(ErrorReport(other))
     }
-  }
 
   /**
     * return a given page of snapshot references from Workspace Manager, optionally returning only those
@@ -94,29 +128,40 @@ class SnapshotService(protected val ctx: RawlsRequestContext, val dataSource: Sl
     * @param referencedSnapshotId the TDR snapshotId for which to return matching references
     * @return the list of snapshot references
     */
-  def enumerateSnapshots(workspaceName: WorkspaceName, offset: Int, limit: Int, referencedSnapshotId: Option[UUID] = None): Future[SnapshotListResponse] = {
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
+  def enumerateSnapshots(workspaceName: WorkspaceName,
+                         offset: Int,
+                         limit: Int,
+                         referencedSnapshotId: Option[UUID] = None
+  ): Future[SnapshotListResponse] =
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.read,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ).map { workspaceContext =>
       referencedSnapshotId match {
-        case None => retrieveSnapshotReferences(workspaceContext.workspaceIdAsUUID, offset, limit)
+        case None     => retrieveSnapshotReferences(workspaceContext.workspaceIdAsUUID, offset, limit)
         case Some(id) => findBySnapshotId(workspaceContext.workspaceIdAsUUID, id, offset, limit)
       }
     }
-  }
 
-   /*
-    * Returns all snapshot references from Workspace Manager that refer to a specified snapshotId.
-    * Internal method; does not check authorization for the given workspace.
-    *
-    * @param workspaceName the workspace owning the snapshot references
-    * @param snapshotId the snapshotId to look for
-    * @param userOffset pagination offset for the final list of results
-    * @param userLimit pagination limit for the final list of results
-    * @param batchSize optional, default 200: internal param exposed for unit-testing purposes that controls
-    *                  the size of pages requested from Workspace Manager while looking for the specified
-    *                  snapshotId.
-    * @return the list of all snapshot references that refer to the specified snapshotId
-    */
-  protected[snapshot] def findBySnapshotId(workspaceId: UUID, snapshotId: UUID, userOffset: Int, userLimit: Int, batchSize: Int = 200): SnapshotListResponse = {
+  /*
+   * Returns all snapshot references from Workspace Manager that refer to a specified snapshotId.
+   * Internal method; does not check authorization for the given workspace.
+   *
+   * @param workspaceName the workspace owning the snapshot references
+   * @param snapshotId the snapshotId to look for
+   * @param userOffset pagination offset for the final list of results
+   * @param userLimit pagination limit for the final list of results
+   * @param batchSize optional, default 200: internal param exposed for unit-testing purposes that controls
+   *                  the size of pages requested from Workspace Manager while looking for the specified
+   *                  snapshotId.
+   * @return the list of all snapshot references that refer to the specified snapshotId
+   */
+  protected[snapshot] def findBySnapshotId(workspaceId: UUID,
+                                           snapshotId: UUID,
+                                           userOffset: Int,
+                                           userLimit: Int,
+                                           batchSize: Int = 200
+  ): SnapshotListResponse = {
 
     val snapshotIdCriteria = snapshotId.toString // just so we're not calling toString on every iteration through loops
 
@@ -125,16 +170,16 @@ class SnapshotService(protected val ctx: RawlsRequestContext, val dataSource: Sl
       // get this page of references from WSM
       val newPage = retrieveSnapshotReferences(workspaceId, offset, batchSize)
       // filter the page to just those with a matching snapshotId
-      val found = newPage.gcpDataRepoSnapshots.filter{ res =>
+      val found = newPage.gcpDataRepoSnapshots.filter { res =>
         Try(res.getAttributes.getSnapshot.equals(snapshotIdCriteria)).toOption.getOrElse(false)
       }
       // append the ones we just found to those found on previous pages
       val accum = alreadyFound ++ found
 
-      if (newPage.gcpDataRepoSnapshots.size < batchSize || accum.size >= userOffset+userLimit) {
+      if (newPage.gcpDataRepoSnapshots.size < batchSize || accum.size >= userOffset + userLimit) {
         // the page we retrieved from WSM was the last page, OR we have already found enough results
         // to satisfy the user's requested pagination criteria; return everything we found so far
-        accum.slice(userOffset, userOffset+userLimit)
+        accum.slice(userOffset, userOffset + userLimit)
       } else {
         // the page we retrieved from WSM was NOT the last page; continue looping through the next page
         findInPage(offset + batchSize, accum)
@@ -146,42 +191,55 @@ class SnapshotService(protected val ctx: RawlsRequestContext, val dataSource: Sl
     SnapshotListResponse(refs)
   }
 
-  def updateSnapshot(workspaceName: WorkspaceName, snapshotId: String, updateInfo: UpdateDataRepoSnapshotReferenceRequestBody): Future[Unit] = {
+  def updateSnapshot(workspaceName: WorkspaceName,
+                     snapshotId: String,
+                     updateInfo: UpdateDataRepoSnapshotReferenceRequestBody
+  ): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ).map { workspaceContext =>
       // check that snapshot exists before updating it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)
       // build the update request body, ignoring any changes to instanceName and snapshot, and requiring either name or description
       if (Option(updateInfo.getName).isEmpty && Option(updateInfo.getDescription).isEmpty) {
-        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Either name or description is required."))
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Either name or description is required.")
+        )
       }
       val updateBody = new UpdateDataRepoSnapshotReferenceRequestBody()
       updateBody.setName(updateInfo.getName)
       updateBody.setDescription(updateInfo.getDescription)
       // perform the update
-      workspaceManagerDAO.updateDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, updateBody, ctx)
+      workspaceManagerDAO.updateDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID,
+                                                          snapshotUuid,
+                                                          updateBody,
+                                                          ctx
+      )
     }
   }
 
   def deleteSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write, Some(WorkspaceAttributeSpecs(all = false))).map { workspaceContext =>
+    getWorkspaceContextAndPermissions(workspaceName,
+                                      SamWorkspaceActions.write,
+                                      Some(WorkspaceAttributeSpecs(all = false))
+    ).map { workspaceContext =>
       // check that snapshot exists before deleting it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)
       workspaceManagerDAO.deleteDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)
     }
   }
 
-  private def workspaceStubExists(workspaceId: UUID, ctx: RawlsRequestContext): Boolean = {
+  private def workspaceStubExists(workspaceId: UUID, ctx: RawlsRequestContext): Boolean =
     Try(workspaceManagerDAO.getWorkspace(workspaceId, ctx)).isSuccess
-  }
 
-  private def validateSnapshotId(snapshotId: String): UUID = {
+  private def validateSnapshotId(snapshotId: String): UUID =
     Try(UUID.fromString(snapshotId)) match {
       case Success(snapshotUuid) => snapshotUuid
       case Failure(_) =>
         throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "SnapshotId must be a valid UUID."))
     }
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -23,34 +23,58 @@ import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
 
 object SpendReportingService {
-  def constructor(dataSource: SlickDataSource, bigQueryService: cats.effect.Resource[IO, GoogleBigQueryService[IO]], samDAO: SamDAO, spendReportingServiceConfig: SpendReportingServiceConfig)
-                 (ctx: RawlsRequestContext)
-                 (implicit executionContext: ExecutionContext): SpendReportingService = {
+  def constructor(dataSource: SlickDataSource,
+                  bigQueryService: cats.effect.Resource[IO, GoogleBigQueryService[IO]],
+                  samDAO: SamDAO,
+                  spendReportingServiceConfig: SpendReportingServiceConfig
+  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SpendReportingService =
     new SpendReportingService(ctx, dataSource, bigQueryService, samDAO, spendReportingServiceConfig)
-  }
 }
 
-class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSource, bigQueryService: cats.effect.Resource[IO, GoogleBigQueryService[IO]], samDAO: SamDAO, spendReportingServiceConfig: SpendReportingServiceConfig)
-                           (implicit val executionContext: ExecutionContext) extends LazyLogging {
-  private def requireProjectAction[T](projectName: RawlsBillingProjectName, action: SamResourceAction)(op: => Future[T]): Future[T] = {
+class SpendReportingService(ctx: RawlsRequestContext,
+                            dataSource: SlickDataSource,
+                            bigQueryService: cats.effect.Resource[IO, GoogleBigQueryService[IO]],
+                            samDAO: SamDAO,
+                            spendReportingServiceConfig: SpendReportingServiceConfig
+)(implicit val executionContext: ExecutionContext)
+    extends LazyLogging {
+  private def requireProjectAction[T](projectName: RawlsBillingProjectName, action: SamResourceAction)(
+    op: => Future[T]
+  ): Future[T] =
     samDAO.userHasAction(SamResourceTypeNames.billingProject, projectName.value, action, ctx.userInfo).flatMap {
       case true => op
-      case false => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, s"${ctx.userInfo.userEmail.value} cannot perform ${action.value} on project ${projectName.value}")))
+      case false =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(
+              StatusCodes.Forbidden,
+              s"${ctx.userInfo.userEmail.value} cannot perform ${action.value} on project ${projectName.value}"
+            )
+          )
+        )
     }
-  }
 
-  private def requireAlphaUser[T]()(op: => Future[T]): Future[T] = {
-    samDAO.userHasAction(SamResourceTypeNames.managedGroup, "Alpha_Spend_Report_Users", SamResourceAction("use"), ctx.userInfo).flatMap {
-      case true => op
-      case false => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "This API is not live yet.")))
-    }
-  }
+  private def requireAlphaUser[T]()(op: => Future[T]): Future[T] =
+    samDAO
+      .userHasAction(SamResourceTypeNames.managedGroup,
+                     "Alpha_Spend_Report_Users",
+                     SamResourceAction("use"),
+                     ctx.userInfo
+      )
+      .flatMap {
+        case true => op
+        case false =>
+          Future.failed(
+            new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "This API is not live yet."))
+          )
+      }
 
   def extractSpendReportingResults(rows: List[FieldValueList],
                                    startTime: DateTime,
                                    endTime: DateTime,
                                    workspaceProjectsToNames: Map[GoogleProject, WorkspaceName],
-                                   aggregationKeys: Set[SpendReportingAggregationKeyWithSub]): SpendReportingResults = {
+                                   aggregationKeys: Set[SpendReportingAggregationKeyWithSub]
+  ): SpendReportingResults = {
     val currency = getCurrency(rows)
     val spendAggregations = aggregationKeys.map { aggregationKey =>
       extractSpendAggregation(rows, currency, aggregationKey, workspaceProjectsToNames)
@@ -70,20 +94,34 @@ class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSourc
       if (x.equals(y)) {
         x
       } else {
-        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadGateway, s"Inconsistent currencies found while aggregating spend data: $x and $y cannot be combined"))
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadGateway,
+                      s"Inconsistent currencies found while aggregating spend data: $x and $y cannot be combined"
+          )
+        )
       }
     })
   }
 
-  private def extractSpendAggregation(rows: List[FieldValueList], currency: Currency, aggregationKey: SpendReportingAggregationKeyWithSub, workspaceProjectsToNames: Map[GoogleProject, WorkspaceName] = Map.empty): SpendReportingAggregation = {
+  private def extractSpendAggregation(rows: List[FieldValueList],
+                                      currency: Currency,
+                                      aggregationKey: SpendReportingAggregationKeyWithSub,
+                                      workspaceProjectsToNames: Map[GoogleProject, WorkspaceName] = Map.empty
+  ): SpendReportingAggregation =
     aggregationKey match {
-      case SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category, subAggregationKey) => extractCategorySpendAggregation(rows, currency, subAggregationKey, workspaceProjectsToNames)
-      case SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, subAggregationKey) => extractWorkspaceSpendAggregation(rows, currency, subAggregationKey, workspaceProjectsToNames)
-      case SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily, subAggregationKey) => extractDailySpendAggregation(rows, currency, subAggregationKey, workspaceProjectsToNames)
+      case SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category, subAggregationKey) =>
+        extractCategorySpendAggregation(rows, currency, subAggregationKey, workspaceProjectsToNames)
+      case SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, subAggregationKey) =>
+        extractWorkspaceSpendAggregation(rows, currency, subAggregationKey, workspaceProjectsToNames)
+      case SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily, subAggregationKey) =>
+        extractDailySpendAggregation(rows, currency, subAggregationKey, workspaceProjectsToNames)
     }
-  }
 
-  private def extractSpendSummary(rows: List[FieldValueList], currency: Currency, startTime: DateTime, endTime: DateTime): SpendReportingForDateRange = {
+  private def extractSpendSummary(rows: List[FieldValueList],
+                                  currency: Currency,
+                                  startTime: DateTime,
+                                  endTime: DateTime
+  ): SpendReportingForDateRange = {
     val (cost, credits) = sumCostsAndCredits(rows, currency)
 
     SpendReportingForDateRange(
@@ -95,22 +133,42 @@ class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSourc
     )
   }
 
-  private def sumCostsAndCredits(rows: List[FieldValueList], currency: Currency): (BigDecimal, BigDecimal) = {
+  private def sumCostsAndCredits(rows: List[FieldValueList], currency: Currency): (BigDecimal, BigDecimal) =
     (
-      rows.map(row => BigDecimal(row.get("cost").getDoubleValue)).sum.setScale(currency.getDefaultFractionDigits, RoundingMode.HALF_EVEN),
-      rows.map(row => BigDecimal(row.get("credits").getDoubleValue)).sum.setScale(currency.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
+      rows
+        .map(row => BigDecimal(row.get("cost").getDoubleValue))
+        .sum
+        .setScale(currency.getDefaultFractionDigits, RoundingMode.HALF_EVEN),
+      rows
+        .map(row => BigDecimal(row.get("credits").getDoubleValue))
+        .sum
+        .setScale(currency.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
     )
-  }
 
-  private def extractWorkspaceSpendAggregation(rows: List[FieldValueList], currency: Currency, subAggregationKey: Option[SpendReportingAggregationKey] = None, workspaceProjectsToNames: Map[GoogleProject, WorkspaceName]): SpendReportingAggregation = {
-    val spendByGoogleProjectId: Map[GoogleProject, List[FieldValueList]] = rows.groupBy(row => GoogleProject(row.get("googleProjectId").getStringValue))
+  private def extractWorkspaceSpendAggregation(rows: List[FieldValueList],
+                                               currency: Currency,
+                                               subAggregationKey: Option[SpendReportingAggregationKey] = None,
+                                               workspaceProjectsToNames: Map[GoogleProject, WorkspaceName]
+  ): SpendReportingAggregation = {
+    val spendByGoogleProjectId: Map[GoogleProject, List[FieldValueList]] =
+      rows.groupBy(row => GoogleProject(row.get("googleProjectId").getStringValue))
     val workspaceSpend = spendByGoogleProjectId.map { case (googleProjectId, rowsForGoogleProjectId) =>
       val (cost, credits) = sumCostsAndCredits(rowsForGoogleProjectId, currency)
       val subAggregation = subAggregationKey.map { key =>
-        extractSpendAggregation(rowsForGoogleProjectId, currency, aggregationKey = SpendReportingAggregationKeyWithSub(key), workspaceProjectsToNames = workspaceProjectsToNames)
+        extractSpendAggregation(rowsForGoogleProjectId,
+                                currency,
+                                aggregationKey = SpendReportingAggregationKeyWithSub(key),
+                                workspaceProjectsToNames = workspaceProjectsToNames
+        )
       }
-      val workspaceName = workspaceProjectsToNames.getOrElse(googleProjectId, throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadGateway, s"unexpected project ${googleProjectId.value} returned by BigQuery")))
-      SpendReportingForDateRange(cost.toString(),
+      val workspaceName = workspaceProjectsToNames.getOrElse(
+        googleProjectId,
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadGateway, s"unexpected project ${googleProjectId.value} returned by BigQuery")
+        )
+      )
+      SpendReportingForDateRange(
+        cost.toString(),
         credits.toString(),
         currency.getCurrencyCode,
         workspace = Option(workspaceName),
@@ -120,16 +178,26 @@ class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSourc
     }.toList
 
     SpendReportingAggregation(
-      SpendReportingAggregationKeys.Workspace, workspaceSpend
+      SpendReportingAggregationKeys.Workspace,
+      workspaceSpend
     )
   }
 
-  private def extractCategorySpendAggregation(rows: List[FieldValueList], currency: Currency, subAggregationKey: Option[SpendReportingAggregationKey] = None, workspaceProjectsToNames: Map[GoogleProject, WorkspaceName] = Map.empty): SpendReportingAggregation = {
-    val spendByCategory: Map[TerraSpendCategory, List[FieldValueList]] = rows.groupBy(row => TerraSpendCategories.categorize(row.get("service").getStringValue))
+  private def extractCategorySpendAggregation(rows: List[FieldValueList],
+                                              currency: Currency,
+                                              subAggregationKey: Option[SpendReportingAggregationKey] = None,
+                                              workspaceProjectsToNames: Map[GoogleProject, WorkspaceName] = Map.empty
+  ): SpendReportingAggregation = {
+    val spendByCategory: Map[TerraSpendCategory, List[FieldValueList]] =
+      rows.groupBy(row => TerraSpendCategories.categorize(row.get("service").getStringValue))
     val categorySpend = spendByCategory.map { case (category, rowsForCategory) =>
       val (cost, credits) = sumCostsAndCredits(rowsForCategory, currency)
       val subAggregation = subAggregationKey.map { key =>
-        extractSpendAggregation(rowsForCategory, currency, aggregationKey = SpendReportingAggregationKeyWithSub(key), workspaceProjectsToNames = workspaceProjectsToNames)
+        extractSpendAggregation(rowsForCategory,
+                                currency,
+                                aggregationKey = SpendReportingAggregationKeyWithSub(key),
+                                workspaceProjectsToNames = workspaceProjectsToNames
+        )
       }
       SpendReportingForDateRange(
         cost.toString,
@@ -141,16 +209,26 @@ class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSourc
     }.toList
 
     SpendReportingAggregation(
-      SpendReportingAggregationKeys.Category, categorySpend
+      SpendReportingAggregationKeys.Category,
+      categorySpend
     )
   }
 
-  private def extractDailySpendAggregation(rows: List[FieldValueList], currency: Currency, subAggregationKey: Option[SpendReportingAggregationKey] = None, workspaceProjectsToNames: Map[GoogleProject, WorkspaceName] = Map.empty): SpendReportingAggregation = {
-    val spendByStartTime: Map[DateTime, List[FieldValueList]] = rows.groupBy(row => DateTime.parse(row.get("date").getStringValue))
+  private def extractDailySpendAggregation(rows: List[FieldValueList],
+                                           currency: Currency,
+                                           subAggregationKey: Option[SpendReportingAggregationKey] = None,
+                                           workspaceProjectsToNames: Map[GoogleProject, WorkspaceName] = Map.empty
+  ): SpendReportingAggregation = {
+    val spendByStartTime: Map[DateTime, List[FieldValueList]] =
+      rows.groupBy(row => DateTime.parse(row.get("date").getStringValue))
     val dailySpend = spendByStartTime.map { case (startTime, rowsForStartTime) =>
       val (cost, credits) = sumCostsAndCredits(rowsForStartTime, currency)
       val subAggregation = subAggregationKey.map { key =>
-        extractSpendAggregation(rowsForStartTime, currency, aggregationKey = SpendReportingAggregationKeyWithSub(key), workspaceProjectsToNames = workspaceProjectsToNames)
+        extractSpendAggregation(rowsForStartTime,
+                                currency,
+                                aggregationKey = SpendReportingAggregationKeyWithSub(key),
+                                workspaceProjectsToNames = workspaceProjectsToNames
+        )
       }
       SpendReportingForDateRange(
         cost.toString,
@@ -163,78 +241,115 @@ class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSourc
     }.toList
 
     SpendReportingAggregation(
-      SpendReportingAggregationKeys.Daily, dailySpend
+      SpendReportingAggregationKeys.Daily,
+      dailySpend
     )
   }
 
   private def dateTimeToISODateString(dt: DateTime): String = dt.toString(ISODateTimeFormat.date())
 
-  private def getSpendExportConfiguration(billingProjectName: RawlsBillingProjectName): Future[BillingProjectSpendExport] = {
-    dataSource.inTransaction { dataAccess =>
-       dataAccess.rawlsBillingProjectQuery.getBillingProjectSpendConfiguration(billingProjectName)
-    }.recover {
-      case _: RawlsException => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"billing account not found on billing project ${billingProjectName.value}"))
-    }.map(_.getOrElse(throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"billing project ${billingProjectName.value} not found"))))
-  }
+  private def getSpendExportConfiguration(
+    billingProjectName: RawlsBillingProjectName
+  ): Future[BillingProjectSpendExport] =
+    dataSource
+      .inTransaction { dataAccess =>
+        dataAccess.rawlsBillingProjectQuery.getBillingProjectSpendConfiguration(billingProjectName)
+      }
+      .recover { case _: RawlsException =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest,
+                      s"billing account not found on billing project ${billingProjectName.value}"
+          )
+        )
+      }
+      .map(
+        _.getOrElse(
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.NotFound, s"billing project ${billingProjectName.value} not found")
+          )
+        )
+      )
 
-  private def getWorkspaceGoogleProjects(billingProjectName: RawlsBillingProjectName): Future[Map[GoogleProject, WorkspaceName]] = {
-    dataSource.inTransaction { dataAccess =>
+  private def getWorkspaceGoogleProjects(
+    billingProjectName: RawlsBillingProjectName
+  ): Future[Map[GoogleProject, WorkspaceName]] =
+    dataSource
+      .inTransaction { dataAccess =>
         dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
-    }.map { workspaces =>
-      workspaces.collect {
-        case workspace if workspace.workspaceVersion == WorkspaceVersions.V2 => GoogleProject(workspace.googleProjectId.value) -> workspace.toWorkspaceName
-      }.toMap
-    }
-  }
+      }
+      .map { workspaces =>
+        workspaces.collect {
+          case workspace if workspace.workspaceVersion == WorkspaceVersions.V2 =>
+            GoogleProject(workspace.googleProjectId.value) -> workspace.toWorkspaceName
+        }.toMap
+      }
 
-  private def validateReportParameters(startDate: DateTime, endDate: DateTime): Unit = {
+  private def validateReportParameters(startDate: DateTime, endDate: DateTime): Unit =
     if (startDate.isAfter(endDate)) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"start date ${dateTimeToISODateString(startDate)} must be before end date ${dateTimeToISODateString(endDate)}"))
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.BadRequest,
+          s"start date ${dateTimeToISODateString(startDate)} must be before end date ${dateTimeToISODateString(endDate)}"
+        )
+      )
     } else if (Days.daysBetween(startDate, endDate).getDays > spendReportingServiceConfig.maxDateRange) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"provided dates exceed maximum report date range of ${spendReportingServiceConfig.maxDateRange} days"))
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.BadRequest,
+          s"provided dates exceed maximum report date range of ${spendReportingServiceConfig.maxDateRange} days"
+        )
+      )
     }
-  }
 
-  private def stringQueryParameterValue(parameterValue: String): QueryParameterValue = {
-    QueryParameterValue.newBuilder()
+  private def stringQueryParameterValue(parameterValue: String): QueryParameterValue =
+    QueryParameterValue
+      .newBuilder()
       .setType(StandardSQLTypeName.STRING)
       .setValue(parameterValue)
       .build()
-  }
 
   private def stringArrayQueryParameterValue(parameterValues: List[String]): QueryParameterValue = {
     val queryParameterArrayValues = parameterValues.map { parameterValue =>
-      QueryParameterValue.newBuilder()
+      QueryParameterValue
+        .newBuilder()
         .setType(StandardSQLTypeName.STRING)
         .setValue(parameterValue)
         .build()
     }.asJava
 
-    QueryParameterValue.newBuilder()
+    QueryParameterValue
+      .newBuilder()
       .setType(StandardSQLTypeName.ARRAY)
       .setArrayType(StandardSQLTypeName.STRING)
       .setArrayValues(queryParameterArrayValues)
       .build()
   }
 
-  def getQuery(aggregationKeys: Set[SpendReportingAggregationKey], tableName: String, customTimePartitionColumn: Option[String]): String = {
+  def getQuery(aggregationKeys: Set[SpendReportingAggregationKey],
+               tableName: String,
+               customTimePartitionColumn: Option[String]
+  ): String = {
     // The Broad table uses a view with a different column name.
     val timePartitionColumn = customTimePartitionColumn.getOrElse("_PARTITIONTIME")
     val queryClause = s"""
-       | SELECT
-       |  SUM(cost) as cost,
-       |  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
-       |  currency ${aggregationKeys.map(_.bigQueryAliasClause()).mkString}
-       | FROM `$tableName`
-       | WHERE billing_account_id = @billingAccountId
-       | AND $timePartitionColumn BETWEEN @startDate AND @endDate
-       | AND project.id in UNNEST(@projects)
-       | GROUP BY currency ${aggregationKeys.map(_.bigQueryGroupByClause()).mkString}
-       |""".stripMargin
+                         | SELECT
+                         |  SUM(cost) as cost,
+                         |  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
+                         |  currency ${aggregationKeys.map(_.bigQueryAliasClause()).mkString}
+                         | FROM `$tableName`
+                         | WHERE billing_account_id = @billingAccountId
+                         | AND $timePartitionColumn BETWEEN @startDate AND @endDate
+                         | AND project.id in UNNEST(@projects)
+                         | GROUP BY currency ${aggregationKeys.map(_.bigQueryGroupByClause()).mkString}
+                         |""".stripMargin
     queryClause.replace("REPLACE_TIME_PARTITION_COLUMN", timePartitionColumn)
   }
 
-  def getSpendForBillingProject(billingProjectName: RawlsBillingProjectName, startDate: DateTime, endDate: DateTime, aggregationKeyParameters: Set[SpendReportingAggregationKeyWithSub] = Set.empty): Future[SpendReportingResults] = {
+  def getSpendForBillingProject(billingProjectName: RawlsBillingProjectName,
+                                startDate: DateTime,
+                                endDate: DateTime,
+                                aggregationKeyParameters: Set[SpendReportingAggregationKeyWithSub] = Set.empty
+  ): Future[SpendReportingResults] = {
     validateReportParameters(startDate, endDate)
     requireAlphaUser() {
       requireProjectAction(billingProjectName, SamBillingProjectActions.readSpendReport) {
@@ -243,27 +358,40 @@ class SpendReportingService(ctx: RawlsRequestContext, dataSource: SlickDataSourc
           workspaceProjectsToNames <- getWorkspaceGoogleProjects(billingProjectName)
 
           // Unbox potentially many SpendReportingAggregationKeyWithSubs, all of which have optional subAggregationKeys and convert to Set[SpendReportingAggregationKey]
-          aggregationKeys = aggregationKeyParameters.flatMap(maybeKeys => Set(Option(maybeKeys.key), maybeKeys.subAggregationKey).flatten)
+          aggregationKeys = aggregationKeyParameters.flatMap(maybeKeys =>
+            Set(Option(maybeKeys.key), maybeKeys.subAggregationKey).flatten
+          )
 
-          spendReportTableName = spendExportConf.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
+          spendReportTableName = spendExportConf.spendExportTable.getOrElse(
+            spendReportingServiceConfig.defaultTableName
+          )
           isBroadTable = spendReportTableName == spendReportingServiceConfig.defaultTableName
           timePartitionColumn = if (isBroadTable) Some(spendReportingServiceConfig.defaultTimePartitionColumn) else None
           query = getQuery(aggregationKeys, spendReportTableName, timePartitionColumn)
 
           queryJobConfiguration = QueryJobConfiguration
             .newBuilder(query)
-            .addNamedParameter("billingAccountId", stringQueryParameterValue(spendExportConf.billingAccountId.withoutPrefix()))
+            .addNamedParameter("billingAccountId",
+                               stringQueryParameterValue(spendExportConf.billingAccountId.withoutPrefix())
+            )
             .addNamedParameter("startDate", stringQueryParameterValue(dateTimeToISODateString(startDate)))
             .addNamedParameter("endDate", stringQueryParameterValue(dateTimeToISODateString(endDate)))
-            .addNamedParameter("projects", stringArrayQueryParameterValue(workspaceProjectsToNames.keySet.map(_.value).toList))
+            .addNamedParameter("projects",
+                               stringArrayQueryParameterValue(workspaceProjectsToNames.keySet.map(_.value).toList)
+            )
             .build()
 
           result <- bigQueryService.use(_.query(queryJobConfiguration)).unsafeToFuture()
-        } yield {
-          result.getValues.asScala.toList match {
-            case Nil => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"no spend data found for billing project ${billingProjectName.value} between dates ${dateTimeToISODateString(startDate)} and ${dateTimeToISODateString(endDate)}"))
-            case rows => extractSpendReportingResults(rows, startDate, endDate, workspaceProjectsToNames, aggregationKeyParameters)
-          }
+        } yield result.getValues.asScala.toList match {
+          case Nil =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(
+                StatusCodes.NotFound,
+                s"no spend data found for billing project ${billingProjectName.value} between dates ${dateTimeToISODateString(startDate)} and ${dateTimeToISODateString(endDate)}"
+              )
+            )
+          case rows =>
+            extractSpendReportingResults(rows, startDate, endDate, workspaceProjectsToNames, aggregationKeyParameters)
         }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -43,31 +43,51 @@ object UserService {
                   servicePerimeterService: ServicePerimeterService,
                   adminRegisterBillingAccountId: RawlsBillingAccountName,
                   billingProfileManagerDAO: BillingProfileManagerDAO
-                 )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext) =
-    new UserService(ctx, dataSource, googleServicesDAO, samDAO, bqServiceFactory, bigQueryCredentialJson, requesterPaysRole, dmConfig, projectTemplate, servicePerimeterService, adminRegisterBillingAccountId, billingProfileManagerDAO)
+  )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext) =
+    new UserService(
+      ctx,
+      dataSource,
+      googleServicesDAO,
+      samDAO,
+      bqServiceFactory,
+      bigQueryCredentialJson,
+      requesterPaysRole,
+      dmConfig,
+      projectTemplate,
+      servicePerimeterService,
+      adminRegisterBillingAccountId,
+      billingProfileManagerDAO
+    )
 
   case class OverwriteGroupMembers(groupRef: RawlsGroupRef, memberList: RawlsGroupMemberList)
 
-  def syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO: SamDAO, projectName: RawlsBillingProjectName)(implicit ec: ExecutionContext): Future[WorkbenchEmail] = {
+  def syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO: SamDAO, projectName: RawlsBillingProjectName)(implicit
+    ec: ExecutionContext
+  ): Future[WorkbenchEmail] =
     samDAO
       .syncPolicyToGoogle(SamResourceTypeNames.billingProject, projectName.value, SamBillingProjectPolicyNames.owner)
       .map(_.keys.headOption.getOrElse(throw new RawlsException("Error getting owner policy email")))
-  }
 
   // this will no longer be used after v1 compute permissions are removed from billing projects (https://broadworkbench.atlassian.net/browse/CA-913)
-  def syncBillingProjectComputeUserPolicyToGoogleAndGetEmail(samDAO: SamDAO, projectName: RawlsBillingProjectName)(implicit ec: ExecutionContext): Future[WorkbenchEmail] = {
+  def syncBillingProjectComputeUserPolicyToGoogleAndGetEmail(samDAO: SamDAO, projectName: RawlsBillingProjectName)(
+    implicit ec: ExecutionContext
+  ): Future[WorkbenchEmail] =
     samDAO
-      .syncPolicyToGoogle(SamResourceTypeNames.billingProject, projectName.value, SamBillingProjectPolicyNames.canComputeUser)
+      .syncPolicyToGoogle(SamResourceTypeNames.billingProject,
+                          projectName.value,
+                          SamBillingProjectPolicyNames.canComputeUser
+      )
       .map(_.keys.headOption.getOrElse(throw new RawlsException("Error getting can compute user policy email")))
-  }
 
-  def getDefaultGoogleProjectPolicies(ownerGroupEmail: WorkbenchEmail, computeUserGroupEmail: WorkbenchEmail, requesterPaysRole: String) = {
+  def getDefaultGoogleProjectPolicies(ownerGroupEmail: WorkbenchEmail,
+                                      computeUserGroupEmail: WorkbenchEmail,
+                                      requesterPaysRole: String
+  ) =
     Map(
       "roles/viewer" -> Set(s"group:${ownerGroupEmail.value}"),
       requesterPaysRole -> Set(s"group:${ownerGroupEmail.value}", s"group:${computeUserGroupEmail.value}"),
       "roles/bigquery.jobUser" -> Set(s"group:${ownerGroupEmail.value}", s"group:${computeUserGroupEmail.value}")
     )
-  }
 }
 
 class UserService(protected val ctx: RawlsRequestContext,
@@ -82,56 +102,80 @@ class UserService(protected val ctx: RawlsRequestContext,
                   servicePerimeterService: ServicePerimeterService,
                   adminRegisterBillingAccountId: RawlsBillingAccountName,
                   billingProfileManagerDAO: BillingProfileManagerDAO
-                 )(implicit protected val executionContext: ExecutionContext) extends RoleSupport with FutureSupport with UserWiths with LazyLogging with StringValidationUtils {
+)(implicit protected val executionContext: ExecutionContext)
+    extends RoleSupport
+    with FutureSupport
+    with UserWiths
+    with LazyLogging
+    with StringValidationUtils {
   implicit val errorReportSource = ErrorReportSource("rawls")
 
   import dataSource.dataAccess.driver.api._
 
-  def requireProjectAction[T](projectName: RawlsBillingProjectName, action: SamResourceAction)(op: => Future[T]): Future[T] = {
+  def requireProjectAction[T](projectName: RawlsBillingProjectName, action: SamResourceAction)(
+    op: => Future[T]
+  ): Future[T] =
     samDAO.userHasAction(SamResourceTypeNames.billingProject, projectName.value, action, ctx.userInfo).flatMap {
       case true => op
-      case false => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, "You must be a project owner.")))
+      case false =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.Forbidden, "You must be a project owner.")
+          )
+        )
     }
-  }
 
-  def requireServicePerimeterAction[T](servicePerimeterName: ServicePerimeterName, action: SamResourceAction)(op: => Future[T]): Future[T] = {
-    samDAO.userHasAction(SamResourceTypeNames.servicePerimeter, URLEncoder.encode(servicePerimeterName.value, UTF_8.name), action, ctx.userInfo).flatMap {
-      case true => op
-      case false => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, "Service Perimeter does not exist or you do not have access")))
-    }
-  }
+  def requireServicePerimeterAction[T](servicePerimeterName: ServicePerimeterName, action: SamResourceAction)(
+    op: => Future[T]
+  ): Future[T] =
+    samDAO
+      .userHasAction(SamResourceTypeNames.servicePerimeter,
+                     URLEncoder.encode(servicePerimeterName.value, UTF_8.name),
+                     action,
+                     ctx.userInfo
+      )
+      .flatMap {
+        case true => op
+        case false =>
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              errorReport =
+                ErrorReport(StatusCodes.NotFound, "Service Perimeter does not exist or you do not have access")
+            )
+          )
+      }
 
-  def isAdmin(userEmail: RawlsUserEmail): Future[Boolean] = {
+  def isAdmin(userEmail: RawlsUserEmail): Future[Boolean] =
     toFutureTry(tryIsFCAdmin(userEmail)) map {
-      case Failure(t) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
+      case Failure(t) =>
+        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
       case Success(b) => b
     }
-  }
 
-  def isLibraryCurator(userEmail: RawlsUserEmail): Future[Boolean] = {
+  def isLibraryCurator(userEmail: RawlsUserEmail): Future[Boolean] =
     toFutureTry(gcsDAO.isLibraryCurator(userEmail.value)) map {
-      case Failure(t) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
+      case Failure(t) =>
+        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
       case Success(b) => b
     }
-  }
 
-  def adminAddLibraryCurator(userEmail: RawlsUserEmail): Future[Unit] = {
+  def adminAddLibraryCurator(userEmail: RawlsUserEmail): Future[Unit] =
     asFCAdmin {
       toFutureTry(gcsDAO.addLibraryCurator(userEmail.value)) map {
-        case Failure(t) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
+        case Failure(t) =>
+          throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
         case Success(result) => result
       }
     }
-  }
 
-  def adminRemoveLibraryCurator(userEmail: RawlsUserEmail): Future[Unit] = {
+  def adminRemoveLibraryCurator(userEmail: RawlsUserEmail): Future[Unit] =
     asFCAdmin {
       toFutureTry(gcsDAO.removeLibraryCurator(userEmail.value)) map {
-        case Failure(t) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
+        case Failure(t) =>
+          throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, t))
         case Success(result) => result
       }
     }
-  }
 
   def listBillingAccounts(firecloudHasAccess: Option[Boolean] = None): Future[Seq[RawlsBillingAccount]] =
     gcsDAO.listBillingAccounts(ctx.userInfo, firecloudHasAccess)
@@ -139,27 +183,27 @@ class UserService(protected val ctx: RawlsRequestContext,
   def getBillingProjectStatus(projectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectStatus]] = {
     val statusFuture: Future[Option[RawlsBillingProjectStatus]] = for {
       policies <- samDAO.getPoliciesForType(SamResourceTypeNames.billingProject, ctx.userInfo)
-      projectDetail <- dataSource.inTransaction { dataAccess => dataAccess.rawlsBillingProjectQuery.load(projectName) }
-    } yield {
-      policies.find { policy =>
+      projectDetail <- dataSource.inTransaction(dataAccess => dataAccess.rawlsBillingProjectQuery.load(projectName))
+    } yield policies
+      .find { policy =>
         projectDetail.isDefined &&
         policy.resourceId.equals(projectDetail.get.projectName.value)
-      }.flatMap { policy =>
+      }
+      .flatMap { policy =>
         Some(RawlsBillingProjectStatus(RawlsBillingProjectName(policy.resourceId), projectDetail.get.status))
       }
-    }
     statusFuture
   }
 
-  def getBillingProject(billingProjectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectResponse]] = {
+  def getBillingProject(billingProjectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectResponse]] =
     for {
-      projectRoles <- samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, billingProjectName.value, ctx.userInfo)
+      projectRoles <- samDAO
+        .listUserRolesForResource(SamResourceTypeNames.billingProject, billingProjectName.value, ctx.userInfo)
         .map(resourceRoles => samRolesToProjectRoles(resourceRoles))
-      maybeBillingProject <- dataSource.inTransaction { dataAccess => dataAccess.rawlsBillingProjectQuery.load(billingProjectName) }
-    } yield {
-      constructBillingProjectResponseFromOptionalAndRoles(maybeBillingProject, projectRoles)
-    }
-  }
+      maybeBillingProject <- dataSource.inTransaction { dataAccess =>
+        dataAccess.rawlsBillingProjectQuery.load(billingProjectName)
+      }
+    } yield constructBillingProjectResponseFromOptionalAndRoles(maybeBillingProject, projectRoles)
 
   private def makeBillingProjectResponse(projectRoles: Set[ProjectRole], billingProject: RawlsBillingProject) =
     RawlsBillingProjectResponse(
@@ -173,7 +217,7 @@ class UserService(protected val ctx: RawlsRequestContext,
       billingProject.azureManagedAppCoordinates
     )
 
-  def listBillingProjectsV2(): Future[List[RawlsBillingProjectResponse]] = {
+  def listBillingProjectsV2(): Future[List[RawlsBillingProjectResponse]] =
     for {
       samUserResources <- samDAO.listUserResources(SamResourceTypeNames.billingProject, ctx.userInfo)
       projectNames = samUserResources.map(r => RawlsBillingProjectName(r.resourceId)).toSet
@@ -182,9 +226,10 @@ class UserService(protected val ctx: RawlsRequestContext,
       }
       bpmProfiles <- billingProfileManagerDAO.listBillingProfiles(samUserResources, ctx)
     } yield constructBillingProjectResponses(samUserResources, projectsInDB ++ bpmProfiles)
-  }
 
-  private def constructBillingProjectResponses(samUserResources: Seq[SamUserResource], billingProjectsInRawlsDB: Seq[RawlsBillingProject]): List[RawlsBillingProjectResponse] = {
+  private def constructBillingProjectResponses(samUserResources: Seq[SamUserResource],
+                                               billingProjectsInRawlsDB: Seq[RawlsBillingProject]
+  ): List[RawlsBillingProjectResponse] = {
     val projectsByName = billingProjectsInRawlsDB.map(p => p.projectName.value -> p).toMap
     samUserResources.toList
       .flatMap { samUserResource =>
@@ -194,57 +239,76 @@ class UserService(protected val ctx: RawlsRequestContext,
       .sortBy(_.projectName.value)
   }
 
-  def listBillingProjects(): Future[List[RawlsBillingProjectMembership]] = {
+  def listBillingProjects(): Future[List[RawlsBillingProjectMembership]] =
     for {
       resourceIdsWithPolicyNames <- samDAO.getPoliciesForType(SamResourceTypeNames.billingProject, ctx.userInfo)
-      projectDetailsByName <- dataSource.inTransaction { dataAccess => dataAccess.rawlsBillingProjectQuery.getBillingProjectDetails(resourceIdsWithPolicyNames.map(idWithPolicyName => RawlsBillingProjectName(idWithPolicyName.resourceId))) }
-    } yield {
-      projectPoliciesToRoles(resourceIdsWithPolicyNames).flatMap { case (resourceId, role) =>
+      projectDetailsByName <- dataSource.inTransaction { dataAccess =>
+        dataAccess.rawlsBillingProjectQuery.getBillingProjectDetails(
+          resourceIdsWithPolicyNames.map(idWithPolicyName => RawlsBillingProjectName(idWithPolicyName.resourceId))
+        )
+      }
+    } yield projectPoliciesToRoles(resourceIdsWithPolicyNames)
+      .flatMap { case (resourceId, role) =>
         projectDetailsByName.get(resourceId).map { case (projectStatus, message) =>
           RawlsBillingProjectMembership(RawlsBillingProjectName(resourceId), role, projectStatus, message)
         }
-      }.toList.sortBy(_.projectName.value)
-    }
-  }
+      }
+      .toList
+      .sortBy(_.projectName.value)
 
-  private def samRolesToProjectRoles(samRoles: Set[SamResourceRole]): Set[ProjectRole] = {
+  private def samRolesToProjectRoles(samRoles: Set[SamResourceRole]): Set[ProjectRole] =
     samRoles.collect {
-      case SamResourceRole(SamBillingProjectRoles.owner.value) => ProjectRoles.Owner
+      case SamResourceRole(SamBillingProjectRoles.owner.value)            => ProjectRoles.Owner
       case SamResourceRole(SamBillingProjectRoles.workspaceCreator.value) => ProjectRoles.User
     }
-  }
 
-  private def projectPoliciesToRoles(resourceIdsWithPolicyNames: Set[SamResourceIdWithPolicyName]) = {
+  private def projectPoliciesToRoles(resourceIdsWithPolicyNames: Set[SamResourceIdWithPolicyName]) =
     resourceIdsWithPolicyNames.collect {
-      case SamResourceIdWithPolicyName(resourceId, SamBillingProjectPolicyNames.owner, _, _, _) => (resourceId, ProjectRoles.Owner)
-      case SamResourceIdWithPolicyName(resourceId, SamBillingProjectPolicyNames.workspaceCreator, _, _, _) => (resourceId, ProjectRoles.User)
+      case SamResourceIdWithPolicyName(resourceId, SamBillingProjectPolicyNames.owner, _, _, _) =>
+        (resourceId, ProjectRoles.Owner)
+      case SamResourceIdWithPolicyName(resourceId, SamBillingProjectPolicyNames.workspaceCreator, _, _, _) =>
+        (resourceId, ProjectRoles.User)
     }
-  }
 
-  def getBillingProjectMembers(projectName: RawlsBillingProjectName): Future[Set[RawlsBillingProjectMember]] = {
-    samDAO.listUserActionsForResource(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo).flatMap {
-      // the JSON responses for listPoliciesForResource and getPolicy are shaped slightly differently.
-      // the initial 2 cases will coerce the data into the same shape so the final yield can be re-used for both cases.
-      // only project owners can call listPoliciesForResource, whereas project users must call getPolicy directly on the owner policy
-      case actions if actions.contains(SamBillingProjectActions.readPolicies) =>
-        samDAO.listPoliciesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo).map { policiesWithNameAndEmail =>
-          policiesWithNameAndEmail.map(policyWithNameAndEmail => policyWithNameAndEmail.policyName -> policyWithNameAndEmail.policy)
-        }
-      case actions if actions.contains(SamBillingProjectActions.readPolicy(SamBillingProjectPolicyNames.owner)) =>
-        samDAO.getPolicy(SamResourceTypeNames.billingProject, projectName.value, SamBillingProjectPolicyNames.owner, ctx.userInfo).map { policy =>
-          Set(SamBillingProjectPolicyNames.owner -> policy)
-        }
-      case _ => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, "You do not have the required actions to perform this.")))
-    }.map { policies =>
-      for {
-        (role, policy) <- policies.collect {
-          case (SamBillingProjectPolicyNames.owner, policy) => (ProjectRoles.Owner, policy)
-          case (SamBillingProjectPolicyNames.workspaceCreator, policy) => (ProjectRoles.User, policy)
-        }
-        email <- policy.memberEmails
-      } yield RawlsBillingProjectMember(RawlsUserEmail(email.value), role)
-    }
-  }
+  def getBillingProjectMembers(projectName: RawlsBillingProjectName): Future[Set[RawlsBillingProjectMember]] =
+    samDAO
+      .listUserActionsForResource(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo)
+      .flatMap {
+        // the JSON responses for listPoliciesForResource and getPolicy are shaped slightly differently.
+        // the initial 2 cases will coerce the data into the same shape so the final yield can be re-used for both cases.
+        // only project owners can call listPoliciesForResource, whereas project users must call getPolicy directly on the owner policy
+        case actions if actions.contains(SamBillingProjectActions.readPolicies) =>
+          samDAO.listPoliciesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo).map {
+            policiesWithNameAndEmail =>
+              policiesWithNameAndEmail
+                .map(policyWithNameAndEmail => policyWithNameAndEmail.policyName -> policyWithNameAndEmail.policy)
+          }
+        case actions if actions.contains(SamBillingProjectActions.readPolicy(SamBillingProjectPolicyNames.owner)) =>
+          samDAO
+            .getPolicy(SamResourceTypeNames.billingProject,
+                       projectName.value,
+                       SamBillingProjectPolicyNames.owner,
+                       ctx.userInfo
+            )
+            .map { policy =>
+              Set(SamBillingProjectPolicyNames.owner -> policy)
+            }
+        case _ =>
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              errorReport = ErrorReport(StatusCodes.Forbidden, "You do not have the required actions to perform this.")
+            )
+          )
+      }
+      .map { policies =>
+        for {
+          (role, policy) <- policies.collect {
+            case (SamBillingProjectPolicyNames.owner, policy)            => (ProjectRoles.Owner, policy)
+            case (SamBillingProjectPolicyNames.workspaceCreator, policy) => (ProjectRoles.User, policy)
+          }
+          email <- policy.memberEmails
+        } yield RawlsBillingProjectMember(RawlsUserEmail(email.value), role)
+      }
 
   /**
    * Unregisters a billing project with OwnerInfo provided in the request body.
@@ -256,15 +320,20 @@ class UserService(protected val ctx: RawlsRequestContext,
    * @param projectName The project name to be unregistered.
    * @param ownerInfo A map parsed from request body contains the project's owner info.
    * */
-  def adminUnregisterBillingProjectWithOwnerInfo(projectName: RawlsBillingProjectName, ownerInfo: Map[String, String]): Future[Unit] = {
+  def adminUnregisterBillingProjectWithOwnerInfo(projectName: RawlsBillingProjectName,
+                                                 ownerInfo: Map[String, String]
+  ): Future[Unit] =
     asFCAdmin {
-      val ownerUserInfo = UserInfo(RawlsUserEmail(ownerInfo("newOwnerEmail")), OAuth2BearerToken(ownerInfo("newOwnerToken")), 3600, RawlsUserSubjectId("0"))
+      val ownerUserInfo = UserInfo(RawlsUserEmail(ownerInfo("newOwnerEmail")),
+                                   OAuth2BearerToken(ownerInfo("newOwnerToken")),
+                                   3600,
+                                   RawlsUserSubjectId("0")
+      )
       for {
         _ <- deleteGoogleProjectIfChild(projectName, ownerUserInfo, deleteGoogleProjectWithGoogle = false)
         result <- unregisterBillingProjectWithUserInfo(projectName, ownerUserInfo)
       } yield result
     }
-  }
 
   /**
    * Unregisters a billing project with UserInfo provided in parameter
@@ -272,44 +341,52 @@ class UserService(protected val ctx: RawlsRequestContext,
    * @param projectName The project name to be unregistered.
    * @param ownerUserInfo The project's owner user info with {@code UserInfo} format.
    * */
-  def unregisterBillingProjectWithUserInfo(projectName: RawlsBillingProjectName, ownerUserInfo: UserInfo): Future[Unit] = {
+  def unregisterBillingProjectWithUserInfo(projectName: RawlsBillingProjectName,
+                                           ownerUserInfo: UserInfo
+  ): Future[Unit] =
     for {
       _ <- dataSource.inTransaction { dataAccess =>
         dataAccess.rawlsBillingProjectQuery.delete(projectName)
       }
-      _ <- samDAO.deleteResource(SamResourceTypeNames.billingProject, projectName.value, ownerUserInfo) recoverWith { // Moving this to the end so that the rawls record is cleared even if there are issues clearing the Sam resource (theoretical workaround for https://broadworkbench.atlassian.net/browse/CA-1206)
-        case t:Throwable => {
-          logger.warn(s"Unexpected failure deleting billing project (while deleting billing project in Sam) for billing project `${projectName.value}`", t)
+      _ <- samDAO
+        .deleteResource(SamResourceTypeNames.billingProject, projectName.value, ownerUserInfo) recoverWith { // Moving this to the end so that the rawls record is cleared even if there are issues clearing the Sam resource (theoretical workaround for https://broadworkbench.atlassian.net/browse/CA-1206)
+        case t: Throwable =>
+          logger.warn(
+            s"Unexpected failure deleting billing project (while deleting billing project in Sam) for billing project `${projectName.value}`",
+            t
+          )
           throw t
-        }
       }
     } yield {}
-  }
 
-  private def deletePetsInProject(projectName: GoogleProjectId, userInfo: UserInfo): Future[Unit] = {
+  private def deletePetsInProject(projectName: GoogleProjectId, userInfo: UserInfo): Future[Unit] =
     for {
-      projectUsers <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo)
+      projectUsers <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject,
+                                                      projectName.value,
+                                                      ctx.userInfo
+      )
       _ <- projectUsers.toList.traverse(destroyPet(_, projectName))
     } yield ()
-  }
 
-  private def destroyPet(userIdInfo: UserIdInfo, projectName: GoogleProjectId): Future[Unit] = {
+  private def destroyPet(userIdInfo: UserIdInfo, projectName: GoogleProjectId): Future[Unit] =
     for {
       petSAJson <- samDAO.getPetServiceAccountKeyForUser(projectName, RawlsUserEmail(userIdInfo.userEmail))
       petUserInfo <- gcsDAO.getUserInfoUsingJson(petSAJson)
       _ <- samDAO.deleteUserPetServiceAccount(projectName, petUserInfo)
     } yield ()
-  }
 
-  def adminDeleteBillingProject(projectName: RawlsBillingProjectName, ownerInfo: Map[String, String]): Future[Unit] = {
+  def adminDeleteBillingProject(projectName: RawlsBillingProjectName, ownerInfo: Map[String, String]): Future[Unit] =
     asFCAdmin {
-      val ownerUserInfo = UserInfo(RawlsUserEmail(ownerInfo("newOwnerEmail")), OAuth2BearerToken(ownerInfo("newOwnerToken")), 3600, RawlsUserSubjectId("0"))
+      val ownerUserInfo = UserInfo(RawlsUserEmail(ownerInfo("newOwnerEmail")),
+                                   OAuth2BearerToken(ownerInfo("newOwnerToken")),
+                                   3600,
+                                   RawlsUserSubjectId("0")
+      )
       for {
         _ <- deleteGoogleProjectIfChild(projectName, ownerUserInfo)
         _ <- unregisterBillingProjectWithUserInfo(projectName, ownerUserInfo)
       } yield {}
     }
-  }
 
   def deleteBillingProject(projectName: RawlsBillingProjectName): Future[Unit] =
     requireProjectAction(projectName, SamBillingProjectActions.deleteBillingProject) {
@@ -320,7 +397,9 @@ class UserService(protected val ctx: RawlsRequestContext,
       } yield {}
     }
 
-  def setBillingProjectSpendConfiguration(billingProjectName: RawlsBillingProjectName, spendReportConfiguration: BillingProjectSpendConfiguration): Future[Int] = {
+  def setBillingProjectSpendConfiguration(billingProjectName: RawlsBillingProjectName,
+                                          spendReportConfiguration: BillingProjectSpendConfiguration
+  ): Future[Int] = {
 
     val datasetName = spendReportConfiguration.datasetName
     val datasetGoogleProject = spendReportConfiguration.datasetGoogleProject
@@ -329,73 +408,121 @@ class UserService(protected val ctx: RawlsRequestContext,
     validateGoogleProjectName(datasetGoogleProject.value)
 
     requireProjectAction(billingProjectName, SamBillingProjectActions.alterSpendReportConfiguration) {
-      val bqService = bqServiceFactory.getServiceFromJson(bigQueryCredentialJson, GoogleProject(billingProjectName.value))
+      val bqService =
+        bqServiceFactory.getServiceFromJson(bigQueryCredentialJson, GoogleProject(billingProjectName.value))
 
       for {
-        //Get the dataset to validate that it exists and that we have permission to see it
+        // Get the dataset to validate that it exists and that we have permission to see it
         _ <- bqService.use(_.getDataset(datasetGoogleProject, datasetName)).unsafeToFuture().map {
-          case None => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"The dataset $datasetName could not be found."))
+          case None =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, s"The dataset $datasetName could not be found.")
+            )
           case dataset => dataset
         }
 
         billingAccountId <- dataSource.inTransaction { dataAccess =>
           dataAccess.rawlsBillingProjectQuery.load(billingProjectName).map {
-            case Some(RawlsBillingProject(_, _, Some(billingAccountName), _, _, _, _, false, _, _, _, _, _)) => billingAccountName.withoutPrefix()
-            case _ => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"The Google project associated with billing project ${billingProjectName.value} is not linked to an active billing account."))
+            case Some(RawlsBillingProject(_, _, Some(billingAccountName), _, _, _, _, false, _, _, _, _, _)) =>
+              billingAccountName.withoutPrefix()
+            case _ =>
+              throw new RawlsExceptionWithErrorReport(
+                ErrorReport(
+                  StatusCodes.BadRequest,
+                  s"The Google project associated with billing project ${billingProjectName.value} is not linked to an active billing account."
+                )
+              )
           }
         }
 
-        //Get the table and validate that it exists and that we have permission to see it
-        //Note that the table name replaces all dashes in the billing account ID with underscores
+        // Get the table and validate that it exists and that we have permission to see it
+        // Note that the table name replaces all dashes in the billing account ID with underscores
         tableName = BigQueryTableName(s"gcp_billing_export_v1_${billingAccountId.replace("-", "_")}")
         table <- bqService.use(_.getTable(datasetGoogleProject, datasetName, tableName)).unsafeToFuture()
 
-        res <- if(table.isDefined) {
-                //Isolate the db txn so we're not running any REST calls inside of it
-                dataSource.inTransaction { dataAccess =>
-                  dataAccess.rawlsBillingProjectQuery.setBillingProjectSpendConfiguration(billingProjectName, Option(datasetName), Option(tableName), Option(datasetGoogleProject))
-                }
-              } else throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"The billing export table ${tableName} in dataset ${datasetName} could not be found."))
-      } yield {
-        res
-      }
+        res <-
+          if (table.isDefined) {
+            // Isolate the db txn so we're not running any REST calls inside of it
+            dataSource.inTransaction { dataAccess =>
+              dataAccess.rawlsBillingProjectQuery.setBillingProjectSpendConfiguration(billingProjectName,
+                                                                                      Option(datasetName),
+                                                                                      Option(tableName),
+                                                                                      Option(datasetGoogleProject)
+              )
+            }
+          } else
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest,
+                          s"The billing export table ${tableName} in dataset ${datasetName} could not be found."
+              )
+            )
+      } yield res
     }
   }
 
-  def clearBillingProjectSpendConfiguration(billingProjectName: RawlsBillingProjectName): Future[Int] = {
+  def clearBillingProjectSpendConfiguration(billingProjectName: RawlsBillingProjectName): Future[Int] =
     requireProjectAction(billingProjectName, SamBillingProjectActions.alterSpendReportConfiguration) {
       dataSource.inTransaction { dataAccess =>
         dataAccess.rawlsBillingProjectQuery.clearBillingProjectSpendConfiguration(billingProjectName)
       }
     }
-  }
 
-  def getBillingProjectSpendConfiguration(billingProjectName: RawlsBillingProjectName): Future[Option[BillingProjectSpendConfiguration]] = {
+  def getBillingProjectSpendConfiguration(
+    billingProjectName: RawlsBillingProjectName
+  ): Future[Option[BillingProjectSpendConfiguration]] =
     requireProjectAction(billingProjectName, SamBillingProjectActions.readSpendReportConfiguration) {
       dataSource.inTransaction { dataAccess =>
         dataAccess.rawlsBillingProjectQuery.load(billingProjectName).map {
-          case Some(RawlsBillingProject(_, _, _, _, _, _, _, _, Some(spendReportDataset), Some(spendReportTable), Some(spendReportDatasetGoogleProject), _, _)) => Option(BillingProjectSpendConfiguration(spendReportDatasetGoogleProject, spendReportDataset))
+          case Some(
+                RawlsBillingProject(_,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    Some(spendReportDataset),
+                                    Some(spendReportTable),
+                                    Some(spendReportDatasetGoogleProject),
+                                    _,
+                                    _
+                )
+              ) =>
+            Option(BillingProjectSpendConfiguration(spendReportDatasetGoogleProject, spendReportDataset))
           case Some(_) => None
-          case None => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Billing project ${billingProjectName.value} could not be found"))
+          case None =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.NotFound, s"Billing project ${billingProjectName.value} could not be found")
+            )
         }
       }
     }
-  }
 
   private def failUnlessHasNoWorkspaces(projectName: RawlsBillingProjectName): Future[Unit] =
     dataSource.inTransaction(_.workspaceQuery.countByNamespace(projectName)) map { count =>
-      if (count == 0) () else throw new RawlsExceptionWithErrorReport(ErrorReport(
-        StatusCodes.BadRequest,
-        "Project cannot be deleted because it contains workspaces."
-      ))
+      if (count == 0) ()
+      else
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(
+            StatusCodes.BadRequest,
+            "Project cannot be deleted because it contains workspaces."
+          )
+        )
     }
 
   // TODO - once workspace migration is complete and there are no more v1 workspaces or v1 billing projects, we can remove this https://broadworkbench.atlassian.net/browse/CA-1118
-  private def deleteGoogleProjectIfChild(projectName: RawlsBillingProjectName, userInfoForSam: UserInfo, deleteGoogleProjectWithGoogle: Boolean = true) = {
+  private def deleteGoogleProjectIfChild(projectName: RawlsBillingProjectName,
+                                         userInfoForSam: UserInfo,
+                                         deleteGoogleProjectWithGoogle: Boolean = true
+  ) = {
     def rawlsCreatedGoogleProjectExists(projectId: GoogleProjectId) =
       gcsDAO.getGoogleProject(projectId) transform {
         case Success(_) => Success(true)
-        case Failure(e: HttpResponseException) if e.getStatusCode == 404 || e.getStatusCode == 403 => Success(false) //Either the Google project doesn't exist, or we don't have access to it because Rawls didn't create it.
+        case Failure(e: HttpResponseException) if e.getStatusCode == 404 || e.getStatusCode == 403 =>
+          Success(
+            false
+          ) // Either the Google project doesn't exist, or we don't have access to it because Rawls didn't create it.
         case Failure(t) => Failure(t)
       }
 
@@ -408,35 +535,66 @@ class UserService(protected val ctx: RawlsRequestContext,
       } yield ()
 
     val projectId = GoogleProjectId(projectName.value)
-    samDAO.listResourceChildren(SamResourceTypeNames.billingProject, projectName.value, userInfoForSam) flatMap { resourceChildren =>
-      F.whenA(resourceChildren contains SamFullyQualifiedResourceId(projectName.value, SamResourceTypeNames.googleProject.value))(
-        for {
-          _ <- rawlsCreatedGoogleProjectExists(projectId).ifM(deleteResourcesInGoogle(projectId), F.unit)
-          _ <- samDAO.deleteResource(SamResourceTypeNames.googleProject, projectName.value, userInfoForSam)
-        } yield ()
-      )
+    samDAO.listResourceChildren(SamResourceTypeNames.billingProject, projectName.value, userInfoForSam) flatMap {
+      resourceChildren =>
+        F.whenA(
+          resourceChildren contains SamFullyQualifiedResourceId(projectName.value,
+                                                                SamResourceTypeNames.googleProject.value
+          )
+        )(
+          for {
+            _ <- rawlsCreatedGoogleProjectExists(projectId).ifM(deleteResourcesInGoogle(projectId), F.unit)
+            _ <- samDAO.deleteResource(SamResourceTypeNames.googleProject, projectName.value, userInfoForSam)
+          } yield ()
+        )
     }
   }
 
-  //very sad: have to pass the new owner's token in the POST body (oh no!)
-  //we could instead exploit the fact that Sam will let you create pets in projects you're not in (!!!),
-  //but that seems extremely shady
+  // very sad: have to pass the new owner's token in the POST body (oh no!)
+  // we could instead exploit the fact that Sam will let you create pets in projects you're not in (!!!),
+  // but that seems extremely shady
   // We believe this is mostly used by gpalloc/only used by gpalloc, which is why the billing account
   // is hard coded.
-  def adminRegisterBillingProject(xfer: RawlsBillingProjectTransfer): Future[Unit] = {
+  def adminRegisterBillingProject(xfer: RawlsBillingProjectTransfer): Future[Unit] =
     asFCAdmin {
       val billingProjectName = RawlsBillingProjectName(xfer.project)
-      val project = RawlsBillingProject(billingProjectName, CreationStatuses.Ready, Option(adminRegisterBillingAccountId), None)
-      val ownerUserInfo = UserInfo(RawlsUserEmail(xfer.newOwnerEmail), OAuth2BearerToken(xfer.newOwnerToken), 3600, RawlsUserSubjectId("0"))
-
+      val project =
+        RawlsBillingProject(billingProjectName, CreationStatuses.Ready, Option(adminRegisterBillingAccountId), None)
+      val ownerUserInfo = UserInfo(RawlsUserEmail(xfer.newOwnerEmail),
+                                   OAuth2BearerToken(xfer.newOwnerToken),
+                                   3600,
+                                   RawlsUserSubjectId("0")
+      )
 
       (for {
-        _ <- dataSource.inTransaction { dataAccess => dataAccess.rawlsBillingProjectQuery.create(project) }
+        _ <- dataSource.inTransaction(dataAccess => dataAccess.rawlsBillingProjectQuery.create(project))
 
         _ <- samDAO.createResource(SamResourceTypeNames.billingProject, billingProjectName.value, ownerUserInfo)
-        _ <- samDAO.createResourceFull(SamResourceTypeNames.googleProject, project.projectName.value, Map.empty, Set.empty, ownerUserInfo, Option(SamFullyQualifiedResourceId(project.projectName.value, SamResourceTypeNames.billingProject.value)))
-        _ <- samDAO.overwritePolicy(SamResourceTypeNames.billingProject, billingProjectName.value, SamBillingProjectPolicyNames.workspaceCreator, SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.workspaceCreator)), ownerUserInfo)
-        _ <- samDAO.overwritePolicy(SamResourceTypeNames.billingProject, billingProjectName.value, SamBillingProjectPolicyNames.canComputeUser, SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.batchComputeUser, SamBillingProjectRoles.notebookUser)), ownerUserInfo)
+        _ <- samDAO.createResourceFull(
+          SamResourceTypeNames.googleProject,
+          project.projectName.value,
+          Map.empty,
+          Set.empty,
+          ownerUserInfo,
+          Option(SamFullyQualifiedResourceId(project.projectName.value, SamResourceTypeNames.billingProject.value))
+        )
+        _ <- samDAO.overwritePolicy(
+          SamResourceTypeNames.billingProject,
+          billingProjectName.value,
+          SamBillingProjectPolicyNames.workspaceCreator,
+          SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.workspaceCreator)),
+          ownerUserInfo
+        )
+        _ <- samDAO.overwritePolicy(
+          SamResourceTypeNames.billingProject,
+          billingProjectName.value,
+          SamBillingProjectPolicyNames.canComputeUser,
+          SamPolicy(Set.empty,
+                    Set.empty,
+                    Set(SamBillingProjectRoles.batchComputeUser, SamBillingProjectRoles.notebookUser)
+          ),
+          ownerUserInfo
+        )
         ownerGroupEmail <- syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO, project.projectName)
         computeUserGroupEmail <- syncBillingProjectComputeUserPolicyToGoogleAndGetEmail(samDAO, project.projectName)
 
@@ -444,224 +602,382 @@ class UserService(protected val ctx: RawlsRequestContext,
 
         _ <- gcsDAO.addPolicyBindings(project.googleProjectId, policiesToAdd)
         _ <- gcsDAO.grantReadAccess(xfer.bucket, Set(ownerGroupEmail, computeUserGroupEmail))
-      } yield {}).recoverWith {
-        case t: Throwable =>
-          // attempt cleanup then rethrow
-          for {
-            _ <- samDAO.deleteResource(SamResourceTypeNames.googleProject, project.projectName.value, ownerUserInfo).recover {
-              case x => logger.debug(s"failure deleting google project ${project.projectName.value} from sam during error recovery cleanup.", x)
+      } yield {}).recoverWith { case t: Throwable =>
+        // attempt cleanup then rethrow
+        for {
+          _ <- samDAO
+            .deleteResource(SamResourceTypeNames.googleProject, project.projectName.value, ownerUserInfo)
+            .recover { case x =>
+              logger.debug(
+                s"failure deleting google project ${project.projectName.value} from sam during error recovery cleanup.",
+                x
+              )
             }
-            _ <- samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, ownerUserInfo).recover {
-              case x => logger.debug(s"failure deleting billing project ${project.projectName.value} from sam during error recovery cleanup.", x)
+          _ <- samDAO
+            .deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, ownerUserInfo)
+            .recover { case x =>
+              logger.debug(
+                s"failure deleting billing project ${project.projectName.value} from sam during error recovery cleanup.",
+                x
+              )
             }
-            _ <- dataSource.inTransaction { dataAccess => dataAccess.rawlsBillingProjectQuery.delete(project.projectName) }.recover {
-              case x => logger.debug(s"failure deleting billing project ${project.projectName.value} from rawls db during error recovery cleanup.", x)
+          _ <- dataSource
+            .inTransaction(dataAccess => dataAccess.rawlsBillingProjectQuery.delete(project.projectName))
+            .recover { case x =>
+              logger.debug(
+                s"failure deleting billing project ${project.projectName.value} from rawls db during error recovery cleanup.",
+                x
+              )
             }
-          } yield throw t
+        } yield throw t
       }
     }
-  }
 
-  def addUserToBillingProject(projectName: RawlsBillingProjectName, projectAccessUpdate: ProjectAccessUpdate): Future[Unit] = {
+  def addUserToBillingProject(projectName: RawlsBillingProjectName,
+                              projectAccessUpdate: ProjectAccessUpdate
+  ): Future[Unit] =
     requireProjectAction(projectName, SamBillingProjectActions.alterPolicies) {
       val policies = projectAccessUpdate.role match {
         case ProjectRoles.Owner => Seq(SamBillingProjectPolicyNames.owner)
-        case ProjectRoles.User => Seq(SamBillingProjectPolicyNames.workspaceCreator, SamBillingProjectPolicyNames.canComputeUser)
+        case ProjectRoles.User =>
+          Seq(SamBillingProjectPolicyNames.workspaceCreator, SamBillingProjectPolicyNames.canComputeUser)
       }
 
       for {
         _ <- Future.traverse(policies) { policy =>
-          samDAO.addUserToPolicy(SamResourceTypeNames.billingProject, projectName.value, policy, projectAccessUpdate.email, ctx.userInfo).recoverWith {
-            case regrets: Throwable =>
+          samDAO
+            .addUserToPolicy(SamResourceTypeNames.billingProject,
+                             projectName.value,
+                             policy,
+                             projectAccessUpdate.email,
+                             ctx.userInfo
+            )
+            .recoverWith { case regrets: Throwable =>
               if (policy == SamBillingProjectPolicyNames.canComputeUser) {
-                logger.info(s"error adding user to canComputeUser policy for $projectName likely because it is a v2 billing project which does not have a canComputeUser policy. regrets: ${regrets.getMessage}")
+                logger.info(
+                  s"error adding user to canComputeUser policy for $projectName likely because it is a v2 billing project which does not have a canComputeUser policy. regrets: ${regrets.getMessage}"
+                )
                 Future.successful(())
               } else {
                 Future.failed(regrets)
               }
-          }
+            }
         }
       } yield {}
     }
-  }
 
-  def removeUserFromBillingProject(projectName: RawlsBillingProjectName, projectAccessUpdate: ProjectAccessUpdate): Future[Unit] = {
+  def removeUserFromBillingProject(projectName: RawlsBillingProjectName,
+                                   projectAccessUpdate: ProjectAccessUpdate
+  ): Future[Unit] =
     requireProjectAction(projectName, SamBillingProjectActions.alterPolicies) {
       val policy = projectAccessUpdate.role match {
         case ProjectRoles.Owner => SamBillingProjectPolicyNames.owner
-        case ProjectRoles.User => SamBillingProjectPolicyNames.workspaceCreator
+        case ProjectRoles.User  => SamBillingProjectPolicyNames.workspaceCreator
       }
 
       for {
-        _ <- samDAO.removeUserFromPolicy(SamResourceTypeNames.billingProject, projectName.value, policy, projectAccessUpdate.email, ctx.userInfo).recover {
-          case e: RawlsExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.BadRequest) => throw new RawlsExceptionWithErrorReport(e.errorReport.copy(statusCode = Some(StatusCodes.NotFound)))
-        }
+        _ <- samDAO
+          .removeUserFromPolicy(SamResourceTypeNames.billingProject,
+                                projectName.value,
+                                policy,
+                                projectAccessUpdate.email,
+                                ctx.userInfo
+          )
+          .recover {
+            case e: RawlsExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.BadRequest) =>
+              throw new RawlsExceptionWithErrorReport(e.errorReport.copy(statusCode = Some(StatusCodes.NotFound)))
+          }
       } yield {}
     }
-  }
 
-  def updateBillingProjectBillingAccount(billingProjectName: RawlsBillingProjectName, updateAccountRequest: UpdateRawlsBillingAccountRequest): Future[Option[RawlsBillingProjectResponse]] = {
+  def updateBillingProjectBillingAccount(billingProjectName: RawlsBillingProjectName,
+                                         updateAccountRequest: UpdateRawlsBillingAccountRequest
+  ): Future[Option[RawlsBillingProjectResponse]] = {
     validateBillingAccountName(updateAccountRequest.billingAccount.value)
 
     requireProjectAction(billingProjectName, SamBillingProjectActions.updateBillingAccount) {
       for {
         hasAccess <- gcsDAO.testBillingAccountAccess(updateAccountRequest.billingAccount, ctx.userInfo)
         _ = if (!hasAccess) {
-          throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Billing account does not exist, user does not have access, or Terra does not have access"))
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest,
+                        "Billing account does not exist, user does not have access, or Terra does not have access"
+            )
+          )
         }
         result <- updateBillingAccountInternal(billingProjectName, Option(updateAccountRequest.billingAccount))
       } yield result
     }
   }
 
-  def deleteBillingAccount(billingProjectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectResponse]] = {
+  def deleteBillingAccount(billingProjectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectResponse]] =
     requireProjectAction(billingProjectName, SamBillingProjectActions.updateBillingAccount) {
       updateBillingAccountInternal(billingProjectName, None)
     }
-  }
 
-  def startBillingProjectCreation(createProjectRequest: CreateRawlsBillingProjectFullRequest): Future[Unit] = {
+  def startBillingProjectCreation(createProjectRequest: CreateRawlsBillingProjectFullRequest): Future[Unit] =
     for {
       _ <- validateV1CreateProjectRequest(createProjectRequest)
       _ <- ServicePerimeterService.checkServicePerimeterAccess(samDAO, createProjectRequest.servicePerimeter, ctx)
       billingAccount <- checkBillingAccountAccess(createProjectRequest.billingAccount)
       result <- internalStartBillingProjectCreation(createProjectRequest, billingAccount)
     } yield result
-  }
 
-  private def validateV1CreateProjectRequest(createProjectRequest: CreateRawlsBillingProjectFullRequest): Future[Unit] = {
+  private def validateV1CreateProjectRequest(createProjectRequest: CreateRawlsBillingProjectFullRequest): Future[Unit] =
     for {
       _ <- validateBillingProjectName(createProjectRequest.projectName.value)
-      _ <- if ((createProjectRequest.enableFlowLogs.getOrElse(false) || createProjectRequest.privateIpGoogleAccess.getOrElse(false)) && !createProjectRequest.highSecurityNetwork.getOrElse(false)) {
-        //flow logs and private google access both require HSN, so error if someone asks for either of the former without the latter
-        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "enableFlowLogs or privateIpGoogleAccess both require highSecurityNetwork = true")))
-      } else {
-        Future.successful(())
-      }
+      _ <-
+        if (
+          (createProjectRequest.enableFlowLogs.getOrElse(false) || createProjectRequest.privateIpGoogleAccess.getOrElse(
+            false
+          )) && !createProjectRequest.highSecurityNetwork.getOrElse(false)
+        ) {
+          // flow logs and private google access both require HSN, so error if someone asks for either of the former without the latter
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest,
+                          "enableFlowLogs or privateIpGoogleAccess both require highSecurityNetwork = true"
+              )
+            )
+          )
+        } else {
+          Future.successful(())
+        }
     } yield ()
-  }
 
   private def checkBillingAccountAccess(billingAccountName: RawlsBillingAccountName): Future[RawlsBillingAccount] = {
-    def createForbiddenErrorMessage(who: String, billingAccountName: RawlsBillingAccountName) = {
+    def createForbiddenErrorMessage(who: String, billingAccountName: RawlsBillingAccountName) =
       s"""${who} must have the permission "Billing Account User" on ${billingAccountName.value} to create a project with it."""
-    }
 
     gcsDAO.listBillingAccounts(ctx.userInfo) flatMap { billingAccountNames =>
       billingAccountNames.find(_.accountName == billingAccountName) match {
-        case None => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, createForbiddenErrorMessage("You", billingAccountName))))
+        case None =>
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.Forbidden, createForbiddenErrorMessage("You", billingAccountName))
+            )
+          )
         case Some(billingAccount) =>
           if (billingAccount.firecloudHasAccess)
             Future.successful(billingAccount)
           else
-            Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, createForbiddenErrorMessage(gcsDAO.billingEmail, billingAccountName))))
+            Future.failed(
+              new RawlsExceptionWithErrorReport(
+                ErrorReport(StatusCodes.BadRequest,
+                            createForbiddenErrorMessage(gcsDAO.billingEmail, billingAccountName)
+                )
+              )
+            )
       }
     }
   }
 
-  private def internalStartBillingProjectCreation(createProjectRequest: CreateRawlsBillingProjectFullRequest, billingAccount: RawlsBillingAccount): Future[Unit] = {
+  private def internalStartBillingProjectCreation(createProjectRequest: CreateRawlsBillingProjectFullRequest,
+                                                  billingAccount: RawlsBillingAccount
+  ): Future[Unit] =
     for {
       project <- dataSource.inTransaction { dataAccess =>
         dataAccess.rawlsBillingProjectQuery.load(createProjectRequest.projectName) flatMap {
           case None =>
             for {
-              _ <- DBIO.from(samDAO.createResource(SamResourceTypeNames.billingProject, createProjectRequest.projectName.value, ctx.userInfo))
-              _ <- DBIO.from(samDAO.createResourceFull(SamResourceTypeNames.googleProject, createProjectRequest.projectName.value, Map.empty, Set.empty, ctx.userInfo, Option(SamFullyQualifiedResourceId(createProjectRequest.projectName.value, SamResourceTypeNames.billingProject.value))))
-              _ <- DBIO.from(samDAO.overwritePolicy(SamResourceTypeNames.billingProject, createProjectRequest.projectName.value, SamBillingProjectPolicyNames.workspaceCreator, SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.workspaceCreator)), ctx.userInfo))
-              _ <- DBIO.from(samDAO.overwritePolicy(SamResourceTypeNames.billingProject, createProjectRequest.projectName.value, SamBillingProjectPolicyNames.canComputeUser, SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.batchComputeUser, SamBillingProjectRoles.notebookUser)), ctx.userInfo))
-              project <- dataAccess.rawlsBillingProjectQuery.create(RawlsBillingProject(createProjectRequest.projectName, CreationStatuses.Creating, Option(createProjectRequest.billingAccount), None, None, createProjectRequest.servicePerimeter))
+              _ <- DBIO.from(
+                samDAO.createResource(SamResourceTypeNames.billingProject,
+                                      createProjectRequest.projectName.value,
+                                      ctx.userInfo
+                )
+              )
+              _ <- DBIO.from(
+                samDAO.createResourceFull(
+                  SamResourceTypeNames.googleProject,
+                  createProjectRequest.projectName.value,
+                  Map.empty,
+                  Set.empty,
+                  ctx.userInfo,
+                  Option(
+                    SamFullyQualifiedResourceId(createProjectRequest.projectName.value,
+                                                SamResourceTypeNames.billingProject.value
+                    )
+                  )
+                )
+              )
+              _ <- DBIO.from(
+                samDAO.overwritePolicy(
+                  SamResourceTypeNames.billingProject,
+                  createProjectRequest.projectName.value,
+                  SamBillingProjectPolicyNames.workspaceCreator,
+                  SamPolicy(Set.empty, Set.empty, Set(SamBillingProjectRoles.workspaceCreator)),
+                  ctx.userInfo
+                )
+              )
+              _ <- DBIO.from(
+                samDAO.overwritePolicy(
+                  SamResourceTypeNames.billingProject,
+                  createProjectRequest.projectName.value,
+                  SamBillingProjectPolicyNames.canComputeUser,
+                  SamPolicy(Set.empty,
+                            Set.empty,
+                            Set(SamBillingProjectRoles.batchComputeUser, SamBillingProjectRoles.notebookUser)
+                  ),
+                  ctx.userInfo
+                )
+              )
+              project <- dataAccess.rawlsBillingProjectQuery.create(
+                RawlsBillingProject(
+                  createProjectRequest.projectName,
+                  CreationStatuses.Creating,
+                  Option(createProjectRequest.billingAccount),
+                  None,
+                  None,
+                  createProjectRequest.servicePerimeter
+                )
+              )
             } yield project
 
-          case Some(_) => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Conflict, "project by that name already exists"))
+          case Some(_) =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.Conflict, "project by that name already exists")
+            )
         }
       }
 
-      //NOTE: we're syncing this to Sam ahead of the resource actually existing. is this fine? (ps these are sam calls)
+      // NOTE: we're syncing this to Sam ahead of the resource actually existing. is this fine? (ps these are sam calls)
       ownerGroupEmail <- syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO, createProjectRequest.projectName)
-      computeUserGroupEmail <- syncBillingProjectComputeUserPolicyToGoogleAndGetEmail(samDAO, createProjectRequest.projectName)
+      computeUserGroupEmail <- syncBillingProjectComputeUserPolicyToGoogleAndGetEmail(samDAO,
+                                                                                      createProjectRequest.projectName
+      )
 
       // each service perimeter should have a folder which is used to make an aggregate log sink for flow logs
       parentFolderId <- createProjectRequest.servicePerimeter.traverse(lookupFolderIdFromServicePerimeterName)
 
-      createProjectOperation <- gcsDAO.createProject(project.googleProjectId, billingAccount, dmConfig.templatePath, createProjectRequest.highSecurityNetwork.getOrElse(false), createProjectRequest.enableFlowLogs.getOrElse(false), createProjectRequest.privateIpGoogleAccess.getOrElse(false), requesterPaysRole, ownerGroupEmail, computeUserGroupEmail, projectTemplate, parentFolderId).recoverWith {
-        case t: Throwable =>
+      createProjectOperation <- gcsDAO
+        .createProject(
+          project.googleProjectId,
+          billingAccount,
+          dmConfig.templatePath,
+          createProjectRequest.highSecurityNetwork.getOrElse(false),
+          createProjectRequest.enableFlowLogs.getOrElse(false),
+          createProjectRequest.privateIpGoogleAccess.getOrElse(false),
+          requesterPaysRole,
+          ownerGroupEmail,
+          computeUserGroupEmail,
+          projectTemplate,
+          parentFolderId
+        )
+        .recoverWith { case t: Throwable =>
           // failed to create project in google land, rollback inserts above
-          dataSource.inTransaction { dataAccess => dataAccess.rawlsBillingProjectQuery.delete(createProjectRequest.projectName) } map(_ => throw t)
-      }
+          dataSource.inTransaction { dataAccess =>
+            dataAccess.rawlsBillingProjectQuery.delete(createProjectRequest.projectName)
+          } map (_ => throw t)
+        }
 
       _ <- dataSource.inTransaction { dataAccess =>
         dataAccess.rawlsBillingProjectQuery.insertOperations(Seq(createProjectOperation))
       }
     } yield {}
-  }
 
-  private def updateBillingAccountInternal(projectName: RawlsBillingProjectName, billingAccount: Option[RawlsBillingAccountName]): Future[Option[RawlsBillingProjectResponse]] = {
+  private def updateBillingAccountInternal(projectName: RawlsBillingProjectName,
+                                           billingAccount: Option[RawlsBillingAccountName]
+  ): Future[Option[RawlsBillingProjectResponse]] =
     for {
       maybeBillingProject <- updateBillingAccountInDatabase(projectName, billingAccount)
-      projectRoles <- samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo)
+      projectRoles <- samDAO
+        .listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx.userInfo)
         .map(resourceRoles => samRolesToProjectRoles(resourceRoles))
-    } yield {
-      constructBillingProjectResponseFromOptionalAndRoles(maybeBillingProject, projectRoles)
-    }
-  }
+    } yield constructBillingProjectResponseFromOptionalAndRoles(maybeBillingProject, projectRoles)
 
-  private def updateBillingAccountInDatabase(billingProjectName: RawlsBillingProjectName, billingAccountName: Option[RawlsBillingAccountName]): Future[Option[RawlsBillingProject]] =
+  private def updateBillingAccountInDatabase(billingProjectName: RawlsBillingProjectName,
+                                             billingAccountName: Option[RawlsBillingAccountName]
+  ): Future[Option[RawlsBillingProject]] =
     dataSource.inTransaction { dataAccess =>
       val F = Applicative[ReadWriteAction]
-      dataAccess.rawlsBillingProjectQuery.load(billingProjectName).flatMap(_.traverse { project =>
-        F.pure(project.copy(billingAccount = billingAccountName)) <* F.whenA(project.billingAccount != billingAccountName) {
-          for {
-            _ <- dataAccess.rawlsBillingProjectQuery.updateBillingAccount(billingProjectName, billingAccountName, ctx.userInfo.userSubjectId)
-            // Since the billing account has been updated, any existing spend configuration is now out of date
-            _ <- dataAccess.rawlsBillingProjectQuery.clearBillingProjectSpendConfiguration(billingProjectName)
-            // if any workspaces failed to be updated last time, clear out the error message so the monitor will pick them up and try to update them again
-            _ <- dataAccess.workspaceQuery.deleteAllWorkspaceBillingAccountErrorMessagesInBillingProject(billingProjectName)
-          } yield ()
-        }
-      })
+      dataAccess.rawlsBillingProjectQuery
+        .load(billingProjectName)
+        .flatMap(_.traverse { project =>
+          F.pure(project.copy(billingAccount = billingAccountName)) <* F
+            .whenA(project.billingAccount != billingAccountName) {
+              for {
+                _ <- dataAccess.rawlsBillingProjectQuery.updateBillingAccount(billingProjectName,
+                                                                              billingAccountName,
+                                                                              ctx.userInfo.userSubjectId
+                )
+                // Since the billing account has been updated, any existing spend configuration is now out of date
+                _ <- dataAccess.rawlsBillingProjectQuery.clearBillingProjectSpendConfiguration(billingProjectName)
+                // if any workspaces failed to be updated last time, clear out the error message so the monitor will pick them up and try to update them again
+                _ <- dataAccess.workspaceQuery
+                  .deleteAllWorkspaceBillingAccountErrorMessagesInBillingProject(billingProjectName)
+              } yield ()
+            }
+        })
     }
 
-  private def constructBillingProjectResponseFromOptionalAndRoles(maybeBillingProject: Option[RawlsBillingProject], projectRoles: Set[ProjectRole]) = {
+  private def constructBillingProjectResponseFromOptionalAndRoles(maybeBillingProject: Option[RawlsBillingProject],
+                                                                  projectRoles: Set[ProjectRole]
+  ) =
     maybeBillingProject match {
-      case Some(billingProject) if projectRoles.nonEmpty => Option(makeBillingProjectResponse(projectRoles, billingProject))
+      case Some(billingProject) if projectRoles.nonEmpty =>
+        Option(makeBillingProjectResponse(projectRoles, billingProject))
       case _ => None
     }
-  }
 
   private def lookupFolderIdFromServicePerimeterName(perimeterName: ServicePerimeterName): Future[String] = {
     val folderName = perimeterName.value.split("/").last
     gcsDAO.getFolderId(folderName).flatMap {
-      case None => Future.failed(new RawlsException(s"folder named $folderName corresponding to perimeter $perimeterName not found"))
+      case None =>
+        Future
+          .failed(new RawlsException(s"folder named $folderName corresponding to perimeter $perimeterName not found"))
       case Some(folderId) => Future.successful(folderId)
     }
   }
 
   // User needs to be an owner of the billing project and have the AddProject action on the service perimeter
-  private def requirePermissionsToAddToServicePerimeter[T](servicePerimeterName: ServicePerimeterName, projectName: RawlsBillingProjectName)(op: => Future[T]): Future[T] = {
+  private def requirePermissionsToAddToServicePerimeter[T](servicePerimeterName: ServicePerimeterName,
+                                                           projectName: RawlsBillingProjectName
+  )(op: => Future[T]): Future[T] =
     requireServicePerimeterAction(servicePerimeterName, SamServicePerimeterActions.addProject) {
       requireProjectAction[T](projectName, SamBillingProjectActions.addToServicePerimeter) {
         op
       }
     }
-  }
 
-  def addProjectToServicePerimeter(servicePerimeterName: ServicePerimeterName, projectName: RawlsBillingProjectName): Future[Unit] = {
+  def addProjectToServicePerimeter(servicePerimeterName: ServicePerimeterName,
+                                   projectName: RawlsBillingProjectName
+  ): Future[Unit] =
     requirePermissionsToAddToServicePerimeter(servicePerimeterName, projectName) {
       for {
         billingProject <- dataSource.inTransaction { dataAccess =>
           dataAccess.rawlsBillingProjectQuery.load(projectName).map { billingProjectOpt =>
-            billingProjectOpt.getOrElse(throw new RawlsException(s"Sam thinks user has access to project ${projectName.value} but project not found in database"))
+            billingProjectOpt.getOrElse(
+              throw new RawlsException(
+                s"Sam thinks user has access to project ${projectName.value} but project not found in database"
+              )
+            )
           }
         }
 
         _ <- billingProject.servicePerimeter match {
-          case Some(existingServicePerimeter) => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"project ${billingProject.projectName.value} is already in service perimeter $existingServicePerimeter")))
+          case Some(existingServicePerimeter) =>
+            Future.failed(
+              new RawlsExceptionWithErrorReport(
+                ErrorReport(
+                  StatusCodes.BadRequest,
+                  s"project ${billingProject.projectName.value} is already in service perimeter $existingServicePerimeter"
+                )
+              )
+            )
           case None => Future.successful(())
         }
 
         // Even if the project's status is 'Creating' and could possibly still have a perimeter added to it, we throw an exception to avoid a race condition
         _ <- billingProject.status match {
           case CreationStatuses.Ready => Future.successful(())
-          case status => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"project ${billingProject.projectName.value} should be Ready but is $status")))
+          case status =>
+            Future.failed(
+              new RawlsExceptionWithErrorReport(
+                ErrorReport(StatusCodes.BadRequest,
+                            s"project ${billingProject.projectName.value} should be Ready but is $status"
+                )
+              )
+            )
         }
 
         // each service perimeter should have a folder which is used to make an aggregate log sink for flow logs
@@ -669,8 +985,10 @@ class UserService(protected val ctx: RawlsRequestContext,
 
         googleProjectNumber <- billingProject.googleProjectNumber match {
           case Some(existingGoogleProjectNumber) => Future.successful(existingGoogleProjectNumber)
-          case None => gcsDAO.getGoogleProject(billingProject.googleProjectId).map(googleProject =>
-            gcsDAO.getGoogleProjectNumber(googleProject))
+          case None =>
+            gcsDAO
+              .getGoogleProject(billingProject.googleProjectId)
+              .map(googleProject => gcsDAO.getGoogleProjectNumber(googleProject))
         }
 
         _ <- dataSource.inTransaction { dataAccess =>
@@ -680,9 +998,15 @@ class UserService(protected val ctx: RawlsRequestContext,
             // Google project number, but any v1 workspaces should store the Terra billing project's
             // Google project number
             v1Workspaces = workspaces.filterNot(_.googleProjectNumber.isDefined)
-            _ <- dataAccess.workspaceQuery.updateGoogleProjectNumber(v1Workspaces.map(_.workspaceIdAsUUID), googleProjectNumber)
-            _ <- dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(billingProject.projectName, servicePerimeterName.some)
-            _ <- dataAccess.rawlsBillingProjectQuery.updateGoogleProjectNumber(billingProject.projectName, googleProjectNumber.some)
+            _ <- dataAccess.workspaceQuery.updateGoogleProjectNumber(v1Workspaces.map(_.workspaceIdAsUUID),
+                                                                     googleProjectNumber
+            )
+            _ <- dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(billingProject.projectName,
+                                                                            servicePerimeterName.some
+            )
+            _ <- dataAccess.rawlsBillingProjectQuery.updateGoogleProjectNumber(billingProject.projectName,
+                                                                               googleProjectNumber.some
+            )
           } yield ()
         }
 
@@ -692,12 +1016,12 @@ class UserService(protected val ctx: RawlsRequestContext,
         }
       } yield {}
     }
-  }
 
-  def moveGoogleProjectToServicePerimeterFolder(servicePerimeterName: ServicePerimeterName, googleProjectId: GoogleProjectId): Future[Unit] = {
+  def moveGoogleProjectToServicePerimeterFolder(servicePerimeterName: ServicePerimeterName,
+                                                googleProjectId: GoogleProjectId
+  ): Future[Unit] =
     for {
       folderId <- lookupFolderIdFromServicePerimeterName(servicePerimeterName)
       _ <- gcsDAO.addProjectToFolder(googleProjectId, folderId)
     } yield ()
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/EntitySupport.scala
@@ -7,7 +7,13 @@ import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityRecord, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, ErrorReport, RawlsRequestContext, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  Entity,
+  ErrorReport,
+  RawlsRequestContext,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
 
 import scala.concurrent.ExecutionContext
@@ -19,77 +25,146 @@ trait EntitySupport {
 
   import dataSource.dataAccess.driver.api._
 
-  //Finds a single entity record in the db.
-  def withSingleEntityRec[T](entityType: String, entityName: String, workspaceContext: Workspace, dataAccess: DataAccess)(op: (Seq[EntityRecord]) => ReadWriteAction[T]): ReadWriteAction[T] = {
-    val entityRec = dataAccess.entityQuery.findEntityByName(workspaceContext.workspaceIdAsUUID, entityType, entityName).result
+  // Finds a single entity record in the db.
+  def withSingleEntityRec[T](entityType: String,
+                             entityName: String,
+                             workspaceContext: Workspace,
+                             dataAccess: DataAccess
+  )(op: (Seq[EntityRecord]) => ReadWriteAction[T]): ReadWriteAction[T] = {
+    val entityRec =
+      dataAccess.entityQuery.findEntityByName(workspaceContext.workspaceIdAsUUID, entityType, entityName).result
     entityRec flatMap { entities =>
       if (entities.isEmpty) {
-        DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"No entity of type ${entityType} named ${entityName} exists in this workspace.")))
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.NotFound,
+                                      s"No entity of type ${entityType} named ${entityName} exists in this workspace."
+            )
+          )
+        )
       } else if (entities.size == 1) {
         op(entities)
       } else {
-        DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"More than one entity of type ${entityType} named ${entityName} exists in this workspace?!")))
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport =
+              ErrorReport(StatusCodes.NotFound,
+                          s"More than one entity of type ${entityType} named ${entityName} exists in this workspace?!"
+              )
+          )
+        )
       }
     }
   }
 
-  def withAllEntityRefs[T](workspaceContext: Workspace, dataAccess: DataAccess, entities: Seq[AttributeEntityReference], context: RawlsRequestContext)(op: (Seq[AttributeEntityReference]) => ReadWriteAction[T]): ReadWriteAction[T] = {
+  def withAllEntityRefs[T](workspaceContext: Workspace,
+                           dataAccess: DataAccess,
+                           entities: Seq[AttributeEntityReference],
+                           context: RawlsRequestContext
+  )(op: (Seq[AttributeEntityReference]) => ReadWriteAction[T]): ReadWriteAction[T] =
     // query the db to see which of the specified entity refs exist in the workspace and are active
-    traceDBIOWithParent("withAllEntityRefs.getActiveRefs", context)(_ => dataAccess.entityQuery.getActiveRefs(workspaceContext.workspaceIdAsUUID, entities.toSet)) flatMap { found =>
+    traceDBIOWithParent("withAllEntityRefs.getActiveRefs", context)(_ =>
+      dataAccess.entityQuery.getActiveRefs(workspaceContext.workspaceIdAsUUID, entities.toSet)
+    ) flatMap { found =>
       // were any of the user's entities not found in our query?
       val notFound = entities diff found
       if (notFound.nonEmpty) {
         // generate error messages
-        val failureMessages = notFound.map { e => s"${e.entityType} ${e.entityName} does not exist in ${workspaceContext.toWorkspaceName}" }
-        val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = (Seq("Entities were not found:") ++ failureMessages) mkString System.lineSeparator())
+        val failureMessages = notFound.map { e =>
+          s"${e.entityType} ${e.entityName} does not exist in ${workspaceContext.toWorkspaceName}"
+        }
+        val err = ErrorReport(statusCode = StatusCodes.BadRequest,
+                              message =
+                                (Seq("Entities were not found:") ++ failureMessages) mkString System.lineSeparator()
+        )
         DBIO.failed(new RawlsExceptionWithErrorReport(err))
       } else {
         op(found)
       }
     }
-  }
 
-  def withEntityRecsForExpressionEval[T](expressionEvaluationContext: ExpressionEvaluationContext, workspaceContext: Workspace, dataAccess: DataAccess)(op: (Option[Seq[EntityRecord]]) => ReadWriteAction[T]): ReadWriteAction[T] = {
-    if( expressionEvaluationContext.rootEntityType.isEmpty ) {
+  def withEntityRecsForExpressionEval[T](expressionEvaluationContext: ExpressionEvaluationContext,
+                                         workspaceContext: Workspace,
+                                         dataAccess: DataAccess
+  )(op: (Option[Seq[EntityRecord]]) => ReadWriteAction[T]): ReadWriteAction[T] =
+    if (expressionEvaluationContext.rootEntityType.isEmpty) {
       op(None)
     } else {
       val rootEntityType = expressionEvaluationContext.rootEntityType.get
 
-      //If there's an expression, evaluate it to get the list of entities to run this job on.
-      //Otherwise, use the entity given in the submission.
+      // If there's an expression, evaluate it to get the list of entities to run this job on.
+      // Otherwise, use the entity given in the submission.
       expressionEvaluationContext.expression match {
         case None =>
           if (expressionEvaluationContext.entityType.getOrElse("") != rootEntityType) {
-            val whatYouGaveUs = if (expressionEvaluationContext.entityType.isDefined) s"an entity of type ${expressionEvaluationContext.entityType.get}" else "no entity"
-            DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Method configuration expects an entity of type $rootEntityType, but you gave us $whatYouGaveUs.")))
+            val whatYouGaveUs =
+              if (expressionEvaluationContext.entityType.isDefined)
+                s"an entity of type ${expressionEvaluationContext.entityType.get}"
+              else "no entity"
+            DBIO.failed(
+              new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.BadRequest,
+                  s"Method configuration expects an entity of type $rootEntityType, but you gave us $whatYouGaveUs."
+                )
+              )
+            )
           } else {
-            withSingleEntityRec(expressionEvaluationContext.entityType.get, expressionEvaluationContext.entityName.get, workspaceContext, dataAccess)(rec => op(Some(rec)))
+            withSingleEntityRec(expressionEvaluationContext.entityType.get,
+                                expressionEvaluationContext.entityName.get,
+                                workspaceContext,
+                                dataAccess
+            )(rec => op(Some(rec)))
           }
         case Some(expression) =>
-          ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, workspaceContext, expressionEvaluationContext.entityType.get, expressionEvaluationContext.entityName.get) { evaluator =>
+          ExpressionEvaluator.withNewExpressionEvaluator(dataAccess,
+                                                         workspaceContext,
+                                                         expressionEvaluationContext.entityType.get,
+                                                         expressionEvaluationContext.entityName.get
+          ) { evaluator =>
             evaluator.evalFinalEntity(workspaceContext, expression).asTry
-          } flatMap { //gotta close out the expression evaluator to wipe the EXPREVAL_TEMP table
-            case Failure(regret) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret)))
+          } flatMap { // gotta close out the expression evaluator to wipe the EXPREVAL_TEMP table
+            case Failure(regret) =>
+              DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret)))
             case Success(entityRecords) =>
               if (entityRecords.isEmpty) {
-                DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "No entities eligible for submission were found.")))
+                DBIO.failed(
+                  new RawlsExceptionWithErrorReport(
+                    errorReport = ErrorReport(StatusCodes.BadRequest, "No entities eligible for submission were found.")
+                  )
+                )
               } else {
                 val eligibleEntities = entityRecords.filter(_.entityType == rootEntityType).toSeq
                 if (eligibleEntities.isEmpty)
-                  DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"The expression in your SubmissionRequest matched only entities of the wrong type. (Expected type ${rootEntityType}.)")))
+                  DBIO.failed(
+                    new RawlsExceptionWithErrorReport(
+                      errorReport = ErrorReport(
+                        StatusCodes.BadRequest,
+                        s"The expression in your SubmissionRequest matched only entities of the wrong type. (Expected type ${rootEntityType}.)"
+                      )
+                    )
+                  )
                 else
                   op(Some(eligibleEntities))
               }
           }
       }
     }
-  }
 
-  def withEntity[T](workspaceContext: Workspace, entityType: String, entityName: String, dataAccess: DataAccess)(op: (Entity) => ReadWriteAction[T]): ReadWriteAction[T] = {
+  def withEntity[T](workspaceContext: Workspace, entityType: String, entityName: String, dataAccess: DataAccess)(
+    op: (Entity) => ReadWriteAction[T]
+  ): ReadWriteAction[T] =
     dataAccess.entityQuery.get(workspaceContext, entityType, entityName) flatMap {
-      case None => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in ${workspaceContext.toWorkspaceName}")))
+      case None =>
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport =
+              ErrorReport(StatusCodes.NotFound,
+                          s"${entityType} ${entityName} does not exist in ${workspaceContext.toWorkspaceName}"
+              )
+          )
+        )
       case Some(entity) => op(entity)
     }
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/LibraryPermissionsSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/LibraryPermissionsSupport.scala
@@ -20,23 +20,28 @@ trait LibraryPermissionsSupport extends RoleSupport {
   def withLibraryPermissions(ctx: Workspace,
                              operations: Seq[AttributeUpdateOperation],
                              userInfo: UserInfo,
-                             isCurator: Boolean)
-                            (op: => Future[Workspace]): Future[Workspace] = {
+                             isCurator: Boolean
+  )(op: => Future[Workspace]): Future[Workspace] = {
     val names = operations.map(attribute => attribute.name)
 
     getPermissionChecker(names, isCurator, ctx.workspaceId)(op)
   }
 
-  def getPermissionChecker(names: Seq[AttributeName], isCurator: Boolean, workspaceId: String): ((=> Future[Workspace]) => Future[Workspace]) = {
+  def getPermissionChecker(names: Seq[AttributeName],
+                           isCurator: Boolean,
+                           workspaceId: String
+  ): ((=> Future[Workspace]) => Future[Workspace]) =
     // need to combine multiple delete and add ops when changing discoverable attribute
     names.distinct match {
-      case Seq(`publishedFlag`) => changePublishedChecker(isCurator, workspaceId) _
+      case Seq(`publishedFlag`)           => changePublishedChecker(isCurator, workspaceId) _
       case Seq(`discoverableWSAttribute`) => changeDiscoverabilityChecker(workspaceId) _
-      case x if x.contains(publishedFlag) => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Unsupported parameter - can't modify published with other attributes"))
+      case x if x.contains(publishedFlag) =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, "Unsupported parameter - can't modify published with other attributes")
+        )
       case x if x.contains(discoverableWSAttribute) => changeDiscoverabilityAndMetadataChecker(workspaceId) _
-      case _ => changeMetadataChecker(workspaceId) _
+      case _                                        => changeMetadataChecker(workspaceId) _
     }
-  }
 
   def withLibraryAttributeNamespaceCheck[T](attributeNames: Iterable[AttributeName])(op: => T): T = {
     val namespaces = attributeNames.map(_.namespace).toSet
@@ -45,33 +50,39 @@ trait LibraryPermissionsSupport extends RoleSupport {
     val invalidNamespaces = namespaces -- Set(AttributeName.libraryNamespace)
     if (invalidNamespaces.isEmpty) op
     else {
-      val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"All attributes must be in the library namespace")
+      val err =
+        ErrorReport(statusCode = StatusCodes.BadRequest, message = s"All attributes must be in the library namespace")
       throw new RawlsExceptionWithErrorReport(errorReport = err)
     }
   }
 
-  private def maybeExecuteOp(canModify: Future[Boolean], cantModifyMessage: String, op: => Future[Workspace]) = {
+  private def maybeExecuteOp(canModify: Future[Boolean], cantModifyMessage: String, op: => Future[Workspace]) =
     canModify.flatMap {
       case true => op
-      case false => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, cantModifyMessage)))
+      case false =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, cantModifyMessage))
+        )
     }
-  }
 
-  def hasAnyAction(workspaceId: String, actions: SamResourceAction*): Future[Boolean] = {
-    Future.traverse(actions) { action =>
-      samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, action, ctx.userInfo)
-    }.map(_.contains(true))
-  }
+  def hasAnyAction(workspaceId: String, actions: SamResourceAction*): Future[Boolean] =
+    Future
+      .traverse(actions) { action =>
+        samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, action, ctx.userInfo)
+      }
+      .map(_.contains(true))
 
   def canChangeMetadata(workspaceId: String): Future[Boolean] =
     hasAnyAction(workspaceId, SamWorkspaceActions.write, SamWorkspaceActions.catalog)
 
   def canChangeDiscoverability(workspaceId: String): Future[Boolean] =
-    hasAnyAction(workspaceId,
+    hasAnyAction(
+      workspaceId,
       SamWorkspaceActions.own,
       SamWorkspaceActions.catalog,
       SamWorkspaceActions.sharePolicy(SamWorkspacePolicyNames.shareWriter.value),
-      SamWorkspaceActions.sharePolicy(SamWorkspacePolicyNames.shareReader.value))
+      SamWorkspaceActions.sharePolicy(SamWorkspacePolicyNames.shareReader.value)
+    )
 
   def canChangePublished(isCurator: Boolean, workspaceId: String): Future[Boolean] =
     if (!isCurator) {
@@ -80,19 +91,25 @@ trait LibraryPermissionsSupport extends RoleSupport {
       hasAnyAction(workspaceId, SamWorkspaceActions.own, SamWorkspaceActions.catalog)
     }
 
-
   def changeMetadataChecker(workspaceId: String)(op: => Future[Workspace]): Future[Workspace] =
     maybeExecuteOp(canChangeMetadata(workspaceId), "You must have write+ or catalog with read permissions.", op)
 
   def changeDiscoverabilityChecker(workspaceId: String)(op: => Future[Workspace]): Future[Workspace] =
-    maybeExecuteOp(canChangeDiscoverability(workspaceId), "You must be an owner or have catalog or share permissions.", op)
+    maybeExecuteOp(canChangeDiscoverability(workspaceId),
+                   "You must be an owner or have catalog or share permissions.",
+                   op
+    )
 
   def changePublishedChecker(isCurator: Boolean, workspaceId: String)(op: => Future[Workspace]): Future[Workspace] =
-    maybeExecuteOp(canChangePublished(isCurator, workspaceId), "You must be a curator and either be an owner or have catalog with read+.", op)
+    maybeExecuteOp(canChangePublished(isCurator, workspaceId),
+                   "You must be a curator and either be an owner or have catalog with read+.",
+                   op
+    )
 
   def changeDiscoverabilityAndMetadataChecker(workspaceId: String)(op: => Future[Workspace]): Future[Workspace] = {
-    val canDo = Future.sequence(Seq(canChangeMetadata(workspaceId), canChangeDiscoverability(workspaceId))).map(_.forall(identity))
+    val canDo = Future
+      .sequence(Seq(canChangeMetadata(workspaceId), canChangeDiscoverability(workspaceId)))
+      .map(_.forall(identity))
     maybeExecuteOp(canDo, "You must be an owner or have catalog with read permissions.", op)
   }
 }
-

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/RoleSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/RoleSupport.scala
@@ -15,23 +15,33 @@ trait RoleSupport {
   protected val ctx: RawlsRequestContext
   implicit protected val executionContext: ExecutionContext
 
-  def tryIsFCAdmin(userEmail: RawlsUserEmail): Future[Boolean] = {
-    gcsDAO.isAdmin(userEmail.value) recoverWith { case t => throw new RawlsException("Unable to query for admin status.", t) }
-  }
+  def tryIsFCAdmin(userEmail: RawlsUserEmail): Future[Boolean] =
+    gcsDAO.isAdmin(userEmail.value) recoverWith { case t =>
+      throw new RawlsException("Unable to query for admin status.", t)
+    }
 
-  def asFCAdmin[T](op: => Future[T]): Future[T] = {
+  def asFCAdmin[T](op: => Future[T]): Future[T] =
     tryIsFCAdmin(ctx.userInfo.userEmail) flatMap { isAdmin =>
-      if (isAdmin) op else Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, "You must be an admin.")))
+      if (isAdmin) op
+      else
+        Future.failed(
+          new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, "You must be an admin."))
+        )
     }
-  }
-  
-  def tryIsCurator(userEmail: RawlsUserEmail): Future[Boolean] = {
-    gcsDAO.isLibraryCurator(userEmail.value) recoverWith { case t => throw new RawlsException("Unable to query for library curator status.", t) }
-  }
 
-  def asCurator[T](op: => Future[T]): Future[T] = {
-    tryIsCurator(ctx.userInfo.userEmail) flatMap { isCurator =>
-      if (isCurator) op else Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, "You must be a library curator.")))
+  def tryIsCurator(userEmail: RawlsUserEmail): Future[Boolean] =
+    gcsDAO.isLibraryCurator(userEmail.value) recoverWith { case t =>
+      throw new RawlsException("Unable to query for library curator status.", t)
     }
-  }
+
+  def asCurator[T](op: => Future[T]): Future[T] =
+    tryIsCurator(ctx.userInfo.userEmail) flatMap { isCurator =>
+      if (isCurator) op
+      else
+        Future.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.Forbidden, "You must be a library curator.")
+          )
+        )
+    }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/TracingUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/TracingUtils.scala
@@ -9,37 +9,44 @@ import slick.dbio.{DBIO, DBIOAction, Effect, NoStream}
 import scala.concurrent.{ExecutionContext, Future}
 
 object TracingUtils {
-  def traceDBIOWithParent[T, E <: Effect](name: String, parentContext: RawlsRequestContext)(f: RawlsRequestContext => DBIOAction[T, NoStream, E])(implicit executor: ExecutionContext): DBIOAction[T, NoStream, E with Effect] = {
-    val childContext = parentContext.copy(tracingSpan = Option(startSpanWithParent(name, parentContext.tracingSpan.orNull)))
+  def traceDBIOWithParent[T, E <: Effect](name: String, parentContext: RawlsRequestContext)(
+    f: RawlsRequestContext => DBIOAction[T, NoStream, E]
+  )(implicit executor: ExecutionContext): DBIOAction[T, NoStream, E with Effect] = {
+    val childContext =
+      parentContext.copy(tracingSpan = Option(startSpanWithParent(name, parentContext.tracingSpan.orNull)))
     f(childContext).cleanUp { _ =>
       endSpan(childContext.tracingSpan.orNull, Status.OK)
       DBIO.successful(())
     }
   }
 
-  def traceWithParent[T](name: String, parentContext: RawlsRequestContext)(f: RawlsRequestContext => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def traceWithParent[T](name: String, parentContext: RawlsRequestContext)(
+    f: RawlsRequestContext => Future[T]
+  )(implicit ec: ExecutionContext): Future[T] =
     Tracing.traceWithParent(name, parentContext.tracingSpan.orNull) { span =>
       f(parentContext.copy(tracingSpan = Option(span)))
     }
-  }
 
-  def traceDBIOWithParent[T, E <: Effect](name: String, parentContext: RawlsTracingContext)(f: RawlsTracingContext => DBIOAction[T, NoStream, E])(implicit executor: ExecutionContext): DBIOAction[T, NoStream, E with Effect] = {
-    val childContext = parentContext.copy(tracingSpan = Option(startSpanWithParent(name, parentContext.tracingSpan.orNull)))
+  def traceDBIOWithParent[T, E <: Effect](name: String, parentContext: RawlsTracingContext)(
+    f: RawlsTracingContext => DBIOAction[T, NoStream, E]
+  )(implicit executor: ExecutionContext): DBIOAction[T, NoStream, E with Effect] = {
+    val childContext =
+      parentContext.copy(tracingSpan = Option(startSpanWithParent(name, parentContext.tracingSpan.orNull)))
     f(childContext).cleanUp { _ =>
       endSpan(childContext.tracingSpan.orNull, Status.OK)
       DBIO.successful(())
     }
   }
 
-  def traceWithParent[T](name: String, parentContext: RawlsTracingContext)(f: RawlsTracingContext => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def traceWithParent[T](name: String, parentContext: RawlsTracingContext)(
+    f: RawlsTracingContext => Future[T]
+  )(implicit ec: ExecutionContext): Future[T] =
     Tracing.traceWithParent(name, parentContext.tracingSpan.orNull) { span =>
       f(parentContext.copy(tracingSpan = Option(span)))
     }
-  }
 
-  def trace[T](name: String)(f: RawlsTracingContext => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  def trace[T](name: String)(f: RawlsTracingContext => Future[T])(implicit ec: ExecutionContext): Future[T] =
     Tracing.trace(name) { span =>
       f(RawlsTracingContext(Option(span)))
     }
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSpanFilter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WithSpanFilter.scala
@@ -17,11 +17,9 @@ import javax.ws.rs.ext.Provider
 class WithSpanFilter(span: Span) extends ClientRequestFilter with ClientResponseFilter {
   private var scope: Scope = _
 
-  override def filter(requestContext: ClientRequestContext): Unit = {
+  override def filter(requestContext: ClientRequestContext): Unit =
     scope = Tracing.getTracer.withSpan(span)
-  }
 
-  override def filter(requestContext: ClientRequestContext, responseContext: ClientResponseContext): Unit = {
+  override def filter(requestContext: ClientRequestContext, responseContext: ClientResponseContext): Unit =
     scope.close()
-  }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -2,10 +2,29 @@ package org.broadinstitute.dsde.rawls.util
 
 import akka.http.scaladsl.model.StatusCodes
 import io.opencensus.trace.Span
-import org.broadinstitute.dsde.rawls.{LockedWorkspaceException, NoSuchWorkspaceException, RawlsExceptionWithErrorReport, WorkspaceAccessDeniedException}
+import org.broadinstitute.dsde.rawls.{
+  LockedWorkspaceException,
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  WorkspaceAccessDeniedException
+}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamBillingProjectRoles, SamResourceAction, SamResourceTypeNames, SamWorkspaceActions, UserInfo, Workspace, WorkspaceAttributeSpecs, WorkspaceName, WorkspaceRequest}
+import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamBillingProjectActions,
+  SamBillingProjectRoles,
+  SamResourceAction,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  UserInfo,
+  Workspace,
+  WorkspaceAttributeSpecs,
+  WorkspaceName,
+  WorkspaceRequest
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
 
 import java.util.UUID
@@ -19,125 +38,177 @@ trait WorkspaceSupport {
 
   import dataSource.dataAccess.driver.api._
 
-  //Access/permission helpers
+  // Access/permission helpers
 
-  def accessCheck(workspace: Workspace, requiredAction: SamResourceAction, ignoreLock: Boolean): Future[Unit] = {
-    samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, requiredAction, ctx.userInfo) flatMap { hasRequiredLevel =>
-      if (hasRequiredLevel) {
-        val actionsBlockedByLock = Set(SamWorkspaceActions.write, SamWorkspaceActions.compute, SamWorkspaceActions.delete)
-        if (actionsBlockedByLock.contains(requiredAction) && workspace.isLocked && !ignoreLock)
-          Future.failed(LockedWorkspaceException(workspace.toWorkspaceName))
-        else
-          Future.successful(())
-      } else {
-        samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx.userInfo) flatMap { canRead =>
-          if (canRead) {
-            Future.failed(WorkspaceAccessDeniedException(workspace.toWorkspaceName))
-          }
-          else {
-            Future.failed(NoSuchWorkspaceException(workspace.toWorkspaceName))
+  def accessCheck(workspace: Workspace, requiredAction: SamResourceAction, ignoreLock: Boolean): Future[Unit] =
+    samDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, requiredAction, ctx.userInfo) flatMap {
+      hasRequiredLevel =>
+        if (hasRequiredLevel) {
+          val actionsBlockedByLock =
+            Set(SamWorkspaceActions.write, SamWorkspaceActions.compute, SamWorkspaceActions.delete)
+          if (actionsBlockedByLock.contains(requiredAction) && workspace.isLocked && !ignoreLock)
+            Future.failed(LockedWorkspaceException(workspace.toWorkspaceName))
+          else
+            Future.successful(())
+        } else {
+          samDAO.userHasAction(SamResourceTypeNames.workspace,
+                               workspace.workspaceId,
+                               SamWorkspaceActions.read,
+                               ctx.userInfo
+          ) flatMap { canRead =>
+            if (canRead) {
+              Future.failed(WorkspaceAccessDeniedException(workspace.toWorkspaceName))
+            } else {
+              Future.failed(NoSuchWorkspaceException(workspace.toWorkspaceName))
+            }
           }
         }
-      }
     }
-  }
 
-  def requireAccessF[T](workspace: Workspace, requiredAction: SamResourceAction)(codeBlock: => Future[T]): Future[T] = {
+  def requireAccessF[T](workspace: Workspace, requiredAction: SamResourceAction)(codeBlock: => Future[T]): Future[T] =
     accessCheck(workspace, requiredAction, ignoreLock = false) flatMap { _ => codeBlock }
-  }
 
-  def requireAccessIgnoreLockF[T](workspace: Workspace, requiredAction: SamResourceAction)(codeBlock: => Future[T]): Future[T] = {
+  def requireAccessIgnoreLockF[T](workspace: Workspace, requiredAction: SamResourceAction)(
+    codeBlock: => Future[T]
+  ): Future[T] =
     accessCheck(workspace, requiredAction, ignoreLock = true) flatMap { _ => codeBlock }
-  }
 
-  def requireComputePermission(workspaceName: WorkspaceName): Future[Unit] = {
+  def requireComputePermission(workspaceName: WorkspaceName): Future[Unit] =
     for {
       workspaceContext <- getWorkspaceContext(workspaceName)
-      hasCompute <- {
-        samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceContext.workspaceId, SamWorkspaceActions.compute, ctx.userInfo).flatMap { launchBatchCompute =>
-          if (launchBatchCompute) Future.successful(())
-          else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceContext.workspaceId, SamWorkspaceActions.read, ctx.userInfo).flatMap { workspaceRead =>
-            if (workspaceRead) Future.failed(WorkspaceAccessDeniedException(workspaceName))
-            else Future.failed(NoSuchWorkspaceException(workspaceName))
+      hasCompute <-
+        samDAO
+          .userHasAction(SamResourceTypeNames.workspace,
+                         workspaceContext.workspaceId,
+                         SamWorkspaceActions.compute,
+                         ctx.userInfo
+          )
+          .flatMap { launchBatchCompute =>
+            if (launchBatchCompute) Future.successful(())
+            else
+              samDAO
+                .userHasAction(SamResourceTypeNames.workspace,
+                               workspaceContext.workspaceId,
+                               SamWorkspaceActions.read,
+                               ctx.userInfo
+                )
+                .flatMap { workspaceRead =>
+                  if (workspaceRead) Future.failed(WorkspaceAccessDeniedException(workspaceName))
+                  else Future.failed(NoSuchWorkspaceException(workspaceName))
+                }
           }
-        }
-      }
-    } yield {
-      hasCompute
-    }
-  }
+    } yield hasCompute
 
   // TODO: find and assess all usages. This is written to reside inside a DB transaction, but it makes a REST call to Sam.
   // Will process op only if User has the `createWorkspace` action on the specified Billing Project, otherwise will
   // Fail with 403 Forbidden
-  def requireCreateWorkspaceAccess[T](workspaceRequest: WorkspaceRequest, dataAccess: DataAccess, parentContext: RawlsRequestContext)(op: => ReadWriteAction[T]): ReadWriteAction[T] = {
+  def requireCreateWorkspaceAccess[T](workspaceRequest: WorkspaceRequest,
+                                      dataAccess: DataAccess,
+                                      parentContext: RawlsRequestContext
+  )(op: => ReadWriteAction[T]): ReadWriteAction[T] = {
     val projectName = RawlsBillingProjectName(workspaceRequest.namespace)
     for {
-      userHasAction <- traceDBIOWithParent("userHasAction", parentContext)(_ => DBIO.from(samDAO.userHasAction(SamResourceTypeNames.billingProject, projectName.value, SamBillingProjectActions.createWorkspace, ctx.userInfo)))
+      userHasAction <- traceDBIOWithParent("userHasAction", parentContext)(_ =>
+        DBIO.from(
+          samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                               projectName.value,
+                               SamBillingProjectActions.createWorkspace,
+                               ctx.userInfo
+          )
+        )
+      )
       response <- userHasAction match {
         case true => op
-        case false => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Forbidden, s"You are not authorized to create a workspace in billing project ${workspaceRequest.toWorkspaceName.namespace}")))
+        case false =>
+          DBIO.failed(
+            new RawlsExceptionWithErrorReport(
+              errorReport = ErrorReport(
+                StatusCodes.Forbidden,
+                s"You are not authorized to create a workspace in billing project ${workspaceRequest.toWorkspaceName.namespace}"
+              )
+            )
+          )
       }
     } yield response
   }
 
   // Creating a Workspace without an Owner policy is allowed only if the requesting User has the `owner` role
   // granted on the Workspace's Billing Project
-  def maybeRequireBillingProjectOwnerAccess[T](workspaceRequest: WorkspaceRequest, parentContext: RawlsRequestContext)(op: => ReadWriteAction[T]): ReadWriteAction[T] = {
+  def maybeRequireBillingProjectOwnerAccess[T](workspaceRequest: WorkspaceRequest, parentContext: RawlsRequestContext)(
+    op: => ReadWriteAction[T]
+  ): ReadWriteAction[T] =
     workspaceRequest.noWorkspaceOwner match {
       case Some(true) =>
         for {
-          billingProjectRoles <- traceDBIOWithParent("listUserRolesForResource", parentContext)(_ => DBIO.from(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, workspaceRequest.namespace, ctx.userInfo)))
+          billingProjectRoles <- traceDBIOWithParent("listUserRolesForResource", parentContext)(_ =>
+            DBIO.from(
+              samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                              workspaceRequest.namespace,
+                                              ctx.userInfo
+              )
+            )
+          )
           userIsBillingProjectOwner = billingProjectRoles.contains(SamBillingProjectRoles.owner)
           response <- userIsBillingProjectOwner match {
             case true => op
-            case false => DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"Missing ${SamBillingProjectRoles.owner} role on billing project '${workspaceRequest.namespace}'.")))
+            case false =>
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  ErrorReport(
+                    StatusCodes.Forbidden,
+                    s"Missing ${SamBillingProjectRoles.owner} role on billing project '${workspaceRequest.namespace}'."
+                  )
+                )
+              )
           }
         } yield response
       case _ =>
         op
     }
 
-  }
-
   // can't use withClonedAuthDomain because the Auth Domain -> no Auth Domain logic is different
-  def authDomainCheck(sourceWorkspaceADs: Set[String], destWorkspaceADs: Set[String]): ReadWriteAction[Boolean] = {
+  def authDomainCheck(sourceWorkspaceADs: Set[String], destWorkspaceADs: Set[String]): ReadWriteAction[Boolean] =
     // if the source has any auth domains, the dest must also *at least* have those auth domains
-    if(sourceWorkspaceADs.subsetOf(destWorkspaceADs)) DBIO.successful(true)
+    if (sourceWorkspaceADs.subsetOf(destWorkspaceADs)) DBIO.successful(true)
     else {
       val missingGroups = sourceWorkspaceADs -- destWorkspaceADs
-      val errorMsg = s"Source workspace has an Authorization Domain containing the groups ${missingGroups.mkString(", ")}, which are missing on the destination workspace"
+      val errorMsg =
+        s"Source workspace has an Authorization Domain containing the groups ${missingGroups.mkString(", ")}, which are missing on the destination workspace"
       DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.UnprocessableEntity, errorMsg)))
     }
-  }
 
-  //WorkspaceContext helpers
+  // WorkspaceContext helpers
 
   // function name may be misleading. This returns the workspace context and checks the user's permission,
   // but does not return the permissions.
-  def getWorkspaceContextAndPermissions(workspaceName: WorkspaceName, requiredAction: SamResourceAction, attributeSpecs: Option[WorkspaceAttributeSpecs] = None): Future[Workspace] = {
+  def getWorkspaceContextAndPermissions(workspaceName: WorkspaceName,
+                                        requiredAction: SamResourceAction,
+                                        attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Workspace] =
     for {
       workspaceContext <- getWorkspaceContext(workspaceName, attributeSpecs)
       _ <- accessCheck(workspaceContext, requiredAction, ignoreLock = false) // throws if user does not have permission
     } yield workspaceContext
-  }
 
-  def getWorkspaceContext(workspaceName: WorkspaceName, attributeSpecs: Option[WorkspaceAttributeSpecs] = None): Future[Workspace] = {
+  def getWorkspaceContext(workspaceName: WorkspaceName,
+                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Workspace] =
     dataSource.inTransaction { dataAccess =>
       withWorkspaceContext(workspaceName, dataAccess, attributeSpecs) { workspaceContext =>
         DBIO.successful(workspaceContext)
       }
     }
-  }
 
-  def withWorkspaceContext[T](workspaceName: WorkspaceName, dataAccess: DataAccess, attributeSpecs: Option[WorkspaceAttributeSpecs] = None)(op: (Workspace) => ReadWriteAction[T]) = {
+  def withWorkspaceContext[T](workspaceName: WorkspaceName,
+                              dataAccess: DataAccess,
+                              attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  )(op: (Workspace) => ReadWriteAction[T]) =
     dataAccess.workspaceQuery.findByName(workspaceName, attributeSpecs) flatMap {
-      case None => throw NoSuchWorkspaceException(workspaceName)
+      case None            => throw NoSuchWorkspaceException(workspaceName)
       case Some(workspace) => op(workspace)
     }
-  }
 
-  def withWorkspaceBucketRegionCheck[T](bucketRegion: Option[String])(op: => Future[T]): Future[T] = {
+  def withWorkspaceBucketRegionCheck[T](bucketRegion: Option[String])(op: => Future[T]): Future[T] =
     bucketRegion match {
       case Some(region) =>
         // if the user specifies a region for the workspace bucket, it must be in the proper format for a single region or the default bucket location (US multi region)
@@ -145,12 +216,14 @@ trait WorkspaceSupport {
         val validUSPattern = "US"
         if (region.matches(singleRegionPattern) || region.equals(validUSPattern)) op
         else {
-          val err = ErrorReport(statusCode = StatusCodes.BadRequest, message = s"Workspace bucket location must be a single " +
-            s"region of format: $singleRegionPattern or the default bucket location ('US').")
+          val err = ErrorReport(
+            statusCode = StatusCodes.BadRequest,
+            message = s"Workspace bucket location must be a single " +
+              s"region of format: $singleRegionPattern or the default bucket location ('US')."
+          )
           throw new RawlsExceptionWithErrorReport(errorReport = err)
         }
       case None => op
     }
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiService.scala
@@ -38,12 +38,20 @@ trait BillingApiService extends UserInfoDirectives {
           path(Segment / Segment) { (workbenchRole, userEmail) =>
             put {
               complete {
-                userServiceConstructor(ctx).addUserToBillingProject(RawlsBillingProjectName(projectId), ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))).map(_ => StatusCodes.OK)
+                userServiceConstructor(ctx)
+                  .addUserToBillingProject(RawlsBillingProjectName(projectId),
+                                           ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
+                  )
+                  .map(_ => StatusCodes.OK)
               }
             } ~
               delete {
                 complete {
-                  userServiceConstructor(ctx).removeUserFromBillingProject(RawlsBillingProjectName(projectId), ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))).map(_ => StatusCodes.OK)
+                  userServiceConstructor(ctx)
+                    .removeUserFromBillingProject(RawlsBillingProjectName(projectId),
+                                                  ProjectAccessUpdate(userEmail, ProjectRoles.withName(workbenchRole))
+                    )
+                    .map(_ => StatusCodes.OK)
                 }
               }
           }
@@ -52,7 +60,9 @@ trait BillingApiService extends UserInfoDirectives {
           post {
             entity(as[CreateRawlsBillingProjectFullRequest]) { createProjectRequest =>
               complete {
-                userServiceConstructor(ctx).startBillingProjectCreation(createProjectRequest).map(_ => StatusCodes.Created)
+                userServiceConstructor(ctx)
+                  .startBillingProjectCreation(createProjectRequest)
+                  .map(_ => StatusCodes.Created)
               }
             }
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -8,7 +8,11 @@ import akka.http.scaladsl.server.Directives._
 import io.opencensus.scala.akka.http.TracingDirective.traceRequest
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.entities.EntityService
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, AttributeUpdateOperationFormat, EntityUpdateDefinition}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AttributeUpdateOperation,
+  AttributeUpdateOperationFormat,
+  EntityUpdateDefinition
+}
 import org.broadinstitute.dsde.rawls.model.FilterOperators.And
 import org.broadinstitute.dsde.rawls.model.SortDirections.Ascending
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
@@ -36,41 +40,61 @@ trait EntityApiService extends UserInfoDirectives {
       parameters("dataReference".?, "billingProject".?) { (dataReferenceString, billingProjectString) =>
         val dataReference = dataReferenceString.map(DataReferenceName)
         val billingProject = billingProjectString.map(GoogleProjectId)
-        path("workspaces" / Segment / Segment / "entityQuery" / Segment) { (workspaceNamespace, workspaceName, entityType) =>
-          get {
-            parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?) { (page, pageSize, sortField, sortDirection, filterTerms, filterOperator) =>
-              parameterSeq { allParams =>
-                val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) => k -> Try(s.map(_.toInt)) }
-                val sortDirectionTry = sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
-                val operatorTry = filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
+        path("workspaces" / Segment / Segment / "entityQuery" / Segment) {
+          (workspaceNamespace, workspaceName, entityType) =>
+            get {
+              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?) {
+                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator) =>
+                  parameterSeq { allParams =>
+                    val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
+                      k -> Try(s.map(_.toInt))
+                    }
+                    val sortDirectionTry =
+                      sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
+                    val operatorTry =
+                      filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
 
-                val errors = toIntTries.collect {
-                  case (k, Failure(t)) => s"$k must be a positive integer"
-                  case (k, Success(Some(i))) if i <= 0 => s"$k must be a positive integer"
-                } ++ (if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty)
+                    val errors = toIntTries.collect {
+                      case (k, Failure(t))                 => s"$k must be a positive integer"
+                      case (k, Success(Some(i))) if i <= 0 => s"$k must be a positive integer"
+                    } ++ (if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty)
 
-                if (errors.isEmpty) {
-                  val entityQuery = EntityQuery(toIntTries("page").get.getOrElse(1), toIntTries("pageSize").get.getOrElse(10),
-                    sortField.getOrElse("name"), sortDirectionTry.get,
-                    filterTerms, operatorTry.get,
-                    WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"))
-                  complete {
-                    entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName), dataReference, entityType, entityQuery, billingProject)
+                    if (errors.isEmpty) {
+                      val entityQuery = EntityQuery(
+                        toIntTries("page").get.getOrElse(1),
+                        toIntTries("pageSize").get.getOrElse(10),
+                        sortField.getOrElse("name"),
+                        sortDirectionTry.get,
+                        filterTerms,
+                        operatorTry.get,
+                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
+                      )
+                      complete {
+                        entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                    dataReference,
+                                                                    entityType,
+                                                                    entityQuery,
+                                                                    billingProject
+                        )
+                      }
+                    } else {
+                      complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
+                    }
                   }
-                } else {
-                  complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
-                }
               }
             }
-          }
         } ~
           path("workspaces" / Segment / Segment / "entities") { (workspaceNamespace, workspaceName) =>
             get {
-              //if useCache param is unset or set to a value that won't coerce to a boolean, default to true
-              parameters('useCache.?) { (useCache) =>
+              // if useCache param is unset or set to a value that won't coerce to a boolean, default to true
+              parameters('useCache.?) { useCache =>
                 val useCacheBool = Try(useCache.getOrElse("true").toBoolean).getOrElse(true)
                 complete {
-                  entityServiceConstructor(ctx).entityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName), dataReference, None, useCacheBool)
+                  entityServiceConstructor(ctx).entityTypeMetadata(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                   dataReference,
+                                                                   None,
+                                                                   useCacheBool
+                  )
                 }
               }
             }
@@ -80,36 +104,51 @@ trait EntityApiService extends UserInfoDirectives {
               entity(as[Entity]) { entity =>
                 addLocationHeader(entity.path(WorkspaceName(workspaceNamespace, workspaceName))) {
                   complete {
-                    entityServiceConstructor(ctx).createEntity(WorkspaceName(workspaceNamespace, workspaceName), entity).map(StatusCodes.Created -> _)
+                    entityServiceConstructor(ctx)
+                      .createEntity(WorkspaceName(workspaceNamespace, workspaceName), entity)
+                      .map(StatusCodes.Created -> _)
                   }
                 }
               }
             }
           } ~
-          path("workspaces" / Segment / Segment / "entities" / Segment / Segment) { (workspaceNamespace, workspaceName, entityType, entityName) =>
-            get {
-              complete {
-                entityServiceConstructor(ctx).getEntity(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityName, dataReference, billingProject)
-              }
-            }
-          } ~
-          path("workspaces" / Segment / Segment / "entities" / Segment / Segment) { (workspaceNamespace, workspaceName, entityType, entityName) =>
-            patch {
-              entity(as[Array[AttributeUpdateOperation]]) { operations =>
+          path("workspaces" / Segment / Segment / "entities" / Segment / Segment) {
+            (workspaceNamespace, workspaceName, entityType, entityName) =>
+              get {
                 complete {
-                  entityServiceConstructor(ctx).updateEntity(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityName, operations)
+                  entityServiceConstructor(ctx).getEntity(WorkspaceName(workspaceNamespace, workspaceName),
+                                                          entityType,
+                                                          entityName,
+                                                          dataReference,
+                                                          billingProject
+                  )
                 }
               }
-            }
+          } ~
+          path("workspaces" / Segment / Segment / "entities" / Segment / Segment) {
+            (workspaceNamespace, workspaceName, entityType, entityName) =>
+              patch {
+                entity(as[Array[AttributeUpdateOperation]]) { operations =>
+                  complete {
+                    entityServiceConstructor(ctx).updateEntity(WorkspaceName(workspaceNamespace, workspaceName),
+                                                               entityType,
+                                                               entityName,
+                                                               operations
+                    )
+                  }
+                }
+              }
           } ~
           path("workspaces" / Segment / Segment / "entities" / "delete") { (workspaceNamespace, workspaceName) =>
             post {
               entity(as[Array[AttributeEntityReference]]) { entities =>
                 complete {
-                  entityServiceConstructor(ctx).deleteEntities(WorkspaceName(workspaceNamespace, workspaceName), entities, None, None).map {
-                    case entities if entities.isEmpty => StatusCodes.NoContent -> None
-                    case entities => StatusCodes.Conflict -> Option(entities)
-                  }
+                  entityServiceConstructor(ctx)
+                    .deleteEntities(WorkspaceName(workspaceNamespace, workspaceName), entities, None, None)
+                    .map {
+                      case entities if entities.isEmpty => StatusCodes.NoContent -> None
+                      case entities                     => StatusCodes.Conflict -> Option(entities)
+                    }
                 }
               }
             }
@@ -119,7 +158,13 @@ trait EntityApiService extends UserInfoDirectives {
               withSizeLimit(batchUpsertMaxBytes) {
                 entity(as[Array[EntityUpdateDefinition]]) { operations =>
                   complete {
-                    entityServiceConstructor(ctx).batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName), operations, dataReference, billingProject).map(_ => StatusCodes.NoContent)
+                    entityServiceConstructor(ctx)
+                      .batchUpsertEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                           operations,
+                                           dataReference,
+                                           billingProject
+                      )
+                      .map(_ => StatusCodes.NoContent)
                   }
                 }
               }
@@ -129,91 +174,138 @@ trait EntityApiService extends UserInfoDirectives {
             post {
               entity(as[Array[EntityUpdateDefinition]]) { operations =>
                 complete {
-                  entityServiceConstructor(ctx).batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName), operations, dataReference, billingProject).map(_ => StatusCodes.NoContent)
+                  entityServiceConstructor(ctx)
+                    .batchUpdateEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                         operations,
+                                         dataReference,
+                                         billingProject
+                    )
+                    .map(_ => StatusCodes.NoContent)
                 }
               }
             }
           } ~
-          path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "rename") { (workspaceNamespace, workspaceName, entityType, entityName) =>
-            post {
-              entity(as[EntityName]) { newEntityName =>
-                complete {
-                  entityServiceConstructor(ctx).renameEntity(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityName, newEntityName.name).map(_ => StatusCodes.NoContent)
-                }
-              }
-            }
-          } ~
-          path("workspaces" / Segment / Segment / "entityTypes" / Segment) { (workspaceNamespace, workspaceName, entityType) =>
-            patch {
-              entity(as[EntityTypeRename]) { rename =>
-                complete {
-                  entityServiceConstructor(ctx).renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), entityType, rename).map(_ => StatusCodes.NoContent)
-                }
-              }
-            } ~
-              delete {
-                complete {
-                  entityServiceConstructor(ctx).deleteEntitiesOfType(WorkspaceName(workspaceNamespace, workspaceName), entityType, None, None).map(_ => StatusCodes.NoContent)
+          path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "rename") {
+            (workspaceNamespace, workspaceName, entityType, entityName) =>
+              post {
+                entity(as[EntityName]) { newEntityName =>
+                  complete {
+                    entityServiceConstructor(ctx)
+                      .renameEntity(WorkspaceName(workspaceNamespace, workspaceName),
+                                    entityType,
+                                    entityName,
+                                    newEntityName.name
+                      )
+                      .map(_ => StatusCodes.NoContent)
+                  }
                 }
               }
           } ~
-          path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "evaluate") { (workspaceNamespace, workspaceName, entityType, entityName) =>
-            post {
-              entity(as[String]) { expression =>
-                complete {
-                  entityServiceConstructor(ctx).evaluateExpression(WorkspaceName(workspaceNamespace, workspaceName), entityType, entityName, expression)
+          path("workspaces" / Segment / Segment / "entityTypes" / Segment) {
+            (workspaceNamespace, workspaceName, entityType) =>
+              patch {
+                entity(as[EntityTypeRename]) { rename =>
+                  complete {
+                    entityServiceConstructor(ctx)
+                      .renameEntityType(WorkspaceName(workspaceNamespace, workspaceName), entityType, rename)
+                      .map(_ => StatusCodes.NoContent)
+                  }
+                }
+              } ~
+                delete {
+                  complete {
+                    entityServiceConstructor(ctx)
+                      .deleteEntitiesOfType(WorkspaceName(workspaceNamespace, workspaceName), entityType, None, None)
+                      .map(_ => StatusCodes.NoContent)
+                  }
+                }
+          } ~
+          path("workspaces" / Segment / Segment / "entities" / Segment / Segment / "evaluate") {
+            (workspaceNamespace, workspaceName, entityType, entityName) =>
+              post {
+                entity(as[String]) { expression =>
+                  complete {
+                    entityServiceConstructor(ctx).evaluateExpression(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                     entityType,
+                                                                     entityName,
+                                                                     expression
+                    )
+                  }
                 }
               }
-            }
           } ~
-          path("workspaces" / Segment / Segment / "entities" / Segment) { (workspaceNamespace, workspaceName, entityType) =>
-            get {
-              complete {
-                entityServiceConstructor(ctx).listEntities(WorkspaceName(workspaceNamespace, workspaceName), entityType)
-              }
-            } ~
-              delete {
-                parameterSeq { allParams =>
-                  def parseAttributeNames() = {
-                    val paramName = "attributeNames"
-                    WorkspaceFieldSpecs.fromQueryParams(allParams, paramName).fields match {
-                      case None => throw new RawlsExceptionWithErrorReport(ErrorReport(BadRequest, s"Parameter '$paramName' must be included.")(ErrorReportSource("rawls")))
-                      case Some(atts) => atts.toSet.map { (value: String) => AttributeName.fromDelimitedName(value.trim) }
+          path("workspaces" / Segment / Segment / "entities" / Segment) {
+            (workspaceNamespace, workspaceName, entityType) =>
+              get {
+                complete {
+                  entityServiceConstructor(ctx).listEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                                             entityType
+                  )
+                }
+              } ~
+                delete {
+                  parameterSeq { allParams =>
+                    def parseAttributeNames() = {
+                      val paramName = "attributeNames"
+                      WorkspaceFieldSpecs.fromQueryParams(allParams, paramName).fields match {
+                        case None =>
+                          throw new RawlsExceptionWithErrorReport(
+                            ErrorReport(BadRequest, s"Parameter '$paramName' must be included.")(
+                              ErrorReportSource("rawls")
+                            )
+                          )
+                        case Some(atts) =>
+                          atts.toSet.map((value: String) => AttributeName.fromDelimitedName(value.trim))
+                      }
+                    }
+
+                    complete {
+                      entityServiceConstructor(ctx)
+                        .deleteEntityAttributes(WorkspaceName(workspaceNamespace, workspaceName),
+                                                entityType,
+                                                parseAttributeNames()
+                        )
+                        .map(_ => StatusCodes.NoContent)
                     }
                   }
-
-                  complete {
-                    entityServiceConstructor(ctx).deleteEntityAttributes(WorkspaceName(workspaceNamespace, workspaceName), entityType, parseAttributeNames()).map(_ => StatusCodes.NoContent)
-                  }
                 }
-              }
           } ~
           path("workspaces" / "entities" / "copy") {
             post {
-              parameters('linkExistingEntities.?) { (linkExistingEntities) =>
+              parameters('linkExistingEntities.?) { linkExistingEntities =>
                 extractRequest { request =>
                   val linkExistingEntitiesBool = Try(linkExistingEntities.getOrElse("false").toBoolean).getOrElse(false)
                   entity(as[EntityCopyDefinition]) { copyDefinition =>
                     complete {
-                      entityServiceConstructor(ctx).copyEntities(copyDefinition, request.uri, linkExistingEntitiesBool).map { response =>
-                        if (response.hardConflicts.isEmpty && (response.softConflicts.isEmpty || linkExistingEntitiesBool)) StatusCodes.Created -> response
-                        else StatusCodes.Conflict -> response
-                      }
+                      entityServiceConstructor(ctx)
+                        .copyEntities(copyDefinition, request.uri, linkExistingEntitiesBool)
+                        .map { response =>
+                          if (
+                            response.hardConflicts.isEmpty && (response.softConflicts.isEmpty || linkExistingEntitiesBool)
+                          ) StatusCodes.Created -> response
+                          else StatusCodes.Conflict -> response
+                        }
                     }
                   }
                 }
               }
             }
           } ~
-          path("workspaces" / Segment / Segment / "entityTypes" / Segment / "attributes" / Segment) { (workspaceNamespace, workspaceName, entityType, attributeName) =>
-            patch {
-              entity(as[AttributeRename]) { attributeRenameRequest =>
-                complete {
-                  entityServiceConstructor(ctx).renameAttribute(WorkspaceName(workspaceNamespace, workspaceName),
-                    entityType, AttributeName.fromDelimitedName(attributeName), attributeRenameRequest).map(_ => StatusCodes.NoContent)
+          path("workspaces" / Segment / Segment / "entityTypes" / Segment / "attributes" / Segment) {
+            (workspaceNamespace, workspaceName, entityType, attributeName) =>
+              patch {
+                entity(as[AttributeRename]) { attributeRenameRequest =>
+                  complete {
+                    entityServiceConstructor(ctx)
+                      .renameAttribute(WorkspaceName(workspaceNamespace, workspaceName),
+                                       entityType,
+                                       AttributeName.fromDelimitedName(attributeName),
+                                       attributeRenameRequest
+                      )
+                      .map(_ => StatusCodes.NoContent)
+                  }
                 }
               }
-            }
           }
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/ServicePerimeterApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/ServicePerimeterApiService.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.webservice
 
-
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
@@ -27,7 +26,11 @@ trait ServicePerimeterApiService extends UserInfoDirectives {
       path("servicePerimeters" / Segment / "projects" / Segment) { (servicePerimeterName, projectId) =>
         put {
           complete {
-            userServiceConstructor(ctx).addProjectToServicePerimeter(ServicePerimeterName(URLDecoder.decode(servicePerimeterName, UTF_8.name)), RawlsBillingProjectName(projectId)).map(_ => StatusCodes.NoContent)
+            userServiceConstructor(ctx)
+              .addProjectToServicePerimeter(ServicePerimeterName(URLDecoder.decode(servicePerimeterName, UTF_8.name)),
+                                            RawlsBillingProjectName(projectId)
+              )
+              .map(_ => StatusCodes.NoContent)
           }
         }
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -27,45 +27,65 @@ trait SnapshotApiService extends UserInfoDirectives {
         post {
           entity(as[NamedDataRepoSnapshot]) { namedDataRepoSnapshot =>
             complete {
-              snapshotServiceConstructor(ctx).createSnapshot(WorkspaceName(workspaceNamespace, workspaceName), namedDataRepoSnapshot).map(StatusCodes.Created -> _)
+              snapshotServiceConstructor(ctx)
+                .createSnapshot(WorkspaceName(workspaceNamespace, workspaceName), namedDataRepoSnapshot)
+                .map(StatusCodes.Created -> _)
             }
           }
         } ~
           get {
             // N.B. the "as[UUID]" delegates to SnapshotService.validateSnapshotId, which is in scope;
             // that method provides a 400 Bad Request response and nice error message
-            parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) { (offset, limit, referencedSnapshotId) =>
-              complete {
-                snapshotServiceConstructor(ctx).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName), offset, limit, referencedSnapshotId)
-              }
+            parameters("offset".as[Int], "limit".as[Int], "referencedSnapshotId".as[UUID].optional) {
+              (offset, limit, referencedSnapshotId) =>
+                complete {
+                  snapshotServiceConstructor(ctx).enumerateSnapshots(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                     offset,
+                                                                     limit,
+                                                                     referencedSnapshotId
+                  )
+                }
             }
           }
       } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) { (workspaceNamespace, workspaceName, snapshotId) =>
-          get {
-            complete {
-              snapshotServiceConstructor(ctx).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId)
-            }
-          } ~
-            patch {
-              entity(as[UpdateDataRepoSnapshotReferenceRequestBody]) { updateDataRepoSnapshotReferenceRequestBody =>
-                complete {
-                  snapshotServiceConstructor(ctx).updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId, updateDataRepoSnapshotReferenceRequestBody).map(_ => StatusCodes.NoContent)
-                }
+        path("workspaces" / Segment / Segment / "snapshots" / "v2" / Segment) {
+          (workspaceNamespace, workspaceName, snapshotId) =>
+            get {
+              complete {
+                snapshotServiceConstructor(ctx).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName),
+                                                            snapshotId
+                )
               }
             } ~
-            delete {
+              patch {
+                entity(as[UpdateDataRepoSnapshotReferenceRequestBody]) { updateDataRepoSnapshotReferenceRequestBody =>
+                  complete {
+                    snapshotServiceConstructor(ctx)
+                      .updateSnapshot(WorkspaceName(workspaceNamespace, workspaceName),
+                                      snapshotId,
+                                      updateDataRepoSnapshotReferenceRequestBody
+                      )
+                      .map(_ => StatusCodes.NoContent)
+                  }
+                }
+              } ~
+              delete {
+                complete {
+                  snapshotServiceConstructor(ctx)
+                    .deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId)
+                    .map(_ => StatusCodes.NoContent)
+                }
+              }
+        } ~
+        path("workspaces" / Segment / Segment / "snapshots" / "v2" / "name" / Segment) {
+          (workspaceNamespace, workspaceName, referenceName) =>
+            get {
               complete {
-                snapshotServiceConstructor(ctx).deleteSnapshot(WorkspaceName(workspaceNamespace, workspaceName), snapshotId).map(_ => StatusCodes.NoContent)
+                snapshotServiceConstructor(ctx).getSnapshotByName(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                  referenceName
+                )
               }
             }
-        } ~
-        path("workspaces" / Segment / Segment / "snapshots" / "v2" / "name" / Segment) { (workspaceNamespace, workspaceName, referenceName) =>
-          get {
-            complete {
-              snapshotServiceConstructor(ctx).getSnapshotByName(WorkspaceName(workspaceNamespace, workspaceName), referenceName)
-            }
-          }
         }
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -26,7 +26,6 @@ trait SubmissionApiService extends UserInfoDirectives {
   val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService
   val submissionTimeout: FiniteDuration
 
-
   val submissionRoutes: server.Route = traceRequest { span =>
     requireUserInfo(Option(span)) { userInfo =>
       val ctx = RawlsRequestContext(userInfo, Option(span))
@@ -48,7 +47,9 @@ trait SubmissionApiService extends UserInfoDirectives {
           post {
             entity(as[SubmissionRequest]) { submission =>
               complete {
-                workspaceServiceConstructor(ctx).createSubmission(WorkspaceName(workspaceNamespace, workspaceName), submission).map(StatusCodes.Created -> _)
+                workspaceServiceConstructor(ctx)
+                  .createSubmission(WorkspaceName(workspaceNamespace, workspaceName), submission)
+                  .map(StatusCodes.Created -> _)
               }
             }
           }
@@ -57,70 +58,116 @@ trait SubmissionApiService extends UserInfoDirectives {
           post {
             entity(as[SubmissionRequest]) { submission =>
               complete {
-                workspaceServiceConstructor(ctx).validateSubmission(WorkspaceName(workspaceNamespace, workspaceName), submission)
+                workspaceServiceConstructor(ctx).validateSubmission(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                    submission
+                )
               }
             }
           }
         } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment) { (workspaceNamespace, workspaceName, submissionId) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx).getSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment) { (workspaceNamespace, workspaceName, submissionId) =>
-          patch {
-            entity(as[UserCommentUpdateOperation]) { newComment =>
+        path("workspaces" / Segment / Segment / "submissions" / Segment) {
+          (workspaceNamespace, workspaceName, submissionId) =>
+            get {
               complete {
-                workspaceServiceConstructor(ctx).updateSubmissionUserComment(WorkspaceName(workspaceNamespace, workspaceName), submissionId, newComment).map { rowsUpdated =>
-                  if (rowsUpdated == 1) StatusCodes.NoContent -> None
-                  else StatusCodes.NotFound -> Option(ErrorReport(StatusCodes.NotFound, s"Unable to update userComment for submission. Submission ${submissionId} could not be found."))
+                workspaceServiceConstructor(ctx).getSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                     submissionId
+                )
+              }
+            }
+        } ~
+        path("workspaces" / Segment / Segment / "submissions" / Segment) {
+          (workspaceNamespace, workspaceName, submissionId) =>
+            patch {
+              entity(as[UserCommentUpdateOperation]) { newComment =>
+                complete {
+                  workspaceServiceConstructor(ctx)
+                    .updateSubmissionUserComment(WorkspaceName(workspaceNamespace, workspaceName),
+                                                 submissionId,
+                                                 newComment
+                    )
+                    .map { rowsUpdated =>
+                      if (rowsUpdated == 1) StatusCodes.NoContent -> None
+                      else
+                        StatusCodes.NotFound -> Option(
+                          ErrorReport(
+                            StatusCodes.NotFound,
+                            s"Unable to update userComment for submission. Submission ${submissionId} could not be found."
+                          )
+                        )
+                    }
                 }
               }
             }
-          }
         } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment) { (workspaceNamespace, workspaceName, submissionId) =>
-          delete {
-            complete {
-              workspaceServiceConstructor(ctx).abortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId).map { count =>
-                if (count == 1) StatusCodes.NoContent -> None
-                else StatusCodes.NotFound -> Option(s"Unable to abort submission. Submission ${submissionId} could not be found.")
-              }
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "configuration") { (workspaceNamespace, workspaceName, submissionId) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx).getSubmissionMethodConfiguration(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
-            }
-          }
-        } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment) { (workspaceNamespace, workspaceName, submissionId, workflowId) =>
-          get {
-            parameters("includeKey".as[String].*, "excludeKey".as[String].*, "expandSubWorkflows".as[Boolean] ? false) { (includes, excludes, expandSubWorkflows) =>
+        path("workspaces" / Segment / Segment / "submissions" / Segment) {
+          (workspaceNamespace, workspaceName, submissionId) =>
+            delete {
               complete {
-                workspaceServiceConstructor(ctx).workflowMetadata(WorkspaceName(workspaceNamespace, workspaceName),
-                  submissionId, workflowId, MetadataParams(includes.toSet, excludes.toSet, expandSubWorkflows))
+                workspaceServiceConstructor(ctx)
+                  .abortSubmission(WorkspaceName(workspaceNamespace, workspaceName), submissionId)
+                  .map { count =>
+                    if (count == 1) StatusCodes.NoContent -> None
+                    else
+                      StatusCodes.NotFound -> Option(
+                        s"Unable to abort submission. Submission ${submissionId} could not be found."
+                      )
+                  }
               }
             }
-          }
         } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "outputs") { (workspaceNamespace, workspaceName, submissionId, workflowId) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx).workflowOutputs(WorkspaceName(workspaceNamespace, workspaceName), submissionId, workflowId)
+        path("workspaces" / Segment / Segment / "submissions" / Segment / "configuration") {
+          (workspaceNamespace, workspaceName, submissionId) =>
+            get {
+              complete {
+                workspaceServiceConstructor(ctx).getSubmissionMethodConfiguration(WorkspaceName(workspaceNamespace,
+                                                                                                workspaceName
+                                                                                  ),
+                                                                                  submissionId
+                )
+              }
             }
-          }
         } ~
-        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "cost") { (workspaceNamespace, workspaceName, submissionId, workflowId) =>
-          get {
-            complete {
-              workspaceServiceConstructor(ctx).workflowCost(WorkspaceName(workspaceNamespace, workspaceName), submissionId, workflowId)
+        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment) {
+          (workspaceNamespace, workspaceName, submissionId, workflowId) =>
+            get {
+              parameters("includeKey".as[String].*,
+                         "excludeKey".as[String].*,
+                         "expandSubWorkflows".as[Boolean] ? false
+              ) { (includes, excludes, expandSubWorkflows) =>
+                complete {
+                  workspaceServiceConstructor(ctx).workflowMetadata(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                    submissionId,
+                                                                    workflowId,
+                                                                    MetadataParams(includes.toSet,
+                                                                                   excludes.toSet,
+                                                                                   expandSubWorkflows
+                                                                    )
+                  )
+                }
+              }
             }
-          }
+        } ~
+        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "outputs") {
+          (workspaceNamespace, workspaceName, submissionId, workflowId) =>
+            get {
+              complete {
+                workspaceServiceConstructor(ctx).workflowOutputs(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                 submissionId,
+                                                                 workflowId
+                )
+              }
+            }
+        } ~
+        path("workspaces" / Segment / Segment / "submissions" / Segment / "workflows" / Segment / "cost") {
+          (workspaceNamespace, workspaceName, submissionId, workflowId) =>
+            get {
+              complete {
+                workspaceServiceConstructor(ctx).workflowCost(WorkspaceName(workspaceNamespace, workspaceName),
+                                                              submissionId,
+                                                              workflowId
+                )
+              }
+            }
         } ~
         path("workflows" / Segment / "genomics" / Segments) { (workflowId, operationId) =>
           get {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/UserApiService.scala
@@ -42,7 +42,7 @@ trait UserApiService extends UserInfoDirectives {
                 import spray.json._
                 userServiceConstructor(ctx).getBillingProjectStatus(RawlsBillingProjectName(projectName)).map {
                   case Some(status) => StatusCodes.OK -> Option(status).toJson
-                  case _ => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
+                  case _            => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
                 }
               }
             }
@@ -50,7 +50,9 @@ trait UserApiService extends UserInfoDirectives {
           path(Segment) { projectName =>
             delete {
               complete {
-                userServiceConstructor(ctx).deleteBillingProject(RawlsBillingProjectName(projectName)).map(_ => StatusCodes.NoContent)
+                userServiceConstructor(ctx)
+                  .deleteBillingProject(RawlsBillingProjectName(projectName))
+                  .map(_ => StatusCodes.NoContent)
               }
             }
           }
@@ -59,7 +61,7 @@ trait UserApiService extends UserInfoDirectives {
           get {
             complete {
               userServiceConstructor(ctx).isAdmin(userInfo.userEmail).map {
-                case true => StatusCodes.OK
+                case true  => StatusCodes.OK
                 case false => StatusCodes.NotFound
               }
             }
@@ -69,7 +71,7 @@ trait UserApiService extends UserInfoDirectives {
           get {
             complete {
               userServiceConstructor(ctx).isLibraryCurator(userInfo.userEmail).map {
-                case true => StatusCodes.OK
+                case true  => StatusCodes.OK
                 case false => StatusCodes.NotFound
               }
             }
@@ -77,7 +79,7 @@ trait UserApiService extends UserInfoDirectives {
         } ~
         path("user" / "billingAccounts") {
           get {
-            parameters("firecloudHasAccess".as[Boolean].optional) { (firecloudHasAccess) =>
+            parameters("firecloudHasAccess".as[Boolean].optional) { firecloudHasAccess =>
               complete {
                 userServiceConstructor(ctx).listBillingAccounts(firecloudHasAccess)
               }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -800,8 +800,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         workspace <- getWorkspaceContext(workspaceName) flatMap { workspace =>
           withLibraryPermissions(workspace, operations, ctx.userInfo, isCurator) {
             dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))(
-              dataAccess =>
-                updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName),
+              dataAccess => updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName),
               TransactionIsolation.ReadCommitted
             ) // read committed to avoid deadlocks on workspace attr scratch table
           }
@@ -817,8 +816,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       for {
         workspace <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write)
         workspace <- dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))(
-          dataAccess =>
-            updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName),
+          dataAccess => updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName),
           TransactionIsolation.ReadCommitted
         ) // read committed to avoid deadlocks on workspace attr scratch table
         authDomain <- loadResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx.userInfo)
@@ -1104,7 +1102,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                               }
                             }
                           }
-                    },
+                      },
                     TransactionIsolation.ReadCommitted
                   )
                   // read committed to avoid deadlocks on workspace attr scratch table

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.startSpanWithParent
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
-import io.opencensus.trace.{Span, Status, AttributeValue => OpenCensusAttributeValue}
+import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span, Status}
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls._
 import slick.jdbc.TransactionIsolation
@@ -44,7 +44,13 @@ import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
-import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchException, WorkbenchGroupName, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{
+  Notifications,
+  WorkbenchEmail,
+  WorkbenchException,
+  WorkbenchGroupName,
+  WorkbenchUserId
+}
 import org.broadinstitute.dsde.workbench.model.Notifications.{WorkspaceName => NotificationWorkspaceName}
 import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol._
@@ -62,28 +68,64 @@ import scala.util.{Failure, Success, Try}
  */
 //noinspection TypeAnnotation
 object WorkspaceService {
-  def constructor(dataSource: SlickDataSource, methodRepoDAO: MethodRepoDAO, cromiamDAO: ExecutionServiceDAO,
-                  executionServiceCluster: ExecutionServiceCluster, execServiceBatchSize: Int, workspaceManagerDAO: WorkspaceManagerDAO,
-                  methodConfigResolver: MethodConfigResolver, gcsDAO: GoogleServicesDAO, samDAO: SamDAO,
-                  notificationDAO: NotificationDAO, userServiceConstructor: RawlsRequestContext => UserService,
-                  genomicsServiceConstructor: RawlsRequestContext => GenomicsService, maxActiveWorkflowsTotal: Int,
-                  maxActiveWorkflowsPerUser: Int, workbenchMetricBaseName: String, submissionCostService: SubmissionCostService,
-                  config: WorkspaceServiceConfig, requesterPaysSetupService: RequesterPaysSetupService,
-                  entityManager: EntityManager, resourceBufferService: ResourceBufferService, resourceBufferSaEmail: String,
+  def constructor(dataSource: SlickDataSource,
+                  methodRepoDAO: MethodRepoDAO,
+                  cromiamDAO: ExecutionServiceDAO,
+                  executionServiceCluster: ExecutionServiceCluster,
+                  execServiceBatchSize: Int,
+                  workspaceManagerDAO: WorkspaceManagerDAO,
+                  methodConfigResolver: MethodConfigResolver,
+                  gcsDAO: GoogleServicesDAO,
+                  samDAO: SamDAO,
+                  notificationDAO: NotificationDAO,
+                  userServiceConstructor: RawlsRequestContext => UserService,
+                  genomicsServiceConstructor: RawlsRequestContext => GenomicsService,
+                  maxActiveWorkflowsTotal: Int,
+                  maxActiveWorkflowsPerUser: Int,
+                  workbenchMetricBaseName: String,
+                  submissionCostService: SubmissionCostService,
+                  config: WorkspaceServiceConfig,
+                  requesterPaysSetupService: RequesterPaysSetupService,
+                  entityManager: EntityManager,
+                  resourceBufferService: ResourceBufferService,
+                  resourceBufferSaEmail: String,
                   servicePerimeterService: ServicePerimeterService,
-                  googleIamDao: GoogleIamDAO, terraBillingProjectOwnerRole: String, terraWorkspaceCanComputeRole: String, terraWorkspaceNextflowRole: String)
-                 (ctx: RawlsRequestContext)
-                 (implicit materializer: Materializer, executionContext: ExecutionContext): WorkspaceService = {
-
-    new WorkspaceService(ctx, dataSource, entityManager, methodRepoDAO, cromiamDAO,
-      executionServiceCluster, execServiceBatchSize, workspaceManagerDAO,
-      methodConfigResolver, gcsDAO, samDAO,
-      notificationDAO, userServiceConstructor,
-      genomicsServiceConstructor, maxActiveWorkflowsTotal,
-      maxActiveWorkflowsPerUser, workbenchMetricBaseName, submissionCostService,
-      config, requesterPaysSetupService, resourceBufferService, resourceBufferSaEmail, servicePerimeterService,
-      googleIamDao, terraBillingProjectOwnerRole, terraWorkspaceCanComputeRole, terraWorkspaceNextflowRole)
-  }
+                  googleIamDao: GoogleIamDAO,
+                  terraBillingProjectOwnerRole: String,
+                  terraWorkspaceCanComputeRole: String,
+                  terraWorkspaceNextflowRole: String
+  )(
+    ctx: RawlsRequestContext
+  )(implicit materializer: Materializer, executionContext: ExecutionContext): WorkspaceService =
+    new WorkspaceService(
+      ctx,
+      dataSource,
+      entityManager,
+      methodRepoDAO,
+      cromiamDAO,
+      executionServiceCluster,
+      execServiceBatchSize,
+      workspaceManagerDAO,
+      methodConfigResolver,
+      gcsDAO,
+      samDAO,
+      notificationDAO,
+      userServiceConstructor,
+      genomicsServiceConstructor,
+      maxActiveWorkflowsTotal,
+      maxActiveWorkflowsPerUser,
+      workbenchMetricBaseName,
+      submissionCostService,
+      config,
+      requesterPaysSetupService,
+      resourceBufferService,
+      resourceBufferSaEmail,
+      servicePerimeterService,
+      googleIamDao,
+      terraBillingProjectOwnerRole,
+      terraWorkspaceCanComputeRole,
+      terraWorkspaceNextflowRole
+    )
 
   val SECURITY_LABEL_KEY = "security"
   val HIGH_SECURITY_LABEL = "high"
@@ -96,7 +138,10 @@ object WorkspaceService {
     implicit val opMetadataFormat = jsonFormat1(OpMetadata)
 
     for {
-      calls <- metadataJson.convertTo[OpMetadata].calls.toList // toList on the Option makes the compiler like the for comp
+      calls <- metadataJson
+        .convertTo[OpMetadata]
+        .calls
+        .toList // toList on the Option makes the compiler like the for comp
       call <- calls.values.flatten
       jobId <- call.jobId
     } yield jobId
@@ -104,11 +149,12 @@ object WorkspaceService {
 
   private[workspace] def getTerminalStatusDate(submission: Submission, workflowID: Option[String]): Option[DateTime] = {
     // find all workflows that have finished
-    val terminalWorkflows = submission.workflows.filter(workflow => WorkflowStatuses.terminalStatuses.contains(workflow.status))
+    val terminalWorkflows =
+      submission.workflows.filter(workflow => WorkflowStatuses.terminalStatuses.contains(workflow.status))
     // optionally limit the list to a specific workflowID
     val workflows = workflowID match {
       case Some(_) => terminalWorkflows.filter(_.workflowId == workflowID)
-      case None => terminalWorkflows
+      case None    => terminalWorkflows
     }
     if (workflows.isEmpty) {
       None
@@ -130,7 +176,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                        val workspaceManagerDAO: WorkspaceManagerDAO,
                        val methodConfigResolver: MethodConfigResolver,
                        protected val gcsDAO: GoogleServicesDAO,
-                       val samDAO: SamDAO, notificationDAO: NotificationDAO,
+                       val samDAO: SamDAO,
+                       notificationDAO: NotificationDAO,
                        userServiceConstructor: RawlsRequestContext => UserService,
                        genomicsServiceConstructor: RawlsRequestContext => GenomicsService,
                        maxActiveWorkflowsTotal: Int,
@@ -145,19 +192,20 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                        googleIamDao: GoogleIamDAO,
                        terraBillingProjectOwnerRole: String,
                        terraWorkspaceCanComputeRole: String,
-                       terraWorkspaceNextflowRole: String)
-                      (implicit protected val executionContext: ExecutionContext) extends RoleSupport
-  with LibraryPermissionsSupport
-  with FutureSupport
-  with MethodWiths
-  with UserWiths
-  with LazyLogging
-  with RawlsInstrumented
-  with JsonFilterUtils
-  with WorkspaceSupport
-  with EntitySupport
-  with AttributeSupport
-  with StringValidationUtils {
+                       terraWorkspaceNextflowRole: String
+)(implicit protected val executionContext: ExecutionContext)
+    extends RoleSupport
+    with LibraryPermissionsSupport
+    with FutureSupport
+    with MethodWiths
+    with UserWiths
+    with LazyLogging
+    with RawlsInstrumented
+    with JsonFilterUtils
+    with WorkspaceSupport
+    with EntitySupport
+    with AttributeSupport
+    with StringValidationUtils {
 
   import dataSource.dataAccess.driver.api._
 
@@ -167,22 +215,36 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   // If it is changed, it must also be updated in that repository.
   private val UserCommentMaxLength: Int = 1000
 
-  def createWorkspace(workspaceRequest: WorkspaceRequest, parentContext: RawlsRequestContext = ctx): Future[Workspace] = {
-    traceWithParent("withAttributeNamespaceCheck", parentContext)(s1 => withAttributeNamespaceCheck(workspaceRequest) {
-      traceWithParent("withWorkspaceBucketRegionCheck", s1)(s2 => withWorkspaceBucketRegionCheck(workspaceRequest.bucketLocation) {
-        traceWithParent("withBillingProjectContext", s1)(s2 => withBillingProjectContext(workspaceRequest.namespace, s2) { billingProject =>
-          for {
-            workspace <- traceWithParent("withNewWorkspaceContext", s2)(s3 => dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))({ dataAccess =>
-              withNewWorkspaceContext(workspaceRequest, billingProject, sourceBucketName = None, dataAccess, s3) { workspaceContext =>
-                createdWorkspaceCounter.inc()
-                DBIO.successful(workspaceContext)
+  def createWorkspace(workspaceRequest: WorkspaceRequest, parentContext: RawlsRequestContext = ctx): Future[Workspace] =
+    traceWithParent("withAttributeNamespaceCheck", parentContext)(s1 =>
+      withAttributeNamespaceCheck(workspaceRequest) {
+        traceWithParent("withWorkspaceBucketRegionCheck", s1)(s2 =>
+          withWorkspaceBucketRegionCheck(workspaceRequest.bucketLocation) {
+            traceWithParent("withBillingProjectContext", s1)(s2 =>
+              withBillingProjectContext(workspaceRequest.namespace, s2) { billingProject =>
+                for {
+                  workspace <- traceWithParent("withNewWorkspaceContext", s2)(s3 =>
+                    dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))(
+                      dataAccess =>
+                        withNewWorkspaceContext(workspaceRequest,
+                                                billingProject,
+                                                sourceBucketName = None,
+                                                dataAccess,
+                                                s3
+                        ) { workspaceContext =>
+                          createdWorkspaceCounter.inc()
+                          DBIO.successful(workspaceContext)
+                        },
+                      TransactionIsolation.ReadCommitted
+                    )
+                  ) // read committed to avoid deadlocks on workspace attr scratch table
+                } yield workspace
               }
-            }, TransactionIsolation.ReadCommitted)) // read committed to avoid deadlocks on workspace attr scratch table
-          } yield workspace
-        })
-      })
-    })
-  }
+            )
+          }
+        )
+      }
+    )
 
   /** Returns the Set of legal field names supplied by the user, trimmed of whitespace.
     * Throws an error if the user supplied an unrecognized field name.
@@ -205,13 +267,16 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     args
   }
 
-  def getWorkspace(workspaceName: WorkspaceName, params: WorkspaceFieldSpecs, parentContext: RawlsRequestContext = ctx): Future[JsObject] = {
+  def getWorkspace(workspaceName: WorkspaceName,
+                   params: WorkspaceFieldSpecs,
+                   parentContext: RawlsRequestContext = ctx
+  ): Future[JsObject] = {
     val span = startSpanWithParent("optionsProcessing", parentContext.tracingSpan.orNull)
 
     // validate the inbound parameters
     val options = Try(validateParams(params, WorkspaceFieldNames.workspaceResponseFieldNames)) match {
       case Success(opts) => opts
-      case Failure(ex) => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, ex))
+      case Failure(ex)   => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, ex))
     }
 
     // dummy function that returns a Future(None)
@@ -220,133 +285,171 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     // if user requested the entire attributes map, or any individual attributes, retrieve attributes.
     val attrSpecs = WorkspaceAttributeSpecs(
       options.contains("workspace.attributes"),
-      options.filter(_.startsWith("workspace.attributes."))
-        .map(str => AttributeName.fromDelimitedName(str.replaceFirst("workspace.attributes.",""))).toList
+      options
+        .filter(_.startsWith("workspace.attributes."))
+        .map(str => AttributeName.fromDelimitedName(str.replaceFirst("workspace.attributes.", "")))
+        .toList
     )
     span.setStatus(Status.OK)
     span.end()
 
-    traceWithParent("getWorkspaceContextAndPermissions", parentContext)(s1 => getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Option(attrSpecs)) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        val azureInfo: Option[AzureManagedAppCoordinates] = getAzureCloudContextFromWorkspaceManager(workspaceContext, s1)
+    traceWithParent("getWorkspaceContextAndPermissions", parentContext)(s1 =>
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Option(attrSpecs)) flatMap {
+        workspaceContext =>
+          dataSource.inTransaction { dataAccess =>
+            val azureInfo: Option[AzureManagedAppCoordinates] =
+              getAzureCloudContextFromWorkspaceManager(workspaceContext, s1)
 
-        // maximum access level is required to calculate canCompute and canShare. Therefore, if any of
-        // accessLevel, canCompute, canShare is specified, we have to get it.
-        def accessLevelFuture(): Future[WorkspaceAccessLevels.WorkspaceAccessLevel] =
-          if (options.contains("accessLevel") || options.contains("canCompute") || options.contains("canShare")) {
-            getMaximumAccessLevel(workspaceContext.workspaceIdAsUUID.toString)
-          } else {
-            Future.successful(WorkspaceAccessLevels.NoAccess)
-          }
+            // maximum access level is required to calculate canCompute and canShare. Therefore, if any of
+            // accessLevel, canCompute, canShare is specified, we have to get it.
+            def accessLevelFuture(): Future[WorkspaceAccessLevels.WorkspaceAccessLevel] =
+              if (options.contains("accessLevel") || options.contains("canCompute") || options.contains("canShare")) {
+                getMaximumAccessLevel(workspaceContext.workspaceIdAsUUID.toString)
+              } else {
+                Future.successful(WorkspaceAccessLevels.NoAccess)
+              }
 
-        // determine whether or not to retrieve attributes
-        val useAttributes = options.contains("workspace") || attrSpecs.all || attrSpecs.attrsToSelect.nonEmpty
+            // determine whether or not to retrieve attributes
+            val useAttributes = options.contains("workspace") || attrSpecs.all || attrSpecs.attrsToSelect.nonEmpty
 
-        traceDBIOWithParent("accessLevelFuture", s1)(s2 => DBIO.from(accessLevelFuture())) flatMap { accessLevel =>
-          // we may have calculated accessLevel because canShare/canCompute needs it;
-          // but if the user didn't ask for it, don't return it
-          val optionalAccessLevelForResponse = if (options.contains("accessLevel")) { Option(accessLevel) } else { None }
+            traceDBIOWithParent("accessLevelFuture", s1)(s2 => DBIO.from(accessLevelFuture())) flatMap { accessLevel =>
+              // we may have calculated accessLevel because canShare/canCompute needs it;
+              // but if the user didn't ask for it, don't return it
+              val optionalAccessLevelForResponse = if (options.contains("accessLevel")) { Option(accessLevel) }
+              else { None }
 
-          // determine which functions to use for the various part of the response
-          def bucketOptionsFuture(): Future[Option[WorkspaceBucketOptions]] = if (options.contains("bucketOptions")) {
-            azureInfo match {
-              case None => traceWithParent("getBucketDetails", s1)(_ => gcsDAO.getBucketDetails(workspaceContext.bucketName, workspaceContext.googleProjectId).map(Option(_)))
-              case _ => noFuture
+              // determine which functions to use for the various part of the response
+              def bucketOptionsFuture(): Future[Option[WorkspaceBucketOptions]] =
+                if (options.contains("bucketOptions")) {
+                  azureInfo match {
+                    case None =>
+                      traceWithParent("getBucketDetails", s1)(_ =>
+                        gcsDAO
+                          .getBucketDetails(workspaceContext.bucketName, workspaceContext.googleProjectId)
+                          .map(Option(_))
+                      )
+                    case _ => noFuture
+                  }
+                } else {
+                  noFuture
+                }
+              def canComputeFuture(): Future[Option[Boolean]] = if (options.contains("canCompute")) {
+                traceWithParent("getUserComputePermissions", s1)(_ =>
+                  getUserComputePermissions(workspaceContext.workspaceIdAsUUID.toString, accessLevel).map(Option(_))
+                )
+              } else {
+                noFuture
+              }
+              def canShareFuture(): Future[Option[Boolean]] = if (options.contains("canShare")) {
+                // convoluted but accessLevel for both params because user could at most share with their own access level
+                traceWithParent("getUserSharePermissions", s1)(_ =>
+                  getUserSharePermissions(workspaceContext.workspaceIdAsUUID.toString, accessLevel, accessLevel)
+                    .map(Option(_))
+                )
+              } else {
+                noFuture
+              }
+              def catalogFuture(): Future[Option[Boolean]] = if (options.contains("catalog")) {
+                traceWithParent("getUserCatalogPermissions", s1)(_ =>
+                  getUserCatalogPermissions(workspaceContext.workspaceIdAsUUID.toString).map(Option(_))
+                )
+              } else {
+                noFuture
+              }
+
+              def ownersFuture(): Future[Option[Set[String]]] = if (options.contains("owners")) {
+                traceWithParent("getWorkspaceOwners", s1)(_ =>
+                  getWorkspaceOwners(workspaceContext.workspaceIdAsUUID.toString).map(_.map(_.value)).map(Option(_))
+                )
+              } else {
+                noFuture
+              }
+
+              def workspaceAuthorizationDomainFuture(): Future[Option[Set[ManagedGroupRef]]] =
+                if (options.contains("workspace.authorizationDomain") || options.contains("workspace")) {
+                  traceWithParent("loadResourceAuthDomain", s1)(_ =>
+                    loadResourceAuthDomain(SamResourceTypeNames.workspace, workspaceContext.workspaceId, ctx.userInfo)
+                      .map(Option(_))
+                  )
+                } else {
+                  noFuture
+                }
+
+              def workspaceSubmissionStatsFuture(): slick.ReadAction[Option[WorkspaceSubmissionStats]] =
+                if (options.contains("workspaceSubmissionStats")) {
+                  getWorkspaceSubmissionStats(workspaceContext, dataAccess).map(Option(_))
+                } else {
+                  DBIO.from(noFuture)
+                }
+
+              // run these futures in parallel. this is equivalent to running the for-comp with the futures already defined and running
+              val futuresInParallel = (
+                catalogFuture(),
+                canShareFuture(),
+                canComputeFuture(),
+                ownersFuture(),
+                workspaceAuthorizationDomainFuture(),
+                bucketOptionsFuture()
+              ).tupled
+
+              for {
+                (canCatalog, canShare, canCompute, owners, authDomain, bucketDetails) <- DBIO.from(futuresInParallel)
+                stats <- traceDBIOWithParent("workspaceSubmissionStatsFuture", s1)(_ =>
+                  workspaceSubmissionStatsFuture()
+                )
+              } yield {
+                // post-process JSON to remove calculated-but-undesired keys
+                val workspaceResponse = WorkspaceResponse(
+                  optionalAccessLevelForResponse,
+                  canShare,
+                  canCompute,
+                  canCatalog,
+                  WorkspaceDetails.fromWorkspaceAndOptions(workspaceContext, authDomain, useAttributes),
+                  stats,
+                  bucketDetails,
+                  owners,
+                  azureInfo
+                )
+                val filteredJson = deepFilterJsObject(workspaceResponse.toJson.asJsObject, options)
+                filteredJson
+              }
             }
-          } else {
-            noFuture
           }
-          def canComputeFuture(): Future[Option[Boolean]] = if (options.contains("canCompute")) {
-            traceWithParent("getUserComputePermissions",s1)(_ =>  getUserComputePermissions(workspaceContext.workspaceIdAsUUID.toString, accessLevel).map(Option(_)))
-          } else {
-            noFuture
-          }
-          def canShareFuture(): Future[Option[Boolean]] = if (options.contains("canShare")) {
-            //convoluted but accessLevel for both params because user could at most share with their own access level
-            traceWithParent("getUserSharePermissions",s1)(_ =>  getUserSharePermissions(workspaceContext.workspaceIdAsUUID.toString, accessLevel, accessLevel).map(Option(_)))
-          } else {
-            noFuture
-          }
-          def catalogFuture(): Future[Option[Boolean]] = if (options.contains("catalog")) {
-            traceWithParent("getUserCatalogPermissions",s1)(_ =>  getUserCatalogPermissions(workspaceContext.workspaceIdAsUUID.toString).map(Option(_)))
-          } else {
-            noFuture
-          }
-
-          def ownersFuture(): Future[Option[Set[String]]] = if (options.contains("owners")) {
-            traceWithParent("getWorkspaceOwners",s1)(_ =>  getWorkspaceOwners(workspaceContext.workspaceIdAsUUID.toString).map(_.map(_.value)).map(Option(_)))
-          } else {
-            noFuture
-          }
-
-          def workspaceAuthorizationDomainFuture(): Future[Option[Set[ManagedGroupRef]]] = if (options.contains("workspace.authorizationDomain") || options.contains("workspace")) {
-            traceWithParent("loadResourceAuthDomain",s1)(_ =>  loadResourceAuthDomain(SamResourceTypeNames.workspace, workspaceContext.workspaceId, ctx.userInfo).map(Option(_)))
-          } else {
-            noFuture
-          }
-
-          def workspaceSubmissionStatsFuture(): slick.ReadAction[Option[WorkspaceSubmissionStats]] = if (options.contains("workspaceSubmissionStats")) {
-            getWorkspaceSubmissionStats(workspaceContext, dataAccess).map(Option(_))
-          } else {
-            DBIO.from(noFuture)
-          }
-
-          //run these futures in parallel. this is equivalent to running the for-comp with the futures already defined and running
-          val futuresInParallel = (
-            catalogFuture(),
-            canShareFuture(),
-            canComputeFuture(),
-            ownersFuture(),
-            workspaceAuthorizationDomainFuture(),
-            bucketOptionsFuture()
-          ).tupled
-
-          for {
-            (canCatalog, canShare, canCompute, owners, authDomain, bucketDetails) <- DBIO.from(futuresInParallel)
-            stats <- traceDBIOWithParent("workspaceSubmissionStatsFuture", s1)(_ => workspaceSubmissionStatsFuture())
-          } yield {
-            // post-process JSON to remove calculated-but-undesired keys
-            val workspaceResponse = WorkspaceResponse(
-              optionalAccessLevelForResponse,
-              canShare,
-              canCompute,
-              canCatalog,
-              WorkspaceDetails.fromWorkspaceAndOptions(workspaceContext, authDomain, useAttributes),
-              stats,
-              bucketDetails,
-              owners,
-              azureInfo)
-            val filteredJson = deepFilterJsObject(workspaceResponse.toJson.asJsObject, options)
-            filteredJson
-          }
-        }
       }
-    })
+    )
   }
 
-  private def getAzureCloudContextFromWorkspaceManager(workspaceContext: Workspace, parentContext: RawlsRequestContext) = {
+  private def getAzureCloudContextFromWorkspaceManager(workspaceContext: Workspace,
+                                                       parentContext: RawlsRequestContext
+  ) =
     workspaceContext.workspaceType match {
-      case WorkspaceType.McWorkspace => {
+      case WorkspaceType.McWorkspace =>
         val span = startSpanWithParent("getWorkspaceFromWorkspaceManager", parentContext.tracingSpan.orNull)
 
         try {
           val wsmInfo = workspaceManagerDAO.getWorkspace(workspaceContext.workspaceIdAsUUID, ctx)
 
           Option(wsmInfo.getAzureContext) match {
-            case Some(azureContext) => Some(AzureManagedAppCoordinates(
-              UUID.fromString(azureContext.getTenantId),
-              UUID.fromString(azureContext.getSubscriptionId),
-              azureContext.getResourceGroupId)
-            )
-            case None => {
-                throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(
-                  StatusCodes.NotImplemented, s"Non-azure MC workspaces not supported [id=${workspaceContext.workspaceId}]"
-              ))
-            }
+            case Some(azureContext) =>
+              Some(
+                AzureManagedAppCoordinates(UUID.fromString(azureContext.getTenantId),
+                                           UUID.fromString(azureContext.getSubscriptionId),
+                                           azureContext.getResourceGroupId
+                )
+              )
+            case None =>
+              throw new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.NotImplemented,
+                  s"Non-azure MC workspaces not supported [id=${workspaceContext.workspaceId}]"
+                )
+              )
           }
         } catch {
           case e: ApiException =>
-            logger.warn(s"Error retrieving MC workspace from workspace manager [id=${workspaceContext.workspaceId}, code=${e.getCode}]")
+            logger.warn(
+              s"Error retrieving MC workspace from workspace manager [id=${workspaceContext.workspaceId}, code=${e.getCode}]"
+            )
 
             if (e.getCode == StatusCodes.NotFound.intValue) {
               span.setStatus(Status.NOT_FOUND)
@@ -355,18 +458,19 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
               span.setStatus(Status.INTERNAL)
               throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(e.getCode, e))
             }
-        } finally {
+        } finally
           span.end()
-        }
-      }
       case _ => None
     }
-  }
 
-  def getWorkspaceById(workspaceId: String, params: WorkspaceFieldSpecs, parentContext: RawlsRequestContext = ctx): Future[JsObject] = {
+  def getWorkspaceById(workspaceId: String,
+                       params: WorkspaceFieldSpecs,
+                       parentContext: RawlsRequestContext = ctx
+  ): Future[JsObject] = {
     val workspaceUuid = Try(UUID.fromString(workspaceId)) match {
       case Success(uid) => uid
-      case Failure(_) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "invalid UUID"))
+      case Failure(_) =>
+        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "invalid UUID"))
     }
     // retrieve the namespace/name for this workspace and then delegate to getWorkspace(WorkspaceName).
     // note that this id -> namespace/name lookup does not enforce security; that's enforced in getWorkspace(WorkspaceName).
@@ -375,50 +479,58 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
     workspaceRecords.flatMap { recsFound: Seq[(String, String)] =>
       recsFound.headOption match {
-        case Some(ws) => {
+        case Some(ws) =>
           // if the call to getWorkspace(WorkspaceName) fails with an exception
           // map exceptions containing the workspace name to an exception that uses the workspace id instead
           getWorkspace(WorkspaceName(ws._1, ws._2), params, parentContext).recover { e =>
             throw e match {
               case workspaceException: WorkspaceException => workspaceException.usingId(workspaceId)
-              case _ => e
+              case _                                      => e
             }
           }
-        }
         case None =>
           throw NoSuchWorkspaceException(workspaceId)
       }
     }
   }
 
-  def getBucketOptions(workspaceName: WorkspaceName): Future[WorkspaceBucketOptions] = {
+  def getBucketOptions(workspaceName: WorkspaceName): Future[WorkspaceBucketOptions] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
-        DBIO.from(gcsDAO.getBucketDetails(workspaceContext.bucketName, workspaceContext.googleProjectId)) map { details =>
-          details
+        DBIO.from(gcsDAO.getBucketDetails(workspaceContext.bucketName, workspaceContext.googleProjectId)) map {
+          details =>
+            details
         }
       }
     }
-  }
 
-  private def loadResourceAuthDomain(resourceTypeName: SamResourceTypeName, resourceId: String, userInfo: UserInfo): Future[Set[ManagedGroupRef]] = {
-    samDAO.getResourceAuthDomain(resourceTypeName, resourceId, userInfo).map(_.map(g => ManagedGroupRef(RawlsGroupName(g))).toSet)
-  }
+  private def loadResourceAuthDomain(resourceTypeName: SamResourceTypeName,
+                                     resourceId: String,
+                                     userInfo: UserInfo
+  ): Future[Set[ManagedGroupRef]] =
+    samDAO
+      .getResourceAuthDomain(resourceTypeName, resourceId, userInfo)
+      .map(_.map(g => ManagedGroupRef(RawlsGroupName(g))).toSet)
 
-  def getUserComputePermissions(workspaceId: String, userAccessLevel: WorkspaceAccessLevel): Future[Boolean] = {
-    if(userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+  def getUserComputePermissions(workspaceId: String, userAccessLevel: WorkspaceAccessLevel): Future[Boolean] =
+    if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
     else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx.userInfo)
-  }
 
-  def getUserSharePermissions(workspaceId: String, userAccessLevel: WorkspaceAccessLevel, accessLevelToShareWith: WorkspaceAccessLevel): Future[Boolean] = {
+  def getUserSharePermissions(workspaceId: String,
+                              userAccessLevel: WorkspaceAccessLevel,
+                              accessLevelToShareWith: WorkspaceAccessLevel
+  ): Future[Boolean] =
     if (userAccessLevel < WorkspaceAccessLevels.Read) Future.successful(false)
-    else if(userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
-    else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.sharePolicy(accessLevelToShareWith.toString.toLowerCase), ctx.userInfo)
-  }
+    else if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+    else
+      samDAO.userHasAction(SamResourceTypeNames.workspace,
+                           workspaceId,
+                           SamWorkspaceActions.sharePolicy(accessLevelToShareWith.toString.toLowerCase),
+                           ctx.userInfo
+      )
 
-  def getUserCatalogPermissions(workspaceId: String): Future[Boolean] = {
+  def getUserCatalogPermissions(workspaceId: String): Future[Boolean] =
     samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.catalog, ctx.userInfo)
-  }
 
   /**
     * Sums up all the user's roles in a workspace to a single access level.
@@ -429,54 +541,60 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * @param workspaceId
     * @return
     */
-  def getMaximumAccessLevel(workspaceId: String): Future[WorkspaceAccessLevel] = {
+  def getMaximumAccessLevel(workspaceId: String): Future[WorkspaceAccessLevel] =
     samDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspaceId, ctx.userInfo).map { roles =>
       roles.flatMap(role => WorkspaceAccessLevels.withRoleName(role.value)).fold(WorkspaceAccessLevels.NoAccess)(max)
     }
-  }
 
-  def getWorkspaceOwners(workspaceId: String): Future[Set[WorkbenchEmail]] = {
-    samDAO.getPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.owner, ctx.userInfo).map(_.memberEmails)
-  }
+  def getWorkspaceOwners(workspaceId: String): Future[Set[WorkbenchEmail]] =
+    samDAO
+      .getPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.owner, ctx.userInfo)
+      .map(_.memberEmails)
 
-  def deleteWorkspace(workspaceName: WorkspaceName): Future[Option[String]] =  {
-    traceWithParent("getWorkspaceContextAndPermissions", ctx)(_ => getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.delete) flatMap { workspace =>
-      traceWithParent("maybeLoadMCWorkspace", ctx)(_ => maybeLoadMcWorkspace(workspace)) flatMap { maybeMcWorkspace =>
-        traceWithParent("deleteWorkspaceInternal", ctx)(s1 => deleteWorkspaceInternal(workspace, maybeMcWorkspace, s1))
+  def deleteWorkspace(workspaceName: WorkspaceName): Future[Option[String]] =
+    traceWithParent("getWorkspaceContextAndPermissions", ctx)(_ =>
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.delete) flatMap { workspace =>
+        traceWithParent("maybeLoadMCWorkspace", ctx)(_ => maybeLoadMcWorkspace(workspace)) flatMap { maybeMcWorkspace =>
+          traceWithParent("deleteWorkspaceInternal", ctx)(s1 =>
+            deleteWorkspaceInternal(workspace, maybeMcWorkspace, s1)
+          )
+        }
       }
-    })
-  }
+    )
 
-  def maybeLoadMcWorkspace(workspaceContext: Workspace): Future[Option[WorkspaceDescription]] = {
+  def maybeLoadMcWorkspace(workspaceContext: Workspace): Future[Option[WorkspaceDescription]] =
     workspaceContext.workspaceType match {
-      case WorkspaceType.McWorkspace => Future(Option(workspaceManagerDAO.getWorkspace(workspaceContext.workspaceIdAsUUID, ctx)))
+      case WorkspaceType.McWorkspace =>
+        Future(Option(workspaceManagerDAO.getWorkspace(workspaceContext.workspaceIdAsUUID, ctx)))
       case WorkspaceType.RawlsWorkspace => Future(None)
     }
-  }
 
-  private def gatherWorkflowsToAbortAndSetStatusToAborted(workspaceName: WorkspaceName, workspaceContext: Workspace) = {
+  private def gatherWorkflowsToAbortAndSetStatusToAborted(workspaceName: WorkspaceName, workspaceContext: Workspace) =
     dataSource.inTransaction { dataAccess =>
       for {
         // Gather any active workflows with external ids
         workflowsToAbort <- dataAccess.workflowQuery.findActiveWorkflowsWithExternalIds(workspaceContext)
 
-        //If a workflow is not done, automatically change its status to Aborted
+        // If a workflow is not done, automatically change its status to Aborted
         _ <- dataAccess.workflowQuery.findWorkflowsByWorkspace(workspaceContext).result.map { workflowRecords =>
-          workflowRecords.filter(workflowRecord => !WorkflowStatuses.withName(workflowRecord.status).isDone)
-          .foreach { workflowRecord =>
-            dataAccess.workflowQuery.updateStatus(workflowRecord, WorkflowStatuses.Aborted) { status =>
-              if (config.trackDetailedSubmissionMetrics) Option(workflowStatusCounter(workspaceSubmissionMetricBuilder(workspaceName, workflowRecord.submissionId))(status))
-              else None
+          workflowRecords
+            .filter(workflowRecord => !WorkflowStatuses.withName(workflowRecord.status).isDone)
+            .foreach { workflowRecord =>
+              dataAccess.workflowQuery.updateStatus(workflowRecord, WorkflowStatuses.Aborted) { status =>
+                if (config.trackDetailedSubmissionMetrics)
+                  Option(
+                    workflowStatusCounter(workspaceSubmissionMetricBuilder(workspaceName, workflowRecord.submissionId))(
+                      status
+                    )
+                  )
+                else None
+              }
             }
-          }
         }
-      } yield {
-        workflowsToAbort
-      }
+      } yield workflowsToAbort
     }
-  }
 
-  private def deleteWorkspaceTransaction(workspaceContext: Workspace) = {
+  private def deleteWorkspaceTransaction(workspaceContext: Workspace) =
     dataSource.inTransaction { dataAccess =>
       for {
         // Delete components of the workspace
@@ -491,71 +609,90 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         _ <- dataAccess.workspaceQuery.delete(workspaceContext.toWorkspaceName)
       } yield ()
     }
-  }
 
-  private def deleteWorkspaceInternal(workspaceContext: Workspace, maybeMcWorkspace: Option[WorkspaceDescription], parentContext: RawlsRequestContext): Future[Option[String]] = {
+  private def deleteWorkspaceInternal(workspaceContext: Workspace,
+                                      maybeMcWorkspace: Option[WorkspaceDescription],
+                                      parentContext: RawlsRequestContext
+  ): Future[Option[String]] =
     for {
       _ <- traceWithParent("requesterPaysSetupService.revokeAllUsersFromWorkspace", parentContext)(_ =>
-        requesterPaysSetupService.revokeAllUsersFromWorkspace(workspaceContext) recoverWith {
-          case t:Throwable => {
-            logger.warn(s"Unexpected failure deleting workspace (while revoking 'requester pays' users) for workspace `${workspaceContext.toWorkspaceName}`", t)
-            Future.failed(t)
-          }
+        requesterPaysSetupService.revokeAllUsersFromWorkspace(workspaceContext) recoverWith { case t: Throwable =>
+          logger.warn(
+            s"Unexpected failure deleting workspace (while revoking 'requester pays' users) for workspace `${workspaceContext.toWorkspaceName}`",
+            t
+          )
+          Future.failed(t)
         }
       )
 
       workflowsToAbort <- traceWithParent("gatherWorkflowsToAbortAndSetStatusToAborted", parentContext)(_ =>
         gatherWorkflowsToAbortAndSetStatusToAborted(workspaceContext.toWorkspaceName, workspaceContext) recoverWith {
-          case t:Throwable => {
-            logger.warn(s"Unexpected failure deleting workspace (while gathering workflows that need to be aborted) for workspace `${workspaceContext.toWorkspaceName}`", t)
+          case t: Throwable =>
+            logger.warn(
+              s"Unexpected failure deleting workspace (while gathering workflows that need to be aborted) for workspace `${workspaceContext.toWorkspaceName}`",
+              t
+            )
             Future.failed(t)
-          }
         }
       )
 
-      //Attempt to abort any running workflows so they don't write any more to the bucket.
-      //Notice that we're kicking off Futures to do the aborts concurrently, but we never collect their results!
-      //This is because there's nothing we can do if Cromwell fails, so we might as well move on and let the
-      //ExecutionContext run the futures whenever
+      // Attempt to abort any running workflows so they don't write any more to the bucket.
+      // Notice that we're kicking off Futures to do the aborts concurrently, but we never collect their results!
+      // This is because there's nothing we can do if Cromwell fails, so we might as well move on and let the
+      // ExecutionContext run the futures whenever
       aborts = traceWithParent("abortRunningWorkflows", parentContext)(_ =>
-        Future.traverse(workflowsToAbort) { wf => executionServiceCluster.abort(wf, ctx.userInfo) } recoverWith {
-          case t:Throwable => {
-            logger.warn(s"Unexpected failure deleting workspace (while aborting workflows) for workspace `${workspaceContext.toWorkspaceName}`", t)
+        Future.traverse(workflowsToAbort)(wf => executionServiceCluster.abort(wf, ctx.userInfo)) recoverWith {
+          case t: Throwable =>
+            logger.warn(
+              s"Unexpected failure deleting workspace (while aborting workflows) for workspace `${workspaceContext.toWorkspaceName}`",
+              t
+            )
             Future.failed(t)
-          }
         }
       )
 
       // Delete Google Project
       _ <- traceWithParent("maybeDeleteGoogleProject", parentContext)(_ =>
         if (!isAzureMcWorkspace(maybeMcWorkspace)) {
-          maybeDeleteGoogleProject(workspaceContext.googleProjectId, workspaceContext.workspaceVersion, ctx.userInfo) recoverWith {
-            case t: Throwable => {
-              logger.error(s"Unexpected failure deleting workspace (while deleting google project) for workspace `${workspaceContext.toWorkspaceName}`", t)
-              Future.failed(t)
-            }
+          maybeDeleteGoogleProject(workspaceContext.googleProjectId,
+                                   workspaceContext.workspaceVersion,
+                                   ctx.userInfo
+          ) recoverWith { case t: Throwable =>
+            logger.error(
+              s"Unexpected failure deleting workspace (while deleting google project) for workspace `${workspaceContext.toWorkspaceName}`",
+              t
+            )
+            Future.failed(t)
           }
         } else Future.successful()
       )
 
       // Delete the workspace records in Rawls. Do this after deleting the google project to prevent service perimeter leaks.
       _ <- traceWithParent("deleteWorkspaceTransaction", parentContext)(_ =>
-        deleteWorkspaceTransaction(workspaceContext) recoverWith {
-          case t:Throwable => {
-            logger.error(s"Unexpected failure deleting workspace (while deleting workspace in Rawls DB) for workspace `${workspaceContext.toWorkspaceName}`", t)
-            Future.failed(t)
-          }
+        deleteWorkspaceTransaction(workspaceContext) recoverWith { case t: Throwable =>
+          logger.error(
+            s"Unexpected failure deleting workspace (while deleting workspace in Rawls DB) for workspace `${workspaceContext.toWorkspaceName}`",
+            t
+          )
+          Future.failed(t)
         }
       )
 
       // Delete workflowCollection resource in sam outside of DB transaction
       _ <- traceWithParent("deleteWorkflowCollectionSamResource", parentContext)(_ =>
-        workspaceContext.workflowCollectionName.map( cn => samDAO.deleteResource(SamResourceTypeNames.workflowCollection, cn, ctx.userInfo) ).getOrElse(Future.successful(())) recoverWith {
+        workspaceContext.workflowCollectionName
+          .map(cn => samDAO.deleteResource(SamResourceTypeNames.workflowCollection, cn, ctx.userInfo))
+          .getOrElse(Future.successful(())) recoverWith {
           case t: RawlsExceptionWithErrorReport if t.errorReport.statusCode.contains(StatusCodes.NotFound) =>
-            logger.warn(s"Received 404 from delete workflowCollection resource in Sam (while deleting workspace) for workspace `${workspaceContext.toWorkspaceName}`: [${t.errorReport.message}]")
+            logger.warn(
+              s"Received 404 from delete workflowCollection resource in Sam (while deleting workspace) for workspace `${workspaceContext.toWorkspaceName}`: [${t.errorReport.message}]"
+            )
             Future.successful()
           case t: RawlsExceptionWithErrorReport =>
-            logger.error(s"Unexpected failure deleting workspace (while deleting workflowCollection in Sam) for workspace `${workspaceContext.toWorkspaceName}`.", t)
+            logger.error(
+              s"Unexpected failure deleting workspace (while deleting workflowCollection in Sam) for workspace `${workspaceContext.toWorkspaceName}`.",
+              t
+            )
             Future.failed(t)
         }
       )
@@ -563,31 +700,41 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       // Delete workspace manager record (which will only exist if there had ever been a TDR snapshot in the WS)
       _ <- traceWithParent("deleteWorkspaceInWSM", parentContext)(_ =>
         Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, ctx)).recoverWith {
-          //this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle all exceptions here
-          case e: ApiException => {
-            if(e.getCode != StatusCodes.NotFound.intValue) {
-              logger.warn(s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceContext.toWorkspaceName}. Received ${e.getCode}: [${e.getResponseBody}]")
+          // this will only ever succeed if a TDR snapshot had been created in the WS, so we gracefully handle all exceptions here
+          case e: ApiException =>
+            if (e.getCode != StatusCodes.NotFound.intValue) {
+              logger.warn(
+                s"Unexpected failure deleting workspace (while deleting in Workspace Manager) for workspace `${workspaceContext.toWorkspaceName}. Received ${e.getCode}: [${e.getResponseBody}]"
+              )
             }
             Future.successful()
-          }
         }
       )
 
       _ <- traceWithParent("deleteWorkspaceSamResource", parentContext)(_ =>
         if (workspaceContext.workspaceType != WorkspaceType.McWorkspace) { // WSM will delete Sam resources for McWorkspaces
-          samDAO.deleteResource(SamResourceTypeNames.workspace, workspaceContext.workspaceIdAsUUID.toString, ctx.userInfo) recoverWith {
+          samDAO.deleteResource(SamResourceTypeNames.workspace,
+                                workspaceContext.workspaceIdAsUUID.toString,
+                                ctx.userInfo
+          ) recoverWith {
             case t: RawlsExceptionWithErrorReport if t.errorReport.statusCode.contains(StatusCodes.NotFound) =>
-              logger.warn(s"Received 404 from delete workspace resource in Sam (while deleting workspace) for workspace `${workspaceContext.toWorkspaceName}`: [${t.errorReport.message}]")
+              logger.warn(
+                s"Received 404 from delete workspace resource in Sam (while deleting workspace) for workspace `${workspaceContext.toWorkspaceName}`: [${t.errorReport.message}]"
+              )
               Future.successful()
             case t: RawlsExceptionWithErrorReport =>
-              logger.error(s"Unexpected failure deleting workspace (while deleting workspace in Sam) for workspace `${workspaceContext.toWorkspaceName}`.", t)
+              logger.error(
+                s"Unexpected failure deleting workspace (while deleting workspace in Sam) for workspace `${workspaceContext.toWorkspaceName}`.",
+                t
+              )
               Future.failed(t)
           }
         } else { Future.successful() }
       )
     } yield {
       aborts.onComplete {
-        case Failure(t) => logger.info(s"failure aborting workflows while deleting workspace ${workspaceContext.toWorkspaceName}", t)
+        case Failure(t) =>
+          logger.info(s"failure aborting workflows while deleting workspace ${workspaceContext.toWorkspaceName}", t)
         case _ => /* ok */
       }
 
@@ -595,84 +742,92 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         Option(workspaceContext.bucketName)
       } else None
     }
-  }
 
-  private def isAzureMcWorkspace(maybeMcWorkspace: Option[WorkspaceDescription]): Boolean = {
+  private def isAzureMcWorkspace(maybeMcWorkspace: Option[WorkspaceDescription]): Boolean =
     maybeMcWorkspace.flatMap(mcWorkspace => Option(mcWorkspace.getAzureContext)).isDefined
-  }
 
   // TODO - once workspace migration is complete and there are no more v1 workspaces or v1 billing projects, we can remove this https://broadworkbench.atlassian.net/browse/CA-1118
-  private def maybeDeleteGoogleProject(googleProjectId: GoogleProjectId, workspaceVersion: WorkspaceVersion, userInfoForSam: UserInfo): Future[Unit] = {
+  private def maybeDeleteGoogleProject(googleProjectId: GoogleProjectId,
+                                       workspaceVersion: WorkspaceVersion,
+                                       userInfoForSam: UserInfo
+  ): Future[Unit] =
     if (workspaceVersion == WorkspaceVersions.V2) {
       deleteGoogleProject(googleProjectId, userInfoForSam)
     } else {
       Future.successful()
     }
-  }
 
-  def deleteGoogleProject(googleProjectId: GoogleProjectId, userInfoForSam: UserInfo): Future[Unit] = {
-        for {
-          _ <- deletePetsInProject(googleProjectId, userInfoForSam)
-          _ <- gcsDAO.deleteGoogleProject(googleProjectId)
-          _ <- samDAO.deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, userInfoForSam).recover {
-            case regrets: RawlsExceptionWithErrorReport if regrets.errorReport.statusCode == Option(StatusCodes.NotFound) =>
-              logger.info(s"google-project resource ${googleProjectId.value} not found in Sam. Continuing with workspace deletion")
-          }
-        } yield ()
-  }
-
-  private def deletePetsInProject(projectName: GoogleProjectId, userInfo: UserInfo): Future[Unit] = {
+  def deleteGoogleProject(googleProjectId: GoogleProjectId, userInfoForSam: UserInfo): Future[Unit] =
     for {
-      projectUsers <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, projectName.value, userInfo).recover {
+      _ <- deletePetsInProject(googleProjectId, userInfoForSam)
+      _ <- gcsDAO.deleteGoogleProject(googleProjectId)
+      _ <- samDAO.deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, userInfoForSam).recover {
         case regrets: RawlsExceptionWithErrorReport if regrets.errorReport.statusCode == Option(StatusCodes.NotFound) =>
-          logger.info(s"google-project resource ${projectName.value} not found in Sam. Continuing with workspace deletion")
-          Set[UserIdInfo]()
+          logger.info(
+            s"google-project resource ${googleProjectId.value} not found in Sam. Continuing with workspace deletion"
+          )
       }
+    } yield ()
+
+  private def deletePetsInProject(projectName: GoogleProjectId, userInfo: UserInfo): Future[Unit] =
+    for {
+      projectUsers <- samDAO
+        .listAllResourceMemberIds(SamResourceTypeNames.googleProject, projectName.value, userInfo)
+        .recover {
+          case regrets: RawlsExceptionWithErrorReport
+              if regrets.errorReport.statusCode == Option(StatusCodes.NotFound) =>
+            logger.info(
+              s"google-project resource ${projectName.value} not found in Sam. Continuing with workspace deletion"
+            )
+            Set[UserIdInfo]()
+        }
       _ <- projectUsers.toList.traverse(destroyPet(_, projectName))
     } yield ()
-  }
 
-  private def destroyPet(userIdInfo: UserIdInfo, projectName: GoogleProjectId): Future[Unit] = {
+  private def destroyPet(userIdInfo: UserIdInfo, projectName: GoogleProjectId): Future[Unit] =
     for {
       petSAJson <- samDAO.getPetServiceAccountKeyForUser(projectName, RawlsUserEmail(userIdInfo.userEmail))
       petUserInfo <- gcsDAO.getUserInfoUsingJson(petSAJson)
       _ <- samDAO.deleteUserPetServiceAccount(projectName, petUserInfo)
     } yield ()
-  }
 
-  def updateLibraryAttributes(workspaceName: WorkspaceName, operations: Seq[AttributeUpdateOperation]): Future[WorkspaceDetails] = {
+  def updateLibraryAttributes(workspaceName: WorkspaceName,
+                              operations: Seq[AttributeUpdateOperation]
+  ): Future[WorkspaceDetails] =
     withLibraryAttributeNamespaceCheck(operations.map(_.name)) {
       for {
         isCurator <- tryIsCurator(ctx.userInfo.userEmail)
         workspace <- getWorkspaceContext(workspaceName) flatMap { workspace =>
           withLibraryPermissions(workspace, operations, ctx.userInfo, isCurator) {
-            dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))({ dataAccess =>
-              updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName)
-            }, TransactionIsolation.ReadCommitted) // read committed to avoid deadlocks on workspace attr scratch table
+            dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))(
+              dataAccess =>
+                updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName),
+              TransactionIsolation.ReadCommitted
+            ) // read committed to avoid deadlocks on workspace attr scratch table
           }
         }
         authDomain <- loadResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx.userInfo)
-      } yield {
-        WorkspaceDetails(workspace, authDomain)
-      }
+      } yield WorkspaceDetails(workspace, authDomain)
     }
-  }
 
-  def updateWorkspace(workspaceName: WorkspaceName, operations: Seq[AttributeUpdateOperation]): Future[WorkspaceDetails] = {
+  def updateWorkspace(workspaceName: WorkspaceName,
+                      operations: Seq[AttributeUpdateOperation]
+  ): Future[WorkspaceDetails] =
     withAttributeNamespaceCheck(operations.map(_.name)) {
       for {
         workspace <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write)
-        workspace <- dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))({ dataAccess =>
-            updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName)
-        }, TransactionIsolation.ReadCommitted) // read committed to avoid deadlocks on workspace attr scratch table
+        workspace <- dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))(
+          dataAccess =>
+            updateWorkspace(operations, dataAccess)(workspace.toWorkspaceName),
+          TransactionIsolation.ReadCommitted
+        ) // read committed to avoid deadlocks on workspace attr scratch table
         authDomain <- loadResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx.userInfo)
-      } yield {
-        WorkspaceDetails(workspace, authDomain)
-      }
+      } yield WorkspaceDetails(workspace, authDomain)
     }
-  }
 
-  private def updateWorkspace(operations: Seq[AttributeUpdateOperation], dataAccess: DataAccess)(workspaceName: WorkspaceName): ReadWriteAction[Workspace] = {
+  private def updateWorkspace(operations: Seq[AttributeUpdateOperation], dataAccess: DataAccess)(
+    workspaceName: WorkspaceName
+  ): ReadWriteAction[Workspace] =
     // get the source workspace again, to avoid race conditions where the workspace was updated outside of this transaction
     withWorkspaceContext(workspaceName, dataAccess) { workspaceContext =>
       val workspace = workspaceContext
@@ -682,24 +837,29 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       } match {
         case Success(result) => result
         case Failure(e: AttributeUpdateOperationException) =>
-          DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Unable to update ${workspace.name}", ErrorReport(e))))
+          DBIO.failed(
+            new RawlsExceptionWithErrorReport(
+              errorReport = ErrorReport(StatusCodes.BadRequest, s"Unable to update ${workspace.name}", ErrorReport(e))
+            )
+          )
         case Failure(regrets) => DBIO.failed(regrets)
       }
     }
-  }
 
-  def getTags(query: Option[String], limit: Option[Int] = None): Future[Seq[WorkspaceTag]] = {
+  def getTags(query: Option[String], limit: Option[Int] = None): Future[Seq[WorkspaceTag]] =
     for {
       workspacesForUser <- samDAO.getPoliciesForType(SamResourceTypeNames.workspace, ctx.userInfo)
-      //Filter out non-UUID workspaceIds, which are possible in Sam but not valid in Rawls
-      workspaceIdsForUser = workspacesForUser.map(resource => Try(UUID.fromString(resource.resourceId))).collect {
-        case Success(workspaceId) => workspaceId
-      }.toSeq
+      // Filter out non-UUID workspaceIds, which are possible in Sam but not valid in Rawls
+      workspaceIdsForUser = workspacesForUser
+        .map(resource => Try(UUID.fromString(resource.resourceId)))
+        .collect { case Success(workspaceId) =>
+          workspaceId
+        }
+        .toSeq
       result <- dataSource.inTransaction { dataAccess =>
         dataAccess.workspaceQuery.getTags(query, limit, Some(workspaceIdsForUser))
       }
     } yield result
-  }
 
   def listWorkspaces(params: WorkspaceFieldSpecs): Future[JsValue] = {
 
@@ -715,8 +875,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     // if user requested the entire attributes map, or any individual attributes, retrieve attributes.
     val attributeSpecs = WorkspaceAttributeSpecs(
       options.contains("workspace.attributes"),
-      options.filter(_.startsWith("workspace.attributes."))
-        .map(str => AttributeName.fromDelimitedName(str.replaceFirst("workspace.attributes.", ""))).toList
+      options
+        .filter(_.startsWith("workspace.attributes."))
+        .map(str => AttributeName.fromDelimitedName(str.replaceFirst("workspace.attributes.", "")))
+        .toList
     )
 
     // Can this be shared with get-workspace somehow?
@@ -730,7 +892,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
 
     for {
-      workspacePolicies <- traceWithParent("getPolicies", ctx)(_ => samDAO.getPoliciesForType(SamResourceTypeNames.workspace, ctx.userInfo))
+      workspacePolicies <- traceWithParent("getPolicies", ctx)(_ =>
+        samDAO.getPoliciesForType(SamResourceTypeNames.workspace, ctx.userInfo)
+      )
       // filter out the policies that are not related to access levels, if a user has only those ignore the workspace
       // also filter out any policy whose resourceId is not a UUID; these will never match a known workspace
       accessLevelWorkspacePolicies = workspacePolicies.filter(p =>
@@ -738,199 +902,282 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           Try(UUID.fromString(p.resourceId)).isSuccess
       )
       accessLevelWorkspacePolicyUUIDs = accessLevelWorkspacePolicies.map(p => UUID.fromString(p.resourceId)).toSeq
-      result <- dataSource.inTransaction({ dataAccess =>
-
-        def workspaceSubmissionStatsFuture(): slick.ReadAction[Map[UUID, WorkspaceSubmissionStats]] = if (submissionStatsEnabled) {
-          dataAccess.workspaceQuery.listSubmissionSummaryStats(accessLevelWorkspacePolicyUUIDs)
-        } else {
-          DBIO.from(Future(Map()))
-        }
-
-        val query: ReadAction[(Map[UUID, WorkspaceSubmissionStats], Seq[Workspace])] = for {
-          submissionSummaryStats <- traceDBIOWithParent("submissionStats", ctx)(_ => workspaceSubmissionStatsFuture())
-          workspaces <- traceDBIOWithParent("listByIds", ctx)(_ => dataAccess.workspaceQuery.listByIds(accessLevelWorkspacePolicyUUIDs, Option(attributeSpecs)))
-        } yield (submissionSummaryStats, workspaces)
-
-        val results = traceDBIOWithParent("finalResults", ctx)(_ => query.map { case (submissionSummaryStats, workspaces) =>
-          val policiesByWorkspaceId = accessLevelWorkspacePolicies.groupBy(_.resourceId).map { case (workspaceId, policies) =>
-            workspaceId -> policies.reduce { (p1, p2) =>
-              val betterAccessPolicyName = (WorkspaceAccessLevels.withPolicyName(p1.accessPolicyName.value), WorkspaceAccessLevels.withPolicyName(p2.accessPolicyName.value)) match {
-                case (Some(p1Level), Some(p2Level)) if p1Level > p2Level => p1.accessPolicyName
-                case (Some(_), Some(_)) => p2.accessPolicyName
-                case _ => throw new RawlsException(s"unexpected state, both $p1 and $p2 should be related to access levels at this point")
-              }
-              SamResourceIdWithPolicyName(
-                p1.resourceId,
-                betterAccessPolicyName,
-                p1.authDomainGroups ++ p2.authDomainGroups,
-                p1.missingAuthDomainGroups ++ p2.missingAuthDomainGroups,
-                p1.public || p2.public
-              )
+      result <- dataSource.inTransaction(
+        { dataAccess =>
+          def workspaceSubmissionStatsFuture(): slick.ReadAction[Map[UUID, WorkspaceSubmissionStats]] =
+            if (submissionStatsEnabled) {
+              dataAccess.workspaceQuery.listSubmissionSummaryStats(accessLevelWorkspacePolicyUUIDs)
+            } else {
+              DBIO.from(Future(Map()))
             }
-          }
-          workspaces.mapFilter { workspace =>
-            try {
-              val cloudPlatform = workspace.workspaceType match {
-              case WorkspaceType.McWorkspace => Option(workspaceManagerDAO.getWorkspace(workspace.workspaceIdAsUUID, ctx)) match {
-                  case Some(mcWorkspace) if (mcWorkspace.getAzureContext != null) => Option(WorkspaceCloudPlatform.Azure)
-                  case Some(mcWorkspace) if (mcWorkspace.getGcpContext != null) => Option(WorkspaceCloudPlatform.Gcp)
-                  case _ => throw new RawlsException(s"unexpected state, no cloud context found for workspace ${workspace.workspaceId}")
+
+          val query: ReadAction[(Map[UUID, WorkspaceSubmissionStats], Seq[Workspace])] = for {
+            submissionSummaryStats <- traceDBIOWithParent("submissionStats", ctx)(_ => workspaceSubmissionStatsFuture())
+            workspaces <- traceDBIOWithParent("listByIds", ctx)(_ =>
+              dataAccess.workspaceQuery.listByIds(accessLevelWorkspacePolicyUUIDs, Option(attributeSpecs))
+            )
+          } yield (submissionSummaryStats, workspaces)
+
+          val results = traceDBIOWithParent("finalResults", ctx)(_ =>
+            query.map { case (submissionSummaryStats, workspaces) =>
+              val policiesByWorkspaceId =
+                accessLevelWorkspacePolicies.groupBy(_.resourceId).map { case (workspaceId, policies) =>
+                  workspaceId -> policies.reduce { (p1, p2) =>
+                    val betterAccessPolicyName = (WorkspaceAccessLevels.withPolicyName(p1.accessPolicyName.value),
+                                                  WorkspaceAccessLevels.withPolicyName(p2.accessPolicyName.value)
+                    ) match {
+                      case (Some(p1Level), Some(p2Level)) if p1Level > p2Level => p1.accessPolicyName
+                      case (Some(_), Some(_))                                  => p2.accessPolicyName
+                      case _ =>
+                        throw new RawlsException(
+                          s"unexpected state, both $p1 and $p2 should be related to access levels at this point"
+                        )
+                    }
+                    SamResourceIdWithPolicyName(
+                      p1.resourceId,
+                      betterAccessPolicyName,
+                      p1.authDomainGroups ++ p2.authDomainGroups,
+                      p1.missingAuthDomainGroups ++ p2.missingAuthDomainGroups,
+                      p1.public || p2.public
+                    )
+                  }
                 }
-                case WorkspaceType.RawlsWorkspace => Option(WorkspaceCloudPlatform.Gcp)
-              }
-              val wsId = UUID.fromString(workspace.workspaceId)
-              val workspacePolicy = policiesByWorkspaceId(workspace.workspaceId)
-              val accessLevel = if (workspacePolicy.missingAuthDomainGroups.nonEmpty) WorkspaceAccessLevels.NoAccess else WorkspaceAccessLevels.withPolicyName(workspacePolicy.accessPolicyName.value).getOrElse(WorkspaceAccessLevels.NoAccess)
-              // remove attributes if they were not requested
-              val workspaceDetails = WorkspaceDetails.fromWorkspaceAndOptions(workspace, Option(workspacePolicy.authDomainGroups.map(groupName => ManagedGroupRef(RawlsGroupName(groupName.value)))), attributesEnabled, cloudPlatform)
-              // remove submission stats if they were not requested
-              val submissionStats: Option[WorkspaceSubmissionStats] = if (submissionStatsEnabled) {
-                Option(submissionSummaryStats(wsId))
-              } else {
-                None
-              }
-              Option(WorkspaceListResponse(accessLevel, workspaceDetails, submissionStats, workspacePolicy.public))
-            } catch {
-              // Internal folks may create MCWorkspaces in local WorkspaceManager instances, and those will not
-              // be reachable when running against the dev environment.
-              case ex: ApiException if (WorkspaceType.McWorkspace == workspace.workspaceType) && (ex.getCode == StatusCodes.NotFound.intValue) => {
-                logger.warn(s"MC Workspace ${workspace.name} (${workspace.workspaceIdAsUUID}) does not exist in the current WSM instance. ")
-                None
+              workspaces.mapFilter { workspace =>
+                try {
+                  val cloudPlatform = workspace.workspaceType match {
+                    case WorkspaceType.McWorkspace =>
+                      Option(workspaceManagerDAO.getWorkspace(workspace.workspaceIdAsUUID, ctx)) match {
+                        case Some(mcWorkspace) if mcWorkspace.getAzureContext != null =>
+                          Option(WorkspaceCloudPlatform.Azure)
+                        case Some(mcWorkspace) if mcWorkspace.getGcpContext != null =>
+                          Option(WorkspaceCloudPlatform.Gcp)
+                        case _ =>
+                          throw new RawlsException(
+                            s"unexpected state, no cloud context found for workspace ${workspace.workspaceId}"
+                          )
+                      }
+                    case WorkspaceType.RawlsWorkspace => Option(WorkspaceCloudPlatform.Gcp)
+                  }
+                  val wsId = UUID.fromString(workspace.workspaceId)
+                  val workspacePolicy = policiesByWorkspaceId(workspace.workspaceId)
+                  val accessLevel =
+                    if (workspacePolicy.missingAuthDomainGroups.nonEmpty) WorkspaceAccessLevels.NoAccess
+                    else
+                      WorkspaceAccessLevels
+                        .withPolicyName(workspacePolicy.accessPolicyName.value)
+                        .getOrElse(WorkspaceAccessLevels.NoAccess)
+                  // remove attributes if they were not requested
+                  val workspaceDetails =
+                    WorkspaceDetails.fromWorkspaceAndOptions(workspace,
+                                                             Option(
+                                                               workspacePolicy.authDomainGroups.map(groupName =>
+                                                                 ManagedGroupRef(RawlsGroupName(groupName.value))
+                                                               )
+                                                             ),
+                                                             attributesEnabled,
+                                                             cloudPlatform
+                    )
+                  // remove submission stats if they were not requested
+                  val submissionStats: Option[WorkspaceSubmissionStats] = if (submissionStatsEnabled) {
+                    Option(submissionSummaryStats(wsId))
+                  } else {
+                    None
+                  }
+                  Option(WorkspaceListResponse(accessLevel, workspaceDetails, submissionStats, workspacePolicy.public))
+                } catch {
+                  // Internal folks may create MCWorkspaces in local WorkspaceManager instances, and those will not
+                  // be reachable when running against the dev environment.
+                  case ex: ApiException
+                      if (WorkspaceType.McWorkspace == workspace.workspaceType) && (ex.getCode == StatusCodes.NotFound.intValue) =>
+                    logger.warn(
+                      s"MC Workspace ${workspace.name} (${workspace.workspaceIdAsUUID}) does not exist in the current WSM instance. "
+                    )
+                    None
+                }
               }
             }
-          }
-        })
+          )
 
-        results.map { responses =>
-          if (!optionsExist) {
-            responses.toJson
-          } else {
-            // perform json-filtering of payload
-            deepFilterJsValue(responses.toJson, options)
+          results.map { responses =>
+            if (!optionsExist) {
+              responses.toJson
+            } else {
+              // perform json-filtering of payload
+              deepFilterJsValue(responses.toJson, options)
+            }
           }
-        }
-      }, TransactionIsolation.ReadCommitted)
+        },
+        TransactionIsolation.ReadCommitted
+      )
     } yield result
   }
 
-  private def getWorkspaceSubmissionStats(workspaceContext: Workspace, dataAccess: DataAccess): ReadAction[WorkspaceSubmissionStats] = {
+  private def getWorkspaceSubmissionStats(workspaceContext: Workspace,
+                                          dataAccess: DataAccess
+  ): ReadAction[WorkspaceSubmissionStats] =
     // listSubmissionSummaryStats works against a sequence of workspaces; we call it just for this one workspace
     dataAccess.workspaceQuery
       .listSubmissionSummaryStats(Seq(workspaceContext.workspaceIdAsUUID))
-      .map {p => p.get(workspaceContext.workspaceIdAsUUID).get}
-  }
+      .map(p => p.get(workspaceContext.workspaceIdAsUUID).get)
 
   // NOTE: Orchestration has its own implementation of cloneWorkspace. When changing something here, you may also need to update orchestration's implementation (maybe helpful search term: `Post(workspacePath + "/clone"`).
   def cloneWorkspace(sourceWorkspaceName: WorkspaceName, destWorkspaceRequest: WorkspaceRequest): Future[Workspace] = {
     destWorkspaceRequest.copyFilesWithPrefix.foreach(prefix => validateFileCopyPrefix(prefix))
 
-    val (libraryAttributeNames, workspaceAttributeNames) = destWorkspaceRequest.attributes.keys.partition(name => name.namespace == AttributeName.libraryNamespace)
+    val (libraryAttributeNames, workspaceAttributeNames) =
+      destWorkspaceRequest.attributes.keys.partition(name => name.namespace == AttributeName.libraryNamespace)
     withAttributeNamespaceCheck(workspaceAttributeNames) {
       withLibraryAttributeNamespaceCheck(libraryAttributeNames) {
         withBillingProjectContext(destWorkspaceRequest.namespace, ctx) { destBillingProject =>
-          getWorkspaceContextAndPermissions(sourceWorkspaceName, SamWorkspaceActions.read).flatMap { permCtx =>
-            withWorkspaceBucketRegionCheck(destWorkspaceRequest.bucketLocation) {
-              // if bucket location is specified, then we just use that for the destination workspace's bucket location.
-              // if bucket location is NOT specified then we want to use the same location as the source workspace.
-              // Since the destination workspace's Google project has not been claimed at this point, we cannot charge
-              // the Google request that checks the source workspace bucket's location to the destination workspace's
-              // Google project. To get around this, we pass in the source workspace bucket's name to
-              // withNewWorkspaceContext and get the source workspace bucket's location after we've claimed a Google
-              // project and before we create the destination workspace's bucket.
-              val sourceBucketNameOption: Option[String] = destWorkspaceRequest.bucketLocation match {
-                case Some(_) => None
-                case None => Option(permCtx.bucketName)
-              }
+          getWorkspaceContextAndPermissions(sourceWorkspaceName, SamWorkspaceActions.read)
+            .flatMap { permCtx =>
+              withWorkspaceBucketRegionCheck(destWorkspaceRequest.bucketLocation) {
+                // if bucket location is specified, then we just use that for the destination workspace's bucket location.
+                // if bucket location is NOT specified then we want to use the same location as the source workspace.
+                // Since the destination workspace's Google project has not been claimed at this point, we cannot charge
+                // the Google request that checks the source workspace bucket's location to the destination workspace's
+                // Google project. To get around this, we pass in the source workspace bucket's name to
+                // withNewWorkspaceContext and get the source workspace bucket's location after we've claimed a Google
+                // project and before we create the destination workspace's bucket.
+                val sourceBucketNameOption: Option[String] = destWorkspaceRequest.bucketLocation match {
+                  case Some(_) => None
+                  case None    => Option(permCtx.bucketName)
+                }
 
-              for {
-                workspaceTuple <- dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))({ dataAccess =>
-                  // get the source workspace again, to avoid race conditions where the workspace was updated outside of this transaction
-                  withWorkspaceContext(permCtx.toWorkspaceName, dataAccess) { sourceWorkspaceContext =>
-                    DBIO.from(samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, sourceWorkspaceContext.workspaceId, ctx.userInfo)).flatMap { sourceAuthDomains =>
-                      withClonedAuthDomain(sourceAuthDomains.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet, destWorkspaceRequest.authorizationDomain.getOrElse(Set.empty)) { newAuthDomain =>
-                        // add to or replace current attributes, on an individual basis
-                        val newAttrs = sourceWorkspaceContext.attributes ++ destWorkspaceRequest.attributes
-                        traceDBIOWithParent("withNewWorkspaceContext (cloneWorkspace)", ctx) { s1 =>
-                          withNewWorkspaceContext(destWorkspaceRequest.copy(authorizationDomain = Option(newAuthDomain), attributes = newAttrs), destBillingProject, sourceBucketNameOption, dataAccess, s1) { destWorkspaceContext =>
-                            dataAccess.entityQuery.copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID, destWorkspaceContext.workspaceIdAsUUID).map { counts: (Int, Int) =>
-                              clonedWorkspaceEntityHistogram += counts._1
-                              clonedWorkspaceAttributeHistogram += counts._2
-                            } andThen {
-                              dataAccess.methodConfigurationQuery.listActive(sourceWorkspaceContext).flatMap { methodConfigShorts =>
-                                val inserts = methodConfigShorts.map { methodConfigShort =>
-                                  dataAccess.methodConfigurationQuery.get(sourceWorkspaceContext, methodConfigShort.namespace, methodConfigShort.name).flatMap { methodConfig =>
-                                    dataAccess.methodConfigurationQuery.create(destWorkspaceContext, methodConfig.get)
+                for {
+                  workspaceTuple <- dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Workspace))(
+                    dataAccess =>
+                      // get the source workspace again, to avoid race conditions where the workspace was updated outside of this transaction
+                      withWorkspaceContext(permCtx.toWorkspaceName, dataAccess) { sourceWorkspaceContext =>
+                        DBIO
+                          .from(
+                            samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace,
+                                                         sourceWorkspaceContext.workspaceId,
+                                                         ctx.userInfo
+                            )
+                          )
+                          .flatMap { sourceAuthDomains =>
+                            withClonedAuthDomain(sourceAuthDomains.map(n => ManagedGroupRef(RawlsGroupName(n))).toSet,
+                                                 destWorkspaceRequest.authorizationDomain.getOrElse(Set.empty)
+                            ) { newAuthDomain =>
+                              // add to or replace current attributes, on an individual basis
+                              val newAttrs = sourceWorkspaceContext.attributes ++ destWorkspaceRequest.attributes
+                              traceDBIOWithParent("withNewWorkspaceContext (cloneWorkspace)", ctx) { s1 =>
+                                withNewWorkspaceContext(destWorkspaceRequest.copy(authorizationDomain =
+                                                                                    Option(newAuthDomain),
+                                                                                  attributes = newAttrs
+                                                        ),
+                                                        destBillingProject,
+                                                        sourceBucketNameOption,
+                                                        dataAccess,
+                                                        s1
+                                ) { destWorkspaceContext =>
+                                  dataAccess.entityQuery
+                                    .copyEntitiesToNewWorkspace(sourceWorkspaceContext.workspaceIdAsUUID,
+                                                                destWorkspaceContext.workspaceIdAsUUID
+                                    )
+                                    .map { counts: (Int, Int) =>
+                                      clonedWorkspaceEntityHistogram += counts._1
+                                      clonedWorkspaceAttributeHistogram += counts._2
+                                    } andThen {
+                                    dataAccess.methodConfigurationQuery.listActive(sourceWorkspaceContext).flatMap {
+                                      methodConfigShorts =>
+                                        val inserts = methodConfigShorts.map { methodConfigShort =>
+                                          dataAccess.methodConfigurationQuery
+                                            .get(sourceWorkspaceContext,
+                                                 methodConfigShort.namespace,
+                                                 methodConfigShort.name
+                                            )
+                                            .flatMap { methodConfig =>
+                                              dataAccess.methodConfigurationQuery.create(destWorkspaceContext,
+                                                                                         methodConfig.get
+                                              )
+                                            }
+                                        }
+                                        DBIO.seq(inserts: _*)
+                                    } andThen {
+                                      clonedWorkspaceCounter.inc()
+                                      DBIO.successful((sourceWorkspaceContext, destWorkspaceContext))
+                                    }
                                   }
                                 }
-                                DBIO.seq(inserts: _*)
-                              } andThen {
-                                clonedWorkspaceCounter.inc()
-                                DBIO.successful((sourceWorkspaceContext, destWorkspaceContext))
                               }
                             }
                           }
-                        }
-                      }
-                    }
-                  }
-                }, TransactionIsolation.ReadCommitted)
-                // read committed to avoid deadlocks on workspace attr scratch table
-              } yield workspaceTuple
-            }
-          }.map { case (sourceWorkspaceContext, destWorkspaceContext) =>
-            //we will fire and forget this. a more involved, but robust, solution involves using the Google Storage Transfer APIs
-            //in most of our use cases, these files should copy quickly enough for there to be no noticeable delay to the user
-            //we also don't want to block returning a response on this call because it's already a slow endpoint
-            destWorkspaceRequest.copyFilesWithPrefix.foreach { prefix =>
-              dataSource.inTransaction { dataAccess =>
-                dataAccess.cloneWorkspaceFileTransferQuery.save(destWorkspaceContext.workspaceIdAsUUID, sourceWorkspaceContext.workspaceIdAsUUID, prefix)
+                    },
+                    TransactionIsolation.ReadCommitted
+                  )
+                  // read committed to avoid deadlocks on workspace attr scratch table
+                } yield workspaceTuple
               }
             }
+            .map { case (sourceWorkspaceContext, destWorkspaceContext) =>
+              // we will fire and forget this. a more involved, but robust, solution involves using the Google Storage Transfer APIs
+              // in most of our use cases, these files should copy quickly enough for there to be no noticeable delay to the user
+              // we also don't want to block returning a response on this call because it's already a slow endpoint
+              destWorkspaceRequest.copyFilesWithPrefix.foreach { prefix =>
+                dataSource.inTransaction { dataAccess =>
+                  dataAccess.cloneWorkspaceFileTransferQuery.save(destWorkspaceContext.workspaceIdAsUUID,
+                                                                  sourceWorkspaceContext.workspaceIdAsUUID,
+                                                                  prefix
+                  )
+                }
+              }
 
-            destWorkspaceContext
-          }
+              destWorkspaceContext
+            }
         }
       }
     }
   }
 
-  private def validateFileCopyPrefix(copyFilesWithPrefix: String): Unit = {
-    if(copyFilesWithPrefix.isEmpty) throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, """You may not specify an empty string for `copyFilesWithPrefix`. Did you mean to specify "/" or leave the field out entirely?"""))
-  }
+  private def validateFileCopyPrefix(copyFilesWithPrefix: String): Unit =
+    if (copyFilesWithPrefix.isEmpty)
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.BadRequest,
+          """You may not specify an empty string for `copyFilesWithPrefix`. Did you mean to specify "/" or leave the field out entirely?"""
+        )
+      )
 
-  def listPendingFileTransfersForWorkspace(workspaceName: WorkspaceName): Future[Seq[PendingCloneWorkspaceFileTransfer]] = {
+  def listPendingFileTransfersForWorkspace(
+    workspaceName: WorkspaceName
+  ): Future[Seq[PendingCloneWorkspaceFileTransfer]] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         dataAccess.cloneWorkspaceFileTransferQuery.listPendingTransfers(Option(workspaceContext.workspaceIdAsUUID))
       }
     }
-  }
 
-  private def withClonedAuthDomain[T](sourceWorkspaceADs: Set[ManagedGroupRef], destWorkspaceADs: Set[ManagedGroupRef])(op: (Set[ManagedGroupRef]) => ReadWriteAction[T]): ReadWriteAction[T] = {
+  private def withClonedAuthDomain[T](sourceWorkspaceADs: Set[ManagedGroupRef], destWorkspaceADs: Set[ManagedGroupRef])(
+    op: (Set[ManagedGroupRef]) => ReadWriteAction[T]
+  ): ReadWriteAction[T] =
     // if the source has an auth domain, the dest must also have that auth domain as a subset
     // otherwise, the caller may choose to add to the auth domain
-    if(sourceWorkspaceADs.subsetOf(destWorkspaceADs)) op(sourceWorkspaceADs ++ destWorkspaceADs)
+    if (sourceWorkspaceADs.subsetOf(destWorkspaceADs)) op(sourceWorkspaceADs ++ destWorkspaceADs)
     else {
       val missingGroups = sourceWorkspaceADs -- destWorkspaceADs
-      val errorMsg = s"Source workspace has an Authorization Domain containing the groups ${missingGroups.map(_.membersGroupName.value).mkString(", ")}, which are missing on the destination workspace"
+      val errorMsg =
+        s"Source workspace has an Authorization Domain containing the groups ${missingGroups.map(_.membersGroupName.value).mkString(", ")}, which are missing on the destination workspace"
       DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.UnprocessableEntity, errorMsg)))
     }
-  }
 
-  private def isUserPending(userEmail: String): Future[Boolean] = {
+  private def isUserPending(userEmail: String): Future[Boolean] =
     samDAO.getUserIdInfo(userEmail, ctx.userInfo).map {
-      case SamDAO.User(x) => x.googleSubjectId.isEmpty
-      case SamDAO.NotUser => false
+      case SamDAO.User(x)  => x.googleSubjectId.isEmpty
+      case SamDAO.NotUser  => false
       case SamDAO.NotFound => true
     }
-  }
 
-  //API_CHANGE: project owners no longer returned (because it would just show a policy and not everyone can read the members of that policy)
+  // API_CHANGE: project owners no longer returned (because it would just show a policy and not everyone can read the members of that policy)
   private def getACLInternal(workspaceName: WorkspaceName): Future[WorkspaceACL] = {
 
-    def loadPolicy(policyName: SamResourcePolicyName, policyList: Set[SamPolicyWithNameAndEmail]): SamPolicyWithNameAndEmail = {
-      policyList.find(_.policyName.value.equalsIgnoreCase(policyName.value)).getOrElse(throw new WorkbenchException(s"Could not load $policyName policy"))
-    }
+    def loadPolicy(policyName: SamResourcePolicyName,
+                   policyList: Set[SamPolicyWithNameAndEmail]
+    ): SamPolicyWithNameAndEmail =
+      policyList
+        .find(_.policyName.value.equalsIgnoreCase(policyName.value))
+        .getOrElse(throw new WorkbenchException(s"Could not load $policyName policy"))
 
     val policyMembers = for {
       workspaceId <- loadWorkspaceId(workspaceName)
@@ -942,88 +1189,146 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       val shareReaderPolicyMembers = loadPolicy(SamWorkspacePolicyNames.shareReader, currentACL).policy.memberEmails
       val shareWriterPolicyMembers = loadPolicy(SamWorkspacePolicyNames.shareWriter, currentACL).policy.memberEmails
       val computePolicyMembers = loadPolicy(SamWorkspacePolicyNames.canCompute, currentACL).policy.memberEmails
-      //note: can-catalog is a policy on the side and is not a part of the core workspace ACL so we won't load it
+      // note: can-catalog is a policy on the side and is not a part of the core workspace ACL so we won't load it
 
-      (ownerPolicyMembers, writerPolicyMembers, readerPolicyMembers, shareReaderPolicyMembers, shareWriterPolicyMembers, computePolicyMembers)
+      (ownerPolicyMembers,
+       writerPolicyMembers,
+       readerPolicyMembers,
+       shareReaderPolicyMembers,
+       shareWriterPolicyMembers,
+       computePolicyMembers
+      )
     }
 
-    policyMembers.flatMap { case (ownerPolicyMembers, writerPolicyMembers, readerPolicyMembers, shareReaderPolicyMembers, shareWriterPolicyMembers, computePolicyMembers) =>
-      val sharers = shareReaderPolicyMembers ++ shareWriterPolicyMembers
+    policyMembers.flatMap {
+      case (ownerPolicyMembers,
+            writerPolicyMembers,
+            readerPolicyMembers,
+            shareReaderPolicyMembers,
+            shareWriterPolicyMembers,
+            computePolicyMembers
+          ) =>
+        val sharers = shareReaderPolicyMembers ++ shareWriterPolicyMembers
 
-      for {
-        ownersPending <- Future.traverse(ownerPolicyMembers) { email => isUserPending(email.value).map(pending => email -> pending) }
-        writersPending <- Future.traverse(writerPolicyMembers) { email => isUserPending(email.value).map(pending => email -> pending) }
-        readersPending <- Future.traverse(readerPolicyMembers) { email => isUserPending(email.value).map(pending => email -> pending) }
-      } yield {
-        val owners = ownerPolicyMembers.map(email => email.value -> AccessEntry(WorkspaceAccessLevels.Owner, ownersPending.toMap.getOrElse(email, true), true, true)) //API_CHANGE: pending owners used to show as false for canShare and canCompute. they now show true. this is more accurate anyway
-        val writers = writerPolicyMembers.map(email => email.value -> AccessEntry(WorkspaceAccessLevels.Write, writersPending.toMap.getOrElse(email, true), sharers.contains(email), computePolicyMembers.contains(email)))
-        val readers = readerPolicyMembers.map(email => email.value -> AccessEntry(WorkspaceAccessLevels.Read, readersPending.toMap.getOrElse(email, true), sharers.contains(email), computePolicyMembers.contains(email)))
+        for {
+          ownersPending <- Future.traverse(ownerPolicyMembers) { email =>
+            isUserPending(email.value).map(pending => email -> pending)
+          }
+          writersPending <- Future.traverse(writerPolicyMembers) { email =>
+            isUserPending(email.value).map(pending => email -> pending)
+          }
+          readersPending <- Future.traverse(readerPolicyMembers) { email =>
+            isUserPending(email.value).map(pending => email -> pending)
+          }
+        } yield {
+          val owners = ownerPolicyMembers.map(email =>
+            email.value -> AccessEntry(WorkspaceAccessLevels.Owner,
+                                       ownersPending.toMap.getOrElse(email, true),
+                                       true,
+                                       true
+            )
+          ) // API_CHANGE: pending owners used to show as false for canShare and canCompute. they now show true. this is more accurate anyway
+          val writers = writerPolicyMembers.map(email =>
+            email.value -> AccessEntry(WorkspaceAccessLevels.Write,
+                                       writersPending.toMap.getOrElse(email, true),
+                                       sharers.contains(email),
+                                       computePolicyMembers.contains(email)
+            )
+          )
+          val readers = readerPolicyMembers.map(email =>
+            email.value -> AccessEntry(WorkspaceAccessLevels.Read,
+                                       readersPending.toMap.getOrElse(email, true),
+                                       sharers.contains(email),
+                                       computePolicyMembers.contains(email)
+            )
+          )
 
-        WorkspaceACL((owners ++ writers ++ readers).toMap)
-      }
+          WorkspaceACL((owners ++ writers ++ readers).toMap)
+        }
     }
   }
 
-  def getACL(workspaceName: WorkspaceName): Future[WorkspaceACL] = {
+  def getACL(workspaceName: WorkspaceName): Future[WorkspaceACL] =
     getACLInternal(workspaceName)
-  }
 
-  def getCatalog(workspaceName: WorkspaceName): Future[Set[WorkspaceCatalog]] = {
+  def getCatalog(workspaceName: WorkspaceName): Future[Set[WorkspaceCatalog]] =
     loadWorkspaceId(workspaceName).flatMap { workspaceId =>
-      samDAO.getPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.canCatalog, ctx.userInfo).map { members => members.memberEmails.map(email => WorkspaceCatalog(email.value, true))}
+      samDAO
+        .getPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.canCatalog, ctx.userInfo)
+        .map(members => members.memberEmails.map(email => WorkspaceCatalog(email.value, true)))
     }
-  }
 
-  private def loadWorkspaceId(workspaceName: WorkspaceName): Future[String] = {
-    dataSource.inTransaction { dataAccess => dataAccess.workspaceQuery.getWorkspaceId(workspaceName) }.map {
-      case None => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "unable to load workspace"))
+  private def loadWorkspaceId(workspaceName: WorkspaceName): Future[String] =
+    dataSource.inTransaction(dataAccess => dataAccess.workspaceQuery.getWorkspaceId(workspaceName)).map {
+      case None =>
+        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "unable to load workspace"))
       case Some(id) => id.toString
     }
-  }
 
-  def updateCatalog(workspaceName: WorkspaceName, input: Seq[WorkspaceCatalog]): Future[WorkspaceCatalogUpdateResponseList] = {
+  def updateCatalog(workspaceName: WorkspaceName,
+                    input: Seq[WorkspaceCatalog]
+  ): Future[WorkspaceCatalogUpdateResponseList] =
     for {
       workspaceId <- loadWorkspaceId(workspaceName)
       results <- Future.traverse(input) {
         case WorkspaceCatalog(email, true) =>
-          toFutureTry(samDAO.addUserToPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.canCatalog, email, ctx.userInfo)).
-            map(_.map(_ => Either.right[String, WorkspaceCatalogResponse](WorkspaceCatalogResponse(email, true))).recover {
-              case t: RawlsExceptionWithErrorReport if t.errorReport.statusCode.contains(StatusCodes.BadRequest) => Left(email)
-            })
+          toFutureTry(
+            samDAO.addUserToPolicy(SamResourceTypeNames.workspace,
+                                   workspaceId,
+                                   SamWorkspacePolicyNames.canCatalog,
+                                   email,
+                                   ctx.userInfo
+            )
+          ).map(
+            _.map(_ => Either.right[String, WorkspaceCatalogResponse](WorkspaceCatalogResponse(email, true))).recover {
+              case t: RawlsExceptionWithErrorReport if t.errorReport.statusCode.contains(StatusCodes.BadRequest) =>
+                Left(email)
+            }
+          )
 
         case WorkspaceCatalog(email, false) =>
-          toFutureTry(samDAO.removeUserFromPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.canCatalog, email, ctx.userInfo)).
-            map(_.map(_ => Either.right[String, WorkspaceCatalogResponse](WorkspaceCatalogResponse(email, false))).recover {
-              case t: RawlsExceptionWithErrorReport if t.errorReport.statusCode.contains(StatusCodes.BadRequest) => Left(email)
-            })
+          toFutureTry(
+            samDAO.removeUserFromPolicy(SamResourceTypeNames.workspace,
+                                        workspaceId,
+                                        SamWorkspacePolicyNames.canCatalog,
+                                        email,
+                                        ctx.userInfo
+            )
+          ).map(
+            _.map(_ => Either.right[String, WorkspaceCatalogResponse](WorkspaceCatalogResponse(email, false))).recover {
+              case t: RawlsExceptionWithErrorReport if t.errorReport.statusCode.contains(StatusCodes.BadRequest) =>
+                Left(email)
+            }
+          )
       }
     } yield {
-      val failures = results.collect {
-        case Failure(regrets) => ErrorReport(regrets)
+      val failures = results.collect { case Failure(regrets) =>
+        ErrorReport(regrets)
       }
       if (failures.nonEmpty) {
         throw new RawlsExceptionWithErrorReport(ErrorReport("Error setting catalog permissions", failures))
       } else {
-        WorkspaceCatalogUpdateResponseList(results.collect { case Success(Right(wc)) => wc }, results.collect { case Success(Left(email)) => email })
+        WorkspaceCatalogUpdateResponseList(results.collect { case Success(Right(wc)) => wc },
+                                           results.collect { case Success(Left(email)) => email }
+        )
       }
     }
-  }
 
-  private def getWorkspacePolicies(workspaceName: WorkspaceName): Future[Set[SamPolicyWithNameAndEmail]] = {
+  private def getWorkspacePolicies(workspaceName: WorkspaceName): Future[Set[SamPolicyWithNameAndEmail]] =
     for {
       workspaceId <- loadWorkspaceId(workspaceName)
       policies <- samDAO.listPoliciesForResource(SamResourceTypeNames.workspace, workspaceId, ctx.userInfo)
     } yield policies
-  }
 
-  def collectMissingUsers(userEmails: Set[String]): Future[Set[String]] = {
-    Future.traverse(userEmails) { email =>
-      samDAO.getUserIdInfo(email, ctx.userInfo).map {
-        case SamDAO.NotFound => Option(email)
-        case _ => None
+  def collectMissingUsers(userEmails: Set[String]): Future[Set[String]] =
+    Future
+      .traverse(userEmails) { email =>
+        samDAO.getUserIdInfo(email, ctx.userInfo).map {
+          case SamDAO.NotFound => Option(email)
+          case _               => None
+        }
       }
-    }.map(_.flatten)
-  }
+      .map(_.flatten)
 
   /**
    * updates acls for a workspace
@@ -1032,7 +1337,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
    *                   Set, use NoAccess to remove an entry, all other preexisting accesses remain unchanged
    * @return
    */
-  def updateACL(workspaceName: WorkspaceName, aclUpdates: Set[WorkspaceACLUpdate], inviteUsersNotFound: Boolean): Future[WorkspaceACLUpdateResponseList] = {
+  def updateACL(workspaceName: WorkspaceName,
+                aclUpdates: Set[WorkspaceACLUpdate],
+                inviteUsersNotFound: Boolean
+  ): Future[WorkspaceACLUpdateResponseList] = {
     if (aclUpdates.map(_.email).size < aclUpdates.size) {
       throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Only 1 entry per email allowed."))
     }
@@ -1044,11 +1352,20 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       * @return
       */
     def policiesToAclUpdate(userEmail: String, samWorkspacePolicyNames: Set[SamResourcePolicyName]) = {
-      val accessLevel = samWorkspacePolicyNames.flatMap(n => WorkspaceAccessLevels.withPolicyName(n.value)).fold(WorkspaceAccessLevels.NoAccess)(WorkspaceAccessLevels.max)
-      val ownerLevel = samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.projectOwner) || samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.owner)
+      val accessLevel = samWorkspacePolicyNames
+        .flatMap(n => WorkspaceAccessLevels.withPolicyName(n.value))
+        .fold(WorkspaceAccessLevels.NoAccess)(WorkspaceAccessLevels.max)
+      val ownerLevel =
+        samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.projectOwner) || samWorkspacePolicyNames.contains(
+          SamWorkspacePolicyNames.owner
+        )
       val canShare = ownerLevel ||
-        (samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.reader) && samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.shareReader)) ||
-        (samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.writer) && samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.shareWriter))
+        (samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.reader) && samWorkspacePolicyNames.contains(
+          SamWorkspacePolicyNames.shareReader
+        )) ||
+        (samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.writer) && samWorkspacePolicyNames.contains(
+          SamWorkspacePolicyNames.shareWriter
+        ))
       val canCompute = ownerLevel || samWorkspacePolicyNames.contains(SamWorkspacePolicyNames.canCompute)
       WorkspaceACLUpdate(userEmail, accessLevel, Option(canShare), Option(canCompute))
     }
@@ -1058,42 +1375,53 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       * @param workspaceACLUpdate
       * @return
       */
-    def aclUpdateToPolicies(workspaceACLUpdate: WorkspaceACLUpdate)= {
+    def aclUpdateToPolicies(workspaceACLUpdate: WorkspaceACLUpdate) = {
       val sharePolicy = workspaceACLUpdate match {
-        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, Some(true), _) => SamWorkspacePolicyNames.shareReader.some
-        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, Some(true), _) => SamWorkspacePolicyNames.shareWriter.some
+        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, Some(true), _) =>
+          SamWorkspacePolicyNames.shareReader.some
+        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, Some(true), _) =>
+          SamWorkspacePolicyNames.shareWriter.some
         case _ => None
       }
 
       // canCompute is only applicable to write access, readers can't have it and owners have it implicitly
       val computePolicy = workspaceACLUpdate.canCompute match {
         case Some(false) => None
-        case _ if workspaceACLUpdate.accessLevel == WorkspaceAccessLevels.Write => SamWorkspacePolicyNames.canCompute.some
+        case _ if workspaceACLUpdate.accessLevel == WorkspaceAccessLevels.Write =>
+          SamWorkspacePolicyNames.canCompute.some
         case _ => None
       }
 
       Set(workspaceACLUpdate.accessLevel.toPolicyName.map(SamResourcePolicyName), sharePolicy, computePolicy).flatten
     }
 
-    def normalize(aclUpdates: Set[WorkspaceACLUpdate]) = {
+    def normalize(aclUpdates: Set[WorkspaceACLUpdate]) =
       aclUpdates.map { update =>
         val ownerLevel = update.accessLevel >= WorkspaceAccessLevels.Owner
-        val normalizedCanCompute = ownerLevel || update.canCompute.getOrElse(update.accessLevel == WorkspaceAccessLevels.Write)
-        update.copy(canShare = Option(ownerLevel || update.canShare.getOrElse(false)), canCompute = Option(normalizedCanCompute)) }
-    }
+        val normalizedCanCompute =
+          ownerLevel || update.canCompute.getOrElse(update.accessLevel == WorkspaceAccessLevels.Write)
+        update.copy(canShare = Option(ownerLevel || update.canShare.getOrElse(false)),
+                    canCompute = Option(normalizedCanCompute)
+        )
+      }
 
     collectMissingUsers(aclUpdates.map(_.email)).flatMap { userToInvite =>
       if (userToInvite.isEmpty || inviteUsersNotFound) {
         getWorkspacePolicies(workspaceName).flatMap { existingPolicies =>
           // the acl update code does not deal with the can catalog permission, there are separate functions for that.
           // exclude any existing can catalog policies so we don't inadvertently remove them
-          val existingPoliciesExcludingCatalog = existingPolicies.filterNot(_.policyName == SamWorkspacePolicyNames.canCatalog)
+          val existingPoliciesExcludingCatalog =
+            existingPolicies.filterNot(_.policyName == SamWorkspacePolicyNames.canCatalog)
 
           // convert all the existing policy memberships into WorkspaceAclUpdate objects
-          val existingPoliciesWithMembers = existingPoliciesExcludingCatalog.flatMap(p => p.policy.memberEmails.map(email => email -> p.policyName))
-          val existingAcls = existingPoliciesWithMembers.groupBy(_._1).map { case (email, policyNames) =>
-            policiesToAclUpdate(email.value, policyNames.map(_._2))
-          }.toSet
+          val existingPoliciesWithMembers =
+            existingPoliciesExcludingCatalog.flatMap(p => p.policy.memberEmails.map(email => email -> p.policyName))
+          val existingAcls = existingPoliciesWithMembers
+            .groupBy(_._1)
+            .map { case (email, policyNames) =>
+              policiesToAclUpdate(email.value, policyNames.map(_._2))
+            }
+            .toSet
 
           // figure out which of the incoming aclUpdates are actually changes by removing all the existingAcls
           val aclChanges = normalize(aclUpdates) -- existingAcls
@@ -1104,7 +1432,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           val policyRemovals = aclChanges.flatMap { aclChange =>
             val desiredPolicies = aclUpdateToPolicies(aclChange)
             existingPoliciesWithMembers.collect {
-              case (email, policyName) if email.value.equalsIgnoreCase(aclChange.email) && !desiredPolicies.contains(policyName) => (policyName, aclChange.email)
+              case (email, policyName)
+                  if email.value.equalsIgnoreCase(aclChange.email) && !desiredPolicies.contains(policyName) =>
+                (policyName, aclChange.email)
             }
           }
 
@@ -1112,29 +1442,49 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           val policyAdditions = aclChanges.flatMap { aclChange =>
             val desiredPolicies = aclUpdateToPolicies(aclChange)
             desiredPolicies.collect {
-              case policyName if !existingPoliciesWithMembers.exists(x => x._1.value.equalsIgnoreCase(aclChange.email) && x._2 == policyName) => (policyName, aclChange.email)
+              case policyName
+                  if !existingPoliciesWithMembers
+                    .exists(x => x._1.value.equalsIgnoreCase(aclChange.email) && x._2 == policyName) =>
+                (policyName, aclChange.email)
             }
           }
 
           // now do all the work: invites, additions, removals, notifications
           for {
-            maybeWorkspace <- dataSource.inTransaction { dataAccess => dataAccess.workspaceQuery.findByName(workspaceName) }
+            maybeWorkspace <- dataSource.inTransaction { dataAccess =>
+              dataAccess.workspaceQuery.findByName(workspaceName)
+            }
             workspace = maybeWorkspace.getOrElse(throw new RawlsException(s"workspace $workspaceName not found"))
 
             inviteNotifications <- Future.traverse(userToInvite) { invite =>
               samDAO.inviteUser(invite, ctx.userInfo).map { _ =>
-                Notifications.WorkspaceInvitedNotification(WorkbenchEmail(invite), WorkbenchUserId(ctx.userInfo.userSubjectId.value), NotificationWorkspaceName(workspaceName.namespace, workspaceName.name), workspace.bucketName)
+                Notifications.WorkspaceInvitedNotification(
+                  WorkbenchEmail(invite),
+                  WorkbenchUserId(ctx.userInfo.userSubjectId.value),
+                  NotificationWorkspaceName(workspaceName.namespace, workspaceName.name),
+                  workspace.bucketName
+                )
               }
             }
 
             // do additions before removals so users are not left unable to access the workspace in case of errors that
             // lead to incomplete application of these changes, remember: this is not transactional
             _ <- Future.traverse(policyAdditions) { case (policyName, email) =>
-                samDAO.addUserToPolicy(SamResourceTypeNames.workspace, workspace.workspaceId, policyName, email, ctx.userInfo)
+              samDAO.addUserToPolicy(SamResourceTypeNames.workspace,
+                                     workspace.workspaceId,
+                                     policyName,
+                                     email,
+                                     ctx.userInfo
+              )
             }
 
             _ <- Future.traverse(policyRemovals) { case (policyName, email) =>
-              samDAO.removeUserFromPolicy(SamResourceTypeNames.workspace, workspace.workspaceId, policyName, email, ctx.userInfo)
+              samDAO.removeUserFromPolicy(SamResourceTypeNames.workspace,
+                                          workspace.workspaceId,
+                                          policyName,
+                                          email,
+                                          ctx.userInfo
+              )
             }
 
             _ <- revokeRequesterPaysForLinkedSAs(workspace, policyRemovals, policyAdditions)
@@ -1143,13 +1493,20 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
           } yield {
             val (invites, updates) = aclChanges.partition(acl => userToInvite.contains(acl.email))
-            sendACLUpdateNotifications(workspaceName, updates) //we can blindly fire off this future because we don't care about the results and it happens async anyway
+            sendACLUpdateNotifications(workspaceName,
+                                       updates
+            ) // we can blindly fire off this future because we don't care about the results and it happens async anyway
             notificationDAO.fireAndForgetNotifications(inviteNotifications)
-            WorkspaceACLUpdateResponseList(updates, invites, Set.empty) //API_CHANGE: no longer return invitesUpdated because you technically can't do that anymore...
+            WorkspaceACLUpdateResponseList(updates,
+                                           invites,
+                                           Set.empty
+            ) // API_CHANGE: no longer return invitesUpdated because you technically can't do that anymore...
           }
         }
-      }
-      else Future.successful(WorkspaceACLUpdateResponseList(Set.empty, Set.empty, aclUpdates.filter(au => userToInvite.contains(au.email))))
+      } else
+        Future.successful(
+          WorkspaceACLUpdateResponseList(Set.empty, Set.empty, aclUpdates.filter(au => userToInvite.contains(au.email)))
+        )
     }
   }
 
@@ -1166,7 +1523,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * @param policyAdditions
     * @return
     */
-  private def revokeRequesterPaysForLinkedSAs(workspace: Workspace, policyRemovals: Set[(SamResourcePolicyName, String)], policyAdditions: Set[(SamResourcePolicyName, String)]): Future[Unit] = {
+  private def revokeRequesterPaysForLinkedSAs(workspace: Workspace,
+                                              policyRemovals: Set[(SamResourcePolicyName, String)],
+                                              policyAdditions: Set[(SamResourcePolicyName, String)]
+  ): Future[Unit] = {
     val applicablePolicies = Set(SamWorkspacePolicyNames.owner, SamWorkspacePolicyNames.writer)
     val applicableRemovals = policyRemovals.collect {
       case (policy, email) if applicablePolicies.contains(policy) => RawlsUserEmail(email)
@@ -1174,105 +1534,159 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     val applicableAdditions = policyAdditions.collect {
       case (policy, email) if applicablePolicies.contains(policy) => RawlsUserEmail(email)
     }
-    Future.traverse(applicableRemovals -- applicableAdditions) { emailToRevoke => requesterPaysSetupService.revokeUserFromWorkspace(emailToRevoke, workspace) }.void
+    Future
+      .traverse(applicableRemovals -- applicableAdditions) { emailToRevoke =>
+        requesterPaysSetupService.revokeUserFromWorkspace(emailToRevoke, workspace)
+      }
+      .void
   }
 
   private def validateAclChanges(aclChanges: Set[WorkspaceACLUpdate], existingAcls: Set[WorkspaceACLUpdate]) = {
     val emailsBeingChanged = aclChanges.map(_.email.toLowerCase)
-    if (aclChanges.exists(_.accessLevel == WorkspaceAccessLevels.ProjectOwner) || existingAcls.exists(existingAcl => existingAcl.accessLevel == ProjectOwner && emailsBeingChanged.contains(existingAcl.email.toLowerCase))) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "project owner permissions cannot be changed"))
+    if (
+      aclChanges.exists(_.accessLevel == WorkspaceAccessLevels.ProjectOwner) || existingAcls.exists(existingAcl =>
+        existingAcl.accessLevel == ProjectOwner && emailsBeingChanged.contains(existingAcl.email.toLowerCase)
+      )
+    ) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "project owner permissions cannot be changed")
+      )
     }
     if (aclChanges.exists(_.email.equalsIgnoreCase(ctx.userInfo.userEmail.value))) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "you may not change your own permissions"))
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "you may not change your own permissions")
+      )
     }
-    if (aclChanges.exists {
-      case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, _, Some(true)) => true
-      case _ => false
-    }) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "may not grant readers compute access"))
+    if (
+      aclChanges.exists {
+        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, _, Some(true)) => true
+        case _                                                                => false
+      }
+    ) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "may not grant readers compute access")
+      )
     }
   }
 
   // called from test harness
-  private[workspace] def maybeShareProjectComputePolicy(policyAdditions: Set[(SamResourcePolicyName, String)], workspaceName: WorkspaceName): Future[Unit] = {
-    val newWriterEmails = policyAdditions.collect {
-      case (SamWorkspacePolicyNames.canCompute, email)  => email
+  private[workspace] def maybeShareProjectComputePolicy(policyAdditions: Set[(SamResourcePolicyName, String)],
+                                                        workspaceName: WorkspaceName
+  ): Future[Unit] = {
+    val newWriterEmails = policyAdditions.collect { case (SamWorkspacePolicyNames.canCompute, email) =>
+      email
     }
-    Future.traverse(newWriterEmails) { email =>
-      samDAO.addUserToPolicy(SamResourceTypeNames.billingProject, workspaceName.namespace, SamBillingProjectPolicyNames.canComputeUser, email, ctx.userInfo).recoverWith {
-        case regrets: Throwable =>
-          logger.info(s"error adding user to canComputeUser policy of Terra billing project while updating ${workspaceName.toString} likely because it is a v2 billing project which does not have a canComputeUser policy. regrets: ${regrets.getMessage}")
-          Future.successful(())
+    Future
+      .traverse(newWriterEmails) { email =>
+        samDAO
+          .addUserToPolicy(SamResourceTypeNames.billingProject,
+                           workspaceName.namespace,
+                           SamBillingProjectPolicyNames.canComputeUser,
+                           email,
+                           ctx.userInfo
+          )
+          .recoverWith { case regrets: Throwable =>
+            logger.info(
+              s"error adding user to canComputeUser policy of Terra billing project while updating ${workspaceName.toString} likely because it is a v2 billing project which does not have a canComputeUser policy. regrets: ${regrets.getMessage}"
+            )
+            Future.successful(())
+          }
       }
-    }.map(_ => ())
+      .map(_ => ())
   }
 
-  private def sendACLUpdateNotifications(workspaceName: WorkspaceName, usersModified: Set[WorkspaceACLUpdate]): Unit = {
+  private def sendACLUpdateNotifications(workspaceName: WorkspaceName, usersModified: Set[WorkspaceACLUpdate]): Unit =
     Future.traverse(usersModified) { accessUpdate =>
       for {
         userIdInfo <- samDAO.getUserIdInfo(accessUpdate.email, ctx.userInfo)
-      } yield {
-        userIdInfo match {
-          case SamDAO.User(UserIdInfo(_, _, Some(googleSubjectId))) =>
-            if(accessUpdate.accessLevel == WorkspaceAccessLevels.NoAccess)
-              notificationDAO.fireAndForgetNotification(Notifications.WorkspaceRemovedNotification(WorkbenchUserId(googleSubjectId), NoAccess.toString, NotificationWorkspaceName(workspaceName.namespace, workspaceName.name), WorkbenchUserId(ctx.userInfo.userSubjectId.value)))
-            else
-              notificationDAO.fireAndForgetNotification(Notifications.WorkspaceAddedNotification(WorkbenchUserId(googleSubjectId), accessUpdate.accessLevel.toString, NotificationWorkspaceName(workspaceName.namespace, workspaceName.name), WorkbenchUserId(ctx.userInfo.userSubjectId.value)))
-          case _ =>
-        }
+      } yield userIdInfo match {
+        case SamDAO.User(UserIdInfo(_, _, Some(googleSubjectId))) =>
+          if (accessUpdate.accessLevel == WorkspaceAccessLevels.NoAccess)
+            notificationDAO.fireAndForgetNotification(
+              Notifications.WorkspaceRemovedNotification(
+                WorkbenchUserId(googleSubjectId),
+                NoAccess.toString,
+                NotificationWorkspaceName(workspaceName.namespace, workspaceName.name),
+                WorkbenchUserId(ctx.userInfo.userSubjectId.value)
+              )
+            )
+          else
+            notificationDAO.fireAndForgetNotification(
+              Notifications.WorkspaceAddedNotification(
+                WorkbenchUserId(googleSubjectId),
+                accessUpdate.accessLevel.toString,
+                NotificationWorkspaceName(workspaceName.namespace, workspaceName.name),
+                WorkbenchUserId(ctx.userInfo.userSubjectId.value)
+              )
+            )
+        case _ =>
       }
     }
-  }
 
-  def sendChangeNotifications(workspaceName: WorkspaceName): Future[String] = {
+  def sendChangeNotifications(workspaceName: WorkspaceName): Future[String] =
     for {
       workspaceContext <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.own)
 
-      userIdInfos <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.workspace, workspaceContext.workspaceId, ctx.userInfo)
+      userIdInfos <- samDAO.listAllResourceMemberIds(SamResourceTypeNames.workspace,
+                                                     workspaceContext.workspaceId,
+                                                     ctx.userInfo
+      )
 
-      notificationMessages = userIdInfos.collect {
-        case UserIdInfo(_, _, Some(userId)) => Notifications.WorkspaceChangedNotification(WorkbenchUserId(userId), NotificationWorkspaceName(workspaceName.namespace, workspaceName.name))
+      notificationMessages = userIdInfos.collect { case UserIdInfo(_, _, Some(userId)) =>
+        Notifications.WorkspaceChangedNotification(
+          WorkbenchUserId(userId),
+          NotificationWorkspaceName(workspaceName.namespace, workspaceName.name)
+        )
       }
     } yield {
       notificationDAO.fireAndForgetNotifications(notificationMessages)
       notificationMessages.size.toString
     }
-  }
 
-  def lockWorkspace(workspaceName: WorkspaceName): Future[Boolean] = {
-    //don't do the sam REST call inside the db transaction.
+  def lockWorkspace(workspaceName: WorkspaceName): Future[Boolean] =
+    // don't do the sam REST call inside the db transaction.
     getWorkspaceContext(workspaceName) flatMap { workspaceContext =>
       requireAccessIgnoreLockF(workspaceContext, SamWorkspaceActions.own) {
-        //if we get here, we passed all the hoops
+        // if we get here, we passed all the hoops
 
         dataSource.inTransaction { dataAccess =>
           lockWorkspaceInternal(workspaceContext, dataAccess)
         }
       }
     }
-  }
 
-  private def lockWorkspaceInternal(workspaceContext: Workspace, dataAccess: DataAccess) = {
+  private def lockWorkspaceInternal(workspaceContext: Workspace, dataAccess: DataAccess) =
     dataAccess.submissionQuery.list(workspaceContext).flatMap { submissions =>
       if (!submissions.forall(_.status.isTerminated)) {
-        DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"There are running submissions in workspace ${workspaceContext.toWorkspaceName}, so it cannot be locked.")))
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(
+              StatusCodes.Conflict,
+              s"There are running submissions in workspace ${workspaceContext.toWorkspaceName}, so it cannot be locked."
+            )
+          )
+        )
       } else {
         import dataAccess.WorkspaceExtensions
         dataAccess.workspaceQuery.withWorkspaceId(workspaceContext.workspaceIdAsUUID).lock
       }
     }
-  }
 
   def unlockWorkspace(workspaceName: WorkspaceName): Future[Boolean] =
-    //don't do the sam REST call inside the db transaction.
+    // don't do the sam REST call inside the db transaction.
     getWorkspaceContext(workspaceName) flatMap { workspaceContext =>
       requireAccessIgnoreLockF(workspaceContext, SamWorkspaceActions.own) {
-        //if we get here, we passed all the hoops
+        // if we get here, we passed all the hoops
 
         dataSource.inTransaction { dataAccess =>
           import dataAccess.WorkspaceExtensions
           dataAccess.workspaceMigrationQuery.isMigrating(workspaceContext).flatMap {
-            case true => DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "cannot unlock migrating workspace")))
+            case true =>
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  ErrorReport(StatusCodes.BadRequest, "cannot unlock migrating workspace")
+                )
+              )
             case false => dataAccess.workspaceQuery.withWorkspaceId(workspaceContext.workspaceIdAsUUID).unlock
           }
         }
@@ -1288,131 +1702,216 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
    * @throws AttributeUpdateOperationException when adding or removing from an attribute that is not a list
    * @return the updated entity
    */
-  def applyOperationsToWorkspace(workspace: Workspace, operations: Seq[AttributeUpdateOperation]): Workspace = {
+  def applyOperationsToWorkspace(workspace: Workspace, operations: Seq[AttributeUpdateOperation]): Workspace =
     workspace.copy(attributes = applyAttributeUpdateOperations(workspace, operations))
-  }
 
-  //validates the expressions in the method configuration, taking into account optional inputs
-  private def validateMethodConfiguration(methodConfiguration: MethodConfiguration, workspaceContext: Workspace): Future[ValidatedMethodConfiguration] = {
+  // validates the expressions in the method configuration, taking into account optional inputs
+  private def validateMethodConfiguration(methodConfiguration: MethodConfiguration,
+                                          workspaceContext: Workspace
+  ): Future[ValidatedMethodConfiguration] =
     for {
       entityProvider <- getEntityProviderForMethodConfig(workspaceContext, methodConfiguration)
       gatherInputsResult <- gatherMethodConfigInputs(methodConfiguration)
       vmc <- entityProvider.expressionValidator.validateMCExpressions(methodConfiguration, gatherInputsResult)
     } yield vmc
-  }
 
-  private def getEntityProviderForMethodConfig(workspaceContext: Workspace, methodConfiguration: MethodConfiguration): Future[EntityProvider] = {
-    entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx, methodConfiguration.dataReferenceName, None))
-  }
+  private def getEntityProviderForMethodConfig(workspaceContext: Workspace,
+                                               methodConfiguration: MethodConfiguration
+  ): Future[EntityProvider] =
+    entityManager.resolveProviderFuture(
+      EntityRequestArguments(workspaceContext, ctx, methodConfiguration.dataReferenceName, None)
+    )
 
-  def getAndValidateMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String): Future[ValidatedMethodConfiguration] = {
+  def getAndValidateMethodConfiguration(workspaceName: WorkspaceName,
+                                        methodConfigurationNamespace: String,
+                                        methodConfigurationName: String
+  ): Future[ValidatedMethodConfiguration] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       for {
         methodConfig <- dataSource.inTransaction { dataAccess =>
-          withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { methodConfig =>
-            DBIO.successful(methodConfig)
+          withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) {
+            methodConfig =>
+              DBIO.successful(methodConfig)
           }
         }
         vmc <- validateMethodConfiguration(methodConfig, workspaceContext)
       } yield vmc
     }
-  }
 
-  def createMethodConfiguration(workspaceName: WorkspaceName, methodConfiguration: MethodConfiguration): Future[ValidatedMethodConfiguration] = {
+  def createMethodConfiguration(workspaceName: WorkspaceName,
+                                methodConfiguration: MethodConfiguration
+  ): Future[ValidatedMethodConfiguration] =
     withAttributeNamespaceCheck(methodConfiguration) {
       getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
-        dataSource.inTransaction { dataAccess =>
-          dataAccess.methodConfigurationQuery.get(workspaceContext, methodConfiguration.namespace, methodConfiguration.name) flatMap {
-            case Some(_) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"${methodConfiguration.name} already exists in ${workspaceName}")))
-            case None => dataAccess.methodConfigurationQuery.create(workspaceContext, methodConfiguration)
-          }
-        }.flatMap { methodConfig =>
-          validateMethodConfiguration(methodConfig, workspaceContext) }
-      }
-    }
-  }
-
-  def deleteMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String): Future[Boolean] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { methodConfig =>
-          dataAccess.methodConfigurationQuery.delete(workspaceContext, methodConfigurationNamespace, methodConfigurationName)
-        }
-      }
-    }
-
-  def renameMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String, newName: MethodConfigurationName): Future[MethodConfiguration] =
-    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        //It's terrible that we pass unnecessary junk that we don't read in the payload, but a big refactor of the API is going to have to wait until Some Other Time.
-        if(newName.workspaceName != workspaceName) {
-          DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "Workspace name and namespace in payload must match those in the URI")))
-        } else {
-          withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { methodConfiguration =>
-            //If a different MC exists at the target location, return 409. But it's okay to want to overwrite your own MC.
-            dataAccess.methodConfigurationQuery.get(workspaceContext, newName.namespace, newName.name) flatMap {
-              case Some(_) if methodConfigurationNamespace != newName.namespace || methodConfigurationName != newName.name =>
-                DBIO.failed(new RawlsExceptionWithErrorReport(errorReport =
-                  ErrorReport(StatusCodes.Conflict, s"There is already a method configuration at ${methodConfiguration.namespace}/${methodConfiguration.name} in ${workspaceName}.")))
-              case Some(_) => DBIO.successful(methodConfiguration) //renaming self to self: no-op
-              case None =>
-                dataAccess.methodConfigurationQuery.update(workspaceContext, methodConfigurationNamespace, methodConfigurationName, methodConfiguration.copy(name = newName.name, namespace = newName.namespace))
+        dataSource
+          .inTransaction { dataAccess =>
+            dataAccess.methodConfigurationQuery.get(workspaceContext,
+                                                    methodConfiguration.namespace,
+                                                    methodConfiguration.name
+            ) flatMap {
+              case Some(_) =>
+                DBIO.failed(
+                  new RawlsExceptionWithErrorReport(
+                    errorReport = ErrorReport(StatusCodes.Conflict,
+                                              s"${methodConfiguration.name} already exists in ${workspaceName}"
+                    )
+                  )
+                )
+              case None => dataAccess.methodConfigurationQuery.create(workspaceContext, methodConfiguration)
             }
           }
-        }
-      }
-    }
-
-  //Overwrite the method configuration at methodConfiguration[namespace|name] with the new method configuration.
-  def overwriteMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String, methodConfiguration: MethodConfiguration): Future[ValidatedMethodConfiguration] = {
-    withAttributeNamespaceCheck(methodConfiguration) {
-      // check permissions
-      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
-        // create transaction
-        dataSource.inTransaction { dataAccess =>
-          if (methodConfiguration.namespace != methodConfigurationNamespace || methodConfiguration.name != methodConfigurationName) {
-            DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest,
-              s"The method configuration name and namespace in the URI should match the method configuration name and namespace in the request body. If you want to move this method configuration, use POST.")))
-          } else {
-            dataAccess.methodConfigurationQuery.create(workspaceContext, methodConfiguration)
+          .flatMap { methodConfig =>
+            validateMethodConfiguration(methodConfig, workspaceContext)
           }
-        }.flatMap { methodConfig =>
-          validateMethodConfiguration(methodConfig, workspaceContext)
+      }
+    }
+
+  def deleteMethodConfiguration(workspaceName: WorkspaceName,
+                                methodConfigurationNamespace: String,
+                                methodConfigurationName: String
+  ): Future[Boolean] =
+    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
+      dataSource.inTransaction { dataAccess =>
+        withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) {
+          methodConfig =>
+            dataAccess.methodConfigurationQuery.delete(workspaceContext,
+                                                       methodConfigurationNamespace,
+                                                       methodConfigurationName
+            )
         }
       }
     }
-  }
 
-  //Move the method configuration at methodConfiguration[namespace|name] to the location specified in methodConfiguration, _and_ update it.
-  //It's like a rename and upsert all rolled into one.
-  def updateMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String, methodConfiguration: MethodConfiguration): Future[ValidatedMethodConfiguration] = {
-    withAttributeNamespaceCheck(methodConfiguration) {
-      // check permissions
-      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
-        // create transaction
-        dataSource.inTransaction { dataAccess =>
-          withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { _ =>
-              dataAccess.methodConfigurationQuery.get(workspaceContext, methodConfiguration.namespace, methodConfiguration.name) flatMap {
-                //If a different MC exists at the target location, return 409. But it's okay to want to overwrite your own MC.
-                case Some(_) if methodConfigurationNamespace != methodConfiguration.namespace || methodConfigurationName != methodConfiguration.name =>
-                  DBIO.failed(new RawlsExceptionWithErrorReport(errorReport =
-                    ErrorReport(StatusCodes.Conflict, s"There is already a method configuration at ${methodConfiguration.namespace}/${methodConfiguration.name} in ${workspaceName}.")))
-                case _ =>
-                  dataAccess.methodConfigurationQuery.update(workspaceContext, methodConfigurationNamespace, methodConfigurationName, methodConfiguration)
+  def renameMethodConfiguration(workspaceName: WorkspaceName,
+                                methodConfigurationNamespace: String,
+                                methodConfigurationName: String,
+                                newName: MethodConfigurationName
+  ): Future[MethodConfiguration] =
+    getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
+      dataSource.inTransaction { dataAccess =>
+        // It's terrible that we pass unnecessary junk that we don't read in the payload, but a big refactor of the API is going to have to wait until Some Other Time.
+        if (newName.workspaceName != workspaceName) {
+          DBIO.failed(
+            new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest, "Workspace name and namespace in payload must match those in the URI")
+            )
+          )
+        } else {
+          withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) {
+            methodConfiguration =>
+              // If a different MC exists at the target location, return 409. But it's okay to want to overwrite your own MC.
+              dataAccess.methodConfigurationQuery.get(workspaceContext, newName.namespace, newName.name) flatMap {
+                case Some(_)
+                    if methodConfigurationNamespace != newName.namespace || methodConfigurationName != newName.name =>
+                  DBIO.failed(
+                    new RawlsExceptionWithErrorReport(
+                      errorReport = ErrorReport(
+                        StatusCodes.Conflict,
+                        s"There is already a method configuration at ${methodConfiguration.namespace}/${methodConfiguration.name} in ${workspaceName}."
+                      )
+                    )
+                  )
+                case Some(_) => DBIO.successful(methodConfiguration) // renaming self to self: no-op
+                case None =>
+                  dataAccess.methodConfigurationQuery.update(workspaceContext,
+                                                             methodConfigurationNamespace,
+                                                             methodConfigurationName,
+                                                             methodConfiguration.copy(name = newName.name,
+                                                                                      namespace = newName.namespace
+                                                             )
+                  )
               }
           }
-        }.flatMap { updatedMethodConfig =>
-          validateMethodConfiguration(updatedMethodConfig, workspaceContext)
         }
       }
     }
-  }
 
-  def getMethodConfiguration(workspaceName: WorkspaceName, methodConfigurationNamespace: String, methodConfigurationName: String): Future[MethodConfiguration] =
+  // Overwrite the method configuration at methodConfiguration[namespace|name] with the new method configuration.
+  def overwriteMethodConfiguration(workspaceName: WorkspaceName,
+                                   methodConfigurationNamespace: String,
+                                   methodConfigurationName: String,
+                                   methodConfiguration: MethodConfiguration
+  ): Future[ValidatedMethodConfiguration] =
+    withAttributeNamespaceCheck(methodConfiguration) {
+      // check permissions
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
+        // create transaction
+        dataSource
+          .inTransaction { dataAccess =>
+            if (
+              methodConfiguration.namespace != methodConfigurationNamespace || methodConfiguration.name != methodConfigurationName
+            ) {
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  errorReport = ErrorReport(
+                    StatusCodes.BadRequest,
+                    s"The method configuration name and namespace in the URI should match the method configuration name and namespace in the request body. If you want to move this method configuration, use POST."
+                  )
+                )
+              )
+            } else {
+              dataAccess.methodConfigurationQuery.create(workspaceContext, methodConfiguration)
+            }
+          }
+          .flatMap { methodConfig =>
+            validateMethodConfiguration(methodConfig, workspaceContext)
+          }
+      }
+    }
+
+  // Move the method configuration at methodConfiguration[namespace|name] to the location specified in methodConfiguration, _and_ update it.
+  // It's like a rename and upsert all rolled into one.
+  def updateMethodConfiguration(workspaceName: WorkspaceName,
+                                methodConfigurationNamespace: String,
+                                methodConfigurationName: String,
+                                methodConfiguration: MethodConfiguration
+  ): Future[ValidatedMethodConfiguration] =
+    withAttributeNamespaceCheck(methodConfiguration) {
+      // check permissions
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
+        // create transaction
+        dataSource
+          .inTransaction { dataAccess =>
+            withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { _ =>
+              dataAccess.methodConfigurationQuery.get(workspaceContext,
+                                                      methodConfiguration.namespace,
+                                                      methodConfiguration.name
+              ) flatMap {
+                // If a different MC exists at the target location, return 409. But it's okay to want to overwrite your own MC.
+                case Some(_)
+                    if methodConfigurationNamespace != methodConfiguration.namespace || methodConfigurationName != methodConfiguration.name =>
+                  DBIO.failed(
+                    new RawlsExceptionWithErrorReport(
+                      errorReport = ErrorReport(
+                        StatusCodes.Conflict,
+                        s"There is already a method configuration at ${methodConfiguration.namespace}/${methodConfiguration.name} in ${workspaceName}."
+                      )
+                    )
+                  )
+                case _ =>
+                  dataAccess.methodConfigurationQuery.update(workspaceContext,
+                                                             methodConfigurationNamespace,
+                                                             methodConfigurationName,
+                                                             methodConfiguration
+                  )
+              }
+            }
+          }
+          .flatMap { updatedMethodConfig =>
+            validateMethodConfiguration(updatedMethodConfig, workspaceContext)
+          }
+      }
+    }
+
+  def getMethodConfiguration(workspaceName: WorkspaceName,
+                             methodConfigurationNamespace: String,
+                             methodConfigurationName: String
+  ): Future[MethodConfiguration] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
-        withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) { methodConfig =>
-          DBIO.successful(methodConfig)
+        withMethodConfig(workspaceContext, methodConfigurationNamespace, methodConfigurationName, dataAccess) {
+          methodConfig =>
+            DBIO.successful(methodConfig)
         }
       }
     }
@@ -1420,87 +1919,150 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   def copyMethodConfiguration(mcnp: MethodConfigurationNamePair): Future[ValidatedMethodConfiguration] = {
     // split into two transactions because we need to call out to Google after retrieving the source MC
 
-    val transaction1Result = getWorkspaceContextAndPermissions(mcnp.destination.workspaceName, SamWorkspaceActions.write) flatMap { destContext =>
-      getWorkspaceContextAndPermissions(mcnp.source.workspaceName, SamWorkspaceActions.read) flatMap { sourceContext =>
-        dataSource.inTransaction { dataAccess =>
-          dataAccess.methodConfigurationQuery.get(sourceContext, mcnp.source.namespace, mcnp.source.name) flatMap {
-            case None =>
-              val err = ErrorReport(StatusCodes.NotFound, s"There is no method configuration named ${mcnp.source.namespace}/${mcnp.source.name} in ${mcnp.source.workspaceName}.")
-              DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = err))
-            case Some(methodConfig) => DBIO.successful((methodConfig, destContext))
+    val transaction1Result =
+      getWorkspaceContextAndPermissions(mcnp.destination.workspaceName, SamWorkspaceActions.write) flatMap {
+        destContext =>
+          getWorkspaceContextAndPermissions(mcnp.source.workspaceName, SamWorkspaceActions.read) flatMap {
+            sourceContext =>
+              dataSource.inTransaction { dataAccess =>
+                dataAccess.methodConfigurationQuery.get(sourceContext,
+                                                        mcnp.source.namespace,
+                                                        mcnp.source.name
+                ) flatMap {
+                  case None =>
+                    val err = ErrorReport(
+                      StatusCodes.NotFound,
+                      s"There is no method configuration named ${mcnp.source.namespace}/${mcnp.source.name} in ${mcnp.source.workspaceName}."
+                    )
+                    DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = err))
+                  case Some(methodConfig) => DBIO.successful((methodConfig, destContext))
+                }
+              }
           }
-        }
       }
-    }
 
     transaction1Result flatMap { case (methodConfig, destContext) =>
       withAttributeNamespaceCheck(methodConfig) {
-        dataSource.inTransaction { dataAccess =>
-          saveCopiedMethodConfiguration(methodConfig, mcnp.destination, destContext, dataAccess)
-        }.flatMap { methodConfig =>
-          validateMethodConfiguration(methodConfig, destContext)
-        }
+        dataSource
+          .inTransaction { dataAccess =>
+            saveCopiedMethodConfiguration(methodConfig, mcnp.destination, destContext, dataAccess)
+          }
+          .flatMap { methodConfig =>
+            validateMethodConfiguration(methodConfig, destContext)
+          }
       }
     }
   }
 
-  def copyMethodConfigurationFromMethodRepo(methodRepoQuery: MethodRepoConfigurationImport): Future[ValidatedMethodConfiguration] =
-    methodRepoDAO.getMethodConfig(methodRepoQuery.methodRepoNamespace, methodRepoQuery.methodRepoName, methodRepoQuery.methodRepoSnapshotId, ctx.userInfo) flatMap {
+  def copyMethodConfigurationFromMethodRepo(
+    methodRepoQuery: MethodRepoConfigurationImport
+  ): Future[ValidatedMethodConfiguration] =
+    methodRepoDAO.getMethodConfig(methodRepoQuery.methodRepoNamespace,
+                                  methodRepoQuery.methodRepoName,
+                                  methodRepoQuery.methodRepoSnapshotId,
+                                  ctx.userInfo
+    ) flatMap {
       case None =>
-        val name = s"${methodRepoQuery.methodRepoNamespace}/${methodRepoQuery.methodRepoName}/${methodRepoQuery.methodRepoSnapshotId}"
+        val name =
+          s"${methodRepoQuery.methodRepoNamespace}/${methodRepoQuery.methodRepoName}/${methodRepoQuery.methodRepoSnapshotId}"
         val err = ErrorReport(StatusCodes.NotFound, s"There is no method configuration named $name in the repository.")
         Future.failed(new RawlsExceptionWithErrorReport(errorReport = err))
-      case Some(agoraEntity) => Future.fromTry(parseAgoraEntity(agoraEntity)) flatMap { targetMethodConfig =>
-        withAttributeNamespaceCheck(targetMethodConfig) {
-          getWorkspaceContextAndPermissions(methodRepoQuery.destination.workspaceName, SamWorkspaceActions.write) flatMap { destContext =>
-            dataSource.inTransaction { dataAccess =>
-              saveCopiedMethodConfiguration(targetMethodConfig, methodRepoQuery.destination, destContext, dataAccess)
-            }.flatMap { methodConfig =>
-              validateMethodConfiguration(methodConfig, destContext)
+      case Some(agoraEntity) =>
+        Future.fromTry(parseAgoraEntity(agoraEntity)) flatMap { targetMethodConfig =>
+          withAttributeNamespaceCheck(targetMethodConfig) {
+            getWorkspaceContextAndPermissions(methodRepoQuery.destination.workspaceName,
+                                              SamWorkspaceActions.write
+            ) flatMap { destContext =>
+              dataSource
+                .inTransaction { dataAccess =>
+                  saveCopiedMethodConfiguration(targetMethodConfig,
+                                                methodRepoQuery.destination,
+                                                destContext,
+                                                dataAccess
+                  )
+                }
+                .flatMap { methodConfig =>
+                  validateMethodConfiguration(methodConfig, destContext)
+                }
             }
           }
         }
-      }
     }
 
   private def parseAgoraEntity(agoraEntity: AgoraEntity): Try[MethodConfiguration] = {
     val parsed = Try {
       agoraEntity.payload.map(JsonParser(_).convertTo[AgoraMethodConfiguration])
-    } recoverWith {
-      case e: Exception =>
-        Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.UnprocessableEntity, "Error parsing Method Repo response message.", ErrorReport(e))))
+    } recoverWith { case e: Exception =>
+      Failure(
+        new RawlsExceptionWithErrorReport(
+          errorReport =
+            ErrorReport(StatusCodes.UnprocessableEntity, "Error parsing Method Repo response message.", ErrorReport(e))
+        )
+      )
     }
 
     parsed flatMap {
       case Some(agoraMC) => Success(convertToMethodConfiguration(agoraMC))
-      case None => Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.UnprocessableEntity, "Method Repo missing configuration payload")))
+      case None =>
+        Failure(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.UnprocessableEntity, "Method Repo missing configuration payload")
+          )
+        )
     }
   }
 
-  private def convertToMethodConfiguration(agoraMethodConfig: AgoraMethodConfiguration): MethodConfiguration = {
-    MethodConfiguration(agoraMethodConfig.namespace, agoraMethodConfig.name, Some(agoraMethodConfig.rootEntityType), Some(Map.empty[String, AttributeString]), agoraMethodConfig.inputs, agoraMethodConfig.outputs, agoraMethodConfig.methodRepoMethod)
-  }
+  private def convertToMethodConfiguration(agoraMethodConfig: AgoraMethodConfiguration): MethodConfiguration =
+    MethodConfiguration(
+      agoraMethodConfig.namespace,
+      agoraMethodConfig.name,
+      Some(agoraMethodConfig.rootEntityType),
+      Some(Map.empty[String, AttributeString]),
+      agoraMethodConfig.inputs,
+      agoraMethodConfig.outputs,
+      agoraMethodConfig.methodRepoMethod
+    )
 
-  def copyMethodConfigurationToMethodRepo(methodRepoQuery: MethodRepoConfigurationExport): Future[AgoraEntity] = {
-    getWorkspaceContextAndPermissions(methodRepoQuery.source.workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        withMethodConfig(workspaceContext, methodRepoQuery.source.namespace, methodRepoQuery.source.name, dataAccess) { methodConfig =>
-
-          DBIO.from(methodRepoDAO.postMethodConfig(
-            methodRepoQuery.methodRepoNamespace,
-            methodRepoQuery.methodRepoName,
-            methodConfig.copy(namespace = methodRepoQuery.methodRepoNamespace, name = methodRepoQuery.methodRepoName),
-            ctx.userInfo))
+  def copyMethodConfigurationToMethodRepo(methodRepoQuery: MethodRepoConfigurationExport): Future[AgoraEntity] =
+    getWorkspaceContextAndPermissions(methodRepoQuery.source.workspaceName, SamWorkspaceActions.read) flatMap {
+      workspaceContext =>
+        dataSource.inTransaction { dataAccess =>
+          withMethodConfig(workspaceContext,
+                           methodRepoQuery.source.namespace,
+                           methodRepoQuery.source.name,
+                           dataAccess
+          ) { methodConfig =>
+            DBIO.from(
+              methodRepoDAO.postMethodConfig(
+                methodRepoQuery.methodRepoNamespace,
+                methodRepoQuery.methodRepoName,
+                methodConfig.copy(namespace = methodRepoQuery.methodRepoNamespace,
+                                  name = methodRepoQuery.methodRepoName
+                ),
+                ctx.userInfo
+              )
+            )
+          }
         }
-      }
     }
-  }
 
-  private def saveCopiedMethodConfiguration(methodConfig: MethodConfiguration, dest: MethodConfigurationName, destContext: Workspace, dataAccess: DataAccess) = {
+  private def saveCopiedMethodConfiguration(methodConfig: MethodConfiguration,
+                                            dest: MethodConfigurationName,
+                                            destContext: Workspace,
+                                            dataAccess: DataAccess
+  ) = {
     val target = methodConfig.copy(name = dest.name, namespace = dest.namespace)
 
     dataAccess.methodConfigurationQuery.get(destContext, dest.namespace, dest.name).flatMap {
-      case Some(existingMethodConfig) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"A method configuration named ${dest.namespace}/${dest.name} already exists in ${dest.workspaceName}")))
+      case Some(existingMethodConfig) =>
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(
+              StatusCodes.Conflict,
+              s"A method configuration named ${dest.namespace}/${dest.name} already exists in ${dest.workspaceName}"
+            )
+          )
+        )
       case None => dataAccess.methodConfigurationQuery.create(destContext, target)
     }
   }
@@ -1521,43 +2083,44 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
     }
 
-  def createMethodConfigurationTemplate(methodRepoMethod: MethodRepoMethod ): Future[MethodConfiguration] = {
+  def createMethodConfigurationTemplate(methodRepoMethod: MethodRepoMethod): Future[MethodConfiguration] =
     dataSource.inTransaction { _ =>
       withMethod(methodRepoMethod, ctx.userInfo) { wdl: WDL =>
         methodConfigResolver.toMethodConfiguration(ctx.userInfo, wdl, methodRepoMethod) match {
-          case Failure(exception) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, exception)))
+          case Failure(exception) =>
+            DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, exception)))
           case Success(methodConfig) => DBIO.successful(methodConfig)
         }
       }
     }
-  }
 
-  def getMethodInputsOutputs(userInfo: UserInfo, methodRepoMethod: MethodRepoMethod ): Future[MethodInputsOutputs] = {
+  def getMethodInputsOutputs(userInfo: UserInfo, methodRepoMethod: MethodRepoMethod): Future[MethodInputsOutputs] =
     dataSource.inTransaction { _ =>
       withMethod(methodRepoMethod, userInfo) { wdl: WDL =>
         methodConfigResolver.getMethodInputsOutputs(userInfo, wdl) match {
-          case Failure(exception) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, exception)))
+          case Failure(exception) =>
+            DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, exception)))
           case Success(inputsOutputs) => DBIO.successful(inputsOutputs)
         }
       }
     }
-  }
 
   def listSubmissions(workspaceName: WorkspaceName): Future[Seq[SubmissionListResponse]] = {
-    val costlessSubmissionsFuture = getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        dataAccess.submissionQuery.listWithSubmitter(workspaceContext)
-      }
+    val costlessSubmissionsFuture = getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap {
+      workspaceContext =>
+        dataSource.inTransaction { dataAccess =>
+          dataAccess.submissionQuery.listWithSubmitter(workspaceContext)
+        }
     }
 
     // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
     // val costMapFuture = costlessSubmissionsFuture flatMap { submissions =>
     //   submissionCostService.getWorkflowCosts(submissions.flatMap(_.workflowIds).flatten, workspaceName.namespace)
     // }
-    val costMapFuture = Future.successful(Map.empty[String,Float])
+    val costMapFuture = Future.successful(Map.empty[String, Float])
 
     toFutureTry(costMapFuture) flatMap { costMapTry =>
-      val costMap: Map[String,Float] = costMapTry match {
+      val costMap: Map[String, Float] = costMapTry match {
         case Failure(ex) =>
           logger.error("Unable to get cost data from BigQuery", ex)
           Map()
@@ -1584,17 +2147,37 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
     }
 
-  def createSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest): Future[SubmissionReport] = {
+  def createSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest): Future[SubmissionReport] =
     for {
-      (workspaceContext, submissionId, submissionParameters, workflowFailureMode, header, submissionRoot) <- prepareSubmission(workspaceName, submissionRequest)
-      submission <- saveSubmission(workspaceContext, submissionId, submissionRequest, submissionRoot, submissionParameters, workflowFailureMode, header)
-    } yield {
-      SubmissionReport(submissionRequest, submission.submissionId, submission.submissionDate, ctx.userInfo.userEmail.value, submission.status, header, submissionParameters.filter(_.inputResolutions.forall(_.error.isEmpty)))
-    }
-  }
+      (workspaceContext, submissionId, submissionParameters, workflowFailureMode, header, submissionRoot) <-
+        prepareSubmission(workspaceName, submissionRequest)
+      submission <- saveSubmission(workspaceContext,
+                                   submissionId,
+                                   submissionRequest,
+                                   submissionRoot,
+                                   submissionParameters,
+                                   workflowFailureMode,
+                                   header
+      )
+    } yield SubmissionReport(
+      submissionRequest,
+      submission.submissionId,
+      submission.submissionDate,
+      ctx.userInfo.userEmail.value,
+      submission.status,
+      header,
+      submissionParameters.filter(_.inputResolutions.forall(_.error.isEmpty))
+    )
 
-  private def prepareSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest):
-  Future[(Workspace, UUID, Stream[SubmissionValidationEntityInputs], Option[WorkflowFailureMode], SubmissionValidationHeader, String)] = {
+  private def prepareSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest): Future[
+    (Workspace,
+     UUID,
+     Stream[SubmissionValidationEntityInputs],
+     Option[WorkflowFailureMode],
+     SubmissionValidationHeader,
+     String
+    )
+  ] = {
 
     val submissionId: UUID = UUID.randomUUID()
 
@@ -1609,10 +2192,18 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       submissionRoot = s"gs://${workspaceContext.bucketName}/submissions/${submissionId}"
 
       methodConfigOption <- dataSource.inTransaction { dataAccess =>
-        dataAccess.methodConfigurationQuery.get(workspaceContext, submissionRequest.methodConfigurationNamespace, submissionRequest.methodConfigurationName)
+        dataAccess.methodConfigurationQuery.get(workspaceContext,
+                                                submissionRequest.methodConfigurationNamespace,
+                                                submissionRequest.methodConfigurationName
+        )
       }
       methodConfig = methodConfigOption.getOrElse(
-        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"${submissionRequest.methodConfigurationNamespace}/${submissionRequest.methodConfigurationName} does not exist in ${workspaceContext}"))
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            StatusCodes.NotFound,
+            s"${submissionRequest.methodConfigurationNamespace}/${submissionRequest.methodConfigurationName} does not exist in ${workspaceContext}"
+          )
+        )
       )
 
       entityProvider <- getEntityProviderForMethodConfig(workspaceContext, methodConfig)
@@ -1623,22 +2214,34 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
       gatherInputsResult <- gatherMethodConfigInputs(methodConfig)
 
-      validationResult <- entityProvider.expressionValidator.validateExpressionsForSubmission(methodConfig, gatherInputsResult)
+      validationResult <- entityProvider.expressionValidator.validateExpressionsForSubmission(methodConfig,
+                                                                                              gatherInputsResult
+      )
 
       // calling .get on the Try will throw the validation error
       _ = validationResult.get
 
-      methodConfigInputs = gatherInputsResult.processableInputs.map { methodInput => SubmissionValidationInput(methodInput.workflowInput.getName, methodInput.expression) }
+      methodConfigInputs = gatherInputsResult.processableInputs.map { methodInput =>
+        SubmissionValidationInput(methodInput.workflowInput.getName, methodInput.expression)
+      }
       header = SubmissionValidationHeader(methodConfig.rootEntityType, methodConfigInputs, entityProvider.entityStoreId)
 
       workspaceExpressionResults <- evaluateWorkspaceExpressions(workspaceContext, gatherInputsResult)
-      submissionParameters <- entityProvider.evaluateExpressions(ExpressionEvaluationContext(submissionRequest.entityType, submissionRequest.entityName, submissionRequest.expression, methodConfig.rootEntityType), gatherInputsResult, workspaceExpressionResults)
-    } yield {
-      (workspaceContext, submissionId, submissionParameters, workflowFailureMode, header, submissionRoot)
-    }
+      submissionParameters <- entityProvider.evaluateExpressions(
+        ExpressionEvaluationContext(submissionRequest.entityType,
+                                    submissionRequest.entityName,
+                                    submissionRequest.expression,
+                                    methodConfig.rootEntityType
+        ),
+        gatherInputsResult,
+        workspaceExpressionResults
+      )
+    } yield (workspaceContext, submissionId, submissionParameters, workflowFailureMode, header, submissionRoot)
   }
 
-  private def evaluateWorkspaceExpressions(workspace: Workspace, gatherInputResults: GatherInputsResult): Future[Map[LookupExpression, Try[Iterable[AttributeValue]]]] = {
+  private def evaluateWorkspaceExpressions(workspace: Workspace,
+                                           gatherInputResults: GatherInputsResult
+  ): Future[Map[LookupExpression, Try[Iterable[AttributeValue]]]] =
     dataSource.inTransaction { dataAccess =>
       ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, None) { expressionEvaluator =>
         val expressionQueries = gatherInputResults.processableInputs.map { input =>
@@ -1648,29 +2251,56 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         // reduce(_ ++ _) collapses the series of maps into a single map
         // duplicate map keys are dropped but that is ok as the values should be duplicate
         DBIO.sequence(expressionQueries.toSeq).map {
-          case Seq() => Map.empty[LookupExpression, Try[Iterable[AttributeValue]]]
+          case Seq()   => Map.empty[LookupExpression, Try[Iterable[AttributeValue]]]
           case results => results.reduce(_ ++ _)
         }
       }
     }
-  }
 
-  private def gatherMethodConfigInputs(methodConfig: MethodConfiguration): Future[MethodConfigResolver.GatherInputsResult] = {
+  private def gatherMethodConfigInputs(
+    methodConfig: MethodConfiguration
+  ): Future[MethodConfigResolver.GatherInputsResult] =
     toFutureTry(methodRepoDAO.getMethod(methodConfig.methodRepoMethod, ctx.userInfo)).map {
-      case Success(None) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."))
-      case Success(Some(wdl)) => methodConfigResolver.gatherInputs(ctx.userInfo, methodConfig, wdl).recoverWith { case regrets =>
-        Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
-      }.get
-      case Failure(throwable) => throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadGateway, s"Unable to query the method repo.", methodRepoDAO.toErrorReport(throwable)))
+      case Success(None) =>
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(StatusCodes.NotFound,
+                                    s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."
+          )
+        )
+      case Success(Some(wdl)) =>
+        methodConfigResolver
+          .gatherInputs(ctx.userInfo, methodConfig, wdl)
+          .recoverWith { case regrets =>
+            Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
+          }
+          .get
+      case Failure(throwable) =>
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(StatusCodes.BadGateway,
+                                    s"Unable to query the method repo.",
+                                    methodRepoDAO.toErrorReport(throwable)
+          )
+        )
     }
-  }
 
-  def saveSubmission(workspaceContext: Workspace, submissionId: UUID, submissionRequest: SubmissionRequest, submissionRoot: String, submissionParameters: Seq[SubmissionValidationEntityInputs], workflowFailureMode: Option[WorkflowFailureMode], header: SubmissionValidationHeader): Future[Submission] = {
+  def saveSubmission(workspaceContext: Workspace,
+                     submissionId: UUID,
+                     submissionRequest: SubmissionRequest,
+                     submissionRoot: String,
+                     submissionParameters: Seq[SubmissionValidationEntityInputs],
+                     workflowFailureMode: Option[WorkflowFailureMode],
+                     header: SubmissionValidationHeader
+  ): Future[Submission] =
     dataSource.inTransaction { dataAccess =>
-      val (successes, failures) = submissionParameters.partition({ entityInputs => entityInputs.inputResolutions.forall(_.error.isEmpty) })
+      val (successes, failures) = submissionParameters.partition { entityInputs =>
+        entityInputs.inputResolutions.forall(_.error.isEmpty)
+      }
       val workflows = successes map { entityInputs =>
-        val workflowEntityOpt = header.entityType.map(_ => AttributeEntityReference(entityType = header.entityType.get, entityName = entityInputs.entityName))
-        Workflow(workflowId = None,
+        val workflowEntityOpt = header.entityType.map(_ =>
+          AttributeEntityReference(entityType = header.entityType.get, entityName = entityInputs.entityName)
+        )
+        Workflow(
+          workflowId = None,
           status = WorkflowStatuses.Queued,
           statusLastChangedDate = DateTime.now,
           workflowEntity = workflowEntityOpt,
@@ -1679,23 +2309,32 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
 
       val workflowFailures = failures map { entityInputs =>
-        val workflowEntityOpt = header.entityType.map(_ => AttributeEntityReference(entityType = header.entityType.get, entityName = entityInputs.entityName))
-        Workflow(workflowId = None,
+        val workflowEntityOpt = header.entityType.map(_ =>
+          AttributeEntityReference(entityType = header.entityType.get, entityName = entityInputs.entityName)
+        )
+        Workflow(
+          workflowId = None,
           status = WorkflowStatuses.Failed,
           statusLastChangedDate = DateTime.now,
           workflowEntity = workflowEntityOpt,
           inputResolutions = entityInputs.inputResolutions.toSeq,
-          messages = (for (entityValue <- entityInputs.inputResolutions if entityValue.error.isDefined) yield AttributeString(entityValue.inputName + " - " + entityValue.error.get)).toSeq
+          messages = (for (entityValue <- entityInputs.inputResolutions if entityValue.error.isDefined)
+            yield AttributeString(entityValue.inputName + " - " + entityValue.error.get)).toSeq
         )
       }
 
       val submissionEntityOpt = if (header.entityType.isEmpty || submissionRequest.entityName.isEmpty) {
         None
       } else {
-        Some(AttributeEntityReference(entityType = submissionRequest.entityType.get, entityName = submissionRequest.entityName.get))
+        Some(
+          AttributeEntityReference(entityType = submissionRequest.entityType.get,
+                                   entityName = submissionRequest.entityName.get
+          )
+        )
       }
 
-      val submission = Submission(submissionId = submissionId.toString,
+      val submission = Submission(
+        submissionId = submissionId.toString,
         submissionDate = DateTime.now(),
         submitter = WorkbenchEmail(ctx.userInfo.userEmail.value),
         methodConfigurationNamespace = submissionRequest.methodConfigurationNamespace,
@@ -1719,73 +2358,102 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       // implicitly passed to SubmissionComponent.create
       implicit val subStatusCounter = submissionStatusCounter(workspaceMetricBuilder(workspaceContext.toWorkspaceName))
       implicit val wfStatusCounter = (status: WorkflowStatus) =>
-        if (config.trackDetailedSubmissionMetrics) Option(workflowStatusCounter(workspaceSubmissionMetricBuilder(workspaceContext.toWorkspaceName, submissionId))(status))
+        if (config.trackDetailedSubmissionMetrics)
+          Option(
+            workflowStatusCounter(workspaceSubmissionMetricBuilder(workspaceContext.toWorkspaceName, submissionId))(
+              status
+            )
+          )
         else None
 
       dataAccess.submissionQuery.create(workspaceContext, submission)
     }
-  }
 
-  def validateSubmission(workspaceName: WorkspaceName, submissionRequest: SubmissionRequest): Future[SubmissionValidationReport] = {
+  def validateSubmission(workspaceName: WorkspaceName,
+                         submissionRequest: SubmissionRequest
+  ): Future[SubmissionValidationReport] =
     for {
       (_, _, submissionParameters, _, header, _) <- prepareSubmission(workspaceName, submissionRequest)
     } yield {
       val (failed, succeeded) = submissionParameters.partition(_.inputResolutions.exists(_.error.isDefined))
       SubmissionValidationReport(submissionRequest, header, succeeded, failed)
     }
-  }
 
-  def getSubmissionMethodConfiguration(workspaceName: WorkspaceName, submissionId: String): Future[MethodConfiguration] = {
+  def getSubmissionMethodConfiguration(workspaceName: WorkspaceName,
+                                       submissionId: String
+  ): Future[MethodConfiguration] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
-        dataAccess.submissionQuery.getSubmissionMethodConfigId(workspaceContext, UUID.fromString(submissionId)).flatMap { id =>
-          id match {
-            case Some(id) => dataAccess.methodConfigurationQuery.get(id).map {
-              case Some(methodConfig) => methodConfig
-              case None => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"The method configuration for submission ${submissionId} could not be found."))
+        dataAccess.submissionQuery
+          .getSubmissionMethodConfigId(workspaceContext, UUID.fromString(submissionId))
+          .flatMap { id =>
+            id match {
+              case Some(id) =>
+                dataAccess.methodConfigurationQuery.get(id).map {
+                  case Some(methodConfig) => methodConfig
+                  case None =>
+                    throw new RawlsExceptionWithErrorReport(
+                      ErrorReport(StatusCodes.NotFound,
+                                  s"The method configuration for submission ${submissionId} could not be found."
+                      )
+                    )
+                }
+              case None =>
+                throw new RawlsExceptionWithErrorReport(
+                  ErrorReport(StatusCodes.NotFound,
+                              s"The method configuration for submission ${submissionId} could not be found."
+                  )
+                )
             }
-            case None => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"The method configuration for submission ${submissionId} could not be found."))
           }
-        }
       }
     }
-  }
 
   def getSubmissionStatus(workspaceName: WorkspaceName, submissionId: String): Future[Submission] = {
-    val submissionWithoutCostsAndWorkspace = getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        withSubmission(workspaceContext, submissionId, dataAccess) { submission =>
-          DBIO.successful((submission, workspaceContext))
+    val submissionWithoutCostsAndWorkspace =
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
+        dataSource.inTransaction { dataAccess =>
+          withSubmission(workspaceContext, submissionId, dataAccess) { submission =>
+            DBIO.successful((submission, workspaceContext))
+          }
         }
       }
-    }
 
-    submissionWithoutCostsAndWorkspace flatMap {
-      case (submission, workspace) => {
-        val allWorkflowIds: Seq[String] = submission.workflows.flatMap(_.workflowId)
-        val submissionDoneDate: Option[DateTime] = WorkspaceService.getTerminalStatusDate(submission, None)
+    submissionWithoutCostsAndWorkspace flatMap { case (submission, workspace) =>
+      val allWorkflowIds: Seq[String] = submission.workflows.flatMap(_.workflowId)
+      val submissionDoneDate: Option[DateTime] = WorkspaceService.getTerminalStatusDate(submission, None)
 
-        getSpendReportTableName(RawlsBillingProjectName(workspaceName.namespace)) flatMap { tableName =>
-          toFutureTry(submissionCostService.getSubmissionCosts(submissionId, allWorkflowIds, workspace.googleProjectId, submission.submissionDate, submissionDoneDate, tableName)) map {
-            case Failure(ex) =>
-              logger.error(s"Unable to get workflow costs for submission $submissionId", ex)
-              submission
-            case Success(costMap) =>
-              val costedWorkflows = submission.workflows.map { workflow =>
-                workflow.workflowId match {
-                  case Some(wfId) => workflow.copy(cost = costMap.get(wfId))
-                  case None => workflow
-                }
+      getSpendReportTableName(RawlsBillingProjectName(workspaceName.namespace)) flatMap { tableName =>
+        toFutureTry(
+          submissionCostService.getSubmissionCosts(submissionId,
+                                                   allWorkflowIds,
+                                                   workspace.googleProjectId,
+                                                   submission.submissionDate,
+                                                   submissionDoneDate,
+                                                   tableName
+          )
+        ) map {
+          case Failure(ex) =>
+            logger.error(s"Unable to get workflow costs for submission $submissionId", ex)
+            submission
+          case Success(costMap) =>
+            val costedWorkflows = submission.workflows.map { workflow =>
+              workflow.workflowId match {
+                case Some(wfId) => workflow.copy(cost = costMap.get(wfId))
+                case None       => workflow
               }
-              val costedSubmission = submission.copy(cost = Some(costMap.values.sum), workflows = costedWorkflows)
-              costedSubmission
-          }
+            }
+            val costedSubmission = submission.copy(cost = Some(costMap.values.sum), workflows = costedWorkflows)
+            costedSubmission
         }
       }
     }
   }
 
-  def updateSubmissionUserComment(workspaceName: WorkspaceName, submissionId: String, newComment: UserCommentUpdateOperation): Future[Int] = {
+  def updateSubmissionUserComment(workspaceName: WorkspaceName,
+                                  submissionId: String,
+                                  newComment: UserCommentUpdateOperation
+  ): Future[Int] = {
     validateMaxStringLength(newComment.userComment, "userComment", UserCommentMaxLength)
 
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
@@ -1797,40 +2465,45 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
   }
 
-  def abortSubmission(workspaceName: WorkspaceName, submissionId: String): Future[Int] = {
+  def abortSubmission(workspaceName: WorkspaceName, submissionId: String): Future[Int] =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.write) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         abortSubmission(workspaceContext, submissionId, dataAccess)
       }
     }
-  }
 
-  private def abortSubmission(workspaceContext: Workspace, submissionId: String, dataAccess: DataAccess): ReadWriteAction[Int] = {
+  private def abortSubmission(workspaceContext: Workspace,
+                              submissionId: String,
+                              dataAccess: DataAccess
+  ): ReadWriteAction[Int] =
     withSubmissionId(workspaceContext, submissionId, dataAccess) { submissionId =>
       // implicitly passed to SubmissionComponent.updateStatus
       implicit val subStatusCounter = submissionStatusCounter(workspaceMetricBuilder(workspaceContext.toWorkspaceName))
       dataAccess.submissionQuery.updateStatus(submissionId, SubmissionStatuses.Aborting)
     }
-  }
 
   /**
    * Munges together the output of Cromwell's /outputs and /logs endpoints, grouping them by task name */
-  private def mergeWorkflowOutputs(execOuts: ExecutionServiceOutputs, execLogs: ExecutionServiceLogs, workflowId: String): WorkflowOutputs = {
+  private def mergeWorkflowOutputs(execOuts: ExecutionServiceOutputs,
+                                   execLogs: ExecutionServiceLogs,
+                                   workflowId: String
+  ): WorkflowOutputs = {
     val outs = execOuts.outputs
     val logs = execLogs.calls getOrElse Map()
 
-    //Cromwell workflow outputs look like workflow_name.task_name.output_name.
-    //Under perverse conditions it might just be workflow_name.output_name.
-    //Group outputs by everything left of the rightmost dot.
-    val outsByTask = outs groupBy { case (k,_) => k.split('.').dropRight(1).mkString(".") }
+    // Cromwell workflow outputs look like workflow_name.task_name.output_name.
+    // Under perverse conditions it might just be workflow_name.output_name.
+    // Group outputs by everything left of the rightmost dot.
+    val outsByTask = outs groupBy { case (k, _) => k.split('.').dropRight(1).mkString(".") }
 
-    val taskMap = (outsByTask.keySet ++ logs.keySet).map( key => key -> TaskOutput( logs.get(key), outsByTask.get(key)) ).toMap
+    val taskMap =
+      (outsByTask.keySet ++ logs.keySet).map(key => key -> TaskOutput(logs.get(key), outsByTask.get(key))).toMap
     WorkflowOutputs(workflowId, taskMap)
   }
 
   /**
    * Get the list of outputs for a given workflow in this submission */
-  def workflowOutputs(workspaceName: WorkspaceName, submissionId: String, workflowId: String) = {
+  def workflowOutputs(workspaceName: WorkspaceName, submissionId: String, workflowId: String) =
     getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         withWorkflowRecord(workspaceName, submissionId, workflowId, dataAccess) { wr =>
@@ -1840,17 +2513,33 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
             case (Success(outputs), Success(logs)) =>
               mergeWorkflowOutputs(outputs, logs, workflowId)
             case (Failure(outputsFailure), Success(logs)) =>
-              throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadGateway, s"Unable to get outputs for ${submissionId}.", executionServiceCluster.toErrorReport(outputsFailure)))
+              throw new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(StatusCodes.BadGateway,
+                                          s"Unable to get outputs for ${submissionId}.",
+                                          executionServiceCluster.toErrorReport(outputsFailure)
+                )
+              )
             case (Success(outputs), Failure(logsFailure)) =>
-              throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadGateway, s"Unable to get logs for ${submissionId}.", executionServiceCluster.toErrorReport(logsFailure)))
+              throw new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(StatusCodes.BadGateway,
+                                          s"Unable to get logs for ${submissionId}.",
+                                          executionServiceCluster.toErrorReport(logsFailure)
+                )
+              )
             case (Failure(outputsFailure), Failure(logsFailure)) =>
-              throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadGateway, s"Unable to get outputs and unable to get logs for ${submissionId}.",
-                Seq(executionServiceCluster.toErrorReport(outputsFailure),executionServiceCluster.toErrorReport(logsFailure))))
+              throw new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.BadGateway,
+                  s"Unable to get outputs and unable to get logs for ${submissionId}.",
+                  Seq(executionServiceCluster.toErrorReport(outputsFailure),
+                      executionServiceCluster.toErrorReport(logsFailure)
+                  )
+                )
+              )
           })
         }
       }
     }
-  }
 
   // retrieve the cost of this Workflow from BigQuery, if available
   def workflowCost(workspaceName: WorkspaceName, submissionId: String, workflowId: String): Future[WorkflowCost] = {
@@ -1858,14 +2547,16 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     // confirm: the user can Read this Workspace, the Submission is in this Workspace,
     // and the Workflow is in the Submission
 
-    val execIdFutOpt = getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        withSubmissionAndWorkflowExecutionServiceKey(workspaceContext, submissionId, workflowId, dataAccess) { optExecKey =>
-          withSubmission(workspaceContext, submissionId, dataAccess) { submission =>
-            DBIO.successful((optExecKey, submission, workspaceContext))
+    val execIdFutOpt = getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap {
+      workspaceContext =>
+        dataSource.inTransaction { dataAccess =>
+          withSubmissionAndWorkflowExecutionServiceKey(workspaceContext, submissionId, workflowId, dataAccess) {
+            optExecKey =>
+              withSubmission(workspaceContext, submissionId, dataAccess) { submission =>
+                DBIO.successful((optExecKey, submission, workspaceContext))
+              }
           }
         }
-      }
     }
 
     for {
@@ -1876,11 +2567,20 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       // if we weren't able to do so above
       _ <- executionServiceCluster.findExecService(submissionId, workflowId, ctx.userInfo, optExecId)
       submissionDoneDate = WorkspaceService.getTerminalStatusDate(submission, Option(workflowId))
-      costs <- submissionCostService.getWorkflowCost(workflowId, workspace.googleProjectId, submission.submissionDate, submissionDoneDate, tableName)
+      costs <- submissionCostService.getWorkflowCost(workflowId,
+                                                     workspace.googleProjectId,
+                                                     submission.submissionDate,
+                                                     submissionDoneDate,
+                                                     tableName
+      )
     } yield WorkflowCost(workflowId, costs.get(workflowId))
   }
 
-  def workflowMetadata(workspaceName: WorkspaceName, submissionId: String, workflowId: String, metadataParams: MetadataParams): Future[JsObject] = {
+  def workflowMetadata(workspaceName: WorkspaceName,
+                       submissionId: String,
+                       workflowId: String,
+                       metadataParams: MetadataParams
+  ): Future[JsObject] = {
 
     // two possibilities here:
     //
@@ -1895,13 +2595,15 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     // * in practice, one shard does everything except for some older workflows on shard 2.  Revisit this if that changes!
 
     // determine which case this is, and close the DB transaction
-    val execIdFutOpt: Future[Option[ExecutionServiceId]] = getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        withSubmissionAndWorkflowExecutionServiceKey(workspaceContext, submissionId, workflowId, dataAccess) { optExecKey =>
-          DBIO.successful(optExecKey)
+    val execIdFutOpt: Future[Option[ExecutionServiceId]] =
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
+        dataSource.inTransaction { dataAccess =>
+          withSubmissionAndWorkflowExecutionServiceKey(workspaceContext, submissionId, workflowId, dataAccess) {
+            optExecKey =>
+              DBIO.successful(optExecKey)
+          }
         }
       }
-    }
 
     // query the execution service(s) for the metadata
     execIdFutOpt flatMap {
@@ -1909,7 +2611,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
   }
 
-  def workflowQueueStatus(): Future[WorkflowQueueStatusResponse] = {
+  def workflowQueueStatus(): Future[WorkflowQueueStatusResponse] =
     dataSource.inTransaction { dataAccess =>
       dataAccess.workflowQuery.countWorkflowsByQueueStatus.flatMap { statusMap =>
         // determine the current size of the workflow queue
@@ -1918,25 +2620,27 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
             for {
               timeEstimate <- dataAccess.workflowAuditStatusQuery.queueTimeMostRecentSubmittedWorkflow
               workflowsAhead <- dataAccess.workflowQuery.countWorkflowsAheadOfUserInQueue(ctx.userInfo)
-            } yield {
-              WorkflowQueueStatusResponse(timeEstimate, workflowsAhead, statusMap)
-            }
+            } yield WorkflowQueueStatusResponse(timeEstimate, workflowsAhead, statusMap)
           case _ => DBIO.successful(WorkflowQueueStatusResponse(0, 0, statusMap))
         }
       }
     }
-  }
 
-  def adminWorkflowQueueStatusByUser(): Future[WorkflowQueueStatusByUserResponse] = {
+  def adminWorkflowQueueStatusByUser(): Future[WorkflowQueueStatusByUserResponse] =
     asFCAdmin {
-      dataSource.inTransaction ({ dataAccess =>
-        for {
-          global <- dataAccess.workflowQuery.countWorkflowsByQueueStatus
-          perUser <- dataAccess.workflowQuery.countWorkflowsByQueueStatusByUser
-        } yield WorkflowQueueStatusByUserResponse(global, perUser, maxActiveWorkflowsTotal, maxActiveWorkflowsPerUser)
-      }, TransactionIsolation.ReadUncommitted)
+      dataSource.inTransaction(
+        dataAccess =>
+          for {
+            global <- dataAccess.workflowQuery.countWorkflowsByQueueStatus
+            perUser <- dataAccess.workflowQuery.countWorkflowsByQueueStatusByUser
+          } yield WorkflowQueueStatusByUserResponse(global,
+                                                    perUser,
+                                                    maxActiveWorkflowsTotal,
+                                                    maxActiveWorkflowsPerUser
+          ),
+        TransactionIsolation.ReadUncommitted
+      )
     }
-  }
 
   /*
    If the user only has read access, check the bucket using the default pet.
@@ -1948,10 +2652,12 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
      would constantly hit limits on the number of allowed service accounts.
 
    If the user has write access, we need to use the pet for this workspace's project in order to get accurate results.
- */
-  def checkBucketReadAccess(workspaceName: WorkspaceName): Future[Unit] = {
+   */
+  def checkBucketReadAccess(workspaceName: WorkspaceName): Future[Unit] =
     for {
-      (workspace, maxAccessLevel) <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
+      (workspace, maxAccessLevel) <- getWorkspaceContextAndPermissions(workspaceName,
+                                                                       SamWorkspaceActions.read
+      ) flatMap { workspaceContext =>
         dataSource.inTransaction { dataAccess =>
           DBIO.from(getMaximumAccessLevel(workspaceContext.workspaceIdAsUUID.toString)).map { accessLevel =>
             (workspaceContext, accessLevel)
@@ -1959,26 +2665,27 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       }
 
-      petKey <- if (maxAccessLevel >= WorkspaceAccessLevels.Write)
-        samDAO.getPetServiceAccountKeyForUser(workspace.googleProjectId, ctx.userInfo.userEmail)
-      else
-        samDAO.getDefaultPetServiceAccountKeyForUser(ctx.userInfo)
+      petKey <-
+        if (maxAccessLevel >= WorkspaceAccessLevels.Write)
+          samDAO.getPetServiceAccountKeyForUser(workspace.googleProjectId, ctx.userInfo.userEmail)
+        else
+          samDAO.getDefaultPetServiceAccountKeyForUser(ctx.userInfo)
 
       accessToken <- gcsDAO.getAccessTokenUsingJson(petKey)
 
       (petEmail, petSubjectId) = petKey.parseJson match {
-        case JsObject(fields) => (RawlsUserEmail(fields("client_email").toString), RawlsUserSubjectId(fields("client_id").toString))
+        case JsObject(fields) =>
+          (RawlsUserEmail(fields("client_email").toString), RawlsUserSubjectId(fields("client_id").toString))
         case _ => throw new RawlsException("pet service account key was not a json object")
       }
 
-      resultsForPet <- gcsDAO.diagnosticBucketRead(UserInfo(petEmail, OAuth2BearerToken(accessToken), 60, petSubjectId), workspace.bucketName)
-    } yield {
-      resultsForPet match {
-        case None => ()
-        case Some(report) => throw new RawlsExceptionWithErrorReport(report)
-      }
+      resultsForPet <- gcsDAO.diagnosticBucketRead(UserInfo(petEmail, OAuth2BearerToken(accessToken), 60, petSubjectId),
+                                                   workspace.bucketName
+      )
+    } yield resultsForPet match {
+      case None         => ()
+      case Some(report) => throw new RawlsExceptionWithErrorReport(report)
     }
-  }
 
   def checkSamActionWithLock(workspaceName: WorkspaceName, samAction: SamResourceAction): Future[Boolean] = {
     val wsCtxFuture = dataSource.inTransaction { dataAccess =>
@@ -1987,26 +2694,25 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
     }
 
-    //don't do the sam REST call inside the db transaction.
+    // don't do the sam REST call inside the db transaction.
     val access: Future[Boolean] = wsCtxFuture flatMap { workspaceContext =>
       requireAccessF(workspaceContext, samAction) {
-        Future.successful(true) //if we get here, we passed all the hoops
+        Future.successful(true) // if we get here, we passed all the hoops
       }
     }
 
-    //if we failed for any reason, the user can't do that thing on the workspace
+    // if we failed for any reason, the user can't do that thing on the workspace
     access.recover { case _ => false }
   }
 
-  def adminListAllActiveSubmissions(): Future[Seq[ActiveSubmission]] = {
+  def adminListAllActiveSubmissions(): Future[Seq[ActiveSubmission]] =
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         dataAccess.submissionQuery.listAllActiveSubmissions()
       }
     }
-  }
 
-  def adminAbortSubmission(workspaceName: WorkspaceName, submissionId: String): Future[Int] = {
+  def adminAbortSubmission(workspaceName: WorkspaceName, submissionId: String): Future[Int] =
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         withWorkspaceContext(workspaceName, dataAccess) { workspaceContext =>
@@ -2014,32 +2720,31 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       }
     }
-  }
 
-  def listAllWorkspaces() = {
+  def listAllWorkspaces() =
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         dataAccess.workspaceQuery.listAll.map(workspaces => workspaces.map(w => WorkspaceDetails(w, Set.empty)))
       }
     }
-  }
 
-  def adminListWorkspacesWithAttribute(attributeName: AttributeName, attributeValue: AttributeValue): Future[Seq[WorkspaceDetails]] = {
+  def adminListWorkspacesWithAttribute(attributeName: AttributeName,
+                                       attributeValue: AttributeValue
+  ): Future[Seq[WorkspaceDetails]] =
     asFCAdmin {
       for {
         workspaces <- dataSource.inTransaction { dataAccess =>
           dataAccess.workspaceQuery.listWithAttribute(attributeName, attributeValue)
         }
         results <- Future.traverse(workspaces) { workspace =>
-          loadResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx.userInfo).map(WorkspaceDetails(workspace, _))
+          loadResourceAuthDomain(SamResourceTypeNames.workspace, workspace.workspaceId, ctx.userInfo).map(
+            WorkspaceDetails(workspace, _)
+          )
         }
-      } yield {
-        results
-      }
+      } yield results
     }
-  }
 
-  def adminListWorkspaceFeatureFlags(workspaceName: WorkspaceName): Future[Seq[WorkspaceFeatureFlag]] = {
+  def adminListWorkspaceFeatureFlags(workspaceName: WorkspaceName): Future[Seq[WorkspaceFeatureFlag]] =
     asFCAdmin {
       dataSource.inTransaction { dataAccess =>
         withWorkspaceContext(workspaceName, dataAccess) { workspaceContext =>
@@ -2047,9 +2752,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       }
     }
-  }
 
-  def adminOverwriteWorkspaceFeatureFlags(workspaceName: WorkspaceName, flagNames: List[String]): Future[Seq[WorkspaceFeatureFlag]] = {
+  def adminOverwriteWorkspaceFeatureFlags(workspaceName: WorkspaceName,
+                                          flagNames: List[String]
+  ): Future[Seq[WorkspaceFeatureFlag]] =
     asFCAdmin {
       val flags = flagNames.map(WorkspaceFeatureFlag)
       dataSource.inTransaction { dataAccess =>
@@ -2057,26 +2763,22 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           for {
             _ <- dataAccess.workspaceFeatureFlagQuery.deleteAllForWorkspace(workspaceContext.workspaceIdAsUUID)
             _ <- dataAccess.workspaceFeatureFlagQuery.saveAll(workspaceContext.workspaceIdAsUUID, flags)
-          } yield {
-            flags
-          }
+          } yield flags
         }
       }
     }
-  }
 
-  def getBucketUsage(workspaceName: WorkspaceName): Future[BucketUsageResponse] = {
-    //don't do the sam REST call inside the db transaction.
+  def getBucketUsage(workspaceName: WorkspaceName): Future[BucketUsageResponse] =
+    // don't do the sam REST call inside the db transaction.
     getWorkspaceContext(workspaceName) flatMap { workspaceContext =>
       requireAccessIgnoreLockF(workspaceContext, SamWorkspaceActions.write) {
-        //if we get here, we passed all the hoops, otherwise an exception would have been thrown
+        // if we get here, we passed all the hoops, otherwise an exception would have been thrown
 
         gcsDAO.getBucketUsage(workspaceContext.googleProjectId, workspaceContext.bucketName)
       }
     }
-  }
 
-  def getAccessInstructions(workspaceName: WorkspaceName): Future[Seq[ManagedGroupAccessInstructions]] = {
+  def getAccessInstructions(workspaceName: WorkspaceName): Future[Seq[ManagedGroupAccessInstructions]] =
     for {
       workspaceId <- loadWorkspaceId(workspaceName)
       authDomains <- samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, workspaceId, ctx.userInfo)
@@ -2086,37 +2788,39 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       }
     } yield instructions.flatten
-  }
 
-  def getGenomicsOperationV2(workflowId: String, operationId: List[String]): Future[Option[JsObject]] = {
+  def getGenomicsOperationV2(workflowId: String, operationId: List[String]): Future[Option[JsObject]] =
     // note that cromiam should only give back metadata if the user is authorized to see it
-    cromiamDAO.callLevelMetadata(workflowId, MetadataParams(includeKeys = Set("jobId")), ctx.userInfo).flatMap { metadataJson =>
-      val operationIds: Iterable[String] = WorkspaceService.extractOperationIdsFromCromwellMetadata(metadataJson)
+    cromiamDAO.callLevelMetadata(workflowId, MetadataParams(includeKeys = Set("jobId")), ctx.userInfo).flatMap {
+      metadataJson =>
+        val operationIds: Iterable[String] = WorkspaceService.extractOperationIdsFromCromwellMetadata(metadataJson)
 
-      val operationIdString = operationId.mkString("/")
-      // check that the requested operation id actually exists in the workflow
-      if (operationIds.toList.contains(operationIdString)) {
-        val genomicsServiceRef = genomicsServiceConstructor(ctx)
-        genomicsServiceRef.getOperation(operationIdString)
-      } else {
-        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"operation id ${operationIdString} not found in workflow $workflowId")))
-      }
+        val operationIdString = operationId.mkString("/")
+        // check that the requested operation id actually exists in the workflow
+        if (operationIds.toList.contains(operationIdString)) {
+          val genomicsServiceRef = genomicsServiceConstructor(ctx)
+          genomicsServiceRef.getOperation(operationIdString)
+        } else {
+          Future.failed(
+            new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.NotFound, s"operation id ${operationIdString} not found in workflow $workflowId")
+            )
+          )
+        }
     }
-  }
 
-  def enableRequesterPaysForLinkedSAs(workspaceName: WorkspaceName): Future[Unit] = {
+  def enableRequesterPaysForLinkedSAs(workspaceName: WorkspaceName): Future[Unit] =
     for {
-      maybeWorkspace <- dataSource.inTransaction { dataAccess => dataAccess.workspaceQuery.findByName(workspaceName) }
+      maybeWorkspace <- dataSource.inTransaction(dataAccess => dataAccess.workspaceQuery.findByName(workspaceName))
       workspace <- maybeWorkspace match {
-        case None => Future.failed(NoSuchWorkspaceException(workspaceName))
+        case None            => Future.failed(NoSuchWorkspaceException(workspaceName))
         case Some(workspace) => Future.successful(workspace)
       }
       _ <- accessCheck(workspace, SamWorkspaceActions.compute, ignoreLock = false)
       _ <- requesterPaysSetupService.grantRequesterPaysToLinkedSAs(ctx.userInfo, workspace)
     } yield {}
-  }
 
-  def disableRequesterPaysForLinkedSAs(workspaceName: WorkspaceName): Future[Unit] = {
+  def disableRequesterPaysForLinkedSAs(workspaceName: WorkspaceName): Future[Unit] =
     // note that this does not throw an error if the workspace does not exist
     // the user may no longer have access to the workspace so we can't confirm it exists
     // but the user does have the right to remove their linked SAs
@@ -2128,39 +2832,58 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         requesterPaysSetupService.revokeUserFromWorkspace(ctx.userInfo.userEmail, workspace)
       }
     } yield {}
-  }
 
   // helper methods
 
-  private def createWorkflowCollectionForWorkspace(workspaceId: String, policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail], parentContext: RawlsRequestContext) = {
+  private def createWorkflowCollectionForWorkspace(workspaceId: String,
+                                                   policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail],
+                                                   parentContext: RawlsRequestContext
+  ) =
     for {
-      _ <- traceWithParent("createResourceFull", parentContext)( _ => samDAO.createResourceFull(
-              SamResourceTypeNames.workflowCollection,
-              workspaceId,
-              Map(
-                SamWorkflowCollectionPolicyNames.workflowCollectionOwnerPolicyName ->
-                  SamPolicy(Set(policyEmailsByName(SamWorkspacePolicyNames.projectOwner), policyEmailsByName(SamWorkspacePolicyNames.owner)), Set.empty, Set(SamWorkflowCollectionRoles.owner)),
-                SamWorkflowCollectionPolicyNames.workflowCollectionWriterPolicyName ->
-                  SamPolicy(Set(policyEmailsByName(SamWorkspacePolicyNames.canCompute)), Set.empty, Set(SamWorkflowCollectionRoles.writer)),
-                SamWorkflowCollectionPolicyNames.workflowCollectionReaderPolicyName ->
-                  SamPolicy(Set(policyEmailsByName(SamWorkspacePolicyNames.reader), policyEmailsByName(SamWorkspacePolicyNames.writer)), Set.empty, Set(SamWorkflowCollectionRoles.reader))
+      _ <- traceWithParent("createResourceFull", parentContext)(_ =>
+        samDAO.createResourceFull(
+          SamResourceTypeNames.workflowCollection,
+          workspaceId,
+          Map(
+            SamWorkflowCollectionPolicyNames.workflowCollectionOwnerPolicyName ->
+              SamPolicy(
+                Set(policyEmailsByName(SamWorkspacePolicyNames.projectOwner),
+                    policyEmailsByName(SamWorkspacePolicyNames.owner)
+                ),
+                Set.empty,
+                Set(SamWorkflowCollectionRoles.owner)
               ),
-              Set.empty,
-              ctx.userInfo,
-              None
-            ))
-    } yield {
-    }
-  }
+            SamWorkflowCollectionPolicyNames.workflowCollectionWriterPolicyName ->
+              SamPolicy(Set(policyEmailsByName(SamWorkspacePolicyNames.canCompute)),
+                        Set.empty,
+                        Set(SamWorkflowCollectionRoles.writer)
+              ),
+            SamWorkflowCollectionPolicyNames.workflowCollectionReaderPolicyName ->
+              SamPolicy(
+                Set(policyEmailsByName(SamWorkspacePolicyNames.reader),
+                    policyEmailsByName(SamWorkspacePolicyNames.writer)
+                ),
+                Set.empty,
+                Set(SamWorkflowCollectionRoles.reader)
+              )
+          ),
+          Set.empty,
+          ctx.userInfo,
+          None
+        )
+      )
+    } yield {}
 
   def createGoogleProject(billingProject: RawlsBillingProject,
                           rbsHandoutRequestId: String,
-                          parentContext: RawlsRequestContext = ctx): Future[(GoogleProjectId, GoogleProjectNumber)] =
+                          parentContext: RawlsRequestContext = ctx
+  ): Future[(GoogleProjectId, GoogleProjectNumber)] =
     for {
       googleProjectId <- traceWithParent("getGoogleProjectFromBuffer", parentContext) { _ =>
         resourceBufferService.getGoogleProjectFromBuffer(
           if (billingProject.servicePerimeter.isDefined)
-            ProjectPoolType.ExfiltrationControlled else
+            ProjectPoolType.ExfiltrationControlled
+          else
             ProjectPoolType.Regular,
           rbsHandoutRequestId
         )
@@ -2175,9 +2898,11 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
       googleProject <- gcsDAO.getGoogleProject(googleProjectId)
       _ <- traceWithParent("remove RBS SA from owner policy", parentContext) { _ =>
-        gcsDAO.removePolicyBindings(googleProjectId, Map(
-          "roles/owner" -> Set("serviceAccount:" + resourceBufferSaEmail)
-        ))
+        gcsDAO.removePolicyBindings(googleProjectId,
+                                    Map(
+                                      "roles/owner" -> Set("serviceAccount:" + resourceBufferSaEmail)
+                                    )
+        )
       }
     } yield (googleProjectId, gcsDAO.getGoogleProjectNumber(googleProject))
 
@@ -2185,9 +2910,12 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                                billingProject: RawlsBillingProject,
                                billingAccount: RawlsBillingAccountName,
                                workspaceId: String,
-                               parentContext: RawlsRequestContext = ctx): Future[ProjectBillingInfo] =
+                               parentContext: RawlsRequestContext = ctx
+  ): Future[ProjectBillingInfo] =
     traceWithParent("updateGoogleProjectBillingAccount", parentContext) { childContext =>
-      logger.info(s"Setting billing account for ${googleProjectId} to ${billingAccount} replacing existing billing account.")
+      logger.info(
+        s"Setting billing account for ${googleProjectId} to ${billingAccount} replacing existing billing account."
+      )
       childContext.tracingSpan.foreach { s =>
         s.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId))
         s.putAttribute("googleProjectId", OpenCensusAttributeValue.stringAttributeValue(googleProjectId.value))
@@ -2196,11 +2924,11 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       gcsDAO.setBillingAccountName(googleProjectId, billingAccount, childContext.tracingSpan.orNull)
     }
 
-
   def setupGoogleProjectIam(googleProjectId: GoogleProjectId,
                             policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail],
                             billingProjectOwnerPolicyEmail: WorkbenchEmail,
-                            parentContext: RawlsRequestContext = ctx): Future[Unit] =
+                            parentContext: RawlsRequestContext = ctx
+  ): Future[Unit] =
     traceWithParent("updateGoogleProjectIam", parentContext) { _ =>
       logger.info(s"Updating google project IAM ${googleProjectId}.")
 
@@ -2217,9 +2945,16 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       // todo: update this line as part of https://broadworkbench.atlassian.net/browse/CA-1220
       // This is done sequentially intentionally in order to avoid conflict exceptions as a result of concurrent IAM updates.
       List(
-        billingProjectOwnerPolicyEmail -> Set(terraBillingProjectOwnerRole, terraWorkspaceCanComputeRole, terraWorkspaceNextflowRole),
-        policyEmailsByName(SamWorkspacePolicyNames.owner) -> Set(terraWorkspaceCanComputeRole, terraWorkspaceNextflowRole),
-        policyEmailsByName(SamWorkspacePolicyNames.canCompute) -> Set(terraWorkspaceCanComputeRole, terraWorkspaceNextflowRole)
+        billingProjectOwnerPolicyEmail -> Set(terraBillingProjectOwnerRole,
+                                              terraWorkspaceCanComputeRole,
+                                              terraWorkspaceNextflowRole
+        ),
+        policyEmailsByName(SamWorkspacePolicyNames.owner) -> Set(terraWorkspaceCanComputeRole,
+                                                                 terraWorkspaceNextflowRole
+        ),
+        policyEmailsByName(SamWorkspacePolicyNames.canCompute) -> Set(terraWorkspaceCanComputeRole,
+                                                                      terraWorkspaceNextflowRole
+        )
       )
         .traverse_ { case (email, roles) =>
           googleIamDao.addIamRoles(
@@ -2236,20 +2971,20 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * Update google project with the labels and google project name to reduce the number of calls made to google so we can avoid quota issues
     */
   def renameAndLabelProject(googleProjectId: GoogleProjectId,
-                                    workspaceId: String,
-                                    workspaceName: WorkspaceName,
-                                    parentContext: RawlsRequestContext = ctx
-                                   ): Future[Unit] =
+                            workspaceId: String,
+                            workspaceName: WorkspaceName,
+                            parentContext: RawlsRequestContext = ctx
+  ): Future[Unit] =
     traceWithParent("renameAndLabelProject", parentContext) { _ =>
       for {
         googleProject <- gcsDAO.getGoogleProject(googleProjectId)
 
         newLabels = gcsDAO.labelSafeMap(Map(
-          "workspaceNamespace" -> workspaceName.namespace,
-          "workspaceName" -> workspaceName.name,
-          "workspaceId" -> workspaceId
-        ),
-          ""
+                                          "workspaceNamespace" -> workspaceName.namespace,
+                                          "workspaceName" -> workspaceName.name,
+                                          "workspaceId" -> workspaceId
+                                        ),
+                                        ""
         )
 
         googleProjectName = gcsDAO.googleProjectNameSafeString(s"${workspaceName.namespace}--${workspaceName.name}")
@@ -2270,12 +3005,15 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * @param span
     * @return Future[Unit]
     */
-  private def maybeUpdateGoogleProjectsInPerimeter(billingProject: RawlsBillingProject, dataAccess: DataAccess, span: Span = null): ReadAction[Unit] = {
+  private def maybeUpdateGoogleProjectsInPerimeter(billingProject: RawlsBillingProject,
+                                                   dataAccess: DataAccess,
+                                                   span: Span = null
+  ): ReadAction[Unit] =
     billingProject.servicePerimeter match {
-      case Some(servicePerimeterName) => servicePerimeterService.overwriteGoogleProjectsInPerimeter(servicePerimeterName, dataAccess)
+      case Some(servicePerimeterName) =>
+        servicePerimeterService.overwriteGoogleProjectsInPerimeter(servicePerimeterName, dataAccess)
       case None => DBIO.successful()
     }
-  }
 
   /**
     * takes a RawlsBillingProject and checks that Rawls has the appropriate permissions on the underlying Billing
@@ -2283,36 +3021,47 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * BillingProject to persist latest 'invalidBillingAccount' info.  Returns TRUE if user has right IAM access, else
     * FALSE
     */
-  def updateAndGetBillingAccountAccess(billingProject: RawlsBillingProject, parentContext: RawlsRequestContext): Future[Boolean] = {
+  def updateAndGetBillingAccountAccess(billingProject: RawlsBillingProject,
+                                       parentContext: RawlsRequestContext
+  ): Future[Boolean] = {
     val billingAccountName: RawlsBillingAccountName = billingProject.billingAccount.getOrElse(
-      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(
-        StatusCodes.InternalServerError,
-        s"Billing Project ${billingProject.projectName.value} has no Billing Account associated with it")))
+      throw new RawlsExceptionWithErrorReport(
+        errorReport =
+          ErrorReport(StatusCodes.InternalServerError,
+                      s"Billing Project ${billingProject.projectName.value} has no Billing Account associated with it"
+          )
+      )
+    )
 
     for {
-      hasAccess <- traceWithParent("checkBillingAccountIAM", parentContext)(_ => gcsDAO.testDMBillingAccountAccess(billingAccountName))
+      hasAccess <- traceWithParent("checkBillingAccountIAM", parentContext)(_ =>
+        gcsDAO.testDMBillingAccountAccess(billingAccountName)
+      )
       invalidBillingAccount = !hasAccess
-      _ <- if (billingProject.invalidBillingAccount != invalidBillingAccount) {
-        dataSource.inTransaction { dataAccess =>
-          traceDBIOWithParent("updateInvalidBillingAccountField", parentContext)(_ =>
-            dataAccess.rawlsBillingProjectQuery.updateBillingAccountValidity(
-              billingAccountName,
-              invalidBillingAccount))
+      _ <-
+        if (billingProject.invalidBillingAccount != invalidBillingAccount) {
+          dataSource.inTransaction { dataAccess =>
+            traceDBIOWithParent("updateInvalidBillingAccountField", parentContext)(_ =>
+              dataAccess.rawlsBillingProjectQuery.updateBillingAccountValidity(billingAccountName,
+                                                                               invalidBillingAccount
+              )
+            )
+          }
+        } else {
+          Future.successful(Seq[Int]())
         }
-      } else {
-        Future.successful(Seq[Int]())
-      }
     } yield hasAccess
   }
 
-  def getWorkspaceMigrationAttempts(workspaceName: WorkspaceName): Future[List[WorkspaceMigrationMetadata]] = asFCAdmin {
-    for {
-      workspace <- getWorkspaceContext(workspaceName)
-      attempts <- dataSource.inTransaction { dataAccess =>
-        dataAccess.workspaceMigrationQuery.getMigrationAttempts(workspace)
-      }
-    } yield attempts.mapWithIndex(WorkspaceMigrationMetadata.fromWorkspaceMigration)
-  }
+  def getWorkspaceMigrationAttempts(workspaceName: WorkspaceName): Future[List[WorkspaceMigrationMetadata]] =
+    asFCAdmin {
+      for {
+        workspace <- getWorkspaceContext(workspaceName)
+        attempts <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceMigrationQuery.getMigrationAttempts(workspace)
+        }
+      } yield attempts.mapWithIndex(WorkspaceMigrationMetadata.fromWorkspaceMigration)
+    }
 
   def migrateWorkspace(workspaceName: WorkspaceName): Future[WorkspaceMigrationMetadata] =
     asFCAdmin {
@@ -2334,10 +3083,12 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
           (errors, migrationAttempts) = errorsOrMigrationAttempts.partitionMap(identity)
           _ <- MonadThrow[ReadWriteAction].raiseUnless(errors.isEmpty) {
-            new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest,
-              "One or more workspaces could not be scheduled for migration",
-              errors.map(ErrorReport.apply)
-            ))
+            new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.BadRequest,
+                          "One or more workspaces could not be scheduled for migration",
+                          errors.map(ErrorReport.apply)
+              )
+            )
           }
 
         } yield migrationAttempts
@@ -2347,15 +3098,26 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   private def failUnlessBillingProjectReady(billingProject: RawlsBillingProject) =
     billingProject.status match {
       case CreationStatuses.Ready => Future.unit
-      case _ => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Billing Project ${billingProject.projectName} is not ready")))
+      case _ =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport =
+              ErrorReport(StatusCodes.BadRequest, s"Billing Project ${billingProject.projectName} is not ready")
+          )
+        )
     }
 
-  private def failUnlessBillingAccountHasAccess(billingProject: RawlsBillingProject, parentContext: RawlsRequestContext) =
+  private def failUnlessBillingAccountHasAccess(billingProject: RawlsBillingProject,
+                                                parentContext: RawlsRequestContext
+  ) =
     updateAndGetBillingAccountAccess(billingProject, parentContext).map { hasAccess =>
-      if (!hasAccess) throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(
-        StatusCodes.Forbidden,
-        s"Terra does not have required permissions on Billing Account: ${billingProject.billingAccount}.  Please ensure that 'terra-billing@terra.bio' is a member of your Billing Account with the 'Billing Account User' role"
-      ))
+      if (!hasAccess)
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            StatusCodes.Forbidden,
+            s"Terra does not have required permissions on Billing Account: ${billingProject.billingAccount}.  Please ensure that 'terra-billing@terra.bio' is a member of your Billing Account with the 'Billing Account User' role"
+          )
+        )
     }
 
   /**
@@ -2368,8 +3130,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * @tparam T
     * @return
     */
-  private def withBillingProjectContext[T](billingProjectName: String, parentContext: RawlsRequestContext)
-                                          (op: (RawlsBillingProject) => Future[T]): Future[T] = {
+  private def withBillingProjectContext[T](billingProjectName: String, parentContext: RawlsRequestContext)(
+    op: (RawlsBillingProject) => Future[T]
+  ): Future[T] =
     for {
       maybeBillingProject <- dataSource.inTransaction { dataAccess =>
         traceDBIOWithParent("loadBillingProject", parentContext) { _ =>
@@ -2377,71 +3140,116 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       }
 
-      billingProject = maybeBillingProject.getOrElse(throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Billing Project ${billingProjectName} does not exist")))
+      billingProject = maybeBillingProject.getOrElse(
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(StatusCodes.BadRequest, s"Billing Project ${billingProjectName} does not exist")
+        )
+      )
       _ <- failUnlessBillingProjectReady(billingProject)
       _ <- failUnlessBillingAccountHasAccess(billingProject, parentContext)
       result <- op(billingProject)
     } yield result
-  }
 
-  private def createWorkspaceResourceInSam(workspaceId: String, billingProjectOwnerPolicyEmail: WorkbenchEmail, workspaceRequest: WorkspaceRequest, parentContext: RawlsRequestContext): ReadWriteAction[SamCreateResourceResponse] = {
+  private def createWorkspaceResourceInSam(workspaceId: String,
+                                           billingProjectOwnerPolicyEmail: WorkbenchEmail,
+                                           workspaceRequest: WorkspaceRequest,
+                                           parentContext: RawlsRequestContext
+  ): ReadWriteAction[SamCreateResourceResponse] = {
 
-    val projectOwnerPolicy = SamWorkspacePolicyNames.projectOwner -> SamPolicy(Set(billingProjectOwnerPolicyEmail), Set.empty, Set(SamWorkspaceRoles.owner, SamWorkspaceRoles.projectOwner))
+    val projectOwnerPolicy =
+      SamWorkspacePolicyNames.projectOwner -> SamPolicy(Set(billingProjectOwnerPolicyEmail),
+                                                        Set.empty,
+                                                        Set(SamWorkspaceRoles.owner, SamWorkspaceRoles.projectOwner)
+      )
     val ownerPolicyMembership: Set[WorkbenchEmail] = if (workspaceRequest.noWorkspaceOwner.getOrElse(false)) {
       Set.empty
     } else {
       Set(WorkbenchEmail(ctx.userInfo.userEmail.value))
     }
-    val ownerPolicy = SamWorkspacePolicyNames.owner -> SamPolicy(ownerPolicyMembership, Set.empty, Set(SamWorkspaceRoles.owner))
+    val ownerPolicy =
+      SamWorkspacePolicyNames.owner -> SamPolicy(ownerPolicyMembership, Set.empty, Set(SamWorkspaceRoles.owner))
     val writerPolicy = SamWorkspacePolicyNames.writer -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.writer))
     val readerPolicy = SamWorkspacePolicyNames.reader -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.reader))
-    val shareReaderPolicy = SamWorkspacePolicyNames.shareReader -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.shareReader))
-    val shareWriterPolicy = SamWorkspacePolicyNames.shareWriter -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.shareWriter))
-    val canComputePolicy = SamWorkspacePolicyNames.canCompute -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCompute))
-    val canCatalogPolicy = SamWorkspacePolicyNames.canCatalog -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCatalog))
+    val shareReaderPolicy =
+      SamWorkspacePolicyNames.shareReader -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.shareReader))
+    val shareWriterPolicy =
+      SamWorkspacePolicyNames.shareWriter -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.shareWriter))
+    val canComputePolicy =
+      SamWorkspacePolicyNames.canCompute -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCompute))
+    val canCatalogPolicy =
+      SamWorkspacePolicyNames.canCatalog -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCatalog))
 
-    val allPolicies = Map(projectOwnerPolicy, ownerPolicy, writerPolicy, readerPolicy, shareReaderPolicy, shareWriterPolicy, canComputePolicy, canCatalogPolicy)
+    val allPolicies = Map(projectOwnerPolicy,
+                          ownerPolicy,
+                          writerPolicy,
+                          readerPolicy,
+                          shareReaderPolicy,
+                          shareWriterPolicy,
+                          canComputePolicy,
+                          canCatalogPolicy
+    )
 
     DBIO.from(
       traceWithParent("createResourceFull (workspace)", parentContext)(_ =>
-        samDAO.createResourceFull(SamResourceTypeNames.workspace, workspaceId, allPolicies, workspaceRequest.authorizationDomain.getOrElse(Set.empty).map(_.membersGroupName.value), ctx.userInfo, None))
+        samDAO.createResourceFull(
+          SamResourceTypeNames.workspace,
+          workspaceId,
+          allPolicies,
+          workspaceRequest.authorizationDomain.getOrElse(Set.empty).map(_.membersGroupName.value),
+          ctx.userInfo,
+          None
+        )
+      )
     )
   }
 
-  private def syncPolicies(workspaceId: String, policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail], workspaceRequest: WorkspaceRequest, parentContext: RawlsRequestContext) = {
-    traceWithParent("traversePolicies", parentContext) (s1 =>
+  private def syncPolicies(workspaceId: String,
+                           policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail],
+                           workspaceRequest: WorkspaceRequest,
+                           parentContext: RawlsRequestContext
+  ) =
+    traceWithParent("traversePolicies", parentContext)(s1 =>
       Future.traverse(policyEmailsByName.keys) { policyName =>
-        if (policyName == SamWorkspacePolicyNames.projectOwner && workspaceRequest.authorizationDomain.getOrElse(Set.empty).isEmpty) {
+        if (
+          policyName == SamWorkspacePolicyNames.projectOwner && workspaceRequest.authorizationDomain
+            .getOrElse(Set.empty)
+            .isEmpty
+        ) {
           // when there isn't an auth domain, we will use the billing project admin policy email directly on workspace
           // resources instead of synching an extra group. This helps to keep the number of google groups a user is in below
           // the limit of 2000
           Future.successful(())
-        } else if (WorkspaceAccessLevels.withPolicyName(policyName.value).isDefined || policyName == SamWorkspacePolicyNames.canCompute) {
+        } else if (
+          WorkspaceAccessLevels
+            .withPolicyName(policyName.value)
+            .isDefined || policyName == SamWorkspacePolicyNames.canCompute
+        ) {
           // only sync policies that have corresponding WorkspaceAccessLevels to google because only those are
           // granted bucket access (and thus need a google group)
-          traceWithParent(s"syncPolicy-${policyName}", s1)(_ => samDAO.syncPolicyToGoogle(SamResourceTypeNames.workspace, workspaceId, policyName))
+          traceWithParent(s"syncPolicy-${policyName}", s1)(_ =>
+            samDAO.syncPolicyToGoogle(SamResourceTypeNames.workspace, workspaceId, policyName)
+          )
         } else {
           Future.successful(())
         }
       }
     )
-  }
 
-  private def createWorkspaceInDatabase(
-                                         workspaceId: String,
-                                         workspaceRequest: WorkspaceRequest,
-                                         bucketName: String,
-                                         billingProjectOwnerPolicyEmail: WorkbenchEmail,
-                                         googleProjectId: GoogleProjectId,
-                                         googleProjectNumber: Option[GoogleProjectNumber],
-                                         currentBillingAccountOnWorkspace: Option[RawlsBillingAccountName],
-                                         dataAccess: DataAccess,
-                                         parentContext: RawlsRequestContext,
-                                         workspaceType: WorkspaceType = WorkspaceType.RawlsWorkspace): ReadWriteAction[Workspace] = {
+  private def createWorkspaceInDatabase(workspaceId: String,
+                                        workspaceRequest: WorkspaceRequest,
+                                        bucketName: String,
+                                        billingProjectOwnerPolicyEmail: WorkbenchEmail,
+                                        googleProjectId: GoogleProjectId,
+                                        googleProjectNumber: Option[GoogleProjectNumber],
+                                        currentBillingAccountOnWorkspace: Option[RawlsBillingAccountName],
+                                        dataAccess: DataAccess,
+                                        parentContext: RawlsRequestContext,
+                                        workspaceType: WorkspaceType = WorkspaceType.RawlsWorkspace
+  ): ReadWriteAction[Workspace] = {
     val currentDate = DateTime.now
     val completedCloneWorkspaceFileTransfer = workspaceRequest.copyFilesWithPrefix match {
       case Some(_) => None
-      case None => Option(currentDate)
+      case None    => Option(currentDate)
     }
 
     val workspace = Workspace(
@@ -2468,90 +3276,206 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   }
 
   // TODO: find and assess all usages. This is written to reside inside a DB transaction, but it makes external REST calls.
-  private def withNewWorkspaceContext[T](workspaceRequest: WorkspaceRequest, billingProject: RawlsBillingProject, sourceBucketName: Option[String], dataAccess: DataAccess, parentContext: RawlsRequestContext)
-                                     (op: (Workspace) => ReadWriteAction[T]): ReadWriteAction[T] = {
+  private def withNewWorkspaceContext[T](workspaceRequest: WorkspaceRequest,
+                                         billingProject: RawlsBillingProject,
+                                         sourceBucketName: Option[String],
+                                         dataAccess: DataAccess,
+                                         parentContext: RawlsRequestContext
+  )(op: (Workspace) => ReadWriteAction[T]): ReadWriteAction[T] = {
 
-    def getBucketName(workspaceId: String, secure: Boolean) = s"${config.workspaceBucketNamePrefix}-${if(secure) "secure-" else ""}${workspaceId}"
+    def getBucketName(workspaceId: String, secure: Boolean) =
+      s"${config.workspaceBucketNamePrefix}-${if (secure) "secure-" else ""}${workspaceId}"
     def getLabels(authDomain: List[ManagedGroupRef]) = authDomain match {
       case Nil => Map(WorkspaceService.SECURITY_LABEL_KEY -> WorkspaceService.LOW_SECURITY_LABEL)
-      case ads => Map(WorkspaceService.SECURITY_LABEL_KEY -> WorkspaceService.HIGH_SECURITY_LABEL) ++ ads.map(ad => gcsDAO.labelSafeString(ad.membersGroupName.value, "ad-") -> "")
+      case ads =>
+        Map(WorkspaceService.SECURITY_LABEL_KEY -> WorkspaceService.HIGH_SECURITY_LABEL) ++ ads.map(ad =>
+          gcsDAO.labelSafeString(ad.membersGroupName.value, "ad-") -> ""
+        )
     }
 
-    traceDBIOWithParent("requireCreateWorkspaceAccess", parentContext)(childContext1 => requireCreateWorkspaceAccess(workspaceRequest, dataAccess, childContext1) {
-      traceDBIOWithParent("maybeRequireBillingProjectOwnerAccess", parentContext) (childContext2 => maybeRequireBillingProjectOwnerAccess(workspaceRequest, childContext2) {
-        traceDBIOWithParent("findByName", parentContext)(_ => dataAccess.workspaceQuery.findByName(workspaceRequest.toWorkspaceName, Option(WorkspaceAttributeSpecs(all = false, List.empty[AttributeName])))) flatMap {
-          case Some(_) => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.Conflict, s"Workspace ${workspaceRequest.namespace}/${workspaceRequest.name} already exists")))
-          case None =>
-            val workspaceId = UUID.randomUUID.toString
-            logger.info(s"createWorkspace - workspace:'${workspaceRequest.name}' - UUID:${workspaceId}")
-            val bucketName = getBucketName(workspaceId, workspaceRequest.authorizationDomain.exists(_.nonEmpty))
-            // We should never get here with a missing or invalid Billing Account, but we still need to get the value out of the
-            // Option, so we are being thorough
-            val billingAccount = billingProject.billingAccount match {
-              case Some(ba) if !billingProject.invalidBillingAccount => ba
-              case _ => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, s"Billing Account is missing or invalid for Billing Project: ${billingProject}"))
-            }
-            val workspaceName = WorkspaceName(workspaceRequest.namespace, workspaceRequest.name)
-            // add the workspace id to the span so we can find and correlate it later with other services
-            parentContext.tracingSpan.foreach(_.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId)))
-
-            for {
-              billingProjectOwnerPolicyEmail <- traceDBIOWithParent("getPolicySyncStatus", parentContext)(_ => DBIO.from(
-                  samDAO.getPolicySyncStatus(SamResourceTypeNames.billingProject, workspaceRequest.namespace, SamBillingProjectPolicyNames.owner, ctx.userInfo).map(_.email)))
-              resource <- createWorkspaceResourceInSam(workspaceId, billingProjectOwnerPolicyEmail, workspaceRequest, parentContext)
-              policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail] = resource.accessPolicies.map(x => SamResourcePolicyName(x.id.accessPolicyName) -> WorkbenchEmail(x.email)).toMap
-              _ <- DBIO.from({
-                // declare these next two Futures so they start in parallel
-                val createWorkflowCollectionFuture = createWorkflowCollectionForWorkspace(workspaceId, policyEmailsByName, parentContext)
-                val syncPoliciesFuture = syncPolicies(workspaceId, policyEmailsByName, workspaceRequest, parentContext)
-                for {
-                  _ <- createWorkflowCollectionFuture
-                  _ <- syncPoliciesFuture
-                } yield()})
-              (googleProjectId, googleProjectNumber) <- traceDBIOWithParent("setupGoogleProject", parentContext) { span =>
-                DBIO.from(
-                  for {
-                    (googleProjectId, googleProjectNumber) <- createGoogleProject(billingProject, rbsHandoutRequestId = workspaceId, span)
-                    _ <- setProjectBillingAccount(googleProjectId, billingProject, billingAccount, workspaceId, span)
-                    _ <- renameAndLabelProject(googleProjectId, workspaceId, workspaceName, span)
-                    _ <- setupGoogleProjectIam(googleProjectId, policyEmailsByName, billingProjectOwnerPolicyEmail, parentContext)
-                  } yield (googleProjectId, googleProjectNumber)
+    traceDBIOWithParent("requireCreateWorkspaceAccess", parentContext)(childContext1 =>
+      requireCreateWorkspaceAccess(workspaceRequest, dataAccess, childContext1) {
+        traceDBIOWithParent("maybeRequireBillingProjectOwnerAccess", parentContext)(childContext2 =>
+          maybeRequireBillingProjectOwnerAccess(workspaceRequest, childContext2) {
+            traceDBIOWithParent("findByName", parentContext)(_ =>
+              dataAccess.workspaceQuery.findByName(
+                workspaceRequest.toWorkspaceName,
+                Option(WorkspaceAttributeSpecs(all = false, List.empty[AttributeName]))
+              )
+            ) flatMap {
+              case Some(_) =>
+                DBIO.failed(
+                  new RawlsExceptionWithErrorReport(
+                    errorReport =
+                      ErrorReport(StatusCodes.Conflict,
+                                  s"Workspace ${workspaceRequest.namespace}/${workspaceRequest.name} already exists"
+                      )
+                  )
                 )
-              }
-              savedWorkspace <- traceDBIOWithParent("saveNewWorkspace", parentContext)(span =>
-                createWorkspaceInDatabase(workspaceId, workspaceRequest, bucketName, billingProjectOwnerPolicyEmail, googleProjectId, Some(googleProjectNumber), Option(billingAccount), dataAccess, span))
-
-              _ <- traceDBIOWithParent("updateServicePerimeter", parentContext)(_ =>
-                maybeUpdateGoogleProjectsInPerimeter(billingProject, dataAccess))
-
-              // After the workspace has been created, create the google-project resource in Sam with the workspace as the resource parent
-              _ <- traceDBIOWithParent("createResourceFull (google project)", parentContext)(_ => DBIO.from(
-                  samDAO.createResourceFull(SamResourceTypeNames.googleProject, googleProjectId.value, Map.empty, Set.empty, ctx.userInfo, Option(SamFullyQualifiedResourceId(workspaceId, SamResourceTypeNames.workspace.value)))))
-
-              //there's potential for another perf improvement here for workspaces with auth domains. if a workspace is in an auth domain, we'll already have
-              //the projectOwnerEmail, so we don't need to get it from sam. in a pinch, we could also store the project owner email in the rawls DB since it
-              //will never change, which would eliminate the call to sam entirely
-              policyEmails <- DBIO.successful(policyEmailsByName.map { case (policyName, policyEmail) =>
-                if (policyName == SamWorkspacePolicyNames.projectOwner && workspaceRequest.authorizationDomain.getOrElse(Set.empty).isEmpty) {
-                  // when there isn't an auth domain, we will use the billing project admin policy email directly on workspace
-                  // resources instead of synching an extra group. This helps to keep the number of google groups a user is in below
-                  // the limit of 2000
-                  Option(WorkspaceAccessLevels.ProjectOwner -> billingProjectOwnerPolicyEmail)
-                } else {
-                  WorkspaceAccessLevels.withPolicyName(policyName.value).map(_ -> policyEmail)
+              case None =>
+                val workspaceId = UUID.randomUUID.toString
+                logger.info(s"createWorkspace - workspace:'${workspaceRequest.name}' - UUID:${workspaceId}")
+                val bucketName = getBucketName(workspaceId, workspaceRequest.authorizationDomain.exists(_.nonEmpty))
+                // We should never get here with a missing or invalid Billing Account, but we still need to get the value out of the
+                // Option, so we are being thorough
+                val billingAccount = billingProject.billingAccount match {
+                  case Some(ba) if !billingProject.invalidBillingAccount => ba
+                  case _ =>
+                    throw new RawlsExceptionWithErrorReport(
+                      ErrorReport(StatusCodes.BadRequest,
+                                  s"Billing Account is missing or invalid for Billing Project: ${billingProject}"
+                      )
+                    )
                 }
-              }.flatten.toMap)
+                val workspaceName = WorkspaceName(workspaceRequest.namespace, workspaceRequest.name)
+                // add the workspace id to the span so we can find and correlate it later with other services
+                parentContext.tracingSpan.foreach(
+                  _.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceId))
+                )
 
-              workspaceBucketLocation <- traceDBIOWithParent("determineWorkspaceBucketLocation", parentContext)(_ => DBIO.from(
-                determineWorkspaceBucketLocation(workspaceRequest.bucketLocation, sourceBucketName, googleProjectId)))
-              _ <- traceDBIOWithParent("gcsDAO.setupWorkspace", parentContext)(childContext => DBIO.from(
-                  gcsDAO.setupWorkspace(ctx.userInfo, savedWorkspace.googleProjectId, policyEmails, GcsBucketName(bucketName), getLabels(workspaceRequest.authorizationDomain.getOrElse(Set.empty).toList), childContext.tracingSpan.orNull, workspaceBucketLocation)))
-              _ = workspaceRequest.bucketLocation.foreach(location => logger.info(s"Internal bucket for workspace `${workspaceRequest.name}` in namespace `${workspaceRequest.namespace}` was created in region `$location`."))
-              response <- traceDBIOWithParent("doOp", parentContext)(_ => op(savedWorkspace))
-            } yield (response)
-        }
-      })
-    })
+                for {
+                  billingProjectOwnerPolicyEmail <- traceDBIOWithParent("getPolicySyncStatus", parentContext)(_ =>
+                    DBIO.from(
+                      samDAO
+                        .getPolicySyncStatus(SamResourceTypeNames.billingProject,
+                                             workspaceRequest.namespace,
+                                             SamBillingProjectPolicyNames.owner,
+                                             ctx.userInfo
+                        )
+                        .map(_.email)
+                    )
+                  )
+                  resource <- createWorkspaceResourceInSam(workspaceId,
+                                                           billingProjectOwnerPolicyEmail,
+                                                           workspaceRequest,
+                                                           parentContext
+                  )
+                  policyEmailsByName: Map[SamResourcePolicyName, WorkbenchEmail] = resource.accessPolicies
+                    .map(x => SamResourcePolicyName(x.id.accessPolicyName) -> WorkbenchEmail(x.email))
+                    .toMap
+                  _ <- DBIO.from {
+                    // declare these next two Futures so they start in parallel
+                    val createWorkflowCollectionFuture =
+                      createWorkflowCollectionForWorkspace(workspaceId, policyEmailsByName, parentContext)
+                    val syncPoliciesFuture =
+                      syncPolicies(workspaceId, policyEmailsByName, workspaceRequest, parentContext)
+                    for {
+                      _ <- createWorkflowCollectionFuture
+                      _ <- syncPoliciesFuture
+                    } yield ()
+                  }
+                  (googleProjectId, googleProjectNumber) <- traceDBIOWithParent("setupGoogleProject", parentContext) {
+                    span =>
+                      DBIO.from(
+                        for {
+                          (googleProjectId, googleProjectNumber) <- createGoogleProject(billingProject,
+                                                                                        rbsHandoutRequestId =
+                                                                                          workspaceId,
+                                                                                        span
+                          )
+                          _ <- setProjectBillingAccount(googleProjectId,
+                                                        billingProject,
+                                                        billingAccount,
+                                                        workspaceId,
+                                                        span
+                          )
+                          _ <- renameAndLabelProject(googleProjectId, workspaceId, workspaceName, span)
+                          _ <- setupGoogleProjectIam(googleProjectId,
+                                                     policyEmailsByName,
+                                                     billingProjectOwnerPolicyEmail,
+                                                     parentContext
+                          )
+                        } yield (googleProjectId, googleProjectNumber)
+                      )
+                  }
+                  savedWorkspace <- traceDBIOWithParent("saveNewWorkspace", parentContext)(span =>
+                    createWorkspaceInDatabase(
+                      workspaceId,
+                      workspaceRequest,
+                      bucketName,
+                      billingProjectOwnerPolicyEmail,
+                      googleProjectId,
+                      Some(googleProjectNumber),
+                      Option(billingAccount),
+                      dataAccess,
+                      span
+                    )
+                  )
+
+                  _ <- traceDBIOWithParent("updateServicePerimeter", parentContext)(_ =>
+                    maybeUpdateGoogleProjectsInPerimeter(billingProject, dataAccess)
+                  )
+
+                  // After the workspace has been created, create the google-project resource in Sam with the workspace as the resource parent
+                  _ <- traceDBIOWithParent("createResourceFull (google project)", parentContext)(_ =>
+                    DBIO.from(
+                      samDAO.createResourceFull(
+                        SamResourceTypeNames.googleProject,
+                        googleProjectId.value,
+                        Map.empty,
+                        Set.empty,
+                        ctx.userInfo,
+                        Option(SamFullyQualifiedResourceId(workspaceId, SamResourceTypeNames.workspace.value))
+                      )
+                    )
+                  )
+
+                  // there's potential for another perf improvement here for workspaces with auth domains. if a workspace is in an auth domain, we'll already have
+                  // the projectOwnerEmail, so we don't need to get it from sam. in a pinch, we could also store the project owner email in the rawls DB since it
+                  // will never change, which would eliminate the call to sam entirely
+                  policyEmails <- DBIO.successful(
+                    policyEmailsByName
+                      .map { case (policyName, policyEmail) =>
+                        if (
+                          policyName == SamWorkspacePolicyNames.projectOwner && workspaceRequest.authorizationDomain
+                            .getOrElse(Set.empty)
+                            .isEmpty
+                        ) {
+                          // when there isn't an auth domain, we will use the billing project admin policy email directly on workspace
+                          // resources instead of synching an extra group. This helps to keep the number of google groups a user is in below
+                          // the limit of 2000
+                          Option(WorkspaceAccessLevels.ProjectOwner -> billingProjectOwnerPolicyEmail)
+                        } else {
+                          WorkspaceAccessLevels.withPolicyName(policyName.value).map(_ -> policyEmail)
+                        }
+                      }
+                      .flatten
+                      .toMap
+                  )
+
+                  workspaceBucketLocation <- traceDBIOWithParent("determineWorkspaceBucketLocation", parentContext)(_ =>
+                    DBIO.from(
+                      determineWorkspaceBucketLocation(workspaceRequest.bucketLocation,
+                                                       sourceBucketName,
+                                                       googleProjectId
+                      )
+                    )
+                  )
+                  _ <- traceDBIOWithParent("gcsDAO.setupWorkspace", parentContext)(childContext =>
+                    DBIO.from(
+                      gcsDAO.setupWorkspace(
+                        ctx.userInfo,
+                        savedWorkspace.googleProjectId,
+                        policyEmails,
+                        GcsBucketName(bucketName),
+                        getLabels(workspaceRequest.authorizationDomain.getOrElse(Set.empty).toList),
+                        childContext.tracingSpan.orNull,
+                        workspaceBucketLocation
+                      )
+                    )
+                  )
+                  _ = workspaceRequest.bucketLocation.foreach(location =>
+                    logger.info(
+                      s"Internal bucket for workspace `${workspaceRequest.name}` in namespace `${workspaceRequest.namespace}` was created in region `$location`."
+                    )
+                  )
+                  response <- traceDBIOWithParent("doOp", parentContext)(_ => op(savedWorkspace))
+                } yield response
+            }
+          }
+        )
+      }
+    )
   }
 
   // A new workspace request may specify the region where the bucket should be created. In the case of cloning a
@@ -2560,110 +3484,204 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   // to query Google and this query costs money, so we need to make sure that the target Google Project is the one that
   // gets charged. If neither a bucket location nor a source bucket name are provided, a default bucket location from
   // the rawls configuration will be used
-  private def determineWorkspaceBucketLocation(maybeBucketLocation: Option[String], maybeSourceBucketName: Option[String], googleProjectId: GoogleProjectId): Future[Option[String]] = {
+  private def determineWorkspaceBucketLocation(maybeBucketLocation: Option[String],
+                                               maybeSourceBucketName: Option[String],
+                                               googleProjectId: GoogleProjectId
+  ): Future[Option[String]] =
     (maybeBucketLocation, maybeSourceBucketName) match {
-      case (bucketLocation@Some(_), _) => Future(bucketLocation)
-      case (None, Some(sourceBucketName)) => gcsDAO.getRegionForRegionalBucket(sourceBucketName, Option(googleProjectId))
+      case (bucketLocation @ Some(_), _) => Future(bucketLocation)
+      case (None, Some(sourceBucketName)) =>
+        gcsDAO.getRegionForRegionalBucket(sourceBucketName, Option(googleProjectId))
       case (None, None) => Future(Some(config.defaultLocation))
     }
-  }
 
-  private def withSubmission[T](workspaceContext: Workspace, submissionId: String, dataAccess: DataAccess)(op: (Submission) => ReadWriteAction[T]): ReadWriteAction[T] = {
+  private def withSubmission[T](workspaceContext: Workspace, submissionId: String, dataAccess: DataAccess)(
+    op: (Submission) => ReadWriteAction[T]
+  ): ReadWriteAction[T] =
     Try {
       UUID.fromString(submissionId)
     } match {
       case Failure(_) =>
-        DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"Submission id ${submissionId} is not a valid submission id")))
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport =
+              ErrorReport(StatusCodes.NotFound, s"Submission id ${submissionId} is not a valid submission id")
+          )
+        )
       case _ =>
         dataAccess.submissionQuery.get(workspaceContext, submissionId) flatMap {
-          case None => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"Submission with id ${submissionId} not found in workspace ${workspaceContext.toWorkspaceName}")))
+          case None =>
+            DBIO.failed(
+              new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.NotFound,
+                  s"Submission with id ${submissionId} not found in workspace ${workspaceContext.toWorkspaceName}"
+                )
+              )
+            )
           case Some(submission) => op(submission)
         }
     }
-  }
 
   // confirm that the Submission is a member of this workspace, but don't unmarshal it from the DB
-  private def withSubmissionId[T](workspaceContext: Workspace, submissionId: String, dataAccess: DataAccess)(op: UUID => ReadWriteAction[T]): ReadWriteAction[T] = {
+  private def withSubmissionId[T](workspaceContext: Workspace, submissionId: String, dataAccess: DataAccess)(
+    op: UUID => ReadWriteAction[T]
+  ): ReadWriteAction[T] =
     Try {
       UUID.fromString(submissionId)
     } match {
       case Failure(_) =>
-        DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"Submission id ${submissionId} is not a valid submission id")))
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport =
+              ErrorReport(StatusCodes.NotFound, s"Submission id ${submissionId} is not a valid submission id")
+          )
+        )
       case Success(uuid) =>
         dataAccess.submissionQuery.confirmInWorkspace(workspaceContext.workspaceIdAsUUID, uuid) flatMap {
           case None =>
-            val report = ErrorReport(StatusCodes.NotFound, s"Submission with id ${submissionId} not found in workspace ${workspaceContext.toWorkspaceName}")
+            val report = ErrorReport(
+              StatusCodes.NotFound,
+              s"Submission with id ${submissionId} not found in workspace ${workspaceContext.toWorkspaceName}"
+            )
             DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = report))
           case Some(_) => op(uuid)
         }
     }
-  }
 
-  private def withWorkflowRecord[T](workspaceName: WorkspaceName, submissionId: String, workflowId: String, dataAccess: DataAccess)(op: (WorkflowRecord) => ReadWriteAction[T]): ReadWriteAction[T] = {
-    dataAccess.workflowQuery.findWorkflowByExternalIdAndSubmissionId(workflowId, UUID.fromString(submissionId)).result flatMap {
-      case Seq() => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, s"WorkflowRecord with id ${workflowId} not found in submission ${submissionId} in workspace ${workspaceName}")))
+  private def withWorkflowRecord[T](workspaceName: WorkspaceName,
+                                    submissionId: String,
+                                    workflowId: String,
+                                    dataAccess: DataAccess
+  )(op: (WorkflowRecord) => ReadWriteAction[T]): ReadWriteAction[T] =
+    dataAccess.workflowQuery
+      .findWorkflowByExternalIdAndSubmissionId(workflowId, UUID.fromString(submissionId))
+      .result flatMap {
+      case Seq() =>
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(
+              StatusCodes.NotFound,
+              s"WorkflowRecord with id ${workflowId} not found in submission ${submissionId} in workspace ${workspaceName}"
+            )
+          )
+        )
       case Seq(one) => op(one)
-      case tooMany => DBIO.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, s"found multiple WorkflowRecords with id ${workflowId} in submission ${submissionId} in workspace ${workspaceName}")))
+      case tooMany =>
+        DBIO.failed(
+          new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(
+              StatusCodes.InternalServerError,
+              s"found multiple WorkflowRecords with id ${workflowId} in submission ${submissionId} in workspace ${workspaceName}"
+            )
+          )
+        )
     }
-  }
 
   // used as part of the workflow metadata permission check - more detail at workflowMetadata()
 
   // require submission to be present, but don't require the workflow to reference it
   // if the workflow does reference the submission, return its executionServiceKey
 
-  private def withSubmissionAndWorkflowExecutionServiceKey[T](workspaceContext: Workspace, submissionId: String, workflowId: String, dataAccess: DataAccess)(op: Option[ExecutionServiceId] => ReadWriteAction[T]): ReadWriteAction[T] = {
+  private def withSubmissionAndWorkflowExecutionServiceKey[T](workspaceContext: Workspace,
+                                                              submissionId: String,
+                                                              workflowId: String,
+                                                              dataAccess: DataAccess
+  )(op: Option[ExecutionServiceId] => ReadWriteAction[T]): ReadWriteAction[T] =
     withSubmissionId(workspaceContext, submissionId, dataAccess) { _ =>
       dataAccess.workflowQuery.getExecutionServiceIdByExternalId(workflowId, submissionId) flatMap {
         case Some(id) => op(Option(ExecutionServiceId(id)))
-        case _ => op(None)
+        case _        => op(None)
       }
     }
-  }
-
 
   /** Validates the workflow failure mode in the submission request. */
-  private def getWorkflowFailureMode(submissionRequest: SubmissionRequest): Future[Option[WorkflowFailureMode]] = {
+  private def getWorkflowFailureMode(submissionRequest: SubmissionRequest): Future[Option[WorkflowFailureMode]] =
     Try(submissionRequest.workflowFailureMode.map(WorkflowFailureModes.withName)) match {
       case Success(failureMode) => Future.successful(failureMode)
-      case Failure(NonFatal(e)) => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, e.getMessage)))
-      case Failure(e) => Future.failed(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, e.getMessage)))
+      case Failure(NonFatal(e)) =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, e.getMessage))
+        )
+      case Failure(e) =>
+        Future.failed(
+          new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.InternalServerError, e.getMessage))
+        )
     }
-  }
 
-  private def validateSubmissionRootEntity(submissionRequest: SubmissionRequest, methodConfig: MethodConfiguration): Unit = {
+  private def validateSubmissionRootEntity(submissionRequest: SubmissionRequest,
+                                           methodConfig: MethodConfiguration
+  ): Unit = {
     if (submissionRequest.entityName.isDefined != submissionRequest.entityType.isDefined) {
-      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"You must set both entityType and entityName to run on an entity, or neither (to run with literal or workspace inputs)."))
+      throw new RawlsExceptionWithErrorReport(
+        errorReport = ErrorReport(
+          StatusCodes.BadRequest,
+          s"You must set both entityType and entityName to run on an entity, or neither (to run with literal or workspace inputs)."
+        )
+      )
     }
-    if (methodConfig.dataReferenceName.isEmpty && methodConfig.rootEntityType.isDefined != submissionRequest.entityName.isDefined) {
+    if (
+      methodConfig.dataReferenceName.isEmpty && methodConfig.rootEntityType.isDefined != submissionRequest.entityName.isDefined
+    ) {
       if (methodConfig.rootEntityType.isDefined) {
-        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Your method config defines a root entity but you haven't passed one to the submission."))
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            StatusCodes.BadRequest,
+            s"Your method config defines a root entity but you haven't passed one to the submission."
+          )
+        )
       } else {
-        //This isn't _strictly_ necessary, since a single submission entity will create one workflow.
-        //However, passing in a submission entity + an expression doesn't make sense for two reasons:
+        // This isn't _strictly_ necessary, since a single submission entity will create one workflow.
+        // However, passing in a submission entity + an expression doesn't make sense for two reasons:
         // 1. you'd have to write an expression from your submission entity to an entity of "no entity necessary" type
         // 2. even if you _could_ do this, you'd kick off a bunch of identical workflows.
-        //More likely than not, an MC with no root entity + a submission entity = you're doing something wrong. So we'll just say no here.
-        throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, s"Your method config uses no root entity, but you passed one to the submission."))
+        // More likely than not, an MC with no root entity + a submission entity = you're doing something wrong. So we'll just say no here.
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(StatusCodes.BadRequest,
+                                    s"Your method config uses no root entity, but you passed one to the submission."
+          )
+        )
       }
     }
     if (methodConfig.dataReferenceName.isDefined && submissionRequest.entityName.isDefined) {
-      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "Your method config defines a data reference and an entity name. Running on a submission on a single entity in a data reference is not yet supported."))
+      throw new RawlsExceptionWithErrorReport(
+        errorReport = ErrorReport(
+          StatusCodes.BadRequest,
+          "Your method config defines a data reference and an entity name. Running on a submission on a single entity in a data reference is not yet supported."
+        )
+      )
     }
   }
 
-  def getSpendReportTableName(billingProjectName: RawlsBillingProjectName): Future[Option[String]] = {
+  def getSpendReportTableName(billingProjectName: RawlsBillingProjectName): Future[Option[String]] =
     dataSource.inTransaction { dataAccess =>
       dataAccess.rawlsBillingProjectQuery.load(billingProjectName).map { billingProject =>
         billingProject match {
-          case None => throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"Could not find billing project ${billingProjectName.value}"))
-          case Some(RawlsBillingProject(_, _, _, _, _, _, _, _, Some(spendReportDataset), Some(spendReportTable), Some(spendReportDatasetGoogleProject), _, _)) =>
+          case None =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.NotFound, s"Could not find billing project ${billingProjectName.value}")
+            )
+          case Some(
+                RawlsBillingProject(_,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    _,
+                                    Some(spendReportDataset),
+                                    Some(spendReportTable),
+                                    Some(spendReportDatasetGoogleProject),
+                                    _,
+                                    _
+                )
+              ) =>
             Option(s"${spendReportDatasetGoogleProject}.${spendReportDataset}.${spendReportTable}")
           case _ => None
         }
       }
     }
-  }
 
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -6,9 +6,25 @@ import bio.terra.profile.model.{AzureManagedAppModel, AzureManagedAppsResponseMo
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, CreationStatuses, RawlsBillingAccountName, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SamBillingProjectActions, SamBillingProjectRoles, SamResourceAction, SamResourceTypeNames, SamRolesAndActions, SamUserResource, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  CreationStatuses,
+  RawlsBillingAccountName,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamBillingProjectActions,
+  SamBillingProjectRoles,
+  SamResourceAction,
+  SamResourceTypeNames,
+  SamRolesAndActions,
+  SamUserResource,
+  UserInfo
+}
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, times, verify, when}
+import org.mockito.Mockito.{times, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar
@@ -42,11 +58,15 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
   it should "return billing profiles to which the user has access" in {
     val samDAO: SamDAO = mock[SamDAO]
-    when(samDAO.userHasAction(SamResourceTypeNames.managedGroup, azConfig.alphaFeatureGroup,
-      SamResourceAction("use"),
-      userInfo
-    )).thenReturn(Future.successful(true))
-    val bpSamResource = SamUserResource(azConfig.billingProjectName,
+    when(
+      samDAO.userHasAction(SamResourceTypeNames.managedGroup,
+                           azConfig.alphaFeatureGroup,
+                           SamResourceAction("use"),
+                           userInfo
+      )
+    ).thenReturn(Future.successful(true))
+    val bpSamResource = SamUserResource(
+      azConfig.billingProjectName,
       SamRolesAndActions(
         Set(SamBillingProjectRoles.owner),
         Set(SamBillingProjectActions.createWorkspace)
@@ -76,7 +96,8 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     )
 
     val result = Await.result(
-      billingProfileManagerDAO.listBillingProfiles(samUserResources, testContext), Duration.Inf
+      billingProfileManagerDAO.listBillingProfiles(samUserResources, testContext),
+      Duration.Inf
     )
 
     val expected = Seq(
@@ -100,16 +121,17 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
   it should "return no profiles if the user lacks permissions" in {
     val samDAO: SamDAO = mock[SamDAO]
-    when(samDAO.userHasAction(SamResourceTypeNames.managedGroup, azConfig.alphaFeatureGroup,
-      SamResourceAction("use"),
-      userInfo
-    )).thenReturn(Future.successful(false))
+    when(
+      samDAO.userHasAction(SamResourceTypeNames.managedGroup,
+                           azConfig.alphaFeatureGroup,
+                           SamResourceAction("use"),
+                           userInfo
+      )
+    ).thenReturn(Future.successful(false))
     val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
       samDAO,
       mock[BillingProfileManagerClientProvider],
-      new MultiCloudWorkspaceConfig(true, None,
-        Some(azConfig)
-      )
+      new MultiCloudWorkspaceConfig(true, None, Some(azConfig))
     )
 
     val result = Await.result(billingProfileManagerDAO.listBillingProfiles(Seq.empty, testContext), Duration.Inf)
@@ -145,7 +167,6 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     result.isEmpty shouldBe true
   }
 
-
   behavior of "createBillingProfile"
 
   it should "fail when provided with Google billing account information" in {
@@ -154,7 +175,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     val config = new MultiCloudWorkspaceConfig(true, None, None)
     val bpmDAO = new BillingProfileManagerDAOImpl(samDAO, provider, config)
 
-    intercept[NotImplementedError]{
+    intercept[NotImplementedError] {
       bpmDAO.createBillingProfile("fake", Left(RawlsBillingAccountName("fake")), testContext)
     }
   }
@@ -172,7 +193,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
     val profile = Await.result(bpmDAO.createBillingProfile("fake", Right(coords), testContext), Duration.Inf)
 
-    assertResult(expectedProfile){profile}
+    assertResult(expectedProfile)(profile)
     verify(profileApi, times(1)).createProfile(ArgumentMatchers.any[CreateProfileRequest])
   }
 
@@ -185,9 +206,11 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     val subscriptionId = UUID.randomUUID()
     val expectedApp = new AzureManagedAppModel().subscriptionId(subscriptionId)
     when(azureApi.getManagedAppDeployments(ArgumentMatchers.eq(subscriptionId))).thenReturn(
-      new AzureManagedAppsResponseModel().managedApps(java.util.List.of(
-        expectedApp
-      ))
+      new AzureManagedAppsResponseModel().managedApps(
+        java.util.List.of(
+          expectedApp
+        )
+      )
     )
     when(provider.getAzureApi(ArgumentMatchers.eq(testContext))).thenReturn(azureApi)
     val config = new MultiCloudWorkspaceConfig(true, None, None)
@@ -195,6 +218,6 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
     val apps = Await.result(bpmDAO.listManagedApps(subscriptionId, testContext), Duration.Inf)
 
-    assertResult(Seq(expectedApp)) { apps }
+    assertResult(Seq(expectedApp))(apps)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectCreatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectCreatorSpec.scala
@@ -4,7 +4,16 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.{AzureManagedAppModel, ProfileModel}
 import cromwell.client.ApiException
 import org.broadinstitute.dsde.rawls.TestExecutionContext
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, CreateRawlsV2BillingProjectFullRequest, RawlsBillingAccountName, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  CreateRawlsV2BillingProjectFullRequest,
+  RawlsBillingAccountName,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  UserInfo
+}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
@@ -18,12 +27,8 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 class BpmBillingProjectCreatorSpec extends AnyFlatSpec {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
-  val userInfo: UserInfo = UserInfo(
-    RawlsUserEmail("fake@example.com"),
-    OAuth2BearerToken("fake_token"),
-    0,
-    RawlsUserSubjectId("sub"),
-    None)
+  val userInfo: UserInfo =
+    UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
   val testContext = RawlsRequestContext(userInfo)
 
   behavior of "validateBillingProjectCreationRequest"
@@ -89,10 +94,15 @@ class BpmBillingProjectCreatorSpec extends AnyFlatSpec {
       Some(coords)
     )
     when(bpm.listManagedApps(ArgumentMatchers.eq(coords.subscriptionId), ArgumentMatchers.eq(testContext)))
-      .thenReturn(Future.successful(Seq(
-        new AzureManagedAppModel().subscriptionId(coords.subscriptionId)
-          .managedResourceGroupId(coords.managedResourceGroupId)
-          .tenantId(coords.tenantId)))
+      .thenReturn(
+        Future.successful(
+          Seq(
+            new AzureManagedAppModel()
+              .subscriptionId(coords.subscriptionId)
+              .managedResourceGroupId(coords.managedResourceGroupId)
+              .tenantId(coords.tenantId)
+          )
+        )
       )
     val bp = new BpmBillingProjectCreator(mock[BillingRepository], bpm)
 
@@ -112,14 +122,14 @@ class BpmBillingProjectCreatorSpec extends AnyFlatSpec {
     val repo = mock[BillingRepository]
     val bpm = mock[BillingProfileManagerDAO]
     val profileModel = new ProfileModel().id(UUID.randomUUID())
-    when(bpm.createBillingProfile(
-      ArgumentMatchers.eq(createRequest.projectName.value),
-      ArgumentMatchers.eq(createRequest.billingInfo),
-      ArgumentMatchers.eq(testContext)))
+    when(
+      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
+                               ArgumentMatchers.eq(createRequest.billingInfo),
+                               ArgumentMatchers.eq(testContext)
+      )
+    )
       .thenReturn(Future.successful(profileModel))
-    when(repo.setBillingProfileId(
-      createRequest.projectName,
-      profileModel.getId)).thenReturn(Future.successful(1))
+    when(repo.setBillingProfileId(createRequest.projectName, profileModel.getId)).thenReturn(Future.successful(1))
     val bp = new BpmBillingProjectCreator(repo, bpm)
 
     bp.postCreationSteps(createRequest, testContext)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectCreatorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectCreatorSpec.scala
@@ -4,7 +4,19 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
-import org.broadinstitute.dsde.rawls.model.{CreateRawlsV2BillingProjectFullRequest, RawlsBillingAccountName, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SamBillingProjectPolicyNames, SamResourceTypeNames, SamServicePerimeterActions, ServicePerimeterName, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  CreateRawlsV2BillingProjectFullRequest,
+  RawlsBillingAccountName,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamBillingProjectPolicyNames,
+  SamResourceTypeNames,
+  SamServicePerimeterActions,
+  ServicePerimeterName,
+  UserInfo
+}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.Mockito.{verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
@@ -17,14 +29,9 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 class GoogleBillingProjectCreatorSpec extends AnyFlatSpec {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
-  val userInfo: UserInfo = UserInfo(
-    RawlsUserEmail("fake@example.com"),
-    OAuth2BearerToken("fake_token"),
-    0,
-    RawlsUserSubjectId("sub"),
-    None)
+  val userInfo: UserInfo =
+    UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
   val testContext = RawlsRequestContext(userInfo)
-
 
   behavior of "validateBillingProjectCreationRequest"
 
@@ -37,9 +44,10 @@ class GoogleBillingProjectCreatorSpec extends AnyFlatSpec {
       None
     )
     val gcsDAO = mock[GoogleServicesDAO]
-    when(gcsDAO.testBillingAccountAccess(
-      ArgumentMatchers.eq(createRequest.billingAccount.get),
-      ArgumentMatchers.eq(userInfo))
+    when(
+      gcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(createRequest.billingAccount.get),
+                                      ArgumentMatchers.eq(userInfo)
+      )
     ).thenReturn(Future.successful(false))
     val gbp = new GoogleBillingProjectCreator(samDAO, gcsDAO)
 
@@ -61,7 +69,9 @@ class GoogleBillingProjectCreatorSpec extends AnyFlatSpec {
         ArgumentMatchers.eq(SamResourceTypeNames.servicePerimeter),
         ArgumentMatchers.eq(servicePerimeterName.value),
         ArgumentMatchers.eq(SamServicePerimeterActions.addProject),
-        ArgumentMatchers.eq(userInfo))).thenReturn(Future.successful(false))
+        ArgumentMatchers.eq(userInfo)
+      )
+    ).thenReturn(Future.successful(false))
 
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
       RawlsBillingProjectName("fake_billing_project"),
@@ -71,7 +81,7 @@ class GoogleBillingProjectCreatorSpec extends AnyFlatSpec {
     )
     val bpo = new GoogleBillingProjectCreator(
       samDAO,
-      mock[GoogleServicesDAO],
+      mock[GoogleServicesDAO]
     )
 
     val ex = intercept[ServicePerimeterAccessException] {
@@ -97,14 +107,16 @@ class GoogleBillingProjectCreatorSpec extends AnyFlatSpec {
       samDAO.syncPolicyToGoogle(
         ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
         ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner))
+        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+      )
     ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
     val gbp = new GoogleBillingProjectCreator(samDAO, mock[GoogleServicesDAO])
 
     Await.result(gbp.postCreationSteps(createRequest, testContext), Duration.Inf)
 
     verify(samDAO, Mockito.times(1))
-      .syncPolicyToGoogle(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+      .syncPolicyToGoogle(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
         ArgumentMatchers.eq(createRequest.projectName.value),
         ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -1,11 +1,10 @@
-
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import _root_.slick.dbio.DBIOAction
 import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils, model}
+import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsTestUtils}
 
 import java.util.UUID
 
@@ -29,68 +28,108 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   "EntityComponent" should "crud entities" in withEmptyTestDatabase {
     val workspaceId: UUID = UUID.randomUUID()
-    val workspace: Workspace = Workspace("test_namespace", workspaceId.toString, workspaceId.toString, "bucketname", Some("workflow-collection"), currentTime(), currentTime(), "me", Map.empty, false)
+    val workspace: Workspace = Workspace("test_namespace",
+                                         workspaceId.toString,
+                                         workspaceId.toString,
+                                         "bucketname",
+                                         Some("workflow-collection"),
+                                         currentTime(),
+                                         currentTime(),
+                                         "me",
+                                         Map.empty,
+                                         false
+    )
     runAndWait(workspaceQuery.createOrUpdate(workspace))
     val workspaceContext = workspace
 
-    assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(None)(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
     val entity = Entity("name", "type", Map.empty)
 
-    assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
-    assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(entity)(runAndWait(entityQuery.save(workspaceContext, entity)))
+    assertResult(Some(entity))(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
     val target1 = Entity("target1", "type", Map.empty)
     runAndWait(entityQuery.save(workspaceContext, target1))
     val target2 = Entity("target2", "type", Map.empty)
     runAndWait(entityQuery.save(workspaceContext, target2))
 
-    val updatedEntity = entity.copy(attributes = Map(
-      AttributeName.withDefaultNS("string") -> AttributeString("foo"),
-      AttributeName.withDefaultNS("ref") -> target1.toReference,
-      AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(Seq(target1.toReference, target2.toReference))))
+    val updatedEntity = entity.copy(attributes =
+      Map(
+        AttributeName.withDefaultNS("string") -> AttributeString("foo"),
+        AttributeName.withDefaultNS("ref") -> target1.toReference,
+        AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(
+          Seq(target1.toReference, target2.toReference)
+        )
+      )
+    )
 
-    assertResult(updatedEntity) { runAndWait(entityQuery.save(workspaceContext, updatedEntity)) }
-    assertResult(Some(updatedEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(updatedEntity)(runAndWait(entityQuery.save(workspaceContext, updatedEntity)))
+    assertResult(Some(updatedEntity))(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
-    val updatedAgainEntity = updatedEntity.copy(attributes = Map(
-      AttributeName.withDefaultNS("string2") -> AttributeString("foo"),
-      AttributeName.withDefaultNS("ref") -> target2.toReference,
-      AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(Seq(target2.toReference, target1.toReference))))
-    assertResult(updatedAgainEntity) { runAndWait(entityQuery.save(workspaceContext, updatedAgainEntity)) }
-    assertResult(Some(updatedAgainEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    val updatedAgainEntity = updatedEntity.copy(attributes =
+      Map(
+        AttributeName.withDefaultNS("string2") -> AttributeString("foo"),
+        AttributeName.withDefaultNS("ref") -> target2.toReference,
+        AttributeName.withDefaultNS("refList") -> AttributeEntityReferenceList(
+          Seq(target2.toReference, target1.toReference)
+        )
+      )
+    )
+    assertResult(updatedAgainEntity)(runAndWait(entityQuery.save(workspaceContext, updatedAgainEntity)))
+    assertResult(Some(updatedAgainEntity))(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
-    assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
-    assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(entity)(runAndWait(entityQuery.save(workspaceContext, entity)))
+    assertResult(Some(entity))(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
-    //save AttributeValueEmptyList
-    val emptyValListAttributeEntity = entity.copy(name = "emptyValListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList))
+    // save AttributeValueEmptyList
+    val emptyValListAttributeEntity =
+      entity.copy(name = "emptyValListy",
+                  attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueEmptyList)
+      )
     runAndWait(entityQuery.save(workspaceContext, emptyValListAttributeEntity))
-    assertResult(Some(emptyValListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValListy")) }
+    assertResult(Some(emptyValListAttributeEntity)) {
+      runAndWait(entityQuery.get(workspaceContext, "type", "emptyValListy"))
+    }
 
-    //convert AttributeValueList(Seq()) -> AttributeEmptyList
-    val emptyValListEntity = entity.copy(name = "emptyValList", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueList(Seq())))
+    // convert AttributeValueList(Seq()) -> AttributeEmptyList
+    val emptyValListEntity = entity.copy(name = "emptyValList",
+                                         attributes =
+                                           Map(AttributeName.withDefaultNS("emptyList") -> AttributeValueList(Seq()))
+    )
     runAndWait(entityQuery.save(workspaceContext, emptyValListEntity))
-    assertResult(Some(emptyValListAttributeEntity.copy(name="emptyValList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList")) }
+    assertResult(Some(emptyValListAttributeEntity.copy(name = "emptyValList"))) {
+      runAndWait(entityQuery.get(workspaceContext, "type", "emptyValList"))
+    }
 
-    //save AttributeEntityReferenceEmptyList
-    val emptyRefListAttributeEntity = entity.copy(name = "emptyRefListy", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEntityReferenceEmptyList))
+    // save AttributeEntityReferenceEmptyList
+    val emptyRefListAttributeEntity =
+      entity.copy(name = "emptyRefListy",
+                  attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEntityReferenceEmptyList)
+      )
     runAndWait(entityQuery.save(workspaceContext, emptyRefListAttributeEntity))
-    assertResult(Some(emptyRefListAttributeEntity)) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefListy")) }
+    assertResult(Some(emptyRefListAttributeEntity)) {
+      runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefListy"))
+    }
 
-    //convert AttributeEntityReferenceList(Seq()) -> AttributeEntityReferenceEmptyList
-    val emptyRefListEntity = entity.copy(name = "emptyRefList", attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEntityReferenceList(Seq())))
+    // convert AttributeEntityReferenceList(Seq()) -> AttributeEntityReferenceEmptyList
+    val emptyRefListEntity =
+      entity.copy(name = "emptyRefList",
+                  attributes = Map(AttributeName.withDefaultNS("emptyList") -> AttributeEntityReferenceList(Seq()))
+      )
     runAndWait(entityQuery.save(workspaceContext, emptyRefListEntity))
-    assertResult(Some(emptyRefListAttributeEntity.copy(name="emptyRefList"))) { runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList")) }
+    assertResult(Some(emptyRefListAttributeEntity.copy(name = "emptyRefList"))) {
+      runAndWait(entityQuery.get(workspaceContext, "type", "emptyRefList"))
+    }
 
     val (entityCount1, attributeCount1) = countEntitiesAttrs(workspace)
     val (activeEntityCount1, activeAttributeCount1) = countActiveEntitiesAttrs(workspace)
 
     // "hide" deletion
 
-    assertResult(1) { runAndWait(entityQuery.hide(workspaceContext, Seq(entity.toReference))) }
-    assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
-    assertResult(0) { runAndWait(entityQuery.hide(workspaceContext, Seq(entity.toReference))) }
+    assertResult(1)(runAndWait(entityQuery.hide(workspaceContext, Seq(entity.toReference))))
+    assertResult(None)(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
+    assertResult(0)(runAndWait(entityQuery.hide(workspaceContext, Seq(entity.toReference))))
 
     val (entityCount2, attributeCount2) = countEntitiesAttrs(workspace)
     val (activeEntityCount2, activeAttributeCount2) = countActiveEntitiesAttrs(workspace)
@@ -104,8 +143,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
     val entityForDeletion = Entity("delete-me", "type", Map.empty)
 
-    assertResult(entityForDeletion) { runAndWait(entityQuery.save(workspaceContext, entityForDeletion)) }
-    assertResult(Some(entityForDeletion)) { runAndWait(entityQuery.get(workspaceContext, "type", "delete-me")) }
+    assertResult(entityForDeletion)(runAndWait(entityQuery.save(workspaceContext, entityForDeletion)))
+    assertResult(Some(entityForDeletion))(runAndWait(entityQuery.get(workspaceContext, "type", "delete-me")))
 
     val (entityCount3, attributeCount3) = countEntitiesAttrs(workspace)
     val (activeEntityCount3, activeAttributeCount3) = countActiveEntitiesAttrs(workspace)
@@ -115,9 +154,9 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     assertResult(activeEntityCount2 + 1)(activeEntityCount3)
     assertResult(activeAttributeCount2)(activeAttributeCount3)
 
-    assertResult(entityCount3) { runAndWait(entityQuery.deleteFromDb(workspaceContext)) }
-    assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "delete-me")) }
-    assertResult(0) { runAndWait(entityQuery.deleteFromDb(workspaceContext)) }
+    assertResult(entityCount3)(runAndWait(entityQuery.deleteFromDb(workspaceContext)))
+    assertResult(None)(runAndWait(entityQuery.get(workspaceContext, "type", "delete-me")))
+    assertResult(0)(runAndWait(entityQuery.deleteFromDb(workspaceContext)))
 
     val (entityCount4, attributeCount4) = countEntitiesAttrs(workspace)
     val (activeEntityCount4, activeAttributeCount4) = countActiveEntitiesAttrs(workspace)
@@ -132,13 +171,16 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     withWorkspaceContext(constantData.workspace) { context =>
       val caught = intercept[RawlsException] {
         runAndWait(
-          entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "nonexistent"),
+          entityQuery.saveEntityPatch(
+            context,
+            AttributeEntityReference("Sample", "nonexistent"),
             Map(AttributeName.withDefaultNS("newAttribute") -> AttributeNumber(2)),
             Seq(AttributeName.withDefaultNS("type"))
-          ))
+          )
+        )
       }
-      //make sure we get the _right_ RawlsException:
-      //"saveEntityPatch looked up $entityRef expecting 1 record, got 0 instead"
+      // make sure we get the _right_ RawlsException:
+      // "saveEntityPatch looked up $entityRef expecting 1 record, got 0 instead"
       caught.getMessage should include("expecting")
     }
   }
@@ -147,13 +189,16 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     withWorkspaceContext(constantData.workspace) { context =>
       val caught = intercept[RawlsException] {
         runAndWait(
-          entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"),
+          entityQuery.saveEntityPatch(
+            context,
+            AttributeEntityReference("Sample", "sample1"),
             Map(AttributeName.withDefaultNS("type") -> AttributeNumber(2)),
             Seq(AttributeName.withDefaultNS("type"))
-          ))
+          )
+        )
       }
-      //make sure we get the _right_ RawlsException:
-      //"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes <blah>"
+      // make sure we get the _right_ RawlsException:
+      // "Can't saveEntityPatch on $entityRef because upserts and deletes share attributes <blah>"
       caught.getMessage should include("share")
     }
   }
@@ -177,7 +222,6 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "saveEntityPatch" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-
       val inserts = Map(
         AttributeName.withDefaultNS("totallyNew") -> AttributeNumber(2),
         AttributeName.withDefaultNS("quot2") -> testData.aliquot2.toReference
@@ -185,7 +229,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       val updates = Map(
         AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
         AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("c"), AttributeString("d"))),
-        AttributeName.withDefaultNS("quot1") -> testData.aliquot2.toReference //jerk move
+        AttributeName.withDefaultNS("quot1") -> testData.aliquot2.toReference // jerk move
       )
       val deletes = Seq(AttributeName.withDefaultNS("whatsit"), AttributeName.withDefaultNS("nonexistent"))
 
@@ -202,7 +246,18 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // check that the all_attribute_values field was filled in correctly by searching on the new attributes and making sure one filtered result is found
       assertResult(1) {
-        runAndWait(entityQuery.loadEntityPage(context, "Sample", model.EntityQuery(1, 10, "name", SortDirections.Ascending, Option("sample1 2 tumor aliquot2 aliquot1 aliquot2 itsfoo")), testContext))._2
+        runAndWait(
+          entityQuery.loadEntityPage(context,
+                                     "Sample",
+                                     model.EntityQuery(1,
+                                                       10,
+                                                       "name",
+                                                       SortDirections.Ascending,
+                                                       Option("sample1 2 tumor aliquot2 aliquot1 aliquot2 itsfoo")
+                                     ),
+                                     testContext
+          )
+        )._2
       }
     }
   }
@@ -210,29 +265,50 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   it should "update attribute list values" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       // insert new attribute 'myNewList' which is a list with 3 elements
-      val inserts = Map(AttributeName.withDefaultNS("myNewList") -> AttributeValueList(Seq(
-        AttributeString("abc"),
-        AttributeString("def"),
-        AttributeString("xyz")
-      )))
+      val inserts = Map(
+        AttributeName.withDefaultNS("myNewList") -> AttributeValueList(
+          Seq(
+            AttributeString("abc"),
+            AttributeString("def"),
+            AttributeString("xyz")
+          )
+        )
+      )
 
       val expectedAfterInsertion = testData.sample1.attributes ++ inserts
 
-      runAndWait(entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), inserts, Seq.empty[AttributeName]))
+      runAndWait(
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    inserts,
+                                    Seq.empty[AttributeName]
+        )
+      )
 
-      assertSameElements(expectedAfterInsertion, runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes)
+      assertSameElements(expectedAfterInsertion,
+                         runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes
+      )
 
       // update values in the list
       val updates = Map(
-        AttributeName.withDefaultNS("myNewList") -> AttributeValueList(Seq(
-          AttributeString("123"),
-          AttributeString("456"),
-          AttributeString("789")
-        )))
+        AttributeName.withDefaultNS("myNewList") -> AttributeValueList(
+          Seq(
+            AttributeString("123"),
+            AttributeString("456"),
+            AttributeString("789")
+          )
+        )
+      )
 
       val expectedAfterUpdate = testData.sample1.attributes ++ updates
 
-      runAndWait(entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), updates, Seq.empty[AttributeName]))
+      runAndWait(
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    updates,
+                                    Seq.empty[AttributeName]
+        )
+      )
 
       // check that the 'myNewList' attribute has updated values
       assertSameElements(expectedAfterUpdate, runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes)
@@ -242,26 +318,44 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   it should "reflect changes in attribute when attribute value list size increases" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       // insert new attribute 'newEntityList' which is a list with 1 element
-      val inserts = Map(AttributeName.withDefaultNS("newEntityList") -> AttributeValueList(Seq(AttributeString("abc1"))))
+      val inserts =
+        Map(AttributeName.withDefaultNS("newEntityList") -> AttributeValueList(Seq(AttributeString("abc1"))))
 
       val expectedAfterInsertion = testData.sample1.attributes ++ inserts
 
-      runAndWait(entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), inserts, Seq.empty[AttributeName]))
+      runAndWait(
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    inserts,
+                                    Seq.empty[AttributeName]
+        )
+      )
 
-      assertSameElements(expectedAfterInsertion, runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes)
+      assertSameElements(expectedAfterInsertion,
+                         runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes
+      )
 
       // update 'newEntityList' to contain 4 elements
       val updates = Map(
-        AttributeName.withDefaultNS("newEntityList") -> AttributeValueList(Seq(
-          AttributeString("abc2"),
-          AttributeString("def"),
-          AttributeString("abc12"),
-          AttributeString("xyz")
-        )))
+        AttributeName.withDefaultNS("newEntityList") -> AttributeValueList(
+          Seq(
+            AttributeString("abc2"),
+            AttributeString("def"),
+            AttributeString("abc12"),
+            AttributeString("xyz")
+          )
+        )
+      )
 
       val expectedAfterUpdate = testData.sample1.attributes ++ updates
 
-      runAndWait(entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), updates, Seq.empty[AttributeName]))
+      runAndWait(
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    updates,
+                                    Seq.empty[AttributeName]
+        )
+      )
 
       // check that the 'newEntityList' attribute has 4 values now
       assertSameElements(expectedAfterUpdate, runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes)
@@ -271,24 +365,42 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   it should "reflect changes in attribute when attribute value list size decreases" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       // insert new attribute 'anotherList' which is a list with 3 elements
-      val inserts = Map(AttributeName.withDefaultNS("anotherList") -> AttributeValueList(Seq(
-        AttributeString("abc1"),
-        AttributeString("abc2"),
-        AttributeString("abc3")
-      )))
+      val inserts = Map(
+        AttributeName.withDefaultNS("anotherList") -> AttributeValueList(
+          Seq(
+            AttributeString("abc1"),
+            AttributeString("abc2"),
+            AttributeString("abc3")
+          )
+        )
+      )
 
       val expectedAfterInsertion = testData.sample1.attributes ++ inserts
 
-      runAndWait(entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), inserts, Seq.empty[AttributeName]))
+      runAndWait(
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    inserts,
+                                    Seq.empty[AttributeName]
+        )
+      )
 
-      assertSameElements(expectedAfterInsertion, runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes)
+      assertSameElements(expectedAfterInsertion,
+                         runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes
+      )
 
       // update 'anotherList' to contain 1 element
       val updates = Map(AttributeName.withDefaultNS("anotherList") -> AttributeValueList(Seq(AttributeString("1234"))))
 
       val expectedAfterUpdate = testData.sample1.attributes ++ updates
 
-      runAndWait(entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), updates, Seq.empty[AttributeName]))
+      runAndWait(
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    updates,
+                                    Seq.empty[AttributeName]
+        )
+      )
 
       // check that the 'anotherList' attribute has 1 value now
       assertSameElements(expectedAfterUpdate, runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes)
@@ -303,7 +415,9 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "list all entity types with their counts" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      assertResult(Map("PairSet" -> 1, "Individual" -> 2, "Sample" -> 8, "Aliquot" -> 2, "SampleSet" -> 5, "Pair" -> 2)) {
+      assertResult(
+        Map("PairSet" -> 1, "Individual" -> 2, "Sample" -> 8, "Aliquot" -> 2, "SampleSet" -> 5, "Pair" -> 2)
+      ) {
         runAndWait(entityQuery.getEntityTypesWithCounts(context.workspaceIdAsUUID))
       }
     }
@@ -311,9 +425,10 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "skip deleted entities when listing all entity types with their counts" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      val deleteSamples = entityQuery.findActiveEntityByType(context.workspaceIdAsUUID, "Sample").result flatMap { entityRecs =>
-        val deleteActions = entityRecs map { rec => entityQuery.hide(context, Seq(rec.toReference)) }
-        DBIO.seq(deleteActions:_*)
+      val deleteSamples = entityQuery.findActiveEntityByType(context.workspaceIdAsUUID, "Sample").result flatMap {
+        entityRecs =>
+          val deleteActions = entityRecs map { rec => entityQuery.hide(context, Seq(rec.toReference)) }
+          DBIO.seq(deleteActions: _*)
       }
       runAndWait(deleteSamples)
 
@@ -326,23 +441,22 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   it should "list all entity types with their attribute names" in withDefaultTestDatabase {
 
     withWorkspaceContext(testData.workspace) { context =>
-
       val desiredTypesAndAttrNames = Map(
         "Sample" -> Seq("type", "whatsit", "thingies", "quot", "somefoo", "tumortype", "confused", "cycle", "foo_id"),
-        //"Aliquot" -> Seq(), NOTE: this is commented out because the db query doesn't return types that have no attributes.
+        // "Aliquot" -> Seq(), NOTE: this is commented out because the db query doesn't return types that have no attributes.
         "Pair" -> Seq("case", "control", "whatsit"),
         "SampleSet" -> Seq("samples", "hasSamples"),
         "PairSet" -> Seq("pairs"),
         "Individual" -> Seq("sset")
       )
 
-      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
-      //so we test the existence of all keys correctly here...
+      // assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
+      // so we test the existence of all keys correctly here...
       val testTypesAndAttrNames = runAndWait(entityQuery.getAttrNamesAndEntityTypes(context.workspaceIdAsUUID))
       assertSameElements(testTypesAndAttrNames.keys, desiredTypesAndAttrNames.keys)
 
       desiredTypesAndAttrNames foreach { case (eType, attrNames) =>
-        //...and handle that the values are all correct here.
+        // ...and handle that the values are all correct here.
         assertSameElements(testTypesAndAttrNames(eType).map(AttributeName.toDelimitedName), attrNames)
       }
     }
@@ -350,41 +464,59 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "list all entity types with their namespaced attribute names" in withEmptyTestDatabase {
     val workspaceId: UUID = UUID.randomUUID()
-    val workspace: Workspace = Workspace("test_namespace", workspaceId.toString, workspaceId.toString, "bucketname", Some("workflow-collection"), currentTime(), currentTime(), "me", Map.empty, false)
+    val workspace: Workspace = Workspace("test_namespace",
+                                         workspaceId.toString,
+                                         workspaceId.toString,
+                                         "bucketname",
+                                         Some("workflow-collection"),
+                                         currentTime(),
+                                         currentTime(),
+                                         "me",
+                                         Map.empty,
+                                         false
+    )
     runAndWait(workspaceQuery.createOrUpdate(workspace))
     val workspaceContext = workspace
 
     // this entity also tests that namespaced and default attributes of the same name are tracked separately
-    val entity1 = Entity("entity1", "type1", Map(
-      AttributeName.fromDelimitedName("tag:hello") -> AttributeString("world"),
-      AttributeName.fromDelimitedName("tag:ihaveanamespace") -> AttributeString("foo"),
-      AttributeName.fromDelimitedName("tag:ialsohaveanamespace") -> AttributeString("bar"),
-      AttributeName.fromDelimitedName("iamdefault") -> AttributeString("baz"),
-      AttributeName.fromDelimitedName("hello") -> AttributeString("moon"),
-    ))
+    val entity1 = Entity(
+      "entity1",
+      "type1",
+      Map(
+        AttributeName.fromDelimitedName("tag:hello") -> AttributeString("world"),
+        AttributeName.fromDelimitedName("tag:ihaveanamespace") -> AttributeString("foo"),
+        AttributeName.fromDelimitedName("tag:ialsohaveanamespace") -> AttributeString("bar"),
+        AttributeName.fromDelimitedName("iamdefault") -> AttributeString("baz"),
+        AttributeName.fromDelimitedName("hello") -> AttributeString("moon")
+      )
+    )
 
-    val entity2 = Entity("entity2", "type2", Map(
-      AttributeName.fromDelimitedName("tag:morenamespacing") -> AttributeNumber(1),
-      AttributeName.fromDelimitedName("tag:evenmorenamespacing") -> AttributeNumber(2),
-      AttributeName.fromDelimitedName("iamdefault") -> AttributeNumber(3),
-      AttributeName.fromDelimitedName("moredefault") -> AttributeNumber(4)
-    ))
+    val entity2 = Entity(
+      "entity2",
+      "type2",
+      Map(
+        AttributeName.fromDelimitedName("tag:morenamespacing") -> AttributeNumber(1),
+        AttributeName.fromDelimitedName("tag:evenmorenamespacing") -> AttributeNumber(2),
+        AttributeName.fromDelimitedName("iamdefault") -> AttributeNumber(3),
+        AttributeName.fromDelimitedName("moredefault") -> AttributeNumber(4)
+      )
+    )
 
     runAndWait(entityQuery.save(workspaceContext, entity1))
     runAndWait(entityQuery.save(workspaceContext, entity2))
 
     val desiredTypesAndAttrNames = Map(
       "type1" -> Seq("tag:hello", "tag:ihaveanamespace", "tag:ialsohaveanamespace", "iamdefault", "hello"),
-      "type2" -> Seq("tag:morenamespacing", "tag:evenmorenamespacing", "iamdefault", "moredefault"),
+      "type2" -> Seq("tag:morenamespacing", "tag:evenmorenamespacing", "iamdefault", "moredefault")
     )
 
-    //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
-    //so we test the existence of all keys correctly here...
+    // assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
+    // so we test the existence of all keys correctly here...
     val testTypesAndAttrNames = runAndWait(entityQuery.getAttrNamesAndEntityTypes(workspaceContext.workspaceIdAsUUID))
     assertSameElements(testTypesAndAttrNames.keys, desiredTypesAndAttrNames.keys)
 
     desiredTypesAndAttrNames foreach { case (eType, attrNames) =>
-      //...and handle that the values are all correct here.
+      // ...and handle that the values are all correct here.
       assertSameElements(testTypesAndAttrNames(eType).map(AttributeName.toDelimitedName), attrNames)
     }
   }
@@ -417,111 +549,140 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-
   val testWorkspace = new EmptyWorkspace
 
-  it should "trim giant all_attribute_values strings so they don't overflow" in withCustomTestDatabase(testWorkspace) { dataSource =>
-    //it'll be longer than this (and thus will need trimming) because it'll get the entity name too
-    val veryLongString = "a" * EntityComponent.allAttributeValuesColumnSize
-    val sample1 = Entity("sample1", "Sample",
-      Map(AttributeName.withDefaultNS("veryLongString") -> AttributeString(veryLongString)))
-    withWorkspaceContext(testWorkspace.workspace) { context =>
-      runAndWait(entityQuery.save(context, sample1))
+  it should "trim giant all_attribute_values strings so they don't overflow" in withCustomTestDatabase(testWorkspace) {
+    dataSource =>
+      // it'll be longer than this (and thus will need trimming) because it'll get the entity name too
+      val veryLongString = "a" * EntityComponent.allAttributeValuesColumnSize
+      val sample1 = Entity("sample1",
+                           "Sample",
+                           Map(AttributeName.withDefaultNS("veryLongString") -> AttributeString(veryLongString))
+      )
+      withWorkspaceContext(testWorkspace.workspace) { context =>
+        runAndWait(entityQuery.save(context, sample1))
 
-      val entityRec = runAndWait(uniqueResult(entityQueryWithInlineAttributes.findEntityByName(UUID.fromString(testWorkspace.workspace.workspaceId), "Sample", "sample1").result))
-      assertResult(EntityComponent.allAttributeValuesColumnSize) {
-        entityRec.get.allAttributeValues.get.length
+        val entityRec = runAndWait(
+          uniqueResult(
+            entityQueryWithInlineAttributes
+              .findEntityByName(UUID.fromString(testWorkspace.workspace.workspaceId), "Sample", "sample1")
+              .result
+          )
+        )
+        assertResult(EntityComponent.allAttributeValuesColumnSize) {
+          entityRec.get.allAttributeValues.get.length
+        }
       }
-    }
   }
 
   class BugTestData extends TestData {
     val wsName = WorkspaceName("myNamespace2", "myWorkspace2")
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID.toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID.toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
 
-    val sample1 = new Entity("sample1", "Sample",
-      Map(AttributeName.withDefaultNS("aliquot") -> AttributeEntityReference("Aliquot", "aliquot1")))
+    val sample1 = new Entity("sample1",
+                             "Sample",
+                             Map(
+                               AttributeName.withDefaultNS("aliquot") -> AttributeEntityReference("Aliquot", "aliquot1")
+                             )
+    )
 
     val aliquot1 = Entity("aliquot1", "Aliquot", Map.empty)
 
-    override def save() = {
-      DBIOAction.seq(
-        workspaceQuery.createOrUpdate(workspace),
-        entityQuery.save(workspace, aliquot1),
-        entityQuery.save(workspace, sample1))
-    }
+    override def save() =
+      DBIOAction.seq(workspaceQuery.createOrUpdate(workspace),
+                     entityQuery.save(workspace, aliquot1),
+                     entityQuery.save(workspace, sample1)
+      )
 
   }
 
   val bugData = new BugTestData
 
-  it should "get an entity with attribute ref name same as an entity, but different case" in withCustomTestDatabaseInternal(bugData) {
+  it should "get an entity with attribute ref name same as an entity, but different case" in withCustomTestDatabaseInternal(
+    bugData
+  ) {
 
-      withWorkspaceContext(bugData.workspace) { context =>
-        assertResult(Some(bugData.sample1)) {
-          runAndWait(entityQuery.get(context, "Sample", "sample1"))
-        }
+    withWorkspaceContext(bugData.workspace) { context =>
+      assertResult(Some(bugData.sample1)) {
+        runAndWait(entityQuery.get(context, "Sample", "sample1"))
       }
+    }
 
   }
 
   it should "get an entity" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        assertResult(Some(testData.pair1)) {
-          runAndWait(entityQuery.get(context, "Pair", "pair1"))
-        }
-        assertResult(Some(testData.sample1)) {
-          runAndWait(entityQuery.get(context, "Sample", "sample1"))
-        }
-        assertResult(Some(testData.sset1)) {
-          runAndWait(entityQuery.get(context, "SampleSet", "sset1"))
-        }
+    withWorkspaceContext(testData.workspace) { context =>
+      assertResult(Some(testData.pair1)) {
+        runAndWait(entityQuery.get(context, "Pair", "pair1"))
       }
+      assertResult(Some(testData.sample1)) {
+        runAndWait(entityQuery.get(context, "Sample", "sample1"))
+      }
+      assertResult(Some(testData.sset1)) {
+        runAndWait(entityQuery.get(context, "SampleSet", "sset1"))
+      }
+    }
 
   }
 
   it should "return None when an entity does not exist" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        assertResult(None) {
-          runAndWait(entityQuery.get(context, "pair", "fnord"))
-        }
-        assertResult(None) {
-          runAndWait(entityQuery.get(context, "fnord", "pair1"))
-        }
+    withWorkspaceContext(testData.workspace) { context =>
+      assertResult(None) {
+        runAndWait(entityQuery.get(context, "pair", "fnord"))
       }
+      assertResult(None) {
+        runAndWait(entityQuery.get(context, "fnord", "pair1"))
+      }
+    }
 
   }
 
   it should "save a new entity" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        val pair2 = Entity("pair2", "Pair",
-          Map(
-            AttributeName.withDefaultNS("case") -> AttributeEntityReference("Sample", "sample3"),
-            AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")))
-        runAndWait(entityQuery.save(context, pair2))
-        assert {
-          runAndWait(entityQuery.get(testData.workspace, "Pair", "pair2")).isDefined
-        }
+    withWorkspaceContext(testData.workspace) { context =>
+      val pair2 = Entity(
+        "pair2",
+        "Pair",
+        Map(
+          AttributeName.withDefaultNS("case") -> AttributeEntityReference("Sample", "sample3"),
+          AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")
+        )
+      )
+      runAndWait(entityQuery.save(context, pair2))
+      assert {
+        runAndWait(entityQuery.get(testData.workspace, "Pair", "pair2")).isDefined
       }
+    }
 
   }
 
   it should "update a workspace's lastModified date when saving an entity" in withDefaultTestDatabase {
 
     withWorkspaceContext(testData.workspace) { context =>
-
       // get the workspace prior to saving the entity
       val workspaceBefore = runAndWait(workspaceQuery.findById(context.workspaceId))
         .getOrElse(fail(s"could not retrieve workspace ${context.workspaceId} before saving entity"))
 
       // save the entity, assert it saved correctly
-      val pair2 = Entity("pair2", "Pair",
+      val pair2 = Entity(
+        "pair2",
+        "Pair",
         Map(
           AttributeName.withDefaultNS("case") -> AttributeEntityReference("Sample", "sample3"),
-          AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")))
+          AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")
+        )
+      )
       runAndWait(entityQuery.save(context, pair2))
       assert {
         runAndWait(entityQuery.get(testData.workspace, "Pair", "pair2")).isDefined
@@ -531,18 +692,24 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       val workspaceAfter = runAndWait(workspaceQuery.findById(context.workspaceId))
         .getOrElse(fail(s"could not retrieve workspace ${context.workspaceId} after saving entity"))
 
-      assert(workspaceAfter.lastModified.isAfter(workspaceBefore.lastModified),
+      assert(
+        workspaceAfter.lastModified.isAfter(workspaceBefore.lastModified),
         s"workspace lastModified of ${workspaceAfter.lastModified} should be after lastModified of ${workspaceBefore.lastModified}, " +
-          s"since we saved an entity to that workspace.")
+          s"since we saved an entity to that workspace."
+      )
     }
 
   }
 
   it should "not re-update an entity's attributes over many writes if attribute do not change" in withDefaultTestDatabase {
-    val pair2 = Entity("pair2", "Pair",
+    val pair2 = Entity(
+      "pair2",
+      "Pair",
       Map(
         AttributeName.withDefaultNS("case") -> AttributeEntityReference("Sample", "sample3"),
-        AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")))
+        AttributeName.withDefaultNS("control") -> AttributeEntityReference("Sample", "sample1")
+      )
+    )
 
     withWorkspaceContext(testData.workspace) { context =>
       runAndWait(entityQuery.save(context, pair2))
@@ -558,30 +725,36 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         runAndWait(entityQuery.get(testData.workspace, "Pair", "pair2")).isDefined
       }
       assertResult(0) { // the additional writes should not increment this entity's version
-        runAndWait(entityQuery.findEntityByName(testData.workspace.workspaceIdAsUUID, "Pair", "pair2").map(_.version).result).head
+        runAndWait(
+          entityQuery.findEntityByName(testData.workspace.workspaceIdAsUUID, "Pair", "pair2").map(_.version).result
+        ).head
       }
     }
   }
 
   it should "update an entity's attributes many times concurrently if attributes change" in withDefaultTestDatabase {
-    def makeEntity(idx: Int): Entity = {
-      Entity("some-sample", "Sample",
-        Map(
-          AttributeName.withDefaultNS("indexValue") -> AttributeString(s"index-$idx")
-        )
+    def makeEntity(idx: Int): Entity =
+      Entity("some-sample",
+             "Sample",
+             Map(
+               AttributeName.withDefaultNS("indexValue") -> AttributeString(s"index-$idx")
+             )
       )
-    }
 
     withWorkspaceContext(testData.workspace) { context =>
       runAndWait(entityQuery.save(context, makeEntity(0)))
 
       // did we save the entity?
       // did we populate its all_attribute_values?
-      val entityWithAllAttrs = runAndWait(entityQueryWithInlineAttributes.findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample").result)
+      val entityWithAllAttrs = runAndWait(
+        entityQueryWithInlineAttributes
+          .findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample")
+          .result
+      )
       entityWithAllAttrs should have length 1
       entityWithAllAttrs.head.recordVersion shouldBe 0
       entityWithAllAttrs.head.allAttributeValues should not be empty
-      entityWithAllAttrs.head.allAttributeValues.get should include ("index-0")
+      entityWithAllAttrs.head.allAttributeValues.get should include("index-0")
     }
 
     withWorkspaceContext(testData.workspace) { context =>
@@ -591,12 +764,18 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       }
 
       // did we update the record versions and populate its all_attribute_values?
-      val entityWithAllAttrs = runAndWait(entityQueryWithInlineAttributes.findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample").result)
+      val entityWithAllAttrs = runAndWait(
+        entityQueryWithInlineAttributes
+          .findEntityByName(testData.workspace.workspaceIdAsUUID, "Sample", "some-sample")
+          .result
+      )
       entityWithAllAttrs should have length 1
       entityWithAllAttrs.head.recordVersion shouldBe count
       entityWithAllAttrs.head.allAttributeValues should not be empty
       entityWithAllAttrs.head.allAttributeValues.get should not be empty
-      entityWithAllAttrs.head.allAttributeValues.get should include ("index-20") // we should have updated to the newest value
+      entityWithAllAttrs.head.allAttributeValues.get should include(
+        "index-20"
+      ) // we should have updated to the newest value
     }
   }
 
@@ -618,80 +797,125 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       name = testData.wsName.name + "Clone",
       workspaceId = UUID.randomUUID.toString,
       bucketName = "anotherBucket",
-      workflowCollectionName =  Some("workflow-collection"),
+      workflowCollectionName = Some("workflow-collection"),
       createdDate = currentTime(),
       lastModified = currentTime(),
       createdBy = "Joe Biden",
       Map.empty
     )
 
+    val c1 = Entity(
+      "c1",
+      "samples",
+      Map(
+        AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+        AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+        AttributeName.withDefaultNS("cycle1") -> AttributeEntityReference("samples", "c2")
+      )
+    )
+    val c2 = Entity(
+      "c2",
+      "samples",
+      Map(
+        AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+        AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+        AttributeName.withDefaultNS("cycle2") -> AttributeEntityReference("samples", "c3")
+      )
+    )
+    val c3 = Entity("c3",
+                    "samples",
+                    Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+                        AttributeName.withDefaultNS("bar") -> AttributeNumber(3)
+                    )
+    )
 
-      val c1 = Entity("c1", "samples", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3), AttributeName.withDefaultNS("cycle1") -> AttributeEntityReference("samples", "c2")))
-      val c2 = Entity("c2", "samples", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3), AttributeName.withDefaultNS("cycle2") -> AttributeEntityReference("samples", "c3")))
-      val c3 = Entity("c3", "samples", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3)))
+    runAndWait(workspaceQuery.createOrUpdate(workspaceOriginal))
+    runAndWait(workspaceQuery.createOrUpdate(workspaceClone))
 
-      runAndWait(workspaceQuery.createOrUpdate(workspaceOriginal))
-      runAndWait(workspaceQuery.createOrUpdate(workspaceClone))
+    withWorkspaceContext(workspaceOriginal) { originalContext =>
+      withWorkspaceContext(workspaceClone) { cloneContext =>
+        runAndWait(entityQuery.save(originalContext, c3))
+        runAndWait(entityQuery.save(originalContext, c2))
+        runAndWait(entityQuery.save(originalContext, c1))
 
-      withWorkspaceContext(workspaceOriginal) { originalContext =>
-        withWorkspaceContext(workspaceClone) { cloneContext =>
-          runAndWait(entityQuery.save(originalContext, c3))
-          runAndWait(entityQuery.save(originalContext, c2))
-          runAndWait(entityQuery.save(originalContext, c1))
+        val c3_updated = Entity(
+          "c3",
+          "samples",
+          Map(
+            AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+            AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+            AttributeName.withDefaultNS("cycle3") -> AttributeEntityReference("samples", "c1")
+          )
+        )
 
-          val c3_updated = Entity("c3", "samples", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3), AttributeName.withDefaultNS("cycle3") -> AttributeEntityReference("samples", "c1")))
+        runAndWait(entityQuery.save(originalContext, c3_updated))
+        runAndWait(
+          entityQuery.copyEntitiesToNewWorkspace(originalContext.workspaceIdAsUUID, cloneContext.workspaceIdAsUUID)
+        )
 
-          runAndWait(entityQuery.save(originalContext, c3_updated))
-          runAndWait(entityQuery.copyEntitiesToNewWorkspace(originalContext.workspaceIdAsUUID, cloneContext.workspaceIdAsUUID))
-
-          val expectedEntities = Set(c1, c2, c3_updated)
-          assertResult(expectedEntities) {
-            runAndWait(entityQuery.listActiveEntities(originalContext)).toSet
-          }
-          assertResult(expectedEntities) {
-            runAndWait(entityQuery.listActiveEntities(cloneContext)).toSet
-          }
-          val destShardId = determineShard(cloneContext.workspaceIdAsUUID)
-          val destWsId = cloneContext.workspaceIdAsUUID
-          val badEntityReferenceCount = sql"""select count(*) from ENTITY e join ENTITY_ATTRIBUTE_#$destShardId ea on e.id = ea.owner_id
+        val expectedEntities = Set(c1, c2, c3_updated)
+        assertResult(expectedEntities) {
+          runAndWait(entityQuery.listActiveEntities(originalContext)).toSet
+        }
+        assertResult(expectedEntities) {
+          runAndWait(entityQuery.listActiveEntities(cloneContext)).toSet
+        }
+        val destShardId = determineShard(cloneContext.workspaceIdAsUUID)
+        val destWsId = cloneContext.workspaceIdAsUUID
+        val badEntityReferenceCount =
+          sql"""select count(*) from ENTITY e join ENTITY_ATTRIBUTE_#$destShardId ea on e.id = ea.owner_id
                         join ENTITY e_ref on ea.value_entity_ref = e_ref.id
                         where ea.value_entity_ref is not null and e_ref.workspace_id != $destWsId and e.workspace_id = $destWsId"""
-          assertResult(0, "cloned entity references should only point to entities within the same workspace, " +
-            "we found some entity references that don't belong to the destination workspace") {
-            runAndWait(badEntityReferenceCount.as[Int].head)
-          }
+        assertResult(
+          0,
+          "cloned entity references should only point to entities within the same workspace, " +
+            "we found some entity references that don't belong to the destination workspace"
+        ) {
+          runAndWait(badEntityReferenceCount.as[Int].head)
+        }
 
-          val expectedEntityReferenceCount = sql"""select count(*) from ENTITY e join ENTITY_ATTRIBUTE_#$destShardId ea on e.id = ea.owner_id
+        val expectedEntityReferenceCount =
+          sql"""select count(*) from ENTITY e join ENTITY_ATTRIBUTE_#$destShardId ea on e.id = ea.owner_id
                         join ENTITY e_ref on ea.value_entity_ref = e_ref.id
                         where ea.value_entity_ref is not null and e_ref.workspace_id = $destWsId and e.workspace_id = $destWsId"""
-          assertResult(3, "cloned entity references should only point to entities within the same workspace") {
-            runAndWait(expectedEntityReferenceCount.as[Int].head)
-          }
+        assertResult(3, "cloned entity references should only point to entities within the same workspace") {
+          runAndWait(expectedEntityReferenceCount.as[Int].head)
         }
       }
+    }
 
   }
 
   it should "throw an exception if trying to save invalid references" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        val baz = Entity("wig", "wug", Map(AttributeName.withDefaultNS("edgeToNowhere") -> AttributeEntityReference("sample", "notTheSampleYoureLookingFor")))
-        intercept[RawlsException] {
-          runAndWait(entityQuery.save(context, baz))
-        }
+    withWorkspaceContext(testData.workspace) { context =>
+      val baz =
+        Entity("wig",
+               "wug",
+               Map(
+                 AttributeName.withDefaultNS("edgeToNowhere") -> AttributeEntityReference("sample",
+                                                                                          "notTheSampleYoureLookingFor"
+                 )
+               )
+        )
+      intercept[RawlsException] {
+        runAndWait(entityQuery.save(context, baz))
       }
+    }
 
   }
 
   it should "list entities" in withConstantTestDatabase {
-    val expected = Seq(constantData.sample1,
+    val expected = Seq(
+      constantData.sample1,
       constantData.sample2,
       constantData.sample3,
       constantData.sample4,
       constantData.sample5,
       constantData.sample6,
       constantData.sample7,
-      constantData.sample8)
+      constantData.sample8
+    )
 
     withWorkspaceContext(constantData.workspace) { context =>
       assertSameElements(expected, runAndWait(entityQuery.listActiveEntitiesOfType(context, "Sample")))
@@ -700,52 +924,78 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "add cycles to entity graph" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        val sample1Copy = Entity("sample1", "Sample",
-          Map(
-            AttributeName.withDefaultNS("type") -> AttributeString("normal"),
-            AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
-            AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("a"), AttributeString("b"))),
-            AttributeName.withDefaultNS("aliquot") -> AttributeEntityReference("Aliquot", "aliquot1"),
-            AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("SampleSet", "sset1")))
-        runAndWait(entityQuery.save(context, sample1Copy))
-        val sample5Copy = Entity("sample5", "Sample",
-          Map(
-            AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
-            AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
-            AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("a"), AttributeString("b"))),
-            AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("SampleSet", "sset4")))
-        runAndWait(entityQuery.save(context, sample5Copy))
-        val sample7Copy = Entity("sample7", "Sample",
-          Map(
-            AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
-            AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
-            AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("a"), AttributeString("b"))),
-            AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("Sample", "sample6")))
-        runAndWait(entityQuery.save(context, sample7Copy))
-        val sample6Copy = Entity("sample6", "Sample",
-          Map(
-            AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
-            AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
-            AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("a"), AttributeString("b"))),
-            AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("SampleSet", "sset3")))
-        runAndWait(entityQuery.save(context, sample6Copy))
-        val entitiesWithCycles = List(sample1Copy, sample5Copy, sample7Copy, sample6Copy)
-        entitiesWithCycles.foreach( entity =>
-          assertResult(Option(entity)) { runAndWait(entityQuery.get(context, entity.entityType, entity.name)) }
+    withWorkspaceContext(testData.workspace) { context =>
+      val sample1Copy = Entity(
+        "sample1",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("type") -> AttributeString("normal"),
+          AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
+          AttributeName.withDefaultNS("thingies") -> AttributeValueList(
+            Seq(AttributeString("a"), AttributeString("b"))
+          ),
+          AttributeName.withDefaultNS("aliquot") -> AttributeEntityReference("Aliquot", "aliquot1"),
+          AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("SampleSet", "sset1")
         )
-      }
+      )
+      runAndWait(entityQuery.save(context, sample1Copy))
+      val sample5Copy = Entity(
+        "sample5",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+          AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
+          AttributeName.withDefaultNS("thingies") -> AttributeValueList(
+            Seq(AttributeString("a"), AttributeString("b"))
+          ),
+          AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("SampleSet", "sset4")
+        )
+      )
+      runAndWait(entityQuery.save(context, sample5Copy))
+      val sample7Copy = Entity(
+        "sample7",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+          AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
+          AttributeName.withDefaultNS("thingies") -> AttributeValueList(
+            Seq(AttributeString("a"), AttributeString("b"))
+          ),
+          AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("Sample", "sample6")
+        )
+      )
+      runAndWait(entityQuery.save(context, sample7Copy))
+      val sample6Copy = Entity(
+        "sample6",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+          AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
+          AttributeName.withDefaultNS("thingies") -> AttributeValueList(
+            Seq(AttributeString("a"), AttributeString("b"))
+          ),
+          AttributeName.withDefaultNS("cycle") -> AttributeEntityReference("SampleSet", "sset3")
+        )
+      )
+      runAndWait(entityQuery.save(context, sample6Copy))
+      val entitiesWithCycles = List(sample1Copy, sample5Copy, sample7Copy, sample6Copy)
+      entitiesWithCycles.foreach(entity =>
+        assertResult(Option(entity))(runAndWait(entityQuery.get(context, entity.entityType, entity.name)))
+      )
+    }
 
   }
 
   it should "rename an entity" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        assertResult(Option(testData.pair1)) { runAndWait(entityQuery.get(context, "Pair", "pair1")) }
-        assertResult(1) { runAndWait(entityQuery.rename(context, "Pair", "pair1", "amazingPair")) }
-        assertResult(None) { runAndWait(entityQuery.get(context, "Pair", "pair1")) }
-        assertResult(Option(testData.pair1.copy(name = "amazingPair"))) { runAndWait(entityQuery.get(context, "Pair", "amazingPair")) }
+    withWorkspaceContext(testData.workspace) { context =>
+      assertResult(Option(testData.pair1))(runAndWait(entityQuery.get(context, "Pair", "pair1")))
+      assertResult(1)(runAndWait(entityQuery.rename(context, "Pair", "pair1", "amazingPair")))
+      assertResult(None)(runAndWait(entityQuery.get(context, "Pair", "pair1")))
+      assertResult(Option(testData.pair1.copy(name = "amazingPair"))) {
+        runAndWait(entityQuery.get(context, "Pair", "amazingPair"))
       }
+    }
 
   }
 
@@ -754,25 +1004,39 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
    */
   it should "get entity subtrees from a list of entities" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      val sampleSet1Paths = Seq(EntityPath(Seq(testData.sset1.toReference)),
-                                EntityPath(Seq(testData.sset1.toReference, testData.sample1.toReference)),
-                                EntityPath(Seq(testData.sset1.toReference, testData.sample1.toReference, testData.aliquot1.toReference)),
-                                EntityPath(Seq(testData.sset1.toReference, testData.sample2.toReference)),
-                                EntityPath(Seq(testData.sset1.toReference, testData.sample3.toReference)),
-                                EntityPath(Seq(testData.sset1.toReference, testData.sample3.toReference, testData.sample1.toReference)))
+      val sampleSet1Paths = Seq(
+        EntityPath(Seq(testData.sset1.toReference)),
+        EntityPath(Seq(testData.sset1.toReference, testData.sample1.toReference)),
+        EntityPath(Seq(testData.sset1.toReference, testData.sample1.toReference, testData.aliquot1.toReference)),
+        EntityPath(Seq(testData.sset1.toReference, testData.sample2.toReference)),
+        EntityPath(Seq(testData.sset1.toReference, testData.sample3.toReference)),
+        EntityPath(Seq(testData.sset1.toReference, testData.sample3.toReference, testData.sample1.toReference))
+      )
       val sampleSet2Paths = Seq(EntityPath(Seq(testData.sset2.toReference)),
-                                EntityPath(Seq(testData.sset2.toReference, testData.sample2.toReference)))
-      val sampleSet3Paths = Seq(EntityPath(Seq(testData.sset3.toReference)),
-                                EntityPath(Seq(testData.sset3.toReference, testData.sample5.toReference)),
-                                EntityPath(Seq(testData.sset3.toReference, testData.sample6.toReference)))
+                                EntityPath(Seq(testData.sset2.toReference, testData.sample2.toReference))
+      )
+      val sampleSet3Paths = Seq(
+        EntityPath(Seq(testData.sset3.toReference)),
+        EntityPath(Seq(testData.sset3.toReference, testData.sample5.toReference)),
+        EntityPath(Seq(testData.sset3.toReference, testData.sample6.toReference))
+      )
 
       val expected = sampleSet1Paths ++ sampleSet2Paths ++ sampleSet3Paths
-      assertSameElements(expected, runAndWait(entityQuery.getEntitySubtrees(context, "SampleSet", Set("sset1", "sset2", "sset3", "sampleSetDOESNTEXIST"))))
+      assertSameElements(
+        expected,
+        runAndWait(
+          entityQuery.getEntitySubtrees(context, "SampleSet", Set("sset1", "sset2", "sset3", "sampleSetDOESNTEXIST"))
+        )
+      )
 
-      val individual2Paths = Seq(EntityPath(Seq(testData.indiv2.toReference)),
-                                 EntityPath(Seq(testData.indiv2.toReference, testData.sset2.toReference)),
-                                 EntityPath(Seq(testData.indiv2.toReference, testData.sset2.toReference, testData.sample2.toReference)))
-      assertSameElements(individual2Paths, runAndWait(entityQuery.getEntitySubtrees(context, "Individual", Set("indiv2"))))
+      val individual2Paths = Seq(
+        EntityPath(Seq(testData.indiv2.toReference)),
+        EntityPath(Seq(testData.indiv2.toReference, testData.sset2.toReference)),
+        EntityPath(Seq(testData.indiv2.toReference, testData.sset2.toReference, testData.sample2.toReference))
+      )
+      assertSameElements(individual2Paths,
+                         runAndWait(entityQuery.getEntitySubtrees(context, "Individual", Set("indiv2")))
+      )
     }
   }
 
@@ -780,11 +1044,37 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "get the full set of entity references from a list of entities" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      val expected = Set(testData.sample1, testData.sample3, testData.pair1, testData.pair2, testData.sset1, testData.ps1, testData.indiv1).map(_.toReference)
-      assertSameElements(expected, runAndWait(entityQuery.getAllReferringEntities(context, Set(testData.sample1.toReference))))
+      val expected = Set(testData.sample1,
+                         testData.sample3,
+                         testData.pair1,
+                         testData.pair2,
+                         testData.sset1,
+                         testData.ps1,
+                         testData.indiv1
+      ).map(_.toReference)
+      assertSameElements(expected,
+                         runAndWait(entityQuery.getAllReferringEntities(context, Set(testData.sample1.toReference)))
+      )
 
-      val expected2 = Set(testData.aliquot1, testData.aliquot2, testData.sample1, testData.sample3, testData.pair1, testData.pair2, testData.sset1, testData.ps1, testData.indiv1).map(_.toReference)
-      assertSameElements(expected2, runAndWait(entityQuery.getAllReferringEntities(context, Set(testData.aliquot1.toReference, testData.aliquot2.toReference))))
+      val expected2 = Set(testData.aliquot1,
+                          testData.aliquot2,
+                          testData.sample1,
+                          testData.sample3,
+                          testData.pair1,
+                          testData.pair2,
+                          testData.sset1,
+                          testData.ps1,
+                          testData.indiv1
+      ).map(_.toReference)
+      assertSameElements(expected2,
+                         runAndWait(
+                           entityQuery.getAllReferringEntities(context,
+                                                               Set(testData.aliquot1.toReference,
+                                                                   testData.aliquot2.toReference
+                                                               )
+                           )
+                         )
+      )
     }
   }
 
@@ -792,15 +1082,34 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     withWorkspaceContext(testData.workspace) { context =>
       runAndWait(entityQuery.hide(context, Seq(testData.indiv1.toReference, testData.pair2.toReference)))
 
-      val expected = Set(testData.sample1, testData.sample3, testData.pair1, testData.sset1, testData.ps1).map(_.toReference)
-      assertSameElements(expected, runAndWait(entityQuery.getAllReferringEntities(context, Set(testData.sample1.toReference))))
+      val expected =
+        Set(testData.sample1, testData.sample3, testData.pair1, testData.sset1, testData.ps1).map(_.toReference)
+      assertSameElements(expected,
+                         runAndWait(entityQuery.getAllReferringEntities(context, Set(testData.sample1.toReference)))
+      )
 
-      val expected2 = Set(testData.aliquot1, testData.aliquot2, testData.sample1, testData.sample3, testData.pair1, testData.sset1, testData.ps1).map(_.toReference)
-      assertSameElements(expected2, runAndWait(entityQuery.getAllReferringEntities(context, Set(testData.aliquot1.toReference, testData.aliquot2.toReference))))
+      val expected2 = Set(testData.aliquot1,
+                          testData.aliquot2,
+                          testData.sample1,
+                          testData.sample3,
+                          testData.pair1,
+                          testData.sset1,
+                          testData.ps1
+      ).map(_.toReference)
+      assertSameElements(expected2,
+                         runAndWait(
+                           entityQuery.getAllReferringEntities(context,
+                                                               Set(testData.aliquot1.toReference,
+                                                                   testData.aliquot2.toReference
+                                                               )
+                           )
+                         )
+      )
     }
   }
 
-  val x1 = Entity("x1", "SampleSet", Map(AttributeName.withDefaultNS("child") -> AttributeEntityReference("SampleSet", "x2")))
+  val x1 =
+    Entity("x1", "SampleSet", Map(AttributeName.withDefaultNS("child") -> AttributeEntityReference("SampleSet", "x2")))
   val x2 = Entity("x2", "SampleSet", Map.empty)
 
   val workspace2 = Workspace(
@@ -833,7 +1142,10 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       withWorkspaceContext(workspace2) { context2 =>
         runAndWait(entityQuery.save(context2, x2))
         runAndWait(entityQuery.save(context2, x1))
-        val x2_updated = Entity("x2", "SampleSet", Map(AttributeName.withDefaultNS("child") -> AttributeEntityReference("SampleSet", "x1")))
+        val x2_updated = Entity("x2",
+                                "SampleSet",
+                                Map(AttributeName.withDefaultNS("child") -> AttributeEntityReference("SampleSet", "x1"))
+        )
         runAndWait(entityQuery.save(context2, x2_updated))
 
         assert(runAndWait(entityQuery.listActiveEntitiesOfType(context2, "SampleSet")).toList.contains(x1))
@@ -844,9 +1156,14 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
           runAndWait(entityQuery.getCopyConflicts(context1, Seq(x1, x2_updated).map(_.toReference)))
         }
 
-        assertSameElements(Seq(x1.toReference, x2.toReference), runAndWait(entityQuery.checkAndCopyEntities(context2, context1, "SampleSet", Seq("x2"), false, testContext)).entitiesCopied)
+        assertSameElements(
+          Seq(x1.toReference, x2.toReference),
+          runAndWait(
+            entityQuery.checkAndCopyEntities(context2, context1, "SampleSet", Seq("x2"), false, testContext)
+          ).entitiesCopied
+        )
 
-        //verify it was actually copied into the workspace
+        // verify it was actually copied into the workspace
         assert(runAndWait(entityQuery.listActiveEntitiesOfType(context1, "SampleSet")).toList.contains(x1))
         assert(runAndWait(entityQuery.listActiveEntitiesOfType(context1, "SampleSet")).toList.contains(x2_updated))
       }
@@ -859,12 +1176,23 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     withWorkspaceContext(testData.workspace) { context1 =>
       withWorkspaceContext(workspace2) { context2 =>
         val a = Entity("a", "test", Map.empty)
-        val a6 = Entity("a6", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a1")))
-        val a5 = Entity("a5", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a6")))
-        val a4 = Entity("a4", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a5")))
-        val a3 = Entity("a3", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a4"), AttributeName.withDefaultNS("side") -> AttributeEntityReference("test", "a")))
-        val a2 = Entity("a2", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a3")))
-        val a1 = Entity("a1", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a2")))
+        val a6 =
+          Entity("a6", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a1")))
+        val a5 =
+          Entity("a5", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a6")))
+        val a4 =
+          Entity("a4", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a5")))
+        val a3 = Entity(
+          "a3",
+          "test",
+          Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a4"),
+              AttributeName.withDefaultNS("side") -> AttributeEntityReference("test", "a")
+          )
+        )
+        val a2 =
+          Entity("a2", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a3")))
+        val a1 =
+          Entity("a1", "test", Map(AttributeName.withDefaultNS("next") -> AttributeEntityReference("test", "a2")))
         val allEntities = Seq(a, a1, a2, a3, a4, a5, a6)
         runAndWait(entityQuery.save(context2, a))
 
@@ -884,9 +1212,13 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
           runAndWait(entityQuery.getCopyConflicts(context1, allEntities.map(_.toReference)))
         }
 
-        assertSameElements(allEntities.map(_.toReference), runAndWait(entityQuery.checkAndCopyEntities(context2, context1, "test", Seq("a1"), false, testContext)).entitiesCopied)
+        assertSameElements(allEntities.map(_.toReference),
+                           runAndWait(
+                             entityQuery.checkAndCopyEntities(context2, context1, "test", Seq("a1"), false, testContext)
+                           ).entitiesCopied
+        )
 
-        //verify it was actually copied into the workspace
+        // verify it was actually copied into the workspace
         assertSameElements(allEntities, runAndWait(entityQuery.listActiveEntitiesOfType(context1, "test")).toSet)
       }
     }
@@ -895,18 +1227,26 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "copy entities with a conflict" in withDefaultTestDatabase {
 
-      withWorkspaceContext(testData.workspace) { context =>
-        assertResult(Set(testData.sample1.toReference)) {
-          runAndWait(entityQuery.getCopyConflicts(context, Seq(testData.sample1).map(_.toReference))).map(_.toReference).toSet
-        }
-
-        assertResult(Set(EntityHardConflict(testData.sample1.entityType, testData.sample1.name))) {
-          runAndWait(entityQuery.checkAndCopyEntities(context, context, "Sample", Seq("sample1"), false, testContext)).hardConflicts.toSet
-        }
-
-        //verify that it wasn't copied into the workspace again
-        assert(runAndWait(entityQuery.listActiveEntitiesOfType(context, "Sample")).toList.filter(entity => entity == testData.sample1).size == 1)
+    withWorkspaceContext(testData.workspace) { context =>
+      assertResult(Set(testData.sample1.toReference)) {
+        runAndWait(entityQuery.getCopyConflicts(context, Seq(testData.sample1).map(_.toReference)))
+          .map(_.toReference)
+          .toSet
       }
+
+      assertResult(Set(EntityHardConflict(testData.sample1.entityType, testData.sample1.name))) {
+        runAndWait(
+          entityQuery.checkAndCopyEntities(context, context, "Sample", Seq("sample1"), false, testContext)
+        ).hardConflicts.toSet
+      }
+
+      // verify that it wasn't copied into the workspace again
+      assert(
+        runAndWait(entityQuery.listActiveEntitiesOfType(context, "Sample")).toList
+          .filter(entity => entity == testData.sample1)
+          .size == 1
+      )
+    }
 
   }
 
@@ -917,27 +1257,31 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     withWorkspaceContext(workspace2) { context2 =>
       withWorkspaceContext(workspace3) { context3 =>
         val participant1 = Entity("participant1", "participant", Map.empty)
-        val sample1 = Entity("sample1", "sample", Map(AttributeName.withDefaultNS("participant") -> AttributeEntityReference("participant", "participant1")))
+        val sample1 = Entity(
+          "sample1",
+          "sample",
+          Map(AttributeName.withDefaultNS("participant") -> AttributeEntityReference("participant", "participant1"))
+        )
 
         runAndWait(entityQuery.save(context2, participant1))
         runAndWait(entityQuery.save(context3, participant1))
         runAndWait(entityQuery.save(context3, sample1))
 
-        assertResult(List()){
+        assertResult(List()) {
           runAndWait(entityQuery.listActiveEntitiesOfType(context2, "sample")).toList
         }
 
-        assertResult(List(participant1)){
+        assertResult(List(participant1)) {
           runAndWait(entityQuery.listActiveEntitiesOfType(context2, "participant")).toList
         }
 
         runAndWait(entityQuery.checkAndCopyEntities(context3, context2, "sample", Seq("sample1"), true, testContext))
 
-        assertResult(List(sample1)){
+        assertResult(List(sample1)) {
           runAndWait(entityQuery.listActiveEntitiesOfType(context2, "sample")).toList
         }
 
-        assertResult(List(participant1)){
+        assertResult(List(participant1)) {
           runAndWait(entityQuery.listActiveEntitiesOfType(context2, "participant")).toList
         }
 
@@ -951,11 +1295,11 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     val dottyAttr = Entity("dottyAttr", "Sample", Map(AttributeName.withDefaultNS("foo.bar") -> AttributeBoolean(true)))
     val dottyAttr2 = Entity("dottyAttr", "Sample", Map(AttributeName("library", "foo.bar") -> AttributeBoolean(true)))
 
-      withWorkspaceContext(testData.workspace) { context =>
-        intercept[RawlsException] { runAndWait(entityQuery.save(context, dottyType)) }
-        intercept[RawlsException] { runAndWait(entityQuery.save(context, dottyAttr)) }
-        intercept[RawlsException] { runAndWait(entityQuery.save(context, dottyAttr2)) }
-      }
+    withWorkspaceContext(testData.workspace) { context =>
+      intercept[RawlsException](runAndWait(entityQuery.save(context, dottyType)))
+      intercept[RawlsException](runAndWait(entityQuery.save(context, dottyAttr)))
+      intercept[RawlsException](runAndWait(entityQuery.save(context, dottyAttr2)))
+    }
 
   }
 
@@ -985,24 +1329,34 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "save a new entity with the same name as a deleted entity" in withDefaultTestDatabase {
     val workspaceId: UUID = UUID.randomUUID()
-    val workspace: Workspace = Workspace("test_namespace", workspaceId.toString, workspaceId.toString, "bucketname", Some("workflow-collection"), currentTime(), currentTime(), "me", Map.empty, false)
+    val workspace: Workspace = Workspace("test_namespace",
+                                         workspaceId.toString,
+                                         workspaceId.toString,
+                                         "bucketname",
+                                         Some("workflow-collection"),
+                                         currentTime(),
+                                         currentTime(),
+                                         "me",
+                                         Map.empty,
+                                         false
+    )
     runAndWait(workspaceQuery.createOrUpdate(workspace))
     val workspaceContext = workspace
 
-    assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(None)(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
     val entity = Entity("name", "type", Map.empty)
 
-    assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
-    assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(entity)(runAndWait(entityQuery.save(workspaceContext, entity)))
+    assertResult(Some(entity))(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
     val oldId = runAndWait(entityQuery.findEntityByName(workspaceId, "type", "name").result).head.id
 
-    assertResult(1) { runAndWait(entityQuery.hide(workspaceContext, Seq(entity.toReference))) }
-    assertResult(None) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(1)(runAndWait(entityQuery.hide(workspaceContext, Seq(entity.toReference))))
+    assertResult(None)(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
-    assertResult(entity) { runAndWait(entityQuery.save(workspaceContext, entity)) }
-    assertResult(Some(entity)) { runAndWait(entityQuery.get(workspaceContext, "type", "name")) }
+    assertResult(entity)(runAndWait(entityQuery.save(workspaceContext, entity)))
+    assertResult(Some(entity))(runAndWait(entityQuery.get(workspaceContext, "type", "name")))
 
     val newId = runAndWait(entityQuery.findEntityByName(workspaceId, "type", "name").result).head.id
 
@@ -1055,13 +1409,28 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "delete a sample without affecting its individual or any other entities" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-
       val (entityCount1, attributeCount1) = countEntitiesAttrs(testData.workspace)
       val (activeEntityCount1, activeAttributeCount1) = countActiveEntitiesAttrs(testData.workspace)
 
-      val bob = Entity("Bob", "Individual", Map(AttributeName.withDefaultNS("alive") -> AttributeBoolean(false), AttributeName.withDefaultNS("sampleSite") -> AttributeString("head")))
-      val blood = Entity("Bob-Blood", "Sample", Map(AttributeName.withDefaultNS("indiv") -> bob.toReference, AttributeName.withDefaultNS("color") -> AttributeString("red")))
-      val bone = Entity("Bob-Bone", "Sample", Map(AttributeName.withDefaultNS("indiv") -> bob.toReference, AttributeName.withDefaultNS("color") -> AttributeString("white")))
+      val bob = Entity(
+        "Bob",
+        "Individual",
+        Map(AttributeName.withDefaultNS("alive") -> AttributeBoolean(false),
+            AttributeName.withDefaultNS("sampleSite") -> AttributeString("head")
+        )
+      )
+      val blood = Entity("Bob-Blood",
+                         "Sample",
+                         Map(AttributeName.withDefaultNS("indiv") -> bob.toReference,
+                             AttributeName.withDefaultNS("color") -> AttributeString("red")
+                         )
+      )
+      val bone = Entity("Bob-Bone",
+                        "Sample",
+                        Map(AttributeName.withDefaultNS("indiv") -> bob.toReference,
+                            AttributeName.withDefaultNS("color") -> AttributeString("white")
+                        )
+      )
 
       runAndWait(entityQuery.save(context, bob))
       runAndWait(entityQuery.save(context, blood))
@@ -1112,38 +1481,51 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "select the all_attribute_values column when using entityQueryWithInlineAttributes and not otherwise" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-
-      val hasAttrs = Entity("entityWithAttrs", "Pair", Map(
-        AttributeName.withDefaultNS("attrOne") -> AttributeString("one"),
-        AttributeName.withDefaultNS("attrTwo") -> AttributeString("two"),
-        AttributeName.withDefaultNS("attrThree") -> AttributeString("three"),
-        AttributeName.withDefaultNS("attrFour") -> AttributeString("four")
-      ))
+      val hasAttrs = Entity(
+        "entityWithAttrs",
+        "Pair",
+        Map(
+          AttributeName.withDefaultNS("attrOne") -> AttributeString("one"),
+          AttributeName.withDefaultNS("attrTwo") -> AttributeString("two"),
+          AttributeName.withDefaultNS("attrThree") -> AttributeString("three"),
+          AttributeName.withDefaultNS("attrFour") -> AttributeString("four")
+        )
+      )
 
       runAndWait(entityQuery.save(context, hasAttrs))
 
-      val recWithAttrs = runAndWait(entityQueryWithInlineAttributes
-        .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
-          .result.headOption)
+      val recWithAttrs = runAndWait(
+        entityQueryWithInlineAttributes
+          .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
+          .result
+          .headOption
+      )
 
       assert(recWithAttrs.isDefined, "entityQuery should find the record")
-      withClue("entityQueryWithInlineAttributes should return an EntityRecordWithInlineAttributes, which has allAttributeValues") {
+      withClue(
+        "entityQueryWithInlineAttributes should return an EntityRecordWithInlineAttributes, which has allAttributeValues"
+      ) {
         recWithAttrs shouldBe an[Option[EntityRecordWithInlineAttributes]]
       }
       assertResult(Some(Some("entitywithattrs one two three four")), "entityQuery should return allAttributeValues") {
         recWithAttrs.map(_.allAttributeValues)
       }
 
-      val recWithoutAttrs = runAndWait(entityQuery
-        .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
-        .result.headOption)
+      val recWithoutAttrs = runAndWait(
+        entityQuery
+          .filter(e => e.name === "entityWithAttrs" && e.entityType === "Pair")
+          .result
+          .headOption
+      )
 
       assert(recWithoutAttrs.isDefined, "entityQuery should find the record")
       withClue("entityQuery should return an EntityRecord, which does not have allAttributeValues") {
         recWithoutAttrs shouldBe an[Option[EntityRecord]]
       }
 
-      assertResult(recWithoutAttrs, "entityQuery and entityQueryWithInlineAttributes should return the same record otherwise") {
+      assertResult(recWithoutAttrs,
+                   "entityQuery and entityQueryWithInlineAttributes should return the same record otherwise"
+      ) {
         recWithAttrs.map(_.withoutAllAttributeValues)
       }
     }
@@ -1151,15 +1533,28 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "delete all values in an attribute list" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { wsctx =>
-      val entityToSave = Entity("testName", "testType", Map(AttributeName.withDefaultNS("attributeListToDelete") -> AttributeValueList(List(
-        AttributeNumber(1), AttributeNumber(2), AttributeNumber(3), AttributeNumber(4), AttributeNumber(5)))))
+      val entityToSave = Entity(
+        "testName",
+        "testType",
+        Map(
+          AttributeName.withDefaultNS("attributeListToDelete") -> AttributeValueList(
+            List(AttributeNumber(1), AttributeNumber(2), AttributeNumber(3), AttributeNumber(4), AttributeNumber(5))
+          )
+        )
+      )
 
       runAndWait(entityQuery.save(wsctx, entityToSave))
 
       val initialResult = runAndWait(entityQuery.get(wsctx, entityToSave.entityType, entityToSave.name))
       assert(initialResult.get.attributes.nonEmpty)
 
-      runAndWait(entityQuery.saveEntityPatch(wsctx, entityToSave.toReference, Map.empty, List(AttributeName.withDefaultNS("attributeListToDelete"))))
+      runAndWait(
+        entityQuery.saveEntityPatch(wsctx,
+                                    entityToSave.toReference,
+                                    Map.empty,
+                                    List(AttributeName.withDefaultNS("attributeListToDelete"))
+        )
+      )
 
       val updatedResult = runAndWait(entityQuery.get(wsctx, entityToSave.entityType, entityToSave.name))
       assert(updatedResult.get.attributes.isEmpty)
@@ -1168,37 +1563,50 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   private def caseSensitivityFixtures(context: Workspace) = {
     val entitiesToSave = Seq(
-      Entity("name-1", "mytype", Map(
-        AttributeName.withDefaultNS("case") -> AttributeString("value1"),
-        AttributeName.withDefaultNS("foo") -> AttributeString("bar"))),
-      Entity("name-2", "mytype", Map(
-        AttributeName.withDefaultNS("CASE") -> AttributeString("value2"),
-        AttributeName.withDefaultNS("foo") -> AttributeString("bar"))),
-      Entity("name-3", "mytype", Map(
-        AttributeName.withDefaultNS("case") -> AttributeString("value3"),
-        AttributeName.withDefaultNS("CASE") -> AttributeString("value4"))),
-
+      Entity("name-1",
+             "mytype",
+             Map(AttributeName.withDefaultNS("case") -> AttributeString("value1"),
+                 AttributeName.withDefaultNS("foo") -> AttributeString("bar")
+             )
+      ),
+      Entity("name-2",
+             "mytype",
+             Map(AttributeName.withDefaultNS("CASE") -> AttributeString("value2"),
+                 AttributeName.withDefaultNS("foo") -> AttributeString("bar")
+             )
+      ),
+      Entity("name-3",
+             "mytype",
+             Map(AttributeName.withDefaultNS("case") -> AttributeString("value3"),
+                 AttributeName.withDefaultNS("CASE") -> AttributeString("value4")
+             )
+      ),
       Entity("name-4", "anothertype", Map(AttributeName.withDefaultNS("case") -> AttributeString("value5"))),
-      Entity("name-5", "anothertype", Map(AttributeName.withDefaultNS("CASE") -> AttributeString("value6"))),
+      Entity("name-5", "anothertype", Map(AttributeName.withDefaultNS("CASE") -> AttributeString("value6")))
     )
     runAndWait(entityQuery.save(context, entitiesToSave))
 
-    assume(runAndWait(entityQuery.listEntities(context)).size == 5, "filteredCount tests did not set up fixtures correctly")
+    assume(runAndWait(entityQuery.listEntities(context)).size == 5,
+           "filteredCount tests did not set up fixtures correctly"
+    )
 
   }
 
   // following set of filteredCount tests all use the same entity fixtures on top of an empty workspace
   val emptyWorkspace = new EmptyWorkspace
 
-
   List("mytype", "anothertype") foreach { typeName =>
     List("name", "case", "CASE") foreach { sortKey =>
       List(SortDirections.Ascending, SortDirections.Descending) foreach { sortDir =>
-        it should s"return filteredCount == unfilteredCount if no filter terms, type=[$typeName], sortKey=[$sortKey], sortDir=[$sortDir]" in withCustomTestDatabase(emptyWorkspace) { _ =>
+        it should s"return filteredCount == unfilteredCount if no filter terms, type=[$typeName], sortKey=[$sortKey], sortDir=[$sortDir]" in withCustomTestDatabase(
+          emptyWorkspace
+        ) { _ =>
           withWorkspaceContext(emptyWorkspace.workspace) { context =>
             caseSensitivityFixtures(context)
 
-            assume(runAndWait(entityQuery.listEntities(context)).size == 5, "filteredCount tests did not set up fixtures correctly, within first test")
+            assume(runAndWait(entityQuery.listEntities(context)).size == 5,
+                   "filteredCount tests did not set up fixtures correctly, within first test"
+            )
             val unfilteredQuery = EntityQuery(1, 1, sortKey, sortDir, None)
             val pageResult = runAndWait(entityQuery.loadEntityPage(context, typeName, unfilteredQuery, testContext))
             pageResult._2 should be > 0
@@ -1210,15 +1618,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   }
 
   val filterFixtures = Map(
-    "mytype" -> Map(
-      "bar" -> 2,
-      "value1" -> 1,
-      "value" -> 3,
-      "nonexistent" -> 0),
-    "anothertype" -> Map(
-      "value5" -> 1,
-      "value" -> 2,
-      "alsononexistent" -> 0)
+    "mytype" -> Map("bar" -> 2, "value1" -> 1, "value" -> 3, "nonexistent" -> 0),
+    "anothertype" -> Map("value5" -> 1, "value" -> 2, "alsononexistent" -> 0)
   )
 
   filterFixtures foreach { typeFixtures =>
@@ -1229,7 +1630,9 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       val expectedCount = test._2
       List("name", "case", "CASE") foreach { sortKey =>
         List(SortDirections.Ascending, SortDirections.Descending) foreach { sortDir =>
-          it should s"return expected count ($expectedCount) for type=[$typeName], sortKey=[$sortKey], sortDir=[$sortDir], term [$filterTerm]" in withCustomTestDatabase(emptyWorkspace) { _ =>
+          it should s"return expected count ($expectedCount) for type=[$typeName], sortKey=[$sortKey], sortDir=[$sortDir], term [$filterTerm]" in withCustomTestDatabase(
+            emptyWorkspace
+          ) { _ =>
             withWorkspaceContext(emptyWorkspace.workspace) { context =>
               caseSensitivityFixtures(context)
               val filterQuery = EntityQuery(1, 1, sortKey, sortDir, Some(filterTerm))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -6,7 +6,12 @@ import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, DefaultInstrumented, MetricName}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.config.WDLParserConfig
-import org.broadinstitute.dsde.rawls.dataaccess.MockCromwellSwaggerClient.{makeToolInputParameter, makeToolOutputParameter, makeValueType, makeWorkflowDescription}
+import org.broadinstitute.dsde.rawls.dataaccess.MockCromwellSwaggerClient.{
+  makeToolInputParameter,
+  makeToolOutputParameter,
+  makeValueType,
+  makeWorkflowDescription
+}
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import slick.jdbc.MySQLProfile.api._
@@ -57,18 +62,24 @@ object DbResource extends LazyLogging {
 trait TestDriverComponent extends DriverComponent with DataAccess with DefaultInstrumented {
   this: Suite =>
 
-  override implicit val executionContext = TestExecutionContext.testExecutionContext
+  implicit override val executionContext = TestExecutionContext.testExecutionContext
 
   // Implicit counters are required for certain methods on WorkflowComponent and SubmissionComponent
   override lazy val metricBaseName = MetricName("test")
-  implicit def wfStatusCounter(wfStatus: WorkflowStatus): Option[Counter] = Option(metrics.counter(s"${wfStatus.toString}"))
+  implicit def wfStatusCounter(wfStatus: WorkflowStatus): Option[Counter] = Option(
+    metrics.counter(s"${wfStatus.toString}")
+  )
   implicit def subStatusCounter(subStatus: SubmissionStatus): Counter = metrics.counter(s"${subStatus.toString}")
 
   override val driver: JdbcProfile = DbResource.dataConfig.profile
   override val batchSize: Int = DbResource.dataConfig.config.getInt("batchSize")
   val slickDataSource = DbResource.dataSource
 
-  val userInfo = UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345"))
+  val userInfo = UserInfo(RawlsUserEmail("owner-access"),
+                          OAuth2BearerToken("token"),
+                          123,
+                          RawlsUserSubjectId("123456789876543212345")
+  )
   val testContext = RawlsRequestContext(userInfo)
 
   // NOTE: we previously truncated millis here for DB compatibility reasons, but this is is no longer necessary.
@@ -84,12 +95,17 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   // TODO: can we be any more targeted about inTransaction vs. inTransactionWithAttrTempTable here?
   // this is used by many tests to set up fixture data, which includes saving entities, therefore it needs
   // the temp table.
-  def runAndWait[R](action: DBIOAction[R, _ <: NoStream, _ <: Effect], duration: Duration = 1 minutes): R = {
-    Await.result(DbResource.dataSource.inTransactionWithAttrTempTable (Set(AttributeTempTableType.Entity, AttributeTempTableType.Workspace))
-    { _ => action.asInstanceOf[ReadWriteAction[R]] }, duration)
-  }
+  def runAndWait[R](action: DBIOAction[R, _ <: NoStream, _ <: Effect], duration: Duration = 1 minutes): R =
+    Await.result(
+      DbResource.dataSource.inTransactionWithAttrTempTable(
+        Set(AttributeTempTableType.Entity, AttributeTempTableType.Workspace)
+      )(_ => action.asInstanceOf[ReadWriteAction[R]]),
+      duration
+    )
 
-  protected def runMultipleAndWait[R](count: Int, duration: Duration = 1 minutes)(actionGenerator: Int => DBIOAction[R, _ <: NoStream, _ <: Effect]): R = {
+  protected def runMultipleAndWait[R](count: Int, duration: Duration = 1 minutes)(
+    actionGenerator: Int => DBIOAction[R, _ <: NoStream, _ <: Effect]
+  ): R = {
     val futures = (1 to count) map { i => retryConcurrentModificationException(actionGenerator(i)) }
     Await.result(Future.sequence(futures), duration).head
   }
@@ -98,11 +114,15 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
     import scala.language.existentials
 
-    val chain = (DbResource.dataSource.createEntityAttributeTempTable andThen action.map{ x => Thread.sleep((Math.random() * 500).toLong); x } andFinally DbResource.dataSource.dropEntityAttributeTempTable).withPinnedSession
+    val chain = (DbResource.dataSource.createEntityAttributeTempTable andThen action.map { x =>
+      Thread.sleep((Math.random() * 500).toLong); x
+    } andFinally DbResource.dataSource.dropEntityAttributeTempTable).withPinnedSession
 
     DbResource.dataSource.database.run(chain).recoverWith {
       case e: RawlsConcurrentModificationException => retryConcurrentModificationException(action)
-      case rollbackException: SQLTransactionRollbackException if rollbackException.getMessage.contains("try restarting transaction") => retryConcurrentModificationException(action)
+      case rollbackException: SQLTransactionRollbackException
+          if rollbackException.getMessage.contains("try restarting transaction") =>
+        retryConcurrentModificationException(action)
     }
   }
 
@@ -136,10 +156,10 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
                            workflowFailureMode: Option[WorkflowFailureMode] = None,
                            individualWorkflowCost: Option[Float] = None,
                            externalEntityInfo: Option[ExternalEntityInfo] = None
-                          ): Submission = {
+  ): Submission = {
 
     val workflows = workflowEntities map { ref =>
-      val uuid = if(status == WorkflowStatuses.Queued) None else Option(UUID.randomUUID.toString)
+      val uuid = if (status == WorkflowStatuses.Queued) None else Option(UUID.randomUUID.toString)
       Workflow(uuid, status, testDate, Some(ref.toReference), inputResolutions(ref), cost = individualWorkflowCost)
     }
 
@@ -165,7 +185,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     )
   }
 
-  def billingProjectFromName(name: String) = (RawlsBillingProject(RawlsBillingProjectName(name), CreationStatuses.Ready, None, None))
+  def billingProjectFromName(name: String) =
+    RawlsBillingProject(RawlsBillingProjectName(name), CreationStatuses.Ready, None, None)
 
   def makeRawlsGroup(name: String, users: Set[RawlsUserRef], groups: Set[RawlsGroupRef] = Set.empty) =
     RawlsGroup(RawlsGroupName(name), RawlsGroupEmail(s"$name@example.com"), users, groups)
@@ -179,10 +200,27 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
                              lastModified: DateTime,
                              createdBy: String,
                              attributes: AttributeMap,
-                             isLocked: Boolean) = {
-
-    Workspace(project.projectName.value, name, workspaceId, bucketName, workflowCollectionName, createdDate, createdDate, createdBy, attributes, isLocked, WorkspaceVersions.V2, GoogleProjectId(UUID.randomUUID().toString), Option(GoogleProjectNumber(UUID.randomUUID().toString)), project.billingAccount, None, Option(createdDate), WorkspaceType.RawlsWorkspace)
-  }
+                             isLocked: Boolean
+  ) =
+    Workspace(
+      project.projectName.value,
+      name,
+      workspaceId,
+      bucketName,
+      workflowCollectionName,
+      createdDate,
+      createdDate,
+      createdBy,
+      attributes,
+      isLocked,
+      WorkspaceVersions.V2,
+      GoogleProjectId(UUID.randomUUID().toString),
+      Option(GoogleProjectNumber(UUID.randomUUID().toString)),
+      project.billingAccount,
+      None,
+      Option(createdDate),
+      WorkspaceType.RawlsWorkspace
+    )
   def makeWorkspaceWithUsers(project: RawlsBillingProject,
                              name: String,
                              workspaceId: String,
@@ -198,33 +236,84 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
                              googleProjectNumber: Option[GoogleProjectNumber],
                              currentBillingAccountOnWorkspace: Option[RawlsBillingAccountName],
                              billingAccountErrorMessage: Option[String],
-                             completedCloneWorkspaceFileTransfer: Option[DateTime]) = {
-
-    Workspace(project.projectName.value, name, workspaceId, bucketName, workflowCollectionName, createdDate, createdDate, createdBy, attributes, isLocked, workspaceVersion, googleProjectId, googleProjectNumber, currentBillingAccountOnWorkspace, billingAccountErrorMessage, completedCloneWorkspaceFileTransfer, WorkspaceType.RawlsWorkspace)
-  }
+                             completedCloneWorkspaceFileTransfer: Option[DateTime]
+  ) =
+    Workspace(
+      project.projectName.value,
+      name,
+      workspaceId,
+      bucketName,
+      workflowCollectionName,
+      createdDate,
+      createdDate,
+      createdBy,
+      attributes,
+      isLocked,
+      workspaceVersion,
+      googleProjectId,
+      googleProjectNumber,
+      currentBillingAccountOnWorkspace,
+      billingAccountErrorMessage,
+      completedCloneWorkspaceFileTransfer,
+      WorkspaceType.RawlsWorkspace
+    )
 
   class EmptyWorkspace() extends TestData {
     val userOwner = RawlsUser(userInfo)
-    val userWriter = RawlsUser(UserInfo(RawlsUserEmail("writer-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(RawlsUserEmail("reader-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
+    val userWriter = RawlsUser(
+      UserInfo(RawlsUserEmail("writer-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set(userWriter))
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set(userReader))
 
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace)
       )
-    }
   }
 
-  class EmptyWorkspaceWithProjectAndBillingAccount(project: RawlsBillingProject, maybeBillingAccount: Option[RawlsBillingAccountName]) extends TestData {
+  class EmptyWorkspaceWithProjectAndBillingAccount(project: RawlsBillingProject,
+                                                   maybeBillingAccount: Option[RawlsBillingAccountName]
+  ) extends TestData {
     val userOwner = RawlsUser(userInfo)
-    val userWriter = RawlsUser(UserInfo(RawlsUserEmail("writer-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(RawlsUserEmail("reader-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
+    val userWriter = RawlsUser(
+      UserInfo(RawlsUserEmail("writer-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
     val wsName = WorkspaceName(project.projectName.value, UUID.randomUUID().toString)
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set(userWriter))
@@ -234,41 +323,104 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString))
     val billingAccount = maybeBillingAccount
 
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty, false, workspaceVersion, googleProjectId, googleProjectNumber, billingAccount, None, Option(currentTime()), WorkspaceType.RawlsWorkspace)
+    val workspace = Workspace(
+      wsName.namespace,
+      wsName.name,
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty,
+      false,
+      workspaceVersion,
+      googleProjectId,
+      googleProjectNumber,
+      billingAccount,
+      None,
+      Option(currentTime()),
+      WorkspaceType.RawlsWorkspace
+    )
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace)
       )
-    }
   }
 
   class LockedWorkspace() extends TestData {
     val userOwner = RawlsUser(userInfo)
-    val userWriter = RawlsUser(UserInfo(RawlsUserEmail("writer-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(RawlsUserEmail("reader-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
+    val userWriter = RawlsUser(
+      UserInfo(RawlsUserEmail("writer-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set(userWriter))
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set(userReader))
 
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty, isLocked = true)
+    val workspace = Workspace(
+      wsName.namespace,
+      wsName.name,
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty,
+      isLocked = true
+    )
 
-    override def save() = {
-      DBIO.seq (
+    override def save() =
+      DBIO.seq(
         workspaceQuery.createOrUpdate(workspace)
       )
-    }
   }
 
-  //noinspection TypeAnnotation,ScalaUnnecessaryParentheses,ScalaUnusedSymbol
+  // noinspection TypeAnnotation,ScalaUnnecessaryParentheses,ScalaUnusedSymbol
   class DefaultTestData() extends TestData {
     // setup workspace objects
-    val userProjectOwner = RawlsUser(UserInfo(RawlsUserEmail("project-owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543210101")))
+    val userProjectOwner = RawlsUser(
+      UserInfo(RawlsUserEmail("project-owner-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543210101")
+      )
+    )
     val userOwner = RawlsUser(userInfo)
-    val userWriter = RawlsUser(UserInfo(RawlsUserEmail("writer-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(RawlsUserEmail("reader-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
-    val userReaderViaGroup = RawlsUser(UserInfo(RawlsUserEmail("reader-access-via-group"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349")))
+    val userWriter = RawlsUser(
+      UserInfo(RawlsUserEmail("writer-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
+    val userReaderViaGroup = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access-via-group"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212349")
+      )
+    )
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val wsName2 = WorkspaceName("myNamespace", "myWorkspace2")
     val wsName3 = WorkspaceName("myNamespace", "myWSwithADsMethodConfigs")
@@ -290,10 +442,19 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
     val billingAccountName = RawlsBillingAccountName("fakeBillingAcct")
 
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName(wsName.namespace), CreationStatuses.Ready, Option(billingAccountName), None)
+    val billingProject = RawlsBillingProject(RawlsBillingProjectName(wsName.namespace),
+                                             CreationStatuses.Ready,
+                                             Option(billingAccountName),
+                                             None
+    )
 
     val testProject1Name = RawlsBillingProjectName("arbitrary")
-    val testProject1 = RawlsBillingProject(testProject1Name, CreationStatuses.Ready, Option(billingAccountName), None, billingProfileId=Some(UUID.randomUUID().toString))
+    val testProject1 = RawlsBillingProject(testProject1Name,
+                                           CreationStatuses.Ready,
+                                           Option(billingAccountName),
+                                           None,
+                                           billingProfileId = Some(UUID.randomUUID().toString)
+    )
 
     val testProject2Name = RawlsBillingProjectName("project2")
     val testProject2 = RawlsBillingProject(testProject2Name, CreationStatuses.Ready, Option(billingAccountName), None)
@@ -305,20 +466,99 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),
       AttributeName.withDefaultNS("number") -> AttributeNumber(10),
       AttributeName.withDefaultNS("empty") -> AttributeValueEmptyList,
-      AttributeName.withDefaultNS("values") -> AttributeValueList(Seq(AttributeString("another string"), AttributeString("true")))
+      AttributeName.withDefaultNS("values") -> AttributeValueList(
+        Seq(AttributeString("another string"), AttributeString("true"))
+      )
     )
 
-    val workspaceNoGroups = Workspace(wsName.namespace, wsName.name + "3", UUID.randomUUID().toString, "aBucket2", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs)
+    val workspaceNoGroups = Workspace(wsName.namespace,
+                                      wsName.name + "3",
+                                      UUID.randomUUID().toString,
+                                      "aBucket2",
+                                      Some("workflow-collection"),
+                                      currentTime(),
+                                      currentTime(),
+                                      "testUser",
+                                      wsAttrs
+    )
 
-    val (workspace) = makeWorkspaceWithUsers(billingProject, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
-    val (workspaceLocked) = makeWorkspaceWithUsers(billingProject, wsName.name + "_locked", UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, true)
-    val (v1Workspace) = makeWorkspaceWithUsers(billingProject, wsName.name + "v1", UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false, WorkspaceVersions.V1, billingProject.googleProjectId, billingProject.googleProjectNumber, billingProject.billingAccount, None, Option(currentTime()))
+    val (workspace) = makeWorkspaceWithUsers(billingProject,
+                                             wsName.name,
+                                             UUID.randomUUID().toString,
+                                             "aBucket",
+                                             Some("workflow-collection"),
+                                             currentTime(),
+                                             currentTime(),
+                                             "testUser",
+                                             wsAttrs,
+                                             false
+    )
+    val (workspaceLocked) = makeWorkspaceWithUsers(
+      billingProject,
+      wsName.name + "_locked",
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      true
+    )
+    val (v1Workspace) = makeWorkspaceWithUsers(
+      billingProject,
+      wsName.name + "v1",
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      false,
+      WorkspaceVersions.V1,
+      billingProject.googleProjectId,
+      billingProject.googleProjectNumber,
+      billingProject.billingAccount,
+      None,
+      Option(currentTime())
+    )
 
-    val (regionalWorkspace) = makeWorkspaceWithUsers(billingProject, wsRegionalName.name, UUID.randomUUID().toString, "fc-regional-bucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (regionalWorkspace) = makeWorkspaceWithUsers(
+      billingProject,
+      wsRegionalName.name,
+      UUID.randomUUID().toString,
+      "fc-regional-bucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      false
+    )
 
-    val workspacePublished = Workspace(wsName.namespace, wsName.name + "_published", UUID.randomUUID().toString, "aBucket3", Some("workflow-collection"), currentTime(), currentTime(), "testUser",
-      wsAttrs + (AttributeName.withLibraryNS("published") -> AttributeBoolean(true)))
-    val workspaceNoAttrs = Workspace(wsName.namespace, wsName.name + "_noattrs", UUID.randomUUID().toString, "aBucket4", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspacePublished = Workspace(
+      wsName.namespace,
+      wsName.name + "_published",
+      UUID.randomUUID().toString,
+      "aBucket3",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs + (AttributeName.withLibraryNS("published") -> AttributeBoolean(true))
+    )
+    val workspaceNoAttrs = Workspace(
+      wsName.namespace,
+      wsName.name + "_noattrs",
+      UUID.randomUUID().toString,
+      "aBucket4",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty
+    )
 
     val realm = ManagedGroupRef(RawlsGroupName("Test-Realm"))
     val realmWsName = wsName.name + "withRealm"
@@ -326,98 +566,312 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val realm2 = ManagedGroupRef(RawlsGroupName("Test-Realm2"))
     val realmWs2Name = wsName2.name + "withRealm"
 
-    val (workspaceWithRealm) = makeWorkspaceWithUsers(billingProject, realmWsName, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceWithRealm) = makeWorkspaceWithUsers(billingProject,
+                                                      realmWsName,
+                                                      UUID.randomUUID().toString,
+                                                      "aBucket",
+                                                      Some("workflow-collection"),
+                                                      currentTime(),
+                                                      currentTime(),
+                                                      "testUser",
+                                                      wsAttrs,
+                                                      false
+    )
 
-    val (workspaceWithMultiGroupAD) = makeWorkspaceWithUsers(billingProject, wsName10.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceWithMultiGroupAD) = makeWorkspaceWithUsers(billingProject,
+                                                             wsName10.name,
+                                                             UUID.randomUUID().toString,
+                                                             "aBucket",
+                                                             Some("workflow-collection"),
+                                                             currentTime(),
+                                                             currentTime(),
+                                                             "testUser",
+                                                             wsAttrs,
+                                                             false
+    )
 
-    val (controlledWorkspace) = makeWorkspaceWithUsers(billingProject, "test-tcga", UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (controlledWorkspace) = makeWorkspaceWithUsers(billingProject,
+                                                       "test-tcga",
+                                                       UUID.randomUUID().toString,
+                                                       "aBucket",
+                                                       Some("workflow-collection"),
+                                                       currentTime(),
+                                                       currentTime(),
+                                                       "testUser",
+                                                       wsAttrs,
+                                                       false
+    )
 
-    val (otherWorkspaceWithRealm) = makeWorkspaceWithUsers(billingProject, realmWs2Name,  UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (otherWorkspaceWithRealm) = makeWorkspaceWithUsers(billingProject,
+                                                           realmWs2Name,
+                                                           UUID.randomUUID().toString,
+                                                           "aBucket",
+                                                           Some("workflow-collection"),
+                                                           currentTime(),
+                                                           currentTime(),
+                                                           "testUser",
+                                                           wsAttrs,
+                                                           false
+    )
 
     // Workspace with realms, without submissions
-    val (workspaceNoSubmissions) = makeWorkspaceWithUsers(billingProject, wsName3.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceNoSubmissions) = makeWorkspaceWithUsers(billingProject,
+                                                          wsName3.name,
+                                                          UUID.randomUUID().toString,
+                                                          "aBucket",
+                                                          Some("workflow-collection"),
+                                                          currentTime(),
+                                                          currentTime(),
+                                                          "testUser",
+                                                          wsAttrs,
+                                                          false
+    )
 
     // Workspace with no entities
-    val (workspaceNoEntities) = makeWorkspaceWithUsers(billingProject, "no-entities", UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceNoEntities) = makeWorkspaceWithUsers(billingProject,
+                                                       "no-entities",
+                                                       UUID.randomUUID().toString,
+                                                       "aBucket",
+                                                       Some("workflow-collection"),
+                                                       currentTime(),
+                                                       currentTime(),
+                                                       "testUser",
+                                                       wsAttrs,
+                                                       false
+    )
 
     // Workspace with realms, with successful submission
-    val (workspaceSuccessfulSubmission) = makeWorkspaceWithUsers(billingProject, wsName4.name , UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceSuccessfulSubmission) = makeWorkspaceWithUsers(billingProject,
+                                                                 wsName4.name,
+                                                                 UUID.randomUUID().toString,
+                                                                 "aBucket",
+                                                                 Some("workflow-collection"),
+                                                                 currentTime(),
+                                                                 currentTime(),
+                                                                 "testUser",
+                                                                 wsAttrs,
+                                                                 false
+    )
 
     // Workspace with realms, with failed submission
-    val (workspaceFailedSubmission) = makeWorkspaceWithUsers(billingProject, wsName5.name , UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceFailedSubmission) = makeWorkspaceWithUsers(billingProject,
+                                                             wsName5.name,
+                                                             UUID.randomUUID().toString,
+                                                             "aBucket",
+                                                             Some("workflow-collection"),
+                                                             currentTime(),
+                                                             currentTime(),
+                                                             "testUser",
+                                                             wsAttrs,
+                                                             false
+    )
 
     // Workspace with realms, with submitted submission
-    val (workspaceSubmittedSubmission) = makeWorkspaceWithUsers(billingProject, wsName6.name , UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceSubmittedSubmission) = makeWorkspaceWithUsers(billingProject,
+                                                                wsName6.name,
+                                                                UUID.randomUUID().toString,
+                                                                "aBucket",
+                                                                Some("workflow-collection"),
+                                                                currentTime(),
+                                                                currentTime(),
+                                                                "testUser",
+                                                                wsAttrs,
+                                                                false
+    )
 
     // Workspace with realms with mixed workflows
-    val (workspaceMixedSubmissions) = makeWorkspaceWithUsers(billingProject, wsName7.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceMixedSubmissions) = makeWorkspaceWithUsers(billingProject,
+                                                             wsName7.name,
+                                                             UUID.randomUUID().toString,
+                                                             "aBucket",
+                                                             Some("workflow-collection"),
+                                                             currentTime(),
+                                                             currentTime(),
+                                                             "testUser",
+                                                             wsAttrs,
+                                                             false
+    )
 
     // Workspace with realms, with aborted and successful submissions
-    val (workspaceTerminatedSubmissions) = makeWorkspaceWithUsers(billingProject, wsName8.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceTerminatedSubmissions) = makeWorkspaceWithUsers(billingProject,
+                                                                  wsName8.name,
+                                                                  UUID.randomUUID().toString,
+                                                                  "aBucket",
+                                                                  Some("workflow-collection"),
+                                                                  currentTime(),
+                                                                  currentTime(),
+                                                                  "testUser",
+                                                                  wsAttrs,
+                                                                  false
+    )
 
     // Workspace with a successful submission that had another submission run and fail while it was running
-    val (workspaceInterleavedSubmissions) = makeWorkspaceWithUsers(billingProject, wsInterleaved.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceInterleavedSubmissions) = makeWorkspaceWithUsers(
+      billingProject,
+      wsInterleaved.name,
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      false
+    )
 
     // Workspace with a custom workflow failure mode
-    val (workspaceWorkflowFailureMode) = makeWorkspaceWithUsers(billingProject, wsWorkflowFailureMode.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceWorkflowFailureMode) = makeWorkspaceWithUsers(
+      billingProject,
+      wsWorkflowFailureMode.name,
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      false
+    )
 
     // Standard workspace to test grant permissions
-    val (workspaceToTestGrant) = makeWorkspaceWithUsers(billingProject, wsName9.name, workspaceToTestGrantId.toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceToTestGrant) = makeWorkspaceWithUsers(
+      billingProject,
+      wsName9.name,
+      workspaceToTestGrantId.toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      false
+    )
 
     // Test copying configs between workspaces
-    val (workspaceConfigCopyDestination) = makeWorkspaceWithUsers(billingProject, wsNameConfigCopyDestination.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs, false)
+    val (workspaceConfigCopyDestination) = makeWorkspaceWithUsers(
+      billingProject,
+      wsNameConfigCopyDestination.name,
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      wsAttrs,
+      false
+    )
 
     val aliquot1 = Entity("aliquot1", "Aliquot", Map.empty)
     val aliquot2 = Entity("aliquot2", "Aliquot", Map.empty)
 
-    val sample1 = Entity("sample1", "Sample",
+    val sample1 = Entity(
+      "sample1",
+      "Sample",
       Map(
         AttributeName.withDefaultNS("type") -> AttributeString("normal"),
         AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
         AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("a"), AttributeString("b"))),
         AttributeName.withDefaultNS("quot") -> aliquot1.toReference,
-        AttributeName.withDefaultNS("somefoo") -> AttributeString("itsfoo")))
+        AttributeName.withDefaultNS("somefoo") -> AttributeString("itsfoo")
+      )
+    )
 
-    val sample2 = Entity("sample2", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"), AttributeName.withDefaultNS("confused") -> AttributeString("huh?") ) )
-    val sample3 = Entity("sample3", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"), AttributeName.withDefaultNS("confused") -> sample1.toReference ) )
+    val sample2 = Entity(
+      "sample2",
+      "Sample",
+      Map(
+        AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+        AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"),
+        AttributeName.withDefaultNS("confused") -> AttributeString("huh?")
+      )
+    )
+    val sample3 = Entity(
+      "sample3",
+      "Sample",
+      Map(
+        AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+        AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"),
+        AttributeName.withDefaultNS("confused") -> sample1.toReference
+      )
+    )
     val sample4 = Entity("sample4", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
     val sample5 = Entity("sample5", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
     val sample6 = Entity("sample6", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
-    val sample7 = Entity("sample7", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("cycle") -> sample6.toReference))
-    val sample8 = Entity("sample8", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("foo_id") -> AttributeString("1029384756")))
+    val sample7 = Entity("sample7",
+                         "Sample",
+                         Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+                             AttributeName.withDefaultNS("cycle") -> sample6.toReference
+                         )
+    )
+    val sample8 = Entity(
+      "sample8",
+      "Sample",
+      Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+          AttributeName.withDefaultNS("foo_id") -> AttributeString("1029384756")
+      )
+    )
     val extraSample = Entity("extraSample", "Sample", Map.empty)
 
-    val pair1 = Entity("pair1", "Pair",
-      Map(AttributeName.withDefaultNS("case") -> sample2.toReference,
+    val pair1 = Entity(
+      "pair1",
+      "Pair",
+      Map(
+        AttributeName.withDefaultNS("case") -> sample2.toReference,
         AttributeName.withDefaultNS("control") -> sample1.toReference,
-        AttributeName.withDefaultNS("whatsit") -> AttributeString("occurs in sample too! oh no!")) )
-    val pair2 = Entity("pair2", "Pair",
-      Map(AttributeName.withDefaultNS("case") -> sample3.toReference,
-        AttributeName.withDefaultNS("control") -> sample1.toReference) )
+        AttributeName.withDefaultNS("whatsit") -> AttributeString("occurs in sample too! oh no!")
+      )
+    )
+    val pair2 = Entity("pair2",
+                       "Pair",
+                       Map(AttributeName.withDefaultNS("case") -> sample3.toReference,
+                           AttributeName.withDefaultNS("control") -> sample1.toReference
+                       )
+    )
 
-    val sset1 = Entity("sset1", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
-        Seq(sample1.toReference, sample2.toReference, sample3.toReference))))
-    val sset2 = Entity("sset2", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList( Seq(sample2.toReference)) ) )
+    val sset1 = Entity(
+      "sset1",
+      "SampleSet",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(sample1.toReference, sample2.toReference, sample3.toReference)
+        )
+      )
+    )
+    val sset2 = Entity(
+      "sset2",
+      "SampleSet",
+      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample2.toReference)))
+    )
 
-    val sset3 = Entity("sset3", "SampleSet",
-      Map(AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(Seq(sample5.toReference, sample6.toReference))))
+    val sset3 = Entity("sset3",
+                       "SampleSet",
+                       Map(
+                         AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(
+                           Seq(sample5.toReference, sample6.toReference)
+                         )
+                       )
+    )
 
-    val sset4 = Entity("sset4", "SampleSet",
-      Map(AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(Seq(sample7.toReference))))
+    val sset4 = Entity(
+      "sset4",
+      "SampleSet",
+      Map(AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(Seq(sample7.toReference)))
+    )
 
-    val sset_empty = Entity("sset_empty", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList ))
+    val sset_empty =
+      Entity("sset_empty", "SampleSet", Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList))
 
-    val ps1 = Entity("ps1", "PairSet",
-      Map(AttributeName.withDefaultNS("pairs") -> AttributeEntityReferenceList( Seq(pair1.toReference, pair2.toReference)) ) )
+    val ps1 = Entity(
+      "ps1",
+      "PairSet",
+      Map(
+        AttributeName.withDefaultNS("pairs") -> AttributeEntityReferenceList(Seq(pair1.toReference, pair2.toReference))
+      )
+    )
 
-    val indiv1 = Entity("indiv1", "Individual",
-      Map(AttributeName.withDefaultNS("sset") -> sset1.toReference ) )
+    val indiv1 = Entity("indiv1", "Individual", Map(AttributeName.withDefaultNS("sset") -> sset1.toReference))
 
-    val indiv2 = Entity("indiv2", "Individual",
-      Map(AttributeName.withDefaultNS("sset") -> sset2.toReference ) )
+    val indiv2 = Entity("indiv2", "Individual", Map(AttributeName.withDefaultNS("sset") -> sset2.toReference))
 
     val agoraMethod = AgoraMethod("ns-config", "meth1", 1)
 
@@ -458,9 +912,16 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       "good_and_bad",
       Some("samples"),
       Some(Map.empty[String, AttributeString]),
-      Map("goodAndBad.goodAndBadTask.good_in" -> AttributeString("this.foo"), "goodAndBad.goodAndBadTask.bad_in" -> AttributeString("does.not.parse")),
-      Map("goodAndBad.goodAndBadTask.good_out" -> AttributeString("this.bar"), "goodAndBad.goodAndBadTask.bad_out" -> AttributeString("also.does.not.parse"), "empty_out" -> AttributeString("")),
-      goodAndBadMethod)
+      Map("goodAndBad.goodAndBadTask.good_in" -> AttributeString("this.foo"),
+          "goodAndBad.goodAndBadTask.bad_in" -> AttributeString("does.not.parse")
+      ),
+      Map(
+        "goodAndBad.goodAndBadTask.good_out" -> AttributeString("this.bar"),
+        "goodAndBad.goodAndBadTask.bad_out" -> AttributeString("also.does.not.parse"),
+        "empty_out" -> AttributeString("")
+      ),
+      goodAndBadMethod
+    )
 
     val dockstoreMethod = DockstoreMethod("dockstore-method-path", "dockstore-method-version")
 
@@ -474,55 +935,211 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       dockstoreMethod
     )
 
-    val methodConfigDockstore = MethodConfiguration("dsde", "DockstoreConfig", Some("Sample"), Some(Map.empty[String, AttributeString]), Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), DockstoreMethod("dockstore-path", "dockstore-version"))
-    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", Some("Sample"), Some(Map.empty[String, AttributeString]), Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(wsName.namespace, "method-a", 1))
-    val methodConfig3 = MethodConfiguration("dsde", "testConfig", Some("Sample"), Some(Map.empty[String, AttributeString]), Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigDockstore = MethodConfiguration(
+      "dsde",
+      "DockstoreConfig",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map("param1" -> AttributeString("foo"), "param2" -> AttributeString("foo2")),
+      Map("out" -> AttributeString("bar")),
+      DockstoreMethod("dockstore-path", "dockstore-version")
+    )
+    val methodConfig2 = MethodConfiguration(
+      "dsde",
+      "testConfig2",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map("param1" -> AttributeString("foo")),
+      Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")),
+      AgoraMethod(wsName.namespace, "method-a", 1)
+    )
+    val methodConfig3 = MethodConfiguration(
+      "dsde",
+      "testConfig",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map("param1" -> AttributeString("foo"), "param2" -> AttributeString("foo2")),
+      Map("out" -> AttributeString("bar")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Sample"), Some(Map.empty[String, AttributeString]), Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), Some(Map.empty[String, AttributeString]), Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigEntityUpdate = MethodConfiguration(
+      "ns",
+      "testConfig11",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(),
+      Map("o1" -> AttributeString("this.foo")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
+    val methodConfigWorkspaceUpdate = MethodConfiguration(
+      "ns",
+      "testConfig1",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(),
+      Map("o1" -> AttributeString("workspace.foo")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigWorkspaceMaxAttributes = MethodConfiguration("ns", "testConfigMaxWorkspaceAttributes", Some("Sample"), Some(Map.empty[String, AttributeString]), Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigEntityMaxAttributes = MethodConfiguration("ns", "testConfigMaxEntityAttributes", Some("Sample"), Some(Map.empty[String, AttributeString]), Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigWorkspaceMaxAttributes = MethodConfiguration(
+      "ns",
+      "testConfigMaxWorkspaceAttributes",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(),
+      Map("o1" -> AttributeString("this.foo")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
+    val methodConfigEntityMaxAttributes = MethodConfiguration(
+      "ns",
+      "testConfigMaxEntityAttributes",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(),
+      Map("o1" -> AttributeString("workspace.foo")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigWorkspaceLibraryUpdate = MethodConfiguration("ns", "testConfigLib", Some("Sample"), Some(Map.empty[String, AttributeString]), Map(), Map("o1" -> AttributeString("workspace.library:foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigMissingOutputs = MethodConfiguration("ns", "testConfigMissingOutputs", Some("Sample"), Some(Map.empty[String, AttributeString]), Map(), Map("some.workflow.output" -> AttributeString("this.might_not_be_here")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigWorkspaceLibraryUpdate = MethodConfiguration(
+      "ns",
+      "testConfigLib",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(),
+      Map("o1" -> AttributeString("workspace.library:foo")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
+    val methodConfigMissingOutputs = MethodConfiguration(
+      "ns",
+      "testConfigMissingOutputs",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(),
+      Map("some.workflow.output" -> AttributeString("this.might_not_be_here")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseableInputs = MethodConfiguration("dsde", "UnparseableInputsMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseableOutputs = MethodConfiguration("dsde", "UnparseableOutputsMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")), AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseableBoth = MethodConfiguration("dsde", "UnparseableBothMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..is...bad")), outputs=Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")), AgoraMethod("dsde", "three_step", 1))
-    val methodConfigEmptyOutputs = MethodConfiguration("dsde", "EmptyOutputsMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map("three_step.cgrep.count" -> AttributeString("")), AgoraMethod("dsde", "three_step", 1))
-    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", Some("Sample"), prerequisites=Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.confused")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigValid = MethodConfiguration(
+      "dsde",
+      "GoodMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigUnparseableInputs = MethodConfiguration(
+      "dsde",
+      "UnparseableInputsMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigUnparseableOutputs = MethodConfiguration(
+      "dsde",
+      "UnparseableOutputsMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
+      outputs = Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")),
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigUnparseableBoth = MethodConfiguration(
+      "dsde",
+      "UnparseableBothMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this..is...bad")),
+      outputs = Map("three_step.cgrep.count" -> AttributeString("this..wont.parse")),
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigEmptyOutputs = MethodConfiguration(
+      "dsde",
+      "EmptyOutputsMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
+      outputs = Map("three_step.cgrep.count" -> AttributeString("")),
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigNotAllSamples = MethodConfiguration(
+      "dsde",
+      "NotAllSamplesMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigAttrTypeMixup = MethodConfiguration(
+      "dsde",
+      "AttrTypeMixupMethodConfig",
+      Some("Sample"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.confused")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
 
-    val methodConfigArrayType = MethodConfiguration("dsde", "ArrayMethodConfig", Some("SampleSet"), prerequisites=Some(Map.empty[String, AttributeString]),
-      inputs=Map("aggregate_data_workflow.aggregate_data.input_array" -> AttributeString("this.samples.type")),
-      outputs=Map("aggregate_data_workflow.aggregate_data.output_array" -> AttributeString("this.output_array")),
-      AgoraMethod("dsde", "array_task", 1))
+    val methodConfigArrayType = MethodConfiguration(
+      "dsde",
+      "ArrayMethodConfig",
+      Some("SampleSet"),
+      prerequisites = Some(Map.empty[String, AttributeString]),
+      inputs = Map("aggregate_data_workflow.aggregate_data.input_array" -> AttributeString("this.samples.type")),
+      outputs = Map("aggregate_data_workflow.aggregate_data.output_array" -> AttributeString("this.output_array")),
+      AgoraMethod("dsde", "array_task", 1)
+    )
 
-    val methodConfigEntityless = MethodConfiguration("ns", "Entityless", None, Some(Map.empty[String, AttributeString]), inputs=Map("three_step.cgrep.pattern" -> AttributeString("\"bees\"")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
+    val methodConfigEntityless = MethodConfiguration(
+      "ns",
+      "Entityless",
+      None,
+      Some(Map.empty[String, AttributeString]),
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("\"bees\"")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
 
     val agoraMethodConfigName = MethodConfigurationName(agoraMethodConfig.name, agoraMethodConfig.namespace, wsName)
-    val dockstoreMethodConfigName = MethodConfigurationName(dockstoreMethodConfig.name, dockstoreMethodConfig.namespace, wsName)
-    val methodConfigName2 = agoraMethodConfigName.copy(name="novelName")
-    val methodConfigName3 = agoraMethodConfigName.copy(name="noSuchName")
-    val methodConfigName4 = agoraMethodConfigName.copy(name=methodConfigWorkspaceLibraryUpdate.name)
-    val methodConfigNamePairCreated = MethodConfigurationNamePair(agoraMethodConfigName,methodConfigName2)
+    val dockstoreMethodConfigName =
+      MethodConfigurationName(dockstoreMethodConfig.name, dockstoreMethodConfig.namespace, wsName)
+    val methodConfigName2 = agoraMethodConfigName.copy(name = "novelName")
+    val methodConfigName3 = agoraMethodConfigName.copy(name = "noSuchName")
+    val methodConfigName4 = agoraMethodConfigName.copy(name = methodConfigWorkspaceLibraryUpdate.name)
+    val methodConfigNamePairCreated = MethodConfigurationNamePair(agoraMethodConfigName, methodConfigName2)
     // Copy from "myNamespace/myWorkspace" to "myNamespace/configCopyDestinationWS"
-    val methodConfigNamePairCreatedDockstore = MethodConfigurationNamePair(dockstoreMethodConfigName, dockstoreMethodConfigName.copy(workspaceName = wsNameConfigCopyDestination))
-    val methodConfigNamePairConflict = MethodConfigurationNamePair(agoraMethodConfigName,agoraMethodConfigName)
-    val methodConfigNamePairNotFound = MethodConfigurationNamePair(methodConfigName3,methodConfigName2)
-    val methodConfigNamePairFromLibrary = MethodConfigurationNamePair(methodConfigName4,methodConfigName2)
+    val methodConfigNamePairCreatedDockstore = MethodConfigurationNamePair(
+      dockstoreMethodConfigName,
+      dockstoreMethodConfigName.copy(workspaceName = wsNameConfigCopyDestination)
+    )
+    val methodConfigNamePairConflict = MethodConfigurationNamePair(agoraMethodConfigName, agoraMethodConfigName)
+    val methodConfigNamePairNotFound = MethodConfigurationNamePair(methodConfigName3, methodConfigName2)
+    val methodConfigNamePairFromLibrary = MethodConfigurationNamePair(methodConfigName4, methodConfigName2)
     val uniqueMethodConfigName = UUID.randomUUID.toString
     val newMethodConfigName = MethodConfigurationName(uniqueMethodConfigName, agoraMethodConfig.namespace, wsName)
     val methodRepoGood = MethodRepoConfigurationImport("workspace_test", "rawls_test_good", 1, newMethodConfigName)
-    val methodRepoMissing = MethodRepoConfigurationImport("workspace_test", "rawls_test_missing", 1, agoraMethodConfigName)
-    val methodRepoEmptyPayload = MethodRepoConfigurationImport("workspace_test", "rawls_test_empty_payload", 1, agoraMethodConfigName)
-    val methodRepoBadPayload = MethodRepoConfigurationImport("workspace_test", "rawls_test_bad_payload", 1, agoraMethodConfigName)
-    val methodRepoLibrary = MethodRepoConfigurationImport("workspace_test", "rawls_test_library", 1, newMethodConfigName)
+    val methodRepoMissing =
+      MethodRepoConfigurationImport("workspace_test", "rawls_test_missing", 1, agoraMethodConfigName)
+    val methodRepoEmptyPayload =
+      MethodRepoConfigurationImport("workspace_test", "rawls_test_empty_payload", 1, agoraMethodConfigName)
+    val methodRepoBadPayload =
+      MethodRepoConfigurationImport("workspace_test", "rawls_test_bad_payload", 1, agoraMethodConfigName)
+    val methodRepoLibrary =
+      MethodRepoConfigurationImport("workspace_test", "rawls_test_library", 1, newMethodConfigName)
 
-    val methodConfigForWdlStruct = MethodConfiguration("dsde", "WdlStructConfig", Some("Sample"), Some(Map.empty[String, AttributeString]),
-      Map("wdl_struct_wf.struct_obj" -> AttributeString("""{"id":this.participant_id,"sample_name":this.sample_name}""")), Map.empty,
+    val methodConfigForWdlStruct = MethodConfiguration(
+      "dsde",
+      "WdlStructConfig",
+      Some("Sample"),
+      Some(Map.empty[String, AttributeString]),
+      Map(
+        "wdl_struct_wf.struct_obj" -> AttributeString("""{"id":this.participant_id,"sample_name":this.sample_name}""")
+      ),
+      Map.empty,
       AgoraMethod("dsde", "wdl_struct_wf", 1)
     )
 
@@ -543,47 +1160,109 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       methodRepoMethod = AgoraMethod("ns-config", "meth1", 1)
     )
 
-    val inputResolutions = Seq(SubmissionValidationValue(Option(AttributeString("value")), Option("message"), "test_input_name"))
-    val inputResolutions2 = Seq(SubmissionValidationValue(Option(AttributeString("value2")), Option("message2"), "test_input_name2"))
-    val missingOutputResolutions = Seq(SubmissionValidationValue(Option(AttributeString("value")), Option("message"), "test_input_name"))
+    val inputResolutions = Seq(
+      SubmissionValidationValue(Option(AttributeString("value")), Option("message"), "test_input_name")
+    )
+    val inputResolutions2 = Seq(
+      SubmissionValidationValue(Option(AttributeString("value2")), Option("message2"), "test_input_name2")
+    )
+    val missingOutputResolutions = Seq(
+      SubmissionValidationValue(Option(AttributeString("value")), Option("message"), "test_input_name")
+    )
 
-    val submissionNoWorkflows = createTestSubmission(workspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq.empty, Map.empty,
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
-    val submission1 = createTestSubmission(workspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
-    val regionalSubmission = createTestSubmission(regionalWorkspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
-    val costedSubmission1 = createTestSubmission(workspace, agoraMethodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2),
+    val submissionNoWorkflows = createTestSubmission(
+      workspace,
+      agoraMethodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq.empty,
+      Map.empty,
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
+    val submission1 = createTestSubmission(
+      workspace,
+      agoraMethodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
+    val regionalSubmission = createTestSubmission(
+      regionalWorkspace,
+      agoraMethodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
+    val costedSubmission1 = createTestSubmission(
+      workspace,
+      agoraMethodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2),
       // the constant value we set in MockSubmissionCostService
-      individualWorkflowCost = Some(1.23f))
-    val submission2 = createTestSubmission(workspace, methodConfig2, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
+      individualWorkflowCost = Some(1.23f)
+    )
+    val submission2 = createTestSubmission(
+      workspace,
+      methodConfig2,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
 
-    val submissionUpdateEntity = createTestSubmission(workspace, methodConfigEntityUpdate, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(indiv1), Map(indiv1 -> inputResolutions),
-      Seq(indiv2), Map(indiv2 -> inputResolutions2))
-    val submissionUpdateWorkspace = createTestSubmission(workspace, methodConfigWorkspaceUpdate, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(indiv1), Map(indiv1 -> inputResolutions),
-      Seq(indiv2), Map(indiv2 -> inputResolutions2))
+    val submissionUpdateEntity = createTestSubmission(
+      workspace,
+      methodConfigEntityUpdate,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(indiv1),
+      Map(indiv1 -> inputResolutions),
+      Seq(indiv2),
+      Map(indiv2 -> inputResolutions2)
+    )
+    val submissionUpdateWorkspace = createTestSubmission(
+      workspace,
+      methodConfigWorkspaceUpdate,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(indiv1),
+      Map(indiv1 -> inputResolutions),
+      Seq(indiv2),
+      Map(indiv2 -> inputResolutions2)
+    )
 
-    //NOTE: This is deliberately not saved in the list of active submissions!
-    val submissionMissingOutputs = createTestSubmission(workspace, methodConfigMissingOutputs, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(indiv1), Map(indiv1 -> missingOutputResolutions), Seq(), Map())
+    // NOTE: This is deliberately not saved in the list of active submissions!
+    val submissionMissingOutputs = createTestSubmission(workspace,
+                                                        methodConfigMissingOutputs,
+                                                        indiv1,
+                                                        WorkbenchEmail(userOwner.userEmail.value),
+                                                        Seq(indiv1),
+                                                        Map(indiv1 -> missingOutputResolutions),
+                                                        Seq(),
+                                                        Map()
+    )
 
-    //NOTE: This is deliberately not saved in the list of active submissions!
+    // NOTE: This is deliberately not saved in the list of active submissions!
     val submissionUpdateEntityReservedOutput = createTestSubmission(
       workspace = workspace,
       methodConfig = methodConfigEntityUpdateReservedOutput,
       submissionEntity = indiv1,
       rawlsUserEmail = WorkbenchEmail(userOwner.userEmail.value),
       workflowEntities = Seq(indiv1),
-      inputResolutions = Map(indiv1 -> inputResolutions),
+      inputResolutions = Map(indiv1 -> inputResolutions)
     )
 
     val submissionMaxWorkspaceAttributes = createTestSubmission(
@@ -592,7 +1271,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       submissionEntity = indiv1,
       rawlsUserEmail = WorkbenchEmail(userOwner.userEmail.value),
       workflowEntities = Seq(indiv1),
-      inputResolutions = Map(indiv1 -> inputResolutions),
+      inputResolutions = Map(indiv1 -> inputResolutions)
     )
 
     val submissionMaxEntityAttributes = createTestSubmission(
@@ -601,16 +1280,17 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       submissionEntity = indiv1,
       rawlsUserEmail = WorkbenchEmail(userOwner.userEmail.value),
       workflowEntities = Seq(indiv1),
-      inputResolutions = Map(indiv1 -> inputResolutions),
+      inputResolutions = Map(indiv1 -> inputResolutions)
     )
 
-    //NOTE: This is deliberately not saved in the list of active submissions!
+    // NOTE: This is deliberately not saved in the list of active submissions!
     val submissionNoRootEntity = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = methodConfigValid.namespace,
-      methodConfigurationName = methodConfigValid.name,submissionEntity = None,
+      methodConfigurationName = methodConfigValid.name,
+      submissionEntity = None,
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -669,13 +1349,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with a succeeeded workflow
+    // a submission with a succeeeded workflow
     val submissionSuccessful1 = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -691,13 +1372,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with a succeeeded workflow
+    // a submission with a succeeeded workflow
     val submissionSuccessful2 = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -713,13 +1395,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with a failed workflow
+    // a submission with a failed workflow
     val submissionFailed = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -735,13 +1418,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with a submitted workflow
+    // a submission with a submitted workflow
     val submissionSubmitted = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -757,13 +1441,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with an aborted workflow
+    // a submission with an aborted workflow
     val submissionAborted1 = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -779,13 +1464,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with an aborted workflow
+    // a submission with an aborted workflow
     val submissionAborted2 = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -801,7 +1487,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //a submission with multiple failed and succeeded workflows
+    // a submission with multiple failed and succeeded workflows
     val submissionMixed = Submission(
       submissionId = UUID.randomUUID().toString,
       submissionDate = testDate,
@@ -859,7 +1545,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       deleteIntermediateOutputFiles = false
     )
 
-    //two submissions interleaved in time
+    // two submissions interleaved in time
     val t1 = new DateTime(2017, 1, 1, 5, 10)
     val t2 = new DateTime(2017, 1, 1, 5, 15)
     val t3 = new DateTime(2017, 1, 1, 5, 20)
@@ -869,7 +1555,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       submissionDate = t1,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -889,7 +1576,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       submissionDate = t2,
       submitter = WorkbenchEmail(userOwner.userEmail.value),
       methodConfigurationNamespace = agoraMethodConfig.namespace,
-      methodConfigurationName = agoraMethodConfig.name, submissionEntity = Option(indiv1.toReference),
+      methodConfigurationName = agoraMethodConfig.name,
+      submissionEntity = Option(indiv1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -951,7 +1639,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       workspaceWorkflowFailureMode,
       workspaceToTestGrant,
       workspaceConfigCopyDestination,
-      regionalWorkspace)
+      regionalWorkspace
+    )
     val saveAllWorkspacesAction = DBIO.sequence(allWorkspaces.map(workspaceQuery.createOrUpdate))
 
     override def save() = {
@@ -961,143 +1650,316 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
         rawlsBillingProjectQuery.create(testProject2),
         rawlsBillingProjectQuery.create(testProject3),
         saveAllWorkspacesAction,
-        withWorkspaceContext(workspace)({ context =>
+        withWorkspaceContext(workspace) { context =>
           DBIO.seq(
-                entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
+            methodConfigurationQuery.create(context, agoraMethodConfig),
+            methodConfigurationQuery.create(context, agoraMethodConfigMaxWorkspaceAttributes),
+            methodConfigurationQuery.create(context, agoraMethodConfigMaxEntityAttributes),
+            methodConfigurationQuery.create(context, dockstoreMethodConfig),
+            methodConfigurationQuery.create(context, goodAndBadMethodConfig),
+            methodConfigurationQuery.create(context, methodConfig2),
+            methodConfigurationQuery.create(context, methodConfig3),
+            methodConfigurationQuery.create(context, methodConfigValid),
+            methodConfigurationQuery.create(context, methodConfigDockstore),
+            methodConfigurationQuery.create(context, methodConfigUnparseableInputs),
+            methodConfigurationQuery.create(context, methodConfigUnparseableOutputs),
+            methodConfigurationQuery.create(context, methodConfigUnparseableBoth),
+            methodConfigurationQuery.create(context, methodConfigEmptyOutputs),
+            methodConfigurationQuery.create(context, methodConfigNotAllSamples),
+            methodConfigurationQuery.create(context, methodConfigAttrTypeMixup),
+            methodConfigurationQuery.create(context, methodConfigArrayType),
+            methodConfigurationQuery.create(context, methodConfigEntityless),
+            methodConfigurationQuery.create(context, methodConfigEntityUpdate),
+            methodConfigurationQuery.create(context, methodConfigWorkspaceLibraryUpdate),
+            methodConfigurationQuery.create(context, methodConfigMissingOutputs),
+            methodConfigurationQuery.create(context, methodConfigForWdlStruct),
+            methodConfigurationQuery.create(context, methodConfigEntityUpdateReservedOutput),
+            // HANDY HINT: if you're adding a new method configuration, don't reuse the name!
+            // If you do, methodConfigurationQuery.create() will archive the old query and update it to point to the new one!
 
-                methodConfigurationQuery.create(context, agoraMethodConfig),
-                methodConfigurationQuery.create(context, agoraMethodConfigMaxWorkspaceAttributes),
-                methodConfigurationQuery.create(context, agoraMethodConfigMaxEntityAttributes),
-                methodConfigurationQuery.create(context, dockstoreMethodConfig),
-                methodConfigurationQuery.create(context, goodAndBadMethodConfig),
-                methodConfigurationQuery.create(context, methodConfig2),
-                methodConfigurationQuery.create(context, methodConfig3),
-                methodConfigurationQuery.create(context, methodConfigValid),
-                methodConfigurationQuery.create(context, methodConfigDockstore),
-                methodConfigurationQuery.create(context, methodConfigUnparseableInputs),
-                methodConfigurationQuery.create(context, methodConfigUnparseableOutputs),
-                methodConfigurationQuery.create(context, methodConfigUnparseableBoth),
-                methodConfigurationQuery.create(context, methodConfigEmptyOutputs),
-                methodConfigurationQuery.create(context, methodConfigNotAllSamples),
-                methodConfigurationQuery.create(context, methodConfigAttrTypeMixup),
-                methodConfigurationQuery.create(context, methodConfigArrayType),
-                methodConfigurationQuery.create(context, methodConfigEntityless),
-                methodConfigurationQuery.create(context, methodConfigEntityUpdate),
-                methodConfigurationQuery.create(context, methodConfigWorkspaceLibraryUpdate),
-                methodConfigurationQuery.create(context, methodConfigMissingOutputs),
-                methodConfigurationQuery.create(context, methodConfigForWdlStruct),
-                methodConfigurationQuery.create(context, methodConfigEntityUpdateReservedOutput),
-                //HANDY HINT: if you're adding a new method configuration, don't reuse the name!
-                //If you do, methodConfigurationQuery.create() will archive the old query and update it to point to the new one!
+            submissionQuery.create(context, submissionTerminateTest),
+            submissionQuery.create(context, submissionNoWorkflows),
+            submissionQuery.create(context, submission1),
+            submissionQuery.create(context, regionalSubmission),
+            submissionQuery.create(context, costedSubmission1),
+            submissionQuery.create(context, submission2),
+            submissionQuery.create(context, submissionUpdateEntity),
+            submissionQuery.create(context, submissionUpdateWorkspace),
 
-                submissionQuery.create(context, submissionTerminateTest),
-                submissionQuery.create(context, submissionNoWorkflows),
-                submissionQuery.create(context, submission1),
-                submissionQuery.create(context, regionalSubmission),
-                submissionQuery.create(context, costedSubmission1),
-                submissionQuery.create(context, submission2),
-                submissionQuery.create(context, submissionUpdateEntity),
-                submissionQuery.create(context, submissionUpdateWorkspace),
-
-                // update exec key for all test data workflows that have been started.
-                updateWorkflowExecutionServiceKey("unittestdefault")
+            // update exec key for all test data workflows that have been started.
+            updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceWithRealm)({ context =>
+        },
+        withWorkspaceContext(workspaceWithRealm) { context =>
           DBIO.seq(
             entityQuery.save(context, extraSample)
           )
-        }),
-        withWorkspaceContext(workspaceWithMultiGroupAD)({ context =>
+        },
+        withWorkspaceContext(workspaceWithMultiGroupAD) { context =>
           DBIO.seq(
             entityQuery.save(context, extraSample)
           )
-        }),
-        withWorkspaceContext(workspaceNoSubmissions)({ context =>
+        },
+        withWorkspaceContext(workspaceNoSubmissions) { context =>
           DBIO.seq(
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceSuccessfulSubmission)({ context =>
+        },
+        withWorkspaceContext(workspaceSuccessfulSubmission) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
             methodConfigurationQuery.create(context, methodConfig2),
-
             submissionQuery.create(context, submissionSuccessful1),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceFailedSubmission)({ context =>
+        },
+        withWorkspaceContext(workspaceFailedSubmission) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
-
             submissionQuery.create(context, submissionFailed),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceSubmittedSubmission)({ context =>
+        },
+        withWorkspaceContext(workspaceSubmittedSubmission) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
-
             submissionQuery.create(context, submissionSubmitted),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceTerminatedSubmissions)( { context =>
+        },
+        withWorkspaceContext(workspaceTerminatedSubmissions) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
-
             submissionQuery.create(context, submissionAborted2),
             submissionQuery.create(context, submissionSuccessful2),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceMixedSubmissions)({ context =>
+        },
+        withWorkspaceContext(workspaceMixedSubmissions) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
-
             submissionQuery.create(context, submissionAborted1),
             submissionQuery.create(context, submissionMixed),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceInterleavedSubmissions)({ context =>
+        },
+        withWorkspaceContext(workspaceInterleavedSubmissions) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
-
             submissionQuery.create(context, outerSubmission),
             submissionQuery.create(context, innerSubmission),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        }),
-        withWorkspaceContext(workspaceWorkflowFailureMode)({ context =>
+        },
+        withWorkspaceContext(workspaceWorkflowFailureMode) { context =>
           DBIO.seq(
-            entityQuery.save(context, Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)),
-
+            entityQuery.save(
+              context,
+              Seq(aliquot1,
+                  aliquot2,
+                  sample1,
+                  sample2,
+                  sample3,
+                  sample4,
+                  sample5,
+                  sample6,
+                  sample7,
+                  sample8,
+                  pair1,
+                  pair2,
+                  ps1,
+                  sset1,
+                  sset2,
+                  sset3,
+                  sset4,
+                  sset_empty,
+                  indiv1,
+                  indiv2
+              )
+            ),
             methodConfigurationQuery.create(context, agoraMethodConfig),
-
             submissionQuery.create(context, submissionWorkflowFailureMode),
             updateWorkflowExecutionServiceKey("unittestdefault")
           )
-        })
+        }
       )
     }
   }
 
   class MinimalTestData() extends TestData {
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("myNamespace"), CreationStatuses.Ready, Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")), None)
+    val billingProject = RawlsBillingProject(RawlsBillingProjectName("myNamespace"),
+                                             CreationStatuses.Ready,
+                                             Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
+                                             None
+    )
     val wsName = WorkspaceName(billingProject.projectName.value, "myWorkspace")
     val wsName2 = WorkspaceName(billingProject.projectName.value, "myWorkspace2")
     val v1WsName = WorkspaceName(billingProject.projectName.value, "myV1Workspace")
@@ -1108,14 +1970,74 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val ownerGroup2 = makeRawlsGroup(s"${wsName2.namespace}-${wsName2.name}-OWNER", Set.empty)
     val writerGroup2 = makeRawlsGroup(s"${wsName2.namespace}-${wsName2.name}-WRITER", Set.empty)
     val readerGroup2 = makeRawlsGroup(s"${wsName2.namespace}-${wsName2.name}-READER", Set.empty)
-    val userReader = RawlsUser(UserInfo(RawlsUserEmail("reader-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
-    val workspace2 = Workspace(wsName2.namespace, wsName2.name, UUID.randomUUID().toString, "aBucket2", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val userReader = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
+    val workspace2 = Workspace(wsName2.namespace,
+                               wsName2.name,
+                               UUID.randomUUID().toString,
+                               "aBucket2",
+                               Some("workflow-collection"),
+                               currentTime(),
+                               currentTime(),
+                               "testUser",
+                               Map.empty
+    )
     // TODO (CA-1235): Remove these after PPW Migration is complete
-    val v1Workspace = Workspace(v1WsName.namespace, v1WsName.name, UUID.randomUUID().toString, "aBucket3", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty, false, WorkspaceVersions.V1, billingProject.googleProjectId, billingProject.googleProjectNumber, None, None, Option(currentTime()), WorkspaceType.RawlsWorkspace)
-    val v1Workspace2 = Workspace(v1WsName2.namespace, v1WsName2.name, UUID.randomUUID().toString, "aBucket4", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty, false, WorkspaceVersions.V1, billingProject.googleProjectId, billingProject.googleProjectNumber, None, None, Option(currentTime()), WorkspaceType.RawlsWorkspace)
+    val v1Workspace = Workspace(
+      v1WsName.namespace,
+      v1WsName.name,
+      UUID.randomUUID().toString,
+      "aBucket3",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty,
+      false,
+      WorkspaceVersions.V1,
+      billingProject.googleProjectId,
+      billingProject.googleProjectNumber,
+      None,
+      None,
+      Option(currentTime()),
+      WorkspaceType.RawlsWorkspace
+    )
+    val v1Workspace2 = Workspace(
+      v1WsName2.namespace,
+      v1WsName2.name,
+      UUID.randomUUID().toString,
+      "aBucket4",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty,
+      false,
+      WorkspaceVersions.V1,
+      billingProject.googleProjectId,
+      billingProject.googleProjectNumber,
+      None,
+      None,
+      Option(currentTime()),
+      WorkspaceType.RawlsWorkspace
+    )
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace),
         workspaceQuery.createOrUpdate(workspace2),
@@ -1124,17 +2046,38 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
         workspaceQuery.createOrUpdate(v1Workspace2),
         rawlsBillingProjectQuery.create(billingProject)
       )
-    }
   }
 
   class LocalEntityProviderTestData() extends TestData {
     val workspaceName = WorkspaceName("namespace", "workspace-with-cache")
     val wsAttrs = Map(AttributeName.withDefaultNS("description") -> AttributeString("a description"))
     val creationTime = currentTime()
-    val workspace = Workspace(workspaceName.namespace, workspaceName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), creationTime, creationTime, "testUser", wsAttrs)
+    val workspace = Workspace(
+      workspaceName.namespace,
+      workspaceName.name,
+      UUID.randomUUID().toString,
+      "aBucket",
+      Some("workflow-collection"),
+      creationTime,
+      creationTime,
+      "testUser",
+      wsAttrs
+    )
 
-    val participant1 = Entity("participant1", "participant", Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1"), AttributeName.withDefaultNS("attr2") -> AttributeString("value2")))
-    val sample1 = Entity("sample1", "sample", Map(AttributeName.withDefaultNS("attr5") -> AttributeString("value5"), AttributeName.withDefaultNS("attr6") -> AttributeString("value6")))
+    val participant1 = Entity(
+      "participant1",
+      "participant",
+      Map(AttributeName.withDefaultNS("attr1") -> AttributeString("value1"),
+          AttributeName.withDefaultNS("attr2") -> AttributeString("value2")
+      )
+    )
+    val sample1 = Entity(
+      "sample1",
+      "sample",
+      Map(AttributeName.withDefaultNS("attr5") -> AttributeString("value5"),
+          AttributeName.withDefaultNS("attr6") -> AttributeString("value6")
+      )
+    )
 
     val workspaceEntities = Seq(participant1, sample1)
 
@@ -1144,19 +2087,18 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
     val workspaceEntityTypeCacheEntries = workspaceEntities.groupBy(_.entityType).view.mapValues(_.length).toMap
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace),
-        withWorkspaceContext(workspace)({ context =>
+        withWorkspaceContext(workspace) { context =>
           DBIO.seq(
-            //note that we don't save sample1 here, it was only used to generate cache entries that will differ from what full queries return
+            // note that we don't save sample1 here, it was only used to generate cache entries that will differ from what full queries return
             entityQuery.save(context, participant1),
             entityAttributeStatisticsQuery.batchInsert(workspace.workspaceIdAsUUID, workspaceAttrNameCacheEntries),
-            entityTypeStatisticsQuery.batchInsert(workspace.workspaceIdAsUUID, workspaceEntityTypeCacheEntries),
+            entityTypeStatisticsQuery.batchInsert(workspace.workspaceIdAsUUID, workspaceEntityTypeCacheEntries)
           )
-        })
+        }
       )
-    }
 
   }
 
@@ -1165,80 +2107,153 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   class ConstantTestData() extends TestData {
     // setup workspace objects
     val userOwner = RawlsUser(userInfo)
-    val userWriter = RawlsUser(UserInfo(RawlsUserEmail("writer-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(RawlsUserEmail("reader-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
+    val userWriter = RawlsUser(
+      UserInfo(RawlsUserEmail("writer-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(RawlsUserEmail("reader-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val wsName2 = WorkspaceName("myNamespace", "myWorkspace2")
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set(userWriter))
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set(userReader))
 
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName(wsName.namespace), CreationStatuses.Ready, None, None)
+    val billingProject =
+      RawlsBillingProject(RawlsBillingProjectName(wsName.namespace), CreationStatuses.Ready, None, None)
 
     val wsAttrs = Map(
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),
       AttributeName.withDefaultNS("number") -> AttributeNumber(10),
       AttributeName.withDefaultNS("empty") -> AttributeValueEmptyList,
-      AttributeName.withDefaultNS("values") -> AttributeValueList(Seq(AttributeString("another string"), AttributeString("true")))
+      AttributeName.withDefaultNS("values") -> AttributeValueList(
+        Seq(AttributeString("another string"), AttributeString("true"))
+      )
     )
 
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", wsAttrs)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              wsAttrs
+    )
 
     val aliquot1 = Entity("aliquot1", "Aliquot", Map.empty)
     val aliquot2 = Entity("aliquot2", "Aliquot", Map.empty)
 
-    val sample1 = Entity("sample1", "Sample",
+    val sample1 = Entity(
+      "sample1",
+      "Sample",
       Map(
         AttributeName.withDefaultNS("type") -> AttributeString("normal"),
         AttributeName.withDefaultNS("whatsit") -> AttributeNumber(100),
         AttributeName.withDefaultNS("thingies") -> AttributeValueList(Seq(AttributeString("a"), AttributeString("b"))),
         AttributeName.withDefaultNS("quot") -> aliquot1.toReference,
-        AttributeName.withDefaultNS("somefoo") -> AttributeString("itsfoo")))
+        AttributeName.withDefaultNS("somefoo") -> AttributeString("itsfoo")
+      )
+    )
 
-    val sample2 = Entity("sample2", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"), AttributeName.withDefaultNS("confused") -> AttributeString("huh?") ) )
-    val sample3 = Entity("sample3", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"), AttributeName.withDefaultNS("confused") -> sample1.toReference ) )
+    val sample2 = Entity(
+      "sample2",
+      "Sample",
+      Map(
+        AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+        AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"),
+        AttributeName.withDefaultNS("confused") -> AttributeString("huh?")
+      )
+    )
+    val sample3 = Entity(
+      "sample3",
+      "Sample",
+      Map(
+        AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+        AttributeName.withDefaultNS("tumortype") -> AttributeString("LUSC"),
+        AttributeName.withDefaultNS("confused") -> sample1.toReference
+      )
+    )
     val sample4 = Entity("sample4", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
     val sample5 = Entity("sample5", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
     val sample6 = Entity("sample6", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
-    val sample7 = Entity("sample7", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("cycle") -> sample6.toReference))
+    val sample7 = Entity("sample7",
+                         "Sample",
+                         Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+                             AttributeName.withDefaultNS("cycle") -> sample6.toReference
+                         )
+    )
     val sample8 = Entity("sample8", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
 
-    val pair1 = Entity("pair1", "Pair",
-      Map(AttributeName.withDefaultNS("case") -> sample2.toReference,
+    val pair1 = Entity(
+      "pair1",
+      "Pair",
+      Map(
+        AttributeName.withDefaultNS("case") -> sample2.toReference,
         AttributeName.withDefaultNS("control") -> sample1.toReference,
-        AttributeName.withDefaultNS("whatsit") -> AttributeString("occurs in sample too! oh no!")) )
-    val pair2 = Entity("pair2", "Pair",
-      Map(AttributeName.withDefaultNS("case") -> sample3.toReference,
-        AttributeName.withDefaultNS("control") -> sample1.toReference ) )
+        AttributeName.withDefaultNS("whatsit") -> AttributeString("occurs in sample too! oh no!")
+      )
+    )
+    val pair2 = Entity("pair2",
+                       "Pair",
+                       Map(AttributeName.withDefaultNS("case") -> sample3.toReference,
+                           AttributeName.withDefaultNS("control") -> sample1.toReference
+                       )
+    )
 
-    val sset1 = Entity("sset1", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList( Seq(
-        sample1.toReference,
-        sample2.toReference,
-        sample3.toReference)) ) )
-    val sset2 = Entity("sset2", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList( Seq(sample2.toReference)) ) )
+    val sset1 = Entity(
+      "sset1",
+      "SampleSet",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(sample1.toReference, sample2.toReference, sample3.toReference)
+        )
+      )
+    )
+    val sset2 = Entity(
+      "sset2",
+      "SampleSet",
+      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample2.toReference)))
+    )
 
-    val sset3 = Entity("sset3", "SampleSet",
-      Map(AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(Seq(
-        sample5.toReference,
-        sample6.toReference))))
+    val sset3 = Entity("sset3",
+                       "SampleSet",
+                       Map(
+                         AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(
+                           Seq(sample5.toReference, sample6.toReference)
+                         )
+                       )
+    )
 
-    val sset4 = Entity("sset4", "SampleSet",
-      Map(AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(Seq(
-        sample7.toReference))))
+    val sset4 = Entity(
+      "sset4",
+      "SampleSet",
+      Map(AttributeName.withDefaultNS("hasSamples") -> AttributeEntityReferenceList(Seq(sample7.toReference)))
+    )
 
-    val sset_empty = Entity("sset_empty", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList ))
+    val sset_empty =
+      Entity("sset_empty", "SampleSet", Map(AttributeName.withDefaultNS("samples") -> AttributeValueEmptyList))
 
-    val ps1 = Entity("ps1", "PairSet",
-      Map(AttributeName.withDefaultNS("pairs") -> AttributeEntityReferenceList( Seq(pair1.toReference, pair2.toReference)) ) )
+    val ps1 = Entity(
+      "ps1",
+      "PairSet",
+      Map(
+        AttributeName.withDefaultNS("pairs") -> AttributeEntityReferenceList(Seq(pair1.toReference, pair2.toReference))
+      )
+    )
 
-    val indiv1 = Entity("indiv1", "Individual",
-      Map(AttributeName.withDefaultNS("sset") -> sset1.toReference ) )
+    val indiv1 = Entity("indiv1", "Individual", Map(AttributeName.withDefaultNS("sset") -> sset1.toReference))
 
-    val indiv2 = Entity("indiv2", "Individual",
-      Map(AttributeName.withDefaultNS("sset") -> sset2.toReference ) )
+    val indiv2 = Entity("indiv2", "Individual", Map(AttributeName.withDefaultNS("sset") -> sset2.toReference))
 
     val methodConfig = MethodConfiguration(
       "ns",
@@ -1250,51 +2265,182 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       AgoraMethod("ns-config", "meth1", 1)
     )
 
-    val methodConfig2 = MethodConfiguration("dsde", "testConfig2", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(wsName.namespace, "method-a", 1))
-    val methodConfig3 = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo"), "param2"-> AttributeString("foo2")), Map("out" -> AttributeString("bar")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfig2 = MethodConfiguration(
+      "dsde",
+      "testConfig2",
+      Some("Sample"),
+      None,
+      Map("param1" -> AttributeString("foo")),
+      Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")),
+      AgoraMethod(wsName.namespace, "method-a", 1)
+    )
+    val methodConfig3 = MethodConfiguration(
+      "dsde",
+      "testConfig",
+      Some("Sample"),
+      None,
+      Map("param1" -> AttributeString("foo"), "param2" -> AttributeString("foo2")),
+      Map("out" -> AttributeString("bar")),
+      AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Spample"), None, Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), None, Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigEntityUpdate = MethodConfiguration("ns",
+                                                       "testConfig11",
+                                                       Some("Spample"),
+                                                       None,
+                                                       Map(),
+                                                       Map("o1" -> AttributeString("this.foo")),
+                                                       AgoraMethod("ns-config", "meth1", 1)
+    )
+    val methodConfigWorkspaceUpdate = MethodConfiguration("ns",
+                                                          "testConfig1",
+                                                          Some("Sample"),
+                                                          None,
+                                                          Map(),
+                                                          Map("o1" -> AttributeString("workspace.foo")),
+                                                          AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigMaxAttributeWorkspaceUpdate = MethodConfiguration("ns", "testConfig1", Some("Sample"), None, Map(), Map("o1" -> AttributeString("workspace.foo")), AgoraMethod("ns-config", "meth1", 1))
-    val methodConfigMaxAttributeEntityUpdate = MethodConfiguration("ns", "testConfig11", Some("Spample"), None, Map(), Map("o1" -> AttributeString("this.foo")), AgoraMethod("ns-config", "meth1", 1))
+    val methodConfigMaxAttributeWorkspaceUpdate = MethodConfiguration("ns",
+                                                                      "testConfig1",
+                                                                      Some("Sample"),
+                                                                      None,
+                                                                      Map(),
+                                                                      Map("o1" -> AttributeString("workspace.foo")),
+                                                                      AgoraMethod("ns-config", "meth1", 1)
+    )
+    val methodConfigMaxAttributeEntityUpdate = MethodConfiguration("ns",
+                                                                   "testConfig11",
+                                                                   Some("Spample"),
+                                                                   None,
+                                                                   Map(),
+                                                                   Map("o1" -> AttributeString("this.foo")),
+                                                                   AgoraMethod("ns-config", "meth1", 1)
+    )
 
-    val methodConfigValid = MethodConfiguration("dsde", "GoodMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.name")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigUnparseable = MethodConfiguration("dsde", "UnparseableMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigNotAllSamples = MethodConfiguration("dsde", "NotAllSamplesMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-    val methodConfigAttrTypeMixup = MethodConfiguration("dsde", "AttrTypeMixupMethodConfig", Some("Sample"), prerequisites=None, inputs=Map("three_step.cgrep.pattern" -> AttributeString("this.confused")), outputs=Map.empty, AgoraMethod("dsde", "three_step", 1))
-
+    val methodConfigValid = MethodConfiguration(
+      "dsde",
+      "GoodMethodConfig",
+      Some("Sample"),
+      prerequisites = None,
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.name")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigUnparseable = MethodConfiguration(
+      "dsde",
+      "UnparseableMethodConfig",
+      Some("Sample"),
+      prerequisites = None,
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this..wont.parse")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigNotAllSamples = MethodConfiguration(
+      "dsde",
+      "NotAllSamplesMethodConfig",
+      Some("Sample"),
+      prerequisites = None,
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.tumortype")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
+    val methodConfigAttrTypeMixup = MethodConfiguration(
+      "dsde",
+      "AttrTypeMixupMethodConfig",
+      Some("Sample"),
+      prerequisites = None,
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString("this.confused")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1)
+    )
 
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, wsName)
-    val methodConfigName2 = methodConfigName.copy(name="novelName")
-    val methodConfigName3 = methodConfigName.copy(name="noSuchName")
-    val methodConfigNamePairCreated = MethodConfigurationNamePair(methodConfigName,methodConfigName2)
-    val methodConfigNamePairConflict = MethodConfigurationNamePair(methodConfigName,methodConfigName)
-    val methodConfigNamePairNotFound = MethodConfigurationNamePair(methodConfigName3,methodConfigName2)
+    val methodConfigName2 = methodConfigName.copy(name = "novelName")
+    val methodConfigName3 = methodConfigName.copy(name = "noSuchName")
+    val methodConfigNamePairCreated = MethodConfigurationNamePair(methodConfigName, methodConfigName2)
+    val methodConfigNamePairConflict = MethodConfigurationNamePair(methodConfigName, methodConfigName)
+    val methodConfigNamePairNotFound = MethodConfigurationNamePair(methodConfigName3, methodConfigName2)
     val uniqueMethodConfigName = UUID.randomUUID.toString
     val newMethodConfigName = MethodConfigurationName(uniqueMethodConfigName, methodConfig.namespace, wsName)
 
-    val inputResolutions = Seq(SubmissionValidationValue(Option(AttributeString("value")), Option("message"), "test_input_name"))
-    val inputResolutions2 = Seq(SubmissionValidationValue(Option(AttributeString("value2")), Option("message2"), "test_input_name2"))
+    val inputResolutions = Seq(
+      SubmissionValidationValue(Option(AttributeString("value")), Option("message"), "test_input_name")
+    )
+    val inputResolutions2 = Seq(
+      SubmissionValidationValue(Option(AttributeString("value2")), Option("message2"), "test_input_name2")
+    )
 
-    val submissionNoWorkflows = createTestSubmission(workspace, methodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq.empty, Map.empty,
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
-    val submission1 = createTestSubmission(workspace, methodConfig, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
-    val submission2 = createTestSubmission(workspace, methodConfig2, indiv1, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2))
+    val submissionNoWorkflows = createTestSubmission(
+      workspace,
+      methodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq.empty,
+      Map.empty,
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
+    val submission1 = createTestSubmission(
+      workspace,
+      methodConfig,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
+    val submission2 = createTestSubmission(
+      workspace,
+      methodConfig2,
+      indiv1,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> inputResolutions, sample2 -> inputResolutions, sample3 -> inputResolutions),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> inputResolutions2, sample5 -> inputResolutions2, sample6 -> inputResolutions2)
+    )
 
-    val allEntities = Seq(aliquot1, aliquot2, sample1, sample2, sample3, sample4, sample5, sample6, sample7, sample8, pair1, pair2, ps1, sset1, sset2, sset3, sset4, sset_empty, indiv1, indiv2)
-    val allMCs = Seq(methodConfig, methodConfig2, methodConfig3, methodConfigValid, methodConfigUnparseable, methodConfigNotAllSamples, methodConfigAttrTypeMixup, methodConfigEntityUpdate)
-    def saveAllMCs(context: Workspace) = DBIO.sequence(allMCs map { mc => methodConfigurationQuery.create(context, mc) })
+    val allEntities = Seq(aliquot1,
+                          aliquot2,
+                          sample1,
+                          sample2,
+                          sample3,
+                          sample4,
+                          sample5,
+                          sample6,
+                          sample7,
+                          sample8,
+                          pair1,
+                          pair2,
+                          ps1,
+                          sset1,
+                          sset2,
+                          sset3,
+                          sset4,
+                          sset_empty,
+                          indiv1,
+                          indiv2
+    )
+    val allMCs = Seq(
+      methodConfig,
+      methodConfig2,
+      methodConfig3,
+      methodConfigValid,
+      methodConfigUnparseable,
+      methodConfigNotAllSamples,
+      methodConfigAttrTypeMixup,
+      methodConfigEntityUpdate
+    )
+    def saveAllMCs(context: Workspace) = DBIO.sequence(allMCs map { mc =>
+      methodConfigurationQuery.create(context, mc)
+    })
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace),
-        withWorkspaceContext(workspace)({ context =>
+        withWorkspaceContext(workspace) { context =>
           DBIO.seq(
             entityQuery.save(context, allEntities),
             saveAllMCs(context),
@@ -1302,61 +2448,49 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
             submissionQuery.create(context, submission1),
             submissionQuery.create(context, submission2)
           )
-        })
+        }
       )
-    }
   }
 
   val emptyData = new TestData() {
-    override def save() = {
+    override def save() =
       DBIO.successful(())
-    }
   }
 
-  def withEmptyTestDatabase[T](testCode: => T): T = {
+  def withEmptyTestDatabase[T](testCode: => T): T =
     withCustomTestDatabaseInternal(emptyData)(testCode)
-  }
 
-  def withEmptyTestDatabase[T](testCode: SlickDataSource => T): T = {
+  def withEmptyTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(emptyData)(testCode(slickDataSource))
-  }
 
   val testData = new DefaultTestData()
   val constantData = new ConstantTestData()
   val minimalTestData = new MinimalTestData()
   val localEntityProviderTestData = new LocalEntityProviderTestData()
 
-  def withDefaultTestDatabase[T](testCode: => T): T = {
+  def withDefaultTestDatabase[T](testCode: => T): T =
     withCustomTestDatabaseInternal(testData)(testCode)
-  }
 
-  def withDefaultTestDatabase[T](testCode: SlickDataSource => T): T = {
+  def withDefaultTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(testData)(testCode(slickDataSource))
-  }
 
-  def withMinimalTestDatabase[T](testCode: SlickDataSource => T): T ={
+  def withMinimalTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(minimalTestData)(testCode(slickDataSource))
-  }
 
-  def withLocalEntityProviderTestDatabase[T](testCode: SlickDataSource => T): T ={
+  def withLocalEntityProviderTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(localEntityProviderTestData)(testCode(slickDataSource))
-  }
 
-  def withConstantTestDatabase[T](testCode: => T): T = {
+  def withConstantTestDatabase[T](testCode: => T): T =
     withCustomTestDatabaseInternal(constantData)(testCode)
-  }
 
-  def withConstantTestDatabase[T](testCode: SlickDataSource => T): T = {
+  def withConstantTestDatabase[T](testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(constantData)(testCode(slickDataSource))
-  }
 
-  def withCustomTestDatabase[T](data: TestData)(testCode: SlickDataSource => T): T = {
+  def withCustomTestDatabase[T](data: TestData)(testCode: SlickDataSource => T): T =
     withCustomTestDatabaseInternal(data)(testCode(slickDataSource))
-  }
 
-  def withCustomTestDatabaseInternal[T](data: TestData)(testCode: => T): T = {
+  def withCustomTestDatabaseInternal[T](data: TestData)(testCode: => T): T =
     withCustomTestDatabaseInternal(slickDataSource, data)(testCode)
-  }
 
   def withCustomTestDatabaseInternal[T](dataSource: SlickDataSource, data: TestData)(testCode: => T): T = {
     runAndWait(DBIO.seq(dataSource.dataAccess.truncateAll), 2 minutes)
@@ -1368,60 +2502,58 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     }
   }
 
-  def withWorkspaceContext[T](workspace: Workspace)(testCode: (Workspace) => T): T = {
+  def withWorkspaceContext[T](workspace: Workspace)(testCode: (Workspace) => T): T =
     testCode(workspace)
-  }
 
-  def updateWorkflowExecutionServiceKey(execKey: String) = {
+  def updateWorkflowExecutionServiceKey(execKey: String) =
     // when unit tests seed the test data with workflows, those workflows may land in the database as already-started.
     // however, the runtime create() methods we use to seed the data do not set EXEC_SERVICE_KEY, since that should
     // only be set when a workflow is submitted. Therefore, we have this test-only raw sql to update those
     // workflows to an appropriate EXEC_SERVICE_KEY.
-    sql"update WORKFLOW set EXEC_SERVICE_KEY = ${execKey} where EXEC_SERVICE_KEY is null and EXTERNAL_ID is not null;".as[Int]
-  }
-
+    sql"update WORKFLOW set EXEC_SERVICE_KEY = ${execKey} where EXEC_SERVICE_KEY is null and EXTERNAL_ID is not null;"
+      .as[Int]
 
   val threeStepWDL =
     WdlSource("""
-      |task ps {
-      |  command {
-      |    ps
-      |  }
-      |  output {
-      |    File procs = stdout()
-      |  }
-      |}
-      |
-      |task cgrep {
-      |  File in_file
-      |  String pattern
-      |  command {
-      |    grep '${pattern}' ${in_file} | wc -l
-      |  }
-      |  output {
-      |    Int count = read_int(stdout())
-      |  }
-      |}
-      |
-      |task wc {
-      |  File in_file
-      |  command {
-      |    cat ${in_file} | wc -l
-      |  }
-      |  output {
-      |    Int count = read_int(stdout())
-      |  }
-      |}
-      |
-      |workflow three_step {
-      |  call ps
-      |  call cgrep {
-      |    input: in_file=ps.procs
-      |  }
-      |  call wc {
-      |    input: in_file=ps.procs
-      |  }
-      |}
+                |task ps {
+                |  command {
+                |    ps
+                |  }
+                |  output {
+                |    File procs = stdout()
+                |  }
+                |}
+                |
+                |task cgrep {
+                |  File in_file
+                |  String pattern
+                |  command {
+                |    grep '${pattern}' ${in_file} | wc -l
+                |  }
+                |  output {
+                |    Int count = read_int(stdout())
+                |  }
+                |}
+                |
+                |task wc {
+                |  File in_file
+                |  command {
+                |    cat ${in_file} | wc -l
+                |  }
+                |  output {
+                |    Int count = read_int(stdout())
+                |  }
+                |}
+                |
+                |workflow three_step {
+                |  call ps
+                |  call cgrep {
+                |    input: in_file=ps.procs
+                |  }
+                |  call wc {
+                |    input: in_file=ps.procs
+                |  }
+                |}
     """.stripMargin)
 
   val threeStepWDLName = "three_step"
@@ -1430,30 +2562,47 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   val cgrepcountOutput = makeToolOutputParameter("cgrep.count", makeValueType("Int"), "Int")
   val wccountOutput = makeToolOutputParameter("wc.count", makeValueType("Int"), "Int")
   val psprocsOutput = makeToolOutputParameter("ps.procs", makeValueType("File"), "File")
-  val threeStepWDLWorkflowDescription = makeWorkflowDescription(threeStepWDLName, List(patternInput), List(cgrepcountOutput, wccountOutput, psprocsOutput))
+  val threeStepWDLWorkflowDescription =
+    makeWorkflowDescription(threeStepWDLName, List(patternInput), List(cgrepcountOutput, wccountOutput, psprocsOutput))
   mockCromwellSwaggerClient.workflowDescriptions += (threeStepWDL -> threeStepWDLWorkflowDescription)
 
-  val threeStepMethod = AgoraEntity(Some("dsde"),Some(threeStepWDLName),Some(1),None,None,None,None,Option(threeStepWDL.source),None,Some(AgoraEntityType.Workflow))
+  val threeStepMethod = AgoraEntity(Some("dsde"),
+                                    Some(threeStepWDLName),
+                                    Some(1),
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    Option(threeStepWDL.source),
+                                    None,
+                                    Some(AgoraEntityType.Workflow)
+  )
 
   val threeStepDockstoreWDLName = threeStepWDLName + "_dockstore"
   val patternInputDockstore = makeToolInputParameter("cgrep.pattern", false, makeValueType("String"), "String")
   val cgrepcountOutputDockstore = makeToolOutputParameter("cgrep.count", makeValueType("Int"), "Int")
   val wccountOutputDockstore = makeToolOutputParameter("wc.count", makeValueType("Int"), "Int")
   val psprocsOutputDockstore = makeToolOutputParameter("ps.procs", makeValueType("File"), "File")
-  val threeStepDockStoreWDLWorkflowDescription = makeWorkflowDescription(threeStepDockstoreWDLName, List(patternInputDockstore), List(cgrepcountOutputDockstore, wccountOutputDockstore, psprocsOutputDockstore))
-  mockCromwellSwaggerClient.workflowDescriptions += WdlUrl("/url-to-github/from/ga4gh-url-field/three-step-dockstore") -> threeStepDockStoreWDLWorkflowDescription
+  val threeStepDockStoreWDLWorkflowDescription = makeWorkflowDescription(
+    threeStepDockstoreWDLName,
+    List(patternInputDockstore),
+    List(cgrepcountOutputDockstore, wccountOutputDockstore, psprocsOutputDockstore)
+  )
+  mockCromwellSwaggerClient.workflowDescriptions += WdlUrl(
+    "/url-to-github/from/ga4gh-url-field/three-step-dockstore"
+  ) -> threeStepDockStoreWDLWorkflowDescription
 
   val noInputWdl =
     WdlSource("""
-      |task t1 {
-      |  command {
-      |    echo "Hello"
-      |  }
-      |}
-      |
-      |workflow w1 {
-      |  call t1
-      |}
+                |task t1 {
+                |  command {
+                |    echo "Hello"
+                |  }
+                |}
+                |
+                |workflow w1 {
+                |  call t1
+                |}
     """.stripMargin)
 
   val noInputWdlWorkflowDescription = makeWorkflowDescription("w1", List(), List())
@@ -1462,32 +2611,44 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   val noInputMethodDockstoreWDLSource =
     noInputWdl.source.replace("t1", "t1_dockstore")
   val noInputMethodDockstoreResponse =
-    s"""{"type":"WDL","descriptor":"${noInputMethodDockstoreWDLSource.replace("\"", "\\\"").replace("\n","\\n")}","url":"/url-to-github/from/ga4gh-url-field/no-input-dockstore"}"""
+    s"""{"type":"WDL","descriptor":"${noInputMethodDockstoreWDLSource
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")}","url":"/url-to-github/from/ga4gh-url-field/no-input-dockstore"}"""
   val noInputMethodDockstoreWorkflowDescription = makeWorkflowDescription("w1", List(), List())
-  mockCromwellSwaggerClient.workflowDescriptions += WdlUrl("/url-to-github/from/ga4gh-url-field/no-input-dockstore") -> noInputWdlWorkflowDescription
+  mockCromwellSwaggerClient.workflowDescriptions += WdlUrl(
+    "/url-to-github/from/ga4gh-url-field/no-input-dockstore"
+  ) -> noInputWdlWorkflowDescription
 
-
-  val noInputMethod = AgoraEntity(Some("dsde"), Some("no_input"), Some(1), None, None, None, None, Option(noInputWdl.source), None, Some(AgoraEntityType.Workflow))
-
+  val noInputMethod = AgoraEntity(Some("dsde"),
+                                  Some("no_input"),
+                                  Some(1),
+                                  None,
+                                  None,
+                                  None,
+                                  None,
+                                  Option(noInputWdl.source),
+                                  None,
+                                  Some(AgoraEntityType.Workflow)
+  )
 
   val goodAndBadInputsWDL =
     WdlSource("""
-      |workflow goodAndBad {
-      |  call goodAndBadTask
-      |}
-      |
-      |task goodAndBadTask {
-      |  String good_in
-      |  String bad_in
-      |  command {
-      |    echo "hello world"
-      |  }
-      |  output {
-      |    String good_out = "everything is good"
-      |    String bad_out = "everything is bad"
-      |    String empty_out = "everything is empty"
-      |  }
-      |}
+                |workflow goodAndBad {
+                |  call goodAndBadTask
+                |}
+                |
+                |task goodAndBadTask {
+                |  String good_in
+                |  String bad_in
+                |  command {
+                |    echo "hello world"
+                |  }
+                |  output {
+                |    String good_out = "everything is good"
+                |    String bad_out = "everything is bad"
+                |    String empty_out = "everything is empty"
+                |  }
+                |}
     """.stripMargin)
 
   val goodAndBadWDLName = "goodAndBad"
@@ -1496,24 +2657,25 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   val goodOut = makeToolOutputParameter("goodAndBadTask.good_out", makeValueType("String"), "String")
   val badOut = makeToolOutputParameter("goodAndBadTask.bad_out", makeValueType("String"), "String")
   val emptyOut = makeToolOutputParameter("goodAndBadTask.empty_out", makeValueType("String"), "String")
-  val goodAndBadWDLWorkflowDescription = makeWorkflowDescription(goodAndBadWDLName, List(badIn, goodIn), List(goodOut, badOut, emptyOut))
+  val goodAndBadWDLWorkflowDescription =
+    makeWorkflowDescription(goodAndBadWDLName, List(badIn, goodIn), List(goodOut, badOut, emptyOut))
   mockCromwellSwaggerClient.workflowDescriptions += (goodAndBadInputsWDL -> goodAndBadWDLWorkflowDescription)
 
   val meth1WDL =
     WdlSource("""
-      |workflow meth1 {
-      |  call method1
-      |}
-      |
-      |task method1 {
-      |  String i1
-      |  command {
-      |    echo "hello world"
-      |  }
-      |  output {
-      |    String o1 = "output one"
-      |  }
-      |}
+                |workflow meth1 {
+                |  call method1
+                |}
+                |
+                |task method1 {
+                |  String i1
+                |  command {
+                |    echo "hello world"
+                |  }
+                |  output {
+                |    String o1 = "output one"
+                |  }
+                |}
     """.stripMargin)
 
   val meth1WDLName = "meth1"
@@ -1523,37 +2685,36 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   mockCromwellSwaggerClient.workflowDescriptions += (meth1WDL -> meth1WDLWorkflowDescription)
 
   val wdlStructWDL =
-    WdlSource(
-      """
-        |version 1.0
-        |
-        |struct Participant {
-        |  Int id
-        |  String sample_name
-        |}
-        |
-        |task do_something {
-        |  input {
-        |    Int id
-        |    String sample_name
-        |  }
-        |
-        |  command {
-        |    echo "Hello participant ~{id} ~{sample_name} !"
-        |  }
-        |
-        |  runtime {
-        |    docker: "docker image"
-        |  }
-        |}
-        |
-        |workflow wdl_struct_wf {
-        |  input {
-        |    Participant struct_obj
-        |  }
-        |
-        |  call do_something {input: id = struct_obj.id, sample_name = struct_obj.sample_name}
-        |}
+    WdlSource("""
+                |version 1.0
+                |
+                |struct Participant {
+                |  Int id
+                |  String sample_name
+                |}
+                |
+                |task do_something {
+                |  input {
+                |    Int id
+                |    String sample_name
+                |  }
+                |
+                |  command {
+                |    echo "Hello participant ~{id} ~{sample_name} !"
+                |  }
+                |
+                |  runtime {
+                |    docker: "docker image"
+                |  }
+                |}
+                |
+                |workflow wdl_struct_wf {
+                |  input {
+                |    Participant struct_obj
+                |  }
+                |
+                |  call do_something {input: id = struct_obj.id, sample_name = struct_obj.sample_name}
+                |}
       """.stripMargin)
 
   val wdlStructWDLName = "wdl_struct_wf"
@@ -1562,7 +2723,17 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   val wdlStructWDLWorkflowDescription = makeWorkflowDescription(wdlStructWDLName, List(wdlStructWDLInput), List.empty)
   mockCromwellSwaggerClient.workflowDescriptions += (wdlStructWDL -> wdlStructWDLWorkflowDescription)
 
-  val wdlStructMethod = AgoraEntity(Some("dsde"),Some(wdlStructWDLName),Some(1),None,None,None,None,Option(wdlStructWDL.source),None,Some(AgoraEntityType.Workflow))
+  val wdlStructMethod = AgoraEntity(Some("dsde"),
+                                    Some(wdlStructWDLName),
+                                    Some(1),
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    Option(wdlStructWDL.source),
+                                    None,
+                                    Some(AgoraEntityType.Workflow)
+  )
 }
 
 trait TestData {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -17,11 +17,15 @@ import org.scalatestplus.mockito.MockitoSugar
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 
-class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with MockitoSugar with MockitoTestUtils  {
+class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with MockitoSugar with MockitoTestUtils {
   implicit val actorSystem: ActorSystem = ActorSystem("HttpWorkspaceManagerDAOSpec")
   implicit val executionContext: ExecutionContext = new TestExecutionContext()
 
-  val userInfo = UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345"))
+  val userInfo = UserInfo(RawlsUserEmail("owner-access"),
+                          OAuth2BearerToken("token"),
+                          123,
+                          RawlsUserSubjectId("123456789876543212345")
+  )
   val testContext = RawlsRequestContext(userInfo)
 
   behavior of "enableApplication"
@@ -33,19 +37,17 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
     val provider = new WorkspaceManagerApiClientProvider {
       override def getApiClient(ctx: RawlsRequestContext): ApiClient = ???
 
-      override def getWorkspaceApplicationApi(ctx: RawlsRequestContext): WorkspaceApplicationApi = {
+      override def getWorkspaceApplicationApi(ctx: RawlsRequestContext): WorkspaceApplicationApi =
         workspaceApplicationApi
-      }
 
-      override def getControlledAzureResourceApi(ctx: RawlsRequestContext): ControlledAzureResourceApi = {
+      override def getControlledAzureResourceApi(ctx: RawlsRequestContext): ControlledAzureResourceApi =
         controlledAzureResourceApi
-      }
     }
     val wsmDao = new HttpWorkspaceManagerDAO(provider)
     val workspaceId = UUID.randomUUID()
 
-    def assertCommonFields (commonFields: ControlledResourceCommonFields): Unit = {
-      commonFields.getName should endWith (workspaceId.toString)
+    def assertCommonFields(commonFields: ControlledResourceCommonFields): Unit = {
+      commonFields.getName should endWith(workspaceId.toString)
       commonFields.getCloningInstructions shouldBe CloningInstructionsEnum.NOTHING
       commonFields.getAccessScope shouldBe AccessScope.SHARED_ACCESS
       commonFields.getManagedBy shouldBe ManagedBy.USER
@@ -58,14 +60,14 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
     wsmDao.createAzureRelay(workspaceId, "arlington", testContext)
     verify(controlledAzureResourceApi).createAzureRelayNamespace(relayArgumentCaptor.capture, any[UUID])
     relayArgumentCaptor.getValue.getAzureRelayNamespace.getRegion shouldBe "arlington"
-    relayArgumentCaptor.getValue.getAzureRelayNamespace.getNamespaceName should endWith (workspaceId.toString)
+    relayArgumentCaptor.getValue.getAzureRelayNamespace.getNamespaceName should endWith(workspaceId.toString)
     assertCommonFields(relayArgumentCaptor.getValue.getCommon)
 
     val saArgumentCaptor = captor[CreateControlledAzureStorageRequestBody]
     wsmDao.createAzureStorageAccount(workspaceId, "arlington", testContext)
     verify(controlledAzureResourceApi).createAzureStorage(saArgumentCaptor.capture, any[UUID])
     saArgumentCaptor.getValue.getAzureStorage.getRegion shouldBe "arlington"
-    saArgumentCaptor.getValue.getAzureStorage.getStorageAccountName should startWith ("sa")
+    saArgumentCaptor.getValue.getAzureStorage.getStorageAccountName should startWith("sa")
     assertCommonFields(saArgumentCaptor.getValue.getCommon)
 
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -7,11 +7,47 @@ import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleBigQueryServiceFactory,
+  MockBigQueryServiceFactory,
+  SlickDataSource
+}
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
-import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO, RemoteServicesMockServer}
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, CreateAttributeEntityReferenceList, CreateAttributeValueList, RemoveAttribute, RemoveListMember}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeEntityReferenceEmptyList, AttributeEntityReferenceList, AttributeName, AttributeNull, AttributeNumber, AttributeRename, AttributeString, AttributeValueEmptyList, AttributeValueList, Entity, EntityQuery, EntityTypeRename, RawlsRequestContext, RawlsUser, SortDirections, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.mock.{
+  MockDataRepoDAO,
+  MockSamDAO,
+  MockWorkspaceManagerDAO,
+  RemoteServicesMockServer
+}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddListMember,
+  AddUpdateAttribute,
+  CreateAttributeEntityReferenceList,
+  CreateAttributeValueList,
+  RemoveAttribute,
+  RemoveListMember
+}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
+  AttributeEntityReference,
+  AttributeEntityReferenceEmptyList,
+  AttributeEntityReferenceList,
+  AttributeName,
+  AttributeNull,
+  AttributeNumber,
+  AttributeRename,
+  AttributeString,
+  AttributeValueEmptyList,
+  AttributeValueList,
+  Entity,
+  EntityQuery,
+  EntityTypeRename,
+  RawlsRequestContext,
+  RawlsUser,
+  SortDirections,
+  UserInfo,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
@@ -24,14 +60,30 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.concurrent.{Await, ExecutionContext}
 
-class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with TestDriverComponent with RawlsTestUtils with Eventually with MockitoTestUtils with RawlsStatsDTestUtils with BeforeAndAfterAll {
+class EntityServiceSpec
+    extends AnyFlatSpec
+    with ScalatestRouteTest
+    with Matchers
+    with TestDriverComponent
+    with RawlsTestUtils
+    with Eventually
+    with MockitoTestUtils
+    with RawlsStatsDTestUtils
+    with BeforeAndAfterAll {
 
   val attributeList = AttributeValueList(Seq(AttributeString("a"), AttributeString("b"), AttributeBoolean(true)))
-  val s1 = Entity("s1", "samples", Map(
-    AttributeName.withDefaultNS("foo") -> AttributeString("x"),
-    AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
-    AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(Seq(AttributeEntityReference("participant", "p1"))),
-    AttributeName.withDefaultNS("splat") -> attributeList))
+  val s1 = Entity(
+    "s1",
+    "samples",
+    Map(
+      AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+      AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+      AttributeName.withDefaultNS("refs") -> AttributeEntityReferenceList(
+        Seq(AttributeEntityReference("participant", "p1"))
+      ),
+      AttributeName.withDefaultNS("splat") -> attributeList
+    )
+  )
   val workspace = Workspace(
     testData.wsName.namespace,
     testData.wsName.name,
@@ -56,8 +108,11 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
     super.afterAll()
   }
 
-  //noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
-  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit val executionContext: ExecutionContext) extends EntityApiService with MockUserInfoDirectivesWithUser {
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends EntityApiService
+      with MockUserInfoDirectivesWithUser {
     private val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
     lazy val entityService: EntityService = entityServiceConstructor(ctx1)
 
@@ -74,16 +129,24 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"), workbenchMetricBaseName),
+      EntityManager.defaultEntityManager(
+        dataSource,
+        new MockWorkspaceManagerDAO(),
+        new MockDataRepoDAO(mockServer.mockServerBaseUrl),
+        samDAO,
+        bigQueryServiceFactory,
+        DataRepoEntityProviderConfig(100, 10, 0),
+        testConf.getBoolean("entityStatisticsCache.enabled"),
+        workbenchMetricBaseName
+      ),
       7 // <-- specifically chosen to be lower than the number of samples in "workspace" within testData
-    )_
+    ) _
   }
 
-  def withTestDataServices[T](testCode: TestApiService => T): T = {
+  def withTestDataServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withServices(dataSource, testData.userOwner)(testCode)
     }
-  }
 
   private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: (TestApiService) => T) = {
     val apiService = new TestApiService(dataSource, user)
@@ -92,131 +155,210 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
 
   "EntityService" should "add attribute to entity" in withTestDataServices { services =>
     assertResult(Some(AttributeString("foo"))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))).attributes.get(AttributeName.withDefaultNS("newAttribute"))
+      services.entityService
+        .applyOperationsToEntity(
+          s1,
+          Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
+        )
+        .attributes
+        .get(AttributeName.withDefaultNS("newAttribute"))
     }
   }
 
   it should "update attribute in entity" in withTestDataServices { services =>
     assertResult(Some(AttributeString("biz"))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("foo"), AttributeString("biz")))).attributes.get(AttributeName.withDefaultNS("foo"))
+      services.entityService
+        .applyOperationsToEntity(s1,
+                                 Seq(AddUpdateAttribute(AttributeName.withDefaultNS("foo"), AttributeString("biz")))
+        )
+        .attributes
+        .get(AttributeName.withDefaultNS("foo"))
     }
   }
 
   it should "remove attribute from entity" in withTestDataServices { services =>
     assertResult(None) {
-      services.entityService.applyOperationsToEntity(s1, Seq(RemoveAttribute(AttributeName.withDefaultNS("foo")))).attributes.get(AttributeName.withDefaultNS("foo"))
+      services.entityService
+        .applyOperationsToEntity(s1, Seq(RemoveAttribute(AttributeName.withDefaultNS("foo"))))
+        .attributes
+        .get(AttributeName.withDefaultNS("foo"))
     }
   }
 
   it should "add item to existing list in entity" in withTestDataServices { services =>
     assertResult(Some(AttributeValueList(attributeList.list :+ AttributeString("new")))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("splat"), AttributeString("new")))).attributes.get(AttributeName.withDefaultNS("splat"))
+      services.entityService
+        .applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("splat"), AttributeString("new"))))
+        .attributes
+        .get(AttributeName.withDefaultNS("splat"))
     }
   }
 
   it should "add item to non-existing list in entity" in withTestDataServices { services =>
     assertResult(Some(AttributeValueList(Seq(AttributeString("new"))))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("bob"), AttributeString("new")))).attributes.get(AttributeName.withDefaultNS("bob"))
+      services.entityService
+        .applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("bob"), AttributeString("new"))))
+        .attributes
+        .get(AttributeName.withDefaultNS("bob"))
     }
   }
 
-  it should "throw AttributeUpdateOperationException when trying to create a new empty list by inserting AttributeNull" in withTestDataServices { services =>
-    intercept[AttributeUpdateOperationException] {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("nolisthere"), AttributeNull))).attributes.get(AttributeName.withDefaultNS("nolisthere"))
-    }
+  it should "throw AttributeUpdateOperationException when trying to create a new empty list by inserting AttributeNull" in withTestDataServices {
+    services =>
+      intercept[AttributeUpdateOperationException] {
+        services.entityService
+          .applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("nolisthere"), AttributeNull)))
+          .attributes
+          .get(AttributeName.withDefaultNS("nolisthere"))
+      }
   }
 
   it should "create empty AttributeEntityReferenceList" in withTestDataServices { services =>
     assertResult(Some(AttributeEntityReferenceEmptyList)) {
-      services.entityService.applyOperationsToEntity(s1, Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("emptyRefList")))).attributes.get(AttributeName.withDefaultNS("emptyRefList"))
+      services.entityService
+        .applyOperationsToEntity(s1,
+                                 Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("emptyRefList")))
+        )
+        .attributes
+        .get(AttributeName.withDefaultNS("emptyRefList"))
     }
   }
 
-  it should "not wipe existing AttributeEntityReferenceList when calling CreateAttributeEntityReferenceList" in withTestDataServices { services =>
-    assertResult(Some(s1.attributes(AttributeName.withDefaultNS("refs")))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("refs")))).attributes.get(AttributeName.withDefaultNS("refs"))
-    }
+  it should "not wipe existing AttributeEntityReferenceList when calling CreateAttributeEntityReferenceList" in withTestDataServices {
+    services =>
+      assertResult(Some(s1.attributes(AttributeName.withDefaultNS("refs")))) {
+        services.entityService
+          .applyOperationsToEntity(s1, Seq(CreateAttributeEntityReferenceList(AttributeName.withDefaultNS("refs"))))
+          .attributes
+          .get(AttributeName.withDefaultNS("refs"))
+      }
   }
 
   it should "create empty AttributeValueList" in withTestDataServices { services =>
     assertResult(Some(AttributeValueEmptyList)) {
-      services.entityService.applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("emptyValList")))).attributes.get(AttributeName.withDefaultNS("emptyValList"))
+      services.entityService
+        .applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("emptyValList"))))
+        .attributes
+        .get(AttributeName.withDefaultNS("emptyValList"))
     }
   }
 
-  it should "not wipe existing AttributeValueList when calling CreateAttributeValueList" in withTestDataServices { services =>
-    assertResult(Some(s1.attributes(AttributeName.withDefaultNS("splat")))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("splat")))).attributes.get(AttributeName.withDefaultNS("splat"))
-    }
+  it should "not wipe existing AttributeValueList when calling CreateAttributeValueList" in withTestDataServices {
+    services =>
+      assertResult(Some(s1.attributes(AttributeName.withDefaultNS("splat")))) {
+        services.entityService
+          .applyOperationsToEntity(s1, Seq(CreateAttributeValueList(AttributeName.withDefaultNS("splat"))))
+          .attributes
+          .get(AttributeName.withDefaultNS("splat"))
+      }
   }
 
   it should "do nothing to existing lists when adding AttributeNull" in withTestDataServices { services =>
     assertResult(Some(attributeList)) {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("splat"), AttributeNull))).attributes.get(AttributeName.withDefaultNS("splat"))
+      services.entityService
+        .applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("splat"), AttributeNull)))
+        .attributes
+        .get(AttributeName.withDefaultNS("splat"))
     }
   }
 
   it should "remove item from existing listing entity" in withTestDataServices { services =>
     assertResult(Some(AttributeValueList(Seq(AttributeString("b"), AttributeBoolean(true))))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(RemoveListMember(AttributeName.withDefaultNS("splat"), AttributeString("a")))).attributes.get(AttributeName.withDefaultNS("splat"))
+      services.entityService
+        .applyOperationsToEntity(s1, Seq(RemoveListMember(AttributeName.withDefaultNS("splat"), AttributeString("a"))))
+        .attributes
+        .get(AttributeName.withDefaultNS("splat"))
     }
   }
 
-  it should "throw AttributeNotFoundException when removing from a list that does not exist" in withTestDataServices { services =>
-    intercept[AttributeNotFoundException] {
-      services.entityService.applyOperationsToEntity(s1, Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a"))))
-    }
+  it should "throw AttributeNotFoundException when removing from a list that does not exist" in withTestDataServices {
+    services =>
+      intercept[AttributeNotFoundException] {
+        services.entityService.applyOperationsToEntity(
+          s1,
+          Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a")))
+        )
+      }
   }
 
-  it should "throw AttributeUpdateOperationException when remove from an attribute that is not a list" in withTestDataServices { services =>
-    intercept[AttributeUpdateOperationException] {
-      services.entityService.applyOperationsToEntity(s1, Seq(RemoveListMember(AttributeName.withDefaultNS("foo"), AttributeString("a"))))
-    }
+  it should "throw AttributeUpdateOperationException when remove from an attribute that is not a list" in withTestDataServices {
+    services =>
+      intercept[AttributeUpdateOperationException] {
+        services.entityService.applyOperationsToEntity(
+          s1,
+          Seq(RemoveListMember(AttributeName.withDefaultNS("foo"), AttributeString("a")))
+        )
+      }
   }
 
-  it should "throw AttributeUpdateOperationException when adding to an attribute that is not a list" in withTestDataServices { services =>
-    intercept[AttributeUpdateOperationException] {
-      services.entityService.applyOperationsToEntity(s1, Seq(AddListMember(AttributeName.withDefaultNS("foo"), AttributeString("a"))))
-    }
+  it should "throw AttributeUpdateOperationException when adding to an attribute that is not a list" in withTestDataServices {
+    services =>
+      intercept[AttributeUpdateOperationException] {
+        services.entityService.applyOperationsToEntity(
+          s1,
+          Seq(AddListMember(AttributeName.withDefaultNS("foo"), AttributeString("a")))
+        )
+      }
   }
 
   it should "apply attribute updates in order to entity" in withTestDataServices { services =>
     assertResult(Some(AttributeString("splat"))) {
-      services.entityService.applyOperationsToEntity(s1, Seq(
-        AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")),
-        AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")),
-        AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("splat"))
-      )).attributes.get(AttributeName.withDefaultNS("newAttribute"))
+      services.entityService
+        .applyOperationsToEntity(
+          s1,
+          Seq(
+            AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")),
+            AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")),
+            AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("splat"))
+          )
+        )
+        .attributes
+        .get(AttributeName.withDefaultNS("newAttribute"))
     }
   }
 
-  it should "fail to rename an entity type to a name already in use"  in withTestDataServices { services =>
+  it should "fail to rename an entity type to a name already in use" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     val ex = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, EntityTypeRename(testData.pair1.entityType)), waitDuration)
+      Await.result(services.entityService.renameEntityType(testData.wsName,
+                                                           testData.pair1.entityType,
+                                                           EntityTypeRename(testData.pair1.entityType)
+                   ),
+                   waitDuration
+      )
     }
     ex.errorReport.message shouldBe "Pair already exists as an entity type"
   }
 
-  it should "rename an entity type as long as the selected name is not in use"  in withTestDataServices { services =>
+  it should "rename an entity type as long as the selected name is not in use" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
-    assertResult(2) {Await.result(services.entityService.renameEntityType(testData.wsName, testData.pair1.entityType, EntityTypeRename("newPair")), waitDuration)}
+    assertResult(2) {
+      Await.result(services.entityService.renameEntityType(testData.wsName,
+                                                           testData.pair1.entityType,
+                                                           EntityTypeRename("newPair")
+                   ),
+                   waitDuration
+      )
+    }
     // verify there are no longer any entities under the old entity name
-    val queryResult = Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
+    val queryResult =
+      Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
     assert(queryResult.isEmpty)
   }
 
   it should "throw an error when trying to rename entity that does not exist" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     val ex = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.entityService.renameEntityType(testData.wsName, "non-existent-type", EntityTypeRename("new-name")), waitDuration)
+      Await.result(
+        services.entityService.renameEntityType(testData.wsName, "non-existent-type", EntityTypeRename("new-name")),
+        waitDuration
+      )
     }
     ex.errorReport.message shouldBe "Can't find entity type non-existent-type"
     ex.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
   }
 
-
-  it should "respect page size limits for listEntities"  in withTestDataServices { services =>
+  it should "respect page size limits for listEntities" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
 
     // the entityServiceConstructor inside TestApiService sets a pageSizeLimit of 7, so:
@@ -238,7 +380,7 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
     }
   }
 
-  it should "respect page size limits for queryEntities"  in withTestDataServices { services =>
+  it should "respect page size limits for queryEntities" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
 
     // the entityServiceConstructor inside TestApiService sets a pageSizeLimit of 7, so:
@@ -246,8 +388,11 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
     List(1, 5, 6, 7) foreach { pageSize =>
       withClue(s"for page size '$pageSize':") {
         val entityQuery = EntityQuery(1, pageSize, "name", SortDirections.Ascending, None)
-        val queryResult = Await.result(services.entityService.queryEntities(testData.wsName, None, testData.sample1.entityType, entityQuery, None), waitDuration)
-        queryResult.results should not be (empty)
+        val queryResult = Await.result(
+          services.entityService.queryEntities(testData.wsName, None, testData.sample1.entityType, entityQuery, None),
+          waitDuration
+        )
+        queryResult.results should not be empty
       }
     }
     // these should fail
@@ -255,44 +400,67 @@ class EntityServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matcher
       withClue(s"for page size '$pageSize':") {
         val entityQuery = EntityQuery(1, pageSize, "name", SortDirections.Ascending, None)
         val ex = intercept[RawlsExceptionWithErrorReport] {
-          Await.result(services.entityService.queryEntities(testData.wsName, None, testData.sample1.entityType, entityQuery, None), waitDuration)
+          Await.result(
+            services.entityService.queryEntities(testData.wsName, None, testData.sample1.entityType, entityQuery, None),
+            waitDuration
+          )
         }
         ex.errorReport.message shouldBe "Page size cannot exceed 7"
       }
     }
   }
 
-  it should "fail to rename an attribute name to a name already in use"  in withTestDataServices { services =>
+  it should "fail to rename an attribute name to a name already in use" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     val ex = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.entityService.renameAttribute(testData.wsName, testData.pair1.entityType,
-        AttributeName.withDefaultNS("case"), AttributeRename(AttributeName.withDefaultNS("control"))), waitDuration)
+      Await.result(
+        services.entityService.renameAttribute(testData.wsName,
+                                               testData.pair1.entityType,
+                                               AttributeName.withDefaultNS("case"),
+                                               AttributeRename(AttributeName.withDefaultNS("control"))
+        ),
+        waitDuration
+      )
     }
     ex.errorReport.message shouldBe "control already exists as an attribute name"
     ex.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
   }
 
-  it should "rename an attribute name as long as the selected name is not in use"  in withTestDataServices { services =>
+  it should "rename an attribute name as long as the selected name is not in use" in withTestDataServices { services =>
     val oldAttributeName = AttributeName.withDefaultNS("case")
     val waitDuration = Duration(10, SECONDS)
-    val rowsUpdated = Await.result(services.entityService.renameAttribute(testData.wsName, testData.pair1.entityType,
-      oldAttributeName, AttributeRename(AttributeName.withDefaultNS("newAttributeName"))), waitDuration)
+    val rowsUpdated = Await.result(
+      services.entityService.renameAttribute(testData.wsName,
+                                             testData.pair1.entityType,
+                                             oldAttributeName,
+                                             AttributeRename(AttributeName.withDefaultNS("newAttributeName"))
+      ),
+      waitDuration
+    )
     rowsUpdated shouldBe 2
 
     // verify there are no longer any attributes under the old attribute name
-    val queryResult = Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
+    val queryResult =
+      Await.result(services.entityService.listEntities(testData.wsName, testData.pair1.entityType), waitDuration)
     queryResult map { entity =>
       entity.attributes.keySet shouldNot contain(oldAttributeName)
     }
   }
 
-  it should "throw an error when trying to rename an attribute that does not exist" in withTestDataServices { services =>
-    val waitDuration = Duration(10, SECONDS)
-    val ex = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.entityService.renameAttribute(testData.wsName, testData.pair1.entityType,
-        AttributeName.withDefaultNS("non-existent-attribute"), AttributeRename(AttributeName.withDefaultNS("any"))), waitDuration)
-    }
-    ex.errorReport.message shouldBe "Can't find attribute name non-existent-attribute"
-    ex.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
+  it should "throw an error when trying to rename an attribute that does not exist" in withTestDataServices {
+    services =>
+      val waitDuration = Duration(10, SECONDS)
+      val ex = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(
+          services.entityService.renameAttribute(testData.wsName,
+                                                 testData.pair1.entityType,
+                                                 AttributeName.withDefaultNS("non-existent-attribute"),
+                                                 AttributeRename(AttributeName.withDefaultNS("any"))
+          ),
+          waitDuration
+        )
+      }
+      ex.errorReport.message shouldBe "Can't find attribute name non-existent-attribute"
+      ex.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
@@ -5,11 +5,26 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleBigQueryServiceFactory,
+  MockBigQueryServiceFactory,
+  SlickDataSource
+}
 import org.broadinstitute.dsde.rawls.metrics.StatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, RemoveAttribute}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNumber, AttributeString, AttributeValueList, Entity, RawlsRequestContext, RawlsUser, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
+  AttributeName,
+  AttributeNumber,
+  AttributeString,
+  AttributeValueList,
+  Entity,
+  RawlsRequestContext,
+  RawlsUser,
+  UserInfo,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, MockitoTestUtils}
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
@@ -20,15 +35,24 @@ import org.scalatest.matchers.should.Matchers
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 
-class EntityShardingSpec extends AnyFlatSpec with Matchers
-  with ScalaFutures with IntegrationPatience
-  with TestDriverComponent with AttributeSupport
-  with StatsDTestUtils with Eventually with MockitoTestUtils {
+class EntityShardingSpec
+    extends AnyFlatSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with TestDriverComponent
+    with AttributeSupport
+    with StatsDTestUtils
+    with Eventually
+    with MockitoTestUtils {
 
   import driver.api._
 
-  //noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
-  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit val executionContext: ExecutionContext) extends EntityApiService with MockUserInfoDirectivesWithUser {
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends EntityApiService
+      with MockUserInfoDirectivesWithUser {
     private val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
     lazy val entityService: EntityService = entityServiceConstructor(ctx1)
 
@@ -45,9 +69,18 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
       slickDataSource,
       samDAO,
       workbenchMetricBaseName = "test",
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO("mockrepo"), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"), workbenchMetricBaseName),
-     1000
-    )_
+      EntityManager.defaultEntityManager(
+        dataSource,
+        new MockWorkspaceManagerDAO(),
+        new MockDataRepoDAO("mockrepo"),
+        samDAO,
+        bigQueryServiceFactory,
+        DataRepoEntityProviderConfig(100, 10, 0),
+        testConf.getBoolean("entityStatisticsCache.enabled"),
+        workbenchMetricBaseName
+      ),
+      1000
+    ) _
   }
 
   val testWorkspace = new EmptyWorkspace
@@ -55,17 +88,21 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
   val testWorkspaceShardId = determineShard(testWorkspace.workspace.workspaceIdAsUUID)
 
   val attributeList = AttributeValueList(Seq(AttributeString("a"), AttributeString("b"), AttributeString("c")))
-  val s1 = Entity("s1", "samples", Map(
-    AttributeName.withDefaultNS("foo") -> AttributeString("x"),
-    AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
-    AttributeName.withDefaultNS("bool") -> AttributeBoolean(false),
-    AttributeName.withDefaultNS("splat") -> attributeList))
+  val s1 = Entity(
+    "s1",
+    "samples",
+    Map(
+      AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+      AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+      AttributeName.withDefaultNS("bool") -> AttributeBoolean(false),
+      AttributeName.withDefaultNS("splat") -> attributeList
+    )
+  )
 
-  def withTestDataServices[T](testCode: TestApiService => T): T = {
+  def withTestDataServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(testWorkspace) { dataSource: SlickDataSource =>
       withServices(dataSource, testWorkspace.userOwner)(testCode)
     }
-  }
 
   private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: TestApiService => T): T = {
     val apiService = new TestApiService(dataSource, user)
@@ -75,21 +112,21 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
   // checks row counts for each shard
   def checkShardCounts(expected: Map[ShardId, Int] = Map()): Unit = {
     // default to 0 for all shards
-    val default: Map[ShardId, Int] = (allShards).map(_ -> 0).toMap
+    val default: Map[ShardId, Int] = allShards.map(_ -> 0).toMap
     val combined = default ++ expected
-    combined.foreach {
-      case (shardId, expectedCount) =>
-        val actualCount = runAndWait(uniqueResult(sql"select count(1) from ENTITY_ATTRIBUTE_#$shardId".as[Int]))
-          .getOrElse(throw new Exception("did not return a count!"))
-        withClue(s"for table ENTITY_ATTRIBUTE_$shardId, actual row count of ") {
-          actualCount shouldBe expectedCount
-        }
+    combined.foreach { case (shardId, expectedCount) =>
+      val actualCount = runAndWait(uniqueResult(sql"select count(1) from ENTITY_ATTRIBUTE_#$shardId".as[Int]))
+        .getOrElse(throw new Exception("did not return a count!"))
+      withClue(s"for table ENTITY_ATTRIBUTE_$shardId, actual row count of ") {
+        actualCount shouldBe expectedCount
+      }
     }
   }
 
   // tests start with an empty workspace
-  "Entity attribute sharding" should "start with zero rows in each shard and the archive table" in withTestDataServices { _ =>
-    checkShardCounts()
+  "Entity attribute sharding" should "start with zero rows in each shard and the archive table" in withTestDataServices {
+    _ =>
+      checkShardCounts()
   }
 
   it should "only insert rows into the workspace's shard" in withTestDataServices { services =>
@@ -104,8 +141,9 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
 
     checkShardCounts(Map(testWorkspaceShardId -> 6)) // 3 scalar attributes, 1 list attribute with 3 values
 
-    services.entityService.updateEntity(testWorkspaceName, s1.entityType, s1.name,
-      Seq(RemoveAttribute(AttributeName.withDefaultNS("bar")))).futureValue
+    services.entityService
+      .updateEntity(testWorkspaceName, s1.entityType, s1.name, Seq(RemoveAttribute(AttributeName.withDefaultNS("bar"))))
+      .futureValue
 
     withClue("after removing an attribute value") {
       checkShardCounts(Map(testWorkspaceShardId -> 5)) // we removed one attribute
@@ -118,14 +156,21 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
 
     checkShardCounts(Map(testWorkspaceShardId -> 6)) // 3 scalar attributes, 1 list attribute with 3 values
 
-    services.entityService.updateEntity(testWorkspaceName, s1.entityType, s1.name,
-      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("bar"), AttributeNumber(99)))).futureValue
+    services.entityService
+      .updateEntity(testWorkspaceName,
+                    s1.entityType,
+                    s1.name,
+                    Seq(AddUpdateAttribute(AttributeName.withDefaultNS("bar"), AttributeNumber(99)))
+      )
+      .futureValue
 
     withClue("after updating an attribute value") {
       checkShardCounts(Map(testWorkspaceShardId -> 6)) // update should keep row counts the same
     }
 
-    val updatedDbValue = runAndWait(uniqueResult(sql"select value_number from ENTITY_ATTRIBUTE_#$testWorkspaceShardId where name='bar'".as[Int]))
+    val updatedDbValue = runAndWait(
+      uniqueResult(sql"select value_number from ENTITY_ATTRIBUTE_#$testWorkspaceShardId where name='bar'".as[Int])
+    )
 
     withClue("when checking the updated attribute value") {
       updatedDbValue should contain(99)
@@ -136,19 +181,30 @@ class EntityShardingSpec extends AnyFlatSpec with Matchers
     // the empty workspace was created with a random uuid. find another uuid that does not have the same
     // shard identifier.
     var tempId: UUID = UUID.randomUUID()
-    while (determineShard(tempId) == testWorkspaceShardId) {
+    while (determineShard(tempId) == testWorkspaceShardId)
       tempId = UUID.randomUUID()
-    }
     val secondWorkspaceId = UUID.fromString(tempId.toString)
     val secondShardId = determineShard(secondWorkspaceId)
     secondShardId should not be testWorkspaceShardId
-    val anotherWorkspace = Workspace("secondnamespace", "secondname", secondWorkspaceId.toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val anotherWorkspace = Workspace("secondnamespace",
+                                     "secondname",
+                                     secondWorkspaceId.toString,
+                                     "aBucket",
+                                     Some("workflow-collection"),
+                                     currentTime(),
+                                     currentTime(),
+                                     "testUser",
+                                     Map.empty
+    )
 
     val secondWorkspace = runAndWait(workspaceQuery.createOrUpdate(anotherWorkspace))
 
-    val s2 = Entity("s2", "samples", Map(
-    AttributeName.withDefaultNS("one") -> AttributeString("111"),
-    AttributeName.withDefaultNS("two") -> AttributeNumber(222)))
+    val s2 = Entity("s2",
+                    "samples",
+                    Map(AttributeName.withDefaultNS("one") -> AttributeString("111"),
+                        AttributeName.withDefaultNS("two") -> AttributeNumber(222)
+                    )
+    )
 
     // create entity in testWorkspace (entity s1 has 6 attribute rows)
     val created = services.entityService.createEntity(testWorkspaceName, s1).futureValue

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderBuilderSpec.scala
@@ -13,9 +13,14 @@ import org.scalatest.matchers.should.Matchers
 import java.util.UUID
 import scala.util.Failure
 
-class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityProviderSpecSupport with TestDriverComponent with Matchers {
-  override implicit val executionContext = TestExecutionContext.testExecutionContext
-  val defaultEntityRequestArguments = EntityRequestArguments(workspace, testContext, Some(DataReferenceName("referenceName")))
+class DataRepoEntityProviderBuilderSpec
+    extends AnyFlatSpec
+    with DataRepoEntityProviderSpecSupport
+    with TestDriverComponent
+    with Matchers {
+  implicit override val executionContext = TestExecutionContext.testExecutionContext
+  val defaultEntityRequestArguments =
+    EntityRequestArguments(workspace, testContext, Some(DataReferenceName("referenceName")))
 
   behavior of "DataRepoEntityProviderBuilder.build()"
 
@@ -28,31 +33,34 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
   it should "error if data reference not defined" in {
     val builder = createTestBuilder()
 
-    val ex = intercept[DataEntityException] { builder.build(defaultEntityRequestArguments.copy(dataReference = None)).get }
-    assertResult( "data reference must be defined for this provider" ) { ex.getMessage }
+    val ex = intercept[DataEntityException] {
+      builder.build(defaultEntityRequestArguments.copy(dataReference = None)).get
+    }
+    assertResult("data reference must be defined for this provider")(ex.getMessage)
   }
 
   it should "bubble up error if workspace manager errors" in {
     val expectedException = new bio.terra.workspace.client.ApiException("whoops 1")
-    val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Left(expectedException)))
+    val builder = createTestBuilder(workspaceManagerDAO = new SpecWorkspaceManagerDAO(Left(expectedException)))
 
     builder.build(defaultEntityRequestArguments) shouldBe Failure(expectedException)
   }
 
   it should "bubble up error if data repo errors" in {
     val expectedException = new bio.terra.datarepo.client.ApiException("whoops 2")
-    val builder = createTestBuilder(
-      dataRepoDAO = new SpecDataRepoDAO(Left(expectedException)))
+    val builder = createTestBuilder(dataRepoDAO = new SpecDataRepoDAO(Left(expectedException)))
 
     builder.build(defaultEntityRequestArguments) shouldBe Failure(expectedException)
   }
 
   it should "bubble up snapshot does not exist error as DataEntityException" in {
     val builder = createTestBuilder(
-      dataRepoDAO = new SpecDataRepoDAO(Left(new bio.terra.datarepo.client.ApiException(StatusCodes.NotFound.intValue, "not found"))))
+      dataRepoDAO = new SpecDataRepoDAO(
+        Left(new bio.terra.datarepo.client.ApiException(StatusCodes.NotFound.intValue, "not found"))
+      )
+    )
 
-    intercept[DataEntityException] { builder.build(defaultEntityRequestArguments).get }
+    intercept[DataEntityException](builder.build(defaultEntityRequestArguments).get)
   }
 
   it should "bubble up lookupSnapshotForName error" in {
@@ -60,8 +68,10 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
       workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(resourceType = null)))
     )
 
-    val ex = intercept[DataEntityException] { builder.build(defaultEntityRequestArguments).get }
-    assertResult( s"Reference type value for referenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
+    val ex = intercept[DataEntityException](builder.build(defaultEntityRequestArguments).get)
+    assertResult(s"Reference type value for referenceName is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}") {
+      ex.getMessage
+    }
   }
 
   behavior of "DataRepoEntityProviderBuilder.lookupSnapshotForName()"
@@ -71,9 +81,7 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     // isn't mistakenly passing by using defaults where it shouldn't
     val randomName = scala.util.Random.alphanumeric.take(16).mkString
 
-    val expected = createDataRepoSnapshotResource(
-      name = randomName,
-      refSnapshot = UUID.randomUUID().toString)
+    val expected = createDataRepoSnapshotResource(name = randomName, refSnapshot = UUID.randomUUID().toString)
 
     val builder = createTestBuilder(
       workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(expected))
@@ -82,15 +90,18 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
     // NB see comment in SpecWorkspaceManagerDAO; the name we use for lookup is ignored
     val actual = builder.lookupSnapshotForName(DataReferenceName(randomName), defaultEntityRequestArguments)
 
-    assertResult(expected) { actual }
+    assertResult(expected)(actual)
   }
 
-  it should "bubble up error if workspace manager errors" in  {
+  it should "bubble up error if workspace manager errors" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Left(new bio.terra.workspace.client.ApiException("whoops 1"))))
+      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Left(new bio.terra.workspace.client.ApiException("whoops 1")))
+    )
 
-    val ex = intercept[bio.terra.workspace.client.ApiException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
-    assertResult("whoops 1") { ex.getMessage }
+    val ex = intercept[bio.terra.workspace.client.ApiException] {
+      builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments)
+    }
+    assertResult("whoops 1")(ex.getMessage)
   }
 
   it should "error if workspace manager returns a non-snapshot reference type" in {
@@ -98,25 +109,35 @@ class DataRepoEntityProviderBuilderSpec extends AnyFlatSpec with DataRepoEntityP
       workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(resourceType = null)))
     )
 
-    val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
-    assertResult( s"Reference type value for foo is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}" ) { ex.getMessage }
+    val ex = intercept[DataEntityException] {
+      builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments)
+    }
+    assertResult(s"Reference type value for foo is not of type ${ResourceType.DATA_REPO_SNAPSHOT.getValue}") {
+      ex.getMessage
+    }
   }
 
   it should "error if workspace manager reference json `instanceName` value does not match DataRepoDAO's base url" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(refInstanceName = "this is wrong")))
+      workspaceManagerDAO =
+        new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(refInstanceName = "this is wrong")))
     )
 
-    val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
-    assertResult("Reference value for foo contains an unexpected instance name value") { ex.getMessage }
+    val ex = intercept[DataEntityException] {
+      builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments)
+    }
+    assertResult("Reference value for foo contains an unexpected instance name value")(ex.getMessage)
   }
 
   it should "error if workspace manager reference json `snapshot` value is not a valid UUID" in {
     val builder = createTestBuilder(
-      workspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(refSnapshot = "this is not a uuid")))
+      workspaceManagerDAO =
+        new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource(refSnapshot = "this is not a uuid")))
     )
 
-    val ex = intercept[DataEntityException] { builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments) }
-    assertResult("Reference value for foo contains an unexpected snapshot value") { ex.getMessage }
+    val ex = intercept[DataEntityException] {
+      builder.lookupSnapshotForName(DataReferenceName("foo"), defaultEntityRequestArguments)
+    }
+    assertResult("Reference value for foo contains an unexpected snapshot value")(ex.getMessage)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderQueryEntitiesSpec.scala
@@ -8,22 +8,36 @@ import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory
 import org.broadinstitute.dsde.rawls.dataaccess.MockBigQueryServiceFactory.{createKeyList, createTestTableResult}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityTypeNotFoundException, UnsupportedEntityOperationException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  EntityTypeNotFoundException,
+  UnsupportedEntityOperationException
+}
 import org.broadinstitute.dsde.rawls.model._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.jdk.CollectionConverters._
 
-class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRepoEntityProviderSpecSupport with TestDriverComponent with Matchers {
+class DataRepoEntityProviderQueryEntitiesSpec
+    extends AsyncFlatSpec
+    with DataRepoEntityProviderSpecSupport
+    with TestDriverComponent
+    with Matchers {
 
-  override implicit val executionContext = TestExecutionContext.testExecutionContext
+  implicit override val executionContext = TestExecutionContext.testExecutionContext
 
-  val defaultEntityRequestArguments = EntityRequestArguments(workspace, testContext, Some(DataReferenceName("referenceName")))
+  val defaultEntityRequestArguments =
+    EntityRequestArguments(workspace, testContext, Some(DataReferenceName("referenceName")))
 
   behavior of "DataEntityProvider.queryEntities()"
 
-  val defaultEntityQuery: EntityQuery = EntityQuery(page = 1, pageSize = 10, sortField = "datarepo_row_id", sortDirection = SortDirections.Ascending, filterTerms = None)
+  val defaultEntityQuery: EntityQuery = EntityQuery(page = 1,
+                                                    pageSize = 10,
+                                                    sortField = "datarepo_row_id",
+                                                    sortDirection = SortDirections.Ascending,
+                                                    filterTerms = None
+  )
 
   it should "return one entity if all OK and BQ returned one" in {
 
@@ -33,15 +47,23 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
 
     provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
       // this is the default expected value, should it move to the support trait?
-      val expected = Seq(Entity("Row0", "table1", Map(
-        AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString("Row0"),
-        AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
-        AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
-        AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
-      )))
-      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
-      assertResult(expected) { entityQueryResponse.results }
+      val expected = Seq(
+        Entity(
+          "Row0",
+          "table1",
+          Map(
+            AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString("Row0"),
+            AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+            AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+            AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+          )
+        )
+      )
+      assertResult(defaultEntityQuery)(entityQueryResponse.parameters)
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) {
+        entityQueryResponse.resultMetadata
+      }
+      assertResult(expected)(entityQueryResponse.results)
     }
   }
 
@@ -51,17 +73,23 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
 
     provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
       // this is the default expected value, should it move to the support trait?
-      val expected = createKeyList(3) map { stringKey  =>
-        Entity(stringKey, "table1", Map(
-          AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString(stringKey),
-          AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
-          AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
-          AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
-        ))
+      val expected = createKeyList(3) map { stringKey =>
+        Entity(
+          stringKey,
+          "table1",
+          Map(
+            AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString(stringKey),
+            AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+            AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+            AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+          )
+        )
       }
-      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
-      assertResult(expected) { entityQueryResponse.results }
+      assertResult(defaultEntityQuery)(entityQueryResponse.parameters)
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) {
+        entityQueryResponse.resultMetadata
+      }
+      assertResult(expected)(entityQueryResponse.results)
     }
   }
 
@@ -91,17 +119,25 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
       // this is the default expected value, should it move to the support trait?
       val expected = Seq.empty[Entity]
-      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
-      assertResult(expected) { entityQueryResponse.results }
+      assertResult(defaultEntityQuery)(entityQueryResponse.parameters)
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 10, filteredCount = 10, filteredPageCount = 1)) {
+        entityQueryResponse.resultMetadata
+      }
+      assertResult(expected)(entityQueryResponse.results)
     }
   }
 
   it should "return empty Seq and appropriate metadata if Data Repo indicates zero rows" in {
     val emptyTables: List[TableModel] = List(
-      new TableModel().name("table1").primaryKey(null).rowCount(0)
+      new TableModel()
+        .name("table1")
+        .primaryKey(null)
+        .rowCount(0)
         .columns(List("integer-field", "boolean-field", "timestamp-field").map(new ColumnModel().name(_)).asJava),
-      new TableModel().name("table2").primaryKey(List("table2PK").asJava).rowCount(123)
+      new TableModel()
+        .name("table2")
+        .primaryKey(List("table2PK").asJava)
+        .rowCount(123)
         .columns(List("col2a", "col2b").map(new ColumnModel().name(_)).asJava)
     )
 
@@ -110,18 +146,26 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     provider.queryEntities("table1", defaultEntityQuery) map { entityQueryResponse: EntityQueryResponse =>
       // this is the default expected value, should it move to the support trait?
       val expected = Seq.empty[Entity]
-      assertResult(defaultEntityQuery) { entityQueryResponse.parameters }
-      assertResult(EntityQueryResultMetadata(unfilteredCount = 0, filteredCount = 0, filteredPageCount = 1)) { entityQueryResponse.resultMetadata }
-      assertResult(expected) { entityQueryResponse.results }
+      assertResult(defaultEntityQuery)(entityQueryResponse.parameters)
+      assertResult(EntityQueryResultMetadata(unfilteredCount = 0, filteredCount = 0, filteredPageCount = 1)) {
+        entityQueryResponse.resultMetadata
+      }
+      assertResult(expected)(entityQueryResponse.results)
     }
   }
 
-  List (2,10,42,Integer.MAX_VALUE) foreach { x =>
+  List(2, 10, 42, Integer.MAX_VALUE) foreach { x =>
     it should s"throw bad request if Data Repo indicates zero rows and user requested page > 1 (requested page: $x)" in {
       val emptyTables: List[TableModel] = List(
-        new TableModel().name("table1").primaryKey(null).rowCount(0)
+        new TableModel()
+          .name("table1")
+          .primaryKey(null)
+          .rowCount(0)
           .columns(List("integer-field", "boolean-field", "timestamp-field").map(new ColumnModel().name(_)).asJava),
-        new TableModel().name("table2").primaryKey(List("table2PK").asJava).rowCount(123)
+        new TableModel()
+          .name("table2")
+          .primaryKey(List("table2PK").asJava)
+          .rowCount(123)
           .columns(List("col2a", "col2b").map(new ColumnModel().name(_)).asJava)
       )
 
@@ -137,14 +181,15 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
   }
 
   it should "fail if pet credentials not available from Sam" in {
-    val provider = createTestProvider(
-      samDAO = new SpecSamDAO(petKeyForUserResponse = Left(new Exception("sam error"))))
+    val provider = createTestProvider(samDAO = new SpecSamDAO(petKeyForUserResponse = Left(new Exception("sam error"))))
 
     val futureEx = recoverToExceptionIf[Exception] {
       provider.queryEntities("table1", defaultEntityQuery)
     }
     futureEx map { ex =>
-      assertResult(s"Error attempting to use project ${provider.googleProject}. The project does not exist or you do not have permission to use it: sam error") { ex.getMessage }
+      assertResult(
+        s"Error attempting to use project ${provider.googleProject}. The project does not exist or you do not have permission to use it: sam error"
+      )(ex.getMessage)
     }
   }
 
@@ -154,10 +199,10 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     val ex = intercept[DataEntityException] {
       provider.queryEntities("table1", defaultEntityQuery.copy(sortField = "unknownColumn"))
     }
-    assertResult("sortField not valid for this entity type") { ex.getMessage }
+    assertResult("sortField not valid for this entity type")(ex.getMessage)
   }
 
-  List (2,10,42,Integer.MAX_VALUE) foreach { x =>
+  List(2, 10, 42, Integer.MAX_VALUE) foreach { x =>
     it should s"throw bad request if the requested page is greater than actual pages (requested page: $x)" in {
       val provider = createTestProvider()
 
@@ -170,14 +215,14 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     }
   }
 
-  List (0,-1,-42,Integer.MIN_VALUE) foreach { x =>
+  List(0, -1, -42, Integer.MIN_VALUE) foreach { x =>
     it should s"throw bad request if the requested page is less than 1 (requested page: $x)" in {
       val provider = createTestProvider()
 
       val ex = intercept[DataEntityException] {
         provider.queryEntities("table1", defaultEntityQuery.copy(page = x))
       }
-      assertResult("page value must be at least 1.") { ex.getMessage }
+      assertResult("page value must be at least 1.")(ex.getMessage)
     }
   }
 
@@ -187,7 +232,7 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     val ex = intercept[UnsupportedEntityOperationException] {
       provider.queryEntities("table1", defaultEntityQuery.copy(filterTerms = Some("my filter terms")))
     }
-    assertResult("term filtering not supported by this provider.") { ex.getMessage }
+    assertResult("term filtering not supported by this provider.")(ex.getMessage)
   }
 
   ignore should "fail if user is a workspace Reader but did not specify a billing project (canCompute?)" in {
@@ -197,13 +242,12 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
   }
 
   it should "fail if snapshot has no tables in data repo" in {
-    val provider = createTestProvider(
-      snapshotModel = createSnapshotModel( List.empty[TableModel] ))
+    val provider = createTestProvider(snapshotModel = createSnapshotModel(List.empty[TableModel]))
 
     val ex = intercept[EntityTypeNotFoundException] {
       provider.queryEntities("table1", defaultEntityQuery)
     }
-    assertResult("table1") { ex.requestedType }
+    assertResult("table1")(ex.requestedType)
   }
 
   it should "fail if snapshot table not found in data repo's response" in {
@@ -212,23 +256,20 @@ class DataRepoEntityProviderQueryEntitiesSpec extends AsyncFlatSpec with DataRep
     val ex = intercept[EntityTypeNotFoundException] {
       provider.queryEntities("this_table_is_unknown", defaultEntityQuery)
     }
-    assertResult("this_table_is_unknown") { ex.requestedType }
+    assertResult("this_table_is_unknown")(ex.requestedType)
   }
 
   it should "bubble up error if BigQuery errors" in {
     val provider = createTestProvider(
-      bqFactory = MockBigQueryServiceFactory.ioFactory(Left(new BigQueryException(555, "unit test exception message"))))
+      bqFactory = MockBigQueryServiceFactory.ioFactory(Left(new BigQueryException(555, "unit test exception message")))
+    )
 
     val futureEx = recoverToExceptionIf[BigQueryException] {
       provider.queryEntities("table1", defaultEntityQuery)
     }
     futureEx map { ex =>
-      assertResult("unit test exception message") { ex.getMessage }
+      assertResult("unit test exception message")(ex.getMessage)
     }
   }
 
-
 }
-
-
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -14,10 +14,27 @@ import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.ExpressionAndResult
 import org.broadinstitute.dsde.rawls.entities.datarepo.DataRepoBigQuerySupport._
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, EntityNotFoundException, EntityTypeNotFoundException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  EntityNotFoundException,
+  EntityTypeNotFoundException
+}
 import org.broadinstitute.dsde.rawls.expressions.parser.antlr.ParsedEntityLookupExpression
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNumber, AttributeString, AttributeValue, AttributeValueRawJson, DataReferenceName, Entity, EntityTypeMetadata, GoogleProjectId, SubmissionValidationEntityInputs, SubmissionValidationValue}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
+  AttributeName,
+  AttributeNumber,
+  AttributeString,
+  AttributeValue,
+  AttributeValueRawJson,
+  DataReferenceName,
+  Entity,
+  EntityTypeMetadata,
+  GoogleProjectId,
+  SubmissionValidationEntityInputs,
+  SubmissionValidationValue
+}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.mockserver.model.Header
@@ -31,9 +48,13 @@ import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters._
 import scala.util.{Random, Success}
 
-class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProviderSpecSupport with TestDriverComponent with Matchers {
+class DataRepoEntityProviderSpec
+    extends AsyncFlatSpec
+    with DataRepoEntityProviderSpecSupport
+    with TestDriverComponent
+    with Matchers {
 
-  override implicit val executionContext = TestExecutionContext.testExecutionContext
+  implicit override val executionContext = TestExecutionContext.testExecutionContext
 
   behavior of "DataRepoEntityProvider.googleProject"
 
@@ -41,13 +62,13 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val randStr = java.util.UUID.randomUUID().toString
     val gProject = GoogleProjectId(randStr)
     // arguments include an explicit billingProject
-    val args = EntityRequestArguments(
-      workspace = workspace,
-      ctx = testContext,
-      dataReference = Option(DataReferenceName("referenceName")),
-      billingProject = Option(gProject))
+    val args = EntityRequestArguments(workspace = workspace,
+                                      ctx = testContext,
+                                      dataReference = Option(DataReferenceName("referenceName")),
+                                      billingProject = Option(gProject)
+    )
     val provider = createTestProvider(entityRequestArguments = args)
-    provider.googleProject should be (gProject)
+    provider.googleProject should be(gProject)
   }
 
   it should "use the workspace's project if no explicit project was provided" in {
@@ -55,13 +76,13 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val gProject = GoogleProjectId(randStr)
     val testWorkspace = workspace.copy(googleProjectId = gProject)
     // arguments specify None for billingProject, but pass our random string inside the workspace
-    val args = EntityRequestArguments(
-      workspace = testWorkspace,
-      ctx = testContext,
-      dataReference = Option(DataReferenceName("referenceName")),
-      billingProject = None)
+    val args = EntityRequestArguments(workspace = testWorkspace,
+                                      ctx = testContext,
+                                      dataReference = Option(DataReferenceName("referenceName")),
+                                      billingProject = None
+    )
     val provider = createTestProvider(entityRequestArguments = args)
-    provider.googleProject should be (gProject)
+    provider.googleProject should be(gProject)
   }
 
   behavior of "DataEntityProvider.entityTypeMetadata()"
@@ -82,14 +103,14 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
       val expected = Map(
         ("table1", EntityTypeMetadata(10, "datarepo_row_id", Seq("integer-field", "boolean-field", "timestamp-field"))),
         ("table2", EntityTypeMetadata(123, "table2PK", Seq("col2a", "col2b"))),
-        ("table3", EntityTypeMetadata(456, "datarepo_row_id", Seq("col3.1", "col3.2"))))
-      assertResult(expected) { metadata }
+        ("table3", EntityTypeMetadata(456, "datarepo_row_id", Seq("col3.1", "col3.2")))
+      )
+      assertResult(expected)(metadata)
     }
   }
 
   it should "return an empty Map if data repo snapshot has no tables" in {
-    val provider = createTestProvider(
-      snapshotModel = createSnapshotModel( List.empty[TableModel] ) )
+    val provider = createTestProvider(snapshotModel = createSnapshotModel(List.empty[TableModel]))
 
     provider.entityTypeMetadata() map { metadata: Map[String, EntityTypeMetadata] =>
       assert(metadata.isEmpty, "expected response data to be the empty map")
@@ -101,25 +122,25 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
   it should "use primary key of `datarepo_row_id` if snapshot has null primary key" in {
     val input = new TableModel()
     input.setPrimaryKey(null)
-    assertResult("datarepo_row_id") { createTestProvider().pkFromSnapshotTable(input) }
+    assertResult("datarepo_row_id")(createTestProvider().pkFromSnapshotTable(input))
   }
 
   it should "use primary key of `datarepo_row_id` if snapshot has empty-array primary key" in {
     val input = new TableModel()
     input.setPrimaryKey(List.empty[String].asJava)
-    assertResult("datarepo_row_id") { createTestProvider().pkFromSnapshotTable(input) }
+    assertResult("datarepo_row_id")(createTestProvider().pkFromSnapshotTable(input))
   }
 
   it should "use primary key of `datarepo_row_id` if snapshot has multiple primary keys" in {
     val input = new TableModel()
     input.setPrimaryKey(List("one", "two", "three").asJava)
-    assertResult("datarepo_row_id") { createTestProvider().pkFromSnapshotTable(input) }
+    assertResult("datarepo_row_id")(createTestProvider().pkFromSnapshotTable(input))
   }
 
   it should "use primary key from snapshot if one and only one returned" in {
     val input = new TableModel()
     input.setPrimaryKey(List("singlekey").asJava)
-    assertResult("singlekey") { createTestProvider().pkFromSnapshotTable(input) }
+    assertResult("singlekey")(createTestProvider().pkFromSnapshotTable(input))
   }
 
   // to-do: tests for entity/row counts returned by data repo, once TDR supports this (see DR-1003)
@@ -130,28 +151,34 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val tableRowCount = 1
 
     // set up a provider with a mock that returns exactly one BQ row
-    val provider = createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(createTestTableResult(tableRowCount))))
+    val provider =
+      createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(createTestTableResult(tableRowCount))))
     provider.getEntity("table1", "Row0") map { entity: Entity =>
       // this is the default expected value, should it move to the support trait?
-      val expected = Entity("Row0", "table1", Map(
-        AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString("Row0"),
-        AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
-        AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
-        AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
-      ))
-      assertResult(expected) { entity }
+      val expected = Entity(
+        "Row0",
+        "table1",
+        Map(
+          AttributeName.withDefaultNS("datarepo_row_id") -> AttributeString("Row0"),
+          AttributeName.withDefaultNS("integer-field") -> AttributeNumber(42),
+          AttributeName.withDefaultNS("boolean-field") -> AttributeBoolean(true),
+          AttributeName.withDefaultNS("timestamp-field") -> AttributeString("1408452095.22")
+        )
+      )
+      assertResult(expected)(entity)
     }
   }
 
   it should "fail if pet credentials not available from Sam" in {
-    val provider = createTestProvider(
-      samDAO = new SpecSamDAO(petKeyForUserResponse = Left(new Exception("sam error"))))
+    val provider = createTestProvider(samDAO = new SpecSamDAO(petKeyForUserResponse = Left(new Exception("sam error"))))
 
     val futureEx = recoverToExceptionIf[Exception] {
       provider.getEntity("table1", "Row0")
     }
     futureEx map { ex =>
-      assertResult(s"Error attempting to use project ${provider.googleProject}. The project does not exist or you do not have permission to use it: sam error") { ex.getMessage }
+      assertResult(
+        s"Error attempting to use project ${provider.googleProject}. The project does not exist or you do not have permission to use it: sam error"
+      )(ex.getMessage)
     }
   }
 
@@ -167,18 +194,19 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val ex = intercept[EntityTypeNotFoundException] {
       provider.getEntity("this_table_is_unknown", "Row0")
     }
-    assertResult("this_table_is_unknown") { ex.requestedType }
+    assertResult("this_table_is_unknown")(ex.requestedType)
   }
 
   it should "bubble up error if BigQuery errors" in {
     val provider = createTestProvider(
-      bqFactory = MockBigQueryServiceFactory.ioFactory(Left(new BigQueryException(555, "unit test exception message"))))
+      bqFactory = MockBigQueryServiceFactory.ioFactory(Left(new BigQueryException(555, "unit test exception message")))
+    )
 
     val futureEx = recoverToExceptionIf[BigQueryException] {
       provider.getEntity("table1", "Row0")
     }
     futureEx map { ex =>
-      assertResult("unit test exception message") { ex.getMessage }
+      assertResult("unit test exception message")(ex.getMessage)
     }
   }
 
@@ -192,7 +220,7 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
       provider.getEntity("table1", "Row0")
     }
     futureEx map { ex =>
-      assertResult("Entity not found.") { ex.getMessage }
+      assertResult("Entity not found.")(ex.getMessage)
     }
   }
 
@@ -203,10 +231,9 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
       provider.getEntity("table1", "Row0")
     }
     futureEx map { ex =>
-      assertResult("Query succeeded, but returned 3 rows; expected one row.") { ex.getMessage }
+      assertResult("Query succeeded, but returned 3 rows; expected one row.")(ex.getMessage)
     }
   }
-
 
   behavior of "DataEntityProvider.evaluateExpressions()"
 
@@ -216,25 +243,73 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
 
     val tableResult = createTestTableResult(tableRowCount)
     // set up a provider with a mock that returns ..
-    val provider = createTestProvider(snapshotModel = createSnapshotModel(List(new TableModel().name("table1").primaryKey(null).rowCount(3)
-      .columns(List("integer-field", "boolean-field", "timestamp-field").map(new ColumnModel().name(_)).asJava))), bqFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)))
+    val provider = createTestProvider(
+      snapshotModel = createSnapshotModel(
+        List(
+          new TableModel()
+            .name("table1")
+            .primaryKey(null)
+            .rowCount(3)
+            .columns(List("integer-field", "boolean-field", "timestamp-field").map(new ColumnModel().name(_)).asJava)
+        )
+      ),
+      bqFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult))
+    )
     val expressionEvaluationContext = ExpressionEvaluationContext(None, None, None, Some("table1"))
-    val gatherInputsResult = GatherInputsResult(Set(
-      MethodInput(new ToolInputParameter().name("name1").valueType(new ValueType().typeName(ValueType.TypeNameEnum.INT)), "this.integer-field"),
-      MethodInput(new ToolInputParameter().name("name2").valueType(new ValueType().typeName(ValueType.TypeNameEnum.BOOLEAN)), "this.boolean-field"),
-      MethodInput(new ToolInputParameter().name("workspace1").valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING)), "workspace.string"),
-      MethodInput(new ToolInputParameter().name("name3").valueType(new ValueType().typeName(ValueType.TypeNameEnum.OBJECT)), """{"foo": this.boolean-field, "bar": this.timestamp-field, "workspace": workspace.string}""")
-    ), Set.empty, Set.empty, Set.empty)
+    val gatherInputsResult = GatherInputsResult(
+      Set(
+        MethodInput(
+          new ToolInputParameter().name("name1").valueType(new ValueType().typeName(ValueType.TypeNameEnum.INT)),
+          "this.integer-field"
+        ),
+        MethodInput(
+          new ToolInputParameter().name("name2").valueType(new ValueType().typeName(ValueType.TypeNameEnum.BOOLEAN)),
+          "this.boolean-field"
+        ),
+        MethodInput(new ToolInputParameter()
+                      .name("workspace1")
+                      .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING)),
+                    "workspace.string"
+        ),
+        MethodInput(
+          new ToolInputParameter().name("name3").valueType(new ValueType().typeName(ValueType.TypeNameEnum.OBJECT)),
+          """{"foo": this.boolean-field, "bar": this.timestamp-field, "workspace": workspace.string}"""
+        )
+      ),
+      Set.empty,
+      Set.empty,
+      Set.empty
+    )
 
-    provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map("workspace.string" -> Success(List(AttributeString("workspaceValue"))))) map { submissionValidationEntityInputs =>
-      val expectedResults = (stringKeys map { stringKey =>
-        SubmissionValidationEntityInputs(stringKey, Set(
-          SubmissionValidationValue(Some(AttributeNumber(MockBigQueryServiceFactory.FV_INTEGER.getNumericValue)), None, "name1"),
-          SubmissionValidationValue(Some(AttributeBoolean(MockBigQueryServiceFactory.FV_BOOLEAN.getBooleanValue)), None, "name2"),
-          SubmissionValidationValue(Some(AttributeString("workspaceValue")), None, "workspace1"),
-          SubmissionValidationValue(Some(AttributeValueRawJson(s"""{"foo": ${MockBigQueryServiceFactory.FV_BOOLEAN.getBooleanValue}, "bar": "${MockBigQueryServiceFactory.FV_TIMESTAMP.getStringValue}", "workspace": "workspaceValue"}""")), None, "name3")
-        ))
-      })
+    provider.evaluateExpressions(expressionEvaluationContext,
+                                 gatherInputsResult,
+                                 Map("workspace.string" -> Success(List(AttributeString("workspaceValue"))))
+    ) map { submissionValidationEntityInputs =>
+      val expectedResults = stringKeys map { stringKey =>
+        SubmissionValidationEntityInputs(
+          stringKey,
+          Set(
+            SubmissionValidationValue(Some(AttributeNumber(MockBigQueryServiceFactory.FV_INTEGER.getNumericValue)),
+                                      None,
+                                      "name1"
+            ),
+            SubmissionValidationValue(Some(AttributeBoolean(MockBigQueryServiceFactory.FV_BOOLEAN.getBooleanValue)),
+                                      None,
+                                      "name2"
+            ),
+            SubmissionValidationValue(Some(AttributeString("workspaceValue")), None, "workspace1"),
+            SubmissionValidationValue(
+              Some(
+                AttributeValueRawJson(
+                  s"""{"foo": ${MockBigQueryServiceFactory.FV_BOOLEAN.getBooleanValue}, "bar": "${MockBigQueryServiceFactory.FV_TIMESTAMP.getStringValue}", "workspace": "workspaceValue"}"""
+                )
+              ),
+              None,
+              "name3"
+            )
+          )
+        )
+      }
       submissionValidationEntityInputs should contain theSameElementsAs expectedResults
     }
   }
@@ -243,17 +318,39 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val tableRowCount = 123
     val smallMaxInputsPerSubmission = 200
 
-    val provider = createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(createTestTableResult(tableRowCount))), config = DataRepoEntityProviderConfig(smallMaxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0))
+    val provider = createTestProvider(
+      bqFactory = MockBigQueryServiceFactory.ioFactory(Right(createTestTableResult(tableRowCount))),
+      config = DataRepoEntityProviderConfig(smallMaxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
+    )
     val expressionEvaluationContext = ExpressionEvaluationContext(None, None, None, Some("table2"))
 
-    val gatherInputsResult = GatherInputsResult(Set(
-      MethodInput(new ToolInputParameter().name("col2a").valueType(new ValueType().typeName(ValueType.TypeNameEnum.INT)), "this.col2a"),
-      MethodInput(new ToolInputParameter().name("col2b").valueType(new ValueType().typeName(ValueType.TypeNameEnum.BOOLEAN)), "this.col2b"),
-    ), Set.empty, Set.empty, Set.empty)
+    val gatherInputsResult = GatherInputsResult(
+      Set(
+        MethodInput(
+          new ToolInputParameter().name("col2a").valueType(new ValueType().typeName(ValueType.TypeNameEnum.INT)),
+          "this.col2a"
+        ),
+        MethodInput(
+          new ToolInputParameter().name("col2b").valueType(new ValueType().typeName(ValueType.TypeNameEnum.BOOLEAN)),
+          "this.col2b"
+        )
+      ),
+      Set.empty,
+      Set.empty,
+      Set.empty
+    )
 
     intercept[RawlsExceptionWithErrorReport] {
-      Await.result(provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map("workspace.string" -> Success(List(AttributeString("workspaceValue"))))), Duration.Inf)
-    }.errorReport.message should be(s"Too many results. Snapshot row count * number of entity expressions cannot exceed ${smallMaxInputsPerSubmission}.")
+      Await.result(
+        provider.evaluateExpressions(expressionEvaluationContext,
+                                     gatherInputsResult,
+                                     Map("workspace.string" -> Success(List(AttributeString("workspaceValue"))))
+        ),
+        Duration.Inf
+      )
+    }.errorReport.message should be(
+      s"Too many results. Snapshot row count * number of entity expressions cannot exceed ${smallMaxInputsPerSubmission}."
+    )
   }
 
   behavior of "DataEntityProvider.convertToListAndCheckSize()"
@@ -264,14 +361,20 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
 
     intercept[DataEntityException] {
       provider.convertToListAndCheckSize(Stream.fill(size)(("", Map("" -> Success(List(AttributeNumber(2)))))), size)
-    }.getMessage should be(s"Query returned too many results likely due to either large one-to-many relationships or arrays. The limit on the total number bytes is $size.")
+    }.getMessage should be(
+      s"Query returned too many results likely due to either large one-to-many relationships or arrays. The limit on the total number bytes is $size."
+    )
   }
 
   it should "return the right items in expected order" in {
     val provider = createTestProvider()
     val size = 100
-    val expectedResult = List.fill(size)((Random.nextString(5), Map(Random.nextString(5) -> Success(List(AttributeNumber(Random.nextDouble()))))))
-    provider.convertToListAndCheckSize(expectedResult.toStream, size) should contain theSameElementsInOrderAs expectedResult
+    val expectedResult = List.fill(size)(
+      (Random.nextString(5), Map(Random.nextString(5) -> Success(List(AttributeNumber(Random.nextDouble())))))
+    )
+    provider.convertToListAndCheckSize(expectedResult.toStream,
+                                       size
+    ) should contain theSameElementsInOrderAs expectedResult
   }
 
   behavior of "DataEntityProvider.figureOutQueryStructureForExpressions()"
@@ -287,7 +390,8 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val parsedExpressions = Set.empty[ParsedEntityLookupExpression]
 
     val entityTable = EntityTable(snapshotModel, tableName, alias)
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, entityTable, parsedExpressions, datarepoRowIdColumn)
+    val result =
+      provider.figureOutQueryStructureForExpressions(snapshotModel, entityTable, parsedExpressions, datarepoRowIdColumn)
     result should contain theSameElementsAs List(
       SelectAndFrom(entityTable, None, Seq(EntityColumn(entityTable, datarepoRowIdColumn, false)))
     )
@@ -307,19 +411,31 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     }.toSet
 
     val entityTable = EntityTable(snapshotModel, tableName, alias)
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, entityTable, parsedExpressions, datarepoRowIdColumn)
+    val result =
+      provider.figureOutQueryStructureForExpressions(snapshotModel, entityTable, parsedExpressions, datarepoRowIdColumn)
     result should contain theSameElementsAs List(
       // figureOutQueryStructureForExpressions explicitly adds the datarepoRowIdColumn, so we add it here too
-      SelectAndFrom(entityTable, None, (columnNames += datarepoRowIdColumn).sorted.toList.map((column: String) => EntityColumn(entityTable, column, false)))
+      SelectAndFrom(entityTable,
+                    None,
+                    (columnNames += datarepoRowIdColumn).sorted.toList.map((column: String) =>
+                      EntityColumn(entityTable, column, false)
+                    )
+      )
     )
   }
 
   it should "return a single value for many expressions followed by another for a relationship" in {
     val joinColumnName = "donor_id"
-    val rootTable = new TableModel().name("donor").primaryKey(null).rowCount(0)
+    val rootTable = new TableModel()
+      .name("donor")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("string-field", joinColumnName, "datarepo_row_id").map(new ColumnModel().name(_)).asJava)
 
-    val dependentTable = new TableModel().name("sample").primaryKey(null).rowCount(0)
+    val dependentTable = new TableModel()
+      .name("sample")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("another-string-field", joinColumnName, "datarepo_row_id").map(new ColumnModel().name(_)).asJava)
 
     val relationshipName = "my_donor"
@@ -347,27 +463,44 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val rootEntityTable = EntityTable(snapshotModel, rootTableName, "root")
     val dependentEntityTable = EntityTable(snapshotModel, dependentTableName, "entity_1")
 
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, rootEntityTable, parsedExpressions.toSet, datarepoRowIdColumn)
+    val result = provider.figureOutQueryStructureForExpressions(snapshotModel,
+                                                                rootEntityTable,
+                                                                parsedExpressions.toSet,
+                                                                datarepoRowIdColumn
+    )
     result should contain theSameElementsInOrderAs Seq(
-      SelectAndFrom(rootEntityTable, None, rootColumnNames.toList.map((column: String) => EntityColumn(rootEntityTable, column, false))),
       SelectAndFrom(rootEntityTable,
-        Option(EntityJoin(
-          EntityColumn(rootEntityTable, joinColumnName, false),
-          EntityColumn(dependentEntityTable, joinColumnName, false),
-          Seq(relationshipName),
-          "rel_2",
-          false
-        )),
-        dependentColumns.toList.map((column: String) => EntityColumn(dependentEntityTable, column, false)))
+                    None,
+                    rootColumnNames.toList.map((column: String) => EntityColumn(rootEntityTable, column, false))
+      ),
+      SelectAndFrom(
+        rootEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(rootEntityTable, joinColumnName, false),
+            EntityColumn(dependentEntityTable, joinColumnName, false),
+            Seq(relationshipName),
+            "rel_2",
+            false
+          )
+        ),
+        dependentColumns.toList.map((column: String) => EntityColumn(dependentEntityTable, column, false))
+      )
     )
   }
 
   it should "handle case when there are no root table lookup expressions" in {
     val joinColumnName = "donor_id"
-    val rootTable = new TableModel().name("donor").primaryKey(null).rowCount(0)
+    val rootTable = new TableModel()
+      .name("donor")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("string-field", joinColumnName, "datarepo_row_id").map(new ColumnModel().name(_)).asJava)
 
-    val dependentTable = new TableModel().name("sample").primaryKey(null).rowCount(0)
+    val dependentTable = new TableModel()
+      .name("sample")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("another-string-field", joinColumnName, "datarepo_row_id").map(new ColumnModel().name(_)).asJava)
 
     val relationshipName = "my_donor"
@@ -392,27 +525,41 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val rootEntityTable = EntityTable(snapshotModel, rootTableName, "root")
     val dependentEntityTable = EntityTable(snapshotModel, dependentTableName, "entity_1")
 
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, rootEntityTable, parsedExpressions.toSet, datarepoRowIdColumn)
+    val result = provider.figureOutQueryStructureForExpressions(snapshotModel,
+                                                                rootEntityTable,
+                                                                parsedExpressions.toSet,
+                                                                datarepoRowIdColumn
+    )
     result should contain theSameElementsInOrderAs Seq(
       SelectAndFrom(rootEntityTable, None, Seq(EntityColumn(rootEntityTable, datarepoRowIdColumn, false))),
-      SelectAndFrom(rootEntityTable,
-        Option(EntityJoin(
-          EntityColumn(rootEntityTable, joinColumnName, false),
-          EntityColumn(dependentEntityTable, joinColumnName, false),
-          Seq(relationshipName),
-          "rel_2",
-          false
-        )),
-        dependentColumns.toList.map((column: String) => EntityColumn(dependentEntityTable, column, false)))
+      SelectAndFrom(
+        rootEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(rootEntityTable, joinColumnName, false),
+            EntityColumn(dependentEntityTable, joinColumnName, false),
+            Seq(relationshipName),
+            "rel_2",
+            false
+          )
+        ),
+        dependentColumns.toList.map((column: String) => EntityColumn(dependentEntityTable, column, false))
+      )
     )
   }
 
   it should "handle relationship in the other direction" in {
     val joinColumnName = "donor_id"
-    val rootTable = new TableModel().name("donor").primaryKey(null).rowCount(0)
+    val rootTable = new TableModel()
+      .name("donor")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", "string-field", joinColumnName).map(new ColumnModel().name(_)).asJava)
 
-    val dependentTable = new TableModel().name("sample").primaryKey(null).rowCount(0)
+    val dependentTable = new TableModel()
+      .name("sample")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", "another-string-field", joinColumnName).map(new ColumnModel().name(_)).asJava)
 
     val relationshipName = "my_donor"
@@ -442,31 +589,51 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val rootEntityTable = EntityTable(snapshotModel, rootTableName, "entity_1")
     val dependentEntityTable = EntityTable(snapshotModel, dependentTableName, "root")
 
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, dependentEntityTable, parsedExpressions, datarepoRowIdColumn)
+    val result = provider.figureOutQueryStructureForExpressions(snapshotModel,
+                                                                dependentEntityTable,
+                                                                parsedExpressions,
+                                                                datarepoRowIdColumn
+    )
     result should contain theSameElementsInOrderAs Seq(
-      SelectAndFrom(dependentEntityTable, None, dependentColumns.toList.map((column: String) => EntityColumn(dependentEntityTable, column, false))),
       SelectAndFrom(dependentEntityTable,
-        Option(EntityJoin(
-          EntityColumn(dependentEntityTable, joinColumnName, false),
-          EntityColumn(rootEntityTable, joinColumnName, false),
-          List(relationshipName),
-          "rel_2",
-          false
-        )),
-        rootColumnNames.toList.map((column: String) => EntityColumn(rootEntityTable, column, false)))
+                    None,
+                    dependentColumns.toList.map((column: String) => EntityColumn(dependentEntityTable, column, false))
+      ),
+      SelectAndFrom(
+        dependentEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(dependentEntityTable, joinColumnName, false),
+            EntityColumn(rootEntityTable, joinColumnName, false),
+            List(relationshipName),
+            "rel_2",
+            false
+          )
+        ),
+        rootColumnNames.toList.map((column: String) => EntityColumn(rootEntityTable, column, false))
+      )
     )
   }
 
   it should "handle multiple hops with no columns selected in the middle" in {
     val donorIdColumn = "donor_id"
     val sampleIdColumn = "sample_id"
-    val rootTable = new TableModel().name("donor").primaryKey(null).rowCount(0)
+    val rootTable = new TableModel()
+      .name("donor")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", "string-field", donorIdColumn).map(new ColumnModel().name(_)).asJava)
 
-    val middleTable = new TableModel().name("sample").primaryKey(null).rowCount(0)
+    val middleTable = new TableModel()
+      .name("sample")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", sampleIdColumn, donorIdColumn).map(new ColumnModel().name(_)).asJava)
 
-    val finalTable = new TableModel().name("file").primaryKey(null).rowCount(0)
+    val finalTable = new TableModel()
+      .name("file")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", sampleIdColumn, "path").map(new ColumnModel().name(_)).asJava)
 
     val relationshipName1 = "my_donor"
@@ -495,47 +662,74 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val parsedExpressions = rootColumnNames.map { columnName =>
       ParsedEntityLookupExpression(List.empty, columnName, s"this.$columnName")
     }.toSet ++ finalColumns.map { columnName =>
-      ParsedEntityLookupExpression(List(relationshipName1, relationshipName2), columnName, s"this.$relationshipName1.$relationshipName2.$columnName")
+      ParsedEntityLookupExpression(List(relationshipName1, relationshipName2),
+                                   columnName,
+                                   s"this.$relationshipName1.$relationshipName2.$columnName"
+      )
     }
 
     val rootEntityTable = EntityTable(snapshotModel, rootTableName, "root")
     val middleEntityTable = EntityTable(snapshotModel, middleTable.getName, "entity_1")
     val finalEntityTable = EntityTable(snapshotModel, finalTableName, "entity_3")
 
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, rootEntityTable, parsedExpressions, datarepoRowIdColumn)
+    val result = provider.figureOutQueryStructureForExpressions(snapshotModel,
+                                                                rootEntityTable,
+                                                                parsedExpressions,
+                                                                datarepoRowIdColumn
+    )
     result should contain theSameElementsInOrderAs List(
-      SelectAndFrom(rootEntityTable, None, rootColumnNames.toList.map((column: String) => EntityColumn(rootEntityTable, column, false))),
       SelectAndFrom(rootEntityTable,
-        Option(EntityJoin(
-          EntityColumn(rootEntityTable, donorIdColumn, false),
-          EntityColumn(middleEntityTable, donorIdColumn, false),
-          Seq(relationshipName1),
-          "rel_2",
-          false
-        )),
-        Seq.empty),
-      SelectAndFrom(middleEntityTable,
-        Option(EntityJoin(
-          EntityColumn(middleEntityTable, sampleIdColumn, false),
-          EntityColumn(finalEntityTable, sampleIdColumn, false),
-          Seq(relationshipName1, relationshipName2),
-          "rel_4",
-          false
-        )),
-        finalColumns.toList.map((column: String) => EntityColumn(finalEntityTable, column, false)))
+                    None,
+                    rootColumnNames.toList.map((column: String) => EntityColumn(rootEntityTable, column, false))
+      ),
+      SelectAndFrom(
+        rootEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(rootEntityTable, donorIdColumn, false),
+            EntityColumn(middleEntityTable, donorIdColumn, false),
+            Seq(relationshipName1),
+            "rel_2",
+            false
+          )
+        ),
+        Seq.empty
+      ),
+      SelectAndFrom(
+        middleEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(middleEntityTable, sampleIdColumn, false),
+            EntityColumn(finalEntityTable, sampleIdColumn, false),
+            Seq(relationshipName1, relationshipName2),
+            "rel_4",
+            false
+          )
+        ),
+        finalColumns.toList.map((column: String) => EntityColumn(finalEntityTable, column, false))
+      )
     )
   }
 
   it should "handle forked relationships" in {
     val fooIdColumn = "foo_id"
     val barIdColumn = "bar_id"
-    val rootTable = new TableModel().name("donor").primaryKey(null).rowCount(0)
+    val rootTable = new TableModel()
+      .name("donor")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", "string-field", fooIdColumn, barIdColumn).map(new ColumnModel().name(_)).asJava)
 
-    val dependentTable1 = new TableModel().name("foo").primaryKey(null).rowCount(0)
+    val dependentTable1 = new TableModel()
+      .name("foo")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", "table_1_col", fooIdColumn).map(new ColumnModel().name(_)).asJava)
 
-    val dependentTable2 = new TableModel().name("bar").primaryKey(null).rowCount(0)
+    val dependentTable2 = new TableModel()
+      .name("bar")
+      .primaryKey(null)
+      .rowCount(0)
       .columns(List("datarepo_row_id", "table_2_col", barIdColumn).map(new ColumnModel().name(_)).asJava)
 
     val relationshipName1 = "fooed"
@@ -567,27 +761,40 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val dependent1EntityTable = EntityTable(snapshotModel, dependentTable1.getName, "entity_3")
     val dependent2EntityTable = EntityTable(snapshotModel, dependentTable2.getName, "entity_1")
 
-    val result = provider.figureOutQueryStructureForExpressions(snapshotModel, rootEntityTable, parsedExpressions, "string-field")
+    val result =
+      provider.figureOutQueryStructureForExpressions(snapshotModel, rootEntityTable, parsedExpressions, "string-field")
     result should contain theSameElementsInOrderAs Seq(
       SelectAndFrom(rootEntityTable, None, Seq(EntityColumn(rootEntityTable, "string-field", false))),
-      SelectAndFrom(rootEntityTable,
-        Option(EntityJoin(
-          EntityColumn(rootEntityTable, barIdColumn, false),
-          EntityColumn(dependent2EntityTable, barIdColumn, false),
-          Seq(relationshipName2),
-          "rel_2",
-          false
-        )),
-        Seq(EntityColumn(dependent2EntityTable, datarepoRowIdColumn, false), EntityColumn(dependent2EntityTable, "table_2_col", false))),
-      SelectAndFrom(rootEntityTable,
-        Option(EntityJoin(
-          EntityColumn(rootEntityTable, fooIdColumn, false),
-          EntityColumn(dependent1EntityTable, fooIdColumn, false),
-          Seq(relationshipName1),
-          "rel_4",
-          false
-        )),
-        Seq(EntityColumn(dependent1EntityTable, datarepoRowIdColumn, false), EntityColumn(dependent1EntityTable, "table_1_col", false)))
+      SelectAndFrom(
+        rootEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(rootEntityTable, barIdColumn, false),
+            EntityColumn(dependent2EntityTable, barIdColumn, false),
+            Seq(relationshipName2),
+            "rel_2",
+            false
+          )
+        ),
+        Seq(EntityColumn(dependent2EntityTable, datarepoRowIdColumn, false),
+            EntityColumn(dependent2EntityTable, "table_2_col", false)
+        )
+      ),
+      SelectAndFrom(
+        rootEntityTable,
+        Option(
+          EntityJoin(
+            EntityColumn(rootEntityTable, fooIdColumn, false),
+            EntityColumn(dependent1EntityTable, fooIdColumn, false),
+            Seq(relationshipName1),
+            "rel_4",
+            false
+          )
+        ),
+        Seq(EntityColumn(dependent1EntityTable, datarepoRowIdColumn, false),
+            EntityColumn(dependent1EntityTable, "table_1_col", false)
+        )
+      )
     )
   }
 
@@ -596,10 +803,15 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
   it should "handle root entity attributes" in {
     val provider = createTestProvider()
     val table = EntityTable("proj", "view", "table", "root")
-    val selectAndFroms = Seq(SelectAndFrom(table, None, Seq(
-      EntityColumn(table, F_BOOLEAN.getName, false),
-      EntityColumn(table, F_STRING.getName, false),
-      EntityColumn(table, F_INTEGER.getName, false))))
+    val selectAndFroms = Seq(
+      SelectAndFrom(table,
+                    None,
+                    Seq(EntityColumn(table, F_BOOLEAN.getName, false),
+                        EntityColumn(table, F_STRING.getName, false),
+                        EntityColumn(table, F_INTEGER.getName, false)
+                    )
+      )
+    )
 
     val parsedExpressions = Set(
       ParsedEntityLookupExpression(List.empty, F_BOOLEAN.getName, s"this.${F_BOOLEAN.getName}"),
@@ -608,15 +820,23 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
 
     val tableResult = createTestTableResult(3)
 
-    val results = provider.transformQueryResultToExpressionAndResult(datarepoRowIdColumn, parsedExpressions, selectAndFroms, tableResult)
+    val results = provider.transformQueryResultToExpressionAndResult(datarepoRowIdColumn,
+                                                                     parsedExpressions,
+                                                                     selectAndFroms,
+                                                                     tableResult
+    )
 
     val expectedResults: Set[ExpressionAndResult] = for {
       expr <- parsedExpressions
       row <- tableResult.iterateAll().asScala
       field <- Seq(F_BOOLEAN, F_INTEGER) if field.getName == expr.columnName
-    } yield {
-      (expr.expression, Map(row.get(datarepoRowIdColumn).getStringValue -> Success(Seq(provider.fieldToAttribute(field, row).asInstanceOf[AttributeValue]))))
-    }
+    } yield (expr.expression,
+             Map(
+               row.get(datarepoRowIdColumn).getStringValue -> Success(
+                 Seq(provider.fieldToAttribute(field, row).asInstanceOf[AttributeValue])
+               )
+             )
+    )
 
     results should contain theSameElementsAs expectedResults
   }
@@ -630,20 +850,35 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val selectAndFroms = Seq(
       SelectAndFrom(table, None, Seq(EntityColumn(table, F_STRING.getName, false))),
       // the actual to and from columns should not matter anymore
-      SelectAndFrom(relatedTable, Some(EntityJoin(null, null, Seq(relationshipName), relatedAlias, false)), Seq(
-        EntityColumn(relatedTable, F_BOOLEAN.getName, false),
-        EntityColumn(relatedTable, F_STRING.getName, false),
-        EntityColumn(relatedTable, F_INTEGER.getName, false)))
+      SelectAndFrom(
+        relatedTable,
+        Some(EntityJoin(null, null, Seq(relationshipName), relatedAlias, false)),
+        Seq(
+          EntityColumn(relatedTable, F_BOOLEAN.getName, false),
+          EntityColumn(relatedTable, F_STRING.getName, false),
+          EntityColumn(relatedTable, F_INTEGER.getName, false)
+        )
+      )
     )
 
     val parsedExpressions = Set(
-      ParsedEntityLookupExpression(List(relationshipName), F_BOOLEAN.getName, s"this.$relationshipName.${F_BOOLEAN.getName}"),
-      ParsedEntityLookupExpression(List(relationshipName), F_INTEGER.getName, s"this.$relationshipName.${F_INTEGER.getName}")
+      ParsedEntityLookupExpression(List(relationshipName),
+                                   F_BOOLEAN.getName,
+                                   s"this.$relationshipName.${F_BOOLEAN.getName}"
+      ),
+      ParsedEntityLookupExpression(List(relationshipName),
+                                   F_INTEGER.getName,
+                                   s"this.$relationshipName.${F_INTEGER.getName}"
+      )
     )
 
     val tableResult = createTestTableResultWithNestedStruct(3, relatedAlias)
 
-    val results = provider.transformQueryResultToExpressionAndResult(datarepoRowIdColumn, parsedExpressions, selectAndFroms, tableResult)
+    val results = provider.transformQueryResultToExpressionAndResult(datarepoRowIdColumn,
+                                                                     parsedExpressions,
+                                                                     selectAndFroms,
+                                                                     tableResult
+    )
 
     val expectedResults: Set[ExpressionAndResult] = for {
       expr <- parsedExpressions
@@ -663,10 +898,13 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
 
   it should "create basic query" in {
     val table = EntityTable("proj", "view", "table", "root")
-    val selectAndFroms = Seq(SelectAndFrom(table, None, Seq(EntityColumn(table, "zoe", false), EntityColumn(table, "bob", true))))
+    val selectAndFroms =
+      Seq(SelectAndFrom(table, None, Seq(EntityColumn(table, "zoe", false), EntityColumn(table, "bob", true))))
 
     val provider = new DataRepoBigQuerySupport {}
-    provider.generateExpressionSQL(selectAndFroms) shouldBe "SELECT `root`.`zoe`, `root`.`bob` FROM `proj.view.table` `root`;"
+    provider.generateExpressionSQL(
+      selectAndFroms
+    ) shouldBe "SELECT `root`.`zoe`, `root`.`bob` FROM `proj.view.table` `root`;"
   }
 
   it should "create query with regular joins" in {
@@ -674,9 +912,13 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val depTable = EntityTable("proj", "view", "debTable", "dep")
     val selectAndFroms = Seq(
       SelectAndFrom(rootTable, None, Seq(EntityColumn(rootTable, "zoe", false), EntityColumn(rootTable, "bob", true))),
-      SelectAndFrom(depTable,
-        Option(EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", false)),
-        Seq(EntityColumn(depTable, "zoe", false), EntityColumn(depTable, "bob", false)))
+      SelectAndFrom(
+        depTable,
+        Option(
+          EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", false)
+        ),
+        Seq(EntityColumn(depTable, "zoe", false), EntityColumn(depTable, "bob", false))
+      )
     )
 
     val provider = new DataRepoBigQuerySupport {}
@@ -697,9 +939,13 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val depTable = EntityTable("proj", "view", "debTable", "dep")
     val selectAndFroms = Seq(
       SelectAndFrom(rootTable, None, Seq(EntityColumn(rootTable, "zoe", false), EntityColumn(rootTable, "bob", true))),
-      SelectAndFrom(depTable,
-        Option(EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", true)),
-        Seq(EntityColumn(depTable, "zoe", false), EntityColumn(depTable, "bob", false)))
+      SelectAndFrom(
+        depTable,
+        Option(
+          EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", true)
+        ),
+        Seq(EntityColumn(depTable, "zoe", false), EntityColumn(depTable, "bob", false))
+      )
     )
 
     val provider = new DataRepoBigQuerySupport {}
@@ -721,9 +967,18 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val depTable = EntityTable("proj", "view", "debTable", "dep")
     val selectAndFroms = Seq(
       SelectAndFrom(rootTable, None, Seq(EntityColumn(rootTable, "zoe", false), EntityColumn(rootTable, "bob", true))),
-      SelectAndFrom(depTable,
-        Option(EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", false)),
-        Seq(EntityColumn(depTable, "zoe", true), EntityColumn(depTable, "bob", true), EntityColumn(depTable, datarepoRowIdColumn, false), EntityColumn(depTable, "another", false)))
+      SelectAndFrom(
+        depTable,
+        Option(
+          EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", false)
+        ),
+        Seq(
+          EntityColumn(depTable, "zoe", true),
+          EntityColumn(depTable, "bob", true),
+          EntityColumn(depTable, datarepoRowIdColumn, false),
+          EntityColumn(depTable, "another", false)
+        )
+      )
     )
 
     val provider = new DataRepoBigQuerySupport {}
@@ -747,9 +1002,18 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val depTable = EntityTable("proj", "view", "debTable", "dep")
     val selectAndFroms = Seq(
       SelectAndFrom(rootTable, None, Seq(EntityColumn(rootTable, "zoe", false), EntityColumn(rootTable, "bob", true))),
-      SelectAndFrom(depTable,
-        Option(EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", true)),
-        Seq(EntityColumn(depTable, "zoe", true), EntityColumn(depTable, "bob", true), EntityColumn(depTable, datarepoRowIdColumn, false), EntityColumn(depTable, "another", false)))
+      SelectAndFrom(
+        depTable,
+        Option(
+          EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", true)
+        ),
+        Seq(
+          EntityColumn(depTable, "zoe", true),
+          EntityColumn(depTable, "bob", true),
+          EntityColumn(depTable, datarepoRowIdColumn, false),
+          EntityColumn(depTable, "another", false)
+        )
+      )
     )
 
     val provider = new DataRepoBigQuerySupport {}
@@ -775,12 +1039,25 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val depTable2 = EntityTable("proj", "view", "debTable2", "dep2")
     val selectAndFroms = Seq(
       SelectAndFrom(rootTable, None, Seq(EntityColumn(rootTable, "zoe", false), EntityColumn(rootTable, "bob", true))),
-      SelectAndFrom(depTable,
-        Option(EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", false)),
-        Seq.empty),
-      SelectAndFrom(depTable,
-        Option(EntityJoin(EntityColumn(depTable, "fk2", false), EntityColumn(depTable2, "fk2", false), Seq.empty, "bar", false)),
-        Seq(EntityColumn(depTable, "zoe", true), EntityColumn(depTable, "bob", false)))
+      SelectAndFrom(
+        depTable,
+        Option(
+          EntityJoin(EntityColumn(rootTable, "fk", false), EntityColumn(depTable, "fk", false), Seq.empty, "foo", false)
+        ),
+        Seq.empty
+      ),
+      SelectAndFrom(
+        depTable,
+        Option(
+          EntityJoin(EntityColumn(depTable, "fk2", false),
+                     EntityColumn(depTable2, "fk2", false),
+                     Seq.empty,
+                     "bar",
+                     false
+          )
+        ),
+        Seq(EntityColumn(depTable, "zoe", true), EntityColumn(depTable, "bob", false))
+      )
     )
 
     val provider = new DataRepoBigQuerySupport {}
@@ -811,16 +1088,18 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
     val mockPort = 32123
 
     val mockServer = startClientAndServer(mockPort)
-    mockServer.when(
-      request()
-        .withMethod("GET")
-        .withPath(s"/api/repository/v1/snapshots/${mockSnapshotId.toString}")
-    ).respond(
-      response()
-        .withHeaders(jsonHeader)
-        .withBody(s"""{"id":"${mockSnapshotId.toString}"}""")
-        .withStatusCode(StatusCodes.OK.intValue)
-    )
+    mockServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(s"/api/repository/v1/snapshots/${mockSnapshotId.toString}")
+      )
+      .respond(
+        response()
+          .withHeaders(jsonHeader)
+          .withBody(s"""{"id":"${mockSnapshotId.toString}"}""")
+          .withStatusCode(StatusCodes.OK.intValue)
+      )
 
     val dataRepoDAO = new HttpDataRepoDAO("mock", s"http://localhost:$mockPort")
     val snapshotResponse = dataRepoDAO.getSnapshot(mockSnapshotId, userInfo.accessToken)
@@ -830,6 +1109,3 @@ class DataRepoEntityProviderSpec extends AsyncFlatSpec with DataRepoEntityProvid
   }
 
 }
-
-
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpecSupport.scala
@@ -5,10 +5,22 @@ import bio.terra.datarepo.model.{ColumnModel, RelationshipModel, SnapshotModel, 
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleBigQueryServiceFactory,
+  MockBigQueryServiceFactory,
+  SamDAO,
+  SlickDataSource
+}
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
-import org.broadinstitute.dsde.rawls.model.{DataReferenceName, GoogleProjectId, RawlsRequestContext, RawlsUserEmail, UserInfo, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceName,
+  GoogleProjectId,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  UserInfo,
+  Workspace
+}
 import org.joda.time.DateTime
 
 import java.util.UUID
@@ -29,8 +41,17 @@ trait DataRepoEntityProviderSpecSupport {
   val snapshot: String = snapshotUUID.toString
 
   // default Workspace object, mostly irrelevant for DataRepoEntityProviderSpec but necessary to exist
-  val workspace = Workspace("namespace", "name", wsId.toString, "bucketName", None,
-    DateTime.now(), DateTime.now(), "createdBy", Map.empty, false)
+  val workspace = Workspace("namespace",
+                            "name",
+                            wsId.toString,
+                            "bucketName",
+                            None,
+                            DateTime.now(),
+                            DateTime.now(),
+                            "createdBy",
+                            Map.empty,
+                            false
+  )
 
   // defaults for DataRepoEntityProviderConfig
   val maxInputsPerSubmission: Int = 1000
@@ -39,25 +60,27 @@ trait DataRepoEntityProviderSpecSupport {
   /* A "factory" method to create a DataRepoEntityProvider, with defaults.
    * Individual unit tests should call this to reduce boilerplate.
    */
-  def createTestProvider(snapshotModel: SnapshotModel = createSnapshotModel(),
-                         samDAO: SamDAO = new MockSamDAO(slickDataSource),
-                         bqFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(),
-                         entityRequestArguments: EntityRequestArguments = EntityRequestArguments(workspace, RawlsRequestContext(userInfo), Some(DataReferenceName("referenceName"))),
-                         config: DataRepoEntityProviderConfig = DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
-                        ): DataRepoEntityProvider = {
+  def createTestProvider(
+    snapshotModel: SnapshotModel = createSnapshotModel(),
+    samDAO: SamDAO = new MockSamDAO(slickDataSource),
+    bqFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(),
+    entityRequestArguments: EntityRequestArguments =
+      EntityRequestArguments(workspace, RawlsRequestContext(userInfo), Some(DataReferenceName("referenceName"))),
+    config: DataRepoEntityProviderConfig =
+      DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
+  ): DataRepoEntityProvider =
     // we may find that tests need to override the DataReferenceDescription provided by createDataRepoSnapshotResource() on the next line
     new DataRepoEntityProvider(snapshotModel, entityRequestArguments, samDAO, bqFactory, config)
-  }
 
-  def createTestBuilder(workspaceManagerDAO: WorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource())),
-                        dataRepoDAO: SpecDataRepoDAO = new SpecDataRepoDAO(Right(createSnapshotModel())),
-                        samDAO: SamDAO = new MockSamDAO(slickDataSource),
-                        bqServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(),
-                        config: DataRepoEntityProviderConfig = DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
-                       ): DataRepoEntityProviderBuilder = {
+  def createTestBuilder(
+    workspaceManagerDAO: WorkspaceManagerDAO = new SpecWorkspaceManagerDAO(Right(createDataRepoSnapshotResource())),
+    dataRepoDAO: SpecDataRepoDAO = new SpecDataRepoDAO(Right(createSnapshotModel())),
+    samDAO: SamDAO = new MockSamDAO(slickDataSource),
+    bqServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(),
+    config: DataRepoEntityProviderConfig =
+      DataRepoEntityProviderConfig(maxInputsPerSubmission, maxBigQueryResponseSizeBytes, 0)
+  ): DataRepoEntityProviderBuilder =
     new DataRepoEntityProviderBuilder(workspaceManagerDAO, dataRepoDAO, samDAO, bqServiceFactory, config)
-  }
-
 
   /* A "factory" method to create DataRepoSnapshotResource objects, with defaults.
    * Allows callers to only specify the arguments they want to override.
@@ -68,9 +91,8 @@ trait DataRepoEntityProviderSpecSupport {
                                      cloningInstructionsEnum: CloningInstructionsEnum = CloningInstructionsEnum.NOTHING,
                                      workspaceId: UUID = wsId,
                                      refInstanceName: String = dataRepoInstanceName,
-                                     refSnapshot: String = snapshot,
-                                    ): DataRepoSnapshotResource = {
-
+                                     refSnapshot: String = snapshot
+  ): DataRepoSnapshotResource = {
 
     val metadata = new ResourceMetadata()
       .name(name)
@@ -79,7 +101,6 @@ trait DataRepoEntityProviderSpecSupport {
       .cloningInstructions(cloningInstructionsEnum)
       .cloudPlatform(CloudPlatform.GCP)
       .workspaceId(workspaceId)
-
 
     val attributes = new DataRepoSnapshotAttributes()
       .instanceName(refInstanceName)
@@ -91,17 +112,28 @@ trait DataRepoEntityProviderSpecSupport {
   }
 
   val defaultTables: List[TableModel] = List(
-    new TableModel().name("table1").primaryKey(null).rowCount(10)
+    new TableModel()
+      .name("table1")
+      .primaryKey(null)
+      .rowCount(10)
       .columns(List("integer-field", "boolean-field", "timestamp-field").map(new ColumnModel().name(_)).asJava),
-    new TableModel().name("table2").primaryKey(List("table2PK").asJava).rowCount(123)
+    new TableModel()
+      .name("table2")
+      .primaryKey(List("table2PK").asJava)
+      .rowCount(123)
       .columns(List("col2a", "col2b").map(new ColumnModel().name(_)).asJava),
-    new TableModel().name("table3").primaryKey(List("compound","pk").asJava).rowCount(456)
+    new TableModel()
+      .name("table3")
+      .primaryKey(List("compound", "pk").asJava)
+      .rowCount(456)
       .columns(List("col3.1", "col3.2").map(new ColumnModel().name(_)).asJava)
   )
 
   /* A "factory" method to create SnapshotModel objects, with default.
    */
-  def createSnapshotModel( tables: List[TableModel] = defaultTables, relationships: List[RelationshipModel] = List.empty): SnapshotModel =
+  def createSnapshotModel(tables: List[TableModel] = defaultTables,
+                          relationships: List[RelationshipModel] = List.empty
+  ): SnapshotModel =
     new SnapshotModel()
       .id(snapshotUUID)
       .tables(tables.asJava)
@@ -113,10 +145,14 @@ trait DataRepoEntityProviderSpecSupport {
   /**
    * Mock for WorkspaceManagerDAO that allows the caller to specify behavior for the getDataRepoSnapshotReferenceByName method.
    */
-  class SpecWorkspaceManagerDAO(refByNameResponse:Either[Throwable, DataRepoSnapshotResource]) extends MockWorkspaceManagerDAO {
-    override def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, ctx: RawlsRequestContext): DataRepoSnapshotResource =
+  class SpecWorkspaceManagerDAO(refByNameResponse: Either[Throwable, DataRepoSnapshotResource])
+      extends MockWorkspaceManagerDAO {
+    override def getDataRepoSnapshotReferenceByName(workspaceId: UUID,
+                                                    refName: DataReferenceName,
+                                                    ctx: RawlsRequestContext
+    ): DataRepoSnapshotResource =
       refByNameResponse match {
-        case Left(t) => throw t
+        case Left(t)    => throw t
         case Right(ref) =>
           // N.B. we don't attempt to replicate the workspace manager's functionality of comparing the workspace id,
           // refName, and so on. We just return what the unit test asked us to return. It is workspace manager's
@@ -129,28 +165,30 @@ trait DataRepoEntityProviderSpecSupport {
    * Mock for DataRepoDAO that allows the caller to specify behavior for the getSnapshot and getBaseURL methods.
    *  method.
    */
-  class SpecDataRepoDAO(getSnapshotResponse:Either[Throwable, SnapshotModel], baseURL: String = dataRepoInstanceName) extends MockDataRepoDAO(baseURL) {
+  class SpecDataRepoDAO(getSnapshotResponse: Either[Throwable, SnapshotModel], baseURL: String = dataRepoInstanceName)
+      extends MockDataRepoDAO(baseURL) {
 
     override def getInstanceName: String = baseURL
 
-    override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = getSnapshotResponse match {
-      case Left(t) => throw t
-      case Right(snap) => snap
-    }
+    override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel =
+      getSnapshotResponse match {
+        case Left(t)     => throw t
+        case Right(snap) => snap
+      }
   }
 
   /**
    * Mock for DataRepoDAO that allows the caller to specify behavior for the getSnapshot and getBaseURL methods.
    */
-  class SpecSamDAO(dataSource: SlickDataSource = slickDataSource,
-                   petKeyForUserResponse: Either[Throwable, String]) extends MockSamDAO(dataSource) {
-    override def getPetServiceAccountKeyForUser(googleProject: GoogleProjectId, userEmail: RawlsUserEmail): Future[String] = {
+  class SpecSamDAO(dataSource: SlickDataSource = slickDataSource, petKeyForUserResponse: Either[Throwable, String])
+      extends MockSamDAO(dataSource) {
+    override def getPetServiceAccountKeyForUser(googleProject: GoogleProjectId,
+                                                userEmail: RawlsUserEmail
+    ): Future[String] =
       petKeyForUserResponse match {
-        case Left(t) => Future.failed(t)
+        case Left(t)    => Future.failed(t)
         case Right(key) => Future.successful(key)
       }
-    }
   }
-
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -9,12 +9,31 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleBigQueryServiceFactory,
+  MockBigQueryServiceFactory,
+  SlickDataSource
+}
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
-import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO, RemoteServicesMockServer}
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeString, RawlsRequestContext, RawlsUser, UserInfo}
+import org.broadinstitute.dsde.rawls.mock.{
+  MockDataRepoDAO,
+  MockSamDAO,
+  MockWorkspaceManagerDAO,
+  RemoteServicesMockServer
+}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddUpdateAttribute,
+  AttributeUpdateOperation,
+  EntityUpdateDefinition
+}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeString,
+  RawlsRequestContext,
+  RawlsUser,
+  UserInfo
+}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
@@ -42,7 +61,17 @@ import scala.io.Source
   * considered to be objective results, and they do not translate to performance on production. They should only be used
   * to compare before/after your code changes.
   */
-class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with TestDriverComponent with RawlsTestUtils with Eventually with MockitoTestUtils with RawlsStatsDTestUtils with BeforeAndAfterAll  with LazyLogging {
+class BatchUpsertScalingSpec
+    extends AnyFlatSpec
+    with ScalatestRouteTest
+    with Matchers
+    with TestDriverComponent
+    with RawlsTestUtils
+    with Eventually
+    with MockitoTestUtils
+    with RawlsStatsDTestUtils
+    with BeforeAndAfterAll
+    with LazyLogging {
 
   // =========== START SERVICES AND MOCKS SETUP ===========
   // copied from EntityServiceSpec
@@ -58,8 +87,11 @@ class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Ma
     super.afterAll()
   }
 
-  //noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
-  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit val executionContext: ExecutionContext) extends EntityApiService with MockUserInfoDirectivesWithUser {
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends EntityApiService
+      with MockUserInfoDirectivesWithUser {
     private val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
     lazy val entityService: EntityService = entityServiceConstructor(ctx1)
 
@@ -76,16 +108,24 @@ class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Ma
       slickDataSource,
       samDAO,
       workbenchMetricBaseName,
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO(mockServer.mockServerBaseUrl), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"), workbenchMetricBaseName),
-     1000
-    )_
+      EntityManager.defaultEntityManager(
+        dataSource,
+        new MockWorkspaceManagerDAO(),
+        new MockDataRepoDAO(mockServer.mockServerBaseUrl),
+        samDAO,
+        bigQueryServiceFactory,
+        DataRepoEntityProviderConfig(100, 10, 0),
+        testConf.getBoolean("entityStatisticsCache.enabled"),
+        workbenchMetricBaseName
+      ),
+      1000
+    ) _
   }
 
-  def withTestDataServices[T](testCode: TestApiService => T): T = {
+  def withTestDataServices[T](testCode: TestApiService => T): T =
     withMinimalTestDatabase { dataSource: SlickDataSource =>
       withServices(dataSource, testData.userOwner)(testCode)
     }
-  }
 
   private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: (TestApiService) => T) = {
     val apiService = new TestApiService(dataSource, user)
@@ -96,83 +136,101 @@ class BatchUpsertScalingSpec extends AnyFlatSpec with ScalatestRouteTest with Ma
   behavior of "Batch Upsert scaling"
 
   // test is currently ignored; manually re-enable it in order to run tests locally
-  it should "calculate perf stats for a medium-sized data table, updating one cell and ignoring unchanged cells" ignore withTestDataServices { testApiService =>
+  it should "calculate perf stats for a medium-sized data table, updating one cell and ignoring unchanged cells" ignore withTestDataServices {
+    testApiService =>
+      // =========== START DATA SETUP ===========
+      // read batch upsert file from src/test/resources
+      val batchUpsertFile: String =
+        Source.fromResource("fixtures/batchUpsert/mediumtext-initial.json").getLines().mkString
 
-    // =========== START DATA SETUP ===========
-    // read batch upsert file from src/test/resources
-    val batchUpsertFile: String = Source.fromResource("fixtures/batchUpsert/mediumtext-initial.json").getLines().mkString
+      // parse into EntityUpdateDefinition. This is our initial load file, as if the user had an empty workspace
+      // and uploaded a TSV to create a new data table.
+      val initialUpsert: Seq[EntityUpdateDefinition] = batchUpsertFile.parseJson.convertTo[Seq[EntityUpdateDefinition]]
 
-    // parse into EntityUpdateDefinition. This is our initial load file, as if the user had an empty workspace
-    // and uploaded a TSV to create a new data table.
-    val initialUpsert: Seq[EntityUpdateDefinition] = batchUpsertFile.parseJson.convertTo[Seq[EntityUpdateDefinition]]
+      // copy the initial upsert, but change one value. This is as if the user downloaded a data table to TSV,
+      // modified one cell, and re-uploaded the entire TSV.
+      val firstUpdateDef: EntityUpdateDefinition = initialUpsert.head
+      val firstAddUpdate: AddUpdateAttribute = firstUpdateDef.operations
+        .collectFirst { case aua: AddUpdateAttribute =>
+          aua
+        }
+        .getOrElse(
+          fail("test or fixture invalid: expected first operation in first update to be an AddUpdateAttribute")
+        )
+      val modifiedAddUpdate: AttributeUpdateOperation = firstAddUpdate.copy(addUpdateAttribute =
+        AttributeString(s"${firstAddUpdate.addUpdateAttribute.toString}-changed")
+      )
+      val modifiedUpdateDef = firstUpdateDef.copy(operations = modifiedAddUpdate +: firstUpdateDef.operations.tail)
+      val modifiedUpsert: Seq[EntityUpdateDefinition] = modifiedUpdateDef +: initialUpsert.tail
 
-    // copy the initial upsert, but change one value. This is as if the user downloaded a data table to TSV,
-    // modified one cell, and re-uploaded the entire TSV.
-    val firstUpdateDef: EntityUpdateDefinition = initialUpsert.head
-    val firstAddUpdate: AddUpdateAttribute = (firstUpdateDef.operations.collectFirst {
-      case aua:AddUpdateAttribute => aua
-    }).getOrElse(fail("test or fixture invalid: expected first operation in first update to be an AddUpdateAttribute"))
-    val modifiedAddUpdate: AttributeUpdateOperation = firstAddUpdate.copy(addUpdateAttribute = AttributeString(s"${firstAddUpdate.addUpdateAttribute.toString}-changed"))
-    val modifiedUpdateDef = firstUpdateDef.copy(operations = (modifiedAddUpdate +: firstUpdateDef.operations.tail))
-    val modifiedUpsert: Seq[EntityUpdateDefinition] = modifiedUpdateDef +: initialUpsert.tail
+      // find all entity refs in the initial file; this represents all the entities we need to delete to remove the entire table
+      val refsToDelete: Seq[AttributeEntityReference] = initialUpsert.map { updateDef =>
+        AttributeEntityReference(updateDef.entityType, updateDef.name)
+      }
+      // =========== END DATA SETUP ===========
 
-    // find all entity refs in the initial file; this represents all the entities we need to delete to remove the entire table
-    val refsToDelete: Seq[AttributeEntityReference] = initialUpsert.map { updateDef =>
-      AttributeEntityReference(updateDef.entityType, updateDef.name)
-    }
-    // =========== END DATA SETUP ===========
-
-    /**
+      /**
       * timer function
       */
-    def profile[T](op: => T): (Long, T) = {
-      val tick = System.nanoTime()
-      val result = op
-      val duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime - tick) // could just stick with nanos for more precision
-      (duration, result)
-    }
-
-    // container class for the timings we measure
-    case class Timing(load: Long, change: Long, delete: Long)
-
-    val NUM_ITERATIONS = 20                 // how many times should we loop over the calls-to-be-profiled?
-    val waitDuration: Duration = 10.minutes // how long should we wait for any call?
-
-    // recursive function to execute the service calls NUM_ITERATIONS times
-    def repeatCalls(iteration: Int, previousTimings: Seq[Timing]): Seq[Timing] = {
-      if (iteration+1 > NUM_ITERATIONS) {
-        previousTimings
-      } else {
-        val (loadDuration, _) = profile {
-          Await.result(testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, initialUpsert, None, None), waitDuration)
-        }
-        val (changeDuration, _) = profile {
-          Await.result(testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, modifiedUpsert, None, None), waitDuration)
-        }
-        val (deleteDuration, _) = profile {
-          Await.result(testApiService.entityService.deleteEntities(minimalTestData.wsName, refsToDelete, None, None), waitDuration)
-        }
-        val thisTiming = Timing(loadDuration, changeDuration, deleteDuration)
-
-        logger.error(s"iteration ${iteration+1} of $NUM_ITERATIONS: load ${loadDuration}ms, change ${changeDuration}ms, delete ${deleteDuration}ms")
-
-        repeatCalls(iteration+1, previousTimings :+ thisTiming)
+      def profile[T](op: => T): (Long, T) = {
+        val tick = System.nanoTime()
+        val result = op
+        val duration =
+          TimeUnit.NANOSECONDS.toMillis(System.nanoTime - tick) // could just stick with nanos for more precision
+        (duration, result)
       }
-    }
 
-    // launch the loop
-    val initialTimings = Seq.empty[Timing]
-    val finalTimings = repeatCalls(0, initialTimings)
+      // container class for the timings we measure
+      case class Timing(load: Long, change: Long, delete: Long)
 
-    // write the timings to the log
-    def outputStats(label: String, timings: Seq[Double]): Unit = {
-      logger.error(s"$label: mean ${mean(timings).toInt}ms, min ${min(timings).toInt}ms, max ${max(timings).toInt}ms, stddev ${stddev(timings).toInt}ms, over $NUM_ITERATIONS iterations")
-    }
-    outputStats("batchUpsert all entities from empty", finalTimings.map(_.load.toDouble))
-    outputStats("batchUpsert single value on top of existing", finalTimings.map(_.change.toDouble))
-    outputStats("Delete (hide) all entities", finalTimings.map(_.delete.toDouble))
+      val NUM_ITERATIONS = 20 // how many times should we loop over the calls-to-be-profiled?
+      val waitDuration: Duration = 10.minutes // how long should we wait for any call?
 
-    // beyond outputting timings to the log, this test doesn't assert anything (well, an exception will fail the test)
+      // recursive function to execute the service calls NUM_ITERATIONS times
+      def repeatCalls(iteration: Int, previousTimings: Seq[Timing]): Seq[Timing] =
+        if (iteration + 1 > NUM_ITERATIONS) {
+          previousTimings
+        } else {
+          val (loadDuration, _) = profile {
+            Await.result(
+              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, initialUpsert, None, None),
+              waitDuration
+            )
+          }
+          val (changeDuration, _) = profile {
+            Await.result(
+              testApiService.entityService.batchUpsertEntities(minimalTestData.wsName, modifiedUpsert, None, None),
+              waitDuration
+            )
+          }
+          val (deleteDuration, _) = profile {
+            Await.result(testApiService.entityService.deleteEntities(minimalTestData.wsName, refsToDelete, None, None),
+                         waitDuration
+            )
+          }
+          val thisTiming = Timing(loadDuration, changeDuration, deleteDuration)
+
+          logger.error(
+            s"iteration ${iteration + 1} of $NUM_ITERATIONS: load ${loadDuration}ms, change ${changeDuration}ms, delete ${deleteDuration}ms"
+          )
+
+          repeatCalls(iteration + 1, previousTimings :+ thisTiming)
+        }
+
+      // launch the loop
+      val initialTimings = Seq.empty[Timing]
+      val finalTimings = repeatCalls(0, initialTimings)
+
+      // write the timings to the log
+      def outputStats(label: String, timings: Seq[Double]): Unit =
+        logger.error(
+          s"$label: mean ${mean(timings).toInt}ms, min ${min(timings).toInt}ms, max ${max(timings).toInt}ms, stddev ${stddev(timings).toInt}ms, over $NUM_ITERATIONS iterations"
+        )
+      outputStats("batchUpsert all entities from empty", finalTimings.map(_.load.toDouble))
+      outputStats("batchUpsert single value on top of existing", finalTimings.map(_.change.toDouble))
+      outputStats("Delete (hide) all entities", finalTimings.map(_.delete.toDouble))
+
+      // beyond outputting timings to the log, this test doesn't assert anything (well, an exception will fail the test)
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -5,14 +5,33 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.typesafe.config.ConfigFactory
 import cromwell.client.model.{ToolInputParameter, ValueType}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleBigQueryServiceFactory, MockBigQueryServiceFactory, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleBigQueryServiceFactory,
+  MockBigQueryServiceFactory,
+  SlickDataSource
+}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationContext
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityRequestArguments, EntityService}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.{GatherInputsResult, MethodInput}
 import org.broadinstitute.dsde.rawls.mock.{MockDataRepoDAO, MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, AttributeRename, AttributeString, Entity, EntityQuery, EntityTypeRename, FilterOperators, RawlsRequestContext, RawlsUser, SortDirections, UserInfo, Workspace, WorkspaceFieldSpecs}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeName,
+  AttributeRename,
+  AttributeString,
+  Entity,
+  EntityQuery,
+  EntityTypeRename,
+  FilterOperators,
+  RawlsRequestContext,
+  RawlsUser,
+  SortDirections,
+  UserInfo,
+  Workspace,
+  WorkspaceFieldSpecs
+}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
 import org.scalatest.concurrent.ScalaFutures
@@ -34,13 +53,12 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   val fooAttribute = AttributeName.withDefaultNS("foo")
 
   // create three entities for each type in our list, using unique names for each entity.
-  val exemplarData = exemplarTypes.toSeq.zipWithIndex flatMap {
-    case (typeName, index) =>
-      Seq(
-        Entity(s"$typeName-$index-001", typeName, Map(fooAttribute -> AttributeString(s"$typeName-001"))),
-        Entity(s"$typeName-$index-002", typeName, Map(fooAttribute -> AttributeString(s"$typeName-002"))),
-        Entity(s"$typeName-$index-003", typeName, Map(fooAttribute -> AttributeString(s"$typeName-003")))
-      )
+  val exemplarData = exemplarTypes.toSeq.zipWithIndex flatMap { case (typeName, index) =>
+    Seq(
+      Entity(s"$typeName-$index-001", typeName, Map(fooAttribute -> AttributeString(s"$typeName-001"))),
+      Entity(s"$typeName-$index-002", typeName, Map(fooAttribute -> AttributeString(s"$typeName-002"))),
+      Entity(s"$typeName-$index-003", typeName, Map(fooAttribute -> AttributeString(s"$typeName-003")))
+    )
   }
 
   // create three entities for each type in our list, reusing names across entity types.
@@ -53,7 +71,9 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   }
 
   val exemplarAttributesMap: Map[AttributeName, AttributeString] = Set("pfb", "tdr").flatMap { namespace =>
-    Set("foo", "Foo", "FOO", "bar").map(name => AttributeName(namespace, name) -> AttributeString(s"$namespace:$name-bar"))
+    Set("foo", "Foo", "FOO", "bar").map(name =>
+      AttributeName(namespace, name) -> AttributeString(s"$namespace:$name-bar")
+    )
   }.toMap
   val exemplarAttributeNames = exemplarAttributesMap.keys.map(toDelimitedName)
   val caseInsensitiveAttributeData = Seq(Entity("005", "cat", exemplarAttributesMap))
@@ -70,7 +90,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           // save exemplar data
           runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
           // get provider
-          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                 slickDataSource,
+                                                 false,
+                                                 "metricsBaseName"
+          )
           // get metadata
           val metadata = provider.entityTypeMetadata(false).futureValue
           metadata.keySet shouldBe exemplarTypes
@@ -84,20 +108,22 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
 
           // get metadata
-          val metadata = services.entityService.entityTypeMetadata(testWorkspace.wsName, None, None, useCache = true).futureValue
+          val metadata =
+            services.entityService.entityTypeMetadata(testWorkspace.wsName, None, None, useCache = true).futureValue
           metadata.keySet shouldBe exemplarTypes
 
           // assert cache is populated and up-to-date
-          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain (0)
+          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain(0)
 
           // get types from cache and verify
           val cachedTypes = runAndWait(entityTypeStatisticsQuery.getAll(testWorkspace.workspace.workspaceIdAsUUID))
           cachedTypes.keySet shouldBe exemplarTypes
           // get metadata again, should come from cache, and verify
-          val cachedMetadata = services.entityService.entityTypeMetadata(testWorkspace.wsName, None, None, useCache = true).futureValue
+          val cachedMetadata =
+            services.entityService.entityTypeMetadata(testWorkspace.wsName, None, None, useCache = true).futureValue
           cachedMetadata.keySet shouldBe exemplarTypes
 
-          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain (0)
+          runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) should contain(0)
         }
 
         exemplarTypes foreach { typeUnderTest =>
@@ -119,7 +145,9 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             newName.toLowerCase shouldBe typeUnderTest.toLowerCase
 
             // rename type
-            services.entityService.renameEntityType(testWorkspace.workspace.toWorkspaceName, typeUnderTest, EntityTypeRename(newName)).futureValue
+            services.entityService
+              .renameEntityType(testWorkspace.workspace.toWorkspaceName, typeUnderTest, EntityTypeRename(newName))
+              .futureValue
             // find actual type names from the db
             val actualTypes = getAllEntityTypes(testWorkspace.workspace)
 
@@ -135,7 +163,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
             // delete all entities from target type
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
             provider.deleteEntitiesOfType(typeUnderTest).futureValue
 
             // get actual entity types from the db
@@ -146,44 +178,53 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         }
 
         exemplarTypes foreach { typeUnderTest =>
-          s"should respect case when deleting all named attributes from target type [$typeUnderTest]" in withTestDataServices { services =>
-            // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+          s"should respect case when deleting all named attributes from target type [$typeUnderTest]" in withTestDataServices {
+            services =>
+              // save exemplar data
+              runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
 
-            // delete all attributes named "foo" from the target type
-            services.entityService.deleteEntityAttributes(testWorkspace.workspace.toWorkspaceName, typeUnderTest, Set(fooAttribute)).futureValue
-            // get actual entities from the db
-            val actualEntities = getAllEntities(testWorkspace.workspace)
+              // delete all attributes named "foo" from the target type
+              services.entityService
+                .deleteEntityAttributes(testWorkspace.workspace.toWorkspaceName, typeUnderTest, Set(fooAttribute))
+                .futureValue
+              // get actual entities from the db
+              val actualEntities = getAllEntities(testWorkspace.workspace)
 
-            // loop through all entities. If the entity is of the target type, it should have no "foo" attribute.
-            // if it is NOT of the target type, it SHOULD have a "foo" attribute.
-            actualEntities foreach { e =>
-              if (e.entityType == typeUnderTest) {
-                e.attributes shouldBe empty
-              } else {
-                e.attributes.keySet shouldBe Set(fooAttribute)
+              // loop through all entities. If the entity is of the target type, it should have no "foo" attribute.
+              // if it is NOT of the target type, it SHOULD have a "foo" attribute.
+              actualEntities foreach { e =>
+                if (e.entityType == typeUnderTest) {
+                  e.attributes shouldBe empty
+                } else {
+                  e.attributes.keySet shouldBe Set(fooAttribute)
+                }
               }
-            }
           }
         }
         exemplarTypes foreach { typeUnderTest =>
-          s"should only rename an entire column within target type [$typeUnderTest]" in withTestDataServices { services =>
-            // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
+          s"should only rename an entire column within target type [$typeUnderTest]" in withTestDataServices {
+            services =>
+              // save exemplar data
+              runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
 
-            // rename attribute from target type
-            services.entityService.renameAttribute(testWorkspace.workspace.toWorkspaceName, typeUnderTest, fooAttribute,
-              AttributeRename(AttributeName.withDefaultNS("new-attr-name"))).futureValue
-            // get actual entities from the db
-            val actualEntities = getAllEntities(testWorkspace.workspace)
+              // rename attribute from target type
+              services.entityService
+                .renameAttribute(testWorkspace.workspace.toWorkspaceName,
+                                 typeUnderTest,
+                                 fooAttribute,
+                                 AttributeRename(AttributeName.withDefaultNS("new-attr-name"))
+                )
+                .futureValue
+              // get actual entities from the db
+              val actualEntities = getAllEntities(testWorkspace.workspace)
 
-            actualEntities foreach { e =>
-              if (e.entityType == typeUnderTest) {
-                e.attributes.keySet shouldBe Set(AttributeName.withDefaultNS("new-attr-name"))
-              } else {
-                e.attributes.keySet shouldBe Set(fooAttribute)
+              actualEntities foreach { e =>
+                if (e.entityType == typeUnderTest) {
+                  e.attributes.keySet shouldBe Set(AttributeName.withDefaultNS("new-attr-name"))
+                } else {
+                  e.attributes.keySet shouldBe Set(fooAttribute)
+                }
               }
-            }
           }
         }
         exemplarTypes foreach { typeUnderTest =>
@@ -191,9 +232,20 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // save exemplar data
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
             // get results for one specific type
-            val queryCriteria = EntityQuery(1, exemplarData.size, "name", SortDirections.Ascending, None, FilterOperators.And, WorkspaceFieldSpecs(None))
+            val queryCriteria = EntityQuery(1,
+                                            exemplarData.size,
+                                            "name",
+                                            SortDirections.Ascending,
+                                            None,
+                                            FilterOperators.And,
+                                            WorkspaceFieldSpecs(None)
+            )
             val queryResponse = provider.queryEntities(typeUnderTest, queryCriteria).futureValue
             // extract distinct entity types from results
             val typesFromResults = queryResponse.results.map(_.entityType).distinct
@@ -206,7 +258,8 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // save exemplar data
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarData))
 
-            val listAllResponse = services.entityService.listEntities(testWorkspace.workspace.toWorkspaceName, typeUnderTest).futureValue
+            val listAllResponse =
+              services.entityService.listEntities(testWorkspace.workspace.toWorkspaceName, typeUnderTest).futureValue
 
             // extract distinct entity types from results
             val typesFromResults = listAllResponse.map(_.entityType).distinct
@@ -223,7 +276,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
 
           // get provider
-          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                 slickDataSource,
+                                                 false,
+                                                 "metricsBaseName"
+          )
           // test gets
           exemplarDataWithCommonNames foreach { entityUnderTest =>
             val actual = provider.getEntity(entityUnderTest.entityType, entityUnderTest.name).futureValue
@@ -237,16 +294,24 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
 
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
             // set up arguments for expression evaluation
-            val expressionEvaluationContext = ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), None, Option(typeUnderTest))
+            val expressionEvaluationContext =
+              ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), None, Option(typeUnderTest))
 
-            val toolInputParameter = new ToolInputParameter().name("my-input-name").valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+            val toolInputParameter = new ToolInputParameter()
+              .name("my-input-name")
+              .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
             val processableInputs = Set(MethodInput(toolInputParameter, "this.foo"))
             val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
 
-            val submissionValidationEntityInputsList = provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
+            val submissionValidationEntityInputsList =
+              provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
             submissionValidationEntityInputsList.size shouldBe 1
 
             val entityInputs = submissionValidationEntityInputsList.head
@@ -254,7 +319,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             entityInputs.inputResolutions.size shouldBe 1
             entityInputs.inputResolutions.head.error shouldBe empty
             entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
-            entityInputs.inputResolutions.head.value should contain (AttributeString(s"$typeUnderTest-002"))
+            entityInputs.inputResolutions.head.value should contain(AttributeString(s"$typeUnderTest-002"))
           }
         }
 
@@ -264,17 +329,25 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
 
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
             // set up arguments for expression evaluation, using "this.${typeUnderTest}_id"
             val expressionString = s"this.${typeUnderTest}_id"
-            val expressionEvaluationContext = ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), None, Option(typeUnderTest))
-            val toolInputParameter = new ToolInputParameter().name("my-input-name").valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+            val expressionEvaluationContext =
+              ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), None, Option(typeUnderTest))
+            val toolInputParameter = new ToolInputParameter()
+              .name("my-input-name")
+              .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
             val processableInputs = Set(MethodInput(toolInputParameter, expressionString))
             val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
 
             // evaluate expression
-            val submissionValidationEntityInputsList = provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
+            val submissionValidationEntityInputsList =
+              provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
             submissionValidationEntityInputsList.size shouldBe 1
 
             // verify expression resolution
@@ -283,36 +356,47 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             entityInputs.inputResolutions.size shouldBe 1
             entityInputs.inputResolutions.head.error shouldBe empty
             entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
-            entityInputs.inputResolutions.head.value should contain (AttributeString(s"002"))
+            entityInputs.inputResolutions.head.value should contain(AttributeString(s"002"))
           }
         }
 
         exemplarTypes foreach { typeUnderTest =>
-          s"should resolve type + _id expressions to an empty result if the type is incorrectly cased [$typeUnderTest]" in withTestDataServices { _ =>
-            // save exemplar data
-            runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
+          s"should resolve type + _id expressions to an empty result if the type is incorrectly cased [$typeUnderTest]" in withTestDataServices {
+            _ =>
+              // save exemplar data
+              runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
 
-            // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+              // get provider
+              val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                     slickDataSource,
+                                                     false,
+                                                     "metricsBaseName"
+              )
 
-            // set up arguments for expression evaluation, using incorrect case for "this.${typeUnderTest}_id"
-            val expressionString = s"this.${typeUnderTest.head.toLower}${typeUnderTest.tail.toUpperCase}_id"
-            val expressionEvaluationContext = ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), None, Option(typeUnderTest))
-            val toolInputParameter = new ToolInputParameter().name("my-input-name").valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
-            val processableInputs = Set(MethodInput(toolInputParameter, expressionString))
-            val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
+              // set up arguments for expression evaluation, using incorrect case for "this.${typeUnderTest}_id"
+              val expressionString = s"this.${typeUnderTest.head.toLower}${typeUnderTest.tail.toUpperCase}_id"
+              val expressionEvaluationContext =
+                ExpressionEvaluationContext(Option(typeUnderTest), Option("002"), None, Option(typeUnderTest))
+              val toolInputParameter = new ToolInputParameter()
+                .name("my-input-name")
+                .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+              val processableInputs = Set(MethodInput(toolInputParameter, expressionString))
+              val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
 
-            // evaluate expression
-            val submissionValidationEntityInputsList = provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
-            submissionValidationEntityInputsList.size shouldBe 1
+              // evaluate expression
+              val submissionValidationEntityInputsList =
+                provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
+              submissionValidationEntityInputsList.size shouldBe 1
 
-            // verify expression resolution
-            val entityInputs = submissionValidationEntityInputsList.head
-            entityInputs.entityName shouldBe "002"
-            entityInputs.inputResolutions.size shouldBe 1
-            entityInputs.inputResolutions.head.error should contain ("Expected single value for workflow input, but evaluated result set was empty")
-            entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
-            entityInputs.inputResolutions.head.value shouldBe empty
+              // verify expression resolution
+              val entityInputs = submissionValidationEntityInputsList.head
+              entityInputs.entityName shouldBe "002"
+              entityInputs.inputResolutions.size shouldBe 1
+              entityInputs.inputResolutions.head.error should contain(
+                "Expected single value for workflow input, but evaluated result set was empty"
+              )
+              entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
+              entityInputs.inputResolutions.head.value shouldBe empty
           }
         }
 
@@ -321,12 +405,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // save exemplar data
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
             // delete two entities of target type
-            val entRefs = Seq(
-              AttributeEntityReference(typeUnderTest, "001"),
-              AttributeEntityReference(typeUnderTest, "002"))
+            val entRefs =
+              Seq(AttributeEntityReference(typeUnderTest, "001"), AttributeEntityReference(typeUnderTest, "002"))
             provider.deleteEntities(entRefs).futureValue
 
             // count actual entities by type
@@ -335,7 +422,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
               case (typeName, entities) => (typeName, entities.size)
             }
             typesToCounts(typeUnderTest) shouldBe 1
-            exemplarTypes-typeUnderTest foreach { otherType =>
+            exemplarTypes - typeUnderTest foreach { otherType =>
               typesToCounts(otherType) shouldBe 3
             }
           }
@@ -347,7 +434,9 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
 
             // rename entity of target type
-            services.entityService.renameEntity(testWorkspace.workspace.toWorkspaceName, typeUnderTest, "003", "my-new-name").futureValue
+            services.entityService
+              .renameEntity(testWorkspace.workspace.toWorkspaceName, typeUnderTest, "003", "my-new-name")
+              .futureValue
 
             // get actual entities
             val actualEntities = getAllEntities(testWorkspace.workspace)
@@ -364,34 +453,47 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // save exemplar data
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
             // create a batch upsert to add an entity reference from 001 to 003
-            val op = AddUpdateAttribute(AttributeName.withDefaultNS("my-entity-reference"), AttributeEntityReference(typeUnderTest, "003"))
+            val op = AddUpdateAttribute(AttributeName.withDefaultNS("my-entity-reference"),
+                                        AttributeEntityReference(typeUnderTest, "003")
+            )
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
             provider.batchUpsertEntities(Seq(upsert)).futureValue
 
-
             // get database-level entity record for the entity containing the reference
-            val entityRecordContainingReference = runAndWait(entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
-              Set(AttributeEntityReference(typeUnderTest, "001")))).head
+            val entityRecordContainingReference = runAndWait(
+              entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
+                                           Set(AttributeEntityReference(typeUnderTest, "001"))
+              )
+            ).head
 
             // get database-level entity record for the entity being referenced
-            val entityRecordBeingReferenced = runAndWait(entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
-              Set(AttributeEntityReference(typeUnderTest, "003")))).head
+            val entityRecordBeingReferenced = runAndWait(
+              entityQuery.getEntityRecords(testWorkspace.workspace.workspaceIdAsUUID,
+                                           Set(AttributeEntityReference(typeUnderTest, "003"))
+              )
+            ).head
 
             // get database-level attribute record for the reference and find the entity id it is referencing
             import driver.api._
-            val actualReferencedIds = runAndWait(entityAttributeShardQuery(testWorkspace.workspace.workspaceIdAsUUID)
-              .findByOwnerQuery(Seq(entityRecordContainingReference.id))
-              .filter(_.name === "my-entity-reference")
-              .map(attr => attr.valueEntityRef)
-              .result)
+            val actualReferencedIds = runAndWait(
+              entityAttributeShardQuery(testWorkspace.workspace.workspaceIdAsUUID)
+                .findByOwnerQuery(Seq(entityRecordContainingReference.id))
+                .filter(_.name === "my-entity-reference")
+                .map(attr => attr.valueEntityRef)
+                .result
+            )
 
             // we should have exactly one reference, and it should point to entityRecordBeingReferenced
             actualReferencedIds.size shouldBe 1
-            actualReferencedIds.head shouldNot be (empty)
+            actualReferencedIds.head shouldNot be(empty)
             actualReferencedIds.head.get shouldBe entityRecordBeingReferenced.id
           }
         }
@@ -401,7 +503,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // save exemplar data
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
             // create a batch upsert to change the target entity's attribute
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
@@ -415,18 +521,21 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // N.B. use this technique - get all entities, use Scala find() - to avoid any complications with the
             // provider.getEntity() method having bugs
             val foundOptAfterUpsert = entitiesAfterUpsert.find(e => e.name == "001" && e.entityType == typeUnderTest)
-            foundOptAfterUpsert shouldNot be (empty)
+            foundOptAfterUpsert shouldNot be(empty)
             val foundAfterUpsert = foundOptAfterUpsert.get
 
             // after upsert, found entity should have an updated attribute
-            val expected = Entity(foundAfterUpsert.name, typeUnderTest, Map(AttributeName.withDefaultNS("foo") -> AttributeString("updated")))
+            val expected = Entity(foundAfterUpsert.name,
+                                  typeUnderTest,
+                                  Map(AttributeName.withDefaultNS("foo") -> AttributeString("updated"))
+            )
             foundAfterUpsert shouldBe expected
             // after upsert, all other entities should NOT have an updated attribute
             entitiesAfterUpsert foreach { e =>
               if (e.name != "001" && e.entityType != typeUnderTest) {
                 val actualFoo = e.attributes.get(fooAttribute)
-                actualFoo shouldNot be (empty)
-                actualFoo shouldNot contain (AttributeString("updated"))
+                actualFoo shouldNot be(empty)
+                actualFoo shouldNot contain(AttributeString("updated"))
               }
             }
           }
@@ -437,7 +546,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // save exemplar data
             runAndWait(entityQuery.save(testWorkspace.workspace, exemplarDataWithCommonNames))
             // get provider
-            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
             // create a batch upsert to change the target entity's attribute
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
@@ -451,18 +564,21 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // N.B. use this technique - get all entities, use Scala find() - to avoid any complications with the
             // provider.getEntity() method having bugs
             val foundOptAfterUpdate = entitiesAfterUpdate.find(e => e.name == "001" && e.entityType == typeUnderTest)
-            foundOptAfterUpdate shouldNot be (empty)
+            foundOptAfterUpdate shouldNot be(empty)
             val foundAfterUpdate = foundOptAfterUpdate.get
 
             // after upsert, found entity should have an updated attribute
-            val expected = Entity(foundAfterUpdate.name, typeUnderTest, Map(AttributeName.withDefaultNS("foo") -> AttributeString("updated")))
+            val expected = Entity(foundAfterUpdate.name,
+                                  typeUnderTest,
+                                  Map(AttributeName.withDefaultNS("foo") -> AttributeString("updated"))
+            )
             foundAfterUpdate shouldBe expected
             // after upsert, all other entities should NOT have an updated attribute
             entitiesAfterUpdate foreach { e =>
               if (e.name != "001" && e.entityType != typeUnderTest) {
                 val actualFoo = e.attributes.get(fooAttribute)
-                actualFoo shouldNot be (empty)
-                actualFoo shouldNot contain (AttributeString("updated"))
+                actualFoo shouldNot be(empty)
+                actualFoo shouldNot contain(AttributeString("updated"))
               }
             }
           }
@@ -476,7 +592,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         // save case insensitive attribute data
         runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               false,
+                                               "metricsBaseName"
+        )
         // get metadata
         val metadata = provider.entityTypeMetadata(false).futureValue
         metadata("cat").attributeNames.size shouldEqual exemplarAttributeNames.size
@@ -491,7 +611,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)) shouldBe empty
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
         provider.entityTypeMetadata(true).futureValue
 
         // cache is now populated
@@ -507,7 +631,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
 
         // query all entities
         val entityQueryParameters = EntityQuery(1, 10, "name", SortDirections.Ascending, None)
@@ -525,7 +653,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
 
         // delete our test entity
         provider.deleteEntities(Seq(AttributeEntityReference("cat", "005"))).futureValue shouldBe 1
@@ -535,12 +667,16 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
         exemplarAttributeNames.size shouldBe allAttributes.size
-        allAttributes.foreach { attr => assert(attr.deleted) }
+        allAttributes.foreach(attr => assert(attr.deleted))
       }
 
       "should create all attributes for a new entity" in withTestDataServices { _ =>
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
 
         // create our entity
         provider.createEntity(caseInsensitiveAttributeData.head).futureValue // Entity
@@ -550,7 +686,9 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
         exemplarAttributeNames.size shouldBe allAttributes.size
-        allAttributes.map(attr => toDelimitedName(AttributeName(attr.namespace, attr.name))) should contain theSameElementsAs exemplarAttributeNames
+        allAttributes.map(attr =>
+          toDelimitedName(AttributeName(attr.namespace, attr.name))
+        ) should contain theSameElementsAs exemplarAttributeNames
       }
 
       "should return all attribute names when listing entities" in withTestDataServices { _ =>
@@ -568,29 +706,33 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
       }
 
       exemplarAttributesMap.keys.foreach { attributeNameToDelete =>
-        s"should delete the correct column based on case when deleting column [${toDelimitedName(attributeNameToDelete)}]" in withTestDataServices { _ =>
-          // save case insensitive attribute data
-          runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        s"should delete the correct column based on case when deleting column [${toDelimitedName(attributeNameToDelete)}]" in withTestDataServices {
+          _ =>
+            // save case insensitive attribute data
+            runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
 
-          // delete column all entities
-          val columnsToDelete = Set(attributeNameToDelete)
-          runAndWait(
-            entityAttributeShardQuery(testWorkspace.workspace).deleteAttributes(testWorkspace.workspace, "cat", columnsToDelete)
-          )
+            // delete column all entities
+            val columnsToDelete = Set(attributeNameToDelete)
+            runAndWait(
+              entityAttributeShardQuery(testWorkspace.workspace).deleteAttributes(testWorkspace.workspace,
+                                                                                  "cat",
+                                                                                  columnsToDelete
+              )
+            )
 
-          // get all attributes to verify deletion
-          import driver.api._
+            // get all attributes to verify deletion
+            import driver.api._
 
-          val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
-            .map(attr => toDelimitedName(AttributeName(attr.namespace, attr.name)))
+            val allAttributes = runAndWait(entityAttributeShardQuery(testWorkspace.workspace).result)
+              .map(attr => toDelimitedName(AttributeName(attr.namespace, attr.name)))
 
-          // verify an attribute is deleted
-          allAttributes.size shouldBe exemplarAttributeNames.size - 1
-          allAttributes shouldNot contain (toDelimitedName(attributeNameToDelete))
+            // verify an attribute is deleted
+            allAttributes.size shouldBe exemplarAttributeNames.size - 1
+            allAttributes shouldNot contain(toDelimitedName(attributeNameToDelete))
 
-          // verify the correct attributes remain
-          val remainingAttributeNames = exemplarAttributeNames.toSet - toDelimitedName(attributeNameToDelete)
-          allAttributes should contain theSameElementsAs remainingAttributeNames
+            // verify the correct attributes remain
+            val remainingAttributeNames = exemplarAttributeNames.toSet - toDelimitedName(attributeNameToDelete)
+            allAttributes should contain theSameElementsAs remainingAttributeNames
         }
       }
 
@@ -599,7 +741,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
 
         // get our entity
         val entity = provider.getEntity("cat", "005").futureValue // Entity
@@ -616,16 +762,16 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
           // now update one attribute value
           val attributeUpdates = Seq(AddUpdateAttribute(attributeToUpdate, AttributeString("new-value")))
-          val updatedEntity = services.entityService.updateEntity(testWorkspace.wsName, "cat", "005", attributeUpdates).futureValue
+          val updatedEntity =
+            services.entityService.updateEntity(testWorkspace.wsName, "cat", "005", attributeUpdates).futureValue
 
           // make sure all attributes are returned, and only the updated attribute is updated
           updatedEntity.attributes.size shouldBe exemplarAttributeNames.size
-          updatedEntity.attributes.foreach {
-            case (attributeName, attributeValue) =>
-              if (attributeName == attributeToUpdate)
-                attributeValue shouldBe AttributeString("new-value")
-              else
-                attributeValue shouldBe AttributeString(s"${toDelimitedName(attributeName)}-bar")
+          updatedEntity.attributes.foreach { case (attributeName, attributeValue) =>
+            if (attributeName == attributeToUpdate)
+              attributeValue shouldBe AttributeString("new-value")
+            else
+              attributeValue shouldBe AttributeString(s"${toDelimitedName(attributeName)}-bar")
           }
 
           services.entityService.deleteEntitiesOfType(testWorkspace.wsName, "cat", None, None).futureValue
@@ -634,11 +780,15 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
       "should add all attributes when batch upserting entities" in withTestDataServices { _ =>
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
 
         val updateDefinition = caseInsensitiveAttributeData.map { entity =>
-          val attributeUpdates = entity.attributes.map {
-            case (attributeName, attributeValue) => AddUpdateAttribute(attributeName, attributeValue)
+          val attributeUpdates = entity.attributes.map { case (attributeName, attributeValue) =>
+            AddUpdateAttribute(attributeName, attributeValue)
           }.toSeq
           EntityUpdateDefinition(entity.name, entity.entityType, attributeUpdates)
         }
@@ -657,13 +807,16 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
 
         // get provider
-        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, true, "metricsBaseName")
+        val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                               slickDataSource,
+                                               true,
+                                               "metricsBaseName"
+        )
 
         // Update all attributes
         val updateDefinition = caseInsensitiveAttributeData.map { entity =>
-          val attributeUpdates = entity.attributes.map {
-            case (attributeName, _) =>
-              AddUpdateAttribute(attributeName, AttributeString(s"${toDelimitedName(attributeName)}: new-attribute"))
+          val attributeUpdates = entity.attributes.map { case (attributeName, _) =>
+            AddUpdateAttribute(attributeName, AttributeString(s"${toDelimitedName(attributeName)}: new-attribute"))
           }.toSeq
           EntityUpdateDefinition(entity.name, entity.entityType, attributeUpdates)
         }
@@ -674,33 +827,44 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
         // make sure all attributes are created
         exemplarAttributeNames.size should equal(entity.attributes.size)
-        exemplarAttributesMap.keys.foreach { attr => entity.attributes.get(attr).get shouldBe AttributeString(s"${toDelimitedName(attr)}: new-attribute") }
+        exemplarAttributesMap.keys.foreach { attr =>
+          entity.attributes.get(attr).get shouldBe AttributeString(s"${toDelimitedName(attr)}: new-attribute")
+        }
       }
 
       exemplarAttributeNames foreach { attributeUnderTest =>
-        s"should respect case for expression evaluation attribute names [$attributeUnderTest]" in withTestDataServices { _ =>
-          // save exemplar data
-          runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
+        s"should respect case for expression evaluation attribute names [$attributeUnderTest]" in withTestDataServices {
+          _ =>
+            // save exemplar data
+            runAndWait(entityQuery.save(testWorkspace.workspace, caseInsensitiveAttributeData))
 
-          // get provider
-          val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext), slickDataSource, false, "metricsBaseName")
+            // get provider
+            val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
+                                                   slickDataSource,
+                                                   false,
+                                                   "metricsBaseName"
+            )
 
-          // set up arguments for expression evaluation
-          val expressionEvaluationContext = ExpressionEvaluationContext(Option("cat"), Option("005"), None, Option("cat"))
+            // set up arguments for expression evaluation
+            val expressionEvaluationContext =
+              ExpressionEvaluationContext(Option("cat"), Option("005"), None, Option("cat"))
 
-          val toolInputParameter = new ToolInputParameter().name("my-input-name").valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
-          val processableInputs = Set(MethodInput(toolInputParameter, s"this.$attributeUnderTest"))
-          val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
+            val toolInputParameter = new ToolInputParameter()
+              .name("my-input-name")
+              .valueType(new ValueType().typeName(ValueType.TypeNameEnum.STRING))
+            val processableInputs = Set(MethodInput(toolInputParameter, s"this.$attributeUnderTest"))
+            val gatherInputsResult = GatherInputsResult(processableInputs, Set(), Set(), Set())
 
-          val submissionValidationEntityInputsList = provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
-          submissionValidationEntityInputsList.size shouldBe 1
+            val submissionValidationEntityInputsList =
+              provider.evaluateExpressions(expressionEvaluationContext, gatherInputsResult, Map()).futureValue.toList
+            submissionValidationEntityInputsList.size shouldBe 1
 
-          val entityInputs = submissionValidationEntityInputsList.head
-          entityInputs.entityName shouldBe "005"
-          entityInputs.inputResolutions.size shouldBe 1
-          entityInputs.inputResolutions.head.error shouldBe empty
-          entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
-          entityInputs.inputResolutions.head.value should contain (AttributeString(s"$attributeUnderTest-bar"))
+            val entityInputs = submissionValidationEntityInputsList.head
+            entityInputs.entityName shouldBe "005"
+            entityInputs.inputResolutions.size shouldBe 1
+            entityInputs.inputResolutions.head.error shouldBe empty
+            entityInputs.inputResolutions.head.inputName shouldBe "my-input-name"
+            entityInputs.inputResolutions.head.value should contain(AttributeString(s"$attributeUnderTest-bar"))
         }
       }
     }
@@ -710,7 +874,8 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
   // Test helpers and fixtures
   // ===================================================================================================================
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(500, Millis)), interval = scaled(Span(15, Millis)))
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(500, Millis)), interval = scaled(Span(15, Millis)))
 
   private def getAllEntities(workspace: Workspace): Seq[Entity] =
     runAndWait(entityQuery.listActiveEntities(workspace)).iterator.toSeq
@@ -720,8 +885,11 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
     actualEntities.map(_.entityType).toSet
   }
 
-  //noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
-  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit val executionContext: ExecutionContext) extends EntityApiService with MockUserInfoDirectivesWithUser {
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends EntityApiService
+      with MockUserInfoDirectivesWithUser {
     private val userInfo1 = UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId)
     private val testContext1 = RawlsRequestContext(userInfo1)
     lazy val entityService: EntityService = entityServiceConstructor(testContext1)
@@ -739,9 +907,18 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
       slickDataSource,
       samDAO,
       workbenchMetricBaseName = "test",
-      EntityManager.defaultEntityManager(dataSource, new MockWorkspaceManagerDAO(), new MockDataRepoDAO("mockrepo"), samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"), "testMetricBaseName"),
+      EntityManager.defaultEntityManager(
+        dataSource,
+        new MockWorkspaceManagerDAO(),
+        new MockDataRepoDAO("mockrepo"),
+        samDAO,
+        bigQueryServiceFactory,
+        DataRepoEntityProviderConfig(100, 10, 0),
+        testConf.getBoolean("entityStatisticsCache.enabled"),
+        "testMetricBaseName"
+      ),
       1000
-    )_
+    ) _
   }
 
   private def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: TestApiService => T): T = {
@@ -749,11 +926,8 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
     testCode(apiService)
   }
 
-  def withTestDataServices[T](testCode: TestApiService => T): T = {
+  def withTestDataServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(testWorkspace) { dataSource: SlickDataSource =>
       withServices(dataSource, testWorkspace.userOwner)(testCode)
     }
-  }
 }
-
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/EntityStatisticsCacheSupportSpec.scala
@@ -2,16 +2,19 @@ package org.broadinstitute.dsde.rawls.entities.local
 
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{EntityRecordWithInlineAttributes, TestDriverComponentWithFlatSpecAndMatchers}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  EntityRecordWithInlineAttributes,
+  TestDriverComponentWithFlatSpecAndMatchers
+}
 import org.broadinstitute.dsde.rawls.model.{EntityTypeMetadata, RawlsRequestContext, Workspace}
 
 import scala.concurrent.ExecutionContext
 
-class CacheSupport(val dataSource: SlickDataSource, val workspaceContext: Workspace) extends EntityStatisticsCacheSupport {
-  override implicit protected val executionContext: ExecutionContext = ExecutionContext.global
+class CacheSupport(val dataSource: SlickDataSource, val workspaceContext: Workspace)
+    extends EntityStatisticsCacheSupport {
+  implicit override protected val executionContext: ExecutionContext = ExecutionContext.global
   val workbenchMetricBaseName: String = "test_metric_base_name"
 }
-
 
 class EntityStatisticsCacheSupportSpec extends TestDriverComponentWithFlatSpecAndMatchers with RawlsTestUtils {
 
@@ -21,11 +24,14 @@ class EntityStatisticsCacheSupportSpec extends TestDriverComponentWithFlatSpecAn
 
   it should "list all entity type metadata" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-
       val cacheSupport = new CacheSupport(slickDataSource, context)
 
       val desiredTypeMetadata = Map[String, EntityTypeMetadata](
-        "Sample" -> EntityTypeMetadata(8, "sample_id", Seq("type", "whatsit", "thingies", "quot", "somefoo", "tumortype", "confused", "cycle", "foo_id")),
+        "Sample" -> EntityTypeMetadata(
+          8,
+          "sample_id",
+          Seq("type", "whatsit", "thingies", "quot", "somefoo", "tumortype", "confused", "cycle", "foo_id")
+        ),
         "Aliquot" -> EntityTypeMetadata(2, "aliquot_id", Seq()),
         "Pair" -> EntityTypeMetadata(2, "pair_id", Seq("case", "control", "whatsit")),
         "SampleSet" -> EntityTypeMetadata(5, "sampleset_id", Seq("samples", "hasSamples")),
@@ -33,16 +39,21 @@ class EntityStatisticsCacheSupportSpec extends TestDriverComponentWithFlatSpecAn
         "Individual" -> EntityTypeMetadata(2, "individual_id", Seq("sset"))
       )
 
-      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
-      //so we test the existence of all keys correctly here...
-      val testTypeMetadata = runAndWait(cacheSupport.calculateMetadataResponse(slickDataSource.dataAccess,
-        countsFromCache = false, attributesFromCache = false, parentContext = RawlsRequestContext(userInfo)))
+      // assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
+      // so we test the existence of all keys correctly here...
+      val testTypeMetadata = runAndWait(
+        cacheSupport.calculateMetadataResponse(slickDataSource.dataAccess,
+                                               countsFromCache = false,
+                                               attributesFromCache = false,
+                                               parentContext = RawlsRequestContext(userInfo)
+        )
+      )
       assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
 
       testTypeMetadata foreach { case (eType, testMetadata) =>
         val desiredMetadata = desiredTypeMetadata(eType)
 
-        //...and test that count and the list of attribute names are correct here.
+        // ...and test that count and the list of attribute names are correct here.
         assert(testMetadata.count == desiredMetadata.count)
         assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
       }
@@ -51,38 +62,63 @@ class EntityStatisticsCacheSupportSpec extends TestDriverComponentWithFlatSpecAn
 
   // GAWB-870
   val testWorkspace = new EmptyWorkspace
-  it should "list all entity type metadata when all_attribute_values is null" in withCustomTestDatabase(testWorkspace) { dataSource =>
-    withWorkspaceContext(testWorkspace.workspace) { context =>
+  it should "list all entity type metadata when all_attribute_values is null" in withCustomTestDatabase(testWorkspace) {
+    dataSource =>
+      withWorkspaceContext(testWorkspace.workspace) { context =>
+        val cacheSupport = new CacheSupport(slickDataSource, context)
 
-      val cacheSupport = new CacheSupport(slickDataSource, context)
+        val id1 = 1
+        val id2 = 2 // arbitrary
 
-      val id1 = 1
-      val id2 = 2   // arbitrary
+        // count distinct misses rows with null columns, like this one
+        runAndWait(
+          entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id1,
+                                                                              "test1",
+                                                                              "null_attrs_type",
+                                                                              context.workspaceIdAsUUID,
+                                                                              0,
+                                                                              None,
+                                                                              deleted = false,
+                                                                              None
+          )
+        )
 
-      // count distinct misses rows with null columns, like this one
-      runAndWait(entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id1, "test1", "null_attrs_type", context.workspaceIdAsUUID, 0, None, deleted = false, None))
+        runAndWait(
+          entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id2,
+                                                                              "test2",
+                                                                              "blank_attrs_type",
+                                                                              context.workspaceIdAsUUID,
+                                                                              0,
+                                                                              Some(""),
+                                                                              deleted = false,
+                                                                              None
+          )
+        )
 
-      runAndWait(entityQueryWithInlineAttributes += EntityRecordWithInlineAttributes(id2, "test2", "blank_attrs_type", context.workspaceIdAsUUID, 0, Some(""), deleted = false, None))
+        val desiredTypeMetadata = Map[String, EntityTypeMetadata](
+          "null_attrs_type" -> EntityTypeMetadata(1, "null_attrs_type_id", Seq()),
+          "blank_attrs_type" -> EntityTypeMetadata(1, "blank_attrs_type", Seq())
+        )
 
-      val desiredTypeMetadata = Map[String, EntityTypeMetadata](
-        "null_attrs_type" -> EntityTypeMetadata(1, "null_attrs_type_id", Seq()),
-        "blank_attrs_type" -> EntityTypeMetadata(1, "blank_attrs_type", Seq())
-      )
+        // assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
+        // so we test the existence of all keys correctly here...
+        val testTypeMetadata = runAndWait(
+          cacheSupport.calculateMetadataResponse(dataSource.dataAccess,
+                                                 countsFromCache = false,
+                                                 attributesFromCache = false,
+                                                 parentContext = RawlsRequestContext(userInfo)
+          )
+        )
+        assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
 
-      //assertSameElements is fine with out-of-order keys but isn't find with out-of-order interable-type values
-      //so we test the existence of all keys correctly here...
-      val testTypeMetadata = runAndWait(cacheSupport.calculateMetadataResponse(dataSource.dataAccess,
-        countsFromCache = false, attributesFromCache = false, parentContext = RawlsRequestContext(userInfo)))
-      assertSameElements(testTypeMetadata.keys, desiredTypeMetadata.keys)
+        testTypeMetadata foreach { case (eType, testMetadata) =>
+          val desiredMetadata = desiredTypeMetadata(eType)
 
-      testTypeMetadata foreach { case (eType, testMetadata) =>
-        val desiredMetadata = desiredTypeMetadata(eType)
-
-        //...and test that count and the list of attribute names are correct here.
-        assert(testMetadata.count == desiredMetadata.count)
-        assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
+          // ...and test that count and the list of attribute names are correct here.
+          assert(testMetadata.count == desiredMetadata.count)
+          assertSameElements(testMetadata.attributeNames, desiredMetadata.attributeNames)
+        }
       }
-    }
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -8,7 +8,19 @@ import org.broadinstitute.dsde.rawls.jobexec.MethodConfigTestSupport
 import org.broadinstitute.dsde.rawls.metrics.StatsDTestUtils
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
-import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeNumber, AttributeString, AttributeValueEmptyList, AttributeValueList, Entity, EntityTypeMetadata, MethodConfiguration, SubmissionValidationValue, WDL, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeName,
+  AttributeNumber,
+  AttributeString,
+  AttributeValueEmptyList,
+  AttributeValueList,
+  Entity,
+  EntityTypeMetadata,
+  MethodConfiguration,
+  SubmissionValidationValue,
+  WDL,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
@@ -23,26 +35,48 @@ import java.time.temporal.ChronoUnit
 import scala.collection.immutable.Map
 import scala.concurrent.ExecutionContext
 
-class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFutures with TestDriverComponent with MethodConfigTestSupport with StatsDTestUtils with Eventually with MockitoTestUtils {
+class LocalEntityProviderSpec
+    extends AnyWordSpecLike
+    with Matchers
+    with ScalaFutures
+    with TestDriverComponent
+    with MethodConfigTestSupport
+    with StatsDTestUtils
+    with Eventually
+    with MockitoTestUtils {
   import driver.api._
 
   val testConf = ConfigFactory.load()
 
-  //Test harness to call resolveInputsForEntities without having to go via the WorkspaceService
-  def testResolveInputs(workspaceContext: Workspace, methodConfig: MethodConfiguration, entity: Entity, wdl: WDL, dataAccess: DataAccess)
-                       (implicit executionContext: ExecutionContext): ReadWriteAction[Map[String, Seq[SubmissionValidationValue]]] = {
+  // Test harness to call resolveInputsForEntities without having to go via the WorkspaceService
+  def testResolveInputs(workspaceContext: Workspace,
+                        methodConfig: MethodConfiguration,
+                        entity: Entity,
+                        wdl: WDL,
+                        dataAccess: DataAccess
+  )(implicit executionContext: ExecutionContext): ReadWriteAction[Map[String, Seq[SubmissionValidationValue]]] = {
 
-    val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, testConf.getBoolean("entityStatisticsCache.enabled"), workbenchMetricBaseName)
+    val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                      slickDataSource,
+                                                      testConf.getBoolean("entityStatisticsCache.enabled"),
+                                                      workbenchMetricBaseName
+    )
 
-    dataAccess.entityQuery.findEntityByName(workspaceContext.workspaceIdAsUUID, entity.entityType, entity.name).result flatMap { entityRecs =>
+    dataAccess.entityQuery
+      .findEntityByName(workspaceContext.workspaceIdAsUUID, entity.entityType, entity.name)
+      .result flatMap { entityRecs =>
       methodConfigResolver.gatherInputs(userInfo, methodConfig, wdl) match {
         case scala.util.Failure(exception) =>
           DBIO.failed(exception)
         case scala.util.Success(gatherInputsResult: GatherInputsResult)
-          if gatherInputsResult.extraInputs.nonEmpty || gatherInputsResult.missingInputs.nonEmpty =>
+            if gatherInputsResult.extraInputs.nonEmpty || gatherInputsResult.missingInputs.nonEmpty =>
           DBIO.failed(new RawlsException(s"gatherInputsResult has missing or extra inputs: $gatherInputsResult"))
         case scala.util.Success(gatherInputsResult: GatherInputsResult) =>
-          localEntityProvider.evaluateExpressionsInternal(workspaceContext, gatherInputsResult.processableInputs, Some(entityRecs), dataAccess)
+          localEntityProvider.evaluateExpressionsInternal(workspaceContext,
+                                                          gatherInputsResult.processableInputs,
+                                                          Some(entityRecs),
+                                                          dataAccess
+          )
       }
     }
   }
@@ -55,26 +89,48 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
         Map(sampleGood.name -> Seq(SubmissionValidationValue(Some(AttributeNumber(1)), None, intArgNameWithWfName)))
 
       runAndWait(testResolveInputs(context, configEvenBetter, sampleGood, littleWdl, this)) shouldBe
-        Map(sampleGood.name -> Seq(SubmissionValidationValue(Some(AttributeNumber(1)), None, intArgNameWithWfName), SubmissionValidationValue(Some(AttributeNumber(1)), None, intOptNameWithWfName)))
+        Map(
+          sampleGood.name -> Seq(
+            SubmissionValidationValue(Some(AttributeNumber(1)), None, intArgNameWithWfName),
+            SubmissionValidationValue(Some(AttributeNumber(1)), None, intOptNameWithWfName)
+          )
+        )
 
       runAndWait(testResolveInputs(context, configSampleSet, sampleSet, arrayWdl, this)) shouldBe
-        Map(sampleSet.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1)))), None, intArrayNameWithWfName)))
+        Map(
+          sampleSet.name -> Seq(
+            SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1)))), None, intArrayNameWithWfName)
+          )
+        )
 
       runAndWait(testResolveInputs(context, configSampleSet, sampleSet2, arrayWdl, this)) shouldBe
-        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1), AttributeNumber(2)))), None, intArrayNameWithWfName)))
+        Map(
+          sampleSet2.name -> Seq(
+            SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(1), AttributeNumber(2)))),
+                                      None,
+                                      intArrayNameWithWfName
+            )
+          )
+        )
 
       // attribute reference with 1 element array should resolve as AttributeValueList
       runAndWait(testResolveInputs(context, configSampleSet, sampleSet4, arrayWdl, this)) shouldBe
-        Map(sampleSet4.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(101)))), None, intArrayNameWithWfName)))
+        Map(
+          sampleSet4.name -> Seq(
+            SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeNumber(101)))), None, intArrayNameWithWfName)
+          )
+        )
 
       // failure cases
       assertResult(true, "Missing values should return an error") {
-        runAndWait(testResolveInputs(context, configGood, sampleMissingValue, littleWdl, this)).get("sampleMissingValue").get match {
+        runAndWait(testResolveInputs(context, configGood, sampleMissingValue, littleWdl, this))
+          .get("sampleMissingValue")
+          .get match {
           case Seq(SubmissionValidationValue(None, Some(_), intArg)) if intArg == intArgNameWithWfName => true
         }
       }
 
-      //MethodConfiguration config_namespace/configMissingExpr is missing definitions for these inputs: w1.t1.int_arg
+      // MethodConfiguration config_namespace/configMissingExpr is missing definitions for these inputs: w1.t1.int_arg
       intercept[RawlsException] {
         runAndWait(testResolveInputs(context, configMissingExpr, sampleGood, littleWdl, this))
       }
@@ -84,13 +140,22 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       val context = workspace
 
       runAndWait(testResolveInputs(context, configEmptyArray, sampleSet2, arrayWdl, this)) shouldBe
-        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueEmptyList), None, intArrayNameWithWfName)))
+        Map(
+          sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueEmptyList), None, intArrayNameWithWfName))
+        )
     }
 
     "resolve empty lists into empty Array in nested WDL Struct" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configNestedWdlStructWithEmptyList, sampleForWdlStruct, wdlStructInputWdlWithNestedStruct, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(
+        testResolveInputs(context,
+                          configNestedWdlStructWithEmptyList,
+                          sampleForWdlStruct,
+                          wdlStructInputWdlWithNestedStruct,
+                          this
+        )
+      )
       val methodProps = resolvedInputs(sampleForWdlStruct.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -102,7 +167,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack AttributeValueRawJson into WDL-arrays" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configRawJsonDoubleArray, sampleSet2, doubleArrayWdl, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] =
+        runAndWait(testResolveInputs(context, configRawJsonDoubleArray, sampleSet2, doubleArrayWdl, this))
       val methodProps = resolvedInputs(sampleSet2.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -114,7 +180,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack array input expression with attribute reference into WDL-arrays" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configArrayWithAttrRef, sampleSet2, doubleArrayWdl, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] =
+        runAndWait(testResolveInputs(context, configArrayWithAttrRef, sampleSet2, doubleArrayWdl, this))
       val methodProps = resolvedInputs(sampleSet2.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -126,7 +193,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "correctly unpack wdl struct expression with attribute references containing 1 element array into WDL Struct input" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configWdlStruct, sampleForWdlStruct2, wdlStructInputWdl, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] =
+        runAndWait(testResolveInputs(context, configWdlStruct, sampleForWdlStruct2, wdlStructInputWdl, this))
       val methodProps = resolvedInputs(sampleForWdlStruct2.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -138,7 +206,9 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "correctly unpack nested wdl struct expression with attribute references containing 1 element array into WDL Struct input" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configNestedWdlStruct, sampleForWdlStruct2, wdlStructInputWdlWithNestedStruct, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(
+        testResolveInputs(context, configNestedWdlStruct, sampleForWdlStruct2, wdlStructInputWdlWithNestedStruct, this)
+      )
       val methodProps = resolvedInputs(sampleForWdlStruct2.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -150,7 +220,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack wdl struct expression with attribute references into WDL Struct input" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configWdlStruct, sampleForWdlStruct, wdlStructInputWdl, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] =
+        runAndWait(testResolveInputs(context, configWdlStruct, sampleForWdlStruct, wdlStructInputWdl, this))
       val methodProps = resolvedInputs(sampleForWdlStruct.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -162,7 +233,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack AttributeValueRawJson into optional WDL-arrays" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configRawJsonDoubleArray, sampleSet2, optionalDoubleArrayWdl, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] =
+        runAndWait(testResolveInputs(context, configRawJsonDoubleArray, sampleSet2, optionalDoubleArrayWdl, this))
       val methodProps = resolvedInputs(sampleSet2.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -174,7 +246,14 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack nested Array into WDL Struct" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configNestedArrayWdlStruct, sampleForWdlStruct, wdlStructInputWdlWithNestedArray, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(
+        testResolveInputs(context,
+                          configNestedArrayWdlStruct,
+                          sampleForWdlStruct,
+                          wdlStructInputWdlWithNestedArray,
+                          this
+        )
+      )
       val methodProps = resolvedInputs(sampleForWdlStruct.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -186,7 +265,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack AttributeValueRawJson into lists-of WDL-arrays" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configRawJsonTripleArray, sampleSet2, tripleArrayWdl, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] =
+        runAndWait(testResolveInputs(context, configRawJsonTripleArray, sampleSet2, tripleArrayWdl, this))
       val methodProps = resolvedInputs(sampleSet2.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -198,7 +278,14 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "unpack triple Array into WDL Struct" in withConfigData {
       val context = workspace
 
-      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(testResolveInputs(context, configTripleArrayWdlStruct, sampleForWdlStruct, wdlStructInputWdlWithTripleArray, this))
+      val resolvedInputs: Map[String, Seq[SubmissionValidationValue]] = runAndWait(
+        testResolveInputs(context,
+                          configTripleArrayWdlStruct,
+                          sampleForWdlStruct,
+                          wdlStructInputWdlWithTripleArray,
+                          this
+        )
+      )
       val methodProps = resolvedInputs(sampleForWdlStruct.name).map { svv: SubmissionValidationValue =>
         svv.inputName -> svv.value.get
       }
@@ -210,235 +297,389 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "cast attribute numbers into strings for string inputs" in withConfigData {
       val context = workspace
       runAndWait(testResolveInputs(context, configStringArgFromNumberAttribute, sampleGood, stringWdl, this)) shouldBe
-        Map(sampleGood.name -> Seq(SubmissionValidationValue(Some(AttributeString("1")), None, stringArgNameWithWfName)))
+        Map(
+          sampleGood.name -> Seq(SubmissionValidationValue(Some(AttributeString("1")), None, stringArgNameWithWfName))
+        )
     }
 
     "cast attribute numbers into strings for string inputs via a set" in withConfigData {
       val context = workspace
-      runAndWait(testResolveInputs(context, configStringArgFromNumberAttributeViaSampleSet, sampleSet2, arrayStringWdl, this)) shouldBe
-        Map(sampleSet2.name -> Seq(SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeString("1"), AttributeString("2")))), None, strArrayNameWithWfName)))
+      runAndWait(
+        testResolveInputs(context, configStringArgFromNumberAttributeViaSampleSet, sampleSet2, arrayStringWdl, this)
+      ) shouldBe
+        Map(
+          sampleSet2.name -> Seq(
+            SubmissionValidationValue(Some(AttributeValueList(Seq(AttributeString("1"), AttributeString("2")))),
+                                      None,
+                                      strArrayNameWithWfName
+            )
+          )
+        )
     }
 
   }
 
-  //The test data for the following entity cache tests are set up so that the cache will return results that are different
-  //than would be returned by not using the cache. This will help us determine that we are correctly calling the cache or going
-  //in for the full DB query
+  // The test data for the following entity cache tests are set up so that the cache will return results that are different
+  // than would be returned by not using the cache. This will help us determine that we are correctly calling the cache or going
+  // in for the full DB query
   "LocalEntityProvider Entity Statistics Cache feature" should {
 
-    val expectedResultWhenUsingCache = localEntityProviderTestData.workspaceEntityTypeCacheEntries.map { case (entityType, entityTypeCount) =>
-      entityType -> EntityTypeMetadata(entityTypeCount, s"${entityType}_id", localEntityProviderTestData.workspaceAttrNameCacheEntries(entityType).map(attrName => toDelimitedName(attrName)))
+    val expectedResultWhenUsingCache = localEntityProviderTestData.workspaceEntityTypeCacheEntries.map {
+      case (entityType, entityTypeCount) =>
+        entityType -> EntityTypeMetadata(entityTypeCount,
+                                         s"${entityType}_id",
+                                         localEntityProviderTestData
+                                           .workspaceAttrNameCacheEntries(entityType)
+                                           .map(attrName => toDelimitedName(attrName))
+        )
     }.toMap
 
-    val expectedResultWhenUsingFullQueries = expectedResultWhenUsingCache - localEntityProviderTestData.sample1.entityType
+    val expectedResultWhenUsingFullQueries =
+      expectedResultWhenUsingCache - localEntityProviderTestData.sample1.entityType
 
-    "use cache for entityTypeMetadata when useCache=true, cache is up to date, and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "use cache for entityTypeMetadata when useCache=true, cache is up to date, and cache is enabled" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      //Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis)))
+        // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis)
+          )
+        )
 
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
 
-      val typeCountCache = runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
-      val attrNamesCache = runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val typeCountCache =
+          runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val attrNamesCache =
+          runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
 
-      //assert that there is something in the cache for this workspace
-      typeCountCache should not be Map.empty
-      attrNamesCache should not be Map.empty
+        // assert that there is something in the cache for this workspace
+        typeCountCache should not be Map.empty
+        attrNamesCache should not be Map.empty
 
-      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingCache
+        entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingCache
     }
 
-    "not use cache for entityTypeMetadata when useCache=true, cache is not up to date, and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "not use cache for entityTypeMetadata when useCache=true, cache is not up to date, and cache is enabled" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
-      // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
+        // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
+        // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis - 10000)
+          )
+        )
 
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
 
-      val typeCountCache = runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
-      val attrNamesCache = runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val typeCountCache =
+          runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val attrNamesCache =
+          runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
 
-      //assert that there is something in the cache for this workspace
-      typeCountCache should not be Map.empty
-      attrNamesCache should not be Map.empty
+        // assert that there is something in the cache for this workspace
+        typeCountCache should not be Map.empty
+        attrNamesCache should not be Map.empty
 
-      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
+        entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
     }
 
-    "not use cache for entityTypeMetadata when useCache=false even if cache is up to date and cache is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "not use cache for entityTypeMetadata when useCache=false even if cache is up to date and cache is enabled" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      //Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis)))
+        // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis)
+          )
+        )
 
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false)))
 
-      val typeCountCache = runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
-      val attrNamesCache = runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val typeCountCache =
+          runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val attrNamesCache =
+          runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
 
-      //assert that there is something in the cache for this workspace
-      typeCountCache should not be Map.empty
-      attrNamesCache should not be Map.empty
+        // assert that there is something in the cache for this workspace
+        typeCountCache should not be Map.empty
+        attrNamesCache should not be Map.empty
 
-      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
+        entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
     }
 
-    "not use cache for entityTypeMetadata when it's disabled at the application level, even if cache is up to date and useCache=true" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, false, workbenchMetricBaseName)
+    "not use cache for entityTypeMetadata when it's disabled at the application level, even if cache is up to date and useCache=true" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          false,
+                                                          workbenchMetricBaseName
+        )
 
-      //Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis)))
+        // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis)
+          )
+        )
 
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(true)))
 
-      val typeCountCache = runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
-      val attrNamesCache = runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val typeCountCache =
+          runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
+        val attrNamesCache =
+          runAndWait(dataSource.dataAccess.entityAttributeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
 
-      //assert that there is something in the cache for this workspace
-      typeCountCache should not be Map.empty
-      attrNamesCache should not be Map.empty
+        // assert that there is something in the cache for this workspace
+        typeCountCache should not be Map.empty
+        attrNamesCache should not be Map.empty
 
-      entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
+        entityTypeMetadataResult should contain theSameElementsAs expectedResultWhenUsingFullQueries
     }
 
-    "use cache for entityTypeMetadata when cache is not up to date but both feature flags are enabled" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "use cache for entityTypeMetadata when cache is not up to date but both feature flags are enabled" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
-      // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
+        // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
+        // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis - 10000)
+          )
+        )
 
-      // add new attributes to the workspace, so we have a difference between cached and uncached, by saving the participant with a
-      // new set of attributes and counts
-      val newEntity = Entity(localEntityProviderTestData.participant1.name, localEntityProviderTestData.participant1.entityType,
-        Map(AttributeName.withDefaultNS("somethingNew") -> AttributeString("foo"),
-          AttributeName.withDefaultNS("anotherNew") -> AttributeString("bar"),
-          AttributeName.withDefaultNS("yetOneMore") -> AttributeString("baz")
-        ))
-      runAndWait(entityQuery.save(localEntityProviderTestData.workspace, newEntity))
+        // add new attributes to the workspace, so we have a difference between cached and uncached, by saving the participant with a
+        // new set of attributes and counts
+        val newEntity = Entity(
+          localEntityProviderTestData.participant1.name,
+          localEntityProviderTestData.participant1.entityType,
+          Map(
+            AttributeName.withDefaultNS("somethingNew") -> AttributeString("foo"),
+            AttributeName.withDefaultNS("anotherNew") -> AttributeString("bar"),
+            AttributeName.withDefaultNS("yetOneMore") -> AttributeString("baz")
+          )
+        )
+        runAndWait(entityQuery.save(localEntityProviderTestData.workspace, newEntity))
 
-      // set both feature flags here before calling entityTypeMetadata
-      runAndWait(workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID, localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_COUNTS))
-      runAndWait(workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID, localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES))
+        // set both feature flags here before calling entityTypeMetadata
+        runAndWait(
+          workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID,
+                                         localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_COUNTS
+          )
+        )
+        runAndWait(
+          workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID,
+                                         localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES
+          )
+        )
 
-      // verify the attribute name cache is stale on first access, because of the feature flags
-      val entityTypeMetadataResultWithFlags = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
-      val addedAttrNamesWithFlags = entityTypeMetadataResultWithFlags("participant").attributeNames
-      addedAttrNamesWithFlags shouldNot contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
+        // verify the attribute name cache is stale on first access, because of the feature flags
+        val entityTypeMetadataResultWithFlags =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val addedAttrNamesWithFlags = entityTypeMetadataResultWithFlags("participant").attributeNames
+        addedAttrNamesWithFlags shouldNot contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
 
-      // verify the counts cache is stale on first access as well
-      entityTypeMetadataResultWithFlags.keySet.foreach { typeName =>
-        entityTypeMetadataResultWithFlags(typeName).count shouldBe expectedResultWhenUsingCache(typeName).count
-      }
-      // now call again, this time without the cache, and make sure the values are updated
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false)))
-      val addedAttrNames = entityTypeMetadataResult("participant").attributeNames
-      addedAttrNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
+        // verify the counts cache is stale on first access as well
+        entityTypeMetadataResultWithFlags.keySet.foreach { typeName =>
+          entityTypeMetadataResultWithFlags(typeName).count shouldBe expectedResultWhenUsingCache(typeName).count
+        }
+        // now call again, this time without the cache, and make sure the values are updated
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false)))
+        val addedAttrNames = entityTypeMetadataResult("participant").attributeNames
+        addedAttrNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
 
-      // verify the counts are updated as well
-      entityTypeMetadataResultWithFlags("participant").count shouldBe expectedResultWhenUsingFullQueries("participant").count
-      entityTypeMetadataResultWithFlags("sample").count shouldBe expectedResultWhenUsingCache("sample").count
+        // verify the counts are updated as well
+        entityTypeMetadataResultWithFlags("participant").count shouldBe expectedResultWhenUsingFullQueries(
+          "participant"
+        ).count
+        entityTypeMetadataResultWithFlags("sample").count shouldBe expectedResultWhenUsingCache("sample").count
     }
 
-    "use cache for types and counts only when cache is not up to date but the type/count feature flag is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "use cache for types and counts only when cache is not up to date but the type/count feature flag is enabled" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
-      // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
+        // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
+        // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis - 10000)
+          )
+        )
 
-      // add new attributes to the workspace, so we have a difference between cached and uncached, by saving the participant with a
-      // new set of attributes and counts
-      val newEntity = Entity(localEntityProviderTestData.participant1.name, localEntityProviderTestData.participant1.entityType,
-        Map(AttributeName.withDefaultNS("somethingNew") -> AttributeString("foo"),
-          AttributeName.withDefaultNS("anotherNew") -> AttributeString("bar"),
-          AttributeName.withDefaultNS("yetOneMore") -> AttributeString("baz")
-        ))
-      runAndWait(entityQuery.save(localEntityProviderTestData.workspace, newEntity))
+        // add new attributes to the workspace, so we have a difference between cached and uncached, by saving the participant with a
+        // new set of attributes and counts
+        val newEntity = Entity(
+          localEntityProviderTestData.participant1.name,
+          localEntityProviderTestData.participant1.entityType,
+          Map(
+            AttributeName.withDefaultNS("somethingNew") -> AttributeString("foo"),
+            AttributeName.withDefaultNS("anotherNew") -> AttributeString("bar"),
+            AttributeName.withDefaultNS("yetOneMore") -> AttributeString("baz")
+          )
+        )
+        runAndWait(entityQuery.save(localEntityProviderTestData.workspace, newEntity))
 
-      // set the type/count feature flag (only) here before calling entityTypeMetadata
-      runAndWait(workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID, localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_COUNTS))
+        // set the type/count feature flag (only) here before calling entityTypeMetadata
+        runAndWait(
+          workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID,
+                                         localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_COUNTS
+          )
+        )
 
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
 
-      // metadata response always contains the union of types found by cache and by full queries
-      val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
-      entityTypeMetadataResult.keySet should contain theSameElementsAs allTypeNames
+        // metadata response always contains the union of types found by cache and by full queries
+        val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
+        entityTypeMetadataResult.keySet should contain theSameElementsAs allTypeNames
 
-      // entityTypeMetadataResult types/counts should match expectedResultWhenUsingCache
-      entityTypeMetadataResult.keySet.foreach { typeName =>
-        entityTypeMetadataResult(typeName).count shouldBe expectedResultWhenUsingCache(typeName).count
-      }
-      // entityTypeMetadataResult attributes should match expectedResultWhenUsingFullQueries for participants;
-      // samples should be the empty list since uncached results have no samples
-      entityTypeMetadataResult("sample").attributeNames shouldBe empty
-      entityTypeMetadataResult("participant").attributeNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
+        // entityTypeMetadataResult types/counts should match expectedResultWhenUsingCache
+        entityTypeMetadataResult.keySet.foreach { typeName =>
+          entityTypeMetadataResult(typeName).count shouldBe expectedResultWhenUsingCache(typeName).count
+        }
+        // entityTypeMetadataResult attributes should match expectedResultWhenUsingFullQueries for participants;
+        // samples should be the empty list since uncached results have no samples
+        entityTypeMetadataResult("sample").attributeNames shouldBe empty
+        entityTypeMetadataResult("participant").attributeNames should contain theSameElementsAs List("somethingNew",
+                                                                                                     "anotherNew",
+                                                                                                     "yetOneMore"
+        )
     }
 
-    "use cache for attributes only when cache is not up to date but the attributes feature flag is enabled" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "use cache for attributes only when cache is not up to date but the attributes feature flag is enabled" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
-      // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
+        // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
+        // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis - 10000)
+          )
+        )
 
-      // add new attributes to the workspace, so we have a difference between cached and uncached, by saving the participant with a
-      // new set of attributes
-      val newEntity = Entity(localEntityProviderTestData.participant1.name, localEntityProviderTestData.participant1.entityType,
-          Map(AttributeName.withDefaultNS("somethingNew") -> AttributeString("foo"),
-          AttributeName.withDefaultNS("anotherNew") -> AttributeString("bar"),
-          AttributeName.withDefaultNS("yetOneMore") -> AttributeString("baz")
-        ))
-      runAndWait(entityQuery.save(localEntityProviderTestData.workspace, newEntity))
+        // add new attributes to the workspace, so we have a difference between cached and uncached, by saving the participant with a
+        // new set of attributes
+        val newEntity = Entity(
+          localEntityProviderTestData.participant1.name,
+          localEntityProviderTestData.participant1.entityType,
+          Map(
+            AttributeName.withDefaultNS("somethingNew") -> AttributeString("foo"),
+            AttributeName.withDefaultNS("anotherNew") -> AttributeString("bar"),
+            AttributeName.withDefaultNS("yetOneMore") -> AttributeString("baz")
+          )
+        )
+        runAndWait(entityQuery.save(localEntityProviderTestData.workspace, newEntity))
 
-      // verify the new attributes are present in uncached metadata
-      val entityTypeMetadataResultBeforeFlags = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        // verify the new attributes are present in uncached metadata
+        val entityTypeMetadataResultBeforeFlags =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
 
-      val addedAttrNames = entityTypeMetadataResultBeforeFlags("participant").attributeNames diff expectedResultWhenUsingFullQueries("participant").attributeNames
-      addedAttrNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
+        val addedAttrNames = entityTypeMetadataResultBeforeFlags(
+          "participant"
+        ).attributeNames diff expectedResultWhenUsingFullQueries("participant").attributeNames
+        addedAttrNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
 
-      // since the cache was out of date, that last request to entityTypeMetadata opportunistically wrote the cache. Reset it so
-      // this unit test will keep working!
-      runAndWait(entityAttributeStatisticsQuery.deleteAllForWorkspace(workspaceContext.workspaceIdAsUUID))
-      runAndWait(entityAttributeStatisticsQuery.batchInsert(workspaceContext.workspaceIdAsUUID, localEntityProviderTestData.workspaceAttrNameCacheEntries))
-      runAndWait(entityTypeStatisticsQuery.deleteAllForWorkspace(workspaceContext.workspaceIdAsUUID))
-      runAndWait(entityTypeStatisticsQuery.batchInsert(workspaceContext.workspaceIdAsUUID, localEntityProviderTestData.workspaceEntityTypeCacheEntries))
+        // since the cache was out of date, that last request to entityTypeMetadata opportunistically wrote the cache. Reset it so
+        // this unit test will keep working!
+        runAndWait(entityAttributeStatisticsQuery.deleteAllForWorkspace(workspaceContext.workspaceIdAsUUID))
+        runAndWait(
+          entityAttributeStatisticsQuery.batchInsert(workspaceContext.workspaceIdAsUUID,
+                                                     localEntityProviderTestData.workspaceAttrNameCacheEntries
+          )
+        )
+        runAndWait(entityTypeStatisticsQuery.deleteAllForWorkspace(workspaceContext.workspaceIdAsUUID))
+        runAndWait(
+          entityTypeStatisticsQuery.batchInsert(workspaceContext.workspaceIdAsUUID,
+                                                localEntityProviderTestData.workspaceEntityTypeCacheEntries
+          )
+        )
 
-      // and update the entityCacheLastUpdated field to be prior to lastModified AGAIN, so we can test our scenario of having a fresh cache
-      // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
+        // and update the entityCacheLastUpdated field to be prior to lastModified AGAIN, so we can test our scenario of having a fresh cache
+        // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                  new Timestamp(workspaceContext.lastModified.getMillis - 10000)
+          )
+        )
 
-      // now, set attribute feature flag (only) here.
-      runAndWait(workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID, localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES))
+        // now, set attribute feature flag (only) here.
+        runAndWait(
+          workspaceFeatureFlagQuery.save(workspaceContext.workspaceIdAsUUID,
+                                         localEntityProvider.FEATURE_ALWAYS_CACHE_TYPE_ATTRIBUTES
+          )
+        )
 
-      // with feature flag set, retrieve metadata again. This time it should use the cache, which will NOT return
-      // the added attribute names
-      val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        // with feature flag set, retrieve metadata again. This time it should use the cache, which will NOT return
+        // the added attribute names
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
 
-      // metadata response always contains the union of types found by cache and by full queries
-      val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
-      entityTypeMetadataResult.keySet should contain theSameElementsAs allTypeNames
+        // metadata response always contains the union of types found by cache and by full queries
+        val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
+        entityTypeMetadataResult.keySet should contain theSameElementsAs allTypeNames
 
-      // entityTypeMetadataResult types/counts should match expectedResultWhenUsingFullQueries for participants.
-      // the count for samples should be 0, since uncached results have no samples
-      entityTypeMetadataResult("participant").count shouldBe expectedResultWhenUsingFullQueries("participant").count
-      entityTypeMetadataResult("sample").count shouldBe 0
+        // entityTypeMetadataResult types/counts should match expectedResultWhenUsingFullQueries for participants.
+        // the count for samples should be 0, since uncached results have no samples
+        entityTypeMetadataResult("participant").count shouldBe expectedResultWhenUsingFullQueries("participant").count
+        entityTypeMetadataResult("sample").count shouldBe 0
 
-      // entityTypeMetadataResult attributes should match expectedResultWhenUsingCache
-      entityTypeMetadataResult.keySet.foreach { typeName =>
-        entityTypeMetadataResult(typeName).attributeNames should contain theSameElementsAs expectedResultWhenUsingCache(typeName).attributeNames
-      }
+        // entityTypeMetadataResult attributes should match expectedResultWhenUsingCache
+        entityTypeMetadataResult.keySet.foreach { typeName =>
+          entityTypeMetadataResult(
+            typeName
+          ).attributeNames should contain theSameElementsAs expectedResultWhenUsingCache(typeName).attributeNames
+        }
     }
 
     "consider cache out of date if no cache record" in withLocalEntityProviderTestDatabase { _ =>
@@ -458,7 +699,8 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
     "consider cache out of date if cache record exists but is old" in withLocalEntityProviderTestDatabase { _ =>
       val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
       val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
-      val wsLastModifiedTimestamp = Timestamp.from(Instant.ofEpochMilli(localEntityProviderTestData.workspace.lastModified.getMillis - 10000))
+      val wsLastModifiedTimestamp =
+        Timestamp.from(Instant.ofEpochMilli(localEntityProviderTestData.workspace.lastModified.getMillis - 10000))
 
       withClue("cache record should not exist before updating") {
         assert(!runAndWait(workspaceFilter.exists.result))
@@ -473,25 +715,26 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    "consider cache to be current if cache record exists and is equal to workspace last-modified" in withLocalEntityProviderTestDatabase { _ =>
-      val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
-      val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
+    "consider cache to be current if cache record exists and is equal to workspace last-modified" in withLocalEntityProviderTestDatabase {
+      _ =>
+        val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
+        val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
 
-      withClue("cache record should not exist before updating") {
-        assert(!runAndWait(workspaceFilter.exists.result))
-      }
+        withClue("cache record should not exist before updating") {
+          assert(!runAndWait(workspaceFilter.exists.result))
+        }
 
-      val existingWorkspace = runAndWait(workspaceQuery.findById(wsid.toString))
-      existingWorkspace should not be empty
-      val wsLastModifiedTimestamp = new Timestamp(existingWorkspace.get.lastModified.getMillis)
+        val existingWorkspace = runAndWait(workspaceQuery.findById(wsid.toString))
+        existingWorkspace should not be empty
+        val wsLastModifiedTimestamp = new Timestamp(existingWorkspace.get.lastModified.getMillis)
 
-      // update cache timestamp
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, wsLastModifiedTimestamp))
+        // update cache timestamp
+        runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, wsLastModifiedTimestamp))
 
-      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
-      withClue("cache should be current") {
-        assert(isCurrent)
-      }
+        val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
+        withClue("cache should be current") {
+          assert(isCurrent)
+        }
     }
 
     "return None from entityCacheStaleness if cache is non-existent" in withLocalEntityProviderTestDatabase { _ =>
@@ -508,25 +751,27 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    "return Some(positive integer) from entityCacheStaleness if cache exists but is stale" in withLocalEntityProviderTestDatabase { _ =>
-      val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
-      val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
-      val wsLastModifiedTimestamp = Timestamp.from(Instant.ofEpochMilli(localEntityProviderTestData.workspace.lastModified.getMillis - 10000))
+    "return Some(positive integer) from entityCacheStaleness if cache exists but is stale" in withLocalEntityProviderTestDatabase {
+      _ =>
+        val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
+        val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
+        val wsLastModifiedTimestamp =
+          Timestamp.from(Instant.ofEpochMilli(localEntityProviderTestData.workspace.lastModified.getMillis - 10000))
 
-      withClue("cache record should not exist before updating") {
-        assert(!runAndWait(workspaceFilter.exists.result))
-      }
-
-      // update cache timestamp
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, wsLastModifiedTimestamp))
-
-      val staleness = runAndWait(entityCacheQuery.entityCacheStaleness(wsid))
-      withClue(s"staleness value of [$staleness] should contain a positive integer") {
-        staleness match {
-          case Some(n) => n should be > 0
-          case None => fail("found None")
+        withClue("cache record should not exist before updating") {
+          assert(!runAndWait(workspaceFilter.exists.result))
         }
-      }
+
+        // update cache timestamp
+        runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, wsLastModifiedTimestamp))
+
+        val staleness = runAndWait(entityCacheQuery.entityCacheStaleness(wsid))
+        withClue(s"staleness value of [$staleness] should contain a positive integer") {
+          staleness match {
+            case Some(n) => n should be > 0
+            case None    => fail("found None")
+          }
+        }
     }
 
     "return Some(0) from entityCacheStaleness if cache is up-to-date" in withLocalEntityProviderTestDatabase { _ =>
@@ -546,7 +791,7 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
 
       val staleness = runAndWait(entityCacheQuery.entityCacheStaleness(wsid))
       withClue("staleness value should be Some(0) for up-to-date caches") {
-        staleness should contain (0)
+        staleness should contain(0)
       }
     }
 
@@ -608,100 +853,134 @@ class LocalEntityProviderSpec extends AnyWordSpecLike with Matchers with ScalaFu
       }
     }
 
-    "nullify error message if cache update succeeds after previous failure" in withLocalEntityProviderTestDatabase { _ =>
-      val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
-      val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
-      val expectedErrorMsg = "intentional error message"
+    "nullify error message if cache update succeeds after previous failure" in withLocalEntityProviderTestDatabase {
+      _ =>
+        val wsid = localEntityProviderTestData.workspace.workspaceIdAsUUID
+        val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
+        val expectedErrorMsg = "intentional error message"
 
-      // save a cache entry that includes a failure
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, EntityStatisticsCacheMonitor.MIN_CACHE_TIME, Some(expectedErrorMsg)))
+        // save a cache entry that includes a failure
+        runAndWait(
+          entityCacheQuery.updateCacheLastUpdated(wsid,
+                                                  EntityStatisticsCacheMonitor.MIN_CACHE_TIME,
+                                                  Some(expectedErrorMsg)
+          )
+        )
 
-      val actualMessage = runAndWait(uniqueResult[Option[String]](workspaceFilter.map(_.errorMessage))).flatten
-      actualMessage should contain(expectedErrorMsg)
+        val actualMessage = runAndWait(uniqueResult[Option[String]](workspaceFilter.map(_.errorMessage))).flatten
+        actualMessage should contain(expectedErrorMsg)
 
-      // save a cache entry that is successful
-      runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, Timestamp.from(Instant.now())))
+        // save a cache entry that is successful
+        runAndWait(entityCacheQuery.updateCacheLastUpdated(wsid, Timestamp.from(Instant.now())))
 
-      val secondMessage = runAndWait(uniqueResult[Option[String]](workspaceFilter.map(_.errorMessage))).flatten
-      secondMessage shouldBe empty
+        val secondMessage = runAndWait(uniqueResult[Option[String]](workspaceFilter.map(_.errorMessage))).flatten
+        secondMessage shouldBe empty
     }
 
-    "opportunistically update cache if user requests metadata while cache is out of date" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
-      val wsid = workspaceContext.workspaceIdAsUUID
-      val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
+    "opportunistically update cache if user requests metadata while cache is out of date" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
+        val wsid = workspaceContext.workspaceIdAsUUID
+        val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
 
-      withClue("cache record should not exist before requesting metadata") {
-        assert(!runAndWait(workspaceFilter.exists.result))
-      }
+        withClue("cache record should not exist before requesting metadata") {
+          assert(!runAndWait(workspaceFilter.exists.result))
+        }
 
-      val isCurrentBefore = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
-      withClue("cache should be not-current before requesting metadata") {
-        assert(!isCurrentBefore)
-      }
+        val isCurrentBefore = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
+        withClue("cache should be not-current before requesting metadata") {
+          assert(!isCurrentBefore)
+        }
 
-      // requesting metadata should update the cache as a side effect
-      localEntityProvider.entityTypeMetadata(true).futureValue
+        // requesting metadata should update the cache as a side effect
+        localEntityProvider.entityTypeMetadata(true).futureValue
 
-      withClue("cache record should exist after requesting metadata") {
-        assert(runAndWait(workspaceFilter.exists.result))
-      }
+        withClue("cache record should exist after requesting metadata") {
+          assert(runAndWait(workspaceFilter.exists.result))
+        }
 
-      val isCurrentAfter = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
-      withClue("cache should be current after requesting metadata") {
-        assert(isCurrentAfter)
-      }
+        val isCurrentAfter = runAndWait(entityCacheQuery.entityCacheStaleness(wsid)).contains(0)
+        withClue("cache should be current after requesting metadata") {
+          assert(isCurrentAfter)
+        }
     }
-
 
   }
 
   "LocalEntityProvider case-sensitivity" should {
-    "return helpful error message when upserting case-divergent entity names (createEntity method)" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "return helpful error message when upserting case-divergent entity names (createEntity method)" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      // create the first entity with name "myname"
-      val entity1 = Entity("myname", "casetest", Map())
-      val created1 = localEntityProvider.createEntity(entity1).futureValue
-      created1 shouldBe entity1
+        // create the first entity with name "myname"
+        val entity1 = Entity("myname", "casetest", Map())
+        val created1 = localEntityProvider.createEntity(entity1).futureValue
+        created1 shouldBe entity1
 
-      // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
-      val entity2 = Entity("MyName", "casetest", Map())
-      val ex = recoverToExceptionIf[Exception] {
-        localEntityProvider.createEntity(entity2)
-      }.futureValue
+        // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
+        val entity2 = Entity("MyName", "casetest", Map())
+        val ex = recoverToExceptionIf[Exception] {
+          localEntityProvider.createEntity(entity2)
+        }.futureValue
 
-      ex match {
-        case er: RawlsExceptionWithErrorReport =>
-          val expectedMessage = s"${entity2.entityType} ${entity2.name} already exists in ${workspaceContext.toWorkspaceName}"
-          er.errorReport.message shouldBe expectedMessage
-        case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
-      }
+        ex match {
+          case er: RawlsExceptionWithErrorReport =>
+            val expectedMessage =
+              s"${entity2.entityType} ${entity2.name} already exists in ${workspaceContext.toWorkspaceName}"
+            er.errorReport.message shouldBe expectedMessage
+          case _ =>
+            fail(
+              s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''"
+            )
+        }
     }
 
-    "return helpful error message when upserting case-divergent entity names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase { dataSource =>
-      val workspaceContext = runAndWait(dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+    "return helpful error message when upserting case-divergent entity names (batchUpsertEntities method)" in withLocalEntityProviderTestDatabase {
+      dataSource =>
+        val workspaceContext = runAndWait(
+          dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+        ).get
+        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                          slickDataSource,
+                                                          cacheEnabled = true,
+                                                          workbenchMetricBaseName
+        )
 
-      // create the first entity with name "myname"
-      val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
-      val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
-      created1.size shouldBe 1
+        // create the first entity with name "myname"
+        val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
+        val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
+        created1.size shouldBe 1
 
-      // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
-      val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))
-      val ex = recoverToExceptionIf[Exception] {
-        localEntityProvider.batchUpsertEntities(upsert2)
-      }.futureValue
+        // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
+        val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))
+        val ex = recoverToExceptionIf[Exception] {
+          localEntityProvider.batchUpsertEntities(upsert2)
+        }.futureValue
 
-      ex match {
-        case er: RawlsExceptionWithErrorReport =>
-          val expectedMessage = "Database error occurred. Check if you are uploading entity names that differ only in case from pre-existing entities."
-          er.errorReport.message shouldBe expectedMessage
-        case _ => fail(s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''")
-      }
+        ex match {
+          case er: RawlsExceptionWithErrorReport =>
+            val expectedMessage =
+              "Database error occurred. Check if you are uploading entity names that differ only in case from pre-existing entities."
+            er.errorReport.message shouldBe expectedMessage
+          case _ =>
+            fail(
+              s"expected a RawlsExceptionWithErrorReport, found ${ex.getClass.getName} with message '${ex.getMessage}''"
+            )
+        }
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -10,7 +10,15 @@ import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Option => _, _}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerClientProvider, BillingProfileManagerDAOImpl}
-import org.broadinstitute.dsde.rawls.config.{DataRepoEntityProviderConfig, DeploymentManagerConfig, MethodRepoConfig, MultiCloudWorkspaceConfig, ResourceBufferConfig, ServicePerimeterServiceConfig, WorkspaceServiceConfig}
+import org.broadinstitute.dsde.rawls.config.{
+  DataRepoEntityProviderConfig,
+  DeploymentManagerConfig,
+  MethodRepoConfig,
+  MultiCloudWorkspaceConfig,
+  ResourceBufferConfig,
+  ServicePerimeterServiceConfig,
+  WorkspaceServiceConfig
+}
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -53,16 +61,17 @@ import scala.util.Try
  * Time: 11:06
  */
 //noinspection TypeAnnotation,ScalaUnusedSymbol
-class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
-  with AnyFlatSpecLike
-  with Matchers
-  with TestDriverComponent
-  with BeforeAndAfterAll
-  with Eventually
-  with MockitoTestUtils
-  with StatsDTestUtils
-  with RawlsTestUtils
-  with DataRepoEntityProviderSpecSupport {
+class SubmissionSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with TestDriverComponent
+    with BeforeAndAfterAll
+    with Eventually
+    with MockitoTestUtils
+    with StatsDTestUtils
+    with RawlsTestUtils
+    with DataRepoEntityProviderSpecSupport {
   import driver.api._
 
   def this() = this(ActorSystem("SubmissionSpec"))
@@ -75,9 +84,12 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
 
   val bigQueryDAO = new MockGoogleBigQueryDAO
   val mockSubmissionCostService = new MockSubmissionCostService(
-    "fakeTableName", "fakeDatePartitionColumn", "fakeServiceProject", 31, bigQueryDAO
+    "fakeTableName",
+    "fakeDatePartitionColumn",
+    "fakeServiceProject",
+    31,
+    bigQueryDAO
   )
-
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -101,23 +113,37 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
   val subTestData = new SubmissionTestData()
 
   class SubmissionTestData() extends TestData {
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("myNamespacexxx"), CreationStatuses.Ready, None, None)
+    val billingProject =
+      RawlsBillingProject(RawlsBillingProjectName("myNamespacexxx"), CreationStatuses.Ready, None, None)
     val wsName = WorkspaceName(billingProject.projectName.value, "myWorkspace")
     val user = RawlsUser(userInfo)
     val ownerGroup = makeRawlsGroup("workspaceOwnerGroup", Set(user))
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
 
-    val sample1 = Entity("sample1", "Sample",
-      Map(AttributeName.withDefaultNS("type") -> AttributeString("normal")))
-    val sample2 = Entity("sample2", "Sample",
-      Map(AttributeName.withDefaultNS("type") -> AttributeString("normal")))
+    val sample1 = Entity("sample1", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("normal")))
+    val sample2 = Entity("sample2", "Sample", Map(AttributeName.withDefaultNS("type") -> AttributeString("normal")))
 
     val existingWorkflowId = Option("69d1d92f-3895-4a7b-880a-82535e9a096e")
     val nonExistingWorkflowId = Option("45def17d-40c2-44cc-89bf-9e77bc2c9999")
     val alreadyTerminatedWorkflowId = Option("45def17d-40c2-44cc-89bf-9e77bc2c8778")
     val badLogsAndMetadataWorkflowId = Option("29b2e816-ecaf-11e6-b006-92361f002671")
 
-    val submissionTestAbortMissingWorkflow = Submission(subMissingWorkflow,testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestAbortMissingWorkflow = Submission(
+      subMissingWorkflow,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -133,7 +159,13 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       deleteIntermediateOutputFiles = false
     )
 
-    val submissionTestAbortMalformedWorkflow = Submission(subMalformedWorkflow,testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestAbortMalformedWorkflow = Submission(
+      subMalformedWorkflow,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       Seq(
         Workflow(
@@ -149,7 +181,13 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       deleteIntermediateOutputFiles = false
     )
 
-    val submissionTestAbortGoodWorkflow = Submission(subGoodWorkflow,testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestAbortGoodWorkflow = Submission(
+      subGoodWorkflow,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -165,7 +203,13 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       deleteIntermediateOutputFiles = false
     )
 
-    val submissionTestAbortTerminalWorkflow = Submission(subTerminalWorkflow,testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestAbortTerminalWorkflow = Submission(
+      subTerminalWorkflow,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -181,7 +225,13 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       deleteIntermediateOutputFiles = false
     )
 
-    val submissionTestAbortOneMissingWorkflow = Submission(subOneMissingWorkflow,testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestAbortOneMissingWorkflow = Submission(
+      subOneMissingWorkflow,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -196,14 +246,21 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
           status = WorkflowStatuses.Submitted,
           statusLastChangedDate = testDate,
           workflowEntity = Option(sample2.toReference),
-          inputResolutions = testData.inputResolutions)
+          inputResolutions = testData.inputResolutions
+        )
       ),
       status = SubmissionStatuses.Submitted,
       useCallCache = false,
       deleteIntermediateOutputFiles = false
     )
 
-    val submissionTestAbortTwoGoodWorkflows = Submission(subTwoGoodWorkflows,testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestAbortTwoGoodWorkflows = Submission(
+      subTwoGoodWorkflows,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -226,7 +283,13 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       deleteIntermediateOutputFiles = false
     )
 
-    val submissionTestCromwellBadWorkflows = Submission(subCromwellBadWorkflows, testDate, WorkbenchEmail(testData.userOwner.userEmail.value), "std","someMethod",Some(sample1.toReference),
+    val submissionTestCromwellBadWorkflows = Submission(
+      subCromwellBadWorkflows,
+      testDate,
+      WorkbenchEmail(testData.userOwner.userEmail.value),
+      "std",
+      "someMethod",
+      Some(sample1.toReference),
       submissionRoot = "gs://fc-someWorkspaceId/someSubmissionId",
       workflows = Seq(
         Workflow(
@@ -242,33 +305,46 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       deleteIntermediateOutputFiles = false
     )
 
-    val extantWorkflowOutputs = WorkflowOutputs( existingWorkflowId.get,
+    val extantWorkflowOutputs = WorkflowOutputs(
+      existingWorkflowId.get,
       Map(
         "wf.y" -> TaskOutput(
-          Some(Seq(
-            ExecutionServiceCallLogs(
-              stdout = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stdout-1.txt",
-              stderr = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stderr-1.txt",
-              backendLogs = Some(Map(
-                "log" -> "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/jes.log",
-                "stdout" -> "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/jes-stdout.log",
-                "stderr" -> "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/jes-stderr.log"
-              ))
-            ),
-            ExecutionServiceCallLogs(
-              stdout = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stdout-2.txt",
-              stderr = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stderr-2.txt")
-          )),
-          Some(Map("wf.y.six" -> Left(AttributeNumber(4))))),
+          Some(
+            Seq(
+              ExecutionServiceCallLogs(
+                stdout = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stdout-1.txt",
+                stderr = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stderr-1.txt",
+                backendLogs = Some(
+                  Map(
+                    "log" -> "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/jes.log",
+                    "stdout" -> "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/jes-stdout.log",
+                    "stderr" -> "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/jes-stderr.log"
+                  )
+                )
+              ),
+              ExecutionServiceCallLogs(
+                stdout = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stdout-2.txt",
+                stderr = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-y/job.stderr-2.txt"
+              )
+            )
+          ),
+          Some(Map("wf.y.six" -> Left(AttributeNumber(4))))
+        ),
         "wf.x" -> TaskOutput(
-          Some(Seq(ExecutionServiceCallLogs(
-            stdout = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-x/job.stdout.txt",
-            stderr = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-x/job.stderr.txt"))),
-          Some(Map(
-            "wf.x.four" -> Left(AttributeNumber(4)),
-            "wf.x.five" -> Left(AttributeNumber(4)))))))
+          Some(
+            Seq(
+              ExecutionServiceCallLogs(
+                stdout = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-x/job.stdout.txt",
+                stderr = "gs://cromwell-dev/cromwell-executions/wf/this_workflow_exists/call-x/job.stderr.txt"
+              )
+            )
+          ),
+          Some(Map("wf.x.four" -> Left(AttributeNumber(4)), "wf.x.five" -> Left(AttributeNumber(4))))
+        )
+      )
+    )
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         rawlsBillingProjectQuery.create(billingProject),
         workspaceQuery.createOrUpdate(workspace),
@@ -276,7 +352,16 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
           DBIO.seq(
             entityQuery.save(context, sample1),
             entityQuery.save(context, sample2),
-            methodConfigurationQuery.create(context, MethodConfiguration("std", "someMethod", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("std", "someMethod", 1))),
+            methodConfigurationQuery.create(context,
+                                            MethodConfiguration("std",
+                                                                "someMethod",
+                                                                Some("Sample"),
+                                                                None,
+                                                                Map.empty,
+                                                                Map.empty,
+                                                                AgoraMethod("std", "someMethod", 1)
+                                            )
+            ),
             submissionQuery.create(context, submissionTestAbortMissingWorkflow),
             submissionQuery.create(context, submissionTestAbortMalformedWorkflow),
             submissionQuery.create(context, submissionTestAbortGoodWorkflow),
@@ -289,34 +374,41 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
           )
         }
       )
-    }
   }
 
-  def withDataAndService[T](
-      testCode: WorkspaceService => T,
-      withDataOp: (SlickDataSource => T) => T,
-      executionServiceDAO: ExecutionServiceDAO = new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName),
-      bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(),
-      dataRepoDAO: DataRepoDAO = mock[DataRepoDAO](RETURNS_SMART_NULLS)): T = {
+  def withDataAndService[T](testCode: WorkspaceService => T,
+                            withDataOp: (SlickDataSource => T) => T,
+                            executionServiceDAO: ExecutionServiceDAO =
+                              new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName),
+                            bigQueryServiceFactory: GoogleBigQueryServiceFactory =
+                              MockBigQueryServiceFactory.ioFactory(),
+                            dataRepoDAO: DataRepoDAO = mock[DataRepoDAO](RETURNS_SMART_NULLS)
+  ): T = {
 
     withDataOp { dataSource =>
-      val execServiceCluster: ExecutionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(executionServiceDAO, dataSource)
+      val execServiceCluster: ExecutionServiceCluster =
+        MockShardedExecutionServiceCluster.fromDAO(executionServiceDAO, dataSource)
 
       val config = SubmissionMonitorConfig(250.milliseconds, trackDetailedSubmissionMetrics = true, 20000, false)
       val gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")
       val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
       val samDAO = new MockSamDAO(dataSource)
       val gpsDAO = new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
-      val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
-        execServiceCluster,
-        new UncoordinatedDataSourceAccess(slickDataSource),
-        samDAO,
-        gcsDAO,
-        mockNotificationDAO,
-        gcsDAO.getBucketServiceAccountCredential,
-        config,
-        workbenchMetricBaseName = workbenchMetricBaseName
-      ).withDispatcher("submission-monitor-dispatcher"), submissionSupervisorActorName)
+      val submissionSupervisor = system.actorOf(
+        SubmissionSupervisor
+          .props(
+            execServiceCluster,
+            new UncoordinatedDataSourceAccess(slickDataSource),
+            samDAO,
+            gcsDAO,
+            mockNotificationDAO,
+            gcsDAO.getBucketServiceAccountCredential,
+            config,
+            workbenchMetricBaseName = workbenchMetricBaseName
+          )
+          .withDispatcher("submission-monitor-dispatcher"),
+        submissionSupervisorActorName
+      )
 
       val testConf = ConfigFactory.load()
 
@@ -343,12 +435,12 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
         servicePerimeterService,
         RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
         billingProfileManagerDAO
-      )_
+      ) _
 
       val genomicsServiceConstructor = GenomicsService.constructor(
         slickDataSource,
         gcsDAO
-      )_
+      ) _
 
       val execServiceBatchSize = 3
       val maxActiveWorkflowsTotal = 10
@@ -360,23 +452,33 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       )
 
       val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
-      val requesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
+      val requesterPaysSetupService =
+        new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
       val workspaceManagerDAO = new MockWorkspaceManagerDAO
-      val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10000, 0), testConf.getBoolean("entityStatisticsCache.enabled"), workbenchMetricBaseName)
+      val entityManager = EntityManager.defaultEntityManager(
+        dataSource,
+        workspaceManagerDAO,
+        dataRepoDAO,
+        samDAO,
+        bigQueryServiceFactory,
+        DataRepoEntityProviderConfig(100, 10000, 0),
+        testConf.getBoolean("entityStatisticsCache.enabled"),
+        workbenchMetricBaseName
+      )
 
       val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
       val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
       val resourceBufferService = new ResourceBufferService(resourceBufferDAO, resourceBufferConfig)
       val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
-
       val workspaceServiceConstructor = WorkspaceService.constructor(
         dataSource,
         new HttpMethodRepoDAO(
           MethodRepoConfig[Agora.type](mockServer.mockServerBaseUrl, ""),
           MethodRepoConfig[Dockstore.type](mockServer.mockServerBaseUrl, ""),
-          workbenchMetricBaseName = workbenchMetricBaseName),
+          workbenchMetricBaseName = workbenchMetricBaseName
+        ),
         new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
         execServiceCluster,
         execServiceBatchSize,
@@ -401,21 +503,18 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
         terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
         terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
         terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole"
-      )_
+      ) _
       lazy val workspaceService: WorkspaceService = workspaceServiceConstructor(testContext)
-      try {
+      try
         testCode(workspaceService)
-      }
-      finally {
+      finally
         // for failed tests we also need to poison pill
         submissionSupervisor ! PoisonPill
-      }
     }
   }
 
-  def withWorkspaceService[T](testCode: WorkspaceService => T): T = {
+  def withWorkspaceService[T](testCode: WorkspaceService => T): T =
     withDataAndService(testCode, withDefaultTestDatabase[T])
-  }
 
   def withWorkspaceServiceMockExecution[T](testCode: MockExecutionServiceDAO => WorkspaceService => T): T = {
     val execSvcDAO = new MockExecutionServiceDAO()
@@ -426,388 +525,452 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     withDataAndService(testCode(execSvcDAO), withDefaultTestDatabase[T], execSvcDAO)
   }
 
-  def withSubmissionTestWorkspaceService[T](testCode: WorkspaceService => T): T = {
+  def withSubmissionTestWorkspaceService[T](testCode: WorkspaceService => T): T =
     withDataAndService(testCode, withCustomTestDatabase[T](new SubmissionTestData))
-  }
 
-  private def checkSubmissionStatus(workspaceService: WorkspaceService, submissionId: String, workspaceName: WorkspaceName = testData.wsName): Submission = {
+  private def checkSubmissionStatus(workspaceService: WorkspaceService,
+                                    submissionId: String,
+                                    workspaceName: WorkspaceName = testData.wsName
+  ): Submission = {
     val submissionStatusRqComplete = workspaceService.getSubmissionStatus(workspaceName, submissionId)
 
     Await.result(submissionStatusRqComplete, Duration.Inf) match {
       case submissionData: Any =>
         val submissionStatusResponse = submissionData.asInstanceOf[Submission]
-        assertResult(submissionId) { submissionStatusResponse.submissionId }
+        assertResult(submissionId)(submissionStatusResponse.submissionId)
         submissionStatusResponse
       case _ => fail("Unable to get submission status")
     }
   }
 
-  "Submission requests" should "400 when given an unparseable entity expression" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.is."),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission( testData.wsName, submissionRq ), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  "Submission requests" should "400 when given an unparseable entity expression" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.is."),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
   private def waitForSubmissionActor(submissionId: String) = {
     var subActor: Option[ActorRef] = None
-    awaitCond({
-      val tr = Try(Await.result(system.actorSelection("/user/" + submissionSupervisorActorName + "/" + submissionId).resolveOne(100 milliseconds), Duration.Inf))
-      subActor = tr.toOption
-      tr.isSuccess
-    }, 1 second)
+    awaitCond(
+      {
+        val tr = Try(
+          Await.result(system
+                         .actorSelection("/user/" + submissionSupervisorActorName + "/" + submissionId)
+                         .resolveOne(100 milliseconds),
+                       Duration.Inf
+          )
+        )
+        subActor = tr.toOption
+        tr.isSuccess
+      },
+      1 second
+    )
     subActor.get
   }
 
-  it should "return a successful Submission and spawn a submission monitor actor when given an entity expression that evaluates to a single entity" in withWorkspaceServiceMockExecution { mockExecSvc => workspaceService =>
+  it should "return a successful Submission and spawn a submission monitor actor when given an entity expression that evaluates to a single entity" in withWorkspaceServiceMockExecution {
+    mockExecSvc => workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Pair"),
+        entityName = Option("pair1"),
+        expression = Option("this.case"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("Pair"),
-      entityName = Option("pair1"),
-      expression = Option("this.case"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      val monitorActor = waitForSubmissionActor(newSubmissionReport.submissionId)
+      // not really necessary, failing to find the actor above will throw an exception and thus fail this test
+      assert(monitorActor != ActorRef.noSender)
 
-    val monitorActor = waitForSubmissionActor(newSubmissionReport.submissionId)
-    //not really necessary, failing to find the actor above will throw an exception and thus fail this test
-    assert(monitorActor != ActorRef.noSender)
+      assert(newSubmissionReport.workflows.size == 1)
 
-    assert(newSubmissionReport.workflows.size == 1)
-
-    checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
+      checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
   }
 
-  it should "continue to monitor a Submission on a deleted entity" in withWorkspaceServiceMockExecution { mockExecSvc => workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("Pair"),
-      entityName = Option("pair1"),
-      expression = Option("this.case"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+  it should "continue to monitor a Submission on a deleted entity" in withWorkspaceServiceMockExecution {
+    mockExecSvc => workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Pair"),
+        entityName = Option("pair1"),
+        expression = Option("this.case"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    runAndWait(entityQuery.hide(testData.workspace, Seq(testData.pair1.toReference)))
+      runAndWait(entityQuery.hide(testData.workspace, Seq(testData.pair1.toReference)))
 
-    val monitorActor = waitForSubmissionActor(newSubmissionReport.submissionId)
-    //not really necessary, failing to find the actor above will throw an exception and thus fail this test
-    assert(monitorActor != ActorRef.noSender)
+      val monitorActor = waitForSubmissionActor(newSubmissionReport.submissionId)
+      // not really necessary, failing to find the actor above will throw an exception and thus fail this test
+      assert(monitorActor != ActorRef.noSender)
 
-    assert(newSubmissionReport.workflows.size == 1)
+      assert(newSubmissionReport.workflows.size == 1)
 
-    checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
+      checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
   }
 
-  it should "fail to submit when given an entity expression that evaluates to a deleted entity" in withWorkspaceServiceMockExecution { mockExecSvc => workspaceService =>
+  it should "fail to submit when given an entity expression that evaluates to a deleted entity" in withWorkspaceServiceMockExecution {
+    mockExecSvc => workspaceService =>
+      runAndWait(entityQuery.hide(testData.workspace, Seq(testData.pair1.toReference)))
 
-    runAndWait(entityQuery.hide(testData.workspace, Seq(testData.pair1.toReference)))
-
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("Pair"),
-      entityName = Option("pair1"), expression = Option("this.case"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    intercept[RawlsException] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Pair"),
+        entityName = Option("pair1"),
+        expression = Option("this.case"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      intercept[RawlsException] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
   }
 
-  it should "return a successful Submission when given an entity expression that evaluates to a set of entities" in withWorkspaceService { workspaceService =>
-    val sset = Entity("testset6", "SampleSet",
-      Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList( Seq(
-        AttributeEntityReference("Sample", "sample1"),
-        AttributeEntityReference("Sample", "sample2"),
-        AttributeEntityReference("Sample", "sample3"),
-        AttributeEntityReference("Sample", "sample4"),
-        AttributeEntityReference("Sample", "sample5"),
-        AttributeEntityReference("Sample", "sample6")))))
+  it should "return a successful Submission when given an entity expression that evaluates to a set of entities" in withWorkspaceService {
+    workspaceService =>
+      val sset = Entity(
+        "testset6",
+        "SampleSet",
+        Map(
+          AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+            Seq(
+              AttributeEntityReference("Sample", "sample1"),
+              AttributeEntityReference("Sample", "sample2"),
+              AttributeEntityReference("Sample", "sample3"),
+              AttributeEntityReference("Sample", "sample4"),
+              AttributeEntityReference("Sample", "sample5"),
+              AttributeEntityReference("Sample", "sample6")
+            )
+          )
+        )
+      )
 
-    runAndWait(entityQuery.save(testData.workspace, sset))
+      runAndWait(entityQuery.save(testData.workspace, sset))
 
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option(sset.entityType),
-      entityName = Option(sset.name),
-      expression = Option("this.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission( testData.wsName, submissionRq ), Duration.Inf)
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option(sset.entityType),
+        entityName = Option(sset.name),
+        expression = Option("this.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assert( newSubmissionReport.workflows.size == 6 )
+      assert(newSubmissionReport.workflows.size == 6)
 
-    checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
+      checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
 
-    val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
-    assert( submission.workflows.forall(_.status == WorkflowStatuses.Queued) )
+      val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+      assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
   }
 
-  it should "return a successful Submission when given an wdl struct entity expression that evaluates to a set of entities" in withWorkspaceService { workspaceService =>
-    val sample1 = Entity("sample1", "Sample", Map(
-      AttributeName.withDefaultNS("participant_id") -> AttributeNumber(101),
-      AttributeName.withDefaultNS("sample_name") -> AttributeString("sample1"),
-    ))
-    val sample2 = Entity("sample2", "Sample", Map(
-      AttributeName.withDefaultNS("participant_id") -> AttributeNumber(102),
-      AttributeName.withDefaultNS("sample_name") -> AttributeString("sample2"),
-    ))
-    val sample3 = Entity("sample3", "Sample", Map(
-      AttributeName.withDefaultNS("participant_id") -> AttributeNumber(103),
-      AttributeName.withDefaultNS("sample_name") -> AttributeString("sample3"),
-    ))
-    val sample4 = Entity("sample4", "Sample", Map(
-      AttributeName.withDefaultNS("participant_id") -> AttributeNumber(104),
-      AttributeName.withDefaultNS("sample_name") -> AttributeString("sample4"),
-    ))
+  it should "return a successful Submission when given an wdl struct entity expression that evaluates to a set of entities" in withWorkspaceService {
+    workspaceService =>
+      val sample1 = Entity(
+        "sample1",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("participant_id") -> AttributeNumber(101),
+          AttributeName.withDefaultNS("sample_name") -> AttributeString("sample1")
+        )
+      )
+      val sample2 = Entity(
+        "sample2",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("participant_id") -> AttributeNumber(102),
+          AttributeName.withDefaultNS("sample_name") -> AttributeString("sample2")
+        )
+      )
+      val sample3 = Entity(
+        "sample3",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("participant_id") -> AttributeNumber(103),
+          AttributeName.withDefaultNS("sample_name") -> AttributeString("sample3")
+        )
+      )
+      val sample4 = Entity(
+        "sample4",
+        "Sample",
+        Map(
+          AttributeName.withDefaultNS("participant_id") -> AttributeNumber(104),
+          AttributeName.withDefaultNS("sample_name") -> AttributeString("sample4")
+        )
+      )
 
-    val sset = Entity("testset6", "SampleSet",
-      Map(
-        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(
-          sample1.toReference,
-          sample2.toReference,
-          sample3.toReference,
-          sample4.toReference
-        ))
-      ))
+      val sset = Entity(
+        "testset6",
+        "SampleSet",
+        Map(
+          AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+            Seq(
+              sample1.toReference,
+              sample2.toReference,
+              sample3.toReference,
+              sample4.toReference
+            )
+          )
+        )
+      )
 
-    val expectedInputResolutions = Seq(
-      AttributeValueRawJson("""{"id":101,"sample_name":"sample1"}"""),
-      AttributeValueRawJson("""{"id":102,"sample_name":"sample2"}"""),
-      AttributeValueRawJson("""{"id":103,"sample_name":"sample3"}"""),
-      AttributeValueRawJson("""{"id":104,"sample_name":"sample4"}""")
-    )
+      val expectedInputResolutions = Seq(
+        AttributeValueRawJson("""{"id":101,"sample_name":"sample1"}"""),
+        AttributeValueRawJson("""{"id":102,"sample_name":"sample2"}"""),
+        AttributeValueRawJson("""{"id":103,"sample_name":"sample3"}"""),
+        AttributeValueRawJson("""{"id":104,"sample_name":"sample4"}""")
+      )
 
-    runAndWait(entityQuery.save(testData.workspace, sample1))
-    runAndWait(entityQuery.save(testData.workspace, sample2))
-    runAndWait(entityQuery.save(testData.workspace, sample3))
-    runAndWait(entityQuery.save(testData.workspace, sample4))
-    runAndWait(entityQuery.save(testData.workspace, sset))
+      runAndWait(entityQuery.save(testData.workspace, sample1))
+      runAndWait(entityQuery.save(testData.workspace, sample2))
+      runAndWait(entityQuery.save(testData.workspace, sample3))
+      runAndWait(entityQuery.save(testData.workspace, sample4))
+      runAndWait(entityQuery.save(testData.workspace, sset))
 
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "WdlStructConfig",
-      entityType = Option(sset.entityType),
-      entityName = Option(sset.name),
-      expression = Option("this.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "WdlStructConfig",
+        entityType = Option(sset.entityType),
+        entityName = Option(sset.name),
+        expression = Option("this.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assert( newSubmissionReport.workflows.size == 4 )
+      assert(newSubmissionReport.workflows.size == 4)
 
-    checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
+      checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
 
-    val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
-    val actualInputResolutions = submission.workflows.flatMap(_.inputResolutions.map(_.value.get))
-    assert( submission.workflows.forall(_.status == WorkflowStatuses.Queued) )
-    assertSameElements(expectedInputResolutions, actualInputResolutions)
+      val submission = runAndWait(submissionQuery.loadSubmission(UUID.fromString(newSubmissionReport.submissionId))).get
+      val actualInputResolutions = submission.workflows.flatMap(_.inputResolutions.map(_.value.get))
+      assert(submission.workflows.forall(_.status == WorkflowStatuses.Queued))
+      assertSameElements(expectedInputResolutions, actualInputResolutions)
   }
 
-  it should "400 when given an entity expression that evaluates to an empty set of entities" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("SampleSet"),
-      entityName = Option("sset_empty"),
-      expression = Option("this.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "400 when given an entity expression that evaluates to an empty set of entities" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("SampleSet"),
+        entityName = Option("sset_empty"),
+        expression = Option("this.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "400 when given a method configuration with unparseable inputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "UnparseableInputsMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+  it should "400 when given a method configuration with unparseable inputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "UnparseableInputsMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
 
-    assert {
-      rqComplete.errorReport.message.contains("Invalid inputs: three_step.cgrep.pattern")
-    }
+      assert {
+        rqComplete.errorReport.message.contains("Invalid inputs: three_step.cgrep.pattern")
+      }
   }
 
-  it should "400 when given a method configuration with unparseable outputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "UnparseableOutputsMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+  it should "400 when given a method configuration with unparseable outputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "UnparseableOutputsMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
 
-    assert {
-      rqComplete.errorReport.message.contains("Invalid outputs: three_step.cgrep.count")
-    }
+      assert {
+        rqComplete.errorReport.message.contains("Invalid outputs: three_step.cgrep.count")
+      }
   }
 
-  it should "400 when given a method configuration with unparseable inputs and outputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "UnparseableBothMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+  it should "400 when given a method configuration with unparseable inputs and outputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "UnparseableBothMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
 
-    assert {
-      rqComplete.errorReport.message.contains("Invalid inputs: three_step.cgrep.pattern")
-    }
-    assert {
-      rqComplete.errorReport.message.contains("Invalid outputs: three_step.cgrep.count")
-    }
+      assert {
+        rqComplete.errorReport.message.contains("Invalid inputs: three_step.cgrep.pattern")
+      }
+      assert {
+        rqComplete.errorReport.message.contains("Invalid outputs: three_step.cgrep.count")
+      }
   }
 
-  it should "return a successful Submission when given a method configuration with empty outputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "EmptyOutputsMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission( testData.wsName, submissionRq ), Duration.Inf)
+  it should "return a successful Submission when given a method configuration with empty outputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "EmptyOutputsMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assert( newSubmissionReport.workflows.size == 3 )
+      assert(newSubmissionReport.workflows.size == 3)
 
-    checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
+      checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
   }
 
-  it should "return a successful Submission with unstarted workflows where method configuration inputs are missing on some entities" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "NotAllSamplesMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission( testData.wsName, submissionRq ), Duration.Inf)
+  it should "return a successful Submission with unstarted workflows where method configuration inputs are missing on some entities" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "NotAllSamplesMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assert( newSubmissionReport.workflows.size == 2 )
+      assert(newSubmissionReport.workflows.size == 2)
 
-    checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
+      checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
   }
 
-  it should "400 when given an entity expression that evaluates to an entity of the wrong type" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("PairSet"),
-      entityName = Option("ps1"),
-      expression = Option("this.pairs"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "400 when given an entity expression that evaluates to an entity of the wrong type" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("PairSet"),
+        entityName = Option("ps1"),
+        expression = Option("this.pairs"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "400 when given no entity expression and an entity of the wrong type" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("PairSet"),
-      entityName = Option("ps1"),
-      expression = None,
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "400 when given no entity expression and an entity of the wrong type" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("PairSet"),
+        entityName = Option("ps1"),
+        expression = None,
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "fail workflows that evaluate to nonsense and put the rest in Queued" in withWorkspaceServiceMockTimeoutExecution { mockExecSvc => workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "NotAllSamplesMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+  it should "fail workflows that evaluate to nonsense and put the rest in Queued" in withWorkspaceServiceMockTimeoutExecution {
+    mockExecSvc => workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "NotAllSamplesMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val newSubmissionReport =
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    val submissionStatusResponse = Await.result(workspaceService.getSubmissionStatus(testData.wsName, newSubmissionReport.submissionId), Duration.Inf)
+      val submissionStatusResponse =
+        Await.result(workspaceService.getSubmissionStatus(testData.wsName, newSubmissionReport.submissionId),
+                     Duration.Inf
+        )
 
-    // Only the workflow with the dodgy expression (sample.tumortype on a normal) should fail
-    assert(submissionStatusResponse.workflows.size == 3)
+      // Only the workflow with the dodgy expression (sample.tumortype on a normal) should fail
+      assert(submissionStatusResponse.workflows.size == 3)
 
-    // the rest are in queued
-    assert( submissionStatusResponse.workflows.count(_.status == WorkflowStatuses.Queued) == 2 )
+      // the rest are in queued
+      assert(submissionStatusResponse.workflows.count(_.status == WorkflowStatuses.Queued) == 2)
   }
 
   it should "run a submission fine with no root entity" in withWorkspaceService { workspaceService =>
-    //Entityless has (duh) no entities and only literals in its outputs
+    // Entityless has (duh) no entities and only literals in its outputs
     val submissionRq = SubmissionRequest(
       methodConfigurationNamespace = testData.methodConfigEntityless.namespace,
       methodConfigurationName = testData.methodConfigEntityless.name,
@@ -817,9 +980,10 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       useCallCache = false,
       deleteIntermediateOutputFiles = false
     )
-    val newSubmissionReport = Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+    val newSubmissionReport =
+      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assert( newSubmissionReport.workflows.size == 1 )
+    assert(newSubmissionReport.workflows.size == 1)
 
     val submissionData = checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
     assert(submissionData.workflows.size == 1)
@@ -827,45 +991,48 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     val subList = Await.result(workspaceService.listSubmissions(testData.wsName), Duration.Inf)
 
     val oneSub = subList.filter(s => s.submissionId == newSubmissionReport.submissionId)
-    assert( oneSub.nonEmpty )
+    assert(oneSub.nonEmpty)
   }
 
-  it should "return BadRequest when running an MC with a root entity without providing one" in withWorkspaceService { workspaceService =>
-    //This method config has a root entity, but we've failed to provide one
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = None,
-      entityName = None,
-      expression = None,
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false)
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission( testData.wsName, submissionRq ), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "return BadRequest when running an MC with a root entity without providing one" in withWorkspaceService {
+    workspaceService =>
+      // This method config has a root entity, but we've failed to provide one
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = None,
+        entityName = None,
+        expression = None,
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "return BadRequest when running against an MC with no root entity and providing one anyway" in withWorkspaceService { workspaceService =>
-    //Entityless has (duh) no entities and only literals in its outputs
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = testData.methodConfigEntityless.namespace,
-      methodConfigurationName = testData.methodConfigEntityless.name,
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+  it should "return BadRequest when running against an MC with no root entity and providing one anyway" in withWorkspaceService {
+    workspaceService =>
+      // Entityless has (duh) no entities and only literals in its outputs
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = testData.methodConfigEntityless.namespace,
+        methodConfigurationName = testData.methodConfigEntityless.name,
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
   it should "create data repo submission" in {
@@ -884,206 +1051,250 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       // change the expression to include both workspace and entity lookups
       val workspaceAttrName = "attr"
       val workspaceAttrValue = "foobar"
-      val inputsWithWorkspaceExpression = methodConfig.inputs.map { case (name, expr) => name -> AttributeString(s"""{"entity": ${expr.value}, "workspace": workspace.$workspaceAttrName}""")}
-      runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig.copy(inputs =  inputsWithWorkspaceExpression)))
-      runAndWait(workspaceQuery.createOrUpdate(minimalTestData.workspace.copy(attributes = Map(AttributeName.withDefaultNS(workspaceAttrName) -> AttributeString(workspaceAttrValue)))))
+      val inputsWithWorkspaceExpression = methodConfig.inputs.map { case (name, expr) =>
+        name -> AttributeString(s"""{"entity": ${expr.value}, "workspace": workspace.$workspaceAttrName}""")
+      }
+      runAndWait(
+        methodConfigurationQuery.upsert(minimalTestData.workspace,
+                                        methodConfig.copy(inputs = inputsWithWorkspaceExpression)
+        )
+      )
+      runAndWait(
+        workspaceQuery.createOrUpdate(
+          minimalTestData.workspace.copy(attributes =
+            Map(AttributeName.withDefaultNS(workspaceAttrName) -> AttributeString(workspaceAttrValue))
+          )
+        )
+      )
 
-      val resultSubmission = Await.result(workspaceService.createSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
+      val resultSubmission =
+        Await.result(workspaceService.createSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
 
       resultSubmission.header.entityStoreId shouldBe Some(snapshotId.toString)
       resultSubmission.header.entityType shouldBe methodConfig.rootEntityType
 
       val expectedValidInputs = tableData.map { case (rowId, resultVal) =>
         val expectedRawJson = s"""{"entity": "$resultVal", "workspace": "$workspaceAttrValue"}"""
-        SubmissionValidationEntityInputs(rowId, Set(SubmissionValidationValue(Option(AttributeValueRawJson(expectedRawJson)), None, methodConfig.inputs.keys.head)))
+        SubmissionValidationEntityInputs(rowId,
+                                         Set(
+                                           SubmissionValidationValue(Option(AttributeValueRawJson(expectedRawJson)),
+                                                                     None,
+                                                                     methodConfig.inputs.keys.head
+                                           )
+                                         )
+        )
       }
       resultSubmission.workflows should contain theSameElementsAs expectedValidInputs
     }
   }
 
-  "Submission validation requests" should "report a BadRequest for an unparseable entity expression" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.is."),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  "Submission validation requests" should "report a BadRequest for an unparseable entity expression" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.is."),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "report a validated input and runnable workflow when given an entity expression that evaluates to a single entity" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("Pair"),
-      entityName = Option("pair1"),
-      expression = Option("this.case"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val vData = Await.result(workspaceService.validateSubmission( testData.wsName, submissionRq ), Duration.Inf)
+  it should "report a validated input and runnable workflow when given an entity expression that evaluates to a single entity" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("Pair"),
+        entityName = Option("pair1"),
+        expression = Option("this.case"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val vData = Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assertResult(1) { vData.validEntities.length }
-    assert(vData.invalidEntities.isEmpty)
+      assertResult(1)(vData.validEntities.length)
+      assert(vData.invalidEntities.isEmpty)
   }
 
-  it should "report validated inputs and runnable workflows when given an entity expression that evaluates to a set of entities" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("SampleSet"),
-      entityName = Option("sset1"),
-      expression = Option("this.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val vData = Await.result(workspaceService.validateSubmission( testData.wsName, submissionRq ), Duration.Inf)
+  it should "report validated inputs and runnable workflows when given an entity expression that evaluates to a set of entities" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("SampleSet"),
+        entityName = Option("sset1"),
+        expression = Option("this.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val vData = Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assertResult(testData.sset1.attributes(AttributeName.withDefaultNS("samples")).asInstanceOf[AttributeEntityReferenceList].list.size) { vData.validEntities.length }
-    assert(vData.invalidEntities.isEmpty)
+      assertResult(
+        testData.sset1
+          .attributes(AttributeName.withDefaultNS("samples"))
+          .asInstanceOf[AttributeEntityReferenceList]
+          .list
+          .size
+      )(vData.validEntities.length)
+      assert(vData.invalidEntities.isEmpty)
   }
 
-  it should "400 when given an entity expression that evaluates to an empty set of entities" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("SampleSet"),
-      entityName = Option("sset_empty"),
-      expression = Option("this.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "400 when given an entity expression that evaluates to an empty set of entities" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("SampleSet"),
+        entityName = Option("sset_empty"),
+        expression = Option("this.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "400 when given a method configuration with unparseable inputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "UnparseableInputsMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+  it should "400 when given a method configuration with unparseable inputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "UnparseableInputsMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
 
-    assert {
-      rqComplete.errorReport.message.contains("Invalid inputs: three_step.cgrep.pattern")
-    }
+      assert {
+        rqComplete.errorReport.message.contains("Invalid inputs: three_step.cgrep.pattern")
+      }
   }
 
-  it should "400 when given a method configuration with unparseable outputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "UnparseableOutputsMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
+  it should "400 when given a method configuration with unparseable outputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "UnparseableOutputsMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
 
-    assert {
-      rqComplete.errorReport.message.contains("Invalid outputs: three_step.cgrep.count")
-    }
+      assert {
+        rqComplete.errorReport.message.contains("Invalid outputs: three_step.cgrep.count")
+      }
   }
 
-  it should "report a successful validation when given a method configuration with empty outputs" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "EmptyOutputsMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val validation = Await.result(workspaceService.validateSubmission( testData.wsName, submissionRq ), Duration.Inf)
+  it should "report a successful validation when given a method configuration with empty outputs" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "EmptyOutputsMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val validation = Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assertResult(3) { validation.validEntities.size }
-    assert { validation.invalidEntities.isEmpty }
+      assertResult(3)(validation.validEntities.size)
+      assert(validation.invalidEntities.isEmpty)
   }
 
-  it should "report validated inputs and a mixture of started and unstarted workflows where method configuration inputs are missing on some entities" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "NotAllSamplesMethodConfig",
-      entityType = Option("Individual"),
-      entityName = Option("indiv1"),
-      expression = Option("this.sset.samples"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val vData = Await.result(workspaceService.validateSubmission( testData.wsName, submissionRq ), Duration.Inf)
+  it should "report validated inputs and a mixture of started and unstarted workflows where method configuration inputs are missing on some entities" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "NotAllSamplesMethodConfig",
+        entityType = Option("Individual"),
+        entityName = Option("indiv1"),
+        expression = Option("this.sset.samples"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val vData = Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
 
-    assertResult(testData.sset1.attributes(AttributeName.withDefaultNS("samples")).asInstanceOf[AttributeEntityReferenceList].list.size-1) { vData.validEntities.length }
-    assertResult(1) { vData.invalidEntities.length }
+      assertResult(
+        testData.sset1
+          .attributes(AttributeName.withDefaultNS("samples"))
+          .asInstanceOf[AttributeEntityReferenceList]
+          .list
+          .size - 1
+      )(vData.validEntities.length)
+      assertResult(1)(vData.invalidEntities.length)
   }
 
-  it should "report errors for an entity expression that evaluates to an entity of the wrong type" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("PairSet"),
-      entityName = Option("ps1"),
-      expression = Option("this.pairs"),
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "report errors for an entity expression that evaluates to an entity of the wrong type" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("PairSet"),
+        entityName = Option("ps1"),
+        expression = Option("this.pairs"),
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.validateSubmission(testData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  it should "report an error when given no entity expression and the entity is of the wrong type" in withWorkspaceService { workspaceService =>
-    val submissionRq = SubmissionRequest(
-      methodConfigurationNamespace = "dsde",
-      methodConfigurationName = "GoodMethodConfig",
-      entityType = Option("PairSet"),
-      entityName = Option("ps1"),
-      expression = None,
-      useCallCache = false,
-      deleteIntermediateOutputFiles = false
-    )
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
-    }
-    assertResult(StatusCodes.BadRequest) {
-      rqComplete.errorReport.statusCode.get
-    }
+  it should "report an error when given no entity expression and the entity is of the wrong type" in withWorkspaceService {
+    workspaceService =>
+      val submissionRq = SubmissionRequest(
+        methodConfigurationNamespace = "dsde",
+        methodConfigurationName = "GoodMethodConfig",
+        entityType = Option("PairSet"),
+        entityName = Option("ps1"),
+        expression = None,
+        useCallCache = false,
+        deleteIntermediateOutputFiles = false
+      )
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
+      }
+      assertResult(StatusCodes.BadRequest) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
-  def dataRepoSubmissionTest[T](tableData: Map[String, String])(test: (WorkspaceService, MethodConfiguration, UUID) => T) = {
+  def dataRepoSubmissionTest[T](
+    tableData: Map[String, String]
+  )(test: (WorkspaceService, MethodConfiguration, UUID) => T) = {
     val tableResult: TableResult = prepareBqData(tableData)
 
     val dataRepoDAO = mock[DataRepoDAO](RETURNS_SMART_NULLS)
@@ -1092,22 +1303,51 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     val tableName = "table1"
     val columnName = "value"
 
-    when(dataRepoDAO.getSnapshot(snapshotUUID, userInfo.accessToken)).thenReturn(createSnapshotModel(List(
-      new TableModel().name(tableName).primaryKey(null).rowCount(0)
-        .columns(List(columnName).map(new ColumnModel().name(_)).asJava))).id(snapshotUUID)
+    when(dataRepoDAO.getSnapshot(snapshotUUID, userInfo.accessToken)).thenReturn(
+      createSnapshotModel(
+        List(
+          new TableModel()
+            .name(tableName)
+            .primaryKey(null)
+            .rowCount(0)
+            .columns(List(columnName).map(new ColumnModel().name(_)).asJava)
+        )
+      ).id(snapshotUUID)
     )
     when(dataRepoDAO.getInstanceName).thenReturn("dataRepoInstance")
 
     val dataReferenceName = DataReferenceName("dataref")
     val dataReferenceDescription = Option(DataReferenceDescriptionField("description"))
 
-    val methodConfig = MethodConfiguration("dsde", "DataRepoMethodConfig", Some(tableName), prerequisites = None, inputs = Map("three_step.cgrep.pattern" -> AttributeString(s"this.$columnName")), outputs = Map.empty, AgoraMethod("dsde", "three_step", 1), dataReferenceName = Option(dataReferenceName))
+    val methodConfig = MethodConfiguration(
+      "dsde",
+      "DataRepoMethodConfig",
+      Some(tableName),
+      prerequisites = None,
+      inputs = Map("three_step.cgrep.pattern" -> AttributeString(s"this.$columnName")),
+      outputs = Map.empty,
+      AgoraMethod("dsde", "three_step", 1),
+      dataReferenceName = Option(dataReferenceName)
+    )
 
-    withDataAndService({ workspaceService =>
-      workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(minimalTestData.workspace.workspaceIdAsUUID, snapshotUUID, dataReferenceName, dataReferenceDescription, dataRepoDAO.getInstanceName, CloningInstructionsEnum.NOTHING, testContext )
-      runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig))
-      test(workspaceService, methodConfig, snapshotUUID)
-    }, withMinimalTestDatabase[Any], bigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)), dataRepoDAO = dataRepoDAO)
+    withDataAndService(
+      { workspaceService =>
+        workspaceService.workspaceManagerDAO.createDataRepoSnapshotReference(
+          minimalTestData.workspace.workspaceIdAsUUID,
+          snapshotUUID,
+          dataReferenceName,
+          dataReferenceDescription,
+          dataRepoDAO.getInstanceName,
+          CloningInstructionsEnum.NOTHING,
+          testContext
+        )
+        runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig))
+        test(workspaceService, methodConfig, snapshotUUID)
+      },
+      withMinimalTestDatabase[Any],
+      bigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)),
+      dataRepoDAO = dataRepoDAO
+    )
   }
 
   private def prepareBqData(tableData: Map[String, String]) = {
@@ -1116,10 +1356,14 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     val schema: Schema = Schema.of(rowIdField, valueField)
 
     val results = tableData map { case (rowId, value) =>
-      FieldValueList.of(List(
-        FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, rowId),
-        FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, value)).asJava,
-        rowIdField, valueField)
+      FieldValueList.of(
+        List(
+          FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, rowId),
+          FieldValue.of(com.google.cloud.bigquery.FieldValue.Attribute.PRIMITIVE, value)
+        ).asJava,
+        rowIdField,
+        valueField
+      )
     }
 
     val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, results.asJava)
@@ -1142,7 +1386,12 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
 
       val vData = Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
 
-      val expectedValidInputs = tableData.map { case (rowId, resultVal) => SubmissionValidationEntityInputs(rowId, Set(SubmissionValidationValue(Option(AttributeString(resultVal)), None, methodConfig.inputs.keys.head))) }
+      val expectedValidInputs = tableData.map { case (rowId, resultVal) =>
+        SubmissionValidationEntityInputs(
+          rowId,
+          Set(SubmissionValidationValue(Option(AttributeString(resultVal)), None, methodConfig.inputs.keys.head))
+        )
+      }
       vData.validEntities should contain theSameElementsAs expectedValidInputs
       assert(vData.invalidEntities.isEmpty)
     }
@@ -1164,7 +1413,18 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       val vData = Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
 
       assert(vData.validEntities.isEmpty)
-      val expectedInvalidInputs = tableData.keys.map(rowId => SubmissionValidationEntityInputs(rowId, Set(SubmissionValidationValue(None, Some("Expected single value for workflow input, but evaluated result set was empty"), methodConfig.inputs.keys.head))))
+      val expectedInvalidInputs = tableData.keys.map(rowId =>
+        SubmissionValidationEntityInputs(
+          rowId,
+          Set(
+            SubmissionValidationValue(
+              None,
+              Some("Expected single value for workflow input, but evaluated result set was empty"),
+              methodConfig.inputs.keys.head
+            )
+          )
+        )
+      )
       vData.invalidEntities should contain theSameElementsAs expectedInvalidInputs
     }
   }
@@ -1182,7 +1442,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       )
 
       val ex = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(workspaceService.validateSubmission( minimalTestData.wsName, submissionRq ), Duration.Inf)
+        Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
       }
       ex.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
       ex.errorReport.message shouldBe "Your method config defines a data reference and an entity name. Running on a submission on a single entity in a data reference is not yet supported."
@@ -1191,7 +1451,11 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
 
   it should "report error when data reference points to unknown snapshot" in {
     dataRepoSubmissionTest(Map.empty) { (workspaceService, methodConfig, snapshotId) =>
-      runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig.copy(dataReferenceName = Some(DataReferenceName("unknown")))))
+      runAndWait(
+        methodConfigurationQuery.upsert(minimalTestData.workspace,
+                                        methodConfig.copy(dataReferenceName = Some(DataReferenceName("unknown")))
+        )
+      )
 
       val submissionRq = SubmissionRequest(
         methodConfigurationNamespace = methodConfig.namespace,
@@ -1204,7 +1468,7 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       )
 
       val ex = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(workspaceService.validateSubmission( minimalTestData.wsName, submissionRq ), Duration.Inf)
+        Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
       }
       ex.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
       ex.errorReport.message shouldBe "Reference name unknown does not exist in workspace myNamespace/myWorkspace."
@@ -1213,7 +1477,9 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
 
   it should "report error when root entity type does not refer to a table in the snapshot" in {
     dataRepoSubmissionTest(Map.empty) { (workspaceService, methodConfig, snapshotId) =>
-      runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig.copy(rootEntityType = Some("unknown"))))
+      runAndWait(
+        methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig.copy(rootEntityType = Some("unknown")))
+      )
 
       val submissionRq = SubmissionRequest(
         methodConfigurationNamespace = methodConfig.namespace,
@@ -1226,20 +1492,24 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
       )
 
       val ex = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(workspaceService.validateSubmission( minimalTestData.wsName, submissionRq ), Duration.Inf)
+        Await.result(workspaceService.validateSubmission(minimalTestData.wsName, submissionRq), Duration.Inf)
       }
       ex.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
       ex.errorReport.message shouldBe "Validation errors: Invalid inputs: three_step.cgrep.pattern -> Table `unknown` does not exist in snapshot"
     }
   }
 
-  "Aborting submissions" should "404 if the workspace doesn't exist" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(workspaceService.abortSubmission(WorkspaceName(name = "nonexistent", namespace = "workspace"), "12345"), Duration.Inf)
-    }
-    assertResult(StatusCodes.NotFound) {
-      rqComplete.errorReport.statusCode.get
-    }
+  "Aborting submissions" should "404 if the workspace doesn't exist" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val rqComplete = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(
+          workspaceService.abortSubmission(WorkspaceName(name = "nonexistent", namespace = "workspace"), "12345"),
+          Duration.Inf
+        )
+      }
+      assertResult(StatusCodes.NotFound) {
+        rqComplete.errorReport.statusCode.get
+      }
   }
 
   it should "404 if the submission doesn't exist" in withSubmissionTestWorkspaceService { workspaceService =>
@@ -1258,76 +1528,85 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
     }
   }
 
-  "Getting workflow outputs" should "return 200 when all is well" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = workspaceService.workflowOutputs(
-      subTestData.wsName,
-      subTestData.submissionTestAbortGoodWorkflow.submissionId,
-      subTestData.existingWorkflowId.get)
-    val data = Await.result(rqComplete, Duration.Inf)
+  "Getting workflow outputs" should "return 200 when all is well" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val rqComplete = workspaceService.workflowOutputs(subTestData.wsName,
+                                                        subTestData.submissionTestAbortGoodWorkflow.submissionId,
+                                                        subTestData.existingWorkflowId.get
+      )
+      val data = Await.result(rqComplete, Duration.Inf)
 
-    assertResult(subTestData.extantWorkflowOutputs) {data}
+      assertResult(subTestData.extantWorkflowOutputs)(data)
   }
 
-  it should "return 404 on getting outputs for a workflow that exists, but not in this submission" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = workspaceService.workflowOutputs(
-      subTestData.wsName,
-      subTestData.submissionTestAbortTerminalWorkflow.submissionId,
-      subTestData.existingWorkflowId.get)
-    val errorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(rqComplete, Duration.Inf)
-    }
+  it should "return 404 on getting outputs for a workflow that exists, but not in this submission" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val rqComplete = workspaceService.workflowOutputs(subTestData.wsName,
+                                                        subTestData.submissionTestAbortTerminalWorkflow.submissionId,
+                                                        subTestData.existingWorkflowId.get
+      )
+      val errorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(rqComplete, Duration.Inf)
+      }
 
-    assertResult(StatusCodes.NotFound) {errorReport.errorReport.statusCode.get}
+      assertResult(StatusCodes.NotFound)(errorReport.errorReport.statusCode.get)
   }
 
-  "Getting a workflow cost" should "return 200 when all is well" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = workspaceService.workflowCost(
-      subTestData.wsName,
-      subTestData.submissionTestAbortGoodWorkflow.submissionId,
-      subTestData.existingWorkflowId.get)
-    val data = Await.result(rqComplete, Duration.Inf)
+  "Getting a workflow cost" should "return 200 when all is well" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val rqComplete = workspaceService.workflowCost(subTestData.wsName,
+                                                     subTestData.submissionTestAbortGoodWorkflow.submissionId,
+                                                     subTestData.existingWorkflowId.get
+      )
+      val data = Await.result(rqComplete, Duration.Inf)
 
-    assertResult(WorkflowCost(subTestData.existingWorkflowId.get, Some(mockSubmissionCostService.fixedCost))) {data}
+      assertResult(WorkflowCost(subTestData.existingWorkflowId.get, Some(mockSubmissionCostService.fixedCost)))(data)
   }
 
-  it should "return 404 on getting the cost for a workflow that exists, but not in this submission" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = workspaceService.workflowCost(
-      subTestData.wsName,
-      subTestData.submissionTestAbortTerminalWorkflow.submissionId,
-      subTestData.existingWorkflowId.get)
-    val errorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(rqComplete, Duration.Inf)
-    }
+  it should "return 404 on getting the cost for a workflow that exists, but not in this submission" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val rqComplete = workspaceService.workflowCost(subTestData.wsName,
+                                                     subTestData.submissionTestAbortTerminalWorkflow.submissionId,
+                                                     subTestData.existingWorkflowId.get
+      )
+      val errorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(rqComplete, Duration.Inf)
+      }
 
-    assertResult(StatusCodes.NotFound) {errorReport.errorReport.statusCode.get}
+      assertResult(StatusCodes.NotFound)(errorReport.errorReport.statusCode.get)
   }
 
-  it should "calculate submission cost as the sum of workflow costs" in withSubmissionTestWorkspaceService { workspaceService =>
-    val submissionData = checkSubmissionStatus(workspaceService, subTestData.submissionTestAbortTwoGoodWorkflows.submissionId, subTestData.wsName)
-    assertResult(Option(mockSubmissionCostService.fixedCost * 2)) {
-      submissionData.cost
-    }
+  it should "calculate submission cost as the sum of workflow costs" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val submissionData = checkSubmissionStatus(workspaceService,
+                                                 subTestData.submissionTestAbortTwoGoodWorkflows.submissionId,
+                                                 subTestData.wsName
+      )
+      assertResult(Option(mockSubmissionCostService.fixedCost * 2)) {
+        submissionData.cost
+      }
   }
 
-  it should "return 502 on getting a workflow if Cromwell barfs" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = workspaceService.workflowOutputs(
-      subTestData.wsName,
-      subTestData.submissionTestCromwellBadWorkflows.submissionId,
-      subTestData.badLogsAndMetadataWorkflowId.get)
-    val errorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(rqComplete, Duration.Inf)
-    }
+  it should "return 502 on getting a workflow if Cromwell barfs" in withSubmissionTestWorkspaceService {
+    workspaceService =>
+      val rqComplete = workspaceService.workflowOutputs(subTestData.wsName,
+                                                        subTestData.submissionTestCromwellBadWorkflows.submissionId,
+                                                        subTestData.badLogsAndMetadataWorkflowId.get
+      )
+      val errorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(rqComplete, Duration.Inf)
+      }
 
-    assertResult(StatusCodes.BadGateway) {errorReport.errorReport.statusCode.get}
-    assertResult("cromwell"){errorReport.errorReport.causes.head.source}
+      assertResult(StatusCodes.BadGateway)(errorReport.errorReport.statusCode.get)
+      assertResult("cromwell")(errorReport.errorReport.causes.head.source)
   }
 
   "Getting workflow metadata" should "return 200" in withSubmissionTestWorkspaceService { workspaceService =>
-    val rqComplete = workspaceService.workflowMetadata(
-      subTestData.wsName,
-      subTestData.submissionTestAbortGoodWorkflow.submissionId,
-      subTestData.existingWorkflowId.get,
-      MetadataParams())
+    val rqComplete = workspaceService.workflowMetadata(subTestData.wsName,
+                                                       subTestData.submissionTestAbortGoodWorkflow.submissionId,
+                                                       subTestData.existingWorkflowId.get,
+                                                       MetadataParams()
+    )
     val data = Await.result(rqComplete, Duration.Inf)
 
     assert(data.fields.nonEmpty)
@@ -1335,14 +1614,28 @@ class SubmissionSpec(_system: ActorSystem) extends TestKit(_system)
 
   "ExecutionService" should "parse unsupported output data types" in {
     val workflowId = "8afafe21-2b70-4180-a565-748cb573e10c"
-    assertResult(ExecutionServiceOutputs(workflowId, Map("aggregate_data_workflow.aggregate_data.output_array" -> Left(AttributeValueRawJson(JsArray(Vector(
-      JsArray(Vector(JsString("foo"), JsString("bar"))),
-      JsArray(Vector(JsString("baz"), JsString("qux")))))))))) {
+    assertResult(
+      ExecutionServiceOutputs(
+        workflowId,
+        Map(
+          "aggregate_data_workflow.aggregate_data.output_array" -> Left(
+            AttributeValueRawJson(
+              JsArray(
+                Vector(JsArray(Vector(JsString("foo"), JsString("bar"))),
+                       JsArray(Vector(JsString("baz"), JsString("qux")))
+                )
+              )
+            )
+          )
+        )
+      )
+    ) {
 
-      Await.result(new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName).outputs(workflowId, userInfo), Duration.Inf)
+      Await.result(new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName)
+                     .outputs(workflowId, userInfo),
+                   Duration.Inf
+      )
     }
 
   }
 }
-
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -7,39 +7,62 @@ import bio.terra.workspace.model.JobReport.StatusEnum
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, ErrorReport, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceDescriptionField,
+  DataReferenceName,
+  ErrorReport,
+  RawlsRequestContext
+}
 
 import java.util.UUID
 import scala.collection.concurrent.TrieMap
 import scala.jdk.CollectionConverters._
 
-class MockWorkspaceManagerDAO(val createCloudContextResult: CreateCloudContextResult = MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.SUCCEEDED),
-                              val createAzureRelayResult: CreateControlledAzureRelayNamespaceResult = MockWorkspaceManagerDAO.getCreateControlledAzureRelayNamespaceResult(StatusEnum.SUCCEEDED)) extends WorkspaceManagerDAO {
+class MockWorkspaceManagerDAO(
+  val createCloudContextResult: CreateCloudContextResult =
+    MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.SUCCEEDED),
+  val createAzureRelayResult: CreateControlledAzureRelayNamespaceResult =
+    MockWorkspaceManagerDAO.getCreateControlledAzureRelayNamespaceResult(StatusEnum.SUCCEEDED)
+) extends WorkspaceManagerDAO {
 
   val references: TrieMap[(UUID, UUID), DataRepoSnapshotResource] = TrieMap()
 
   def mockGetWorkspaceResponse(workspaceId: UUID) = new WorkspaceDescription().id(workspaceId)
   def mockCreateWorkspaceResponse(workspaceId: UUID) = new CreatedWorkspace().id(workspaceId)
-  def mockReferenceResponse(workspaceId: UUID, referenceId: UUID) = references.getOrElse((workspaceId, referenceId), throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "Not found")))
+  def mockReferenceResponse(workspaceId: UUID, referenceId: UUID) = references.getOrElse(
+    (workspaceId, referenceId),
+    throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "Not found"))
+  )
   def mockEnumerateReferenceResponse(workspaceId: UUID) = references.collect {
     case ((wsId, _), refDescription) if wsId == workspaceId => refDescription
   }
-  def mockInitialCreateAzureCloudContextResult() = MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.RUNNING)
+  def mockInitialCreateAzureCloudContextResult() =
+    MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.RUNNING)
   def mockCreateAzureCloudContextResult() = createCloudContextResult
-  def mockInitialAzureRelayNamespaceResult() = MockWorkspaceManagerDAO.getCreateControlledAzureRelayNamespaceResult(StatusEnum.RUNNING)
+  def mockInitialAzureRelayNamespaceResult() =
+    MockWorkspaceManagerDAO.getCreateControlledAzureRelayNamespaceResult(StatusEnum.RUNNING)
   def mockAzureRelayNamespaceResult() = createAzureRelayResult
-  def mockCreateAzureStorageAccountResult() = new CreatedControlledAzureStorage().
-    resourceId(UUID.randomUUID()).azureStorage(new AzureStorageResource())
+  def mockCreateAzureStorageAccountResult() =
+    new CreatedControlledAzureStorage().resourceId(UUID.randomUUID()).azureStorage(new AzureStorageResource())
   def mockCreateAzureStorageContainerResult() = new CreatedControlledAzureStorageContainer()
 
-  override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription = mockGetWorkspaceResponse(workspaceId)
+  override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription =
+    mockGetWorkspaceResponse(workspaceId)
 
-  override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace = mockCreateWorkspaceResponse(workspaceId)
+  override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace =
+    mockCreateWorkspaceResponse(workspaceId)
 
   override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit = ()
 
-  override def createDataRepoSnapshotReference(workspaceId: UUID, snapshotId: UUID, name: DataReferenceName, description: Option[DataReferenceDescriptionField], instanceName: String, cloningInstructions: CloningInstructionsEnum, ctx: RawlsRequestContext): DataRepoSnapshotResource = {
-    if(name.value.contains("fakesnapshot"))
+  override def createDataRepoSnapshotReference(workspaceId: UUID,
+                                               snapshotId: UUID,
+                                               name: DataReferenceName,
+                                               description: Option[DataReferenceDescriptionField],
+                                               instanceName: String,
+                                               cloningInstructions: CloningInstructionsEnum,
+                                               ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource =
+    if (name.value.contains("fakesnapshot"))
       throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "Not found"))
     else {
       val newId = UUID.randomUUID()
@@ -56,91 +79,122 @@ class MockWorkspaceManagerDAO(val createCloudContextResult: CreateCloudContextRe
       references.put((workspaceId, newId), snapshot)
       mockReferenceResponse(workspaceId, newId)
     }
-  }
 
-  override def getDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): DataRepoSnapshotResource = {
+  override def getDataRepoSnapshotReference(workspaceId: UUID,
+                                            referenceId: UUID,
+                                            ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource =
     mockReferenceResponse(workspaceId, referenceId)
-  }
 
-  override def getDataRepoSnapshotReferenceByName(workspaceId: UUID, refName: DataReferenceName, ctx: RawlsRequestContext): DataRepoSnapshotResource = {
-    this.references.find {
-      case ((workspaceUUID, _), ref) => workspaceUUID == workspaceId && ref.getMetadata.getName == refName.value && ref.getMetadata.getResourceType == ResourceType.DATA_REPO_SNAPSHOT
-    }.getOrElse(throw new ApiException(StatusCodes.NotFound.intValue, s"Snapshot $refName not found in workspace $workspaceId"))._2
-  }
+  override def getDataRepoSnapshotReferenceByName(workspaceId: UUID,
+                                                  refName: DataReferenceName,
+                                                  ctx: RawlsRequestContext
+  ): DataRepoSnapshotResource =
+    this.references
+      .find { case ((workspaceUUID, _), ref) =>
+        workspaceUUID == workspaceId && ref.getMetadata.getName == refName.value && ref.getMetadata.getResourceType == ResourceType.DATA_REPO_SNAPSHOT
+      }
+      .getOrElse(
+        throw new ApiException(StatusCodes.NotFound.intValue, s"Snapshot $refName not found in workspace $workspaceId")
+      )
+      ._2
 
-  override def enumerateDataRepoSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList = {
-    val resources = mockEnumerateReferenceResponse(workspaceId).map { resp =>
-      val attributesUnion = new ResourceAttributesUnion().gcpDataRepoSnapshot(resp.getAttributes)
-      new ResourceDescription().metadata(resp.getMetadata).resourceAttributes(attributesUnion)
-    }.toList.asJava
+  override def enumerateDataRepoSnapshotReferences(workspaceId: UUID,
+                                                   offset: Int,
+                                                   limit: Int,
+                                                   ctx: RawlsRequestContext
+  ): ResourceList = {
+    val resources = mockEnumerateReferenceResponse(workspaceId)
+      .map { resp =>
+        val attributesUnion = new ResourceAttributesUnion().gcpDataRepoSnapshot(resp.getAttributes)
+        new ResourceDescription().metadata(resp.getMetadata).resourceAttributes(attributesUnion)
+      }
+      .toList
+      .asJava
     new ResourceList().resources(resources)
   }
 
-  override def updateDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, updateInfo: UpdateDataRepoSnapshotReferenceRequestBody, ctx: RawlsRequestContext): Unit = {
+  override def updateDataRepoSnapshotReference(workspaceId: UUID,
+                                               referenceId: UUID,
+                                               updateInfo: UpdateDataRepoSnapshotReferenceRequestBody,
+                                               ctx: RawlsRequestContext
+  ): Unit =
     if (references.contains(workspaceId, referenceId)) {
       val existingRef = references.get(workspaceId, referenceId).get
-      val newMetadata = existingRef.getMetadata.name(
-        if (updateInfo.getName != null) updateInfo.getName else existingRef.getMetadata.getName
-      ).description(
-        if (updateInfo.getDescription != null) updateInfo.getDescription else existingRef.getMetadata.getDescription
-      )
+      val newMetadata = existingRef.getMetadata
+        .name(
+          if (updateInfo.getName != null) updateInfo.getName else existingRef.getMetadata.getName
+        )
+        .description(
+          if (updateInfo.getDescription != null) updateInfo.getDescription else existingRef.getMetadata.getDescription
+        )
       references.update((workspaceId, referenceId), existingRef.metadata(newMetadata))
     }
-  }
 
-  override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit = {
+  override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit =
     if (references.contains(workspaceId, referenceId))
       references -= ((workspaceId, referenceId))
-  }
 
-  override def createWorkspaceWithSpendProfile(workspaceId: UUID, displayName: String, spendProfileId: String, ctx: RawlsRequestContext): CreatedWorkspace =
+  override def createWorkspaceWithSpendProfile(workspaceId: UUID,
+                                               displayName: String,
+                                               spendProfileId: String,
+                                               ctx: RawlsRequestContext
+  ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                                 azureTenantId: String,
                                                 azureResourceGroupId: String,
                                                 azureSubscriptionId: String,
-                                                ctx: RawlsRequestContext): CreateCloudContextResult = mockInitialCreateAzureCloudContextResult()
+                                                ctx: RawlsRequestContext
+  ): CreateCloudContextResult = mockInitialCreateAzureCloudContextResult()
 
   override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                                     jobControlId: String,
-                                                    ctx: RawlsRequestContext): CreateCloudContextResult = mockCreateAzureCloudContextResult()
+                                                    ctx: RawlsRequestContext
+  ): CreateCloudContextResult = mockCreateAzureCloudContextResult()
 
-  override def enableApplication(workspaceId: UUID, applicationId: String, ctx: RawlsRequestContext): WorkspaceApplicationDescription = {
+  override def enableApplication(workspaceId: UUID,
+                                 applicationId: String,
+                                 ctx: RawlsRequestContext
+  ): WorkspaceApplicationDescription =
     new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
-  }
 
-  override def createAzureRelay(workspaceId: UUID, region: String, ctx: RawlsRequestContext): CreateControlledAzureRelayNamespaceResult = {
+  override def createAzureRelay(workspaceId: UUID,
+                                region: String,
+                                ctx: RawlsRequestContext
+  ): CreateControlledAzureRelayNamespaceResult =
     mockInitialAzureRelayNamespaceResult()
-  }
 
-  override def getCreateAzureRelayResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CreateControlledAzureRelayNamespaceResult = {
+  override def getCreateAzureRelayResult(workspaceId: UUID,
+                                         jobControlId: String,
+                                         ctx: RawlsRequestContext
+  ): CreateControlledAzureRelayNamespaceResult =
     mockAzureRelayNamespaceResult()
-  }
 
-  override def createAzureStorageAccount(workspaceId: UUID, region: String, ctx: RawlsRequestContext): CreatedControlledAzureStorage = {
+  override def createAzureStorageAccount(workspaceId: UUID,
+                                         region: String,
+                                         ctx: RawlsRequestContext
+  ): CreatedControlledAzureStorage =
     mockCreateAzureStorageAccountResult()
-  }
 
-  override def createAzureStorageContainer(workspaceId: UUID, storageAccountId: UUID, ctx: RawlsRequestContext): CreatedControlledAzureStorageContainer = {
+  override def createAzureStorageContainer(workspaceId: UUID,
+                                           storageAccountId: UUID,
+                                           ctx: RawlsRequestContext
+  ): CreatedControlledAzureStorageContainer =
     mockCreateAzureStorageContainerResult()
-  }
 }
 
-
 object MockWorkspaceManagerDAO {
-  def getCreateCloudContextResult(status: StatusEnum): CreateCloudContextResult = {
+  def getCreateCloudContextResult(status: StatusEnum): CreateCloudContextResult =
     new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(status))
-  }
 
-  def getCreateControlledAzureRelayNamespaceResult(status: StatusEnum): CreateControlledAzureRelayNamespaceResult = {
+  def getCreateControlledAzureRelayNamespaceResult(status: StatusEnum): CreateControlledAzureRelayNamespaceResult =
     new CreateControlledAzureRelayNamespaceResult().jobReport(new JobReport().id("relay_fake_id").status(status))
-  }
 
-  def buildWithAsyncResults(createCloudContestStatus: StatusEnum, createAzureRelayStatus: StatusEnum) = {
+  def buildWithAsyncResults(createCloudContestStatus: StatusEnum, createAzureRelayStatus: StatusEnum) =
     new MockWorkspaceManagerDAO(
       getCreateCloudContextResult(createCloudContestStatus),
       getCreateControlledAzureRelayNamespaceResult(createAzureRelayStatus)
     )
-  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -7,8 +7,25 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.MessageRequest
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeFormat, AttributeName, AttributeString, DataReferenceName, Entity, GoogleProjectId, ImportStatuses, RawlsRequestContext, TypedAttributeListSerializer, UserInfo, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AddUpdateAttribute,
+  AttributeUpdateOperation,
+  EntityUpdateDefinition
+}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeFormat,
+  AttributeName,
+  AttributeString,
+  DataReferenceName,
+  Entity,
+  GoogleProjectId,
+  ImportStatuses,
+  RawlsRequestContext,
+  TypedAttributeListSerializer,
+  UserInfo,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.rawls.webservice.ApiServiceSpec
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
@@ -31,43 +48,49 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
 
-class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with MockitoSugar with AnyFlatSpecLike with Matchers with TestDriverComponent with BeforeAndAfterAll with Eventually {
+class AvroUpsertMonitorSpec(_system: ActorSystem)
+    extends ApiServiceSpec
+    with MockitoSugar
+    with AnyFlatSpecLike
+    with Matchers
+    with TestDriverComponent
+    with BeforeAndAfterAll
+    with Eventually {
 
-  case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives
+  case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(
+    implicit override val executionContext: ExecutionContext
+  ) extends ApiServices
+      with MockUserInfoDirectives
 
-  def withApiServices[T](dataSource: SlickDataSource)(testCode: TestApiService =>  T): T = {
+  def withApiServices[T](dataSource: SlickDataSource)(testCode: TestApiService => T): T = {
     val apiService = new TestApiService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withTestDataApiServices[T](testCode: TestApiService =>  T): T = {
+  def withTestDataApiServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withConstantTestDataApiServices[T](testCode: TestApiService =>  T): T = {
+  def withConstantTestDataApiServices[T](testCode: TestApiService => T): T =
     withConstantTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
   def this() = this(ActorSystem("AvroUpsertMonitorSpec"))
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit =
     super.beforeAll()
-  }
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
 
-  val workspaceName =  testData.workspace.toWorkspaceName
+  val workspaceName = testData.workspace.toWorkspaceName
   val importStatusFailingWorkspace = testData.workspaceNoSubmissions.toWorkspaceName
   val googleStorage = FakeGoogleStorageInterpreter
   val importReadPubSubTopic = "request-topic"
@@ -79,12 +102,11 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   val entityType = "test-type"
   val failImportStatusUUID = UUID.randomUUID()
 
-
   def testAttributes(importId: UUID) = Map(
     "workspaceName" -> workspaceName.name,
     "workspaceNamespace" -> workspaceName.namespace,
     "userEmail" -> userInfo.userEmail.toString,
-    "upsertFile" ->  s"$bucketName/${importId.toString}",
+    "upsertFile" -> s"$bucketName/${importId.toString}",
     "jobId" -> importId.toString
   )
 
@@ -100,7 +122,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     1
   )
 
-  private def setUpPubSub(services: TestApiService) = {
+  private def setUpPubSub(services: TestApiService) =
     // create the two topics and the subscription. These are futures so we need to wait for them
     // to complete before allowing tests to run.
     Await.result(
@@ -116,7 +138,6 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
       },
       Duration.apply(10, TimeUnit.SECONDS)
     )
-  }
 
   def setUp(services: TestApiService) = {
     setUpPubSub(services)
@@ -124,17 +145,19 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val mockImportServiceDAO = new MockImportServiceDAO()
 
     // Start the monitor
-    system.actorOf(AvroUpsertMonitorSupervisor.props(
-      services.entityServiceConstructor,
-      services.gcsDAO,
-      services.samDAO,
-      googleStorage,
-      services.gpsDAO,
-      services.gpsDAO,
-      mockImportServiceDAO,
-      config,
-      slickDataSource
-    ))
+    system.actorOf(
+      AvroUpsertMonitorSupervisor.props(
+        services.entityServiceConstructor,
+        services.gcsDAO,
+        services.samDAO,
+        googleStorage,
+        services.gpsDAO,
+        services.gpsDAO,
+        mockImportServiceDAO,
+        config,
+        slickDataSource
+      )
+    )
 
     mockImportServiceDAO
   }
@@ -142,21 +165,24 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   def setUpMockImportService(services: TestApiService) = {
     setUpPubSub(services)
 
-    val mockImportServiceDAO =  mock[ImportServiceDAO]
-    when(mockImportServiceDAO.getImportStatus(failImportStatusUUID, workspaceName, userInfo)).thenReturn(Future.failed(new Exception("User not found")))
+    val mockImportServiceDAO = mock[ImportServiceDAO]
+    when(mockImportServiceDAO.getImportStatus(failImportStatusUUID, workspaceName, userInfo))
+      .thenReturn(Future.failed(new Exception("User not found")))
 
     // Start the monitor
-    system.actorOf(AvroUpsertMonitorSupervisor.props(
-      services.entityServiceConstructor,
-      services.gcsDAO,
-      services.samDAO,
-      googleStorage,
-      services.gpsDAO,
-      services.gpsDAO,
-      mockImportServiceDAO,
-      config,
-      slickDataSource
-    ))
+    system.actorOf(
+      AvroUpsertMonitorSupervisor.props(
+        services.entityServiceConstructor,
+        services.gcsDAO,
+        services.samDAO,
+        googleStorage,
+        services.gpsDAO,
+        services.gpsDAO,
+        mockImportServiceDAO,
+        config,
+        slickDataSource
+      )
+    )
 
     mockImportServiceDAO
   }
@@ -168,24 +194,32 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
     val mockEntityService = mock[EntityService]
 
-    when(mockEntityService.batchUpdateEntitiesInternal(
-      any[WorkspaceName], any[Seq[EntityUpdateDefinition]], any[Boolean], any[Option[DataReferenceName]], any[Option[GoogleProjectId]]
-    )).thenReturn(Future(Seq.empty[Entity]))
+    when(
+      mockEntityService.batchUpdateEntitiesInternal(
+        any[WorkspaceName],
+        any[Seq[EntityUpdateDefinition]],
+        any[Boolean],
+        any[Option[DataReferenceName]],
+        any[Option[GoogleProjectId]]
+      )
+    ).thenReturn(Future(Seq.empty[Entity]))
 
     val mockEntityServiceConstructor: RawlsRequestContext => EntityService = _ => mockEntityService
 
     // Start the monitor
-    system.actorOf(AvroUpsertMonitorSupervisor.props(
-      mockEntityServiceConstructor,
-      services.gcsDAO,
-      services.samDAO,
-      googleStorage,
-      services.gpsDAO,
-      services.gpsDAO,
-      mockImportServiceDAO,
-      config,
-      slickDataSource
-    ))
+    system.actorOf(
+      AvroUpsertMonitorSupervisor.props(
+        mockEntityServiceConstructor,
+        services.gcsDAO,
+        services.samDAO,
+        googleStorage,
+        services.gpsDAO,
+        services.gpsDAO,
+        mockImportServiceDAO,
+        config,
+        slickDataSource
+      )
+    )
 
     (mockImportServiceDAO, mockEntityService)
   }
@@ -193,23 +227,26 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   def setUpMockSamDAO(services: TestApiService) = {
     setUpPubSub(services)
 
-    val mockImportServiceDAO =  new MockImportServiceDAO()
+    val mockImportServiceDAO = new MockImportServiceDAO()
     val mockSamDAO = mock[SamDAO]
 
-    when(mockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, userInfo.userEmail)).thenReturn(Future.failed(new Exception("USer not found")))
+    when(mockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, userInfo.userEmail))
+      .thenReturn(Future.failed(new Exception("USer not found")))
 
     // Start the monitor
-    system.actorOf(AvroUpsertMonitorSupervisor.props(
-      services.entityServiceConstructor,
-      services.gcsDAO,
-      mockSamDAO,
-      googleStorage,
-      services.gpsDAO,
-      services.gpsDAO,
-      mockImportServiceDAO,
-      config,
-      slickDataSource
-    ))
+    system.actorOf(
+      AvroUpsertMonitorSupervisor.props(
+        services.entityServiceConstructor,
+        services.gcsDAO,
+        mockSamDAO,
+        googleStorage,
+        services.gpsDAO,
+        services.gpsDAO,
+        mockImportServiceDAO,
+        config,
+        slickDataSource
+      )
+    )
 
     mockImportServiceDAO
   }
@@ -217,9 +254,10 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
   behavior of "AvroUpsertMonitor"
 
   def upsertRange(upsertQuantity: Int): List[Int] = List.range(1, upsertQuantity + 1)
-  def createUpsertOpsList(upsertRange: List[Int]): List[String] = {
-    upsertRange map ( idx => s"""{"name": "avro-entity-$idx", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}""" )
-  }
+  def createUpsertOpsList(upsertRange: List[Int]): List[String] =
+    upsertRange map (idx =>
+      s"""{"name": "avro-entity-$idx", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}"""
+    )
   def makeOpsJsonString(opsList: List[String]): String = s"[${opsList.mkString(",")}]"
 
   def makeOpsJsonString(upsertQuantity: Int): String = {
@@ -228,26 +266,37 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     makeOpsJsonString(opsList)
   }
 
-  List(1,2,20,250,2345,12345) foreach { upsertQuantity =>
+  List(1, 2, 20, 250, 2345, 12345) foreach { upsertQuantity =>
     it should s"upsert $upsertQuantity entities" in withTestDataApiServices { services =>
       val timeout = 120000 milliseconds
       val interval = 500 milliseconds
       val importId1 = UUID.randomUUID()
 
       // add the imports and their statuses to the mock importserviceDAO
-      val mockImportServiceDAO =  setUp(services)
+      val mockImportServiceDAO = setUp(services)
       mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
       // create upsert json file
       val contents = makeOpsJsonString(upsertQuantity)
 
       // Store upsert json file
-      Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
       // Publish message on the request topic
-      services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+      services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                      List(MessageRequest(importId1.toString, testAttributes(importId1)))
+      )
 
       // check if correct message was posted on request topic
       eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -255,15 +304,15 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
       }
       // Check in db if entities are there
       withWorkspaceContext(testData.workspace) { context =>
-
         eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
           val entitiesOfType = runAndWait(entityQuery.listActiveEntitiesOfType(context, entityType))
-          assertResult(upsertQuantity) { entitiesOfType.size }
+          assertResult(upsertQuantity)(entitiesOfType.size)
           upsertRange(upsertQuantity) foreach { idx =>
             val name = s"avro-entity-$idx"
-            val entity = Entity(name, entityType, Map(AttributeName("default", "avro-attribute") -> AttributeString("foo")))
+            val entity =
+              Entity(name, entityType, Map(AttributeName("default", "avro-attribute") -> AttributeString("foo")))
             val actual = entitiesOfType.find(_.name == name)
-            assertResult(Some(entity)) { actual }
+            assertResult(Some(entity))(actual)
           }
         }
 
@@ -271,20 +320,25 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     }
   }
 
-
   it should "return error for imports with the wrong status" in withTestDataApiServices { services =>
     val importId2 = UUID.randomUUID()
     val importId3 = UUID.randomUUID()
     val importId4 = UUID.randomUUID()
 
-    val mockImportServiceDAO =  setUp(services)
+    val mockImportServiceDAO = setUp(services)
     mockImportServiceDAO.imports += (importId2 -> ImportStatuses.Upserting)
     mockImportServiceDAO.imports += (importId3 -> ImportStatuses.Done)
     mockImportServiceDAO.imports += (importId4 -> ImportStatuses.Error)
 
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId2.toString, testAttributes(importId2))))
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId3.toString, testAttributes(importId3))))
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId4.toString, testAttributes(importId4))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                    List(MessageRequest(importId2.toString, testAttributes(importId2)))
+    )
+    services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                    List(MessageRequest(importId3.toString, testAttributes(importId3)))
+    )
+    services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                    List(MessageRequest(importId4.toString, testAttributes(importId4)))
+    )
 
     Thread.sleep(1000)
 
@@ -300,19 +354,31 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val importId1 = UUID.randomUUID()
 
     // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
+    val mockImportServiceDAO = setUp(services)
     mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
     // create a -malformed- upsert json file, which will cause problems when reading
     val contents = "hey, this isn't valid json! {{{"
 
     // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(
+      googleStorage
+        .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+        .compile
+        .drain
+        .unsafeToFuture(),
+      Duration.apply(10, TimeUnit.SECONDS)
+    )
 
-    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    val blob =
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
     // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                    List(MessageRequest(importId1.toString, testAttributes(importId1)))
+    )
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -321,51 +387,66 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
     // upsert will fail; check that a pubsub message was published to set the import job to error.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
+      val statusMessages =
+        Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
 
       assert(statusMessages.exists { msg =>
         msg.attributes.get("importId").contains(importId1.toString) &&
-          msg.attributes.get("newStatus").contains("Error") &&
-          msg.attributes.get("action").contains("status")
+        msg.attributes.get("newStatus").contains("Error") &&
+        msg.attributes.get("action").contains("status")
       })
     }
   }
 
-  it should "mark the import job as failed on valid json that doesn't match our model" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
-    val interval = 250 milliseconds
-    val importId1 = UUID.randomUUID()
+  it should "mark the import job as failed on valid json that doesn't match our model" in withTestDataApiServices {
+    services =>
+      val timeout = 30000 milliseconds
+      val interval = 250 milliseconds
+      val importId1 = UUID.randomUUID()
 
-    // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
-    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      // add the imports and their statuses to the mock importserviceDAO
+      val mockImportServiceDAO = setUp(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-    // create a valid json file that doesn't contain entities
-    val contents = """[{"foo":"bar"},{"baz":"qux"}]"""
+      // create a valid json file that doesn't contain entities
+      val contents = """[{"foo":"bar"},{"baz":"qux"}]"""
 
-    // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                      List(MessageRequest(importId1.toString, testAttributes(importId1)))
+      )
 
-    // check if correct message was posted on request topic. This will start the upsert attempt.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
-    }
+      // check if correct message was posted on request topic. This will start the upsert attempt.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
+      }
 
-    // upsert will fail; check that a pubsub message was published to set the import job to error.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
+      // upsert will fail; check that a pubsub message was published to set the import job to error.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1),
+                                          Duration.apply(10, TimeUnit.SECONDS)
+        )
 
-      assert(statusMessages.exists { msg =>
-        msg.attributes.get("importId").contains(importId1.toString) &&
+        assert(statusMessages.exists { msg =>
+          msg.attributes.get("importId").contains(importId1.toString) &&
           msg.attributes.get("newStatus").contains("Error") &&
           msg.attributes.get("action").contains("status")
-      })
-    }
+        })
+      }
   }
 
   it should "mark the import job as failed if upsert file doesn't exist" in withTestDataApiServices { services =>
@@ -374,19 +455,31 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val importId1 = UUID.randomUUID()
 
     // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
+    val mockImportServiceDAO = setUp(services)
     mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
     // create a valid json file that doesn't contain entities
-    val contents = s"""[{"name": "avro-entity", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}]"""
+    val contents =
+      s"""[{"name": "avro-entity", "entityType": "test-type", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}]"""
 
     // Store upsert json file, even though we expect the code to look elsewhere and miss this file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(
+      googleStorage
+        .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+        .compile
+        .drain
+        .unsafeToFuture(),
+      Duration.apply(10, TimeUnit.SECONDS)
+    )
 
-    val blob = Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    val blob =
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
     // Publish message on the request topic - but ensure that the gcs: location in the pubsub message is incorrect
-    val badMessageAttrs = testAttributes(importId1) ++ Map("upsertFile" ->  s"$bucketName/intentionally.nonexistent.unittest")
+    val badMessageAttrs =
+      testAttributes(importId1) ++ Map("upsertFile" -> s"$bucketName/intentionally.nonexistent.unittest")
     services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, badMessageAttrs)))
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
@@ -396,100 +489,137 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
     // upsert will fail; check that a pubsub message was published to set the import job to error.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
+      val statusMessages =
+        Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
 
       assert(statusMessages.exists { msg =>
         msg.attributes.get("importId").contains(importId1.toString) &&
-          msg.attributes.get("newStatus").contains("Error") &&
-          msg.attributes.get("action").contains("status")
+        msg.attributes.get("newStatus").contains("Error") &&
+        msg.attributes.get("action").contains("status")
       })
     }
   }
 
-  it should "publish pubsub message to mark import job as Error if upserts result in partial failure" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
-    val interval = 250 milliseconds
-    val importId1 = UUID.randomUUID()
+  it should "publish pubsub message to mark import job as Error if upserts result in partial failure" in withTestDataApiServices {
+    services =>
+      val timeout = 30000 milliseconds
+      val interval = 250 milliseconds
+      val importId1 = UUID.randomUUID()
 
-    // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
-    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      // add the imports and their statuses to the mock importserviceDAO
+      val mockImportServiceDAO = setUp(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-    val successfulBatch = createUpsertOpsList(upsertRange(1000))
-    val failureBatch = s"""{"name": "avro-entity-failure", "entityType": "", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}"""
-    val contents = makeOpsJsonString(successfulBatch :+ failureBatch)
+      val successfulBatch = createUpsertOpsList(upsertRange(1000))
+      val failureBatch =
+        s"""{"name": "avro-entity-failure", "entityType": "", "operations": [{"op": "AddUpdateAttribute", "attributeName": "avro-attribute", "addUpdateAttribute": "foo"}]}"""
+      val contents = makeOpsJsonString(successfulBatch :+ failureBatch)
 
-    // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Make sure the file saved properly
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                      List(MessageRequest(importId1.toString, testAttributes(importId1)))
+      )
 
-    // check if correct message was posted on request topic. This will start the upsert attempt.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
-    }
+      // check if correct message was posted on request topic. This will start the upsert attempt.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
+      }
 
-    // upsert will fail; check that a pubsub message was published to set the import job to error.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
-      assert(statusMessages.exists { msg =>
-        msg.attributes("importId").contains(importId1.toString) &&
+      // upsert will fail; check that a pubsub message was published to set the import job to error.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1),
+                                          Duration.apply(10, TimeUnit.SECONDS)
+        )
+        assert(statusMessages.exists { msg =>
+          msg.attributes("importId").contains(importId1.toString) &&
           msg.attributes("newStatus").contains("Error") &&
           msg.attributes("action").contains("status") &&
-          msg.attributes("errorMessage").contains("Successfully updated 1000 entities; 1 updates failed. First 100 failures are: Invalid input")
-      })
-    }
+          msg
+            .attributes("errorMessage")
+            .contains("Successfully updated 1000 entities; 1 updates failed. First 100 failures are: Invalid input")
+        })
+      }
 
   }
 
-  it should "bubble up useful error message if upserts result in partial failure" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
-    val interval = 250 milliseconds
-    val importId1 = UUID.randomUUID()
+  it should "bubble up useful error message if upserts result in partial failure" in withTestDataApiServices {
+    services =>
+      val timeout = 30000 milliseconds
+      val interval = 250 milliseconds
+      val importId1 = UUID.randomUUID()
 
-    // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
-    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
-    val successfulBatch = createUpsertOpsList(upsertRange(1000))
+      // add the imports and their statuses to the mock importserviceDAO
+      val mockImportServiceDAO = setUp(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      val successfulBatch = createUpsertOpsList(upsertRange(1000))
 
-    // failure creates an entity that refers to a non-existent entity
-    val ref = AttributeEntityReference("test-type", "this-entity-does-not-exist")
-    val op: AttributeUpdateOperation = AddUpdateAttribute(AttributeName.withDefaultNS("intentionallyBadReference"), ref)
-    import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperationFormat
-    import spray.json._
-    implicit val attributeFormat: AttributeFormat = new AttributeFormat with TypedAttributeListSerializer
-    val opJsonString = op.toJson.compactPrint
-    val failureBatch = s"""{"name": "avro-entity-failure", "entityType": "failme", "operations": [$opJsonString]}"""
-    val contents = makeOpsJsonString(successfulBatch :+ failureBatch)
+      // failure creates an entity that refers to a non-existent entity
+      val ref = AttributeEntityReference("test-type", "this-entity-does-not-exist")
+      val op: AttributeUpdateOperation =
+        AddUpdateAttribute(AttributeName.withDefaultNS("intentionallyBadReference"), ref)
+      import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperationFormat
+      import spray.json._
+      implicit val attributeFormat: AttributeFormat = new AttributeFormat with TypedAttributeListSerializer
+      val opJsonString = op.toJson.compactPrint
+      val failureBatch = s"""{"name": "avro-entity-failure", "entityType": "failme", "operations": [$opJsonString]}"""
+      val contents = makeOpsJsonString(successfulBatch :+ failureBatch)
 
-    // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Make sure the file saved properly
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                      List(MessageRequest(importId1.toString, testAttributes(importId1)))
+      )
 
-    // check if correct message was posted on request topic. This will start the upsert attempt.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
-    }
+      // check if correct message was posted on request topic. This will start the upsert attempt.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
+      }
 
-    // upsert will fail; check that a pubsub message was published to set the import job to error.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
-      assert(statusMessages.exists { msg =>
-        msg.attributes("importId").contains(importId1.toString) &&
+      // upsert will fail; check that a pubsub message was published to set the import job to error.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1),
+                                          Duration.apply(10, TimeUnit.SECONDS)
+        )
+        assert(statusMessages.exists { msg =>
+          msg.attributes("importId").contains(importId1.toString) &&
           msg.attributes("newStatus").contains("Error") &&
           msg.attributes("action").contains("status") &&
-          msg.attributes("errorMessage").contains("Successfully updated 1000 entities; 1 updates failed. First 100 failures are: test-type this-entity-does-not-exist not found")
-      })
-    }
+          msg
+            .attributes("errorMessage")
+            .contains(
+              "Successfully updated 1000 entities; 1 updates failed. First 100 failures are: test-type this-entity-does-not-exist not found"
+            )
+        })
+      }
   }
 
   it should "ack pubsub message if upsert published to nonexistent workspace" in withTestDataApiServices { services =>
@@ -498,16 +628,25 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val importId1 = UUID.randomUUID()
 
     // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
+    val mockImportServiceDAO = setUp(services)
     mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
     val contents = makeOpsJsonString(100)
 
     // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(
+      googleStorage
+        .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+        .compile
+        .drain
+        .unsafeToFuture(),
+      Duration.apply(10, TimeUnit.SECONDS)
+    )
 
     // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                 Duration.apply(10, TimeUnit.SECONDS)
+    )
 
     // acks should be empty at this point
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -535,17 +674,26 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val interval = 250 milliseconds
     val importId1 = UUID.randomUUID()
 
-    //MockSamDAO should throw an error when fetching the pet service account
-    val mockImportServiceDAO =  setUpMockSamDAO(services)
+    // MockSamDAO should throw an error when fetching the pet service account
+    val mockImportServiceDAO = setUpMockSamDAO(services)
     mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
     val contents = makeOpsJsonString(100)
 
     // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(
+      googleStorage
+        .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+        .compile
+        .drain
+        .unsafeToFuture(),
+      Duration.apply(10, TimeUnit.SECONDS)
+    )
 
     // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                 Duration.apply(10, TimeUnit.SECONDS)
+    )
 
     // acks should be empty at this point
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -553,7 +701,9 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     }
 
     // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+    services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                    List(MessageRequest(importId1.toString, testAttributes(importId1)))
+    )
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -571,16 +721,26 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     val timeout = 30000 milliseconds
     val interval = 250 milliseconds
 
-    //MockImportService should throw an error when getting import status
+    // MockImportService should throw an error when getting import status
     setUpMockImportService(services)
 
     val contents = makeOpsJsonString(100)
 
     // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(failImportStatusUUID.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(
+      googleStorage
+        .createBlob(bucketName, GcsBlobName(failImportStatusUUID.toString), contents.getBytes())
+        .compile
+        .drain
+        .unsafeToFuture(),
+      Duration.apply(10, TimeUnit.SECONDS)
+    )
 
     // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(failImportStatusUUID.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+    Await.result(
+      googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(failImportStatusUUID.toString)).unsafeToFuture(),
+      Duration.apply(10, TimeUnit.SECONDS)
+    )
 
     // acks should be empty at this point
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -588,7 +748,10 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     }
 
     // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(failImportStatusUUID.toString, testAttributes(failImportStatusUUID))))
+    services.gpsDAO.publishMessages(
+      importReadPubSubTopic,
+      List(MessageRequest(failImportStatusUUID.toString, testAttributes(failImportStatusUUID)))
+    )
 
     // check if correct message was posted on request topic. This will start the upsert attempt.
     eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
@@ -602,116 +765,159 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
 
   }
 
-  it should "update import status to error if upsert published to nonexistent workspace" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
-    val interval = 250 milliseconds
-    val importId1 = UUID.randomUUID()
+  it should "update import status to error if upsert published to nonexistent workspace" in withTestDataApiServices {
+    services =>
+      val timeout = 30000 milliseconds
+      val interval = 250 milliseconds
+      val importId1 = UUID.randomUUID()
 
-    // add the imports and their statuses to the mock importserviceDAO
-    val mockImportServiceDAO =  setUp(services)
-    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      // add the imports and their statuses to the mock importserviceDAO
+      val mockImportServiceDAO = setUp(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-    val contents = makeOpsJsonString(100)
+      val contents = makeOpsJsonString(100)
 
-    // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Make sure the file saved properly
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Publish message on the request topic with a nonexistent workspace
-    val messageAttributes = testAttributes(importId1) ++ Map("workspaceName" -> "does_not_exist")
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, messageAttributes)))
+      // Publish message on the request topic with a nonexistent workspace
+      val messageAttributes = testAttributes(importId1) ++ Map("workspaceName" -> "does_not_exist")
+      services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                      List(MessageRequest(importId1.toString, messageAttributes))
+      )
 
-    // check if correct message was posted on request topic. This will start the upsert attempt.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString))
-    }
+      // check if correct message was posted on request topic. This will start the upsert attempt.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString))
+      }
 
-    // upsert will fail; check that a pubsub message was published to set the import job to error.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
-      assert(statusMessages.exists { msg =>
-        msg.attributes("importId").contains(importId1.toString) &&
+      // upsert will fail; check that a pubsub message was published to set the import job to error.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1),
+                                          Duration.apply(10, TimeUnit.SECONDS)
+        )
+        assert(statusMessages.exists { msg =>
+          msg.attributes("importId").contains(importId1.toString) &&
           msg.attributes("newStatus").contains("Error") &&
           msg.attributes("action").contains("status")
-      })
-    }
+        })
+      }
 
   }
 
-  it should "update import status to error if error occurs when finding pet account" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
-    val interval = 250 milliseconds
-    val importId1 = UUID.randomUUID()
+  it should "update import status to error if error occurs when finding pet account" in withTestDataApiServices {
+    services =>
+      val timeout = 30000 milliseconds
+      val interval = 250 milliseconds
+      val importId1 = UUID.randomUUID()
 
-    //MockSamDAO should throw an error when fetching the pet service account
-    val mockImportServiceDAO =  setUpMockSamDAO(services)
-    mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      // MockSamDAO should throw an error when fetching the pet service account
+      val mockImportServiceDAO = setUpMockSamDAO(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-    val contents = makeOpsJsonString(100)
+      val contents = makeOpsJsonString(100)
 
-    // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Make sure the file saved properly
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, testAttributes(importId1))))
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(importReadPubSubTopic,
+                                      List(MessageRequest(importId1.toString, testAttributes(importId1)))
+      )
 
-    // check if correct message was posted on request topic. This will start the upsert attempt.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString))
-    }
+      // check if correct message was posted on request topic. This will start the upsert attempt.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString))
+      }
 
-    // upsert will fail; check that a pubsub message was published to set the import job to error.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
-      assert(statusMessages.exists { msg =>
-        msg.attributes("importId").contains(importId1.toString) &&
+      // upsert will fail; check that a pubsub message was published to set the import job to error.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1),
+                                          Duration.apply(10, TimeUnit.SECONDS)
+        )
+        assert(statusMessages.exists { msg =>
+          msg.attributes("importId").contains(importId1.toString) &&
           msg.attributes("newStatus").contains("Error") &&
           msg.attributes("action").contains("status")
-      })
-    }
+        })
+      }
 
   }
 
-  it should "update import status to error if error occurs when fetching import status" in withTestDataApiServices { services =>
-    val timeout = 30000 milliseconds
-    val interval = 250 milliseconds
+  it should "update import status to error if error occurs when fetching import status" in withTestDataApiServices {
+    services =>
+      val timeout = 30000 milliseconds
+      val interval = 250 milliseconds
 
-    //MockImportService should throw an error when getting import status
-    setUpMockImportService(services)
+      // MockImportService should throw an error when getting import status
+      setUpMockImportService(services)
 
-    val contents = makeOpsJsonString(100)
+      val contents = makeOpsJsonString(100)
 
-    // Store upsert json file
-    Await.result(googleStorage.createBlob(bucketName, GcsBlobName(failImportStatusUUID.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(failImportStatusUUID.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Make sure the file saved properly
-    Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(failImportStatusUUID.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Make sure the file saved properly
+      Await.result(
+        googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(failImportStatusUUID.toString)).unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-    // Publish message on the request topic
-    services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(failImportStatusUUID.toString, testAttributes(failImportStatusUUID))))
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(
+        importReadPubSubTopic,
+        List(MessageRequest(failImportStatusUUID.toString, testAttributes(failImportStatusUUID)))
+      )
 
-    // check if correct message was posted on request topic. This will start the upsert attempt.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, failImportStatusUUID.toString))
-    }
+      // check if correct message was posted on request topic. This will start the upsert attempt.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, failImportStatusUUID.toString))
+      }
 
-    // upsert will fail; check that a pubsub message was published to set the import job to error.
-    eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-      val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1), Duration.apply(10, TimeUnit.SECONDS))
-      assert(statusMessages.exists { msg =>
-        msg.attributes("importId").contains(failImportStatusUUID.toString) &&
+      // upsert will fail; check that a pubsub message was published to set the import job to error.
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        val statusMessages = Await.result(services.gpsDAO.pullMessages(importWriteSubscriptionName, 1),
+                                          Duration.apply(10, TimeUnit.SECONDS)
+        )
+        assert(statusMessages.exists { msg =>
+          msg.attributes("importId").contains(failImportStatusUUID.toString) &&
           msg.attributes("newStatus").contains("Error") &&
           msg.attributes("action").contains("status")
-      })
-    }
+        })
+      }
 
   }
-
 
   // test cases for upsert vs. update handling:
   // a map of {value in pubsub message attribute}->{expected behavior}
@@ -721,55 +927,67 @@ class AvroUpsertMonitorSpec(_system: ActorSystem) extends ApiServiceSpec with Mo
     Some("true") -> UpsertExpectation(isUpsert = true, "true"),
     Some("tRuE") -> UpsertExpectation(isUpsert = true, "true, case-insensitive"),
     Some("false") -> UpsertExpectation(isUpsert = false, "false"),
-    Some("no thank you") -> UpsertExpectation(isUpsert = false, "some value other than case-insensitive true"),
+    Some("no thank you") -> UpsertExpectation(isUpsert = false, "some value other than case-insensitive true")
   )
 
-  upsertCases foreach {
-    case (inputAttribute, expectation) =>
-      val methodString = if(expectation.isUpsert) "upsert" else "update"
-      it should s"$methodString when isUpsert is ${expectation.message}" in withTestDataApiServices { services =>
-        val timeout = 120000 milliseconds
-        val interval = 500 milliseconds
-        val importId1 = UUID.randomUUID()
+  upsertCases foreach { case (inputAttribute, expectation) =>
+    val methodString = if (expectation.isUpsert) "upsert" else "update"
+    it should s"$methodString when isUpsert is ${expectation.message}" in withTestDataApiServices { services =>
+      val timeout = 120000 milliseconds
+      val interval = 500 milliseconds
+      val importId1 = UUID.randomUUID()
 
-        // add the imports and their statuses to the mock importserviceDAO
-        val (mockImportServiceDAO, mockEntityService) =  setUpMockEntityManager(services)
-        mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
+      // add the imports and their statuses to the mock importserviceDAO
+      val (mockImportServiceDAO, mockEntityService) = setUpMockEntityManager(services)
+      mockImportServiceDAO.imports += (importId1 -> ImportStatuses.ReadyForUpsert)
 
-        // create upsert json file
-        val contents = makeOpsJsonString(1)
+      // create upsert json file
+      val contents = makeOpsJsonString(1)
 
-        // Store upsert json file
-        Await.result(googleStorage.createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes()).compile.drain.unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      // Store upsert json file
+      Await.result(
+        googleStorage
+          .createBlob(bucketName, GcsBlobName(importId1.toString), contents.getBytes())
+          .compile
+          .drain
+          .unsafeToFuture(),
+        Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-        Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(), Duration.apply(10, TimeUnit.SECONDS))
+      Await.result(googleStorage.unsafeGetBlobBody(bucketName, GcsBlobName(importId1.toString)).unsafeToFuture(),
+                   Duration.apply(10, TimeUnit.SECONDS)
+      )
 
-        // message to publish on the request topic:
-        val additionalAttributes = inputAttribute match {
-          case Some(input) => Map("isUpsert" -> input)
-          case None => Map.empty[String, String]
-        }
-        val msg = testAttributes(importId1) ++ additionalAttributes
-
-        // Publish message on the request topic
-        services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, msg)))
-
-        // check if correct message was posted on request topic
-        eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-          assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
-        }
-
-        // check if, eventually, EntityService.batchUpdateEntitiesInternal is called with upsert={expectation.isUpsert}
-        // from BucketDeletionMonitorSpec:
-        // `eventually` now requires an implicit `Retrying` instance. When the statement inside returns future, it'll
-        // try to use `Retrying[Future[T]]`, which gets weird when we're using mockito together with it.
-        // Hence adding ascribing [Unit] explicitly here so that `eventually` will use `Retrying[Unit]`
-        eventually[Unit](Timeout(timeout), Interval(interval)) {
-          verify(mockEntityService, times(1)).batchUpdateEntitiesInternal(
-            any[WorkspaceName], any[Seq[EntityUpdateDefinition]], ArgumentMatchers.eq(expectation.isUpsert), any[Option[DataReferenceName]], any[Option[GoogleProjectId]]
-          )
-        }
+      // message to publish on the request topic:
+      val additionalAttributes = inputAttribute match {
+        case Some(input) => Map("isUpsert" -> input)
+        case None        => Map.empty[String, String]
       }
+      val msg = testAttributes(importId1) ++ additionalAttributes
+
+      // Publish message on the request topic
+      services.gpsDAO.publishMessages(importReadPubSubTopic, List(MessageRequest(importId1.toString, msg)))
+
+      // check if correct message was posted on request topic
+      eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
+        assert(services.gpsDAO.receivedMessage(importReadPubSubTopic, importId1.toString, 1))
+      }
+
+      // check if, eventually, EntityService.batchUpdateEntitiesInternal is called with upsert={expectation.isUpsert}
+      // from BucketDeletionMonitorSpec:
+      // `eventually` now requires an implicit `Retrying` instance. When the statement inside returns future, it'll
+      // try to use `Retrying[Future[T]]`, which gets weird when we're using mockito together with it.
+      // Hence adding ascribing [Unit] explicitly here so that `eventually` will use `Retrying[Unit]`
+      eventually[Unit](Timeout(timeout), Interval(interval)) {
+        verify(mockEntityService, times(1)).batchUpdateEntitiesInternal(
+          any[WorkspaceName],
+          any[Seq[EntityUpdateDefinition]],
+          ArgumentMatchers.eq(expectation.isUpsert),
+          any[Option[DataReferenceName]],
+          any[Option[GoogleProjectId]]
+        )
+      }
+    }
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -11,7 +11,12 @@ import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.local.LocalEntityProvider
 import org.broadinstitute.dsde.rawls.metrics.StatsDTestUtils
 import org.broadinstitute.dsde.rawls.model.Entity
-import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor.{DieAndRestart, ScheduleDelayedSweep, Start, Sweep}
+import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor.{
+  DieAndRestart,
+  ScheduleDelayedSweep,
+  Start,
+  Sweep
+}
 import org.broadinstitute.dsde.rawls.util
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.scalatest.BeforeAndAfterAll
@@ -51,260 +56,336 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
 
   def this() = this(ActorSystem("EntityStatisticsCacheMonitorSpec"))
 
-  override def beforeAll(): Unit = {
+  override def beforeAll(): Unit =
     super.beforeAll()
-  }
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
 
+  "EntityStatisticsCacheMonitor" should "schedule a delayed sweep if the previous sweep was empty" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      val monitor = new EntityStatisticsCacheMonitor {
+        override val dataSource: SlickDataSource = slickDataSource
+        implicit override val executionContext: ExecutionContext = defaultExecutionContext
+        override val standardPollInterval: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+        override val workspaceCooldown: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+        override val timeoutPerWorkspace: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        override val workbenchMetricBaseName: String = metricsPrefix
+      }
 
-  "EntityStatisticsCacheMonitor" should "schedule a delayed sweep if the previous sweep was empty" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    val monitor = new EntityStatisticsCacheMonitor {
-      override val dataSource: SlickDataSource = slickDataSource
-      override implicit val executionContext: ExecutionContext = defaultExecutionContext
-      override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
-      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
-      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricsPrefix
-    }
+      // Scenario: there is one workspace in the test data set used for this test. The first sweep should return Sweep,
+      // and the second sweep should return ScheduleDelayedSweep since it's caught up
+      assertResult(Sweep) {
+        Await.result(monitor.sweep(), Duration.Inf)
+      }
 
-    //Scenario: there is one workspace in the test data set used for this test. The first sweep should return Sweep,
-    // and the second sweep should return ScheduleDelayedSweep since it's caught up
-    assertResult(Sweep) {
-      Await.result(monitor.sweep(), Duration.Inf)
-    }
-
-    assertResult(ScheduleDelayedSweep) {
-      Await.result(monitor.sweep(), Duration.Inf)
-    }
+      assertResult(ScheduleDelayedSweep) {
+        Await.result(monitor.sweep(), Duration.Inf)
+      }
   }
 
-  it should "continue to immediately sweep if the last sweep was not empty" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    val monitor = new EntityStatisticsCacheMonitor {
-      override val dataSource: SlickDataSource = slickDataSource
-      override implicit val executionContext: ExecutionContext = defaultExecutionContext
-      override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
-      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
-      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricsPrefix
-    }
+  it should "continue to immediately sweep if the last sweep was not empty" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      val monitor = new EntityStatisticsCacheMonitor {
+        override val dataSource: SlickDataSource = slickDataSource
+        implicit override val executionContext: ExecutionContext = defaultExecutionContext
+        override val standardPollInterval: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+        override val workspaceCooldown: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+        override val timeoutPerWorkspace: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        override val workbenchMetricBaseName: String = metricsPrefix
+      }
 
-    //Scenario: there is one workspace in the test data set used for this test. The first time we sweep,
-    // the monitor will update that workspace and return Sweep
-    assertResult(Sweep) {
-      Await.result(monitor.sweep(), Duration.Inf)
-    }
+      // Scenario: there is one workspace in the test data set used for this test. The first time we sweep,
+      // the monitor will update that workspace and return Sweep
+      assertResult(Sweep) {
+        Await.result(monitor.sweep(), Duration.Inf)
+      }
   }
 
-  it should "delay the next sweep if the last sweep was empty due to cooldown" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    // default workspaceCooldown in src/test/reference.conf is 0 minutes; override it here
-    // so that the sweep doesn't find a workspace whose last_modified date satisfies the cooldown
-    val monitor = new EntityStatisticsCacheMonitor {
-      override val dataSource: SlickDataSource = slickDataSource
-      override implicit val executionContext: ExecutionContext = defaultExecutionContext
-      override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
-      override val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
-      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricsPrefix
-    }
+  it should "delay the next sweep if the last sweep was empty due to cooldown" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      // default workspaceCooldown in src/test/reference.conf is 0 minutes; override it here
+      // so that the sweep doesn't find a workspace whose last_modified date satisfies the cooldown
+      val monitor = new EntityStatisticsCacheMonitor {
+        override val dataSource: SlickDataSource = slickDataSource
+        implicit override val executionContext: ExecutionContext = defaultExecutionContext
+        override val standardPollInterval: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+        override val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
+        override val timeoutPerWorkspace: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        override val workbenchMetricBaseName: String = metricsPrefix
+      }
 
-    //Scenario: there is one workspace in the test data set used for this test. Because it was saved to the db
-    // as part of test setup, its lastModified date is recent, and this sweep will not find it within
-    // the 5-minute cooldown we specified.
-    assertResult(ScheduleDelayedSweep) {
-      Await.result(monitor.sweep(), Duration.Inf)
-    }
+      // Scenario: there is one workspace in the test data set used for this test. Because it was saved to the db
+      // as part of test setup, its lastModified date is recent, and this sweep will not find it within
+      // the 5-minute cooldown we specified.
+      assertResult(ScheduleDelayedSweep) {
+        Await.result(monitor.sweep(), Duration.Inf)
+      }
   }
 
-  it should "update the cache for a workspace after Sweeping if the cache was out of date" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    val monitor = new EntityStatisticsCacheMonitor {
-      override val dataSource: SlickDataSource = slickDataSource
-      override implicit val executionContext: ExecutionContext = defaultExecutionContext
-      override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
-      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
-      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricsPrefix
-    }
+  it should "update the cache for a workspace after Sweeping if the cache was out of date" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      val monitor = new EntityStatisticsCacheMonitor {
+        override val dataSource: SlickDataSource = slickDataSource
+        implicit override val executionContext: ExecutionContext = defaultExecutionContext
+        override val standardPollInterval: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+        override val workspaceCooldown: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+        override val timeoutPerWorkspace: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        override val workbenchMetricBaseName: String = metricsPrefix
+      }
 
-    val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-    val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+      val workspaceContext = runAndWait(
+        slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+      ).get
+      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                        slickDataSource,
+                                                        cacheEnabled = true,
+                                                        workbenchMetricBaseName
+      )
 
-    //Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
-    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis)))
+      // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
+      runAndWait(
+        entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                new Timestamp(workspaceContext.lastModified.getMillis)
+        )
+      )
 
-    //Load the current cache entries
-    val originalCache = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      // Load the current cache entries
+      val originalCache = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
 
-    //Save a new entity to the workspace
-    val newEntity = Entity("new-entity-name", "new-entity-tpe", Map.empty)
-    Await.result(localEntityProvider.createEntity(newEntity), Duration.Inf)
+      // Save a new entity to the workspace
+      val newEntity = Entity("new-entity-name", "new-entity-tpe", Map.empty)
+      Await.result(localEntityProvider.createEntity(newEntity), Duration.Inf)
 
-    //Force the monitor to sweep and update the oldest stale cache
-    //In this scenario, it's the only workspace so we know it will be picked up
-    assertResult(Sweep) {
-      Await.result(monitor.sweep(), Duration.Inf)
-    }
+      // Force the monitor to sweep and update the oldest stale cache
+      // In this scenario, it's the only workspace so we know it will be picked up
+      assertResult(Sweep) {
+        Await.result(monitor.sweep(), Duration.Inf)
+      }
 
-    //Load the latest cache
-    val newCache = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      // Load the latest cache
+      val newCache = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
 
-    //Assert that the new cache is different than the old one and contains the new entity type that we added earlier
-    originalCache should not be newCache
-    assert(newCache.contains(newEntity.entityType))
+      // Assert that the new cache is different than the old one and contains the new entity type that we added earlier
+      originalCache should not be newCache
+      assert(newCache.contains(newEntity.entityType))
   }
 
-  it should "entityMetadata should return the same results before and after the monitor Sweeps to update the cache" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    val monitor = new EntityStatisticsCacheMonitor {
-      override val dataSource: SlickDataSource = slickDataSource
-      override implicit val executionContext: ExecutionContext = defaultExecutionContext
-      override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
-      override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
-      override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
-      override val workbenchMetricBaseName: String = metricsPrefix
-    }
+  it should "entityMetadata should return the same results before and after the monitor Sweeps to update the cache" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      val monitor = new EntityStatisticsCacheMonitor {
+        override val dataSource: SlickDataSource = slickDataSource
+        implicit override val executionContext: ExecutionContext = defaultExecutionContext
+        override val standardPollInterval: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+        override val workspaceCooldown: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+        override val timeoutPerWorkspace: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        override val workbenchMetricBaseName: String = metricsPrefix
+      }
 
-    val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
-    val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext), slickDataSource, cacheEnabled = true, workbenchMetricBaseName)
+      val workspaceContext = runAndWait(
+        slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+      ).get
+      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
+                                                        slickDataSource,
+                                                        cacheEnabled = true,
+                                                        workbenchMetricBaseName
+      )
 
-    //Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache
-    // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
-    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 10000)))
+      // Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache
+      // N.B. cache staleness has second precision, not millisecond precision, so make sure we set entityCacheLastUpdated far back enough
+      runAndWait(
+        entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                new Timestamp(workspaceContext.lastModified.getMillis - 10000)
+        )
+      )
 
-    //Load the current entityMetadata (which should not use the cache)
-    val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      // Load the current entityMetadata (which should not use the cache)
+      val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
 
-    //Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
-    //Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so
-    //the monitor will update it using its internal code path
-    runAndWait(entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID, new Timestamp(workspaceContext.lastModified.getMillis - 2)))
+      // Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
+      // Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so
+      // the monitor will update it using its internal code path
+      runAndWait(
+        entityCacheQuery.updateCacheLastUpdated(workspaceContext.workspaceIdAsUUID,
+                                                new Timestamp(workspaceContext.lastModified.getMillis - 2)
+        )
+      )
 
-    //Make sure that the timestamps do not match
-    val lastModifiedOriginal = runAndWait(workspaceQuery.findByIdQuery(workspaceContext.workspaceIdAsUUID).result).head.lastModified
-    val entityCacheLastUpdatedOriginal = runAndWait(entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).result).head.entityCacheLastUpdated
+      // Make sure that the timestamps do not match
+      val lastModifiedOriginal =
+        runAndWait(workspaceQuery.findByIdQuery(workspaceContext.workspaceIdAsUUID).result).head.lastModified
+      val entityCacheLastUpdatedOriginal = runAndWait(
+        entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).result
+      ).head.entityCacheLastUpdated
 
-    assert(lastModifiedOriginal.after(entityCacheLastUpdatedOriginal))
+      assert(lastModifiedOriginal.after(entityCacheLastUpdatedOriginal))
 
-    //Force the monitor to sweep and update the oldest stale cache
-    //In this scenario, it's the only workspace so we know it will be picked up
-    assertResult(Sweep) {
-      Await.result(monitor.sweep(), Duration.Inf)
-    }
+      // Force the monitor to sweep and update the oldest stale cache
+      // In this scenario, it's the only workspace so we know it will be picked up
+      assertResult(Sweep) {
+        Await.result(monitor.sweep(), Duration.Inf)
+      }
 
-    //Load the latest entityMetadata, which should use the cache
-    val latestResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      // Load the latest entityMetadata, which should use the cache
+      val latestResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
 
-    //Assert that the new cache is different than the old one and contains the new entity type that we added earlier
-    originalResult shouldBe latestResult
+      // Assert that the new cache is different than the old one and contains the new entity type that we added earlier
+      originalResult shouldBe latestResult
 
-    //Make sure that the timestamps now match
-    val lastModified = runAndWait(workspaceQuery.findByIdQuery(workspaceContext.workspaceIdAsUUID).result).head.lastModified
-    val entityCacheLastUpdated = runAndWait(entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).result).head.entityCacheLastUpdated
+      // Make sure that the timestamps now match
+      val lastModified =
+        runAndWait(workspaceQuery.findByIdQuery(workspaceContext.workspaceIdAsUUID).result).head.lastModified
+      val entityCacheLastUpdated = runAndWait(
+        entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).result
+      ).head.entityCacheLastUpdated
 
-    lastModified shouldBe entityCacheLastUpdated
+      lastModified shouldBe entityCacheLastUpdated
   }
 
-  it should "die and restart properly upon explicit DieAndRestart request" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    // timings for the monitor(s)
-    val timeoutPerWorkspace: FiniteDuration = FiniteDuration(3, TimeUnit.SECONDS)
-    val standardPollInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS)
-    val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
+  it should "die and restart properly upon explicit DieAndRestart request" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      // timings for the monitor(s)
+      val timeoutPerWorkspace: FiniteDuration = FiniteDuration(3, TimeUnit.SECONDS)
+      val standardPollInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS)
+      val workspaceCooldown: FiniteDuration = Duration(5, TimeUnit.MINUTES)
 
-    // timing for TestKit, waiting for actor responses
-    implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
+      // timing for TestKit, waiting for actor responses
+      implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
 
-    // start a monitor actor, and return its ActorRef.
-    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
+      // start a monitor actor, and return its ActorRef.
+      val monitor1 = system.actorOf(
+        EntityStatisticsCacheMonitor.props(slickDataSource,
+                                           timeoutPerWorkspace,
+                                           standardPollInterval,
+                                           workspaceCooldown,
+                                           workbenchMetricBaseName
+        )
+      )
 
-    // set up a TestKit probe for DeathWatch on the monitor
-    val probe1 = TestProbe()
-    probe1.watch(monitor1)
+      // set up a TestKit probe for DeathWatch on the monitor
+      val probe1 = TestProbe()
+      probe1.watch(monitor1)
 
-    // send DieAndRestart to the monitor. It should return an ActorRef to a newly-created monitor, then terminate.
-    val monitor2Any = (monitor1 ? DieAndRestart).futureValue
-    monitor2Any shouldBe a [ActorRef]
+      // send DieAndRestart to the monitor. It should return an ActorRef to a newly-created monitor, then terminate.
+      val monitor2Any = (monitor1 ? DieAndRestart).futureValue
+      monitor2Any shouldBe a[ActorRef]
 
-    // assert that the monitor shut itself down
-    probe1.expectTerminated(monitor1, timeoutPerWorkspace * 3) // EntityStatisticsCacheMonitor waits timeoutPerWorkspace * 2 before terminating
+      // assert that the monitor shut itself down
+      probe1.expectTerminated(monitor1,
+                              timeoutPerWorkspace * 3
+      ) // EntityStatisticsCacheMonitor waits timeoutPerWorkspace * 2 before terminating
 
-    // we want to know if the newly-created monitor is responsive
-    val monitor2 = monitor2Any.asInstanceOf[ActorRef]
-    monitor2 ! Start
-    expectMsg(Sweep)
+      // we want to know if the newly-created monitor is responsive
+      val monitor2 = monitor2Any.asInstanceOf[ActorRef]
+      monitor2 ! Start
+      expectMsg(Sweep)
   }
 
-  it should "resume cache processing after restarting upon ReceiveTimeout" in withLocalEntityProviderTestDatabase { slickDataSource: SlickDataSource =>
-    // workspace for this test
-    val workspaceContext = runAndWait(slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)).get
+  it should "resume cache processing after restarting upon ReceiveTimeout" in withLocalEntityProviderTestDatabase {
+    slickDataSource: SlickDataSource =>
+      // workspace for this test
+      val workspaceContext = runAndWait(
+        slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
+      ).get
 
-    // timings for the monitor(s)
-    val timeoutPerWorkspace: FiniteDuration = FiniteDuration(3, TimeUnit.SECONDS)
-    val standardPollInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS)
-    val workspaceCooldown: FiniteDuration = Duration(1, TimeUnit.SECONDS)
+      // timings for the monitor(s)
+      val timeoutPerWorkspace: FiniteDuration = FiniteDuration(3, TimeUnit.SECONDS)
+      val standardPollInterval: FiniteDuration = FiniteDuration(1, TimeUnit.SECONDS)
+      val workspaceCooldown: FiniteDuration = Duration(1, TimeUnit.SECONDS)
 
-    // timing for TestKit, waiting for actor responses
-    implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
+      // timing for TestKit, waiting for actor responses
+      implicit val testKitTimeout: Timeout = Timeout(scaled(Span(90, Seconds)))
 
-    // start a monitor actor, and return its ActorRef.
-    val monitor1 = system.actorOf(EntityStatisticsCacheMonitor.props(slickDataSource, timeoutPerWorkspace, standardPollInterval, workspaceCooldown, workbenchMetricBaseName))
+      // start a monitor actor, and return its ActorRef.
+      val monitor1 = system.actorOf(
+        EntityStatisticsCacheMonitor.props(slickDataSource,
+                                           timeoutPerWorkspace,
+                                           standardPollInterval,
+                                           workspaceCooldown,
+                                           workbenchMetricBaseName
+        )
+      )
 
-    // this first monitor should, eventually, update the workspace's cache
-    eventually(timeout = timeout(timeoutPerWorkspace*3)) {
-      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)).contains(0)
-      isCurrent shouldBe true
-    }
+      // this first monitor should, eventually, update the workspace's cache
+      eventually(timeout = timeout(timeoutPerWorkspace * 3)) {
+        val isCurrent =
+          runAndWait(entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)).contains(0)
+        isCurrent shouldBe true
+      }
 
-    // set up a TestKit probe for DeathWatch on the monitor
-    val probe1 = TestProbe()
-    probe1.watch(monitor1)
+      // set up a TestKit probe for DeathWatch on the monitor
+      val probe1 = TestProbe()
+      probe1.watch(monitor1)
 
-    // send ReceiveTimeout to the monitor.
-    monitor1 ! ReceiveTimeout
+      // send ReceiveTimeout to the monitor.
+      monitor1 ! ReceiveTimeout
 
-    // assert that the monitor shut itself down
-    probe1.expectTerminated(monitor1, timeoutPerWorkspace * 3) // EntityStatisticsCacheMonitor waits timeoutPerWorkspace * 2 before terminating
+      // assert that the monitor shut itself down
+      probe1.expectTerminated(monitor1,
+                              timeoutPerWorkspace * 3
+      ) // EntityStatisticsCacheMonitor waits timeoutPerWorkspace * 2 before terminating
 
-    // at this point the first monitor is killed, but the second monitor should have been created.
-    // remove the cache record for our test workspace, and wait for the the monitor to sweep and update its cache.
-    val killCacheFuture = for {
-      _ <- entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).delete
-      staleness <- entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)
-    } yield staleness.contains(0)
+      // at this point the first monitor is killed, but the second monitor should have been created.
+      // remove the cache record for our test workspace, and wait for the the monitor to sweep and update its cache.
+      val killCacheFuture = for {
+        _ <- entityCacheQuery.filter(_.workspaceId === workspaceContext.workspaceIdAsUUID).delete
+        staleness <- entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)
+      } yield staleness.contains(0)
 
-    runAndWait(killCacheFuture) shouldBe false
+      runAndWait(killCacheFuture) shouldBe false
 
-    eventually(timeout = timeout(timeoutPerWorkspace*3)) {
-      val isCurrent = runAndWait(entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)).contains(0)
-      isCurrent shouldBe true
-    }
+      eventually(timeout = timeout(timeoutPerWorkspace * 3)) {
+        val isCurrent =
+          runAndWait(entityCacheQuery.entityCacheStaleness(workspaceContext.workspaceIdAsUUID)).contains(0)
+        isCurrent shouldBe true
+      }
   }
 
   List(0, 1, 10, 180) foreach { mins =>
     it should s"properly calculate now minus a duration ($mins minutes)" in {
       val monitor = new EntityStatisticsCacheMonitor {
         override val dataSource: SlickDataSource = slickDataSource
-        override implicit val executionContext: ExecutionContext = defaultExecutionContext
-        override val standardPollInterval: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
-        override val workspaceCooldown: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
-        override val timeoutPerWorkspace: FiniteDuration = util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
+        implicit override val executionContext: ExecutionContext = defaultExecutionContext
+        override val standardPollInterval: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.standardPollInterval"))
+        override val workspaceCooldown: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.workspaceCooldown"))
+        override val timeoutPerWorkspace: FiniteDuration =
+          util.toScalaDuration(testConf.getDuration("entityStatisticsCache.timeoutPerWorkspace"))
         override val workbenchMetricBaseName: String = metricsPrefix
       }
 
       val duration = Duration(mins, TimeUnit.MINUTES)
       val now = Calendar.getInstance.getTime.getTime
       val earlier = monitor.nowMinus(duration).getTime
-      val expectedDiff = duration.toSeconds*1000
+      val expectedDiff = duration.toSeconds * 1000
 
       // we calculate "now" here in the test, but then again inside the monitor's nowMinus method;
       // allow for a minor time difference of 1 second since those "now" values won't be
       // exactly equal.
       val lenience = 1000
 
-      assert( expectedDiff - (now - earlier) <= lenience,
+      assert(
+        expectedDiff - (now - earlier) <= lenience,
         s"[CLUE: nowMinus calculated a diff of ${now - earlier} ms, " +
-          s"but expected a diff of ${expectedDiff-lenience}-$expectedDiff ms]" )
+          s"but expected a diff of ${expectedDiff - lenience}-$expectedDiff ms]"
+      )
 
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/openam/MockUserInfoDirectives.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/openam/MockUserInfoDirectives.scala
@@ -7,9 +7,12 @@ import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, RawlsUserSubjectId, UserInfo}
 
 trait MockUserInfoDirectives extends UserInfoDirectives {
-  protected def userInfo = UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345"))
+  protected def userInfo = UserInfo(RawlsUserEmail("owner-access"),
+                                    OAuth2BearerToken("token"),
+                                    123,
+                                    RawlsUserSubjectId("123456789876543212345")
+  )
 
-  def requireUserInfo(span: Option[Span]): Directive1[UserInfo] = {
+  def requireUserInfo(span: Option[Span]): Directive1[UserInfo] =
     provide(userInfo)
-  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/openam/MockUserInfoDirectivesWithUser.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/openam/MockUserInfoDirectivesWithUser.scala
@@ -11,8 +11,7 @@ import org.broadinstitute.dsde.rawls.model.{RawlsUser, UserInfo}
   */
 trait MockUserInfoDirectivesWithUser extends UserInfoDirectives {
   val user: RawlsUser
-  def requireUserInfo(span: Option[Span]): Directive1[UserInfo] = {
+  def requireUserInfo(span: Option[Span]): Directive1[UserInfo] =
     // just return the cookie text as the common name
     provide(UserInfo(user.userEmail, OAuth2BearerToken("token"), 123, user.userSubjectId))
-  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterServiceSpec.scala
@@ -10,11 +10,17 @@ import org.broadinstitute.dsde.rawls.config.ServicePerimeterServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.google.{AccessContextManagerDAO, MockGoogleAccessContextManagerDAO}
-import org.broadinstitute.dsde.rawls.model.{GoogleProjectNumber, SamResourceTypeNames, SamServicePerimeterActions, ServicePerimeterName, Workspace}
+import org.broadinstitute.dsde.rawls.model.{
+  GoogleProjectNumber,
+  SamResourceTypeNames,
+  SamServicePerimeterActions,
+  ServicePerimeterName,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.mockito.ArgumentMatchers.any
 import org.mockito.{ArgumentMatchers, Mockito}
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, verify, when}
+import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
@@ -25,148 +31,206 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 
-class ServicePerimeterServiceSpec extends AnyFlatSpecLike with TestDriverComponent with MockitoSugar with BeforeAndAfterAll with Matchers with ScalatestRouteTest with MockitoTestUtils with OptionValues {
-  val defaultConfig = ServicePerimeterServiceConfig(Map(ServicePerimeterName("theGreatBarrier") -> Seq(GoogleProjectNumber("555555"), GoogleProjectNumber("121212")),
-    ServicePerimeterName("anotherGoodName") -> Seq(GoogleProjectNumber("777777"), GoogleProjectNumber("343434"))), 1 second, 1 second)
+class ServicePerimeterServiceSpec
+    extends AnyFlatSpecLike
+    with TestDriverComponent
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with Matchers
+    with ScalatestRouteTest
+    with MockitoTestUtils
+    with OptionValues {
+  val defaultConfig = ServicePerimeterServiceConfig(
+    Map(
+      ServicePerimeterName("theGreatBarrier") -> Seq(GoogleProjectNumber("555555"), GoogleProjectNumber("121212")),
+      ServicePerimeterName("anotherGoodName") -> Seq(GoogleProjectNumber("777777"), GoogleProjectNumber("343434"))
+    ),
+    1 second,
+    1 second
+  )
 
-  "ServicePerimeterService" should "attempt to overwrite the service perimeter with correct list of google project numbers" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val googleAccessContextManagerDAO = Mockito.spy(new MockGoogleAccessContextManagerDAO())
-    val gcsDAO = Mockito.spy(new MockGoogleServicesDAO("test", googleAccessContextManagerDAO))
-    val service = new ServicePerimeterService(dataSource, gcsDAO, defaultConfig)
+  "ServicePerimeterService" should "attempt to overwrite the service perimeter with correct list of google project numbers" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val googleAccessContextManagerDAO = Mockito.spy(new MockGoogleAccessContextManagerDAO())
+      val gcsDAO = Mockito.spy(new MockGoogleServicesDAO("test", googleAccessContextManagerDAO))
+      val service = new ServicePerimeterService(dataSource, gcsDAO, defaultConfig)
 
-    val servicePerimeterName: ServicePerimeterName = defaultConfig.staticProjectsInPerimeters.keys.head
-    val staticProjectNumbersInPerimeter: Set[String] = defaultConfig.staticProjectsInPerimeters(servicePerimeterName).map(_.value).toSet
+      val servicePerimeterName: ServicePerimeterName = defaultConfig.staticProjectsInPerimeters.keys.head
+      val staticProjectNumbersInPerimeter: Set[String] =
+        defaultConfig.staticProjectsInPerimeters(servicePerimeterName).map(_.value).toSet
 
-    val billingProject1 = testData.testProject1
-    val billingProject2 = testData.testProject2
-    val billingProjects = Seq(billingProject1, billingProject2)
-    val workspacesPerProject = 2
+      val billingProject1 = testData.testProject1
+      val billingProject2 = testData.testProject2
+      val billingProjects = Seq(billingProject1, billingProject2)
+      val workspacesPerProject = 2
 
-    // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
-    // the Billing Projects and therefore in the Perimeter
-    val workspacesInPerimeter: Seq[Workspace] = billingProjects.flatMap { bp =>
+      // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
+      // the Billing Projects and therefore in the Perimeter
+      val workspacesInPerimeter: Seq[Workspace] = billingProjects.flatMap { bp =>
+        runAndWait {
+          for {
+            _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName,
+                                                                                            servicePerimeterName.some
+            )
+            updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
+          } yield {
+            updatedBillingProject shouldBe defined
+            updatedBillingProject.value.servicePerimeter shouldBe Some(servicePerimeterName)
+          }
+        }
+
+        val workspaces = (1 to workspacesPerProject).map { n =>
+          val workspace = testData.workspace.copy(
+            namespace = bp.projectName.value,
+            name = s"${bp.projectName.value}Workspace${n}",
+            workspaceId = UUID.randomUUID().toString,
+            googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString))
+          )
+          val createWorkspaceDbQuery = slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace)
+          runAndWait(createWorkspaceDbQuery)
+        }
+        workspaces
+      }
+
+      // Add in a v1 billing project (which contains a google project) and without any workspaces
+      val v1BillingProjectWithoutWorkspaces = testData.testProject3
+      val v1BillingProjectGoogleProjectNumber = GoogleProjectNumber(UUID.randomUUID().toString)
       runAndWait {
         for {
-          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName, servicePerimeterName.some)
-          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery
+            .updateServicePerimeter(v1BillingProjectWithoutWorkspaces.projectName, servicePerimeterName.some)
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateGoogleProjectNumber(
+            v1BillingProjectWithoutWorkspaces.projectName,
+            v1BillingProjectGoogleProjectNumber.some
+          )
+          updatedV1BillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(
+            v1BillingProjectWithoutWorkspaces.projectName
+          )
         } yield {
-          updatedBillingProject shouldBe defined
-          updatedBillingProject.value.servicePerimeter shouldBe Some(servicePerimeterName)
+          updatedV1BillingProject shouldBe defined
+          updatedV1BillingProject.value.servicePerimeter shouldBe Some(servicePerimeterName)
+          updatedV1BillingProject.value.googleProjectNumber shouldBe Some(v1BillingProjectGoogleProjectNumber)
         }
       }
 
-      val workspaces = (1 to workspacesPerProject).map { n =>
-        val workspace = testData.workspace.copy(
-          namespace = bp.projectName.value,
-          name = s"${bp.projectName.value}Workspace${n}",
-          workspaceId = UUID.randomUUID().toString,
-          googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString)))
-        val createWorkspaceDbQuery = slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace)
-        runAndWait(createWorkspaceDbQuery)
-      }
-      workspaces
-    }
+      runAndWait(
+        service.overwriteGoogleProjectsInPerimeter(servicePerimeterName, slickDataSource.dataAccess),
+        Duration.Inf
+      )
 
-    // Add in a v1 billing project (which contains a google project) and without any workspaces
-    val v1BillingProjectWithoutWorkspaces = testData.testProject3
-    val v1BillingProjectGoogleProjectNumber = GoogleProjectNumber(UUID.randomUUID().toString)
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(v1BillingProjectWithoutWorkspaces.projectName, servicePerimeterName.some)
-        _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateGoogleProjectNumber(v1BillingProjectWithoutWorkspaces.projectName, v1BillingProjectGoogleProjectNumber.some)
-        updatedV1BillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(v1BillingProjectWithoutWorkspaces.projectName)
-      } yield {
-        updatedV1BillingProject shouldBe defined
-        updatedV1BillingProject.value.servicePerimeter shouldBe Some(servicePerimeterName)
-        updatedV1BillingProject.value.googleProjectNumber shouldBe Some(v1BillingProjectGoogleProjectNumber)
-      }
-    }
+      // Check that we made the call to overwrite the Perimeter exactly once (default) and that the correct perimeter
+      // name was specified with the correct list of projects which should include all pre-existing Workspaces within
+      // Billing Projects using the same Service Perimeter, all static Google Project Numbers specified by the Config, and
+      // the new Google Project Number that we just created
+      val existingProjectNumbersInPerimeter = workspacesInPerimeter.map(_.googleProjectNumber.get.value).toSet
+      val expectedGoogleProjectNumbers: Set[String] =
+        (existingProjectNumbersInPerimeter ++ staticProjectNumbersInPerimeter) + v1BillingProjectGoogleProjectNumber.value
+      val projectNumbersCaptor = captor[Set[String]]
+      val servicePerimeterNameCaptor = captor[ServicePerimeterName]
 
-    runAndWait(
-      service.overwriteGoogleProjectsInPerimeter(servicePerimeterName, slickDataSource.dataAccess),
-      Duration.Inf
-    )
-
-    // Check that we made the call to overwrite the Perimeter exactly once (default) and that the correct perimeter
-    // name was specified with the correct list of projects which should include all pre-existing Workspaces within
-    // Billing Projects using the same Service Perimeter, all static Google Project Numbers specified by the Config, and
-    // the new Google Project Number that we just created
-    val existingProjectNumbersInPerimeter = workspacesInPerimeter.map(_.googleProjectNumber.get.value).toSet
-    val expectedGoogleProjectNumbers: Set[String] = (existingProjectNumbersInPerimeter ++ staticProjectNumbersInPerimeter) + v1BillingProjectGoogleProjectNumber.value
-    val projectNumbersCaptor = captor[Set[String]]
-    val servicePerimeterNameCaptor = captor[ServicePerimeterName]
-
-    // verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was called exactly once and capture
-    // the arguments passed to it so that we can verify that they were correct
-    verify(gcsDAO.accessContextManagerDAO).overwriteProjectsInServicePerimeter(servicePerimeterNameCaptor.capture, projectNumbersCaptor.capture)
-    projectNumbersCaptor.getValue should contain theSameElementsAs expectedGoogleProjectNumbers
-    servicePerimeterNameCaptor.getValue shouldBe servicePerimeterName
+      // verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was called exactly once and capture
+      // the arguments passed to it so that we can verify that they were correct
+      verify(gcsDAO.accessContextManagerDAO).overwriteProjectsInServicePerimeter(servicePerimeterNameCaptor.capture,
+                                                                                 projectNumbersCaptor.capture
+      )
+      projectNumbersCaptor.getValue should contain theSameElementsAs expectedGoogleProjectNumbers
+      servicePerimeterNameCaptor.getValue shouldBe servicePerimeterName
   }
 
-  it should "throw a 500 if the perimeter fails when updating" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val gcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-    val acmDAO = mock[AccessContextManagerDAO](RETURNS_SMART_NULLS)
-    val operationName = "overwritePerimeterOperation"
+  it should "throw a 500 if the perimeter fails when updating" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val gcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      val acmDAO = mock[AccessContextManagerDAO](RETURNS_SMART_NULLS)
+      val operationName = "overwritePerimeterOperation"
 
-    when(gcsDAO.accessContextManagerDAO).thenReturn(acmDAO)
-    when(acmDAO.overwriteProjectsInServicePerimeter(any[ServicePerimeterName], any[Set[String]]))
-      .thenReturn(Future.successful(new Operation().setName(operationName)))
-    when(gcsDAO.pollOperation(OperationId(GoogleApiTypes.AccessContextManagerApi, operationName)))
-      .thenReturn(Future.successful(OperationStatus(done = true, Option("I'm bad at overwriting the perimeter"))))
+      when(gcsDAO.accessContextManagerDAO).thenReturn(acmDAO)
+      when(acmDAO.overwriteProjectsInServicePerimeter(any[ServicePerimeterName], any[Set[String]]))
+        .thenReturn(Future.successful(new Operation().setName(operationName)))
+      when(gcsDAO.pollOperation(OperationId(GoogleApiTypes.AccessContextManagerApi, operationName)))
+        .thenReturn(Future.successful(OperationStatus(done = true, Option("I'm bad at overwriting the perimeter"))))
 
-    val service = new ServicePerimeterService(dataSource, gcsDAO, defaultConfig)
+      val service = new ServicePerimeterService(dataSource, gcsDAO, defaultConfig)
 
-    val servicePerimeterName: ServicePerimeterName = defaultConfig.staticProjectsInPerimeters.keys.head
-    val billingProject1 = testData.testProject1
-    val billingProject2 = testData.testProject2
-    val billingProjects = Seq(billingProject1, billingProject2)
-    val workspacesPerProject = 2
+      val servicePerimeterName: ServicePerimeterName = defaultConfig.staticProjectsInPerimeters.keys.head
+      val billingProject1 = testData.testProject1
+      val billingProject2 = testData.testProject2
+      val billingProjects = Seq(billingProject1, billingProject2)
+      val workspacesPerProject = 2
 
-    // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
-    // the Billing Projects and therefore in the Perimeter
-    billingProjects.flatMap { bp =>
-      runAndWait {
-        for {
-          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName, servicePerimeterName.some)
-          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
-        } yield updatedBillingProject.value.servicePerimeter shouldBe Some(servicePerimeterName)
+      // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
+      // the Billing Projects and therefore in the Perimeter
+      billingProjects.flatMap { bp =>
+        runAndWait {
+          for {
+            _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName,
+                                                                                            servicePerimeterName.some
+            )
+            updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
+          } yield updatedBillingProject.value.servicePerimeter shouldBe Some(servicePerimeterName)
+        }
+
+        (1 to workspacesPerProject).map { n =>
+          val workspace = testData.workspace.copy(
+            namespace = bp.projectName.value,
+            name = s"${bp.projectName.value}Workspace${n}",
+            workspaceId = UUID.randomUUID().toString,
+            googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString))
+          )
+          runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace))
+        }
       }
 
-      (1 to workspacesPerProject).map { n =>
-        val workspace = testData.workspace.copy(
-          namespace = bp.projectName.value,
-          name = s"${bp.projectName.value}Workspace${n}",
-          workspaceId = UUID.randomUUID().toString,
-          googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString)))
-        runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace))
+      val failure = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(slickDataSource.inTransaction { dataAccess =>
+                       service.overwriteGoogleProjectsInPerimeter(servicePerimeterName, dataAccess)
+                     },
+                     Duration.Inf
+        )
       }
-    }
-
-    val failure = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(slickDataSource.inTransaction { dataAccess =>
-        service.overwriteGoogleProjectsInPerimeter(servicePerimeterName, dataAccess)
-      }, Duration.Inf)
-    }
-    failure.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
+      failure.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
   }
 
   behavior of "checkServicePerimeterAccess"
 
   it should "return a successful result when user has appropriate permissions" in {
     val samDAO = mock[SamDAO]
-    when(samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.servicePerimeter), ArgumentMatchers.eq("fake_sp_name"), ArgumentMatchers.eq(SamServicePerimeterActions.addProject), ArgumentMatchers.eq(userInfo)))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.servicePerimeter),
+        ArgumentMatchers.eq("fake_sp_name"),
+        ArgumentMatchers.eq(SamServicePerimeterActions.addProject),
+        ArgumentMatchers.eq(userInfo)
+      )
+    )
       .thenReturn(Future.successful(true))
 
-    Await.result(ServicePerimeterService.checkServicePerimeterAccess(samDAO, Some(ServicePerimeterName("fake_sp_name")), testContext), Duration.Inf)
+    Await.result(ServicePerimeterService.checkServicePerimeterAccess(samDAO,
+                                                                     Some(ServicePerimeterName("fake_sp_name")),
+                                                                     testContext
+                 ),
+                 Duration.Inf
+    )
   }
 
   it should "fail when the user lacks permission" in {
     val samDAO = mock[SamDAO]
-    when(samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.servicePerimeter), ArgumentMatchers.eq("fake_sp_name"), ArgumentMatchers.eq(SamServicePerimeterActions.addProject), ArgumentMatchers.eq(userInfo)))
+    when(
+      samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.servicePerimeter),
+        ArgumentMatchers.eq("fake_sp_name"),
+        ArgumentMatchers.eq(SamServicePerimeterActions.addProject),
+        ArgumentMatchers.eq(userInfo)
+      )
+    )
       .thenReturn(Future.successful(false))
 
     intercept[ServicePerimeterAccessException] {
-      Await.result(ServicePerimeterService.checkServicePerimeterAccess(samDAO, Some(ServicePerimeterName("fake_sp_name")), testContext), Duration.Inf)
+      Await.result(ServicePerimeterService.checkServicePerimeterAccess(samDAO,
+                                                                       Some(ServicePerimeterName("fake_sp_name")),
+                                                                       testContext
+                   ),
+                   Duration.Inf
+      )
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -5,7 +5,16 @@ import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, GoogleProjectId, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceAction, SamResourceTypeNames, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceDescriptionField,
+  DataReferenceName,
+  GoogleProjectId,
+  NamedDataRepoSnapshot,
+  RawlsRequestContext,
+  SamResourceAction,
+  SamResourceTypeNames,
+  UserInfo
+}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -20,16 +29,43 @@ import scala.jdk.CollectionConverters._
 
 class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSugar with TestDriverComponent {
 
-
   "SnapshotService" should {
     "create a new snapshot reference to a TDR snapshot" in withMinimalTestDatabase { _ =>
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
-      when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo])).thenReturn(Future.successful("fake-token"))
+      when(
+        mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                                 any[String],
+                                 any[SamResourceAction],
+                                 any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
+      when(mockSamDAO.getPetServiceAccountToken(any[GoogleProjectId], any[Set[String]], any[UserInfo]))
+        .thenReturn(Future.successful("fake-token"))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
-      when(mockWorkspaceManagerDAO.createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[RawlsRequestContext]))
-        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(UUID.randomUUID()).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
+      when(
+        mockWorkspaceManagerDAO.createDataRepoSnapshotReference(
+          any[UUID],
+          any[UUID],
+          any[DataReferenceName],
+          any[Option[DataReferenceDescriptionField]],
+          any[String],
+          any[CloningInstructionsEnum],
+          any[RawlsRequestContext]
+        )
+      )
+        .thenReturn(
+          new DataRepoSnapshotResource()
+            .metadata(
+              new ResourceMetadata()
+                .resourceId(UUID.randomUUID())
+                .workspaceId(UUID.randomUUID())
+                .name("foo")
+                .description("")
+                .cloningInstructions(CloningInstructionsEnum.NOTHING)
+            )
+            .attributes(new DataRepoSnapshotAttributes())
+        )
 
       val workspace = minimalTestData.workspace
 
@@ -40,20 +76,53 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         "fake-terra-data-repo-dev"
       )(testContext)
 
-      Await.result(snapshotService.createSnapshot(workspace.toWorkspaceName, NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())), Duration.Inf)
+      Await.result(
+        snapshotService.createSnapshot(workspace.toWorkspaceName,
+                                       NamedDataRepoSnapshot(DataReferenceName("foo"),
+                                                             Option(DataReferenceDescriptionField("foo")),
+                                                             UUID.randomUUID()
+                                       )
+        ),
+        Duration.Inf
+      )
 
-      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(any[UUID], any[UUID], any[DataReferenceName], any[Option[DataReferenceDescriptionField]], any[String], any[CloningInstructionsEnum], any[RawlsRequestContext])
+      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(
+        any[UUID],
+        any[UUID],
+        any[DataReferenceName],
+        any[Option[DataReferenceDescriptionField]],
+        any[String],
+        any[CloningInstructionsEnum],
+        any[RawlsRequestContext]
+      )
     }
 
     "remove all resources when a snapshot reference is deleted" in withMinimalTestDatabase { _ =>
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                                 any[String],
+                                 any[SamResourceAction],
+                                 any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
       val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
       val snapshotDataReferenceId = UUID.randomUUID()
       when(mockWorkspaceManagerDAO.getDataRepoSnapshotReference(any[UUID], any[UUID], any[RawlsRequestContext]))
-        .thenReturn(new DataRepoSnapshotResource().metadata(new ResourceMetadata().resourceId(snapshotDataReferenceId).workspaceId(UUID.randomUUID()).name("foo").description("").cloningInstructions(CloningInstructionsEnum.NOTHING)).attributes(new DataRepoSnapshotAttributes()))
+        .thenReturn(
+          new DataRepoSnapshotResource()
+            .metadata(
+              new ResourceMetadata()
+                .resourceId(snapshotDataReferenceId)
+                .workspaceId(UUID.randomUUID())
+                .name("foo")
+                .description("")
+                .cloningInstructions(CloningInstructionsEnum.NOTHING)
+            )
+            .attributes(new DataRepoSnapshotAttributes())
+        )
 
       val workspace = minimalTestData.workspace
 
@@ -68,138 +137,185 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       Await.result(snapshotService.deleteSnapshot(workspace.toWorkspaceName, snapshotUUID.toString), Duration.Inf)
 
-      verify(mockWorkspaceManagerDAO, times(1)).getDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID),any[RawlsRequestContext])
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(ArgumentMatchers.eq(workspace.workspaceIdAsUUID), ArgumentMatchers.eq(snapshotUUID), any[RawlsRequestContext])
+      verify(mockWorkspaceManagerDAO, times(1)).getDataRepoSnapshotReference(
+        ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
+        ArgumentMatchers.eq(snapshotUUID),
+        any[RawlsRequestContext]
+      )
+      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(
+        ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
+        ArgumentMatchers.eq(snapshotUUID),
+        any[RawlsRequestContext]
+      )
     }
 
-    "find one matching snapshot reference by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
-      // generate a single page of ResourceDescriptions
-      val resources = generateTestReferences(20)
+    "find one matching snapshot reference by referenced snapshotId if one page of references" in withMinimalTestDatabase {
+      _ =>
+        // generate a single page of ResourceDescriptions
+        val resources = generateTestReferences(20)
 
-      val snapshotService = mockSnapshotServiceForReferences(resources)
+        val snapshotService = mockSnapshotServiceForReferences(resources)
 
-      // search for one of the snapshotIds that should be in the list
-      val criteria = "00000000-0000-0000-0000-000000000012"
-      val found = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 10, Option(UUID.fromString(criteria))),
-        Duration.Inf).gcpDataRepoSnapshots
-
-      found should have size 1
-      found.head.getAttributes.getSnapshot shouldBe criteria
-    }
-
-    "find multiple matching snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
-      // generate a single page of ResourceDescriptions, but duplicate the first 10 snapshotIds
-      val resources = generateTestReferences(20) ++ generateTestReferences(10)
-
-      val snapshotService = mockSnapshotServiceForReferences(resources)
-
-      // search for one of the snapshotIds that should be duplicated
-      val criteria1 = "00000000-0000-0000-0000-000000000005"
-      val found1 = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 10, Option(UUID.fromString(criteria1))),
-        Duration.Inf).gcpDataRepoSnapshots
-
-      found1 should have size 2
-      found1.foreach { x =>
-        x.getAttributes.getSnapshot shouldBe criteria1
-      }
-
-      // now search for one of the snapshotIds that should NOT be duplicated, to be sure
-      val criteria2 = "00000000-0000-0000-0000-000000000015"
-      val found2 = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,0, 10, Option(UUID.fromString(criteria2))),
-        Duration.Inf).gcpDataRepoSnapshots
-
-      found2 should have size 1
-      found2.foreach { x =>
-        x.getAttributes.getSnapshot shouldBe criteria2
-      }
-
-    }
-
-    "return an empty list of snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase { _ =>
-      // generate a single page of ResourceDescriptions
-      val resources = generateTestReferences(20)
-
-      val snapshotService = mockSnapshotServiceForReferences(resources)
-
-      // search for one of the snapshotIds that should NOT be in the list
-      val criteria = "00000000-0000-0000-0000-000000000099"
-      val found = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 10, Option(UUID.fromString(criteria))),
-        Duration.Inf).gcpDataRepoSnapshots
-
-      found should have size 0
-    }
-
-    "find one matching snapshot reference by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase { _ =>
-      // 10 resources and batchsize of 3 means we should make 4 queries to WSM
-      val resources = generateTestReferences(10)
-      val batchSize = 3
-
-      // yes we're spying on a mock
-      val snapshotService = spy(mockSnapshotServiceForReferences(resources))
-
-      // search for one of the snapshotIds that should be in the list
-      val criteria = "00000000-0000-0000-0000-000000000006"
-      val found = snapshotService
-        .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+        // search for one of the snapshotIds that should be in the list
+        val criteria = "00000000-0000-0000-0000-000000000012"
+        val found = Await
+          .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                     0,
+                                                     10,
+                                                     Option(UUID.fromString(criteria))
+                  ),
+                  Duration.Inf
+          )
           .gcpDataRepoSnapshots
 
-      found should have size 1
-      found.head.getAttributes.getSnapshot shouldBe criteria
-
-      // ensure we paged through the resources properly
-      verify(snapshotService, times(4))
-        .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID), any[Int], ArgumentMatchers.eq(batchSize))
+        found should have size 1
+        found.head.getAttributes.getSnapshot shouldBe criteria
     }
 
-    "find multiple matching snapshot references by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase { _ =>
-      // 21 resources total and batchsize of 5 means we should make 5 queries to WSM
-      val resources = generateTestReferences(10) ++ // contains snapshotId "...0006"
-        generateTestReferences(4) ++                // does not contain snapshotId "...0006"
-        generateTestReferences(7)                   // contains snapshotId "...0006"
-      val batchSize = 5
+    "find multiple matching snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase {
+      _ =>
+        // generate a single page of ResourceDescriptions, but duplicate the first 10 snapshotIds
+        val resources = generateTestReferences(20) ++ generateTestReferences(10)
 
-      // yes we're spying on a mock
-      val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+        val snapshotService = mockSnapshotServiceForReferences(resources)
 
-      // search for one of the snapshotIds that should be in the list
-      val criteria = "00000000-0000-0000-0000-000000000006"
-      val found = snapshotService
-        .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+        // search for one of the snapshotIds that should be duplicated
+        val criteria1 = "00000000-0000-0000-0000-000000000005"
+        val found1 = Await
+          .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                     0,
+                                                     10,
+                                                     Option(UUID.fromString(criteria1))
+                  ),
+                  Duration.Inf
+          )
           .gcpDataRepoSnapshots
 
-      found should have size 2
-      found.foreach { x =>
-        x.getAttributes.getSnapshot shouldBe criteria
-      }
+        found1 should have size 2
+        found1.foreach { x =>
+          x.getAttributes.getSnapshot shouldBe criteria1
+        }
 
-      // ensure we paged through the resources properly
-      verify(snapshotService, times(5))
-        .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID), any[Int], ArgumentMatchers.eq(batchSize))
+        // now search for one of the snapshotIds that should NOT be duplicated, to be sure
+        val criteria2 = "00000000-0000-0000-0000-000000000015"
+        val found2 = Await
+          .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                     0,
+                                                     10,
+                                                     Option(UUID.fromString(criteria2))
+                  ),
+                  Duration.Inf
+          )
+          .gcpDataRepoSnapshots
+
+        found2 should have size 1
+        found2.foreach { x =>
+          x.getAttributes.getSnapshot shouldBe criteria2
+        }
+
     }
 
-    "return an empty list of snapshot references by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase { _ =>
-      // 10 resources and batchsize of 3 means we should make 4 queries to WSM
-      val resources = generateTestReferences(10)
-      val batchSize = 3
+    "return an empty list of snapshot references by referenced snapshotId if one page of references" in withMinimalTestDatabase {
+      _ =>
+        // generate a single page of ResourceDescriptions
+        val resources = generateTestReferences(20)
 
-      // yes we're spying on a mock
-      val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+        val snapshotService = mockSnapshotServiceForReferences(resources)
 
-      // search for one of the snapshotIds that should be in the list
-      val criteria = "00000000-0000-0000-0000-000000000099"
-      val found = snapshotService
-        .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+        // search for one of the snapshotIds that should NOT be in the list
+        val criteria = "00000000-0000-0000-0000-000000000099"
+        val found = Await
+          .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                     0,
+                                                     10,
+                                                     Option(UUID.fromString(criteria))
+                  ),
+                  Duration.Inf
+          )
           .gcpDataRepoSnapshots
 
-      found should have size 0
+        found should have size 0
+    }
 
-      // ensure we paged through the resources properly
-      verify(snapshotService, times(4))
-        .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID), any[Int], ArgumentMatchers.eq(batchSize))
+    "find one matching snapshot reference by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase {
+      _ =>
+        // 10 resources and batchsize of 3 means we should make 4 queries to WSM
+        val resources = generateTestReferences(10)
+        val batchSize = 3
+
+        // yes we're spying on a mock
+        val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+
+        // search for one of the snapshotIds that should be in the list
+        val criteria = "00000000-0000-0000-0000-000000000006"
+        val found = snapshotService
+          .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+          .gcpDataRepoSnapshots
+
+        found should have size 1
+        found.head.getAttributes.getSnapshot shouldBe criteria
+
+        // ensure we paged through the resources properly
+        verify(snapshotService, times(4))
+          .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID),
+                                      any[Int],
+                                      ArgumentMatchers.eq(batchSize)
+          )
+    }
+
+    "find multiple matching snapshot references by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase {
+      _ =>
+        // 21 resources total and batchsize of 5 means we should make 5 queries to WSM
+        val resources = generateTestReferences(10) ++ // contains snapshotId "...0006"
+          generateTestReferences(4) ++ // does not contain snapshotId "...0006"
+          generateTestReferences(7) // contains snapshotId "...0006"
+        val batchSize = 5
+
+        // yes we're spying on a mock
+        val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+
+        // search for one of the snapshotIds that should be in the list
+        val criteria = "00000000-0000-0000-0000-000000000006"
+        val found = snapshotService
+          .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+          .gcpDataRepoSnapshots
+
+        found should have size 2
+        found.foreach { x =>
+          x.getAttributes.getSnapshot shouldBe criteria
+        }
+
+        // ensure we paged through the resources properly
+        verify(snapshotService, times(5))
+          .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID),
+                                      any[Int],
+                                      ArgumentMatchers.eq(batchSize)
+          )
+    }
+
+    "return an empty list of snapshot references by referenced snapshotId if multiple pages of references" in withMinimalTestDatabase {
+      _ =>
+        // 10 resources and batchsize of 3 means we should make 4 queries to WSM
+        val resources = generateTestReferences(10)
+        val batchSize = 3
+
+        // yes we're spying on a mock
+        val snapshotService = spy(mockSnapshotServiceForReferences(resources))
+
+        // search for one of the snapshotIds that should be in the list
+        val criteria = "00000000-0000-0000-0000-000000000099"
+        val found = snapshotService
+          .findBySnapshotId(minimalTestData.workspace.workspaceIdAsUUID, UUID.fromString(criteria), 0, 10, batchSize)
+          .gcpDataRepoSnapshots
+
+        found should have size 0
+
+        // ensure we paged through the resources properly
+        verify(snapshotService, times(4))
+          .retrieveSnapshotReferences(ArgumentMatchers.eq(minimalTestData.workspace.workspaceIdAsUUID),
+                                      any[Int],
+                                      ArgumentMatchers.eq(batchSize)
+          )
     }
 
     "return paginated results (first page) when listing snapshot references by referenced snapshotId" in {
@@ -213,9 +329,15 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000002"
-      val found1 = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, pageOffset, pageLimit, Option(UUID.fromString(criteria1))),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found1 = Await
+        .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                   pageOffset,
+                                                   pageLimit,
+                                                   Option(UUID.fromString(criteria1))
+                ),
+                Duration.Inf
+        )
+        .gcpDataRepoSnapshots
 
       found1 should have size 11
       found1.foreach { x =>
@@ -223,7 +345,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       }
     }
 
-    "return paginated results (second page) when listing snapshot references by referenced snapshotId"  in {
+    "return paginated results (second page) when listing snapshot references by referenced snapshotId" in {
       // should result in 25 references to each of four snapshotIds, for a total of 100 references
       val resources: List[ResourceDescription] = (1 to 25).toList flatMap { _ => generateTestReferences(4) }
 
@@ -231,9 +353,15 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // return the first 8 results for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000003"
-      val found1 = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 0, 8, Option(UUID.fromString(criteria1))),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found1 = Await
+        .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                   0,
+                                                   8,
+                                                   Option(UUID.fromString(criteria1))
+                ),
+                Duration.Inf
+        )
+        .gcpDataRepoSnapshots
 
       found1 should have size 8
       found1.foreach { x =>
@@ -241,9 +369,15 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       }
 
       // now, perform the same search but with an offset of 4 and limit of 3
-      val found2 = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, 4, 3, Option(UUID.fromString(criteria1))),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found2 = Await
+        .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                   4,
+                                                   3,
+                                                   Option(UUID.fromString(criteria1))
+                ),
+                Duration.Inf
+        )
+        .gcpDataRepoSnapshots
 
       found2 should have size 3
       found2.foreach { x =>
@@ -255,7 +389,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
     }
 
-    "return paginated results (last page) when listing snapshot references by referenced snapshotId"  in {
+    "return paginated results (last page) when listing snapshot references by referenced snapshotId" in {
       // should result in 25 references to each of four snapshotIds, for a total of 100 references
       val resources: List[ResourceDescription] = (1 to 25).toList flatMap { _ => generateTestReferences(4) }
 
@@ -266,9 +400,15 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // search for one of the snapshotIds that should be duplicated
       val criteria1 = "00000000-0000-0000-0000-000000000002"
-      val found1 = Await.result(
-        snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName, pageOffset, pageLimit, Option(UUID.fromString(criteria1))),
-        Duration.Inf).gcpDataRepoSnapshots
+      val found1 = Await
+        .result(snapshotService.enumerateSnapshots(minimalTestData.workspace.toWorkspaceName,
+                                                   pageOffset,
+                                                   pageLimit,
+                                                   Option(UUID.fromString(criteria1))
+                ),
+                Duration.Inf
+        )
+        .gcpDataRepoSnapshots
 
       found1 should have size 5
       found1.foreach { x =>
@@ -276,10 +416,9 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       }
     }
 
-
   }
 
-  def generateTestReferences(numReferences: Int): List[ResourceDescription] = {
+  def generateTestReferences(numReferences: Int): List[ResourceDescription] =
     (1 to numReferences).toList.map { idx =>
       val paddedIdx = "%08d".format(idx)
 
@@ -302,21 +441,32 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       rd
     }
-  }
 
   def mockSnapshotServiceForReferences(resources: List[ResourceDescription]): SnapshotService = {
     // mock sam that always says we have permission
     val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    when(mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
+    when(
+      mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                               any[String],
+                               any[SamResourceAction],
+                               any[UserInfo]
+      )
+    ).thenReturn(Future.successful(true))
     // mock WorkspaceManagerDAO, don't set up any method responses yet
     val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
 
-    when(mockWorkspaceManagerDAO.enumerateDataRepoSnapshotReferences(any[UUID], any[Int], any[Int], any[RawlsRequestContext]))
-      .thenAnswer{ answer =>
+    when(
+      mockWorkspaceManagerDAO.enumerateDataRepoSnapshotReferences(any[UUID],
+                                                                  any[Int],
+                                                                  any[Int],
+                                                                  any[RawlsRequestContext]
+      )
+    )
+      .thenAnswer { answer =>
         val offset = answer.getArgument[Int](1)
         val limit = answer.getArgument[Int](2)
         val resList = new ResourceList()
-        resList.setResources(resources.slice(offset, offset+limit).asJava)
+        resList.setResources(resources.slice(offset, offset + limit).asJava)
         resList
       }
 
@@ -328,6 +478,5 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     )(testContext)
 
   }
-
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.spendreporting
 
-
 import akka.http.scaladsl.model.StatusCodes
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Option => _, _}
@@ -9,11 +8,11 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.{MockBigQueryServiceFactory, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, model}
+import org.broadinstitute.dsde.rawls.{model, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, when}
+import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
@@ -24,8 +23,12 @@ import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
 
-
-class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent with MockitoSugar with Matchers with MockitoTestUtils {
+class SpendReportingServiceSpec
+    extends AnyFlatSpecLike
+    with TestDriverComponent
+    with MockitoSugar
+    with Matchers
+    with MockitoTestUtils {
   object SpendReportingTestData {
     object Daily {
       val firstRowCost = 2.4
@@ -57,8 +60,44 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
     object Workspace {
       val workspaceGoogleProject1 = "project1"
       val workspaceGoogleProject2 = "project2"
-      val workspace1: Workspace = model.Workspace(testData.billingProject.projectName.value, "workspace1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator", Map.empty, isLocked = false, WorkspaceVersions.V2, GoogleProjectId(workspaceGoogleProject1), None, None, None, None, WorkspaceType.RawlsWorkspace)
-      val workspace2: Workspace = model.Workspace(testData.billingProject.projectName.value, "workspace2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator", Map.empty, isLocked = false, WorkspaceVersions.V2, GoogleProjectId(workspaceGoogleProject2), None, None, None, None, WorkspaceType.RawlsWorkspace)
+      val workspace1: Workspace = model.Workspace(
+        testData.billingProject.projectName.value,
+        "workspace1",
+        UUID.randomUUID().toString,
+        "bucketName",
+        None,
+        DateTime.now,
+        DateTime.now,
+        "creator",
+        Map.empty,
+        isLocked = false,
+        WorkspaceVersions.V2,
+        GoogleProjectId(workspaceGoogleProject1),
+        None,
+        None,
+        None,
+        None,
+        WorkspaceType.RawlsWorkspace
+      )
+      val workspace2: Workspace = model.Workspace(
+        testData.billingProject.projectName.value,
+        "workspace2",
+        UUID.randomUUID().toString,
+        "bucketName",
+        None,
+        DateTime.now,
+        DateTime.now,
+        "creator",
+        Map.empty,
+        isLocked = false,
+        WorkspaceVersions.V2,
+        GoogleProjectId(workspaceGoogleProject2),
+        None,
+        None,
+        None,
+        None,
+        WorkspaceType.RawlsWorkspace
+      )
 
       val firstRowCost = 100.582
       val secondRowCost = 0.10111
@@ -91,7 +130,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
       val otherRowCostRounded: BigDecimal = BigDecimal(otherRowCost).setScale(2, RoundingMode.HALF_EVEN)
       val computeRowCostRounded: BigDecimal = BigDecimal(computeRowCost).setScale(2, RoundingMode.HALF_EVEN)
       val storageRowCostRounded: BigDecimal = BigDecimal(storageRowCost).setScale(2, RoundingMode.HALF_EVEN)
-      val totalCostRounded: BigDecimal = BigDecimal(otherRowCost + computeRowCost + storageRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val totalCostRounded: BigDecimal =
+        BigDecimal(otherRowCost + computeRowCost + storageRowCost).setScale(2, RoundingMode.HALF_EVEN)
 
       val table: List[Map[String, String]] = List(
         Map(
@@ -119,27 +159,72 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
     object SubAggregation {
       val workspaceGoogleProject1 = "project1"
       val workspaceGoogleProject2 = "project2"
-      val workspace1: Workspace = model.Workspace(testData.billingProject.projectName.value, "workspace1", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator", Map.empty, isLocked = false, WorkspaceVersions.V2, GoogleProjectId(workspaceGoogleProject1), None, None, None, None, WorkspaceType.RawlsWorkspace)
-      val workspace2: Workspace = model.Workspace(testData.billingProject.projectName.value, "workspace2", UUID.randomUUID().toString, "bucketName", None, DateTime.now, DateTime.now, "creator", Map.empty, isLocked = false, WorkspaceVersions.V2, GoogleProjectId(workspaceGoogleProject2), None, None, None, None, WorkspaceType.RawlsWorkspace)
+      val workspace1: Workspace = model.Workspace(
+        testData.billingProject.projectName.value,
+        "workspace1",
+        UUID.randomUUID().toString,
+        "bucketName",
+        None,
+        DateTime.now,
+        DateTime.now,
+        "creator",
+        Map.empty,
+        isLocked = false,
+        WorkspaceVersions.V2,
+        GoogleProjectId(workspaceGoogleProject1),
+        None,
+        None,
+        None,
+        None,
+        WorkspaceType.RawlsWorkspace
+      )
+      val workspace2: Workspace = model.Workspace(
+        testData.billingProject.projectName.value,
+        "workspace2",
+        UUID.randomUUID().toString,
+        "bucketName",
+        None,
+        DateTime.now,
+        DateTime.now,
+        "creator",
+        Map.empty,
+        isLocked = false,
+        WorkspaceVersions.V2,
+        GoogleProjectId(workspaceGoogleProject2),
+        None,
+        None,
+        None,
+        None,
+        WorkspaceType.RawlsWorkspace
+      )
 
       val workspace1OtherRowCost = 204.1025
       val workspace1ComputeRowCost = 50.20
       val workspace2StorageRowCost = 2.5
       val workspace2OtherRowCost = 5.10245
 
-      val workspace1OtherRowCostRounded: BigDecimal = BigDecimal(workspace1OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
-      val workspace1ComputeRowCostRounded: BigDecimal = BigDecimal(workspace1ComputeRowCost).setScale(2, RoundingMode.HALF_EVEN)
-      val workspace2StorageRowCostRounded: BigDecimal = BigDecimal(workspace2StorageRowCost).setScale(2, RoundingMode.HALF_EVEN)
-      val workspace2OtherRowCostRounded: BigDecimal = BigDecimal(workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val workspace1OtherRowCostRounded: BigDecimal =
+        BigDecimal(workspace1OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val workspace1ComputeRowCostRounded: BigDecimal =
+        BigDecimal(workspace1ComputeRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val workspace2StorageRowCostRounded: BigDecimal =
+        BigDecimal(workspace2StorageRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val workspace2OtherRowCostRounded: BigDecimal =
+        BigDecimal(workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
 
-      val otherTotalCostRounded: BigDecimal = BigDecimal(workspace1OtherRowCost + workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val otherTotalCostRounded: BigDecimal =
+        BigDecimal(workspace1OtherRowCost + workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
       val storageTotalCostRounded: BigDecimal = workspace2StorageRowCostRounded
       val computeTotalCostRounded: BigDecimal = workspace1ComputeRowCostRounded
 
-      val workspace1TotalCostRounded: BigDecimal = BigDecimal(workspace1OtherRowCost + workspace1ComputeRowCost).setScale(2, RoundingMode.HALF_EVEN)
-      val workspace2TotalCostRounded: BigDecimal = BigDecimal(workspace2StorageRowCost + workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val workspace1TotalCostRounded: BigDecimal =
+        BigDecimal(workspace1OtherRowCost + workspace1ComputeRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val workspace2TotalCostRounded: BigDecimal =
+        BigDecimal(workspace2StorageRowCost + workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
 
-      val totalCostRounded: BigDecimal = BigDecimal(workspace1OtherRowCost + workspace1ComputeRowCost + workspace2StorageRowCost + workspace2OtherRowCost).setScale(2, RoundingMode.HALF_EVEN)
+      val totalCostRounded: BigDecimal = BigDecimal(
+        workspace1OtherRowCost + workspace1ComputeRowCost + workspace2StorageRowCost + workspace2OtherRowCost
+      ).setScale(2, RoundingMode.HALF_EVEN)
 
       val table: List[Map[String, String]] = List(
         Map(
@@ -192,7 +277,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
     val fields: List[Field] = rawFields.map { field =>
       Field.of(field, StandardSQLTypeName.STRING)
     }
-    val schema: Schema = Schema.of(fields:_*)
+    val schema: Schema = Schema.of(fields: _*)
 
     val fieldValues: List[List[FieldValue]] = values.map { row =>
       row.values.toList.map { value =>
@@ -200,7 +285,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
       }
     }
     val fieldValueLists: List[FieldValueList] = fieldValues.map { row =>
-      FieldValueList.of(row.asJava, fields:_*)
+      FieldValueList.of(row.asJava, fields: _*)
     }
     val page: PageImpl[FieldValueList] = new PageImpl[FieldValueList](null, null, fieldValueLists.asJava)
 
@@ -209,43 +294,80 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
 
   val defaultServiceProject: GoogleProject = GoogleProject("project")
   val spendReportingServiceConfig: SpendReportingServiceConfig = SpendReportingServiceConfig(
-    "fakeTable", "fakeTimePartitionColumn", 90
+    "fakeTable",
+    "fakeTimePartitionColumn",
+    90
   )
 
   // Create Spend Reporting Service with Sam and BQ DAOs that mock happy-path responses and return SpendReportingTestData.Workspace.tableResult. Override Sam and BQ responses as needed
   def createSpendReportingService(
-                                   dataSource: SlickDataSource,
-                                   samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
-                                   tableResult: TableResult = SpendReportingTestData.Workspace.tableResult
-                                 ): SpendReportingService = {
-    when(samDAO.userHasAction(SamResourceTypeNames.managedGroup, "Alpha_Spend_Report_Users", SamResourceAction("use"), userInfo))
+    dataSource: SlickDataSource,
+    samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
+    tableResult: TableResult = SpendReportingTestData.Workspace.tableResult
+  ): SpendReportingService = {
+    when(
+      samDAO.userHasAction(SamResourceTypeNames.managedGroup,
+                           "Alpha_Spend_Report_Users",
+                           SamResourceAction("use"),
+                           userInfo
+      )
+    )
       .thenReturn(Future.successful(true))
-    when(samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject), any[String], mockitoEq(SamBillingProjectActions.readSpendReport), mockitoEq(userInfo)))
+    when(
+      samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
+                           any[String],
+                           mockitoEq(SamBillingProjectActions.readSpendReport),
+                           mockitoEq(userInfo)
+      )
+    )
       .thenReturn(Future.successful(true))
     val mockServiceFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult))
 
-    new SpendReportingService(testContext, dataSource, mockServiceFactory.getServiceFromJson("json", defaultServiceProject), samDAO, spendReportingServiceConfig)
+    new SpendReportingService(testContext,
+                              dataSource,
+                              mockServiceFactory.getServiceFromJson("json", defaultServiceProject),
+                              samDAO,
+                              spendReportingServiceConfig
+    )
   }
 
-  "SpendReportingService" should "break down results from Google by day" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.Daily.tableResult)
+  "SpendReportingService" should "break down results from Google by day" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.Daily.tableResult)
 
-    val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily))), Duration.Inf)
-    reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Daily.totalCostRounded.toString
-    val dailyAggregation = reportingResults.spendDetails.headOption.getOrElse(fail("daily results not parsed correctly"))
-    dailyAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Daily
+      val reportingResults = Await.result(
+        service.getSpendForBillingProject(
+          testData.billingProject.projectName,
+          DateTime.now().minusDays(1),
+          DateTime.now(),
+          Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily))
+        ),
+        Duration.Inf
+      )
+      reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Daily.totalCostRounded.toString
+      val dailyAggregation =
+        reportingResults.spendDetails.headOption.getOrElse(fail("daily results not parsed correctly"))
+      dailyAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Daily
 
-    dailyAggregation.spendData.map { spendForDay =>
-      if (spendForDay.startTime.getOrElse(fail("daily results not parsed correctly"))
-        .toLocalDate.equals(SpendReportingTestData.Daily.firstRowDate.toLocalDate)) {
-        spendForDay.cost shouldBe SpendReportingTestData.Daily.firstRowCostRounded.toString
-      } else if (spendForDay.startTime.getOrElse(fail("daily results not parsed correctly"))
-        .toLocalDate.equals(SpendReportingTestData.Daily.secondRowDate.toLocalDate)) {
-        spendForDay.cost shouldBe SpendReportingTestData.Daily.secondRowCostRounded.toString
-      } else {
-        fail(s"unexpected day found in spend results - $spendForDay")
+      dailyAggregation.spendData.map { spendForDay =>
+        if (
+          spendForDay.startTime
+            .getOrElse(fail("daily results not parsed correctly"))
+            .toLocalDate
+            .equals(SpendReportingTestData.Daily.firstRowDate.toLocalDate)
+        ) {
+          spendForDay.cost shouldBe SpendReportingTestData.Daily.firstRowCostRounded.toString
+        } else if (
+          spendForDay.startTime
+            .getOrElse(fail("daily results not parsed correctly"))
+            .toLocalDate
+            .equals(SpendReportingTestData.Daily.secondRowDate.toLocalDate)
+        ) {
+          spendForDay.cost shouldBe SpendReportingTestData.Daily.secondRowCostRounded.toString
+        } else {
+          fail(s"unexpected day found in spend results - $spendForDay")
+        }
       }
-    }
   }
 
   it should "break down results from Google by workspace" in withDefaultTestDatabase { dataSource: SlickDataSource =>
@@ -254,14 +376,24 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
     runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace1))
     runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace2))
 
-    val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))), Duration.Inf)
+    val reportingResults = Await.result(
+      service.getSpendForBillingProject(
+        testData.billingProject.projectName,
+        DateTime.now().minusDays(1),
+        DateTime.now(),
+        Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))
+      ),
+      Duration.Inf
+    )
     reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Workspace.totalCostRounded.toString
-    val workspaceAggregation = reportingResults.spendDetails.headOption.getOrElse(fail("workspace results not parsed correctly"))
+    val workspaceAggregation =
+      reportingResults.spendDetails.headOption.getOrElse(fail("workspace results not parsed correctly"))
 
     workspaceAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Workspace
 
     workspaceAggregation.spendData.map { spendForWorkspace =>
-      val workspaceGoogleProject = spendForWorkspace.googleProjectId.getOrElse(fail("workspace results not parsed correctly")).value
+      val workspaceGoogleProject =
+        spendForWorkspace.googleProjectId.getOrElse(fail("workspace results not parsed correctly")).value
 
       if (workspaceGoogleProject.equals(SpendReportingTestData.Workspace.workspace1.googleProjectId.value)) {
         spendForWorkspace.cost shouldBe SpendReportingTestData.Workspace.firstRowCostRounded.toString
@@ -271,78 +403,129 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
         fail(s"unexpected workspace found in spend results - $spendForWorkspace")
       }
     }
-    workspaceAggregation.spendData.headOption.getOrElse(fail("workspace results not parsed correctly")).googleProjectId shouldBe defined
-    workspaceAggregation.spendData.headOption.getOrElse(fail("workspace results not parsed correctly")).workspace shouldBe defined
+    workspaceAggregation.spendData.headOption
+      .getOrElse(fail("workspace results not parsed correctly"))
+      .googleProjectId shouldBe defined
+    workspaceAggregation.spendData.headOption
+      .getOrElse(fail("workspace results not parsed correctly"))
+      .workspace shouldBe defined
   }
 
-  it should "break down results from Google by Terra spend category" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.Category.tableResult)
+  it should "break down results from Google by Terra spend category" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.Category.tableResult)
 
-    val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category))), Duration.Inf)
-    reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Category.totalCostRounded.toString
-    val categoryAggregation = reportingResults.spendDetails.headOption.getOrElse(fail("workspace results not parsed correctly"))
+      val reportingResults = Await.result(
+        service.getSpendForBillingProject(
+          testData.billingProject.projectName,
+          DateTime.now().minusDays(1),
+          DateTime.now(),
+          Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category))
+        ),
+        Duration.Inf
+      )
+      reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Category.totalCostRounded.toString
+      val categoryAggregation =
+        reportingResults.spendDetails.headOption.getOrElse(fail("workspace results not parsed correctly"))
 
-    categoryAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Category
+      categoryAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Category
 
-    verifyCategoryAggregation(
-      categoryAggregation,
-      expectedComputeCost = SpendReportingTestData.Category.computeRowCostRounded,
-      expectedStorageCost = SpendReportingTestData.Category.storageRowCostRounded,
-      expectedOtherCost = SpendReportingTestData.Category.otherRowCostRounded
-    )
+      verifyCategoryAggregation(
+        categoryAggregation,
+        expectedComputeCost = SpendReportingTestData.Category.computeRowCostRounded,
+        expectedStorageCost = SpendReportingTestData.Category.storageRowCostRounded,
+        expectedOtherCost = SpendReportingTestData.Category.otherRowCostRounded
+      )
   }
 
-  it should "return summary data only if aggregation key is omitted" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.Workspace.tableResult)
+  it should "return summary data only if aggregation key is omitted" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.Workspace.tableResult)
 
-    val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set.empty), Duration.Inf)
-    reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Workspace.totalCostRounded.toString
-    reportingResults.spendDetails shouldBe empty
+      val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName,
+                                                                            DateTime.now().minusDays(1),
+                                                                            DateTime.now(),
+                                                                            Set.empty
+                                          ),
+                                          Duration.Inf
+      )
+      reportingResults.spendSummary.cost shouldBe SpendReportingTestData.Workspace.totalCostRounded.toString
+      reportingResults.spendDetails shouldBe empty
   }
 
   it should "support sub-aggregations" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.SubAggregation.tableResult)
+    val service =
+      createSpendReportingService(dataSource, tableResult = SpendReportingTestData.SubAggregation.tableResult)
 
     runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace1))
     runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace2))
 
-    val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(SpendReportingAggregationKeys.Category)))), Duration.Inf)
-    val topLevelAggregation = reportingResults.spendDetails.headOption.getOrElse(fail("spend results not parsed correctly"))
+    val reportingResults = Await.result(
+      service.getSpendForBillingProject(
+        testData.billingProject.projectName,
+        DateTime.now().minusDays(1),
+        DateTime.now(),
+        Set(
+          SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace,
+                                              Option(SpendReportingAggregationKeys.Category)
+          )
+        )
+      ),
+      Duration.Inf
+    )
+    val topLevelAggregation =
+      reportingResults.spendDetails.headOption.getOrElse(fail("spend results not parsed correctly"))
 
-    withClue("total cost was incorrect"){
+    withClue("total cost was incorrect") {
       reportingResults.spendSummary.cost shouldBe SpendReportingTestData.SubAggregation.totalCostRounded.toString
     }
     verifyWorkspaceCategorySubAggregation(topLevelAggregation)
   }
 
   it should "support multiple aggregations" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource, tableResult = SpendReportingTestData.SubAggregation.tableResult)
+    val service =
+      createSpendReportingService(dataSource, tableResult = SpendReportingTestData.SubAggregation.tableResult)
 
     runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace1))
     runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace2))
 
-    val reportingResults = Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(SpendReportingAggregationKeys.Category)), SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category))), Duration.Inf)
+    val reportingResults = Await.result(
+      service.getSpendForBillingProject(
+        testData.billingProject.projectName,
+        DateTime.now().minusDays(1),
+        DateTime.now(),
+        Set(
+          SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace,
+                                              Option(SpendReportingAggregationKeys.Category)
+          ),
+          SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category)
+        )
+      ),
+      Duration.Inf
+    )
     withClue("total cost was incorrect") {
       reportingResults.spendSummary.cost shouldBe SpendReportingTestData.SubAggregation.totalCostRounded.toString
     }
 
     reportingResults.spendDetails.map {
-      case workspaceAggregation@SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, _) => {
+      case workspaceAggregation @ SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, _) =>
         verifyWorkspaceCategorySubAggregation(workspaceAggregation)
-      }
-      case categoryAggregation@SpendReportingAggregation(SpendReportingAggregationKeys.Category, _) => {
+      case categoryAggregation @ SpendReportingAggregation(SpendReportingAggregationKeys.Category, _) =>
         verifyCategoryAggregation(
           categoryAggregation,
           expectedComputeCost = SpendReportingTestData.SubAggregation.computeTotalCostRounded,
           expectedStorageCost = SpendReportingTestData.SubAggregation.storageTotalCostRounded,
           expectedOtherCost = SpendReportingTestData.SubAggregation.otherTotalCostRounded
         )
-      }
       case _ => fail("unexpected aggregation key found")
     }
   }
 
-  private def verifyCategoryAggregation(categoryAggregation: SpendReportingAggregation, expectedComputeCost: BigDecimal, expectedStorageCost: BigDecimal, expectedOtherCost: BigDecimal) = {
+  private def verifyCategoryAggregation(categoryAggregation: SpendReportingAggregation,
+                                        expectedComputeCost: BigDecimal,
+                                        expectedStorageCost: BigDecimal,
+                                        expectedOtherCost: BigDecimal
+  ) =
     categoryAggregation.spendData.map { spendDataForCategory =>
       val category = spendDataForCategory.category.getOrElse(fail("results not parsed correctly"))
 
@@ -358,7 +541,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
         }
       }
     }
-  }
 
   private def verifyWorkspaceCategorySubAggregation(topLevelAggregation: SpendReportingAggregation) = {
     topLevelAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Workspace
@@ -374,11 +556,15 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
         }
         subAggregation.spendData.map { subAggregatedSpendData =>
           if (subAggregatedSpendData.category == Option(TerraSpendCategories.Compute)) {
-            withClue(s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace1.toWorkspaceName} was incorrect") {
+            withClue(
+              s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace1.toWorkspaceName} was incorrect"
+            ) {
               subAggregatedSpendData.cost shouldBe SpendReportingTestData.SubAggregation.workspace1ComputeRowCostRounded.toString
             }
           } else if (subAggregatedSpendData.category == Option(TerraSpendCategories.Other)) {
-            withClue(s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace1.toWorkspaceName} was incorrect") {
+            withClue(
+              s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace1.toWorkspaceName} was incorrect"
+            ) {
               subAggregatedSpendData.cost shouldBe SpendReportingTestData.SubAggregation.workspace1OtherRowCostRounded.toString
             }
           } else {
@@ -386,17 +572,23 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
           }
         }
 
-      } else if (workspaceGoogleProject.equals(SpendReportingTestData.SubAggregation.workspace2.googleProjectId.value)) {
+      } else if (
+        workspaceGoogleProject.equals(SpendReportingTestData.SubAggregation.workspace2.googleProjectId.value)
+      ) {
         withClue(s"cost for ${SpendReportingTestData.SubAggregation.workspace2.toWorkspaceName} was incorrect") {
           spendData.cost shouldBe SpendReportingTestData.SubAggregation.workspace2TotalCostRounded.toString
         }
         subAggregation.spendData.map { subAggregatedSpendData =>
           if (subAggregatedSpendData.category == Option(TerraSpendCategories.Storage)) {
-            withClue(s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace2.toWorkspaceName} was incorrect") {
+            withClue(
+              s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace2.toWorkspaceName} was incorrect"
+            ) {
               subAggregatedSpendData.cost shouldBe SpendReportingTestData.SubAggregation.workspace2StorageRowCostRounded.toString
             }
           } else if (subAggregatedSpendData.category == Option(TerraSpendCategories.Other)) {
-            withClue(s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace2.toWorkspaceName} was incorrect") {
+            withClue(
+              s"${subAggregatedSpendData.category} category cost for ${SpendReportingTestData.SubAggregation.workspace2.toWorkspaceName} was incorrect"
+            ) {
               subAggregatedSpendData.cost shouldBe SpendReportingTestData.SubAggregation.workspace2OtherRowCostRounded.toString
             }
           } else {
@@ -414,151 +606,226 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with TestDriverComponent
     val service = createSpendReportingService(dataSource, tableResult = emptyTableResult)
 
     val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now()), Duration.Inf)
+      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName,
+                                                     DateTime.now().minusDays(1),
+                                                     DateTime.now()
+                   ),
+                   Duration.Inf
+      )
     }
     e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
   }
 
-  it should "throw an exception when user does not have read_spend_report" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    val service = createSpendReportingService(dataSource, samDAO = samDAO)
+  it should "throw an exception when user does not have read_spend_report" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      val service = createSpendReportingService(dataSource, samDAO = samDAO)
 
-    when(samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject), any[String], mockitoEq(SamBillingProjectActions.readSpendReport), mockitoEq(userInfo)))
-      .thenReturn(Future.successful(false))
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now()), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
-  }
-
-  it should "throw an exception when user is not in alpha group" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    val service = createSpendReportingService(dataSource, samDAO = samDAO)
-
-    when(samDAO.userHasAction(SamResourceTypeNames.managedGroup, "Alpha_Spend_Report_Users", SamResourceAction("use"), userInfo))
-      .thenReturn(Future.successful(false))
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now()), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
-  }
-
-  it should "throw an exception when start date is after end date" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource)
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, startDate = DateTime.now(), endDate = DateTime.now().minusDays(1)), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
-  }
-
-  it should s"throw an exception when date range is larger than ${spendReportingServiceConfig.maxDateRange} days" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource)
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, startDate = DateTime.now().minusDays(spendReportingServiceConfig.maxDateRange + 1), endDate = DateTime.now()), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
-  }
-
-  it should "throw an exception if the billing project cannot be found" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource)
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(RawlsBillingProjectName("fakeProject"), DateTime.now().minusDays(1), DateTime.now()), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
-  }
-
-  it should "throw an exception if the billing project does not have a linked billing account" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val service = createSpendReportingService(dataSource)
-    val projectName = RawlsBillingProjectName("fakeProject")
-    runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.create(RawlsBillingProject(projectName, CreationStatuses.Ready, billingAccount = None, None)))
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(projectName, DateTime.now().minusDays(1), DateTime.now()), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
-  }
-
-  it should "throw an exception if BigQuery returns multiple kinds of currencies" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val cadRow = Map(
-      "cost" -> "0.10111",
-      "credits" -> "0.0",
-      "currency" -> "CAD",
-      "date" -> DateTime.now().toString
-    )
-
-    val internationalTable = createTableResult(cadRow :: SpendReportingTestData.Daily.table)
-
-    val service = createSpendReportingService(dataSource, tableResult = internationalTable)
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now()), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.BadGateway)
-  }
-
-  it should "throw an exception if BigQuery results include an unexpected Google project" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val badRow = Map(
-      "cost" -> "0.10111",
-      "credits" -> "0.0",
-      "currency" -> "USD",
-      "googleProjectId" -> "fakeProject"
-    )
-
-    val badTable = createTableResult(badRow :: SpendReportingTestData.Workspace.table)
-
-    val service = createSpendReportingService(dataSource, tableResult = badTable)
-    runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace1))
-    runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace2))
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getSpendForBillingProject(testData.billingProject.projectName, DateTime.now().minusDays(1), DateTime.now(), Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))), Duration.Inf)
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.BadGateway)
-  }
-
-  it should "use the custom time partition column name if specified" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    val expectedNoCustom =
-      s"""
-         | SELECT
-         |  SUM(cost) as cost,
-         |  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
-         |  currency , project.id as googleProjectId, DATE(_PARTITIONTIME) as date
-         | FROM `fakeTable`
-         | WHERE billing_account_id = @billingAccountId
-         | AND _PARTITIONTIME BETWEEN @startDate AND @endDate
-         | AND project.id in UNNEST(@projects)
-         | GROUP BY currency , googleProjectId, date
-         |""".stripMargin
-    assertResult(expectedNoCustom) {
-      val service = createSpendReportingService(dataSource)
-      service.getQuery(
-        Set(SpendReportingAggregationKeys.Workspace, SpendReportingAggregationKeys.Daily), "fakeTable", None
+      when(
+        samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
+                             any[String],
+                             mockitoEq(SamBillingProjectActions.readSpendReport),
+                             mockitoEq(userInfo)
+        )
       )
-    }
+        .thenReturn(Future.successful(false))
 
-    val expectedCustom =
-      s"""
-         | SELECT
-         |  SUM(cost) as cost,
-         |  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
-         |  currency , project.id as googleProjectId, DATE(custom_time_partition) as date
-         | FROM `fakeTable`
-         | WHERE billing_account_id = @billingAccountId
-         | AND custom_time_partition BETWEEN @startDate AND @endDate
-         | AND project.id in UNNEST(@projects)
-         | GROUP BY currency , googleProjectId, date
-         |""".stripMargin
-    assertResult(expectedCustom) {
-      val service = createSpendReportingService(dataSource)
-      service.getQuery(
-        Set(SpendReportingAggregationKeys.Workspace, SpendReportingAggregationKeys.Daily), "fakeTable",
-        Some("custom_time_partition")
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getSpendForBillingProject(testData.billingProject.projectName,
+                                                       DateTime.now().minusDays(1),
+                                                       DateTime.now()
+                     ),
+                     Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
+  }
+
+  it should "throw an exception when user is not in alpha group" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      val service = createSpendReportingService(dataSource, samDAO = samDAO)
+
+      when(
+        samDAO.userHasAction(SamResourceTypeNames.managedGroup,
+                             "Alpha_Spend_Report_Users",
+                             SamResourceAction("use"),
+                             userInfo
+        )
       )
-    }
+        .thenReturn(Future.successful(false))
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getSpendForBillingProject(testData.billingProject.projectName,
+                                                       DateTime.now().minusDays(1),
+                                                       DateTime.now()
+                     ),
+                     Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
+  }
+
+  it should "throw an exception when start date is after end date" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource)
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getSpendForBillingProject(testData.billingProject.projectName,
+                                                       startDate = DateTime.now(),
+                                                       endDate = DateTime.now().minusDays(1)
+                     ),
+                     Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
+  }
+
+  it should s"throw an exception when date range is larger than ${spendReportingServiceConfig.maxDateRange} days" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource)
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(
+          service.getSpendForBillingProject(testData.billingProject.projectName,
+                                            startDate =
+                                              DateTime.now().minusDays(spendReportingServiceConfig.maxDateRange + 1),
+                                            endDate = DateTime.now()
+          ),
+          Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
+  }
+
+  it should "throw an exception if the billing project cannot be found" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource)
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getSpendForBillingProject(RawlsBillingProjectName("fakeProject"),
+                                                       DateTime.now().minusDays(1),
+                                                       DateTime.now()
+                     ),
+                     Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+  }
+
+  it should "throw an exception if the billing project does not have a linked billing account" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val service = createSpendReportingService(dataSource)
+      val projectName = RawlsBillingProjectName("fakeProject")
+      runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery.create(
+          RawlsBillingProject(projectName, CreationStatuses.Ready, billingAccount = None, None)
+        )
+      )
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getSpendForBillingProject(projectName, DateTime.now().minusDays(1), DateTime.now()),
+                     Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
+  }
+
+  it should "throw an exception if BigQuery returns multiple kinds of currencies" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val cadRow = Map(
+        "cost" -> "0.10111",
+        "credits" -> "0.0",
+        "currency" -> "CAD",
+        "date" -> DateTime.now().toString
+      )
+
+      val internationalTable = createTableResult(cadRow :: SpendReportingTestData.Daily.table)
+
+      val service = createSpendReportingService(dataSource, tableResult = internationalTable)
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getSpendForBillingProject(testData.billingProject.projectName,
+                                                       DateTime.now().minusDays(1),
+                                                       DateTime.now()
+                     ),
+                     Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.BadGateway)
+  }
+
+  it should "throw an exception if BigQuery results include an unexpected Google project" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val badRow = Map(
+        "cost" -> "0.10111",
+        "credits" -> "0.0",
+        "currency" -> "USD",
+        "googleProjectId" -> "fakeProject"
+      )
+
+      val badTable = createTableResult(badRow :: SpendReportingTestData.Workspace.table)
+
+      val service = createSpendReportingService(dataSource, tableResult = badTable)
+      runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace1))
+      runAndWait(dataSource.dataAccess.workspaceQuery.createOrUpdate(SpendReportingTestData.Workspace.workspace2))
+
+      val e = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(
+          service.getSpendForBillingProject(
+            testData.billingProject.projectName,
+            DateTime.now().minusDays(1),
+            DateTime.now(),
+            Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))
+          ),
+          Duration.Inf
+        )
+      }
+      e.errorReport.statusCode shouldBe Option(StatusCodes.BadGateway)
+  }
+
+  it should "use the custom time partition column name if specified" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val expectedNoCustom =
+        s"""
+           | SELECT
+           |  SUM(cost) as cost,
+           |  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
+           |  currency , project.id as googleProjectId, DATE(_PARTITIONTIME) as date
+           | FROM `fakeTable`
+           | WHERE billing_account_id = @billingAccountId
+           | AND _PARTITIONTIME BETWEEN @startDate AND @endDate
+           | AND project.id in UNNEST(@projects)
+           | GROUP BY currency , googleProjectId, date
+           |""".stripMargin
+      assertResult(expectedNoCustom) {
+        val service = createSpendReportingService(dataSource)
+        service.getQuery(
+          Set(SpendReportingAggregationKeys.Workspace, SpendReportingAggregationKeys.Daily),
+          "fakeTable",
+          None
+        )
+      }
+
+      val expectedCustom =
+        s"""
+           | SELECT
+           |  SUM(cost) as cost,
+           |  SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
+           |  currency , project.id as googleProjectId, DATE(custom_time_partition) as date
+           | FROM `fakeTable`
+           | WHERE billing_account_id = @billingAccountId
+           | AND custom_time_partition BETWEEN @startDate AND @endDate
+           | AND project.id in UNNEST(@projects)
+           | GROUP BY currency , googleProjectId, date
+           |""".stripMargin
+      assertResult(expectedCustom) {
+        val service = createSpendReportingService(dataSource)
+        service.getQuery(
+          Set(SpendReportingAggregationKeys.Workspace, SpendReportingAggregationKeys.Daily),
+          "fakeTable",
+          Some("custom_time_partition")
+        )
+      }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -29,14 +29,28 @@ import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with MockitoSugar with BeforeAndAfterAll with Matchers with ScalaFutures {
+class UserServiceSpec
+    extends AnyFlatSpecLike
+    with TestDriverComponent
+    with MockitoSugar
+    with BeforeAndAfterAll
+    with Matchers
+    with ScalaFutures {
   import driver.api._
 
-  val defaultServicePerimeterName: ServicePerimeterName = ServicePerimeterName("accessPolicies/policyName/servicePerimeters/servicePerimeterName")
+  val defaultServicePerimeterName: ServicePerimeterName = ServicePerimeterName(
+    "accessPolicies/policyName/servicePerimeters/servicePerimeterName"
+  )
   val urlEncodedDefaultServicePerimeterName: String = URLEncoder.encode(defaultServicePerimeterName.value, UTF_8.name)
   val defaultGoogleProjectNumber: GoogleProjectNumber = GoogleProjectNumber("42")
   val defaultBillingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("test-bp")
-  val defaultBillingProject: RawlsBillingProject = RawlsBillingProject(defaultBillingProjectName, CreationStatuses.Ready, None, None, googleProjectNumber = Option(defaultGoogleProjectNumber))
+  val defaultBillingProject: RawlsBillingProject = RawlsBillingProject(defaultBillingProjectName,
+                                                                       CreationStatuses.Ready,
+                                                                       None,
+                                                                       None,
+                                                                       googleProjectNumber =
+                                                                         Option(defaultGoogleProjectNumber)
+  )
   val defaultMockSamDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
   val defaultMockGcsDAO: GoogleServicesDAO = new MockGoogleServicesDAO("test")
   val defaultMockServicePerimeterService: ServicePerimeterService = mock[ServicePerimeterService](RETURNS_SMART_NULLS)
@@ -44,19 +58,34 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
 
   val testConf: Config = ConfigFactory.load()
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(1.second)
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(1.second)
 
   override def beforeAll(): Unit = {
-    when(defaultMockSamDAO.userHasAction(SamResourceTypeNames.servicePerimeter, urlEncodedDefaultServicePerimeterName, SamServicePerimeterActions.addProject, userInfo)).thenReturn(Future.successful(true))
-    when(defaultMockSamDAO.userHasAction(SamResourceTypeNames.billingProject, defaultBillingProjectName.value, SamBillingProjectActions.addToServicePerimeter, userInfo)).thenReturn(Future.successful(true))
+    when(
+      defaultMockSamDAO.userHasAction(SamResourceTypeNames.servicePerimeter,
+                                      urlEncodedDefaultServicePerimeterName,
+                                      SamServicePerimeterActions.addProject,
+                                      userInfo
+      )
+    ).thenReturn(Future.successful(true))
+    when(
+      defaultMockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                      defaultBillingProjectName.value,
+                                      SamBillingProjectActions.addToServicePerimeter,
+                                      userInfo
+      )
+    ).thenReturn(Future.successful(true))
   }
 
   def getUserService(dataSource: SlickDataSource,
                      samDAO: SamDAO = defaultMockSamDAO,
                      gcsDAO: GoogleServicesDAO = defaultMockGcsDAO,
                      servicePerimeterService: ServicePerimeterService = defaultMockServicePerimeterService,
-                     adminRegisterBillingAccountId: RawlsBillingAccountName = RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
-                     billingProfileManagerDAO: BillingProfileManagerDAO = defaultBillingProfileManagerDAO): UserService = {
+                     adminRegisterBillingAccountId: RawlsBillingAccountName = RawlsBillingAccountName(
+                       "billingAccounts/ABCDE-FGHIJ-KLMNO"
+                     ),
+                     billingProfileManagerDAO: BillingProfileManagerDAO = defaultBillingProfileManagerDAO
+  ): UserService =
     new UserService(
       testContext,
       dataSource,
@@ -71,7 +100,6 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       adminRegisterBillingAccountId: RawlsBillingAccountName,
       billingProfileManagerDAO
     )
-  }
 
   // 204 when project exists without perimeter and user is owner of project and has right permissions on service-perimeter
   "UserService" should "add a service perimeter field for an existing project when user has correct permissions" in {
@@ -80,18 +108,28 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockServicePerimeterService = mock[ServicePerimeterService](RETURNS_SMART_NULLS)
-      when(mockServicePerimeterService.overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName, dataSource.dataAccess)).thenReturn(DBIO.successful(()))
+      when(
+        mockServicePerimeterService.overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName,
+                                                                       dataSource.dataAccess
+        )
+      ).thenReturn(DBIO.successful(()))
 
       val userService = getUserService(dataSource, servicePerimeterService = mockServicePerimeterService)
 
-      val actual = userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).futureValue
+      val actual =
+        userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).futureValue
       val expected = ()
       actual shouldEqual expected
-      verify(mockServicePerimeterService).overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName, dataSource.dataAccess)
+      verify(mockServicePerimeterService).overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName,
+                                                                             dataSource.dataAccess
+      )
 
-      val updatedProject = dataSource.inTransaction { dataAccess =>
-        dataAccess.rawlsBillingProjectQuery.load(project.projectName)
-      }.futureValue.getOrElse(fail(s"Project ${project.projectName} not found"))
+      val updatedProject = dataSource
+        .inTransaction { dataAccess =>
+          dataAccess.rawlsBillingProjectQuery.load(project.projectName)
+        }
+        .futureValue
+        .getOrElse(fail(s"Project ${project.projectName} not found"))
 
       updatedProject.servicePerimeter shouldBe Option(defaultServicePerimeterName)
     }
@@ -109,23 +147,35 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val googleProject = new Project().setProjectNumber(googleProjectNumber.value.toLong)
       when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(Future.successful(googleProject))
       val folderId = "folders/1234567"
-      when(mockGcsDAO.getFolderId(defaultServicePerimeterName.value.split("/").last)).thenReturn(Future.successful(Option(folderId)))
+      when(mockGcsDAO.getFolderId(defaultServicePerimeterName.value.split("/").last))
+        .thenReturn(Future.successful(Option(folderId)))
       when(mockGcsDAO.addProjectToFolder(project.googleProjectId, folderId)).thenReturn(Future.successful(()))
       when(mockGcsDAO.getGoogleProjectNumber(googleProject)).thenReturn(googleProjectNumber)
 
       val mockServicePerimeterService = mock[ServicePerimeterService](RETURNS_SMART_NULLS)
-      when(mockServicePerimeterService.overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName, dataSource.dataAccess)).thenReturn(DBIO.successful(()))
+      when(
+        mockServicePerimeterService.overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName,
+                                                                       dataSource.dataAccess
+        )
+      ).thenReturn(DBIO.successful(()))
 
-      val userService = getUserService(dataSource, gcsDAO = mockGcsDAO, servicePerimeterService = mockServicePerimeterService)
+      val userService =
+        getUserService(dataSource, gcsDAO = mockGcsDAO, servicePerimeterService = mockServicePerimeterService)
 
-      val actual = userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).futureValue
+      val actual =
+        userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).futureValue
       val expected = ()
       actual shouldEqual expected
-      verify(mockServicePerimeterService).overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName, dataSource.dataAccess)
+      verify(mockServicePerimeterService).overwriteGoogleProjectsInPerimeter(defaultServicePerimeterName,
+                                                                             dataSource.dataAccess
+      )
 
-      val updatedProject = dataSource.inTransaction { dataAccess =>
-        dataAccess.rawlsBillingProjectQuery.load(project.projectName)
-      }.futureValue.getOrElse(fail(s"Project ${project.projectName} not found"))
+      val updatedProject = dataSource
+        .inTransaction { dataAccess =>
+          dataAccess.rawlsBillingProjectQuery.load(project.projectName)
+        }
+        .futureValue
+        .getOrElse(fail(s"Project ${project.projectName} not found"))
 
       updatedProject.servicePerimeter shouldBe Option(defaultServicePerimeterName)
       updatedProject.googleProjectNumber shouldBe Option(googleProjectNumber)
@@ -135,14 +185,19 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
   // 400 when project has a perimeter already
   it should "fail with a 400 when the project already has a perimeter" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val project = defaultBillingProject.copy(servicePerimeter = Option(ServicePerimeterName("accessPolicies/123/servicePerimeters/other_perimeter")))
+      val project = defaultBillingProject.copy(servicePerimeter =
+        Option(ServicePerimeterName("accessPolicies/123/servicePerimeters/other_perimeter"))
+      )
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val userService = getUserService(dataSource)
 
-      val actual = userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
+      val actual =
+        userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
       assert(actual.isInstanceOf[RawlsExceptionWithErrorReport])
-      actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)
+      actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(
+        StatusCodes.BadRequest
+      )
     }
   }
 
@@ -154,9 +209,12 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
 
       val userService = getUserService(dataSource)
 
-      val actual = userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
+      val actual =
+        userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
       assert(actual.isInstanceOf[RawlsExceptionWithErrorReport])
-      actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(StatusCodes.BadRequest)
+      actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(
+        StatusCodes.BadRequest
+      )
     }
   }
 
@@ -167,14 +225,29 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.servicePerimeter, urlEncodedDefaultServicePerimeterName, SamServicePerimeterActions.addProject, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.addToServicePerimeter, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.servicePerimeter,
+                                 urlEncodedDefaultServicePerimeterName,
+                                 SamServicePerimeterActions.addProject,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 project.projectName.value,
+                                 SamBillingProjectActions.addToServicePerimeter,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
-      val actual = userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
+      val actual =
+        userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
       assert(actual.isInstanceOf[RawlsExceptionWithErrorReport])
-      actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(StatusCodes.Forbidden)
+      actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(
+        StatusCodes.Forbidden
+      )
     }
   }
 
@@ -185,12 +258,25 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.servicePerimeter, urlEncodedDefaultServicePerimeterName, SamServicePerimeterActions.addProject, userInfo)).thenReturn(Future.successful(false))
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.addToServicePerimeter, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.servicePerimeter,
+                                 urlEncodedDefaultServicePerimeterName,
+                                 SamServicePerimeterActions.addProject,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 project.projectName.value,
+                                 SamBillingProjectActions.addToServicePerimeter,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
-      val actual = userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
+      val actual =
+        userService.addProjectToServicePerimeter(defaultServicePerimeterName, project.projectName).failed.futureValue
       assert(actual.isInstanceOf[RawlsExceptionWithErrorReport])
       actual.asInstanceOf[RawlsExceptionWithErrorReport].errorReport.statusCode shouldEqual Option(StatusCodes.NotFound)
     }
@@ -205,13 +291,29 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(userIdInfo)))
-      when(mockSamDAO.getPetServiceAccountKeyForUser(project.googleProjectId, userInfo.userEmail)).thenReturn(Future.successful(petSAJson))
-      when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 project.projectName.value,
+                                 SamBillingProjectActions.deleteBillingProject,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+      ).thenReturn(Future.successful(Set(userIdInfo)))
+      when(mockSamDAO.getPetServiceAccountKeyForUser(project.googleProjectId, userInfo.userEmail))
+        .thenReturn(Future.successful(petSAJson))
+      when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+        .thenReturn(
+          Future.successful(
+            Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
+          )
+        )
       when(mockSamDAO.deleteUserPetServiceAccount(project.googleProjectId, userInfo)).thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)).thenReturn(Future.successful())
+      when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+        .thenReturn(Future.successful())
+      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo))
+        .thenReturn(Future.successful())
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       when(mockGcsDAO.getUserInfoUsingJson(petSAJson)).thenReturn(Future.successful(userInfo))
@@ -239,17 +341,34 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(userIdInfo)))
-      when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))))
-      when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)).thenReturn(Future.successful())
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 project.projectName.value,
+                                 SamBillingProjectActions.deleteBillingProject,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+      ).thenReturn(Future.successful(Set(userIdInfo)))
+      when(mockSamDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+        .thenReturn(
+          Future.successful(
+            Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
+          )
+        )
+      when(mockSamDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+        .thenReturn(Future.successful())
+      when(mockSamDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo))
+        .thenReturn(Future.successful())
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(Future.failed(
-        new HttpResponseException.Builder(404, "project not found", new HttpHeaders())
-          .build()
-      ))
+      when(mockGcsDAO.getGoogleProject(project.googleProjectId)).thenReturn(
+        Future.failed(
+          new HttpResponseException.Builder(404, "project not found", new HttpHeaders())
+            .build()
+        )
+      )
 
       val userService = getUserService(dataSource, mockSamDAO, gcsDAO = mockGcsDAO)
       val actual = userService.deleteBillingProject(defaultBillingProjectName).futureValue
@@ -284,7 +403,13 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(workspaceQuery.createOrUpdate(workspace))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 project.projectName.value,
+                                 SamBillingProjectActions.deleteBillingProject,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
@@ -301,7 +426,13 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, defaultBillingProjectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 defaultBillingProjectName.value,
+                                 SamBillingProjectActions.deleteBillingProject,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
@@ -315,19 +446,49 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
   it should "not delete the Google project when unregistering a Billing project" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val project = defaultBillingProject
-      val ownerInfoMap = Map("newOwnerEmail" -> userInfo.userEmail.value, "newOwnerToken" ->  userInfo.accessToken.value)
+      val ownerInfoMap = Map("newOwnerEmail" -> userInfo.userEmail.value, "newOwnerToken" -> userInfo.accessToken.value)
       val ownerIdInfo = UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId"))
-      val ownerUserInfo = UserInfo(RawlsUserEmail(ownerInfoMap("newOwnerEmail")), OAuth2BearerToken(ownerInfoMap("newOwnerToken")), 3600, RawlsUserSubjectId("0"))
+      val ownerUserInfo = UserInfo(RawlsUserEmail(ownerInfoMap("newOwnerEmail")),
+                                   OAuth2BearerToken(ownerInfoMap("newOwnerToken")),
+                                   3600,
+                                   RawlsUserSubjectId("0")
+      )
       val petSAJson = "petJson"
       runAndWait(rawlsBillingProjectQuery.create(project))
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.listResourceChildren(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[UserInfo])).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))))
-      when(mockSamDAO.listAllResourceMemberIds(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[UserInfo])).thenReturn(Future.successful(Set(ownerIdInfo)))
-      when(mockSamDAO.getPetServiceAccountKeyForUser(project.googleProjectId, ownerUserInfo.userEmail)).thenReturn(Future.successful(petSAJson))
-      when(mockSamDAO.deleteUserPetServiceAccount(project.googleProjectId, ownerUserInfo)).thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.googleProject), ArgumentMatchers.eq(project.googleProjectId.value), any[UserInfo])).thenReturn(Future.successful())
-      when(mockSamDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[UserInfo])).thenReturn(Future.successful())
+      when(
+        mockSamDAO.listResourceChildren(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                        ArgumentMatchers.eq(project.projectName.value),
+                                        any[UserInfo]
+        )
+      ).thenReturn(
+        Future.successful(
+          Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
+        )
+      )
+      when(
+        mockSamDAO.listAllResourceMemberIds(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                            ArgumentMatchers.eq(project.projectName.value),
+                                            any[UserInfo]
+        )
+      ).thenReturn(Future.successful(Set(ownerIdInfo)))
+      when(mockSamDAO.getPetServiceAccountKeyForUser(project.googleProjectId, ownerUserInfo.userEmail))
+        .thenReturn(Future.successful(petSAJson))
+      when(mockSamDAO.deleteUserPetServiceAccount(project.googleProjectId, ownerUserInfo))
+        .thenReturn(Future.successful())
+      when(
+        mockSamDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+                                  ArgumentMatchers.eq(project.googleProjectId.value),
+                                  any[UserInfo]
+        )
+      ).thenReturn(Future.successful())
+      when(
+        mockSamDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                  ArgumentMatchers.eq(project.projectName.value),
+                                  any[UserInfo]
+        )
+      ).thenReturn(Future.successful())
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       when(mockGcsDAO.isAdmin(any[String])).thenReturn(Future.successful(true))
@@ -340,7 +501,10 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
 
       verify(mockSamDAO).deleteUserPetServiceAccount(project.googleProjectId, ownerUserInfo)
       verify(mockSamDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, ownerUserInfo)
-      verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, ownerUserInfo)
+      verify(mockSamDAO).deleteResource(SamResourceTypeNames.googleProject,
+                                        project.googleProjectId.value,
+                                        ownerUserInfo
+      )
       verify(mockGcsDAO, never()).deleteV1Project(project.googleProjectId)
 
       runAndWait(rawlsBillingProjectQuery.load(defaultBillingProjectName)) shouldBe empty
@@ -356,15 +520,30 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
-      Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf) shouldEqual 1
+      Await.result(
+        userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+        Duration.Inf
+      ) shouldEqual 1
 
-      val spendReportConfigInDb = runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.filter(_.projectName === billingProject.projectName.value).map(row => (row.spendReportDataset, row.spendReportTable)).result)
+      val spendReportConfigInDb = runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery
+          .filter(_.projectName === billingProject.projectName.value)
+          .map(row => (row.spendReportDataset, row.spendReportTable))
+          .result
+      )
 
-      val spendReportTableName = s"gcp_billing_export_v1_${billingProject.billingAccount.get.value.stripPrefix("billingAccounts/").replace("-", "_")}"
+      val spendReportTableName =
+        s"gcp_billing_export_v1_${billingProject.billingAccount.get.value.stripPrefix("billingAccounts/").replace("-", "_")}"
       spendReportConfigInDb.head shouldEqual (Some(spendReportDatasetName.value), Some(spendReportTableName))
     }
   }
@@ -377,20 +556,34 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf)
+        Await.result(
+          userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+          Duration.Inf
+        )
       }
 
-      //assert that the entire action was forbidden
+      // assert that the entire action was forbidden
       actual.errorReport.statusCode.get shouldEqual StatusCodes.Forbidden
 
-      val spendReportConfigInDb = runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.filter(_.projectName === billingProject.projectName.value).map(row => (row.spendReportDataset, row.spendReportTable)).result)
+      val spendReportConfigInDb = runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery
+          .filter(_.projectName === billingProject.projectName.value)
+          .map(row => (row.spendReportDataset, row.spendReportTable))
+          .result
+      )
 
-      //assert that no change was made to the spend configuration
+      // assert that no change was made to the spend configuration
       spendReportConfigInDb.head shouldEqual (None, None)
     }
   }
@@ -401,13 +594,26 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportDatasetName = BigQueryDatasetName("test_dataset")
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
-      Await.result(userService.clearBillingProjectSpendConfiguration(billingProject.projectName), Duration.Inf) shouldEqual 1
+      Await.result(userService.clearBillingProjectSpendConfiguration(billingProject.projectName),
+                   Duration.Inf
+      ) shouldEqual 1
 
-      val spendReportConfigInDb = runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.filter(_.projectName === billingProject.projectName.value).map(row => (row.spendReportDataset, row.spendReportTable)).result)
+      val spendReportConfigInDb = runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery
+          .filter(_.projectName === billingProject.projectName.value)
+          .map(row => (row.spendReportDataset, row.spendReportTable))
+          .result
+      )
 
       spendReportConfigInDb.head shouldEqual (None, None)
     }
@@ -420,11 +626,24 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportTableName = BigQueryTableName("should_not_clear_table")
       val spendReportGoogleProject = GoogleProject("some_other_google_project")
 
-      //first, directly set the spend configuration in the DB outside of the user's permissions, so we can assert that it wasn't cleared
-      runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.setBillingProjectSpendConfiguration(billingProject.projectName, Some(spendReportDatasetName), Some(spendReportTableName), Some(spendReportGoogleProject)))
+      // first, directly set the spend configuration in the DB outside of the user's permissions, so we can assert that it wasn't cleared
+      runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery.setBillingProjectSpendConfiguration(
+          billingProject.projectName,
+          Some(spendReportDatasetName),
+          Some(spendReportTableName),
+          Some(spendReportGoogleProject)
+        )
+      )
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
@@ -432,12 +651,17 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
         Await.result(userService.clearBillingProjectSpendConfiguration(billingProject.projectName), Duration.Inf)
       }
 
-      //assert that the entire action was forbidden
+      // assert that the entire action was forbidden
       actual.errorReport.statusCode.get shouldEqual StatusCodes.Forbidden
 
-      val spendReportConfigInDb = runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.filter(_.projectName === billingProject.projectName.value).map(row => (row.spendReportDataset, row.spendReportTable)).result)
+      val spendReportConfigInDb = runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery
+          .filter(_.projectName === billingProject.projectName.value)
+          .map(row => (row.spendReportDataset, row.spendReportTable))
+          .result
+      )
 
-      //assert that no change was made to the spend configuration
+      // assert that no change was made to the spend configuration
       spendReportConfigInDb.head shouldEqual (Some(spendReportDatasetName.value), Some(spendReportTableName.value))
     }
   }
@@ -450,12 +674,21 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf)
+        Await.result(
+          userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+          Duration.Inf
+        )
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
@@ -464,7 +697,8 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
 
   it should "throw a RawlsExceptionWithErrorReport when setting the spend configuration if the table does not exist or can't be accessed" in {
     withMinimalTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(RawlsBillingProjectName("project_without_table"), CreationStatuses.Ready, None, None)
+      val billingProject =
+        RawlsBillingProject(RawlsBillingProjectName("project_without_table"), CreationStatuses.Ready, None, None)
       runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject))
 
       val spendReportDatasetName = BigQueryDatasetName("some_dataset")
@@ -472,12 +706,21 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf)
+        Await.result(
+          userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+          Duration.Inf
+        )
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
@@ -486,7 +729,11 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
 
   it should "throw a RawlsExceptionWithErrorReport when setting the spend configuration if the billing project does not have a billing account associated with it" in {
     withMinimalTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(RawlsBillingProjectName("project_without_billing_account"), CreationStatuses.Ready, None, None)
+      val billingProject = RawlsBillingProject(RawlsBillingProjectName("project_without_billing_account"),
+                                               CreationStatuses.Ready,
+                                               None,
+                                               None
+      )
       runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject))
 
       val spendReportDatasetName = BigQueryDatasetName("some_dataset")
@@ -494,12 +741,21 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf)
+        Await.result(
+          userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+          Duration.Inf
+        )
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
@@ -514,12 +770,21 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf)
+        Await.result(
+          userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+          Duration.Inf
+        )
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
@@ -532,22 +797,45 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val billingAccountName = RawlsBillingAccountName("billingAccounts/111111-111111-111111")
       val newBillingAccountRequest = UpdateRawlsBillingAccountRequest(billingAccountName)
 
-      runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccountValidity(billingAccountName, isInvalid = true))
+      runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccountValidity(billingAccountName,
+                                                                                    isInvalid = true
+        )
+      )
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.updateBillingAccount, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, billingProject.projectName.value, userInfo)).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                            billingProject.projectName.value,
+                                            userInfo
+        )
+      ).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo])).thenReturn(Future.successful(true))
+      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
 
-      Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest), Duration.Inf)
+      Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest),
+                   Duration.Inf
+      )
 
-      val spendReportDatasetInDb = runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.filter(_.projectName === billingProject.projectName.value).map(row => (row.spendReportDataset, row.spendReportTable)).result)
+      val spendReportDatasetInDb = runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery
+          .filter(_.projectName === billingProject.projectName.value)
+          .map(row => (row.spendReportDataset, row.spendReportTable))
+          .result
+      )
 
-      //assert that the spend report configuration has been fully cleared
+      // assert that the spend report configuration has been fully cleared
       spendReportDatasetInDb.head shouldEqual (None, None)
       val project = runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
         .getOrElse(fail("project not found"))
@@ -561,8 +849,19 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val billingProject = minimalTestData.billingProject
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.updateBillingAccount, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, billingProject.projectName.value, userInfo)).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                            billingProject.projectName.value,
+                                            userInfo
+        )
+      ).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
 
@@ -570,13 +869,19 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
 
       Await.result(userService.deleteBillingAccount(billingProject.projectName), Duration.Inf)
 
-      val spendReportDatasetInDb = runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.filter(_.projectName === billingProject.projectName.value).map(row => (row.spendReportDataset, row.spendReportTable)).result)
+      val spendReportDatasetInDb = runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery
+          .filter(_.projectName === billingProject.projectName.value)
+          .map(row => (row.spendReportDataset, row.spendReportTable))
+          .result
+      )
 
-      //assert that the spend report configuration has been fully cleared
+      // assert that the spend report configuration has been fully cleared
       spendReportDatasetInDb.head shouldEqual (None, None)
 
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
-        .getOrElse(fail("project not found")).billingAccount shouldEqual None
+        .getOrElse(fail("project not found"))
+        .billingAccount shouldEqual None
     }
   }
 
@@ -587,22 +892,34 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val newBillingAccountRequest = UpdateRawlsBillingAccountRequest(billingAccountName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.updateBillingAccount, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo])).thenReturn(Future.successful(true))
+      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest), Duration.Inf) shouldEqual()
+        Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName,
+                                                                    newBillingAccountRequest
+                     ),
+                     Duration.Inf
+        ) shouldEqual ()
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.Forbidden
 
       // billing account should remain unchanged
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
-        .getOrElse(fail("project not found")).billingAccount shouldEqual billingProject.billingAccount
+        .getOrElse(fail("project not found"))
+        .billingAccount shouldEqual billingProject.billingAccount
     }
   }
 
@@ -613,22 +930,34 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val newBillingAccountRequest = UpdateRawlsBillingAccountRequest(billingAccountName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.updateBillingAccount, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo])).thenReturn(Future.successful(false))
+      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(false))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest), Duration.Inf) shouldEqual()
+        Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName,
+                                                                    newBillingAccountRequest
+                     ),
+                     Duration.Inf
+        ) shouldEqual ()
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
 
       // billing account should remain unchanged
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
-        .getOrElse(fail("project not found")).billingAccount shouldEqual billingProject.billingAccount
+        .getOrElse(fail("project not found"))
+        .billingAccount shouldEqual billingProject.billingAccount
     }
   }
 
@@ -638,22 +967,30 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val billingAccountName = RawlsBillingAccountName("billingAccounts/111111-111111-111111")
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.updateBillingAccount, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo])).thenReturn(Future.successful(true))
+      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.deleteBillingAccount(billingProject.projectName), Duration.Inf) shouldEqual()
+        Await.result(userService.deleteBillingAccount(billingProject.projectName), Duration.Inf) shouldEqual ()
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.Forbidden
 
       // billing account should remain unchanged
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
-        .getOrElse(fail("project not found")).billingAccount shouldEqual billingProject.billingAccount
+        .getOrElse(fail("project not found"))
+        .billingAccount shouldEqual billingProject.billingAccount
     }
   }
 
@@ -664,22 +1001,34 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val newBillingAccountRequest = UpdateRawlsBillingAccountRequest(billingAccountName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.updateBillingAccount, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo])).thenReturn(Future.successful(true))
+      when(mockGcsDAO.testBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest), Duration.Inf) shouldEqual()
+        Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName,
+                                                                    newBillingAccountRequest
+                     ),
+                     Duration.Inf
+        ) shouldEqual ()
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
 
       // billing account should remain unchanged
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
-        .getOrElse(fail("project not found")).billingAccount shouldEqual billingProject.billingAccount
+        .getOrElse(fail("project not found"))
+        .billingAccount shouldEqual billingProject.billingAccount
     }
   }
 
@@ -691,12 +1040,21 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
       val actual = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf)
+        Await.result(
+          userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+          Duration.Inf
+        )
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.BadRequest
@@ -711,14 +1069,30 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val spendReportConfiguration = BillingProjectSpendConfiguration(spendReportGoogleProject, spendReportDatasetName)
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.readSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.readSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
-      Await.result(userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration), Duration.Inf) shouldEqual 1
+      Await.result(
+        userService.setBillingProjectSpendConfiguration(billingProject.projectName, spendReportConfiguration),
+        Duration.Inf
+      ) shouldEqual 1
 
-      val result = Await.result(userService.getBillingProjectSpendConfiguration(billingProject.projectName), Duration.Inf)
+      val result =
+        Await.result(userService.getBillingProjectSpendConfiguration(billingProject.projectName), Duration.Inf)
 
       result shouldEqual Some(spendReportConfiguration)
     }
@@ -729,12 +1103,25 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val billingProject = minimalTestData.billingProject
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.alterSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.readSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.alterSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.readSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
-      val result = Await.result(userService.getBillingProjectSpendConfiguration(billingProject.projectName), Duration.Inf)
+      val result =
+        Await.result(userService.getBillingProjectSpendConfiguration(billingProject.projectName), Duration.Inf)
 
       result shouldEqual None
     }
@@ -745,7 +1132,13 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val billingProject = minimalTestData.billingProject
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, billingProject.projectName.value, SamBillingProjectActions.readSpendReportConfiguration, userInfo)).thenReturn(Future.successful(false))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.readSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
@@ -762,7 +1155,13 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
       val projectName = RawlsBillingProjectName("fake-project")
 
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(mockSamDAO.userHasAction(SamResourceTypeNames.billingProject, projectName.value, SamBillingProjectActions.readSpendReportConfiguration, userInfo)).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 projectName.value,
+                                 SamBillingProjectActions.readSpendReportConfiguration,
+                                 userInfo
+        )
+      ).thenReturn(Future.successful(true))
 
       val userService = getUserService(dataSource, mockSamDAO)
 
@@ -779,7 +1178,7 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
   it should "return the list of billing projects including azure data when enabled" in {
     withMinimalTestDatabase { dataSource =>
       val ownerProject = billingProjectFromName(UUID.randomUUID().toString)
-      val externalProject =  billingProjectFromName(UUID.randomUUID().toString)
+      val externalProject = billingProjectFromName(UUID.randomUUID().toString)
       runAndWait(rawlsBillingProjectQuery.create(ownerProject))
       val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
       val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
@@ -806,12 +1205,13 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
           SamRolesAndActions(Set.empty, Set.empty),
           Set.empty,
           Set.empty
-        ),
+        )
       )
       when(samDAO.listUserResources(SamResourceTypeNames.billingProject, userInfo)).thenReturn(
         Future.successful(userBillingResources)
       )
-      when(bpmDAO.listBillingProfiles(userBillingResources, testContext)).thenReturn(Future.successful(Seq(externalProject)))
+      when(bpmDAO.listBillingProfiles(userBillingResources, testContext))
+        .thenReturn(Future.successful(Seq(externalProject)))
 
       val userService = getUserService(dataSource, samDAO, billingProfileManagerDAO = bpmDAO)
 
@@ -876,10 +1276,11 @@ class UserServiceSpec extends AnyFlatSpecLike with TestDriverComponent with Mock
           SamRolesAndActions(Set.empty, Set.empty),
           Set.empty,
           Set.empty
-        ),
+        )
       )
       val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-      when(samDAO.listUserResources(SamResourceTypeNames.billingProject, userInfo)).thenReturn(Future.successful(userBillingResources))
+      when(samDAO.listUserResources(SamResourceTypeNames.billingProject, userInfo))
+        .thenReturn(Future.successful(userBillingResources))
       val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
       when(bpmDAO.listBillingProfiles(userBillingResources, testContext))
         .thenReturn(Future.successful(Seq.empty))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, model}
+import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
 import org.mockito.{ArgumentMatchers, Mockito}
@@ -26,107 +26,176 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
   import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport._
   import org.broadinstitute.dsde.rawls.model.SpendReportingJsonSupport._
 
-  case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives {
+  case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(
+    implicit override val executionContext: ExecutionContext
+  ) extends ApiServices
+      with MockUserInfoDirectives {
     override val samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    when(samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
-    when(samDAO.addUserToPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), any[String], any[SamResourcePolicyName], any[String], any[UserInfo])).thenReturn(Future.successful(()))
-    when(samDAO.removeUserFromPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), any[String], any[SamResourcePolicyName], any[String], any[UserInfo])).thenReturn(Future.successful(()))
-    when(googleBillingProjectCreator.validateBillingProjectCreationRequest(any[CreateRawlsV2BillingProjectFullRequest], any[RawlsRequestContext]))
+    when(
+      samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                           any[String],
+                           any[SamResourceAction],
+                           any[UserInfo]
+      )
+    ).thenReturn(Future.successful(true))
+    when(
+      samDAO.addUserToPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                             any[String],
+                             any[SamResourcePolicyName],
+                             any[String],
+                             any[UserInfo]
+      )
+    ).thenReturn(Future.successful(()))
+    when(
+      samDAO.removeUserFromPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                  any[String],
+                                  any[SamResourcePolicyName],
+                                  any[String],
+                                  any[UserInfo]
+      )
+    ).thenReturn(Future.successful(()))
+    when(
+      googleBillingProjectCreator.validateBillingProjectCreationRequest(any[CreateRawlsV2BillingProjectFullRequest],
+                                                                        any[RawlsRequestContext]
+      )
+    )
       .thenReturn(Future.successful())
-    when(googleBillingProjectCreator.postCreationSteps(any[CreateRawlsV2BillingProjectFullRequest], any[RawlsRequestContext]))
+    when(
+      googleBillingProjectCreator.postCreationSteps(any[CreateRawlsV2BillingProjectFullRequest],
+                                                    any[RawlsRequestContext]
+      )
+    )
       .thenReturn(Future.successful())
   }
 
-  case class TestApiServiceWithCustomSpendReporting(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO, spendReportingService: SpendReportingService)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives {
+  case class TestApiServiceWithCustomSpendReporting(dataSource: SlickDataSource,
+                                                    gcsDAO: MockGoogleServicesDAO,
+                                                    gpsDAO: MockGooglePubSubDAO,
+                                                    spendReportingService: SpendReportingService
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectives {
     override val spendReportingConstructor: RawlsRequestContext => SpendReportingService =
       _ => spendReportingService
   }
 
-  def withApiServices[T](dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test"))(testCode: TestApiService =>  T): T = {
+  def withApiServices[T](dataSource: SlickDataSource,
+                         gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")
+  )(testCode: TestApiService => T): T = {
     val apiService = TestApiService(dataSource, gcsDAO, new MockGooglePubSubDAO)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withApiServicesAndCustomSpendReporting[T](dataSource: SlickDataSource, spendReportingService: SpendReportingService)(testCode: TestApiServiceWithCustomSpendReporting =>  T): T = {
-    val apiService = TestApiServiceWithCustomSpendReporting(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO, spendReportingService)
-    try {
+  def withApiServicesAndCustomSpendReporting[T](dataSource: SlickDataSource,
+                                                spendReportingService: SpendReportingService
+  )(testCode: TestApiServiceWithCustomSpendReporting => T): T = {
+    val apiService = TestApiServiceWithCustomSpendReporting(dataSource,
+                                                            new MockGoogleServicesDAO("test"),
+                                                            new MockGooglePubSubDAO,
+                                                            spendReportingService
+    )
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withEmptyDatabaseAndApiServices[T](testCode: TestApiService =>  T): T = {
+  def withEmptyDatabaseAndApiServices[T](testCode: TestApiService => T): T =
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def createProject(projectName: String): RawlsBillingProject = {
+  def createProject(projectName: String): RawlsBillingProject =
     runAndWait(rawlsBillingProjectQuery.create(billingProjectFromName(projectName)))
+
+  "PUT /billing/v2/{projectName}/members/user/{email}" should "return 200 when adding a user to a billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("new_project")
+
+      Put(s"/billing/v2/${project.projectName.value}/members/user/${testData.userWriter.userEmail.value}") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+        }
+
+      Put(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userWriter.userEmail.value}") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+        }
   }
 
-  "PUT /billing/v2/{projectName}/members/user/{email}" should "return 200 when adding a user to a billing project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("new_project")
+  it should "return 403 when adding a user to a non-owned billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("no_access")
 
-    Put(s"/billing/v2/${project.projectName.value}/members/user/${testData.userWriter.userEmail.value}") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-      }
+      when(
+        services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                      ArgumentMatchers.eq(project.projectName.value),
+                                      any[SamResourceAction],
+                                      any[UserInfo]
+        )
+      ).thenReturn(Future.successful(false))
 
-    Put(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userWriter.userEmail.value}") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Put(
+        s"/billing/v2/${project.projectName.value}/members/user/${testData.userReader.userEmail.value}"
+      ) ~> services.sealedInstrumentedRoutes ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
         }
-      }
+
+      Put(
+        s"/billing/v2/${project.projectName.value}/members/owner/${testData.userReader.userEmail.value}"
+      ) ~> services.sealedInstrumentedRoutes ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
+        }
   }
 
-  it should "return 403 when adding a user to a non-owned billing project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("no_access")
+  it should "return 400 when adding a nonexistent user to a billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("no_access")
 
-    when(services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(false))
+      when(
+        services.samDAO.addUserToPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          any[SamResourcePolicyName],
+          ArgumentMatchers.eq("nobody"),
+          any[UserInfo]
+        )
+      ).thenReturn(
+        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "user not found")))
+      )
 
-    Put(s"/billing/v2/${project.projectName.value}/members/user/${testData.userReader.userEmail.value}") ~> services.sealedInstrumentedRoutes ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
+      Put(s"/billing/v2/${project.projectName.value}/members/user/nobody") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
-
-    Put(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userReader.userEmail.value}") ~> services.sealedInstrumentedRoutes ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
-        }
-      }
-  }
-
-  it should "return 400 when adding a nonexistent user to a billing project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("no_access")
-
-    when(services.samDAO.addUserToPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[SamResourcePolicyName], ArgumentMatchers.eq("nobody"), any[UserInfo])).thenReturn(
-      Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "user not found"))))
-
-    Put(s"/billing/v2/${project.projectName.value}/members/user/nobody") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
-        }
-      }
   }
 
   it should "return 403 when adding a user to a nonexistent project" in withEmptyDatabaseAndApiServices { services =>
-    when(services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq("missing_project"), any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(false))
+    when(
+      services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                    ArgumentMatchers.eq("missing_project"),
+                                    any[SamResourceAction],
+                                    any[UserInfo]
+      )
+    ).thenReturn(Future.successful(false))
 
     Put(s"/billing/v2/missing_project/members/user/${testData.userOwner.userEmail.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -137,196 +206,347 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       }
   }
 
-  "DELETE /billing/v2/{projectName}/members/user/{email}" should "return 200 when removing a user from a billing project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("new_project")
+  "DELETE /billing/v2/{projectName}/members/user/{email}" should "return 200 when removing a user from a billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("new_project")
 
-    Delete(s"/billing/v2/${project.projectName.value}/members/user/${testData.userWriter.userEmail.value}") ~> services.sealedInstrumentedRoutes ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Delete(
+        s"/billing/v2/${project.projectName.value}/members/user/${testData.userWriter.userEmail.value}"
+      ) ~> services.sealedInstrumentedRoutes ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 403 when removing a user from a non-owned billing project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("no_access")
-    when(services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(false))
+  it should "return 403 when removing a user from a non-owned billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("no_access")
+      when(
+        services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                      ArgumentMatchers.eq(project.projectName.value),
+                                      any[SamResourceAction],
+                                      any[UserInfo]
+        )
+      ).thenReturn(Future.successful(false))
 
-    Delete(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userWriter.userEmail.value}") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
+      Delete(s"/billing/v2/${project.projectName.value}/members/owner/${testData.userWriter.userEmail.value}") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 when removing a nonexistent user from a billing project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("test_good")
-    when(services.samDAO.removeUserFromPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[SamResourcePolicyName], ArgumentMatchers.eq("nobody"), any[UserInfo])).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, ""))))
+  it should "return 400 when removing a nonexistent user from a billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("test_good")
+      when(
+        services.samDAO.removeUserFromPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          any[SamResourcePolicyName],
+          ArgumentMatchers.eq("nobody"),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, ""))))
 
-    Delete(s"/billing/v2/${project.projectName.value}/members/user/nobody") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+      Delete(s"/billing/v2/${project.projectName.value}/members/user/nobody") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 403 when removing a user from a nonexistent billing project" in withEmptyDatabaseAndApiServices { services =>
-    when(services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq("missing_project"), any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(false))
-    Delete(s"/billing/v2/missing_project/members/user/${testData.userOwner.userEmail.value}") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
+  it should "return 403 when removing a user from a nonexistent billing project" in withEmptyDatabaseAndApiServices {
+    services =>
+      when(
+        services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                      ArgumentMatchers.eq("missing_project"),
+                                      any[SamResourceAction],
+                                      any[UserInfo]
+        )
+      ).thenReturn(Future.successful(false))
+      Delete(s"/billing/v2/missing_project/members/user/${testData.userOwner.userEmail.value}") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
         }
-      }
   }
 
-  "POST /billing/v2" should "return 204 when creating a project with accessible billing account" in withEmptyDatabaseAndApiServices { services =>
-    val projectName = RawlsBillingProjectName("test_good")
+  "POST /billing/v2" should "return 204 when creating a project with accessible billing account" in withEmptyDatabaseAndApiServices {
+    services =>
+      val projectName = RawlsBillingProjectName("test_good")
 
-    mockPositiveBillingProjectCreation(services, projectName)
+      mockPositiveBillingProjectCreation(services, projectName)
 
-    Post("/billing/v2", CreateRawlsV2BillingProjectFullRequest(projectName, Some(services.gcsDAO.accessibleBillingAccountName), None, None)) ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      Post("/billing/v2",
+           CreateRawlsV2BillingProjectFullRequest(projectName,
+                                                  Some(services.gcsDAO.accessibleBillingAccountName),
+                                                  None,
+                                                  None
+           )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
+
+          import driver.api._
+          val query: ReadAction[Seq[RawlsBillingProjectRecord]] =
+            rawlsBillingProjectQuery.filter(_.projectName === projectName.value).result
+          val projects: Seq[RawlsBillingProjectRecord] = runAndWait(query)
+          projects match {
+            case Seq()  => fail("project does not exist in db")
+            case Seq(_) =>
+            case _      => fail("too many projects")
+          }
         }
-
-        import driver.api._
-        val query: ReadAction[Seq[RawlsBillingProjectRecord]] = rawlsBillingProjectQuery.filter(_.projectName === projectName.value).result
-        val projects: Seq[RawlsBillingProjectRecord] = runAndWait(query)
-        projects match {
-          case Seq() => fail("project does not exist in db")
-          case Seq(_) =>
-          case _ => fail("too many projects")
-        }
-      }
   }
 
-  it should "return 400 when creating a project with inaccessible to firecloud billing account" in withEmptyDatabaseAndApiServices { services =>
-    val request = CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("test_bad1"), Some(services.gcsDAO.inaccessibleBillingAccountName), None, None)
-    when(services.googleBillingProjectCreator.validateBillingProjectCreationRequest(ArgumentMatchers.any[CreateRawlsV2BillingProjectFullRequest], ArgumentMatchers.any[RawlsRequestContext]))
-      .thenReturn(Future.failed(new GoogleBillingAccountAccessException(ErrorReport(StatusCodes.BadRequest, "failed"))))
+  it should "return 400 when creating a project with inaccessible to firecloud billing account" in withEmptyDatabaseAndApiServices {
+    services =>
+      val request = CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("test_bad1"),
+                                                           Some(services.gcsDAO.inaccessibleBillingAccountName),
+                                                           None,
+                                                           None
+      )
+      when(
+        services.googleBillingProjectCreator.validateBillingProjectCreationRequest(
+          ArgumentMatchers.any[CreateRawlsV2BillingProjectFullRequest],
+          ArgumentMatchers.any[RawlsRequestContext]
+        )
+      )
+        .thenReturn(
+          Future.failed(new GoogleBillingAccountAccessException(ErrorReport(StatusCodes.BadRequest, "failed")))
+        )
 
-    Post("/billing/v2", request) ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.BadRequest, responseAs[String]) {
-          status
+      Post("/billing/v2", request) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.BadRequest, responseAs[String]) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 when creating a project with a name that is too short" in withEmptyDatabaseAndApiServices { services =>
-    Post("/billing/v2", CreateRawlsBillingProjectFullRequest(RawlsBillingProjectName("short"), services.gcsDAO.accessibleBillingAccountName, None, None, None, None)) ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when creating a project with a name that is too short" in withEmptyDatabaseAndApiServices {
+    services =>
+      Post("/billing/v2",
+           CreateRawlsBillingProjectFullRequest(RawlsBillingProjectName("short"),
+                                                services.gcsDAO.accessibleBillingAccountName,
+                                                None,
+                                                None,
+                                                None,
+                                                None
+           )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 when creating a project with a name that is too long" in withEmptyDatabaseAndApiServices { services =>
-    Post("/billing/v2", CreateRawlsBillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"), services.gcsDAO.accessibleBillingAccountName, None, None, None, None)) ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when creating a project with a name that is too long" in withEmptyDatabaseAndApiServices {
+    services =>
+      Post(
+        "/billing/v2",
+        CreateRawlsBillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"),
+                                             services.gcsDAO.accessibleBillingAccountName,
+                                             None,
+                                             None,
+                                             None,
+                                             None
+        )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 when creating a project with a name that contains invalid characters" in withEmptyDatabaseAndApiServices { services =>
-    Post("/billing/v2", CreateRawlsBillingProjectFullRequest(RawlsBillingProjectName("!@#$%^&*()=+,. "), services.gcsDAO.accessibleBillingAccountName, None, None, None, None)) ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when creating a project with a name that contains invalid characters" in withEmptyDatabaseAndApiServices {
+    services =>
+      Post(
+        "/billing/v2",
+        CreateRawlsBillingProjectFullRequest(RawlsBillingProjectName("!@#$%^&*()=+,. "),
+                                             services.gcsDAO.accessibleBillingAccountName,
+                                             None,
+                                             None,
+                                             None,
+                                             None
+        )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  private def mockPositiveBillingProjectCreation(services: TestApiService, projectName: RawlsBillingProjectName): Unit = {
+  private def mockPositiveBillingProjectCreation(services: TestApiService,
+                                                 projectName: RawlsBillingProjectName
+  ): Unit = {
     val policies = BillingProjectOrchestrator.defaultBillingProjectPolicies(testContext)
-    when(services.samDAO.createResourceFull(
-      ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-      ArgumentMatchers.eq(projectName.value),
-      ArgumentMatchers.eq(policies),
-      ArgumentMatchers.eq(Set.empty),
-      any[UserInfo],
-      ArgumentMatchers.eq(None)
-    )).
-      thenReturn(Future.successful(SamCreateResourceResponse(
-        SamResourceTypeNames.billingProject.value,
-        projectName.value,
-        Set.empty,
-        policies.keySet.map(p => SamCreateResourcePolicyResponse(SamCreateResourceAccessPolicyIdResponse(p.value, SamFullyQualifiedResourceId(projectName.value, SamResourceTypeNames.billingProject.value)), s"${p.value}@foo.com")))))
+    when(
+      services.samDAO.createResourceFull(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(projectName.value),
+        ArgumentMatchers.eq(policies),
+        ArgumentMatchers.eq(Set.empty),
+        any[UserInfo],
+        ArgumentMatchers.eq(None)
+      )
+    ).thenReturn(
+      Future.successful(
+        SamCreateResourceResponse(
+          SamResourceTypeNames.billingProject.value,
+          projectName.value,
+          Set.empty,
+          policies.keySet.map(p =>
+            SamCreateResourcePolicyResponse(
+              SamCreateResourceAccessPolicyIdResponse(
+                p.value,
+                SamFullyQualifiedResourceId(projectName.value, SamResourceTypeNames.billingProject.value)
+              ),
+              s"${p.value}@foo.com"
+            )
+          )
+        )
+      )
+    )
 
-    when(services.samDAO.syncPolicyToGoogle(
-      ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-      ArgumentMatchers.eq(projectName.value),
-      ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
-    )).thenReturn(Future.successful(Map(WorkbenchEmail("owner-policy@google.group") -> Seq())))
+    when(
+      services.samDAO.syncPolicyToGoogle(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(projectName.value),
+        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+      )
+    ).thenReturn(Future.successful(Map(WorkbenchEmail("owner-policy@google.group") -> Seq())))
 
-    when(services.googleBillingProjectCreator.validateBillingProjectCreationRequest(any[CreateRawlsV2BillingProjectFullRequest], any[RawlsRequestContext]))
+    when(
+      services.googleBillingProjectCreator
+        .validateBillingProjectCreationRequest(any[CreateRawlsV2BillingProjectFullRequest], any[RawlsRequestContext])
+    )
       .thenReturn(Future.successful())
-    when(services.googleBillingProjectCreator.postCreationSteps(any[CreateRawlsV2BillingProjectFullRequest], any[RawlsRequestContext]))
+    when(
+      services.googleBillingProjectCreator.postCreationSteps(any[CreateRawlsV2BillingProjectFullRequest],
+                                                             any[RawlsRequestContext]
+      )
+    )
       .thenReturn(Future.successful())
   }
 
-  "GET /billing/v2/{projectName}/members" should "return 200 when listing billing project members as owner" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("test_good")
+  "GET /billing/v2/{projectName}/members" should "return 200 when listing billing project members as owner" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("test_good")
 
-    when(services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[UserInfo])).thenReturn(Future.successful(Set(SamBillingProjectActions.readPolicies)))
+      when(
+        services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                                   ArgumentMatchers.eq(project.projectName.value),
+                                                   any[UserInfo]
+        )
+      ).thenReturn(Future.successful(Set(SamBillingProjectActions.readPolicies)))
 
-    when(services.samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[UserInfo])).thenReturn(Future.successful(
-      Set(
-        model.SamPolicyWithNameAndEmail(SamBillingProjectPolicyNames.owner, SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set.empty, Set.empty), WorkbenchEmail("")),
-        model.SamPolicyWithNameAndEmail(SamBillingProjectPolicyNames.workspaceCreator, SamPolicy(Set.empty, Set.empty, Set.empty), WorkbenchEmail(""))
-      )))
+      when(
+        services.samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                                ArgumentMatchers.eq(project.projectName.value),
+                                                any[UserInfo]
+        )
+      ).thenReturn(
+        Future.successful(
+          Set(
+            model.SamPolicyWithNameAndEmail(SamBillingProjectPolicyNames.owner,
+                                            SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)),
+                                                      Set.empty,
+                                                      Set.empty
+                                            ),
+                                            WorkbenchEmail("")
+            ),
+            model.SamPolicyWithNameAndEmail(SamBillingProjectPolicyNames.workspaceCreator,
+                                            SamPolicy(Set.empty, Set.empty, Set.empty),
+                                            WorkbenchEmail("")
+            )
+          )
+        )
+      )
 
-    Get(s"/billing/v2/${project.projectName.value}/members") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Get(s"/billing/v2/${project.projectName.value}/members") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(Seq(RawlsBillingProjectMember(testData.userOwner.userEmail, ProjectRoles.Owner))) {
+            responseAs[Seq[RawlsBillingProjectMember]]
+          }
         }
-        assertResult(Seq(RawlsBillingProjectMember(testData.userOwner.userEmail, ProjectRoles.Owner))) {
-          responseAs[Seq[RawlsBillingProjectMember]]
-        }
-      }
   }
 
-  it should "return 200 when listing billing project members as non-owner" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("no_access")
+  it should "return 200 when listing billing project members as non-owner" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("no_access")
 
-    when(services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[UserInfo])).thenReturn(Future.successful(Set(SamBillingProjectActions.readPolicy(SamBillingProjectPolicyNames.owner))))
-    when(services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(false))
-    when(services.samDAO.getPolicy(ArgumentMatchers.eq(SamResourceTypeNames.billingProject), ArgumentMatchers.eq(project.projectName.value), ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner), any[UserInfo])).thenReturn(Future.successful(SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set.empty, Set.empty)))
+      when(
+        services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                                   ArgumentMatchers.eq(project.projectName.value),
+                                                   any[UserInfo]
+        )
+      ).thenReturn(Future.successful(Set(SamBillingProjectActions.readPolicy(SamBillingProjectPolicyNames.owner))))
+      when(
+        services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                      ArgumentMatchers.eq(project.projectName.value),
+                                      any[SamResourceAction],
+                                      any[UserInfo]
+        )
+      ).thenReturn(Future.successful(false))
+      when(
+        services.samDAO.getPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner),
+          any[UserInfo]
+        )
+      ).thenReturn(
+        Future.successful(SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set.empty, Set.empty))
+      )
 
-    Get(s"/billing/v2/${project.projectName.value}/members") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Get(s"/billing/v2/${project.projectName.value}/members") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(Seq(RawlsBillingProjectMember(testData.userOwner.userEmail, ProjectRoles.Owner))) {
+            responseAs[Seq[RawlsBillingProjectMember]]
+          }
         }
-        assertResult(Seq(RawlsBillingProjectMember(testData.userOwner.userEmail, ProjectRoles.Owner))) {
-          responseAs[Seq[RawlsBillingProjectMember]]
-        }
-      }
   }
 
   "GET /billing/v2/{projectName}" should "return 200 with owner role" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(
-      SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.owner
-    )))
+    when(
+      services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+    ).thenReturn(
+      Future.successful(
+        Set(
+          SamBillingProjectRoles.workspaceCreator,
+          SamBillingProjectRoles.owner
+        )
+      )
+    )
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -349,9 +569,15 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 200 with user role" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(
-      SamBillingProjectRoles.workspaceCreator
-    )))
+    when(
+      services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+    ).thenReturn(
+      Future.successful(
+        Set(
+          SamBillingProjectRoles.workspaceCreator
+        )
+      )
+    )
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -374,7 +600,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 404 if project does not exist" in withEmptyDatabaseAndApiServices { services =>
     val projectName = "does_not_exist"
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName, userInfo)).thenReturn(Future.successful(Set.empty[SamResourceRole]))
+    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName, userInfo))
+      .thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/$projectName") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -387,7 +614,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 404 if user has no access" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set.empty[SamResourceRole]))
+    when(
+      services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+    ).thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -398,34 +627,67 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       }
   }
 
-  "DELETE /billing/v2/{projectName}" should "return 204 - deleting google project" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("project")
-    // wow there are a lot of sam calls in delete billing project
-    when(services.samDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
-    when(services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, None))))
-    when(services.samDAO.getPetServiceAccountKeyForUser(project.googleProjectId, userInfo.userEmail)).thenReturn(Future.successful("petSAJson"))
-    when(services.samDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))))
-    when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId), any[UserInfo])).thenReturn(Future.successful())
-    when(services.samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful())
-    when(services.samDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)).thenReturn(Future.successful())
+  "DELETE /billing/v2/{projectName}" should "return 204 - deleting google project" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("project")
+      // wow there are a lot of sam calls in delete billing project
+      when(
+        services.samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                      project.projectName.value,
+                                      SamBillingProjectActions.deleteBillingProject,
+                                      userInfo
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.billingProject,
+                                                 project.projectName.value,
+                                                 userInfo
+        )
+      ).thenReturn(Future.successful(Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, None))))
+      when(services.samDAO.getPetServiceAccountKeyForUser(project.googleProjectId, userInfo.userEmail))
+        .thenReturn(Future.successful("petSAJson"))
+      when(
+        services.samDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+      ).thenReturn(
+        Future.successful(
+          Seq(SamFullyQualifiedResourceId(project.googleProjectId.value, SamResourceTypeNames.googleProject.value))
+        )
+      )
+      when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId), any[UserInfo]))
+        .thenReturn(Future.successful())
+      when(services.samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+        .thenReturn(Future.successful())
+      when(services.samDAO.deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo))
+        .thenReturn(Future.successful())
 
-    Delete(s"/billing/v2/${project.projectName.value}") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.NoContent, responseAs[String]) {
-          status
+      Delete(s"/billing/v2/${project.projectName.value}") ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.NoContent, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    verify(services.samDAO).deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId), any[UserInfo])
-    verify(services.samDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
-    verify(services.samDAO).deleteResource(SamResourceTypeNames.googleProject, project.googleProjectId.value, userInfo)
+      verify(services.samDAO).deleteUserPetServiceAccount(ArgumentMatchers.eq(project.googleProjectId), any[UserInfo])
+      verify(services.samDAO).deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+      verify(services.samDAO).deleteResource(SamResourceTypeNames.googleProject,
+                                             project.googleProjectId.value,
+                                             userInfo
+      )
   }
   it should "return 204 - without google project" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
-    when(services.samDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
-    when(services.samDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Seq.empty[SamFullyQualifiedResourceId]))
-    when(services.samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful())
+    when(
+      services.samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                    project.projectName.value,
+                                    SamBillingProjectActions.deleteBillingProject,
+                                    userInfo
+      )
+    ).thenReturn(Future.successful(true))
+    when(services.samDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+      .thenReturn(Future.successful(Seq.empty[SamFullyQualifiedResourceId]))
+    when(services.samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+      .thenReturn(Future.successful())
 
     Delete(s"/billing/v2/${project.projectName.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -440,11 +702,32 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 400 if workspaces exist" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
-    runAndWait(workspaceQuery.createOrUpdate(Workspace(project.projectName.value, "workspace", UUID.randomUUID().toString, "", None, new DateTime(), new DateTime(), "", Map.empty)))
+    runAndWait(
+      workspaceQuery.createOrUpdate(
+        Workspace(project.projectName.value,
+                  "workspace",
+                  UUID.randomUUID().toString,
+                  "",
+                  None,
+                  new DateTime(),
+                  new DateTime(),
+                  "",
+                  Map.empty
+        )
+      )
+    )
 
-    when(services.samDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(true))
-    when(services.samDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Seq.empty[SamFullyQualifiedResourceId]))
-    when(services.samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful())
+    when(
+      services.samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                    project.projectName.value,
+                                    SamBillingProjectActions.deleteBillingProject,
+                                    userInfo
+      )
+    ).thenReturn(Future.successful(true))
+    when(services.samDAO.listResourceChildren(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+      .thenReturn(Future.successful(Seq.empty[SamFullyQualifiedResourceId]))
+    when(services.samDAO.deleteResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo))
+      .thenReturn(Future.successful())
 
     Delete(s"/billing/v2/${project.projectName.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -457,7 +740,13 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 403 if user does not have access" in withEmptyDatabaseAndApiServices { services =>
     val project = billingProjectFromName("no_access")
-    when(services.samDAO.userHasAction(SamResourceTypeNames.billingProject, project.projectName.value, SamBillingProjectActions.deleteBillingProject, userInfo)).thenReturn(Future.successful(false))
+    when(
+      services.samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                    project.projectName.value,
+                                    SamBillingProjectActions.deleteBillingProject,
+                                    userInfo
+      )
+    ).thenReturn(Future.successful(false))
 
     Delete(s"/billing/v2/${project.projectName.value}") ~>
       sealRoute(services.billingRoutesV2) ~>
@@ -469,43 +758,64 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
   }
 
   "GET /billing/v2" should "list all my projects with workspaces" in withEmptyDatabaseAndApiServices { services =>
-    val projects = List.fill(20) { createProject(UUID.randomUUID().toString) }
-    val possibleRoles = List(Option(SamBillingProjectRoles.workspaceCreator), Option(SamBillingProjectRoles.owner), None)
+    val projects = List.fill(20)(createProject(UUID.randomUUID().toString))
+    val possibleRoles =
+      List(Option(SamBillingProjectRoles.workspaceCreator), Option(SamBillingProjectRoles.owner), None)
     val samUserResources = projects.flatMap { p =>
       // randomly select a subset of possible roles
       val roles = Random.shuffle(possibleRoles).take(Random.nextInt(possibleRoles.size)).flatten.toSet
       if (roles.isEmpty) {
         None
       } else {
-        Option(SamUserResource(
-          p.projectName.value,
-          SamRolesAndActions(roles, Set.empty),
+        Option(
+          SamUserResource(
+            p.projectName.value,
+            SamRolesAndActions(roles, Set.empty),
+            SamRolesAndActions(Set.empty, Set.empty),
+            SamRolesAndActions(Set.empty, Set.empty),
+            Set.empty,
+            Set.empty
+          )
+        )
+      }
+    }
+    val workspaces = projects.flatMap { project =>
+      val workspaceWithValidBillingAccount =
+        new EmptyWorkspaceWithProjectAndBillingAccount(project, project.billingAccount)
+      val workspaceTwoWithValidBillingAccount =
+        new EmptyWorkspaceWithProjectAndBillingAccount(project, project.billingAccount)
+      val workspaceWithInvalidBillingAccount =
+        new EmptyWorkspaceWithProjectAndBillingAccount(project,
+                                                       Some(RawlsBillingAccountName("invalid-billing-account"))
+        )
+      val workspaceTwoWithInvalidBillingAccount =
+        new EmptyWorkspaceWithProjectAndBillingAccount(project,
+                                                       Some(RawlsBillingAccountName("invalid-billing-account"))
+        )
+      List(workspaceWithValidBillingAccount,
+           workspaceTwoWithValidBillingAccount,
+           workspaceWithInvalidBillingAccount,
+           workspaceTwoWithInvalidBillingAccount
+      )
+    }
+    workspaces.foreach(workspace => runAndWait(workspace.save()))
+    val samWorkspaceUserResources = workspaces.flatMap { w =>
+      Option(
+        SamUserResource(
+          w.wsName.toString,
+          SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
           SamRolesAndActions(Set.empty, Set.empty),
           SamRolesAndActions(Set.empty, Set.empty),
           Set.empty,
-          Set.empty))
-      }
-    }
-    val workspaces = projects.flatMap(project => {
-      val workspaceWithValidBillingAccount = new EmptyWorkspaceWithProjectAndBillingAccount(project, project.billingAccount)
-      val workspaceTwoWithValidBillingAccount = new EmptyWorkspaceWithProjectAndBillingAccount(project, project.billingAccount)
-      val workspaceWithInvalidBillingAccount = new EmptyWorkspaceWithProjectAndBillingAccount(project, Some(RawlsBillingAccountName("invalid-billing-account")))
-      val workspaceTwoWithInvalidBillingAccount = new EmptyWorkspaceWithProjectAndBillingAccount(project, Some(RawlsBillingAccountName("invalid-billing-account")))
-      List(workspaceWithValidBillingAccount, workspaceTwoWithValidBillingAccount, workspaceWithInvalidBillingAccount, workspaceTwoWithInvalidBillingAccount)
-    })
-    workspaces.foreach(workspace => runAndWait(workspace.save()))
-    val samWorkspaceUserResources = workspaces.flatMap { w =>
-      Option(SamUserResource(
-        w.wsName.toString,
-        SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
-        SamRolesAndActions(Set.empty, Set.empty),
-        SamRolesAndActions(Set.empty, Set.empty),
-        Set.empty,
-        Set.empty))
+          Set.empty
+        )
+      )
     }
 
-    when(services.samDAO.listUserResources(SamResourceTypeNames.billingProject, userInfo)).thenReturn(Future.successful(samUserResources))
-    when(services.samDAO.listUserResources(SamResourceTypeNames.workspace, userInfo)).thenReturn(Future.successful(samWorkspaceUserResources))
+    when(services.samDAO.listUserResources(SamResourceTypeNames.billingProject, userInfo))
+      .thenReturn(Future.successful(samUserResources))
+    when(services.samDAO.listUserResources(SamResourceTypeNames.workspace, userInfo))
+      .thenReturn(Future.successful(samWorkspaceUserResources))
 
     val expected = projects.flatMap { p =>
       samUserResources.find(_.resourceId == p.projectName.value).map { samResource =>
@@ -515,7 +825,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           p.servicePerimeter,
           p.invalidBillingAccount,
           samResource.direct.roles.collect {
-            case SamBillingProjectRoles.owner => ProjectRoles.Owner
+            case SamBillingProjectRoles.owner            => ProjectRoles.Owner
             case SamBillingProjectRoles.workspaceCreator => ProjectRoles.User
           },
           p.status,
@@ -535,26 +845,48 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       }
   }
 
-  "PUT /billing/v2/{projectName}/billingAccount" should "update the billing account" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("project")
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(
-      SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.owner
-    )))
-    Put(s"/billing/v2/${project.projectName.value}/billingAccount", UpdateRawlsBillingAccountRequest(services.gcsDAO.accessibleBillingAccountName)) ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.OK, responseAs[String]) {
-          status
+  "PUT /billing/v2/{projectName}/billingAccount" should "update the billing account" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("project")
+      when(
+        services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                                 project.projectName.value,
+                                                 userInfo
+        )
+      ).thenReturn(
+        Future.successful(
+          Set(
+            SamBillingProjectRoles.workspaceCreator,
+            SamBillingProjectRoles.owner
+          )
+        )
+      )
+      Put(s"/billing/v2/${project.projectName.value}/billingAccount",
+          UpdateRawlsBillingAccountRequest(services.gcsDAO.accessibleBillingAccountName)
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.OK, responseAs[String]) {
+            status
+          }
         }
-      }
   }
 
   it should "fail to update if given inaccessible billing account" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(
-      SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.owner
-    )))
-    Put(s"/billing/v2/${project.projectName.value}/billingAccount", UpdateRawlsBillingAccountRequest(services.gcsDAO.inaccessibleBillingAccountName)) ~>
+    when(
+      services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)
+    ).thenReturn(
+      Future.successful(
+        Set(
+          SamBillingProjectRoles.workspaceCreator,
+          SamBillingProjectRoles.owner
+        )
+      )
+    )
+    Put(s"/billing/v2/${project.projectName.value}/billingAccount",
+        UpdateRawlsBillingAccountRequest(services.gcsDAO.inaccessibleBillingAccountName)
+    ) ~>
       sealRoute(services.billingRoutesV2) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
@@ -563,68 +895,133 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       }
   }
 
-  "DELETE /billing/v2/{projectName}/billingAccount" should "clear the billing account field" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("project")
-    when(services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, userInfo)).thenReturn(Future.successful(Set(
-      SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.owner
-    )))
-    Delete(s"/billing/v2/${project.projectName.value}/billingAccount") ~>
-      sealRoute(services.billingRoutesV2) ~>
-      check {
-        assertResult(StatusCodes.OK, responseAs[String]) {
-          status
-        }
-      }
-  }
-
-  "GET /billing/v2/{projectName}/spendReport" should "200 and return only summary information when aggregation key is not present" in withEmptyTestDatabase { dataSource: SlickDataSource =>
-    val mockSpendReportingService = mock[SpendReportingService](RETURNS_SMART_NULLS)
-    // if the API service does not parse parameters and call the spendReportingService correctly, test will fail
-    when(mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName], any[DateTime], any[DateTime], any[Set[SpendReportingAggregationKeyWithSub]]))
-      .thenReturn(Future.failed(new RawlsException("parameters were not parsed correctly")))
-    when(mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName], any[DateTime], any[DateTime], ArgumentMatchers.eq(Set.empty)))
-      .thenReturn(Future.successful(SpendReportingResults(Seq.empty, SpendReportingForDateRange("0.0", "0.0", "USD", Option(DateTime.now()), Option(DateTime.now())))))
-
-    withApiServicesAndCustomSpendReporting(dataSource, mockSpendReportingService) { services =>
+  "DELETE /billing/v2/{projectName}/billingAccount" should "clear the billing account field" in withEmptyDatabaseAndApiServices {
+    services =>
       val project = createProject("project")
-
-      Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-03-06&endDate=2022-03-07") ~>
+      when(
+        services.samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                                 project.projectName.value,
+                                                 userInfo
+        )
+      ).thenReturn(
+        Future.successful(
+          Set(
+            SamBillingProjectRoles.workspaceCreator,
+            SamBillingProjectRoles.owner
+          )
+        )
+      )
+      Delete(s"/billing/v2/${project.projectName.value}/billingAccount") ~>
         sealRoute(services.billingRoutesV2) ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
           }
-
-          verify(mockSpendReportingService, times(1)).getSpendForBillingProject(any[RawlsBillingProjectName], any[DateTime], any[DateTime], ArgumentMatchers.eq(Set.empty))
         }
-    }
+  }
+
+  "GET /billing/v2/{projectName}/spendReport" should "200 and return only summary information when aggregation key is not present" in withEmptyTestDatabase {
+    dataSource: SlickDataSource =>
+      val mockSpendReportingService = mock[SpendReportingService](RETURNS_SMART_NULLS)
+      // if the API service does not parse parameters and call the spendReportingService correctly, test will fail
+      when(
+        mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName],
+                                                            any[DateTime],
+                                                            any[DateTime],
+                                                            any[Set[SpendReportingAggregationKeyWithSub]]
+        )
+      )
+        .thenReturn(Future.failed(new RawlsException("parameters were not parsed correctly")))
+      when(
+        mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName],
+                                                            any[DateTime],
+                                                            any[DateTime],
+                                                            ArgumentMatchers.eq(Set.empty)
+        )
+      )
+        .thenReturn(
+          Future.successful(
+            SpendReportingResults(
+              Seq.empty,
+              SpendReportingForDateRange("0.0", "0.0", "USD", Option(DateTime.now()), Option(DateTime.now()))
+            )
+          )
+        )
+
+      withApiServicesAndCustomSpendReporting(dataSource, mockSpendReportingService) { services =>
+        val project = createProject("project")
+
+        Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-03-06&endDate=2022-03-07") ~>
+          sealRoute(services.billingRoutesV2) ~>
+          check {
+            assertResult(StatusCodes.OK, responseAs[String]) {
+              status
+            }
+
+            verify(mockSpendReportingService, times(1)).getSpendForBillingProject(any[RawlsBillingProjectName],
+                                                                                  any[DateTime],
+                                                                                  any[DateTime],
+                                                                                  ArgumentMatchers.eq(Set.empty)
+            )
+          }
+      }
   }
 
   it should "200 and parse aggregation keys" in withEmptyTestDatabase { dataSource: SlickDataSource =>
     val mockSpendReportingService = mock[SpendReportingService](RETURNS_SMART_NULLS)
     val expectedAggregationKeys = Set(
-      SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(SpendReportingAggregationKeys.Daily)),
+      SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace,
+                                          Option(SpendReportingAggregationKeys.Daily)
+      ),
       SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category),
-      SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category, Option(SpendReportingAggregationKeys.Category))
+      SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category,
+                                          Option(SpendReportingAggregationKeys.Category)
+      )
     )
     // if the API service does not parse parameters and call the spendReportingService correctly, test will fail
-    when(mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName], any[DateTime], any[DateTime], any[Set[SpendReportingAggregationKeyWithSub]]))
+    when(
+      mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName],
+                                                          any[DateTime],
+                                                          any[DateTime],
+                                                          any[Set[SpendReportingAggregationKeyWithSub]]
+      )
+    )
       .thenReturn(Future.failed(new RawlsException("parameters were not parsed correctly")))
     // we don't care about what it actually returns in this test, just that the mocked service is called correctly
-    when(mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName], any[DateTime], any[DateTime], ArgumentMatchers.eq(expectedAggregationKeys)))
-      .thenReturn(Future.successful(SpendReportingResults(Seq.empty, SpendReportingForDateRange("0.0", "0.0", "USD", Option(DateTime.now()), Option(DateTime.now())))))
+    when(
+      mockSpendReportingService.getSpendForBillingProject(any[RawlsBillingProjectName],
+                                                          any[DateTime],
+                                                          any[DateTime],
+                                                          ArgumentMatchers.eq(expectedAggregationKeys)
+      )
+    )
+      .thenReturn(
+        Future.successful(
+          SpendReportingResults(
+            Seq.empty,
+            SpendReportingForDateRange("0.0", "0.0", "USD", Option(DateTime.now()), Option(DateTime.now()))
+          )
+        )
+      )
 
     withApiServicesAndCustomSpendReporting(dataSource, mockSpendReportingService) { services =>
       val project = createProject("project")
 
-      Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-03-06&endDate=2022-03-07&aggregationKey=Workspace~Daily&aggregationKey=Category&aggregationKey=Category~Category") ~>
+      Get(
+        s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-03-06&endDate=2022-03-07&aggregationKey=Workspace~Daily&aggregationKey=Category&aggregationKey=Category~Category"
+      ) ~>
         sealRoute(services.billingRoutesV2) ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
           }
 
-          verify(mockSpendReportingService, times(1)).getSpendForBillingProject(any[RawlsBillingProjectName], any[DateTime], any[DateTime], ArgumentMatchers.eq(expectedAggregationKeys))
+          verify(mockSpendReportingService, times(1)).getSpendForBillingProject(
+            any[RawlsBillingProjectName],
+            any[DateTime],
+            any[DateTime],
+            ArgumentMatchers.eq(expectedAggregationKeys)
+          )
         }
     }
   }
@@ -644,7 +1041,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
   it should "400 when unsupported aggregation keys are given" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
 
-    Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=Fake&aggregationKey=Workspace~bad") ~>
+    Get(
+      s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=Fake&aggregationKey=Workspace~bad"
+    ) ~>
       sealRoute(services.billingRoutesV2) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
@@ -656,7 +1055,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
   it should "400 when incorrectly formatted aggregation keys are given" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
 
-    Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=Category-Workspace") ~>
+    Get(
+      s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=Category-Workspace"
+    ) ~>
       sealRoute(services.billingRoutesV2) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {
@@ -668,7 +1069,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
   it should "400 when too many sub aggregations are provided" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
 
-    Get(s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=aggregationKey=Category~Workspace~Daily") ~>
+    Get(
+      s"/billing/v2/${project.projectName.value}/spendReport?startDate=2022-02-03&endDate=2022-02-04&aggregationKey=aggregationKey=Category~Workspace~Daily"
+    ) ~>
       sealRoute(services.billingRoutesV2) ~>
       check {
         assertResult(StatusCodes.BadRequest, responseAs[String]) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -31,87 +31,118 @@ import scala.util.Random
  */
 class EntityApiServiceSpec extends ApiServiceSpec {
 
-  case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives
-  case class TestApiServiceForAuthDomains(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives {
+  case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(
+    implicit override val executionContext: ExecutionContext
+  ) extends ApiServices
+      with MockUserInfoDirectives
+  case class TestApiServiceForAuthDomains(dataSource: SlickDataSource,
+                                          gcsDAO: MockGoogleServicesDAO,
+                                          gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectives {
     override val samDAO: MockSamDAOForAuthDomains = new MockSamDAOForAuthDomains(dataSource)
   }
-  case class TestApiServiceForMockedEntityService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectives {
+  case class TestApiServiceForMockedEntityService(dataSource: SlickDataSource,
+                                                  gcsDAO: MockGoogleServicesDAO,
+                                                  gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectives {
     val service = mock[EntityService]
     override val entityServiceConstructor = RawlsRequestContext => service
-    when(service.entityTypeMetadata(any[WorkspaceName], any[Option[DataReferenceName]], any[Option[GoogleProjectId]], any[Boolean]))
-      .thenReturn(Future.successful(Map("Test" -> EntityTypeMetadata(5000, "for-test", List("Attribute1", "Attribute2")))))
+    when(
+      service.entityTypeMetadata(any[WorkspaceName],
+                                 any[Option[DataReferenceName]],
+                                 any[Option[GoogleProjectId]],
+                                 any[Boolean]
+      )
+    )
+      .thenReturn(
+        Future.successful(Map("Test" -> EntityTypeMetadata(5000, "for-test", List("Attribute1", "Attribute2"))))
+      )
 
   }
 
   class MockSamDAOForAuthDomains(slickDataSource: SlickDataSource) extends MockSamDAO(slickDataSource) {
     val authDomains = new TrieMap[(SamResourceTypeName, String), Set[String]]()
 
-    override def createResourceFull(resourceTypeName: SamResourceTypeName, resourceId: String, policies: Map[SamResourcePolicyName, SamPolicy], authDomain: Set[String], userInfo: UserInfo, parent: Option[SamFullyQualifiedResourceId]): Future[SamCreateResourceResponse] = {
+    override def createResourceFull(resourceTypeName: SamResourceTypeName,
+                                    resourceId: String,
+                                    policies: Map[SamResourcePolicyName, SamPolicy],
+                                    authDomain: Set[String],
+                                    userInfo: UserInfo,
+                                    parent: Option[SamFullyQualifiedResourceId]
+    ): Future[SamCreateResourceResponse] = {
       authDomains.put((resourceTypeName, resourceId), authDomain)
       super.createResourceFull(resourceTypeName, resourceId, policies, authDomain, userInfo, parent)
     }
 
-    override def getResourceAuthDomain(resourceTypeName: SamResourceTypeName, resourceId: String, userInfo: UserInfo): Future[Seq[String]] = {
+    override def getResourceAuthDomain(resourceTypeName: SamResourceTypeName,
+                                       resourceId: String,
+                                       userInfo: UserInfo
+    ): Future[Seq[String]] =
       Future.successful(authDomains.getOrElse((resourceTypeName, resourceId), Set.empty).toSeq)
-    }
   }
 
   def withApiServices[T](dataSource: SlickDataSource)(testCode: TestApiService => T): T = {
     val apiService = new TestApiService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
   def withApiServicesForAuthDomains[T](dataSource: SlickDataSource)(testCode: TestApiServiceForAuthDomains => T): T = {
-    val apiService = new TestApiServiceForAuthDomains(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+    val apiService =
+      new TestApiServiceForAuthDomains(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withApiServicesMockedEntityService[T](dataSource: SlickDataSource)(testCode: TestApiServiceForMockedEntityService => T): T = {
-    val apiService = TestApiServiceForMockedEntityService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+  def withApiServicesMockedEntityService[T](
+    dataSource: SlickDataSource
+  )(testCode: TestApiServiceForMockedEntityService => T): T = {
+    val apiService =
+      TestApiServiceForMockedEntityService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withTestDataApiServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withEmptyDatabaseApiServicesForAuthDomains[T](testCode: TestApiServiceForAuthDomains => T): T = {
+  def withEmptyDatabaseApiServicesForAuthDomains[T](testCode: TestApiServiceForAuthDomains => T): T =
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       withApiServicesForAuthDomains(dataSource)(testCode)
     }
-  }
 
-  def withConstantTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withConstantTestDataApiServices[T](testCode: TestApiService => T): T =
     withConstantTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withMockedEntityService[T](testCode: TestApiServiceForMockedEntityService => T): T = {
+  def withMockedEntityService[T](testCode: TestApiServiceForMockedEntityService => T): T =
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       withApiServicesMockedEntityService(dataSource)(testCode)
     }
-  }
 
-  def dbId(ent: Entity): Long = runAndWait(entityQuery.getEntityRecords(testData.workspace.workspaceIdAsUUID, Set(ent.toReference))).head.id
-  def dbName(id: Long): String = runAndWait(entityQuery.getEntities(testData.workspace.workspaceIdAsUUID, Seq(id))).head._2.name
+  def dbId(ent: Entity): Long = runAndWait(
+    entityQuery.getEntityRecords(testData.workspace.workspaceIdAsUUID, Set(ent.toReference))
+  ).head.id
+  def dbName(id: Long): String = runAndWait(
+    entityQuery.getEntities(testData.workspace.workspaceIdAsUUID, Seq(id))
+  ).head._2.name
 
   def entityOfSize(size: Long) = {
-    val json = s"""[{"name":"${"0" * (size - 56).toInt}","entityType":"participant","operations":[]}]""" //template already includes 56 bytes, subtract that from repeated string
+    val json =
+      s"""[{"name":"${"0" * (size - 56).toInt}","entityType":"participant","operations":[]}]""" // template already includes 56 bytes, subtract that from repeated string
 
     assert(json.getBytes.length == size)
 
@@ -141,8 +172,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         services.sealedInstrumentedRoutes ~>
         check {
           assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
-      }
-    } {capturedMetrics =>
+        }
+    } { capturedMetrics =>
       val AttributeEntityReference(eType, _) = testData.sample2.toReference
       val postPath = s"workspaces.redacted.redacted.entities.$eType.redacted.rename"
       val getPath = s"workspaces.redacted.redacted"
@@ -154,7 +185,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "update the workspace last modified date on entity update" in withTestDataApiServices { services =>
-    Patch(testData.sample2.path(testData.workspace), httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation))) ~>
+    Patch(
+      testData.sample2.path(testData.workspace),
+      httpJson(
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
@@ -169,9 +205,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "update the workspace last modified date on entity post and copy" in withTestDataApiServices { services =>
-
     val attributeList = AttributeValueList(Seq(AttributeString("a"), AttributeString("b"), AttributeString("c")))
-    val z1 = Entity("z1", "Sample", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3), AttributeName.withDefaultNS("splat") -> attributeList))
+    val z1 = Entity(
+      "z1",
+      "Sample",
+      Map(
+        AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+        AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+        AttributeName.withDefaultNS("splat") -> attributeList
+      )
+    )
     val workspaceSrcName = new WorkspaceName(testData.wsName.namespace, testData.wsName.name + "_copy_source")
     val workspaceSrcRequest = WorkspaceRequest(
       workspace2Name.namespace,
@@ -224,15 +267,30 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "update the workspace last modified date on entity batchUpsert" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz"))))
+    val update1 = EntityUpdateDefinition(
+      testData.sample1.name,
+      testData.sample1.entityType,
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")))
+    )
+    val update2 = EntityUpdateDefinition(
+      testData.sample2.name,
+      testData.sample2.entityType,
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
+    )
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
         }
-        assertResult(Some(Entity(testData.sample1.name, testData.sample1.entityType, testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))))) {
+        assertResult(
+          Some(
+            Entity(testData.sample1.name,
+                   testData.sample1.entityType,
+                   testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))
+            )
+          )
+        ) {
           runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
         }
       }
@@ -243,42 +301,56 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow an entity of the max content size to be consumed by batchUpsert" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/batchUpsert", entityOfSize(services.batchUpsertMaxBytes)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        //under the hood this will throw a 500. that's expected because the entity name is larger than the DB allows.
-        //all we care about for this test is that we do not hit a Payload Too Large error
-        assert(status != StatusCodes.PayloadTooLarge)
-      }
+  it should "allow an entity of the max content size to be consumed by batchUpsert" in withTestDataApiServices {
+    services =>
+      Post(s"${testData.workspace.path}/entities/batchUpsert", entityOfSize(services.batchUpsertMaxBytes)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          // under the hood this will throw a 500. that's expected because the entity name is larger than the DB allows.
+          // all we care about for this test is that we do not hit a Payload Too Large error
+          assert(status != StatusCodes.PayloadTooLarge)
+        }
   }
 
-  it should "not allow an entity larger than the max content size to be consumed by batchUpsert" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/batchUpsert", entityOfSize(services.batchUpsertMaxBytes + 1)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.PayloadTooLarge) {
-          status
+  it should "not allow an entity larger than the max content size to be consumed by batchUpsert" in withTestDataApiServices {
+    services =>
+      Post(s"${testData.workspace.path}/entities/batchUpsert", entityOfSize(services.batchUpsertMaxBytes + 1)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.PayloadTooLarge) {
+            status
+          }
         }
-      }
   }
 
   it should "update the workspace last modified date on entity batchUpdate" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar"))))
+    val update1 = EntityUpdateDefinition(
+      testData.sample1.name,
+      testData.sample1.entityType,
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")))
+    )
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
         }
-        assertResult(Some(Entity(testData.sample1.name, testData.sample1.entityType, testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))))) {
+        assertResult(
+          Some(
+            Entity(testData.sample1.name,
+                   testData.sample1.entityType,
+                   testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))
+            )
+          )
+        ) {
           runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
         }
       }
     Get(testData.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)      }
+        assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
+      }
   }
 
   it should "return 201 on create entity" in withTestDataApiServices { services =>
@@ -299,7 +371,11 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
         // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(newSample.path(testData.workspace)))))) {
+        assertResult(
+          Some(
+            Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(newSample.path(testData.workspace))))
+          )
+        ) {
           header("Location")
         }
       }
@@ -323,7 +399,11 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
         // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(newSample.path(testData.workspace)))))) {
+        assertResult(
+          Some(
+            Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(newSample.path(testData.workspace))))
+          )
+        ) {
           header("Location")
         }
       }
@@ -376,32 +456,36 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   List("default", "tag", "pfb", "import", "system", "sys", "tdr") foreach { namespace =>
-    it should s"return 201 on create entity with [$namespace]-namespaced attributes" in withTestDataApiServices { services =>
-      val newSample = Entity("sampleNew", "sample", Map(AttributeName(namespace, "attribute") -> AttributeString("foo")))
+    it should s"return 201 on create entity with [$namespace]-namespaced attributes" in withTestDataApiServices {
+      services =>
+        val newSample =
+          Entity("sampleNew", "sample", Map(AttributeName(namespace, "attribute") -> AttributeString("foo")))
 
-      Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-        sealRoute(services.entityRoutes) ~>
-        check {
-          assertResult(StatusCodes.Created) {
-            status
+        Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
+          sealRoute(services.entityRoutes) ~>
+          check {
+            assertResult(StatusCodes.Created) {
+              status
+            }
           }
-        }
     }
   }
   List("defaultX", "library", " tag", "bfp", "imp", "TDR", "xxx", "") foreach { namespace =>
-    it should s"return 403 on create entity with [$namespace]-namespaced attributes" in withTestDataApiServices { services =>
-      val newSample = Entity("sampleNew", "sample", Map(AttributeName(namespace, "attribute") -> AttributeString("foo")))
+    it should s"return 403 on create entity with [$namespace]-namespaced attributes" in withTestDataApiServices {
+      services =>
+        val newSample =
+          Entity("sampleNew", "sample", Map(AttributeName(namespace, "attribute") -> AttributeString("foo")))
 
-      Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
-        sealRoute(services.entityRoutes) ~>
-        check {
-          assertResult(StatusCodes.Forbidden) {
-            status
+        Post(s"${testData.workspace.path}/entities", httpJson(newSample)) ~>
+          sealRoute(services.entityRoutes) ~>
+          check {
+            assertResult(StatusCodes.Forbidden) {
+              status
+            }
+
+            val errorText = responseAs[ErrorReport].message
+            assert(errorText.contains(namespace))
           }
-
-          val errorText = responseAs[ErrorReport].message
-          assert(errorText.contains(namespace))
-        }
     }
   }
 
@@ -498,78 +582,80 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assertResult(activeAttributeCount1)(activeAttributeCount2)
   }
 
+  it should "return 204 on entity delete covering all references including cycles" in withTestDataApiServices {
+    services =>
+      val (entityCount1, attributeCount1) = countEntitiesAttrs(testData.workspace)
+      val (activeEntityCount1, activeAttributeCount1) = countActiveEntitiesAttrs(testData.workspace)
 
-  it should "return 204 on entity delete covering all references including cycles" in withTestDataApiServices { services =>
-    val (entityCount1, attributeCount1) = countEntitiesAttrs(testData.workspace)
-    val (activeEntityCount1, activeAttributeCount1) = countActiveEntitiesAttrs(testData.workspace)
+      val e1 = Entity("e1", "Generic", Map.empty)
+      val e2 = Entity("e2", "Generic", Map(AttributeName.withDefaultNS("link") -> e1.toReference))
+      val e3 = Entity("e3", "Generic", Map(AttributeName.withDefaultNS("link") -> e2.toReference))
 
-    val e1 = Entity("e1", "Generic", Map.empty)
-    val e2 = Entity("e2", "Generic", Map(AttributeName.withDefaultNS("link") -> e1.toReference))
-    val e3 = Entity("e3", "Generic", Map(AttributeName.withDefaultNS("link") -> e2.toReference))
-
-    Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    Post(s"${testData.workspace.path}/entities", httpJson(e3)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e3)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    val update = EntityUpdateDefinition(e1.name, e1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("link"), e3.toReference)))
-    val new_e1 = e1.copy(attributes = Map(AttributeName.withDefaultNS("link") -> e3.toReference))
+      val update = EntityUpdateDefinition(e1.name,
+                                          e1.entityType,
+                                          Seq(AddUpdateAttribute(AttributeName.withDefaultNS("link"), e3.toReference))
+      )
+      val new_e1 = e1.copy(attributes = Map(AttributeName.withDefaultNS("link") -> e3.toReference))
 
-    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(Some(new_e1)) {
+            runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
+          }
         }
-        assertResult(Some(new_e1)) {
-          runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
-        }
-      }
 
-    Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1, e2, e3))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+      Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1, e2, e3))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(testData.workspace, e2.entityType, e2.name))
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(testData.workspace, e3.entityType, e3.name))
+          }
         }
-        assertResult(None) {
-          runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
-        }
-        assertResult(None) {
-          runAndWait(entityQuery.get(testData.workspace, e2.entityType, e2.name))
-        }
-        assertResult(None) {
-          runAndWait(entityQuery.get(testData.workspace, e3.entityType, e3.name))
-        }
-      }
 
+      val (entityCount2, attributeCount2) = countEntitiesAttrs(testData.workspace)
+      val (activeEntityCount2, activeAttributeCount2) = countActiveEntitiesAttrs(testData.workspace)
 
-    val (entityCount2, attributeCount2) = countEntitiesAttrs(testData.workspace)
-    val (activeEntityCount2, activeAttributeCount2) = countActiveEntitiesAttrs(testData.workspace)
-
-    assertResult(entityCount1 + 3)(entityCount2)
-    assertResult(attributeCount1 + 3)(attributeCount2)
-    assertResult(activeEntityCount1)(activeEntityCount2)
-    assertResult(activeAttributeCount1)(activeAttributeCount2)
+      assertResult(entityCount1 + 3)(entityCount2)
+      assertResult(attributeCount1 + 3)(attributeCount2)
+      assertResult(activeEntityCount1)(activeEntityCount2)
+      assertResult(activeAttributeCount1)(activeAttributeCount2)
   }
 
   it should "return 409 with the set of references on referenced entity delete" in withTestDataApiServices { services =>
@@ -602,7 +688,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           status
         }
 
-        val expected = Seq(e1, e2) map  { _.toReference }
+        val expected = Seq(e1, e2) map { _.toReference }
         assertSameElements(expected, responseAs[Seq[AttributeEntityReference]])
         assertResult(Some(e1)) {
           runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
@@ -621,78 +707,82 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assertResult(activeAttributeCount1 + 1)(activeAttributeCount2)
   }
 
-  it should "return 409 with the set of references on referenced entity delete with a cycle" in withTestDataApiServices { services =>
-    val (entityCount1, attributeCount1) = countEntitiesAttrs(testData.workspace)
-    val (activeEntityCount1, activeAttributeCount1) = countActiveEntitiesAttrs(testData.workspace)
+  it should "return 409 with the set of references on referenced entity delete with a cycle" in withTestDataApiServices {
+    services =>
+      val (entityCount1, attributeCount1) = countEntitiesAttrs(testData.workspace)
+      val (activeEntityCount1, activeAttributeCount1) = countActiveEntitiesAttrs(testData.workspace)
 
-    val e1 = Entity("e1", "Generic", Map.empty)
-    val e2 = Entity("e2", "Generic", Map(AttributeName.withDefaultNS("link") -> e1.toReference))
-    val e3 = Entity("e3", "Generic", Map(AttributeName.withDefaultNS("link") -> e2.toReference))
+      val e1 = Entity("e1", "Generic", Map.empty)
+      val e2 = Entity("e2", "Generic", Map(AttributeName.withDefaultNS("link") -> e1.toReference))
+      val e3 = Entity("e3", "Generic", Map(AttributeName.withDefaultNS("link") -> e2.toReference))
 
-    Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e1)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e2)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    Post(s"${testData.workspace.path}/entities", httpJson(e3)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e3)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    val update = EntityUpdateDefinition(e1.name, e1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("link"), e3.toReference)))
-    val new_e1 = e1.copy(attributes = Map(AttributeName.withDefaultNS("link") -> e3.toReference))
+      val update = EntityUpdateDefinition(e1.name,
+                                          e1.entityType,
+                                          Seq(AddUpdateAttribute(AttributeName.withDefaultNS("link"), e3.toReference))
+      )
+      val new_e1 = e1.copy(attributes = Map(AttributeName.withDefaultNS("link") -> e3.toReference))
 
-    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(Some(new_e1)) {
+            runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
+          }
         }
-        assertResult(Some(new_e1)) {
-          runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
-        }
-      }
 
-    Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Conflict) {
-          status
+      Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e1))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Conflict) {
+            status
+          }
+          val expected = Seq(e1, e2, e3) map { _.toReference }
+          assertSameElements(expected, responseAs[Seq[AttributeEntityReference]])
+          assertResult(Some(new_e1)) {
+            runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
+          }
+          assertResult(Some(e2)) {
+            runAndWait(entityQuery.get(testData.workspace, e2.entityType, e2.name))
+          }
+          assertResult(Some(e3)) {
+            runAndWait(entityQuery.get(testData.workspace, e3.entityType, e3.name))
+          }
         }
-        val expected = Seq(e1, e2, e3) map { _.toReference }
-        assertSameElements(expected, responseAs[Seq[AttributeEntityReference]])
-        assertResult(Some(new_e1)) {
-          runAndWait(entityQuery.get(testData.workspace, e1.entityType, e1.name))
-        }
-        assertResult(Some(e2)) {
-          runAndWait(entityQuery.get(testData.workspace, e2.entityType, e2.name))
-        }
-        assertResult(Some(e3)) {
-          runAndWait(entityQuery.get(testData.workspace, e3.entityType, e3.name))
-        }
-      }
 
-    val (entityCount2, attributeCount2) = countEntitiesAttrs(testData.workspace)
-    val (activeEntityCount2, activeAttributeCount2) = countActiveEntitiesAttrs(testData.workspace)
+      val (entityCount2, attributeCount2) = countEntitiesAttrs(testData.workspace)
+      val (activeEntityCount2, activeAttributeCount2) = countActiveEntitiesAttrs(testData.workspace)
 
-    assertResult(entityCount1 + 3)(entityCount2)
-    assertResult(attributeCount1 + 3)(attributeCount2)
-    assertResult(activeEntityCount1 + 3)(activeEntityCount2)
-    assertResult(activeAttributeCount1 + 3)(activeAttributeCount2)
+      assertResult(entityCount1 + 3)(entityCount2)
+      assertResult(attributeCount1 + 3)(attributeCount2)
+      assertResult(activeEntityCount1 + 3)(activeEntityCount2)
+      assertResult(activeAttributeCount1 + 3)(activeAttributeCount2)
   }
 
   it should "return 400 on entity delete where not all entities exist" in withTestDataApiServices { services =>
@@ -741,52 +831,57 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assertResult(activeAttributeCount1)(activeAttributeCount2)
   }
 
-  it should "return 204 when deleting an entity type that has no references to it" in withTestDataApiServices { services =>
-
-    val entities = Seq.tabulate(100){ i =>
-      Entity(s"foo$i", "typeToDelete",
-        Map(
-          AttributeName.withDefaultNS("hello") -> AttributeString("world"),
-          AttributeName.withDefaultNS("foo") -> AttributeString("bar")
+  it should "return 204 when deleting an entity type that has no references to it" in withTestDataApiServices {
+    services =>
+      val entities = Seq.tabulate(100) { i =>
+        Entity(
+          s"foo$i",
+          "typeToDelete",
+          Map(
+            AttributeName.withDefaultNS("hello") -> AttributeString("world"),
+            AttributeName.withDefaultNS("foo") -> AttributeString("bar")
+          )
         )
-      )
-    }
-
-    runAndWait(entityQuery.save(testData.workspace, entities))
-
-    val (entityCountBefore, attributeCountBefore) = countEntitiesAttrs(testData.workspace)
-    val (activeEntityCountBefore, activeAttributeCountBefore) = countActiveEntitiesAttrs(testData.workspace)
-
-    Delete(s"${testData.workspace.path}/entityTypes/typeToDelete") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
-        }
-        assertResult(Seq.empty) {
-          runAndWait(entityQuery.listActiveEntitiesOfType(testData.workspace, "typeToDelete")).toSeq
-        }
       }
 
-    val (entityCountAfter, attributeCountAfter) = countEntitiesAttrs(testData.workspace)
-    val (activeEntityCountAfter, activeAttributeCountAfter) = countActiveEntitiesAttrs(testData.workspace)
+      runAndWait(entityQuery.save(testData.workspace, entities))
 
-    //Ensure that the entity and attribute count (including "deleted" entities is the same before and after
-    assertResult(entityCountBefore)(entityCountAfter)
-    assertResult(attributeCountBefore)(attributeCountAfter)
+      val (entityCountBefore, attributeCountBefore) = countEntitiesAttrs(testData.workspace)
+      val (activeEntityCountBefore, activeAttributeCountBefore) = countActiveEntitiesAttrs(testData.workspace)
 
-    //Ensure that we have marked the appropriate number of entities and attributes as "deleted"
-    assertResult(activeEntityCountBefore - entities.size)(activeEntityCountAfter)
-    assertResult(activeAttributeCountBefore - entities.flatMap(_.attributes).size)(activeAttributeCountAfter)
+      Delete(s"${testData.workspace.path}/entityTypes/typeToDelete") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(Seq.empty) {
+            runAndWait(entityQuery.listActiveEntitiesOfType(testData.workspace, "typeToDelete")).toSeq
+          }
+        }
+
+      val (entityCountAfter, attributeCountAfter) = countEntitiesAttrs(testData.workspace)
+      val (activeEntityCountAfter, activeAttributeCountAfter) = countActiveEntitiesAttrs(testData.workspace)
+
+      // Ensure that the entity and attribute count (including "deleted" entities is the same before and after
+      assertResult(entityCountBefore)(entityCountAfter)
+      assertResult(attributeCountBefore)(attributeCountAfter)
+
+      // Ensure that we have marked the appropriate number of entities and attributes as "deleted"
+      assertResult(activeEntityCountBefore - entities.size)(activeEntityCountAfter)
+      assertResult(activeAttributeCountBefore - entities.flatMap(_.attributes).size)(activeAttributeCountAfter)
   }
 
   it should "return 409 when deleting an entity type that has references to it" in withTestDataApiServices { services =>
-    val entities = Seq.tabulate(100){ i =>
+    val entities = Seq.tabulate(100) { i =>
       Entity(s"foo$i", "typeToDelete", Map.empty)
     }
 
-    val referringEntities = Seq.tabulate(50){ i =>
-      Entity(s"foo$i", "referringType", Map(AttributeName.withDefaultNS("type") -> AttributeEntityReference("typeToDelete", s"foo$i")))
+    val referringEntities = Seq.tabulate(50) { i =>
+      Entity(s"foo$i",
+             "referringType",
+             Map(AttributeName.withDefaultNS("type") -> AttributeEntityReference("typeToDelete", s"foo$i"))
+      )
     }
 
     runAndWait(entityQuery.save(testData.workspace, entities))
@@ -812,7 +907,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val (entityCountAfter, attributeCountAfter) = countEntitiesAttrs(testData.workspace)
     val (activeEntityCountAfter, activeAttributeCountAfter) = countActiveEntitiesAttrs(testData.workspace)
 
-        //Ensure that we have not deleted any entities or their attributes
+    // Ensure that we have not deleted any entities or their attributes
     assertResult(entityCountBefore)(entityCountAfter)
     assertResult(attributeCountBefore)(attributeCountAfter)
     assertResult(activeEntityCountBefore)(activeEntityCountAfter)
@@ -820,8 +915,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 201 on create entity for a previously deleted entity" in withTestDataApiServices { services =>
-    val attrs1 = Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"), AttributeName.withDefaultNS("alive") -> AttributeBoolean(false))
-    val attrs2 = Map(AttributeName.withDefaultNS("type") -> AttributeString("normal"), AttributeName.withDefaultNS("answer") -> AttributeNumber(42))
+    val attrs1 = Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"),
+                     AttributeName.withDefaultNS("alive") -> AttributeBoolean(false)
+    )
+    val attrs2 = Map(AttributeName.withDefaultNS("type") -> AttributeString("normal"),
+                     AttributeName.withDefaultNS("answer") -> AttributeNumber(42)
+    )
     val attrs3 = Map(AttributeName.withDefaultNS("cout") -> AttributeString("wackwack"))
 
     val sample = Entity("ABCD", "Sample", attrs1)
@@ -902,18 +1001,23 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assert(newId != id3)
   }
 
-  it should "return 400 when batch upserting an entity with invalid update operations" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a"))))
-    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when batch upserting an entity with invalid update operations" in withTestDataApiServices {
+    services =>
+      val update1 =
+        EntityUpdateDefinition(testData.sample1.name,
+                               testData.sample1.entityType,
+                               Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a")))
+        )
+      Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          assertResult(1) {
+            responseAs[ErrorReport].causes.length
+          }
         }
-        assertResult(1) {
-          responseAs[ErrorReport].causes.length
-        }
-      }
   }
 
   it should "return 204 when batch upserting nothing" in withTestDataApiServices { services =>
@@ -927,84 +1031,126 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 204 when batch upserting an entity that does not yet exist" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition("newSample", "Sample", Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo"))))
+    val update1 = EntityUpdateDefinition(
+      "newSample",
+      "Sample",
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
+    )
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1))) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.NoContent) {
           status
         }
-        assertResult(Some(Entity("newSample", "Sample", Map(AttributeName.withDefaultNS("newAttribute") -> AttributeString("foo"))))) {
+        assertResult(
+          Some(
+            Entity("newSample", "Sample", Map(AttributeName.withDefaultNS("newAttribute") -> AttributeString("foo")))
+          )
+        ) {
           runAndWait(entityQuery.get(testData.workspace, "Sample", "newSample"))
         }
       }
   }
 
-  it should "return 204 when batch upserting an entity that was previously deleted" in withTestDataApiServices { services =>
+  it should "return 204 when batch upserting an entity that was previously deleted" in withTestDataApiServices {
+    services =>
+      val e = Entity("foo", "bar", Map.empty)
 
-    val e = Entity("foo", "bar", Map.empty)
-
-    Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"${testData.workspace.path}/entities", httpJson(e)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    val oldId = dbId(e)
+      val oldId = dbId(e)
 
-    Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+      Post(s"${testData.workspace.path}/entities/delete", httpJson(EntityDeleteRequest(e))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(testData.workspace, e.entityType, e.name))
+          }
         }
-        assertResult(None) {
-          runAndWait(entityQuery.get(testData.workspace, e.entityType, e.name))
-        }
-      }
 
-    val update = EntityUpdateDefinition(e.name, e.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz"))))
-    val updatedEntity = e.copy(attributes = Map(AttributeName.withDefaultNS("newAttribute") -> AttributeString("baz")))
-    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+      val update = EntityUpdateDefinition(
+        e.name,
+        e.entityType,
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
+      )
+      val updatedEntity =
+        e.copy(attributes = Map(AttributeName.withDefaultNS("newAttribute") -> AttributeString("baz")))
+      Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(Some(updatedEntity)) {
+            runAndWait(entityQuery.get(testData.workspace, e.entityType, e.name))
+          }
         }
-        assertResult(Some(updatedEntity)) {
-          runAndWait(entityQuery.get(testData.workspace, e.entityType, e.name))
-        }
-      }
 
-    val newId = dbId(e)
+      val newId = dbId(e)
 
-    assert { oldId != newId }
+      assert(oldId != newId)
   }
 
-  it should "return 204 when batch upserting an entity with valid update operations" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz"))))
-    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+  it should "return 204 when batch upserting an entity with valid update operations" in withTestDataApiServices {
+    services =>
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")))
+      )
+      val update2 = EntityUpdateDefinition(
+        testData.sample2.name,
+        testData.sample2.entityType,
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(
+            Some(
+              Entity(
+                testData.sample1.name,
+                testData.sample1.entityType,
+                testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))
+              )
+            )
+          ) {
+            runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
+          }
+          assertResult(
+            Some(
+              Entity(
+                testData.sample2.name,
+                testData.sample2.entityType,
+                testData.sample2.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("baz"))
+              )
+            )
+          ) {
+            runAndWait(entityQuery.get(testData.workspace, testData.sample2.entityType, testData.sample2.name))
+          }
         }
-        assertResult(Some(Entity(testData.sample1.name, testData.sample1.entityType, testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))))) {
-          runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
-        }
-        assertResult(Some(Entity(testData.sample2.name, testData.sample2.entityType, testData.sample2.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("baz"))))) {
-          runAndWait(entityQuery.get(testData.workspace, testData.sample2.entityType, testData.sample2.name))
-        }
-      }
   }
 
   it should "return 204 when batch upserting an entities with valid references" in withTestDataApiServices { services =>
     val newEntity = Entity("new_entity", testData.sample2.entityType, Map.empty)
     val referenceList = AttributeEntityReferenceList(Seq(testData.sample2.toReference, newEntity.toReference))
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), referenceList)))
+    val update1 =
+      EntityUpdateDefinition(testData.sample1.name,
+                             testData.sample1.entityType,
+                             Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), referenceList))
+      )
     val update2 = EntityUpdateDefinition(newEntity.name, newEntity.entityType, Seq.empty)
     val blep = httpJson(Seq(update1, update2))
     Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
@@ -1013,7 +1159,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.NoContent) {
           status
         }
-        assertResult(Some(Entity(testData.sample1.name, testData.sample1.entityType, testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> referenceList)))) {
+        assertResult(
+          Some(
+            Entity(testData.sample1.name,
+                   testData.sample1.entityType,
+                   testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> referenceList)
+            )
+          )
+        ) {
           runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
         }
         assertResult(Some(newEntity)) {
@@ -1022,63 +1175,101 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 when batch upserting an entity with references that don't exist" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeEntityReference("bar", "baz"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeEntityReference("bar", "bing"))))
-    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when batch upserting an entity with references that don't exist" in withTestDataApiServices {
+    services =>
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeEntityReference("bar", "baz")))
+      )
+      val update2 = EntityUpdateDefinition(
+        testData.sample2.name,
+        testData.sample2.entityType,
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeEntityReference("bar", "bing")))
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          assertResult(2) {
+            responseAs[ErrorReport].causes.length
+          }
         }
-        assertResult(2) {
-          responseAs[ErrorReport].causes.length
-        }
-      }
   }
 
-  it should "return 403 when batch upserting an entity with invalid-namespace attributes" in withTestDataApiServices { services =>
-    val invalidAttrNamespace = "invalid"
+  it should "return 403 when batch upserting an entity with invalid-namespace attributes" in withTestDataApiServices {
+    services =>
+      val invalidAttrNamespace = "invalid"
 
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute1"), AttributeString("smee"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute2"), AttributeString("blee"))))
-    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden, responseAs[ErrorReport]) {
-          status
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute1"), AttributeString("smee")))
+      )
+      val update2 = EntityUpdateDefinition(
+        testData.sample2.name,
+        testData.sample2.entityType,
+        Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute2"), AttributeString("blee")))
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden, responseAs[ErrorReport]) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 403 when batch upserting an entity with library-namespace attributes " in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute1"), AttributeString("wang"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute2"), AttributeString("chung"))))
-    Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
+  it should "return 403 when batch upserting an entity with library-namespace attributes " in withTestDataApiServices {
+    services =>
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute1"), AttributeString("wang")))
+      )
+      val update2 = EntityUpdateDefinition(
+        testData.sample2.name,
+        testData.sample2.entityType,
+        Seq(
+          AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute2"), AttributeString("chung"))
+        )
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpsert", httpJson(Seq(update1, update2))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 when batch updating an entity with invalid update operations" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a"))))
-    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when batch updating an entity with invalid update operations" in withTestDataApiServices {
+    services =>
+      val update1 =
+        EntityUpdateDefinition(testData.sample1.name,
+                               testData.sample1.entityType,
+                               Seq(RemoveListMember(AttributeName.withDefaultNS("bingo"), AttributeString("a")))
+        )
+      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          assertResult(1) {
+            responseAs[ErrorReport].causes.length
+          }
         }
-        assertResult(1) {
-          responseAs[ErrorReport].causes.length
-        }
-      }
   }
 
   it should "return 400 when batch updating an entity that does not yet exist" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition("superDuperNewSample", "Samples", Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo"))))
+    val update1 = EntityUpdateDefinition(
+      "superDuperNewSample",
+      "Samples",
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("foo")))
+    )
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
       sealRoute(services.entityRoutes) ~>
       check {
@@ -1113,7 +1304,11 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
       }
 
-    val update1 = EntityUpdateDefinition(e.name, e.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz"))))
+    val update1 = EntityUpdateDefinition(
+      e.name,
+      e.entityType,
+      Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("baz")))
+    )
     Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
       sealRoute(services.entityRoutes) ~>
       check {
@@ -1126,18 +1321,31 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 204 when batch updating an entity with valid update operations" in withTestDataApiServices { services =>
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar"))))
-    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+  it should "return 204 when batch updating an entity with valid update operations" in withTestDataApiServices {
+    services =>
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("newAttribute"), AttributeString("bar")))
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(
+            Some(
+              Entity(
+                testData.sample1.name,
+                testData.sample1.entityType,
+                testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))
+              )
+            )
+          ) {
+            runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
+          }
         }
-        assertResult(Some(Entity(testData.sample1.name, testData.sample1.entityType, testData.sample1.attributes + (AttributeName.withDefaultNS("newAttribute") -> AttributeString("bar"))))) {
-          runAndWait(entityQuery.get(testData.workspace, testData.sample1.entityType, testData.sample1.name))
-        }
-      }
   }
 
   it should "return 204 when batch updating nothing" in withTestDataApiServices { services =>
@@ -1150,31 +1358,51 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 403 when batch updating an entity with invalid-namespace attributes" in withTestDataApiServices { services =>
-    val invalidAttrNamespace = "invalid"
+  it should "return 403 when batch updating an entity with invalid-namespace attributes" in withTestDataApiServices {
+    services =>
+      val invalidAttrNamespace = "invalid"
 
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute1"), AttributeString("smee"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute2"), AttributeString("blee"))))
-    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden, responseAs[ErrorReport]) {
-          status
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute1"), AttributeString("smee")))
+      )
+      val update2 = EntityUpdateDefinition(
+        testData.sample2.name,
+        testData.sample2.entityType,
+        Seq(AddUpdateAttribute(AttributeName(invalidAttrNamespace, "newAttribute2"), AttributeString("blee")))
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1, update2))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden, responseAs[ErrorReport]) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 403 when batch updating an entity with library-namespace attributes" in withTestDataApiServices { services =>
-    revokeCuratorRole(services)
-    val update1 = EntityUpdateDefinition(testData.sample1.name, testData.sample1.entityType, Seq(AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute1"), AttributeString("wang"))))
-    val update2 = EntityUpdateDefinition(testData.sample2.name, testData.sample2.entityType, Seq(AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute2"), AttributeString("chung"))))
-    Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1, update2))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
+  it should "return 403 when batch updating an entity with library-namespace attributes" in withTestDataApiServices {
+    services =>
+      revokeCuratorRole(services)
+      val update1 = EntityUpdateDefinition(
+        testData.sample1.name,
+        testData.sample1.entityType,
+        Seq(AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute1"), AttributeString("wang")))
+      )
+      val update2 = EntityUpdateDefinition(
+        testData.sample2.name,
+        testData.sample2.entityType,
+        Seq(
+          AddUpdateAttribute(AttributeName(AttributeName.libraryNamespace, "newAttribute2"), AttributeString("chung"))
+        )
+      )
+      Post(s"${testData.workspace.path}/entities/batchUpdate", httpJson(Seq(update1, update2))) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
         }
-      }
   }
 
   it should "return 200 on get entity" in withTestDataApiServices { services =>
@@ -1193,7 +1421,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             responseAs[Entity]
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
       val expected = expectedHttpRequestMetrics("get", s"$wsPathForRequestMetrics", StatusCodes.OK.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
@@ -1214,7 +1442,11 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   val expectedMetadataMap: Map[String, EntityTypeMetadata] = Map(
-    "Sample" -> EntityTypeMetadata(8, "Sample_id", Seq("confused", "cycle", "quot", "somefoo", "thingies", "tumortype", "type", "whatsit")),
+    "Sample" -> EntityTypeMetadata(
+      8,
+      "Sample_id",
+      Seq("confused", "cycle", "quot", "somefoo", "thingies", "tumortype", "type", "whatsit")
+    ),
     "Aliquot" -> EntityTypeMetadata(2, "Aliquot_id", Seq()),
     "Pair" -> EntityTypeMetadata(2, "Pair_id", Seq("case", "control", "whatsit")),
     "SampleSet" -> EntityTypeMetadata(5, "SampleSet_id", Seq("hasSamples", "samples")),
@@ -1264,14 +1496,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 200 on list all samples" in withConstantTestDataApiServices { services =>
-    val expected = Seq(constantData.sample1,
+    val expected = Seq(
+      constantData.sample1,
       constantData.sample2,
       constantData.sample3,
       constantData.sample4,
       constantData.sample5,
       constantData.sample6,
       constantData.sample7,
-      constantData.sample8)
+      constantData.sample8
+    )
 
     Get(s"${constantData.workspace.path}/entities/Sample") ~>
       sealRoute(services.entityRoutes) ~>
@@ -1287,14 +1521,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "not list deleted samples" in withConstantTestDataApiServices { services =>
-    val expected = Seq(constantData.sample1,
+    val expected = Seq(
+      constantData.sample1,
       constantData.sample2,
       constantData.sample3,
       constantData.sample4,
       constantData.sample5,
       constantData.sample6,
       constantData.sample7,
-      constantData.sample8)
+      constantData.sample8
+    )
 
     val newSample = Entity("foo", "Sample", Map(AttributeName.withDefaultNS("blah") -> AttributeNumber(123)))
 
@@ -1403,35 +1639,42 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
 
         val respEnt = responseAs[Entity]
-        assertResult(e.entityType) { respEnt.entityType }
+        assertResult(e.entityType)(respEnt.entityType)
         assert(e.name != respEnt.name)
-        assertResult(newEnt.name) { respEnt.name }
+        assertResult(newEnt.name)(respEnt.name)
 
-        assertResult(1) { respEnt.attributes.size }
+        assertResult(1)(respEnt.attributes.size)
 
         // same attribute namespace and value but the attribute name has been hidden/renamed on deletion
         val respAttr = respEnt.attributes.head
         val eAttr = e.attributes.head
 
-        assertResult(eAttr._1.namespace) { respAttr._1.namespace }
+        assertResult(eAttr._1.namespace)(respAttr._1.namespace)
         assert(respAttr._1.name.contains(eAttr._1.name + "_"))
-        assertResult(eAttr._2) { respAttr._2 }
+        assertResult(eAttr._2)(respAttr._2)
       }
   }
 
   it should "return 200 on update entity" in withTestDataApiServices { services =>
     withStatsD {
-      Patch(testData.sample2.path(testData.workspace), httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation))) ~>
+      Patch(
+        testData.sample2.path(testData.workspace),
+        httpJson(
+          Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
+        )
+      ) ~>
         services.sealedInstrumentedRoutes ~>
         check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
           }
           assertResult(Option(AttributeString("bang"))) {
-            runAndWait(entityQuery.get(testData.workspace, testData.sample2.entityType, testData.sample2.name)).get.attributes.get(AttributeName.withDefaultNS("boo"))
+            runAndWait(
+              entityQuery.get(testData.workspace, testData.sample2.entityType, testData.sample2.name)
+            ).get.attributes.get(AttributeName.withDefaultNS("boo"))
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
       val expected = expectedHttpRequestMetrics("patch", s"$wsPathForRequestMetrics", StatusCodes.OK.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
@@ -1439,20 +1682,29 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 200 on remove attribute from entity" in withTestDataApiServices { services =>
-    Patch(testData.sample2.path(testData.workspace), httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("bar")): AttributeUpdateOperation))) ~>
+    Patch(testData.sample2.path(testData.workspace),
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("bar")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
           status
         }
         assertResult(None) {
-          runAndWait(entityQuery.get(testData.workspace, testData.sample2.entityType, testData.sample2.name)).get.attributes.get(AttributeName.withDefaultNS("bar"))
+          runAndWait(
+            entityQuery.get(testData.workspace, testData.sample2.entityType, testData.sample2.name)
+          ).get.attributes.get(AttributeName.withDefaultNS("bar"))
         }
       }
   }
 
   it should "return 404 on update to non-existing entity" in withTestDataApiServices { services =>
-    Patch(testData.sample2.copy(name = "DNE").path(testData.workspace), httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation))) ~>
+    Patch(
+      testData.sample2.copy(name = "DNE").path(testData.workspace),
+      httpJson(
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -1483,7 +1735,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
       }
 
-    Patch(e.path(testData.workspace), httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("baz"), AttributeString("bang")): AttributeUpdateOperation))) ~>
+    Patch(
+      e.path(testData.workspace),
+      httpJson(
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("baz"), AttributeString("bang")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -1496,7 +1753,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val name = AttributeName("invalid", "misc")
     val attr = AttributeString("meh")
 
-    Patch(testData.sample2.path(testData.workspace), httpJson(Seq(AddUpdateAttribute(name, attr): AttributeUpdateOperation))) ~>
+    Patch(testData.sample2.path(testData.workspace),
+          httpJson(Seq(AddUpdateAttribute(name, attr): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
@@ -1512,7 +1771,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val name = AttributeName(AttributeName.libraryNamespace, "reader")
     val attr = AttributeString("me")
 
-    Patch(testData.sample2.path(testData.workspace), httpJson(Seq(AddUpdateAttribute(name, attr): AttributeUpdateOperation))) ~>
+    Patch(testData.sample2.path(testData.workspace),
+          httpJson(Seq(AddUpdateAttribute(name, attr): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden, responseAs[String]) {
@@ -1522,7 +1783,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 400 on remove from an attribute that is not a list" in withTestDataApiServices { services =>
-    Patch(testData.sample2.path(testData.workspace), httpJson(Seq(RemoveListMember(AttributeName.withDefaultNS("foo"), AttributeString("adsf")): AttributeUpdateOperation))) ~>
+    Patch(
+      testData.sample2.path(testData.workspace),
+      httpJson(
+        Seq(RemoveListMember(AttributeName.withDefaultNS("foo"), AttributeString("adsf")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
@@ -1531,7 +1797,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
   it should "return 400 on remove from list attribute that does not exist" in withTestDataApiServices { services =>
-    Patch(testData.sample2.path(testData.workspace), httpJson(Seq(RemoveListMember(AttributeName.withDefaultNS("grip"), AttributeString("adsf")): AttributeUpdateOperation))) ~>
+    Patch(
+      testData.sample2.path(testData.workspace),
+      httpJson(
+        Seq(RemoveListMember(AttributeName.withDefaultNS("grip"), AttributeString("adsf")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
@@ -1540,7 +1811,12 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
   it should "return 400 on add to list attribute that is not a list" in withTestDataApiServices { services =>
-    Patch(testData.sample1.path(testData.workspace), httpJson(Seq(AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")): AttributeUpdateOperation))) ~>
+    Patch(
+      testData.sample1.path(testData.workspace),
+      httpJson(
+        Seq(AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
@@ -1549,15 +1825,21 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return an error in real json when patching entity with badly shaped request body" in withTestDataApiServices { services =>
-    Patch(testData.sample1.path(testData.workspace), httpJson(AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")):AttributeUpdateOperation)) ~>
-      sealRoute(services.entityRoutes)(rejectionHandler=RawlsApiService.rejectionHandler) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return an error in real json when patching entity with badly shaped request body" in withTestDataApiServices {
+    services =>
+      Patch(
+        testData.sample1.path(testData.workspace),
+        httpJson(
+          AddListMember(AttributeName.withDefaultNS("somefoo"), AttributeString("adsf")): AttributeUpdateOperation
+        )
+      ) ~>
+        sealRoute(services.entityRoutes)(rejectionHandler = RawlsApiService.rejectionHandler) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          responseAs[JsObject]
         }
-        responseAs[JsObject]
-      }
   }
 
   it should "return 409 on entity rename when rename already exists" in withTestDataApiServices { services =>
@@ -1582,9 +1864,10 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             runAndWait(entityQuery.get(testData.workspace, testData.sample2.entityType, "s2_changed")).isDefined
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
-      val expected = expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.NoContent.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.NoContent.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
   }
@@ -1601,9 +1884,10 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             runAndWait(entityQuery.get(testData.workspace, testData.sample2.entityType, "s2.changed")).isDefined
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
-      val expected = expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.NoContent.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.NoContent.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
   }
@@ -1617,9 +1901,10 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             status
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
-      val expected = expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.BadRequest.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.BadRequest.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
   }
@@ -1633,9 +1918,10 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             status
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
-      val expected = expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.BadRequest.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.BadRequest.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
   }
@@ -1649,15 +1935,18 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             status
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted.entities.${testData.sample2.entityType}.redacted"
-      val expected = expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.BadRequest.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.rename", StatusCodes.BadRequest.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
   }
 
   it should "return 404 on entity rename, entity does not exist" in withTestDataApiServices { services =>
-    Post(s"${testData.sample2.copy(name = "foox").path(testData.workspace)}/rename", httpJson(EntityName("s2_changed"))) ~>
+    Post(s"${testData.sample2.copy(name = "foox").path(testData.workspace)}/rename",
+         httpJson(EntityName("s2_changed"))
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.NotFound) {
@@ -1702,21 +1991,38 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   class DeleteAttributeNameTestData extends TestData {
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "fake-bucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "fake-bucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
 
-    val entitiesWithDefaultNamespace =  Entity("name1", "type1", Map(
-      AttributeName.withDefaultNS("hello") -> AttributeString("world"),
-      AttributeName.withDefaultNS("hello") -> AttributeString("brazil"),
-      AttributeName.withDefaultNS("hello") -> AttributeString("pluto"),
-      AttributeName.withDefaultNS("hi") -> AttributeString("hades"),
-      AttributeName.withDefaultNS("salutations") -> AttributeString("hades"),
-    ))
+    val entitiesWithDefaultNamespace = Entity(
+      "name1",
+      "type1",
+      Map(
+        AttributeName.withDefaultNS("hello") -> AttributeString("world"),
+        AttributeName.withDefaultNS("hello") -> AttributeString("brazil"),
+        AttributeName.withDefaultNS("hello") -> AttributeString("pluto"),
+        AttributeName.withDefaultNS("hi") -> AttributeString("hades"),
+        AttributeName.withDefaultNS("salutations") -> AttributeString("hades")
+      )
+    )
 
-    val entitiesWithNonDefaultNamespace = Entity("name2", "type1", Map(
-      AttributeName.withDefaultNS("hello") -> AttributeString("world"),
-      AttributeName.fromDelimitedName("othernamespace:yo") -> AttributeString("world"),
-      AttributeName.fromDelimitedName("othernamespace:yo") -> AttributeString("atlantis"),
-    ))
+    val entitiesWithNonDefaultNamespace = Entity(
+      "name2",
+      "type1",
+      Map(
+        AttributeName.withDefaultNS("hello") -> AttributeString("world"),
+        AttributeName.fromDelimitedName("othernamespace:yo") -> AttributeString("world"),
+        AttributeName.fromDelimitedName("othernamespace:yo") -> AttributeString("atlantis")
+      )
+    )
 
     val entities = List(entitiesWithDefaultNamespace, entitiesWithNonDefaultNamespace)
 
@@ -1732,80 +2038,89 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   val deleteAttributeNameTestData = new DeleteAttributeNameTestData()
 
-  def withDeleteAttributeNameTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withDeleteAttributeNameTestDataApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(deleteAttributeNameTestData) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
+
+  it should "return a 204 when deleting multiple attributes of default namespace" in withDeleteAttributeNameTestDataApiServices {
+    services =>
+      Delete(s"${testData.workspace.path}/entities/type1?attributeNames=hello,hi") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes
+              .get(AttributeName.withDefaultNS("hello"))
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes
+              .get(AttributeName.withDefaultNS("hi"))
+          }
+          assertResult(Some(AttributeString("hades"))) {
+            runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes
+              .get(AttributeName.withDefaultNS("salutations"))
+          }
+        }
   }
 
-  it should "return a 204 when deleting multiple attributes of default namespace" in withDeleteAttributeNameTestDataApiServices { services =>
-    Delete(s"${testData.workspace.path}/entities/type1?attributeNames=hello,hi") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+  it should "return a 204 when deleting attributes with a specified default namespace" in withDeleteAttributeNameTestDataApiServices {
+    services =>
+      Delete(s"${testData.workspace.path}/entities/type1?attributeNames=default:hello") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes
+              .get(AttributeName.withDefaultNS("hello"))
+          }
         }
-        assertResult(None) {
-          runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes.get(AttributeName.withDefaultNS("hello"))
-        }
-        assertResult(None) {
-          runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes.get(AttributeName.withDefaultNS("hi"))
-        }
-        assertResult(Some(AttributeString("hades"))) {
-          runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes.get(AttributeName.withDefaultNS("salutations"))
-        }
-      }
   }
 
-  it should "return a 204 when deleting attributes with a specified default namespace" in withDeleteAttributeNameTestDataApiServices { services =>
-    Delete(s"${testData.workspace.path}/entities/type1?attributeNames=default:hello") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+  it should "return a 204 when deleting attributes with a non-default namespace" in withDeleteAttributeNameTestDataApiServices {
+    services =>
+      Delete(s"${testData.workspace.path}/entities/type1?attributeNames=othernamespace:yo") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+          assertResult(Some(AttributeString("world"))) {
+            runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name2")).get.attributes
+              .get(AttributeName.withDefaultNS("hello"))
+          }
+          assertResult(None) {
+            runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name2")).get.attributes
+              .get(AttributeName.fromDelimitedName("othernamespace:yo"))
+          }
         }
-        assertResult(None) {
-          runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name1")).get.attributes.get(AttributeName.withDefaultNS("hello"))
-        }
-      }
   }
 
-  it should "return a 204 when deleting attributes with a non-default namespace" in withDeleteAttributeNameTestDataApiServices { services =>
-    Delete(s"${testData.workspace.path}/entities/type1?attributeNames=othernamespace:yo") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NoContent) {
-          status
+  it should "return 400 when deleting entity attribute that does not exist" in withDeleteAttributeNameTestDataApiServices {
+    services =>
+      Delete(s"${testData.workspace.path}/entities/type1?attributeNames=fakeattribute") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-        assertResult(Some(AttributeString("world"))) {
-          runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name2")).get.attributes.get(AttributeName.withDefaultNS("hello"))
-        }
-        assertResult(None) {
-          runAndWait(entityQuery.get(deleteAttributeNameTestData.workspace, "type1", "name2")).get.attributes.get(AttributeName.fromDelimitedName("othernamespace:yo"))
-        }
-      }
   }
 
-  it should "return 400 when deleting entity attribute that does not exist" in withDeleteAttributeNameTestDataApiServices { services =>
-    Delete(s"${testData.workspace.path}/entities/type1?attributeNames=fakeattribute") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when deleting entity attributes with no query params" in withDeleteAttributeNameTestDataApiServices {
+    services =>
+      Delete(s"${testData.workspace.path}/entities/type1") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
-
-  it should "return 400 when deleting entity attributes with no query params" in withDeleteAttributeNameTestDataApiServices { services =>
-    Delete(s"${testData.workspace.path}/entities/type1") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
-        }
-      }
-  }
-
 
   // evaluate expressions
 
@@ -1823,43 +2138,68 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 200 on successfully parsing a raw JSON" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""{"example":"foo", "array": [1, 2, 3]}""")) ~>
+    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+         httpJsonStr("""{"example":"foo", "array": [1, 2, 3]}""")
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(Array(JsObject(Map("example" -> JsString("foo"), "array" -> JsArray(Vector(JsNumber(1), JsNumber(2), JsNumber(3))))))) {
+        assertResult(
+          Array(
+            JsObject(
+              Map("example" -> JsString("foo"), "array" -> JsArray(Vector(JsNumber(1), JsNumber(2), JsNumber(3))))
+            )
+          )
+        ) {
           responseAs[Array[JsObject]]
         }
       }
   }
 
-  it should "return 200 on successfully parsing a JSON with single attribute reference" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""{"example":"foo", "array": this.samples.type}""")) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+  it should "return 200 on successfully parsing a JSON with single attribute reference" in withTestDataApiServices {
+    services =>
+      Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+           httpJsonStr("""{"example":"foo", "array": this.samples.type}""")
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(
+            Array(
+              JsObject(
+                Map("example" -> JsString("foo"),
+                    "array" -> JsArray(Vector(JsString("normal"), JsString("tumor"), JsString("tumor")))
+                )
+              )
+            )
+          ) {
+            responseAs[Array[JsObject]]
+          }
         }
-        assertResult(Array(JsObject(Map("example" -> JsString("foo"), "array" -> JsArray(Vector(JsString("normal"), JsString("tumor"), JsString("tumor"))))))) {
-          responseAs[Array[JsObject]]
-        }
-      }
   }
 
-  it should "return 200 on successfully parsing a nested JSON with multiple attribute reference" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""{"array": this.samples.type, "details": {"values": this.samples.type}}""")) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+  it should "return 200 on successfully parsing a nested JSON with multiple attribute reference" in withTestDataApiServices {
+    services =>
+      Post(
+        s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+        httpJsonStr("""{"array": this.samples.type, "details": {"values": this.samples.type}}""")
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          val attrRefArray = JsArray(Vector(JsString("normal"), JsString("tumor"), JsString("tumor")))
+          assertResult(
+            Array(JsObject(Map("array" -> attrRefArray, "details" -> JsObject(Map("values" -> attrRefArray)))))
+          ) {
+            responseAs[Array[JsObject]]
+          }
         }
-        val attrRefArray = JsArray(Vector(JsString("normal"), JsString("tumor"), JsString("tumor")))
-        assertResult(Array(JsObject(Map("array" -> attrRefArray, "details" -> JsObject(Map("values" -> attrRefArray)))))) {
-          responseAs[Array[JsObject]]
-        }
-      }
   }
 
   it should "return 200 on successfully parsing a raw array" in withTestDataApiServices { services =>
@@ -1876,30 +2216,48 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "return 200 on successfully parsing a raw heterogeneous array" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""[1, 2, 3, "foo", "bar", true]""")) ~>
+    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+         httpJsonStr("""[1, 2, 3, "foo", "bar", true]""")
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(JsArray(Vector(JsNumber(1), JsNumber(2), JsNumber(3), JsString("foo"), JsString("bar"), JsBoolean(true)))) {
+        assertResult(
+          JsArray(Vector(JsNumber(1), JsNumber(2), JsNumber(3), JsString("foo"), JsString("bar"), JsBoolean(true)))
+        ) {
           responseAs[JsArray]
         }
       }
   }
 
-  it should "return 200 on successfully parsing a heterogeneous array with attribute references" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""[1, 2, 3, this.samples.type, ["foo", "bar", this.samples.type]]""")) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+  it should "return 200 on successfully parsing a heterogeneous array with attribute references" in withTestDataApiServices {
+    services =>
+      Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+           httpJsonStr("""[1, 2, 3, this.samples.type, ["foo", "bar", this.samples.type]]""")
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          val attrRefArray = JsArray(Vector(JsString("normal"), JsString("tumor"), JsString("tumor")))
+          assertResult(
+            Array(
+              JsArray(
+                Vector(JsNumber(1),
+                       JsNumber(2),
+                       JsNumber(3),
+                       attrRefArray,
+                       JsArray(JsString("foo"), JsString("bar"), attrRefArray)
+                )
+              )
+            )
+          ) {
+            responseAs[Array[JsArray]]
+          }
         }
-        val attrRefArray = JsArray(Vector(JsString("normal"), JsString("tumor"), JsString("tumor")))
-        assertResult(Array(JsArray(Vector(JsNumber(1), JsNumber(2), JsNumber(3), attrRefArray, JsArray(JsString("foo"), JsString("bar"), attrRefArray))))) {
-          responseAs[Array[JsArray]]
-        }
-      }
   }
 
   it should "return 400 on failing to parse an expression" in withTestDataApiServices { services =>
@@ -1912,28 +2270,36 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 while parsing invalid expression with invalid reference in array" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""[1, 2, "foo", invalid.ref]""")) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 while parsing invalid expression with invalid reference in array" in withTestDataApiServices {
+    services =>
+      Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+           httpJsonStr("""[1, 2, "foo", invalid.ref]""")
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 while parsing invalid expression with invalid reference in JSON" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""{"example": [1, 2], "foo": invalid.ref}""")) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 while parsing invalid expression with invalid reference in JSON" in withTestDataApiServices {
+    services =>
+      Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+           httpJsonStr("""{"example": [1, 2], "foo": invalid.ref}""")
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
   it should "return 400 while parsing expression with non-existent reference" in withTestDataApiServices { services =>
-    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate", httpJsonStr("""{"example": [1, 2], "foo": nonexistent.anything}""")) ~>
+    Post(s"${testData.workspace.path}/entities/SampleSet/sset1/evaluate",
+         httpJsonStr("""{"example": [1, 2], "foo": nonexistent.anything}""")
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
@@ -1943,7 +2309,15 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   val attributeList = AttributeValueList(Seq(AttributeString("a"), AttributeString("b"), AttributeString("c")))
-  val z1 = Entity("z1", "Sample", Map(AttributeName.withDefaultNS("foo") -> AttributeString("x"), AttributeName.withDefaultNS("bar") -> AttributeNumber(3), AttributeName.withDefaultNS("splat") -> attributeList))
+  val z1 = Entity(
+    "z1",
+    "Sample",
+    Map(
+      AttributeName.withDefaultNS("foo") -> AttributeString("x"),
+      AttributeName.withDefaultNS("bar") -> AttributeNumber(3),
+      AttributeName.withDefaultNS("splat") -> attributeList
+    )
+  )
   val workspace2Name = new WorkspaceName(testData.wsName.namespace, testData.wsName.name + "2")
   val workspace2Request = WorkspaceRequest(
     workspace2Name.namespace,
@@ -1951,43 +2325,44 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Map.empty
   )
 
-  it should "return 201 for copying entities into a workspace with no conflicts" in withTestDataApiServices { services =>
-    Post("/workspaces", httpJson(workspace2Request)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
-        }
-        assertResult(workspace2Request) {
-          val ws = runAndWait(workspaceQuery.findByName(workspace2Request.toWorkspaceName)).get
-          WorkspaceRequest(ws.namespace, ws.name, ws.attributes)
-        }
-
-        Post(s"${workspace2Request.path}/entities", httpJson(z1)) ~>
-          sealRoute(services.entityRoutes) ~>
-          check {
-            assertResult(StatusCodes.Created) {
-              status
-            }
-            assertResult(z1) {
-              val ws2 = runAndWait(workspaceQuery.findByName(workspace2Name)).get
-              runAndWait(entityQuery.get(ws2, z1.entityType, z1.name)).get
-            }
-
-            val sourceWorkspace = WorkspaceName(workspace2Request.namespace, workspace2Request.name)
-            val entityCopyDefinition = EntityCopyDefinition(sourceWorkspace, testData.wsName, "Sample", Seq("z1"))
-            Post("/workspaces/entities/copy", httpJson(entityCopyDefinition)) ~>
-              sealRoute(services.entityRoutes) ~>
-              check {
-                assertResult(StatusCodes.Created) {
-                  status
-                }
-                assertResult(z1) {
-                  runAndWait(entityQuery.get(testData.workspace, z1.entityType, z1.name)).get
-                }
-              }
+  it should "return 201 for copying entities into a workspace with no conflicts" in withTestDataApiServices {
+    services =>
+      Post("/workspaces", httpJson(workspace2Request)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
           }
-      }
+          assertResult(workspace2Request) {
+            val ws = runAndWait(workspaceQuery.findByName(workspace2Request.toWorkspaceName)).get
+            WorkspaceRequest(ws.namespace, ws.name, ws.attributes)
+          }
+
+          Post(s"${workspace2Request.path}/entities", httpJson(z1)) ~>
+            sealRoute(services.entityRoutes) ~>
+            check {
+              assertResult(StatusCodes.Created) {
+                status
+              }
+              assertResult(z1) {
+                val ws2 = runAndWait(workspaceQuery.findByName(workspace2Name)).get
+                runAndWait(entityQuery.get(ws2, z1.entityType, z1.name)).get
+              }
+
+              val sourceWorkspace = WorkspaceName(workspace2Request.namespace, workspace2Request.name)
+              val entityCopyDefinition = EntityCopyDefinition(sourceWorkspace, testData.wsName, "Sample", Seq("z1"))
+              Post("/workspaces/entities/copy", httpJson(entityCopyDefinition)) ~>
+                sealRoute(services.entityRoutes) ~>
+                check {
+                  assertResult(StatusCodes.Created) {
+                    status
+                  }
+                  assertResult(z1) {
+                    runAndWait(entityQuery.get(testData.workspace, z1.entityType, z1.name)).get
+                  }
+                }
+            }
+        }
   }
 
   it should "return 409 for copying entities into a workspace with conflicts" in withTestDataApiServices { services =>
@@ -2012,8 +2387,10 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
     val newWorkspaceCreate = WorkspaceRequest(newWorkspace.namespace, newWorkspace.name, Map.empty)
 
-    val copyAliquot1 = EntityCopyDefinition(sourceWorkspace, newWorkspace, testData.aliquot1.entityType, Seq(testData.aliquot1.name))
-    val copySample3 = EntityCopyDefinition(sourceWorkspace, newWorkspace, testData.sample3.entityType, Seq(testData.sample3.name))
+    val copyAliquot1 =
+      EntityCopyDefinition(sourceWorkspace, newWorkspace, testData.aliquot1.entityType, Seq(testData.aliquot1.name))
+    val copySample3 =
+      EntityCopyDefinition(sourceWorkspace, newWorkspace, testData.sample3.entityType, Seq(testData.sample3.name))
 
     Post("/workspaces", httpJson(newWorkspaceCreate)) ~>
       sealRoute(services.workspaceRoutes) ~>
@@ -2050,103 +2427,139 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertSameElements(Seq.empty, copyResponse.hardConflicts)
 
         val expectedSoftConflicts = Seq(
-          EntitySoftConflict(testData.sample3.entityType, testData.sample3.name, Seq(
-            EntitySoftConflict(testData.sample1.entityType, testData.sample1.name, Seq(
-              EntitySoftConflict(testData.aliquot1.entityType, testData.aliquot1.name, Seq.empty))))))
+          EntitySoftConflict(
+            testData.sample3.entityType,
+            testData.sample3.name,
+            Seq(
+              EntitySoftConflict(
+                testData.sample1.entityType,
+                testData.sample1.name,
+                Seq(EntitySoftConflict(testData.aliquot1.entityType, testData.aliquot1.name, Seq.empty))
+              )
+            )
+          )
+        )
 
         assertSameElements(expectedSoftConflicts, copyResponse.softConflicts)
       }
   }
 
-  it should "return 409 for copying entities into a workspace with subtree conflicts, but successfully copy when asked to" in withTestDataApiServices { services =>
-    val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
-    val entityCopyDefinition1 = EntityCopyDefinition(sourceWorkspace, testData.controlledWorkspace.toWorkspaceName, testData.sample1.entityType, Seq(testData.sample1.name))
-    //this will cause a soft conflict because it references sample1
-    val entityCopyDefinition2 = EntityCopyDefinition(sourceWorkspace, testData.controlledWorkspace.toWorkspaceName, testData.sample3.entityType, Seq(testData.sample3.name))
+  it should "return 409 for copying entities into a workspace with subtree conflicts, but successfully copy when asked to" in withTestDataApiServices {
+    services =>
+      val sourceWorkspace = WorkspaceName(testData.workspace.namespace, testData.workspace.name)
+      val entityCopyDefinition1 = EntityCopyDefinition(sourceWorkspace,
+                                                       testData.controlledWorkspace.toWorkspaceName,
+                                                       testData.sample1.entityType,
+                                                       Seq(testData.sample1.name)
+      )
+      // this will cause a soft conflict because it references sample1
+      val entityCopyDefinition2 = EntityCopyDefinition(sourceWorkspace,
+                                                       testData.controlledWorkspace.toWorkspaceName,
+                                                       testData.sample3.entityType,
+                                                       Seq(testData.sample3.name)
+      )
 
-    withStatsD {
-      Post("/workspaces/entities/copy", httpJson(entityCopyDefinition1)) ~>
-        services.sealedInstrumentedRoutes ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
-        }
+      withStatsD {
+        Post("/workspaces/entities/copy", httpJson(entityCopyDefinition1)) ~>
+          services.sealedInstrumentedRoutes ~>
+          check {
+            assertResult(StatusCodes.Created) {
+              status
+            }
 
-        val copyResponse = responseAs[EntityCopyResponse]
+            val copyResponse = responseAs[EntityCopyResponse]
 
-        assertSameElements(Seq(testData.sample1, testData.aliquot1).map(_.toReference), copyResponse.entitiesCopied)
-        assertSameElements(Seq.empty, copyResponse.hardConflicts)
-        assertSameElements(Seq.empty, copyResponse.softConflicts)
+            assertSameElements(Seq(testData.sample1, testData.aliquot1).map(_.toReference), copyResponse.entitiesCopied)
+            assertSameElements(Seq.empty, copyResponse.hardConflicts)
+            assertSameElements(Seq.empty, copyResponse.softConflicts)
+          }
+      } { capturedMetrics =>
+        val expected = expectedHttpRequestMetrics("post", "workspaces.entities.copy", StatusCodes.Created.intValue, 1)
+        assertSubsetOf(expected, capturedMetrics)
       }
-    } {capturedMetrics =>
-      val expected = expectedHttpRequestMetrics("post", "workspaces.entities.copy", StatusCodes.Created.intValue, 1)
-      assertSubsetOf(expected, capturedMetrics)
-    }
 
-    val expectedSoftConflictResponse = EntityCopyResponse(Seq.empty, Seq.empty, Seq(
-      EntitySoftConflict(testData.sample3.entityType, testData.sample3.name, Seq(
-        EntitySoftConflict(testData.sample1.entityType, testData.sample1.name, Seq.empty),
-        EntitySoftConflict(testData.sample1.entityType, testData.sample1.name, Seq(
-          EntitySoftConflict(testData.aliquot1.entityType, testData.aliquot1.name, Seq.empty)))))))
+      val expectedSoftConflictResponse = EntityCopyResponse(
+        Seq.empty,
+        Seq.empty,
+        Seq(
+          EntitySoftConflict(
+            testData.sample3.entityType,
+            testData.sample3.name,
+            Seq(
+              EntitySoftConflict(testData.sample1.entityType, testData.sample1.name, Seq.empty),
+              EntitySoftConflict(
+                testData.sample1.entityType,
+                testData.sample1.name,
+                Seq(EntitySoftConflict(testData.aliquot1.entityType, testData.aliquot1.name, Seq.empty))
+              )
+            )
+          )
+        )
+      )
 
-    //test the default case of no parameter set
-    withStatsD {
-      Post("/workspaces/entities/copy", httpJson(entityCopyDefinition2)) ~>
-      services.sealedInstrumentedRoutes ~>
-      check {
-        assertResult(StatusCodes.Conflict) {
-          status
-        }
-        assertResult(expectedSoftConflictResponse) {
-          responseAs[EntityCopyResponse]
-        }
+      // test the default case of no parameter set
+      withStatsD {
+        Post("/workspaces/entities/copy", httpJson(entityCopyDefinition2)) ~>
+          services.sealedInstrumentedRoutes ~>
+          check {
+            assertResult(StatusCodes.Conflict) {
+              status
+            }
+            assertResult(expectedSoftConflictResponse) {
+              responseAs[EntityCopyResponse]
+            }
+          }
+      } { capturedMetrics =>
+        val expected = expectedHttpRequestMetrics("post", "workspaces.entities.copy", StatusCodes.Conflict.intValue, 1)
+        assertSubsetOf(expected, capturedMetrics)
       }
-    } {capturedMetrics =>
-      val expected = expectedHttpRequestMetrics("post", "workspaces.entities.copy", StatusCodes.Conflict.intValue, 1)
-      assertSubsetOf(expected, capturedMetrics)
-    }
 
-    withStatsD {
-      Post("/workspaces/entities/copy?linkExistingEntities=false", httpJson(entityCopyDefinition2)) ~>
-        services.sealedInstrumentedRoutes ~>
+      withStatsD {
+        Post("/workspaces/entities/copy?linkExistingEntities=false", httpJson(entityCopyDefinition2)) ~>
+          services.sealedInstrumentedRoutes ~>
+          check {
+            assertResult(StatusCodes.Conflict) {
+              status
+            }
+            assertResult(expectedSoftConflictResponse) {
+              responseAs[EntityCopyResponse]
+            }
+          }
+      } { capturedMetrics =>
+        val expected = expectedHttpRequestMetrics("post", "workspaces.entities.copy", StatusCodes.Conflict.intValue, 1)
+        assertSubsetOf(expected, capturedMetrics)
+      }
+
+      Post("/workspaces/entities/copy?linkExistingEntities=true", httpJson(entityCopyDefinition2)) ~>
+        sealRoute(services.entityRoutes) ~>
         check {
-          assertResult(StatusCodes.Conflict) {
+          assertResult(StatusCodes.Created) {
             status
           }
-          assertResult(expectedSoftConflictResponse) {
+          assertResult(EntityCopyResponse(Seq(testData.sample3).map(_.toReference), Seq.empty, Seq.empty)) {
             responseAs[EntityCopyResponse]
           }
         }
-    } {capturedMetrics =>
-      val expected = expectedHttpRequestMetrics("post", "workspaces.entities.copy", StatusCodes.Conflict.intValue, 1)
-      assertSubsetOf(expected, capturedMetrics)
-    }
-
-    Post("/workspaces/entities/copy?linkExistingEntities=true", httpJson(entityCopyDefinition2)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
-        }
-        assertResult(EntityCopyResponse(Seq(testData.sample3).map(_.toReference), Seq.empty, Seq.empty)) {
-          responseAs[EntityCopyResponse]
-        }
-      }
   }
 
-  it should "return 422 when copying entities from a Realm-protected workspace into one not in that Realm" in withEmptyDatabaseApiServicesForAuthDomains { services =>
-    runAndWait(rawlsBillingProjectQuery.create(testData.billingProject))
-    val authDomain = Set(testData.dbGapAuthorizedUsersGroup)
+  it should "return 422 when copying entities from a Realm-protected workspace into one not in that Realm" in withEmptyDatabaseApiServicesForAuthDomains {
+    services =>
+      runAndWait(rawlsBillingProjectQuery.create(testData.billingProject))
+      val authDomain = Set(testData.dbGapAuthorizedUsersGroup)
 
-    // add an entity to a workspace with a Realm
-    val x = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace, testData.workspaceWithRealm.name, Map.empty, Option(authDomain))
-    Post("/workspaces", x) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      // add an entity to a workspace with a Realm
+      val x = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace,
+                               testData.workspaceWithRealm.name,
+                               Map.empty,
+                               Option(authDomain)
+      )
+      Post("/workspaces", x) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
         }
-      }
 
 //    Post(s"${testData.workspaceWithRealm.path}/entities", httpJson(z1)) ~>
 //      sealRoute(services.entityRoutes) ~>
@@ -2159,129 +2572,170 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 //        }
 //      }
 //
-    // attempt to copy an entity to a workspace with the wrong Realm
-    val wrongRealmCloneRequest = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace, name = "copy_add_realm", Map.empty, Option(Set(testData.realm2)))
-    Post(s"/workspaces", httpJson(wrongRealmCloneRequest)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      // attempt to copy an entity to a workspace with the wrong Realm
+      val wrongRealmCloneRequest = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace,
+                                                    name = "copy_add_realm",
+                                                    Map.empty,
+                                                    Option(Set(testData.realm2))
+      )
+      Post(s"/workspaces", httpJson(wrongRealmCloneRequest)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    val wrongRealmCopyDef = EntityCopyDefinition(testData.workspaceWithRealm.toWorkspaceName, wrongRealmCloneRequest.toWorkspaceName, "Sample", Seq("z1"))
-    Post("/workspaces/entities/copy", httpJson(wrongRealmCopyDef)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.UnprocessableEntity) {
-          status
+      val wrongRealmCopyDef = EntityCopyDefinition(testData.workspaceWithRealm.toWorkspaceName,
+                                                   wrongRealmCloneRequest.toWorkspaceName,
+                                                   "Sample",
+                                                   Seq("z1")
+      )
+      Post("/workspaces/entities/copy", httpJson(wrongRealmCopyDef)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.UnprocessableEntity) {
+            status
+          }
         }
-      }
 
-    // attempt to copy an entity to a workspace with no Realm
-    val x2 = WorkspaceRequest(namespace = testData.workspace.namespace, testData.workspace.name, Map.empty, Option(Set.empty))
-    Post("/workspaces", x2) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      // attempt to copy an entity to a workspace with no Realm
+      val x2 = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                testData.workspace.name,
+                                Map.empty,
+                                Option(Set.empty)
+      )
+      Post("/workspaces", x2) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    val noRealmCopyDef = EntityCopyDefinition(testData.workspaceWithRealm.toWorkspaceName, testData.workspace.toWorkspaceName, "Sample", Seq("z1"))
-    Post("/workspaces/entities/copy", httpJson(noRealmCopyDef)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.UnprocessableEntity) {
-          status
+      val noRealmCopyDef = EntityCopyDefinition(testData.workspaceWithRealm.toWorkspaceName,
+                                                testData.workspace.toWorkspaceName,
+                                                "Sample",
+                                                Seq("z1")
+      )
+      Post("/workspaces/entities/copy", httpJson(noRealmCopyDef)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.UnprocessableEntity) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 204 when copying entities from an auth-domain protected workspace into one with a compatible auth-domain" in withEmptyDatabaseApiServicesForAuthDomains { services =>
-    runAndWait(rawlsBillingProjectQuery.create(testData.billingProject))
-    val srcWorkspaceName = WorkspaceName(testData.workspaceWithRealm.namespace, "source_ws")
+  it should "return 204 when copying entities from an auth-domain protected workspace into one with a compatible auth-domain" in withEmptyDatabaseApiServicesForAuthDomains {
+    services =>
+      runAndWait(rawlsBillingProjectQuery.create(testData.billingProject))
+      val srcWorkspaceName = WorkspaceName(testData.workspaceWithRealm.namespace, "source_ws")
 
-    val authDomain = Set(testData.dbGapAuthorizedUsersGroup)
+      val authDomain = Set(testData.dbGapAuthorizedUsersGroup)
 
-    val x = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace, name = "source_ws", Map.empty, Option(authDomain))
-    Post("/workspaces", x) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      val x = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace,
+                               name = "source_ws",
+                               Map.empty,
+                               Option(authDomain)
+      )
+      Post("/workspaces", x) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    val destCloneRequest = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace, name = "copy_of_source_ws", Map.empty, Option(authDomain))
-    Post(s"/workspaces/${srcWorkspaceName.namespace}/source_ws/clone", httpJson(destCloneRequest)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      val destCloneRequest = WorkspaceRequest(namespace = testData.workspaceWithRealm.namespace,
+                                              name = "copy_of_source_ws",
+                                              Map.empty,
+                                              Option(authDomain)
+      )
+      Post(s"/workspaces/${srcWorkspaceName.namespace}/source_ws/clone", httpJson(destCloneRequest)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
+          assertResult(Some(authDomain.map(_.membersGroupName.value))) {
+            services.samDAO.authDomains.get((SamResourceTypeNames.workspace, responseAs[WorkspaceDetails].workspaceId))
+          }
         }
-        assertResult(Some(authDomain.map(_.membersGroupName.value))) {
-          services.samDAO.authDomains.get((SamResourceTypeNames.workspace, responseAs[WorkspaceDetails].workspaceId))
-        }
-      }
 
-    Post(s"/workspaces/${srcWorkspaceName.namespace}/${srcWorkspaceName.name}/entities", httpJson(z1)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      Post(s"/workspaces/${srcWorkspaceName.namespace}/${srcWorkspaceName.name}/entities", httpJson(z1)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
 
-    val destWorkspaceName = destCloneRequest.toWorkspaceName
+      val destWorkspaceName = destCloneRequest.toWorkspaceName
 
-    val copyDef = EntityCopyDefinition(srcWorkspaceName, destWorkspaceName, "Sample", Seq("z1"))
-    Post("/workspaces/entities/copy", httpJson(copyDef)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      val copyDef = EntityCopyDefinition(srcWorkspaceName, destWorkspaceName, "Sample", Seq("z1"))
+      Post("/workspaces/entities/copy", httpJson(copyDef)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 422 when copying entities from an auth domain protected workspace with only a partial match of AD groups" in withEmptyDatabaseApiServicesForAuthDomains { services =>
-    runAndWait(rawlsBillingProjectQuery.create(testData.billingProject))
-    val singleAuthDomain = Set(testData.dbGapAuthorizedUsersGroup)
-    val doubleAuthDomain = Set(testData.dbGapAuthorizedUsersGroup, testData.realm)
+  it should "return 422 when copying entities from an auth domain protected workspace with only a partial match of AD groups" in withEmptyDatabaseApiServicesForAuthDomains {
+    services =>
+      runAndWait(rawlsBillingProjectQuery.create(testData.billingProject))
+      val singleAuthDomain = Set(testData.dbGapAuthorizedUsersGroup)
+      val doubleAuthDomain = Set(testData.dbGapAuthorizedUsersGroup, testData.realm)
 
-    val x = WorkspaceRequest(testData.workspaceWithRealm.namespace, testData.workspaceWithRealm.name, Map.empty, Option(singleAuthDomain))
-    Post("/workspaces", x) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      val x = WorkspaceRequest(testData.workspaceWithRealm.namespace,
+                               testData.workspaceWithRealm.name,
+                               Map.empty,
+                               Option(singleAuthDomain)
+      )
+      Post("/workspaces", x) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    val y = WorkspaceRequest(testData.workspaceWithMultiGroupAD.namespace, testData.workspaceWithMultiGroupAD.name, Map.empty, Option(doubleAuthDomain))
-    Post("/workspaces", y) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      val y = WorkspaceRequest(testData.workspaceWithMultiGroupAD.namespace,
+                               testData.workspaceWithMultiGroupAD.name,
+                               Map.empty,
+                               Option(doubleAuthDomain)
+      )
+      Post("/workspaces", y) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    val wrongRealmCopyDef = EntityCopyDefinition(testData.workspaceWithMultiGroupAD.toWorkspaceName, testData.workspaceWithRealm.toWorkspaceName, "Sample", Seq("z1"))
-    Post("/workspaces/entities/copy", httpJson(wrongRealmCopyDef)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.UnprocessableEntity) {
-          status
+      val wrongRealmCopyDef = EntityCopyDefinition(testData.workspaceWithMultiGroupAD.toWorkspaceName,
+                                                   testData.workspaceWithRealm.toWorkspaceName,
+                                                   "Sample",
+                                                   Seq("z1")
+      )
+      Post("/workspaces/entities/copy", httpJson(wrongRealmCopyDef)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.UnprocessableEntity) {
+            status
+          }
         }
-      }
   }
 
   it should "not allow dots in user-defined strings" in withTestDataApiServices { services =>
     // entity names are validated by validateEntityName, which allows dots;
     // entity types are valaidated by validateUserDefinedString, which does not.
-    val dotSample = Entity("sample.with.dots.in.name", "entity.type.with.dots", Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor")))
+    val dotSample = Entity("sample.with.dots.in.name",
+                           "entity.type.with.dots",
+                           Map(AttributeName.withDefaultNS("type") -> AttributeString("tumor"))
+    )
     Post(s"${testData.workspace.path}/entities", httpJson(dotSample)) ~>
       sealRoute(services.entityRoutes) ~>
       check {
@@ -2292,36 +2746,58 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   }
 
   class PaginationTestData extends TestData {
-    val userOwner = RawlsUser(UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345")))
+    val userOwner = RawlsUser(
+      UserInfo(RawlsUserEmail("owner-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212345")
+      )
+    )
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set())
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set())
 
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
 
     val numEntities = 100
     val vocab1Strings = Map(0 -> "foo", 1 -> "bar", 2 -> "baz")
     val vocab2Strings = Map(0 -> "bim", 1 -> "bam")
     val entityType = "page_entity"
-    val entities = Random.shuffle(for (i <- 1 to numEntities) yield Entity(s"entity_$i", entityType, Map(
-      AttributeName.withDefaultNS("number") -> AttributeNumber(Math.random()),
-      AttributeName.withDefaultNS("random") -> AttributeString(UUID.randomUUID().toString),
-      AttributeName.withDefaultNS("sparse") -> (if (i % 2 == 0) AttributeNull else AttributeNumber(i.toDouble)),
-      AttributeName.withDefaultNS("vocab1") -> AttributeString(vocab1Strings(i % vocab1Strings.size)),
-      AttributeName.withDefaultNS("vocab2") -> AttributeString(vocab2Strings(i % vocab2Strings.size)),
-      AttributeName.withDefaultNS("mixed") -> (i % 3 match {
-        case 0 => AttributeString(s"$i")
-        case 1 => AttributeNumber(i.toDouble)
-        case 2 => AttributeValueList(1 to i map (AttributeNumber(_)) reverse)
-      }),
-      AttributeName.withDefaultNS("mixedNumeric") -> (i % 2 match {
-        case 0 => AttributeNumber(i.toDouble)
-        case 1 => AttributeValueList(1 to i map (AttributeNumber(_)) reverse)
-      }),
-      // pfb:number collides with default:number unless namespaces are honored
-      AttributeName.fromDelimitedName("pfb:number") -> AttributeNumber(Math.random())
-    )))
+    val entities = Random.shuffle(
+      for (i <- 1 to numEntities)
+        yield Entity(
+          s"entity_$i",
+          entityType,
+          Map(
+            AttributeName.withDefaultNS("number") -> AttributeNumber(Math.random()),
+            AttributeName.withDefaultNS("random") -> AttributeString(UUID.randomUUID().toString),
+            AttributeName.withDefaultNS("sparse") -> (if (i % 2 == 0) AttributeNull else AttributeNumber(i.toDouble)),
+            AttributeName.withDefaultNS("vocab1") -> AttributeString(vocab1Strings(i % vocab1Strings.size)),
+            AttributeName.withDefaultNS("vocab2") -> AttributeString(vocab2Strings(i % vocab2Strings.size)),
+            AttributeName.withDefaultNS("mixed") -> (i % 3 match {
+              case 0 => AttributeString(s"$i")
+              case 1 => AttributeNumber(i.toDouble)
+              case 2 => AttributeValueList(1 to i map (AttributeNumber(_)) reverse)
+            }),
+            AttributeName.withDefaultNS("mixedNumeric") -> (i % 2 match {
+              case 0 => AttributeNumber(i.toDouble)
+              case 1 => AttributeValueList(1 to i map (AttributeNumber(_)) reverse)
+            }),
+            // pfb:number collides with default:number unless namespaces are honored
+            AttributeName.fromDelimitedName("pfb:number") -> AttributeNumber(Math.random())
+          )
+        )
+    )
 
     override def save(): ReadWriteAction[Unit] = {
       import driver.api._
@@ -2335,74 +2811,81 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   val paginationTestData = new PaginationTestData()
 
-  def withPaginationTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withPaginationTestDataApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(paginationTestData) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
   val defaultQuery = EntityQuery(1, 10, "name", Ascending, None)
 
   def calculateNumPages(count: Int, pageSize: Int) = Math.ceil(count.toDouble / pageSize).toInt
 
-  "entityQuery API" should "return 400 bad request on entity query when page is not a number" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=asdf") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  "entityQuery API" should "return 400 bad request on entity query when page is not a number" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=asdf") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 bad request on entity query when page size is not a number" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=asdfasdf") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 bad request on entity query when page size is not a number" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=asdfasdf") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 bad request on entity query when page is <= 0" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=-1") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 bad request on entity query when page is <= 0" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=-1") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 bad request on entity query when page size is <= 0" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=-1") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 bad request on entity query when page size is <= 0" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=-1") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 bad request on entity query when page > page count" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=10000000") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 bad request on entity query when page > page count" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?page=10000000") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 bad request on entity query for unknown sort direction" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortDirection=asdfasdfasdf") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 bad request on entity query for unknown sort direction" in withPaginationTestDataApiServices {
+    services =>
+      Get(
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortDirection=asdfasdfasdf"
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
   it should "return 200 OK on entity query for unknown sort field" in withPaginationTestDataApiServices { services =>
@@ -2412,58 +2895,70 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(sortField = "asdfasdfasdf"),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-          paginationTestData.entities.sortBy(_.name).take(defaultQuery.pageSize))) {
+        assertResult(
+          EntityQueryResponse(
+            defaultQuery.copy(sortField = "asdfasdfasdf"),
+            EntityQueryResultMetadata(paginationTestData.numEntities,
+                                      paginationTestData.numEntities,
+                                      calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+            ),
+            paginationTestData.entities.sortBy(_.name).take(defaultQuery.pageSize)
+          )
+        ) {
 
           responseAs[EntityQueryResponse]
         }
       }
   }
 
-  it should "return 404 not found on entity query for workspace that does not exist" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.copy(name = "DNE").path}/entityQuery/${paginationTestData.entityType}") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 not found on entity query for workspace that does not exist" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.copy(name = "DNE").path}/entityQuery/${paginationTestData.entityType}") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 200 OK on entity query when no query params are given" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult(EntityQueryResponse(
-          defaultQuery,
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-          paginationTestData.entities.sortBy(_.name).take(defaultQuery.pageSize))) {
+  it should "return 200 OK on entity query when no query params are given" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(
+            EntityQueryResponse(
+              defaultQuery,
+              EntityQueryResultMetadata(paginationTestData.numEntities,
+                                        paginationTestData.numEntities,
+                                        calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+              ),
+              paginationTestData.entities.sortBy(_.name).take(defaultQuery.pageSize)
+            )
+          ) {
 
-          responseAs[EntityQueryResponse]
+            responseAs[EntityQueryResponse]
+          }
         }
-      }
   }
 
-  it should "return 200 OK on entity query when there are no entities of given type" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/blarf") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult(EntityQueryResponse(
-          defaultQuery,
-          EntityQueryResultMetadata(0, 0, 0),
-          Seq.empty)) {
+  it should "return 200 OK on entity query when there are no entities of given type" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/blarf") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(EntityQueryResponse(defaultQuery, EntityQueryResultMetadata(0, 0, 0), Seq.empty)) {
 
-          responseAs[EntityQueryResponse]
+            responseAs[EntityQueryResponse]
+          }
         }
-      }
   }
 
   it should "not return deleted entities on entity query" in withPaginationTestDataApiServices { services =>
@@ -2497,95 +2992,131 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.OK) {
             status
           }
-          assertResult(EntityQueryResponse(
-            defaultQuery,
-            EntityQueryResultMetadata(0, 0, 0),
-            Seq.empty)) {
+          assertResult(EntityQueryResponse(defaultQuery, EntityQueryResultMetadata(0, 0, 0), Seq.empty)) {
 
             responseAs[EntityQueryResponse]
           }
         }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted"
-      val expected = expectedHttpRequestMetrics("get", s"$wsPathForRequestMetrics.entityQuery.bar", StatusCodes.OK.intValue, 1) ++
-                     expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.entities.delete", StatusCodes.NoContent.intValue, 1) ++
-                     expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.entities", StatusCodes.Created.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("get", s"$wsPathForRequestMetrics.entityQuery.bar", StatusCodes.OK.intValue, 1) ++
+          expectedHttpRequestMetrics("post",
+                                     s"$wsPathForRequestMetrics.entities.delete",
+                                     StatusCodes.NoContent.intValue,
+                                     1
+          ) ++
+          expectedHttpRequestMetrics("post", s"$wsPathForRequestMetrics.entities", StatusCodes.Created.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
   }
 
-  it should "return 200 OK on entity query when all results are filtered" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=qqq") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(filterTerms = Option("qqq")),
-          EntityQueryResultMetadata(paginationTestData.entities.size, 0, 0),
-          Seq.empty)) {
+  it should "return 200 OK on entity query when all results are filtered" in withPaginationTestDataApiServices {
+    services =>
+      Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=qqq") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(
+            EntityQueryResponse(defaultQuery.copy(filterTerms = Option("qqq")),
+                                EntityQueryResultMetadata(paginationTestData.entities.size, 0, 0),
+                                Seq.empty
+            )
+          ) {
 
-          responseAs[EntityQueryResponse]
+            responseAs[EntityQueryResponse]
+          }
         }
-      }
   }
 
-  it should "return 200 OK and use default AND operator on filterTerms when a filterOperator is not specified" in withTestDataApiServices { services =>
-    val fooEntity = Entity("firstSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo")))
-    val barEntity = Entity("secondSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("bar")))
-    val fooBarEntity = Entity("thirdSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo"), AttributeName.withDefaultNS("attrname2") -> AttributeString("bar")))
+  it should "return 200 OK and use default AND operator on filterTerms when a filterOperator is not specified" in withTestDataApiServices {
+    services =>
+      val fooEntity =
+        Entity("firstSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo")))
+      val barEntity =
+        Entity("secondSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("bar")))
+      val fooBarEntity = Entity(
+        "thirdSample",
+        "sample",
+        Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo"),
+            AttributeName.withDefaultNS("attrname2") -> AttributeString("bar")
+        )
+      )
 
-    runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
+      runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
 
-    Get(s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Get(s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(Seq(fooBarEntity)) {
+            responseAs[EntityQueryResponse].results
+          }
         }
-        assertResult(Seq(fooBarEntity)) {
-          responseAs[EntityQueryResponse].results
-        }
-      }
   }
 
-  it should "return 200 OK and use AND operator on filterTerms when AND filterOperator is specified" in withTestDataApiServices { services =>
-    val fooEntity = Entity("firstSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo")))
-    val barEntity = Entity("secondSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("bar")))
-    val fooBarEntity = Entity("thirdSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo"), AttributeName.withDefaultNS("attrname2") -> AttributeString("bar")))
+  it should "return 200 OK and use AND operator on filterTerms when AND filterOperator is specified" in withTestDataApiServices {
+    services =>
+      val fooEntity =
+        Entity("firstSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo")))
+      val barEntity =
+        Entity("secondSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("bar")))
+      val fooBarEntity = Entity(
+        "thirdSample",
+        "sample",
+        Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo"),
+            AttributeName.withDefaultNS("attrname2") -> AttributeString("bar")
+        )
+      )
 
-    runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
+      runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
 
-    Get(s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar&filterOperator=AND") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Get(
+        s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar&filterOperator=AND"
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(Seq(fooBarEntity)) {
+            responseAs[EntityQueryResponse].results
+          }
         }
-        assertResult(Seq(fooBarEntity)) {
-          responseAs[EntityQueryResponse].results
-        }
-      }
   }
 
-  it should "return 200 OK and use OR operator on filterTerms when OR filterOperator is specified" in withTestDataApiServices { services =>
-    val fooEntity = Entity("firstSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo")))
-    val barEntity = Entity("secondSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("bar")))
-    val fooBarEntity = Entity("thirdSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo"), AttributeName.withDefaultNS("attrname2") -> AttributeString("bar")))
+  it should "return 200 OK and use OR operator on filterTerms when OR filterOperator is specified" in withTestDataApiServices {
+    services =>
+      val fooEntity =
+        Entity("firstSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo")))
+      val barEntity =
+        Entity("secondSample", "sample", Map(AttributeName.withDefaultNS("attrname") -> AttributeString("bar")))
+      val fooBarEntity = Entity(
+        "thirdSample",
+        "sample",
+        Map(AttributeName.withDefaultNS("attrname") -> AttributeString("foo"),
+            AttributeName.withDefaultNS("attrname2") -> AttributeString("bar")
+        )
+      )
 
-    runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
+      runAndWait(entityQuery.save(testData.workspaceNoEntities, Seq(fooEntity, barEntity, fooBarEntity)))
 
-    Get(s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar&filterOperator=OR") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Get(
+        s"${testData.workspaceNoEntities.path}/entityQuery/${fooEntity.entityType}?filterTerms=foo%20bar&filterOperator=OR"
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(Seq(fooEntity, barEntity, fooBarEntity)) {
+            responseAs[EntityQueryResponse].results
+          }
         }
-        assertResult(Seq(fooEntity, barEntity, fooBarEntity)) {
-          responseAs[EntityQueryResponse].results
-        }
-      }
   }
 
   it should "return the right page on entity query" in withPaginationTestDataApiServices { services =>
@@ -2597,10 +3128,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(page = page),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-          paginationTestData.entities.sortBy(_.name).slice(offset, offset + defaultQuery.pageSize))) {
+        assertResult(
+          EntityQueryResponse(
+            defaultQuery.copy(page = page),
+            EntityQueryResultMetadata(paginationTestData.numEntities,
+                                      paginationTestData.numEntities,
+                                      calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+            ),
+            paginationTestData.entities.sortBy(_.name).slice(offset, offset + defaultQuery.pageSize)
+          )
+        ) {
 
           responseAs[EntityQueryResponse]
         }
@@ -2616,10 +3153,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(pageSize = pageSize),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, pageSize)),
-          paginationTestData.entities.sortBy(_.name).slice(offset, offset + pageSize))) {
+        assertResult(
+          EntityQueryResponse(
+            defaultQuery.copy(pageSize = pageSize),
+            EntityQueryResultMetadata(paginationTestData.numEntities,
+                                      paginationTestData.numEntities,
+                                      calculateNumPages(paginationTestData.numEntities, pageSize)
+            ),
+            paginationTestData.entities.sortBy(_.name).slice(offset, offset + pageSize)
+          )
+        ) {
 
           responseAs[EntityQueryResponse]
         }
@@ -2634,96 +3177,134 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.OK) {
             status
           }
-          assertResult(EntityQueryResponse(
-            defaultQuery.copy(sortField = "number"),
-            EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-            paginationTestData.entities.sortBy(_.attributes(AttributeName.withDefaultNS("number")).asInstanceOf[AttributeNumber].value).take(defaultQuery.pageSize))) {
+          assertResult(
+            EntityQueryResponse(
+              defaultQuery.copy(sortField = "number"),
+              EntityQueryResultMetadata(paginationTestData.numEntities,
+                                        paginationTestData.numEntities,
+                                        calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+              ),
+              paginationTestData.entities
+                .sortBy(_.attributes(AttributeName.withDefaultNS("number")).asInstanceOf[AttributeNumber].value)
+                .take(defaultQuery.pageSize)
+            )
+          ) {
 
             responseAs[EntityQueryResponse]
+          }
         }
-      }
-    } {capturedMetrics =>
+    } { capturedMetrics =>
       val wsPathForRequestMetrics = s"workspaces.redacted.redacted"
-      val expected = expectedHttpRequestMetrics("get", s"$wsPathForRequestMetrics.entityQuery.${paginationTestData.entityType}", StatusCodes.OK.intValue, 1)
+      val expected =
+        expectedHttpRequestMetrics("get",
+                                   s"$wsPathForRequestMetrics.entityQuery.${paginationTestData.entityType}",
+                                   StatusCodes.OK.intValue,
+                                   1
+        )
       assertSubsetOf(expected, capturedMetrics)
     }
   }
 
   it should "return sorted results on entity query for string field" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=random&sordDirection=asc") ~>
+    Get(
+      s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=random&sordDirection=asc"
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(sortField = "random"),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-          paginationTestData.entities.sortBy(_.attributes(AttributeName.withDefaultNS("random")).asInstanceOf[AttributeString].value).take(defaultQuery.pageSize))) {
+        assertResult(
+          EntityQueryResponse(
+            defaultQuery.copy(sortField = "random"),
+            EntityQueryResultMetadata(paginationTestData.numEntities,
+                                      paginationTestData.numEntities,
+                                      calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+            ),
+            paginationTestData.entities
+              .sortBy(_.attributes(AttributeName.withDefaultNS("random")).asInstanceOf[AttributeString].value)
+              .take(defaultQuery.pageSize)
+          )
+        ) {
 
           responseAs[EntityQueryResponse]
         }
       }
   }
 
-  private def entityLessThan(attributeName: String)(e1: Entity, e2: Entity): Boolean = {
-    (e1.attributes(AttributeName.withDefaultNS(attributeName)), e2.attributes(AttributeName.withDefaultNS(attributeName))) match {
+  private def entityLessThan(attributeName: String)(e1: Entity, e2: Entity): Boolean =
+    (e1.attributes(AttributeName.withDefaultNS(attributeName)),
+     e2.attributes(AttributeName.withDefaultNS(attributeName))
+    ) match {
       case (AttributeNumber(v1), AttributeNumber(v2)) if v1 == v2 => e1.name < e2.name
-      case (AttributeNumber(v1), AttributeNumber(v2)) => v1 < v2
-      case (AttributeNumber(v), _) => true
-      case (_, AttributeNumber(v)) => false
+      case (AttributeNumber(v1), AttributeNumber(v2))             => v1 < v2
+      case (AttributeNumber(v), _)                                => true
+      case (_, AttributeNumber(v))                                => false
 
       case (AttributeString(v1), AttributeString(v2)) if v1 == v2 => e1.name < e2.name
-      case (AttributeString(v1), AttributeString(v2)) => v1 < v2
-      case (AttributeString(v), _) => true
-      case (_, AttributeString(v)) => false
+      case (AttributeString(v1), AttributeString(v2))             => v1 < v2
+      case (AttributeString(v), _)                                => true
+      case (_, AttributeString(v))                                => false
 
       case (l1: AttributeList[_], l2: AttributeList[_]) if l1.list.length == l2.list.length => e1.name < e2.name
       case (l1: AttributeList[_], l2: AttributeList[_]) => l1.list.length < l2.list.length
-      case (l1: AttributeList[_], _) => true
-      case (_, l2: AttributeList[_]) => false
+      case (l1: AttributeList[_], _)                    => true
+      case (_, l2: AttributeList[_])                    => false
 
       case (_, _) => throw new RawlsException("case not covered")
 
     }
+
+  it should "return sorted results on entity query for mixed typed field" in withPaginationTestDataApiServices {
+    services =>
+      Get(
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=mixed&pageSize=${paginationTestData.numEntities}"
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+
+          assertResult(
+            EntityQueryResponse(
+              defaultQuery.copy(sortField = "mixed", pageSize = paginationTestData.numEntities),
+              EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, 1),
+              paginationTestData.entities.sortWith(entityLessThan("mixed"))
+            )
+          ) {
+            responseAs[EntityQueryResponse]
+          }
+        }
   }
 
-  it should "return sorted results on entity query for mixed typed field" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=mixed&pageSize=${paginationTestData.numEntities}") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
+  it should "return sorted results on entity query for mixed numeric-type field including lists" in withPaginationTestDataApiServices {
+    services =>
+      Get(
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=mixedNumeric&pageSize=${paginationTestData.numEntities}"
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
 
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(sortField = "mixed", pageSize = paginationTestData.numEntities),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, 1),
-          paginationTestData.entities.sortWith(entityLessThan("mixed")))) {
-          responseAs[EntityQueryResponse]
+          assertResult(
+            EntityQueryResponse(
+              defaultQuery.copy(sortField = "mixedNumeric", pageSize = paginationTestData.numEntities),
+              EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, 1),
+              paginationTestData.entities.sortWith(entityLessThan("mixedNumeric"))
+            )
+          ) {
+            responseAs[EntityQueryResponse]
+          }
         }
-      }
-  }
-
-  it should "return sorted results on entity query for mixed numeric-type field including lists" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=mixedNumeric&pageSize=${paginationTestData.numEntities}") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(sortField = "mixedNumeric", pageSize = paginationTestData.numEntities),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, 1),
-          paginationTestData.entities.sortWith(entityLessThan("mixedNumeric")))) {
-          responseAs[EntityQueryResponse]
-        }
-      }
   }
 
   it should "return sorted results on entity query for sparse field" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=sparse&pageSize=${paginationTestData.numEntities}") ~>
+    Get(
+      s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=sparse&pageSize=${paginationTestData.numEntities}"
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -2732,42 +3313,70 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
         // all the entities without values should be last, drop them then make sure the resulting list is sorted right
         val resultEntities = responseAs[EntityQueryResponse].results
-        assertResult(paginationTestData.entities.filter(_.attributes.getOrElse(AttributeName.withDefaultNS("sparse"), AttributeNull) != AttributeNull).sortBy(_.attributes(AttributeName.withDefaultNS("sparse")).asInstanceOf[AttributeNumber].value)) {
-          resultEntities.dropWhile(_.attributes.getOrElse(AttributeName.withDefaultNS("sparse"), AttributeNull) == AttributeNull)
+        assertResult(
+          paginationTestData.entities
+            .filter(_.attributes.getOrElse(AttributeName.withDefaultNS("sparse"), AttributeNull) != AttributeNull)
+            .sortBy(_.attributes(AttributeName.withDefaultNS("sparse")).asInstanceOf[AttributeNumber].value)
+        ) {
+          resultEntities.dropWhile(
+            _.attributes.getOrElse(AttributeName.withDefaultNS("sparse"), AttributeNull) == AttributeNull
+          )
         }
       }
   }
 
-  it should "return sorted results on entity query for namespaced attributes" in withPaginationTestDataApiServices { services =>
-    val sortAttr = AttributeName.fromDelimitedName("pfb:number")
+  it should "return sorted results on entity query for namespaced attributes" in withPaginationTestDataApiServices {
+    services =>
+      val sortAttr = AttributeName.fromDelimitedName("pfb:number")
 
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=${toDelimitedName(sortAttr)}") ~>
-      services.sealedInstrumentedRoutes ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(sortField = toDelimitedName(sortAttr)),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-          paginationTestData.entities.sortBy(_.attributes(sortAttr).asInstanceOf[AttributeNumber].value).take(defaultQuery.pageSize))) {
+      Get(
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=${toDelimitedName(sortAttr)}"
+      ) ~>
+        services.sealedInstrumentedRoutes ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(
+            EntityQueryResponse(
+              defaultQuery.copy(sortField = toDelimitedName(sortAttr)),
+              EntityQueryResultMetadata(paginationTestData.numEntities,
+                                        paginationTestData.numEntities,
+                                        calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+              ),
+              paginationTestData.entities
+                .sortBy(_.attributes(sortAttr).asInstanceOf[AttributeNumber].value)
+                .take(defaultQuery.pageSize)
+            )
+          ) {
 
-          responseAs[EntityQueryResponse]
+            responseAs[EntityQueryResponse]
+          }
         }
-      }
   }
 
   it should "return sorted results on entity query descending" in withPaginationTestDataApiServices { services =>
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=random&sortDirection=desc") ~>
+    Get(
+      s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?sortField=random&sortDirection=desc"
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(sortField = "random", sortDirection = Descending),
-          EntityQueryResultMetadata(paginationTestData.numEntities, paginationTestData.numEntities, calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)),
-          paginationTestData.entities.sortBy(_.attributes(AttributeName.withDefaultNS("random")).asInstanceOf[AttributeString].value).reverse.take(defaultQuery.pageSize))) {
+        assertResult(
+          EntityQueryResponse(
+            defaultQuery.copy(sortField = "random", sortDirection = Descending),
+            EntityQueryResultMetadata(paginationTestData.numEntities,
+                                      paginationTestData.numEntities,
+                                      calculateNumPages(paginationTestData.numEntities, defaultQuery.pageSize)
+            ),
+            paginationTestData.entities
+              .sortBy(_.attributes(AttributeName.withDefaultNS("random")).asInstanceOf[AttributeString].value)
+              .reverse
+              .take(defaultQuery.pageSize)
+          )
+        ) {
 
           responseAs[EntityQueryResponse]
         }
@@ -2778,19 +3387,31 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val pageSize = paginationTestData.entities.size
     val vocab1Term = paginationTestData.vocab1Strings(0)
     val vocab2Term = paginationTestData.vocab2Strings(1)
-    val expectedEntities = paginationTestData.entities.
-      filter(e => e.attributes(AttributeName.withDefaultNS("vocab1")) == AttributeString(vocab1Term) && e.attributes(AttributeName.withDefaultNS("vocab2")) == AttributeString(vocab2Term)).
-      sortBy(_.name)
-    Get(s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&filterTerms=$vocab1Term%20$vocab2Term") ~>
+    val expectedEntities = paginationTestData.entities
+      .filter(e =>
+        e.attributes(AttributeName.withDefaultNS("vocab1")) == AttributeString(vocab1Term) && e.attributes(
+          AttributeName.withDefaultNS("vocab2")
+        ) == AttributeString(vocab2Term)
+      )
+      .sortBy(_.name)
+    Get(
+      s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&filterTerms=$vocab1Term%20$vocab2Term"
+    ) ~>
       sealRoute(services.entityRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
           status
         }
-        assertResult(EntityQueryResponse(
-          defaultQuery.copy(pageSize = pageSize, filterTerms = Option(s"$vocab1Term $vocab2Term")),
-          EntityQueryResultMetadata(paginationTestData.numEntities, expectedEntities.size, calculateNumPages(expectedEntities.size, pageSize)),
-          expectedEntities)) {
+        assertResult(
+          EntityQueryResponse(
+            defaultQuery.copy(pageSize = pageSize, filterTerms = Option(s"$vocab1Term $vocab2Term")),
+            EntityQueryResultMetadata(paginationTestData.numEntities,
+                                      expectedEntities.size,
+                                      calculateNumPages(expectedEntities.size, pageSize)
+            ),
+            expectedEntities
+          )
+        ) {
 
           responseAs[EntityQueryResponse]
         }
@@ -2801,13 +3422,28 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   // creates 30 entities, in groups of 10; each group has different attributes, with some overlap.
   class FieldSelectionTestData extends TestData {
-    val userOwner = RawlsUser(UserInfo(RawlsUserEmail("owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345")))
+    val userOwner = RawlsUser(
+      UserInfo(RawlsUserEmail("owner-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212345")
+      )
+    )
     val wsName = WorkspaceName("myNamespace", "myWorkspace")
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set(userOwner))
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set())
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set())
 
-    val workspace = Workspace(wsName.namespace, wsName.name, UUID.randomUUID().toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val workspace = Workspace(wsName.namespace,
+                              wsName.name,
+                              UUID.randomUUID().toString,
+                              "aBucket",
+                              Some("workflow-collection"),
+                              currentTime(),
+                              currentTime(),
+                              "testUser",
+                              Map.empty
+    )
 
     val colorGroup1 = List("allgroups", "group1and2", "red", "yellow", "blue", "brown", "orange")
     val colorGroup2 = List("allgroups", "group1and2", "group2and3", "green", "violet", "black", "carnation", "white")
@@ -2816,14 +3452,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     val numEntities = 100
     val entityType = "fieldselect"
 
-    val entities = List(colorGroup1, colorGroup2, colorGroup3).zipWithIndex.flatMap {
-      case (colorList, groupIdx) =>
-        (0 to 9) map { idx =>
-          val attributes = colorList.map(color => AttributeName.withDefaultNS(color) -> AttributeString(s"$color value")).toMap
-          // default sorting for entityQuery is by name, so ensure the names we generate here are in
-          // ascending order of insertion
-          Entity(s"$groupIdx-$idx", entityType, attributes)
-        }
+    val entities = List(colorGroup1, colorGroup2, colorGroup3).zipWithIndex.flatMap { case (colorList, groupIdx) =>
+      (0 to 9) map { idx =>
+        val attributes =
+          colorList.map(color => AttributeName.withDefaultNS(color) -> AttributeString(s"$color value")).toMap
+        // default sorting for entityQuery is by name, so ensure the names we generate here are in
+        // ascending order of insertion
+        Entity(s"$groupIdx-$idx", entityType, attributes)
+      }
     }
 
     override def save(): ReadWriteAction[Unit] = {
@@ -2838,13 +3474,13 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   val fieldSelectionTestData = new FieldSelectionTestData()
 
-  def withFieldSelectionTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withFieldSelectionTestDataApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(fieldSelectionTestData) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  val fieldSelectionApiPath = s"${fieldSelectionTestData.workspace.path}/entityQuery/${fieldSelectionTestData.entityType}"
+  val fieldSelectionApiPath =
+    s"${fieldSelectionTestData.workspace.path}/entityQuery/${fieldSelectionTestData.entityType}"
 
   def assertFieldSelection(actualResponse: EntityQueryResponse, expectedFields: List[String], expectedPageSize: Int) = {
     withClue("when checking results page size, ") {
@@ -2855,64 +3491,70 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     actual.toSet should contain theSameElementsAs expectedFields.toSet
   }
 
-  it should "return all attributes, name, and entityType if the fields parameter is omitted (all entities)" in withFieldSelectionTestDataApiServices { services =>
-    // query for all entities
-    Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        val expected = fieldSelectionTestData.colorGroup1 ++ fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
-        assertFieldSelection(resp, expected, fieldSelectionTestData.entities.size)
-      }
-  }
-
-  it should "return all attributes, name, and entityType if the fields parameter is omitted (first page)" in withFieldSelectionTestDataApiServices { services =>
-    // query for first page of results
-    Get(s"$fieldSelectionApiPath?pageSize=10") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        val expected = fieldSelectionTestData.colorGroup1
-        assertFieldSelection(resp, expected, 10)
-      }
-  }
-
-  it should "return all attributes, name, and entityType if the fields parameter is omitted (second page)" in withFieldSelectionTestDataApiServices { services =>
-    // query for second page of results
-    Get(s"$fieldSelectionApiPath?pageSize=10&page=2") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        val expected = fieldSelectionTestData.colorGroup2
-        assertFieldSelection(resp, expected, 10)
-      }
-  }
-
-  it should "return all attributes, name, and entityType if the fields parameter is omitted (second page extending into third page)" in withFieldSelectionTestDataApiServices { services =>
-    // query for the second page of results, with a page size that extends us into the third
-    // group of entities from fieldSelectionTestData
-    Get(s"$fieldSelectionApiPath?pageSize=15&page=2") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        val expected = fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
-        assertFieldSelection(resp, expected, 15)
-      }
-  }
-
-  List(List("name"), List("entityType"), List("name", "entityType")) foreach { fieldsUnderTest =>
-    it should s"return [${fieldsUnderTest.mkString(", ")}] if requested in fields" ignore withFieldSelectionTestDataApiServices { services =>
-      Get(s"$fieldSelectionApiPath?pageSize=25&page=1&fields=${fieldsUnderTest.mkString(",")}") ~>
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (all entities)" in withFieldSelectionTestDataApiServices {
+    services =>
+      // query for all entities
+      Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}") ~>
         sealRoute(services.entityRoutes) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
-          assertFieldSelection(resp, fieldsUnderTest, 25)
+          val expected =
+            fieldSelectionTestData.colorGroup1 ++ fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
+          assertFieldSelection(resp, expected, fieldSelectionTestData.entities.size)
         }
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (first page)" in withFieldSelectionTestDataApiServices {
+    services =>
+      // query for first page of results
+      Get(s"$fieldSelectionApiPath?pageSize=10") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          val expected = fieldSelectionTestData.colorGroup1
+          assertFieldSelection(resp, expected, 10)
+        }
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (second page)" in withFieldSelectionTestDataApiServices {
+    services =>
+      // query for second page of results
+      Get(s"$fieldSelectionApiPath?pageSize=10&page=2") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          val expected = fieldSelectionTestData.colorGroup2
+          assertFieldSelection(resp, expected, 10)
+        }
+  }
+
+  it should "return all attributes, name, and entityType if the fields parameter is omitted (second page extending into third page)" in withFieldSelectionTestDataApiServices {
+    services =>
+      // query for the second page of results, with a page size that extends us into the third
+      // group of entities from fieldSelectionTestData
+      Get(s"$fieldSelectionApiPath?pageSize=15&page=2") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          val expected = fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
+          assertFieldSelection(resp, expected, 15)
+        }
+  }
+
+  List(List("name"), List("entityType"), List("name", "entityType")) foreach { fieldsUnderTest =>
+    it should s"return [${fieldsUnderTest.mkString(", ")}] if requested in fields" ignore withFieldSelectionTestDataApiServices {
+      services =>
+        Get(s"$fieldSelectionApiPath?pageSize=25&page=1&fields=${fieldsUnderTest.mkString(",")}") ~>
+          sealRoute(services.entityRoutes) ~>
+          check {
+            status shouldBe StatusCodes.OK
+            val resp = responseAs[EntityQueryResponse]
+            assertFieldSelection(resp, fieldsUnderTest, 25)
+          }
     }
   }
 
@@ -2940,73 +3582,86 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     FieldsTestCase(10, 3, List("cerulean", "apricot")),
     FieldsTestCase(10, 3, List("gray")),
     // test cases for all three groups combined
-    FieldsTestCase(25, 1, fieldSelectionTestData.colorGroup1 ++ fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3),
+    FieldsTestCase(
+      25,
+      1,
+      fieldSelectionTestData.colorGroup1 ++ fieldSelectionTestData.colorGroup2 ++ fieldSelectionTestData.colorGroup3
+    ),
     FieldsTestCase(25, 1, List("allgroups", "group1and2", "group2and3", "red", "green", "dandelion")),
     FieldsTestCase(25, 1, List("yellow", "blue", "violet", "black", "cerulean", "apricot")),
     FieldsTestCase(25, 1, List("yellow", "blue")),
     FieldsTestCase(25, 1, List("violet", "black")),
     FieldsTestCase(25, 1, List("cerulean", "apricot")),
-    FieldsTestCase(25, 1, List("orange", "scarlet")),
+    FieldsTestCase(25, 1, List("orange", "scarlet"))
   )
 
   testCases foreach { testCase =>
     val fieldsUnderTest = testCase.fieldsUnderTest
-    it should s"return only the requested fields (pageSize ${testCase.pageSize}, page ${testCase.page}, fields ${testCase.fieldsUnderTest})" in withFieldSelectionTestDataApiServices { services =>
-      Get(s"$fieldSelectionApiPath?pageSize=${testCase.pageSize}&page=${testCase.page}&fields=${fieldsUnderTest.mkString(",")}") ~>
+    it should s"return only the requested fields (pageSize ${testCase.pageSize}, page ${testCase.page}, fields ${testCase.fieldsUnderTest})" in withFieldSelectionTestDataApiServices {
+      services =>
+        Get(
+          s"$fieldSelectionApiPath?pageSize=${testCase.pageSize}&page=${testCase.page}&fields=${fieldsUnderTest.mkString(",")}"
+        ) ~>
+          sealRoute(services.entityRoutes) ~>
+          check {
+            status shouldBe StatusCodes.OK
+            val resp = responseAs[EntityQueryResponse]
+            assertFieldSelection(resp, fieldsUnderTest, testCase.pageSize)
+          }
+    }
+  }
+
+  it should "return no attributes if requested field exists, but not in this page of results" in withFieldSelectionTestDataApiServices {
+    services =>
+      // get the first page of results, but request a field from the second page
+      Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=violet") ~>
         sealRoute(services.entityRoutes) ~>
         check {
           status shouldBe StatusCodes.OK
           val resp = responseAs[EntityQueryResponse]
-          assertFieldSelection(resp, fieldsUnderTest, testCase.pageSize)
+          assertFieldSelection(resp, List(), 10)
         }
-    }
   }
 
-  it should "return no attributes if requested field exists, but not in this page of results" in withFieldSelectionTestDataApiServices { services =>
-    // get the first page of results, but request a field from the second page
-    Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=violet") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        assertFieldSelection(resp, List(), 10)
-      }
+  it should "return no attributes if unrecognized field names in parameter" in withFieldSelectionTestDataApiServices {
+    services =>
+      // request a totally nonexistent field
+      Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=nonexistent") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          assertFieldSelection(resp, List(), 10)
+        }
   }
 
-  it should "return no attributes if unrecognized field names in parameter" in withFieldSelectionTestDataApiServices { services =>
-    // request a totally nonexistent field
-    Get(s"$fieldSelectionApiPath?pageSize=10&page=1&fields=nonexistent") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        assertFieldSelection(resp, List(), 10)
-      }
+  it should "return requested fields in conjunction with sort and filter" in withFieldSelectionTestDataApiServices {
+    services =>
+      // request all 30 results, but use a filter term that should only return the third page.
+      // request fields from all pages, but expect only the third page's fields back.
+      Get(
+        s"$fieldSelectionApiPath?pageSize=30&page=1&filterTerms=gray&sortField=red&sortDirection=desc&fields=yellow,green,apricot"
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          val expected = List("apricot")
+          assertFieldSelection(resp, expected, 10)
+        }
   }
 
-  it should "return requested fields in conjunction with sort and filter" in withFieldSelectionTestDataApiServices { services =>
-    // request all 30 results, but use a filter term that should only return the third page.
-    // request fields from all pages, but expect only the third page's fields back.
-    Get(s"$fieldSelectionApiPath?pageSize=30&page=1&filterTerms=gray&sortField=red&sortDirection=desc&fields=yellow,green,apricot") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        val expected = List("apricot")
-        assertFieldSelection(resp, expected, 10)
-      }
-  }
-
-  it should "return no attributes if field list is empty, i.e. 'fields='" in withFieldSelectionTestDataApiServices { services =>
-    // query for all entities
-    Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}&fields=") ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        status shouldBe StatusCodes.OK
-        val resp = responseAs[EntityQueryResponse]
-        val expected = List()
-        assertFieldSelection(resp, expected, fieldSelectionTestData.entities.size)
-      }
+  it should "return no attributes if field list is empty, i.e. 'fields='" in withFieldSelectionTestDataApiServices {
+    services =>
+      // query for all entities
+      Get(s"$fieldSelectionApiPath?pageSize=${fieldSelectionTestData.entities.size}&fields=") ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          status shouldBe StatusCodes.OK
+          val resp = responseAs[EntityQueryResponse]
+          val expected = List()
+          assertFieldSelection(resp, expected, fieldSelectionTestData.entities.size)
+        }
   }
   // *********** END entityQuery field-selection tests
 
@@ -3014,12 +3669,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(s"${constantData.workspace.path}/entities") ~>
       sealRoute(services.entityRoutes) ~>
       check {
-        assertResult(StatusCodes.OK, responseAs[String]){
+        assertResult(StatusCodes.OK, responseAs[String]) {
           status
         }
       }
     val argumentCaptor = captor[Boolean]
-    verify(services.service).entityTypeMetadata(any[WorkspaceName], any[Option[DataReferenceName]], any[Option[GoogleProjectId]], argumentCaptor.capture())
+    verify(services.service).entityTypeMetadata(any[WorkspaceName],
+                                                any[Option[DataReferenceName]],
+                                                any[Option[GoogleProjectId]],
+                                                argumentCaptor.capture()
+    )
     assert(argumentCaptor.getValue)
   }
 
@@ -3027,12 +3686,16 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(s"${constantData.workspace.path}/entities?useCache=false") ~>
       sealRoute(services.entityRoutes) ~>
       check {
-        assertResult(StatusCodes.OK, responseAs[String]){
+        assertResult(StatusCodes.OK, responseAs[String]) {
           status
         }
       }
     val argumentCaptor = captor[Boolean]
-    verify(services.service).entityTypeMetadata(any[WorkspaceName], any[Option[DataReferenceName]], any[Option[GoogleProjectId]], argumentCaptor.capture())
+    verify(services.service).entityTypeMetadata(any[WorkspaceName],
+                                                any[Option[DataReferenceName]],
+                                                any[Option[GoogleProjectId]],
+                                                argumentCaptor.capture()
+    )
     assert(!argumentCaptor.getValue)
   }
 
@@ -3040,14 +3703,17 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     Get(s"${constantData.workspace.path}/entities?useCache=mysterious") ~>
       sealRoute(services.entityRoutes) ~>
       check {
-        assertResult(StatusCodes.OK, responseAs[String]){
+        assertResult(StatusCodes.OK, responseAs[String]) {
           status
         }
       }
     val argumentCaptor = captor[Boolean]
-    verify(services.service).entityTypeMetadata(any[WorkspaceName], any[Option[DataReferenceName]], any[Option[GoogleProjectId]], argumentCaptor.capture())
+    verify(services.service).entityTypeMetadata(any[WorkspaceName],
+                                                any[Option[DataReferenceName]],
+                                                any[Option[GoogleProjectId]],
+                                                argumentCaptor.capture()
+    )
     assert(argumentCaptor.getValue)
   }
-
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -19,18 +19,26 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   val v2BaseSnapshotsPath = s"${testData.wsName.path}/snapshots/v2"
 
-  val defaultNamedSnapshotJson = httpJson(NamedDataRepoSnapshot(
-    name = DataReferenceName("foo"),
-    description = Option(DataReferenceDescriptionField("bar")),
-    snapshotId = UUID.randomUUID()
-  ))
-  val defaultSnapshotUpdateBodyJson = httpJson(new UpdateDataRepoSnapshotReferenceRequestBody().name("foo2").description("bar2"))
+  val defaultNamedSnapshotJson = httpJson(
+    NamedDataRepoSnapshot(
+      name = DataReferenceName("foo"),
+      description = Option(DataReferenceDescriptionField("bar")),
+      snapshotId = UUID.randomUUID()
+    )
+  )
+  val defaultSnapshotUpdateBodyJson = httpJson(
+    new UpdateDataRepoSnapshotReferenceRequestBody().name("foo2").description("bar2")
+  )
 
   // base MockWorkspaceManagerDAO always returns a value for enumerateDataReferences.
   // this version, used inside this spec, throws errors on specific workspaces,
   // but otherwise returns a value.
   class SnapshotApiServiceSpecWorkspaceManagerDAO extends MockWorkspaceManagerDAO {
-    override def enumerateDataRepoSnapshotReferences(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList = {
+    override def enumerateDataRepoSnapshotReferences(workspaceId: UUID,
+                                                     offset: Int,
+                                                     limit: Int,
+                                                     ctx: RawlsRequestContext
+    ): ResourceList =
       workspaceId match {
         case testData.workspaceTerminatedSubmissions.workspaceIdAsUUID =>
           throw new ApiException(404, "unit test intentional not-found")
@@ -40,92 +48,114 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
           super.enumerateDataRepoSnapshotReferences(workspaceId, offset, limit, ctx)
       }
 
-    }
   }
 
-  case class TestApiService(dataSource: SlickDataSource, user: String, gcsDAO: MockGoogleServicesDAO,
-                            gpsDAO: MockGooglePubSubDAO, override val workspaceManagerDAO: MockWorkspaceManagerDAO)
-                           (implicit override val executionContext: ExecutionContext)
-    extends ApiServices with MockUserInfoDirectives
+  case class TestApiService(dataSource: SlickDataSource,
+                            user: String,
+                            gcsDAO: MockGoogleServicesDAO,
+                            gpsDAO: MockGooglePubSubDAO,
+                            override val workspaceManagerDAO: MockWorkspaceManagerDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectives
 
-  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO, new SnapshotApiServiceSpecWorkspaceManagerDAO())
-    try {
+  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
+    val apiService = new TestApiService(dataSource,
+                                        user,
+                                        new MockGoogleServicesDAO("test"),
+                                        new MockGooglePubSubDAO,
+                                        new SnapshotApiServiceSpecWorkspaceManagerDAO()
+    )
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withApiServicesSecure[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO, new SnapshotApiServiceSpecWorkspaceManagerDAO()) {
+  def withApiServicesSecure[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
+    val apiService = new TestApiService(dataSource,
+                                        user,
+                                        new MockGoogleServicesDAO("test"),
+                                        new MockGooglePubSubDAO,
+                                        new SnapshotApiServiceSpecWorkspaceManagerDAO()
+    ) {
       override val samDAO: MockSamDAO = new MockSamDAO(dataSource) {
-        override def userHasAction(resourceTypeName: SamResourceTypeName, resourceId: String, action: SamResourceAction, userInfo: UserInfo): Future[Boolean] = {
+        override def userHasAction(resourceTypeName: SamResourceTypeName,
+                                   resourceId: String,
+                                   action: SamResourceAction,
+                                   userInfo: UserInfo
+        ): Future[Boolean] = {
 
           val result = user match {
             case testData.userReader.userEmail.value => Set(SamWorkspaceActions.read).contains(action)
-            case _ => false
+            case _                                   => false
           }
           Future.successful(result)
         }
       }
     }
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withTestDataApiServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withTestDataApiServicesAndUser[T](user: String)(testCode: TestApiService => T): T = {
+  def withTestDataApiServicesAndUser[T](user: String)(testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServicesSecure(dataSource, user) { services =>
         testCode(services)
       }
     }
+
+  "SnapshotV2ApiService" should "return 201 when creating a reference to a snapshot" in withTestDataApiServices {
+    services =>
+      Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
+        }
   }
 
-
-  "SnapshotV2ApiService" should "return 201 when creating a reference to a snapshot" in withTestDataApiServices { services =>
-    Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+  it should "return 404 when creating a reference to a snapshot that doesn't exist" in withTestDataApiServices {
+    services =>
+      Post(
+        v2BaseSnapshotsPath,
+        httpJson(
+          NamedDataRepoSnapshot(
+            name = DataReferenceName("fakesnapshot"),
+            description = Option(DataReferenceDescriptionField("bar")),
+            snapshotId = UUID.randomUUID()
+          )
+        )
+      ) ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 404 when creating a reference to a snapshot that doesn't exist" in withTestDataApiServices { services =>
-    Post(v2BaseSnapshotsPath, httpJson(
-      NamedDataRepoSnapshot(
-        name = DataReferenceName("fakesnapshot"),
-        description = Option(DataReferenceDescriptionField("bar")),
-        snapshotId = UUID.randomUUID()
-      )
-    )) ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 when creating a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices {
+    services =>
+      Post("/workspaces/foo/bar/snapshots/v2", defaultNamedSnapshotJson) ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
-  }
-
-  it should "return 404 when creating a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices { services =>
-    Post("/workspaces/foo/bar/snapshots/v2", defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
-        }
-      }
   }
 
   it should "return 200 when getting a reference to a snapshot" in withTestDataApiServices { services =>
@@ -147,34 +177,37 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 when getting a reference to a snapshot that is not a valid UUID" in withTestDataApiServices { services =>
-    Get(s"${v2BaseSnapshotsPath}/not-a-valid-uuid") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when getting a reference to a snapshot that is not a valid UUID" in withTestDataApiServices {
+    services =>
+      Get(s"${v2BaseSnapshotsPath}/not-a-valid-uuid") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 404 when getting a reference to a snapshot that doesn't exist" in withTestDataApiServices { services =>
-    Get(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 when getting a reference to a snapshot that doesn't exist" in withTestDataApiServices {
+    services =>
+      Get(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 404 when getting a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices { services =>
-    Get(s"/workspaces/foo/bar/snapshots/v2/${UUID.randomUUID().toString}") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 when getting a reference to a snapshot in a workspace that doesn't exist" in withTestDataApiServices {
+    services =>
+      Get(s"/workspaces/foo/bar/snapshots/v2/${UUID.randomUUID().toString}") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
   it should "return 200 when getting a reference to a snapshot-by-name" in withTestDataApiServices { services =>
@@ -196,37 +229,40 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when getting a reference to a snapshot-by-name that doesn't exist" in withTestDataApiServices { services =>
-    Get(s"${v2BaseSnapshotsPath}/name/reference-intentionally-does-not-exist") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
-        }
-      }
-  }
-
-  it should "return 404 when getting a reference to a snapshot-by-name in a workspace that doesn't exist" in withTestDataApiServices { services =>
-    Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        val response = responseAs[DataRepoSnapshotResource]
-        assertResult(StatusCodes.Created) {
-          status
-        }
-
-        Get(s"/workspaces/foo/bar/snapshots/v2/name/${response.getMetadata.getName}") ~>
-          sealRoute(services.snapshotRoutes) ~>
-          check {
-            assertResult(StatusCodes.NotFound) {
-              status
-            }
+  it should "return 404 when getting a reference to a snapshot-by-name that doesn't exist" in withTestDataApiServices {
+    services =>
+      Get(s"${v2BaseSnapshotsPath}/name/reference-intentionally-does-not-exist") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
           }
-      }
+        }
   }
 
+  it should "return 404 when getting a reference to a snapshot-by-name in a workspace that doesn't exist" in withTestDataApiServices {
+    services =>
+      Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          val response = responseAs[DataRepoSnapshotResource]
+          assertResult(StatusCodes.Created) {
+            status
+          }
 
-  it should "return 403 when a user can only read a workspace and tries to add a snapshot" in withTestDataApiServicesAndUser(testData.userReader.userEmail.value) { services =>
+          Get(s"/workspaces/foo/bar/snapshots/v2/name/${response.getMetadata.getName}") ~>
+            sealRoute(services.snapshotRoutes) ~>
+            check {
+              assertResult(StatusCodes.NotFound) {
+                status
+              }
+            }
+        }
+  }
+
+  it should "return 403 when a user can only read a workspace and tries to add a snapshot" in withTestDataApiServicesAndUser(
+    testData.userReader.userEmail.value
+  ) { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -236,7 +272,9 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user tries to add a snapshot to a workspace that they don't have access to" in withTestDataApiServicesAndUser("no-access") { services =>
+  it should "return 404 when a user tries to add a snapshot to a workspace that they don't have access to" in withTestDataApiServicesAndUser(
+    "no-access"
+  ) { services =>
     Post(v2BaseSnapshotsPath, defaultNamedSnapshotJson) ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -246,7 +284,9 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user tries to get a snapshot from a workspace that they don't have access to" in withTestDataApiServicesAndUser("no-access") { services =>
+  it should "return 404 when a user tries to get a snapshot from a workspace that they don't have access to" in withTestDataApiServicesAndUser(
+    "no-access"
+  ) { services =>
     Get(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -265,13 +305,16 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         assertResult(StatusCodes.Created) {
           status
         }
-        Post(v2BaseSnapshotsPath, httpJson(
-          NamedDataRepoSnapshot(
-            name = DataReferenceName("bar"),
-            description = Option(DataReferenceDescriptionField("bar")),
-            snapshotId = UUID.randomUUID()
+        Post(
+          v2BaseSnapshotsPath,
+          httpJson(
+            NamedDataRepoSnapshot(
+              name = DataReferenceName("bar"),
+              description = Option(DataReferenceDescriptionField("bar")),
+              snapshotId = UUID.randomUUID()
+            )
           )
-        )) ~>
+        ) ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
             val response = responseAs[DataRepoSnapshotResource]
@@ -299,7 +342,9 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
 
   }
 
-  it should "return 404 when a user lists references without workspace read permission" in withTestDataApiServicesAndUser("no-access") { services =>
+  it should "return 404 when a user lists references without workspace read permission" in withTestDataApiServicesAndUser(
+    "no-access"
+  ) { services =>
     Get(s"${v2BaseSnapshotsPath}?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -309,7 +354,9 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user lists references in a workspace that doesn't exist" in withTestDataApiServicesAndUser(testData.userReader.userEmail.value) { services =>
+  it should "return 404 when a user lists references in a workspace that doesn't exist" in withTestDataApiServicesAndUser(
+    testData.userReader.userEmail.value
+  ) { services =>
     Get("/workspaces/test/value/snapshots/v2?offset=0&limit=10") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -319,18 +366,19 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 200 and empty list when a user lists all snapshots in a workspace that exists in Rawls but not Workspace Manager" in withTestDataApiServices { services =>
-    // We hijack the "workspaceTerminatedSubmissions" workspace in the shared testData to represent
-    // a workspace that exists in Rawls but returns 404 from Workspace Manager.
-    Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots/v2?offset=0&limit=10") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        val response = responseAs[SnapshotListResponse]
-        assertResult(StatusCodes.OK) {
-          status
+  it should "return 200 and empty list when a user lists all snapshots in a workspace that exists in Rawls but not Workspace Manager" in withTestDataApiServices {
+    services =>
+      // We hijack the "workspaceTerminatedSubmissions" workspace in the shared testData to represent
+      // a workspace that exists in Rawls but returns 404 from Workspace Manager.
+      Get(s"${testData.workspaceTerminatedSubmissions.path}/snapshots/v2?offset=0&limit=10") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          val response = responseAs[SnapshotListResponse]
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assert(response.gcpDataRepoSnapshots.isEmpty)
         }
-        assert(response.gcpDataRepoSnapshots.isEmpty)
-      }
   }
 
   it should "bubble up non-404 errors from Workspace Manager" in withTestDataApiServices { services =>
@@ -375,17 +423,20 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 when a user tries to update a snapshot that is not a valid UUID" in withTestDataApiServices { services =>
-    Patch(s"${v2BaseSnapshotsPath}/not-a-valid-uuid", defaultSnapshotUpdateBodyJson) ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when a user tries to update a snapshot that is not a valid UUID" in withTestDataApiServices {
+    services =>
+      Patch(s"${v2BaseSnapshotsPath}/not-a-valid-uuid", defaultSnapshotUpdateBodyJson) ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 403 when a user can only read a workspace and tries to update a snapshot" in withTestDataApiServicesAndUser("reader-access") { services =>
+  it should "return 403 when a user can only read a workspace and tries to update a snapshot" in withTestDataApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Patch(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}", defaultSnapshotUpdateBodyJson) ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -395,8 +446,21 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user tries to update a snapshot from a workspace that they don't have access to" in withTestDataApiServicesAndUser("no-access") { services =>
-    val id = services.workspaceManagerDAO.createDataRepoSnapshotReference(UUID.fromString(testData.workspace.workspaceId), UUID.randomUUID(), DataReferenceName("test"), Option(DataReferenceDescriptionField("description")), "foo", CloningInstructionsEnum.NOTHING, testContext).getMetadata.getResourceId
+  it should "return 404 when a user tries to update a snapshot from a workspace that they don't have access to" in withTestDataApiServicesAndUser(
+    "no-access"
+  ) { services =>
+    val id = services.workspaceManagerDAO
+      .createDataRepoSnapshotReference(
+        UUID.fromString(testData.workspace.workspaceId),
+        UUID.randomUUID(),
+        DataReferenceName("test"),
+        Option(DataReferenceDescriptionField("description")),
+        "foo",
+        CloningInstructionsEnum.NOTHING,
+        testContext
+      )
+      .getMetadata
+      .getResourceId
     Patch(s"${v2BaseSnapshotsPath}/${id.toString}", defaultSnapshotUpdateBodyJson) ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -406,14 +470,15 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user tries to update a snapshot that doesn't exist" in withTestDataApiServices { services =>
-    Patch(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}", defaultSnapshotUpdateBodyJson) ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 when a user tries to update a snapshot that doesn't exist" in withTestDataApiServices {
+    services =>
+      Patch(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}", defaultSnapshotUpdateBodyJson) ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
   it should "return 204 when a user deletes a snapshot" in withTestDataApiServices { services =>
@@ -432,7 +497,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
             }
           }
 
-        //verify that it was deleted
+        // verify that it was deleted
         Delete(s"${v2BaseSnapshotsPath}/${response.getMetadata.getResourceId}") ~>
           sealRoute(services.snapshotRoutes) ~>
           check {
@@ -443,17 +508,20 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 when a user tries to delete a snapshot that is not a valid UUID" in withTestDataApiServices { services =>
-    Delete(s"${v2BaseSnapshotsPath}/not-a-valid-uuid") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 when a user tries to delete a snapshot that is not a valid UUID" in withTestDataApiServices {
+    services =>
+      Delete(s"${v2BaseSnapshotsPath}/not-a-valid-uuid") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 403 when a user can only read a workspace and tries to delete a snapshot" in withTestDataApiServicesAndUser("reader-access") { services =>
+  it should "return 403 when a user can only read a workspace and tries to delete a snapshot" in withTestDataApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Delete(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -463,8 +531,21 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user tries to delete a snapshot from a workspace that they don't have access to" in withTestDataApiServicesAndUser("no-access") { services =>
-    val id = services.workspaceManagerDAO.createDataRepoSnapshotReference(UUID.fromString(testData.workspace.workspaceId), UUID.randomUUID(), DataReferenceName("test"), Option(DataReferenceDescriptionField("description")), "foo", CloningInstructionsEnum.NOTHING, testContext).getMetadata.getResourceId
+  it should "return 404 when a user tries to delete a snapshot from a workspace that they don't have access to" in withTestDataApiServicesAndUser(
+    "no-access"
+  ) { services =>
+    val id = services.workspaceManagerDAO
+      .createDataRepoSnapshotReference(
+        UUID.fromString(testData.workspace.workspaceId),
+        UUID.randomUUID(),
+        DataReferenceName("test"),
+        Option(DataReferenceDescriptionField("description")),
+        "foo",
+        CloningInstructionsEnum.NOTHING,
+        testContext
+      )
+      .getMetadata
+      .getResourceId
     Delete(s"${v2BaseSnapshotsPath}/${id.toString}") ~>
       sealRoute(services.snapshotRoutes) ~>
       check {
@@ -474,16 +555,15 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 404 when a user tries to delete a snapshot that doesn't exist" in withTestDataApiServices { services =>
-    Delete(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
-      sealRoute(services.snapshotRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 when a user tries to delete a snapshot that doesn't exist" in withTestDataApiServices {
+    services =>
+      Delete(s"${v2BaseSnapshotsPath}/${UUID.randomUUID().toString}") ~>
+        sealRoute(services.snapshotRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-
 }
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -31,35 +31,77 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
 
   trait MockUserInfoDirectivesWithUser extends UserInfoDirectives {
     val user: String
-    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] = {
+    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] =
       // just return the cookie text as the common name
       user match {
-        case testData.userProjectOwner.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userProjectOwner.userSubjectId))
-        case testData.userOwner.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userOwner.userSubjectId))
-        case testData.userWriter.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userWriter.userSubjectId))
-        case testData.userReader.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userReader.userSubjectId))
-        case "no-access" => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212348")))
-        case _ => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349")))
+        case testData.userProjectOwner.userEmail.value =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userProjectOwner.userSubjectId)
+          )
+        case testData.userOwner.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userOwner.userSubjectId))
+        case testData.userWriter.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userWriter.userSubjectId))
+        case testData.userReader.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userReader.userSubjectId))
+        case "no-access" =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212348"))
+          )
+        case _ =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349"))
+          )
       }
-    }
   }
 
-  case class TestApiService(dataSource: SlickDataSource, user: String, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectivesWithUser
+  case class TestApiService(dataSource: SlickDataSource,
+                            user: String,
+                            gcsDAO: MockGoogleServicesDAO,
+                            gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectivesWithUser
 
-  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
+  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
     val apiService = new TestApiService(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
   class TestWorkspaces() extends TestData {
-    val userProjectOwner = RawlsUser(UserInfo(RawlsUserEmail("project-owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543210101")))
-    val userOwner = RawlsUser(UserInfo(testData.userOwner.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345")))
-    val userWriter = RawlsUser(UserInfo(testData.userWriter.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(testData.userReader.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
+    val userProjectOwner = RawlsUser(
+      UserInfo(RawlsUserEmail("project-owner-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543210101")
+      )
+    )
+    val userOwner = RawlsUser(
+      UserInfo(testData.userOwner.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212345")
+      )
+    )
+    val userWriter = RawlsUser(
+      UserInfo(testData.userWriter.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(testData.userReader.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
 
     val billingProject = RawlsBillingProject(RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
 
@@ -67,11 +109,39 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     val workspace2Name = WorkspaceName(billingProject.projectName.value, "emptyattrs")
 
     val workspace1Id = UUID.randomUUID().toString
-    val workspace = makeWorkspaceWithUsers(billingProject, workspaceName.name, workspace1Id, "bucket1", Some(workspace1Id), testDate, testDate, "testUser", Map(AttributeName.withDefaultNS("a") -> AttributeString("x"), AttributeName.withDefaultNS("description") -> AttributeString("my description")), false, WorkspaceVersions.V2, billingProject.googleProjectId, Option(GoogleProjectNumber(UUID.randomUUID().toString)), Some(RawlsBillingAccountName("billing-account")), None, Option(testDate))
+    val workspace = makeWorkspaceWithUsers(
+      billingProject,
+      workspaceName.name,
+      workspace1Id,
+      "bucket1",
+      Some(workspace1Id),
+      testDate,
+      testDate,
+      "testUser",
+      Map(AttributeName.withDefaultNS("a") -> AttributeString("x"),
+          AttributeName.withDefaultNS("description") -> AttributeString("my description")
+      ),
+      false,
+      WorkspaceVersions.V2,
+      billingProject.googleProjectId,
+      Option(GoogleProjectNumber(UUID.randomUUID().toString)),
+      Some(RawlsBillingAccountName("billing-account")),
+      None,
+      Option(testDate)
+    )
 
     val workspace2Id = UUID.randomUUID().toString
-    val workspace2 = makeWorkspaceWithUsers(billingProject, workspace2Name.name, workspace2Id, "bucket2", Some(workspace2Id), testDate, testDate, "testUser", Map(), false)
-
+    val workspace2 = makeWorkspaceWithUsers(billingProject,
+                                            workspace2Name.name,
+                                            workspace2Id,
+                                            "bucket2",
+                                            Some(workspace2Id),
+                                            testDate,
+                                            testDate,
+                                            "testUser",
+                                            Map(),
+                                            false
+    )
 
     val sample1 = Entity("sample1", "sample", Map.empty)
     val sample2 = Entity("sample2", "sample", Map.empty)
@@ -79,17 +149,46 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     val sample4 = Entity("sample4", "sample", Map.empty)
     val sample5 = Entity("sample5", "sample", Map.empty)
     val sample6 = Entity("sample6", "sample", Map.empty)
-    val sampleSet = Entity("sampleset", "sample_set", Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(
-      sample1.toReference,
-      sample2.toReference,
-      sample3.toReference
-    ))))
+    val sampleSet = Entity(
+      "sampleset",
+      "sample_set",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(
+            sample1.toReference,
+            sample2.toReference,
+            sample3.toReference
+          )
+        )
+      )
+    )
 
-    val methodConfig = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(workspaceName.namespace, "method-a", 1))
+    val methodConfig = MethodConfiguration(
+      "dsde",
+      "testConfig",
+      Some("Sample"),
+      None,
+      Map("param1" -> AttributeString("foo")),
+      Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")),
+      AgoraMethod(workspaceName.namespace, "method-a", 1)
+    )
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, workspaceName)
-    val submissionTemplate = createTestSubmission(workspace, methodConfig, sampleSet, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> testData.inputResolutions, sample2 -> testData.inputResolutions, sample3 -> testData.inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> testData.inputResolutions2, sample5 -> testData.inputResolutions2, sample6 -> testData.inputResolutions2))
+    val submissionTemplate = createTestSubmission(
+      workspace,
+      methodConfig,
+      sampleSet,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> testData.inputResolutions,
+          sample2 -> testData.inputResolutions,
+          sample3 -> testData.inputResolutions
+      ),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> testData.inputResolutions2,
+          sample5 -> testData.inputResolutions2,
+          sample6 -> testData.inputResolutions2
+      )
+    )
     val submissionSuccess = submissionTemplate.copy(
       submissionId = UUID.randomUUID().toString,
       status = SubmissionStatuses.Done,
@@ -111,13 +210,11 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
       workflows = submissionTemplate.workflows.map(_.copy(status = WorkflowStatuses.Running))
     )
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         rawlsBillingProjectQuery.create(billingProject),
-
         workspaceQuery.createOrUpdate(workspace),
         workspaceQuery.createOrUpdate(workspace2),
-
         withWorkspaceContext(workspace) { ctx =>
           DBIO.seq(
             entityQuery.save(ctx, sample1),
@@ -127,9 +224,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
             entityQuery.save(ctx, sample5),
             entityQuery.save(ctx, sample6),
             entityQuery.save(ctx, sampleSet),
-
             methodConfigurationQuery.create(ctx, methodConfig),
-
             submissionQuery.create(ctx, submissionSuccess),
             submissionQuery.create(ctx, submissionFail),
             submissionQuery.create(ctx, submissionRunning1),
@@ -137,16 +232,14 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
           )
         }
       )
-    }
   }
 
   val testWorkspaces = new TestWorkspaces
 
-  def withTestWorkspacesApiServices[T](testCode: TestApiService => T): T = {
+  def withTestWorkspacesApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(testWorkspaces) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
   val testTime = currentTime()
 
@@ -164,46 +257,57 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   )
 
   // no includes, no excludes
-  "WorkspaceApi" should "include all options when getting a workspace if no params specified" in withTestWorkspacesApiServices { services =>
-    implicit val timeout: Duration = 10.seconds
-    Get(testWorkspaces.workspace.path) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+  "WorkspaceApi" should "include all options when getting a workspace if no params specified" in withTestWorkspacesApiServices {
+    services =>
+      implicit val timeout: Duration = 10.seconds
+      Get(testWorkspaces.workspace.path) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(fullWorkspaceResponse) {
+            val response = responseAs[WorkspaceResponse]
+            response.copy(workspace = response.workspace.copy(lastModified = testTime))
+          }
         }
-        assertResult(fullWorkspaceResponse){
-          val response = responseAs[WorkspaceResponse]
-          response.copy(workspace = response.workspace.copy(lastModified = testTime))
-        }
-      }
   }
-
 
   // START fields tests
 
   // canonical bare-minimum WorkspaceResponse to use in expectations below
-  val minimalWorkspaceResponse = WorkspaceResponse(None, None, None, None, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = testTime), None, false), None, None, None, None)
+  val minimalWorkspaceResponse = WorkspaceResponse(
+    None,
+    None,
+    None,
+    None,
+    WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = testTime), None, false),
+    None,
+    None,
+    None,
+    None
+  )
 
-  "WorkspaceApi, when using fields param" should "include accessLevel when asked to" in withTestWorkspacesApiServices { services =>
-    Get(testWorkspaces.workspace.path + "?fields=accessLevel") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-        val actual = responseAs[String].parseJson.asJsObject
-        val expected = JsObject("accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString))
-        assertResult(expected) { actual }
-      }
+  "WorkspaceApi, when using fields param" should "include accessLevel when asked to" in withTestWorkspacesApiServices {
+    services =>
+      Get(testWorkspaces.workspace.path + "?fields=accessLevel") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+          val actual = responseAs[String].parseJson.asJsObject
+          val expected = JsObject("accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString))
+          assertResult(expected)(actual)
+        }
   }
 
   it should "include bucketOptions" in withTestWorkspacesApiServices { services =>
     Get(testWorkspaces.workspace.path + "?fields=bucketOptions") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("bucketOptions" -> fullWorkspaceResponse.bucketOptions.get.toJson)
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -211,10 +315,10 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=canCompute") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("canCompute" -> JsBoolean(fullWorkspaceResponse.canCompute.get))
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -222,10 +326,10 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=canShare") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("canShare" -> JsBoolean(fullWorkspaceResponse.canShare.get))
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -233,10 +337,10 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=catalog") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("catalog" -> JsBoolean(fullWorkspaceResponse.catalog.get))
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -244,10 +348,10 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=owners") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("owners" -> JsArray(fullWorkspaceResponse.owners.get.toVector.map(JsString(_))))
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -255,12 +359,15 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=workspace.attributes") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
-        val expected = JsObject("workspace" -> JsObject("attributes" ->
-          JsObject("a" -> JsString("x"), "description" -> JsString("my description"))
-        ))
-        assertResult(expected) { actual }
+        val expected = JsObject(
+          "workspace" -> JsObject(
+            "attributes" ->
+              JsObject("a" -> JsString("x"), "description" -> JsString("my description"))
+          )
+        )
+        assertResult(expected)(actual)
       }
   }
 
@@ -268,12 +375,15 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=workspace.attributes.description") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
-        val expected = JsObject("workspace" -> JsObject("attributes" ->
-          JsObject("description" -> JsString("my description"))
-        ))
-        assertResult(expected) { actual }
+        val expected = JsObject(
+          "workspace" -> JsObject(
+            "attributes" ->
+              JsObject("description" -> JsString("my description"))
+          )
+        )
+        assertResult(expected)(actual)
       }
   }
 
@@ -281,13 +391,19 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=workspace.authorizationDomain") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
-        val expected = JsObject("workspace" -> JsObject("authorizationDomain" ->
-          JsArray(fullWorkspaceResponse.workspace.authorizationDomain.get.toVector.map(groupRef => JsObject("membersGroupName" -> JsString(groupRef.membersGroupName.value))
-          ))
-        ))
-        assertResult(expected) { actual }
+        val expected = JsObject(
+          "workspace" -> JsObject(
+            "authorizationDomain" ->
+              JsArray(
+                fullWorkspaceResponse.workspace.authorizationDomain.get.toVector.map(groupRef =>
+                  JsObject("membersGroupName" -> JsString(groupRef.membersGroupName.value))
+                )
+              )
+          )
+        )
+        assertResult(expected)(actual)
       }
   }
 
@@ -295,10 +411,10 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=workspaceSubmissionStats") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("workspaceSubmissionStats" -> fullWorkspaceResponse.workspaceSubmissionStats.get.toJson)
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -307,19 +423,21 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
   val rm = runtimeMirror(getClass.getClassLoader)
   val workspaceDetailsMirror = rm.reflect(WorkspaceDetails(testWorkspaces.workspace, Set.empty))
 
-  val workspaceDetailsMembers:List[String] = typeOf[WorkspaceDetails].members.collect {
-    case m: MethodSymbol if m.isCaseAccessor && !workspaceDetailsMirror.reflectMethod(m).apply().equals(None) => m.name.toString
+  val workspaceDetailsMembers: List[String] = typeOf[WorkspaceDetails].members.collect {
+    case m: MethodSymbol if m.isCaseAccessor && !workspaceDetailsMirror.reflectMethod(m).apply().equals(None) =>
+      m.name.toString
   }.toList
   workspaceDetailsMembers.foreach { workspaceKey =>
-    it should s"include $workspaceKey subkey of workspace when specifying the top-level key" in withTestWorkspacesApiServices { services =>
-      Get(testWorkspaces.workspace.path + "?fields=workspace") ~>
-        sealRoute(services.workspaceRoutes) ~>
-        check {
-          assertResult(StatusCodes.OK) { status }
-          val actual = responseAs[String].parseJson.asJsObject
-          val workspaceFields  = actual.fields.getOrElse("workspace", new JsObject(Map.empty)).asJsObject.fields
-          assert(workspaceFields.contains(workspaceKey))
-        }
+    it should s"include $workspaceKey subkey of workspace when specifying the top-level key" in withTestWorkspacesApiServices {
+      services =>
+        Get(testWorkspaces.workspace.path + "?fields=workspace") ~>
+          sealRoute(services.workspaceRoutes) ~>
+          check {
+            assertResult(StatusCodes.OK)(status)
+            val actual = responseAs[String].parseJson.asJsObject
+            val workspaceFields = actual.fields.getOrElse("workspace", new JsObject(Map.empty)).asJsObject.fields
+            assert(workspaceFields.contains(workspaceKey))
+          }
     }
   }
 
@@ -327,7 +445,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=canShare,workspace.attributes,accessLevel") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject(
           "accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString),
@@ -336,7 +454,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
             "attributes" -> JsObject("a" -> JsString("x"), "description" -> JsString("my description"))
           )
         )
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -345,10 +463,10 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace2.path + "?fields=workspace.attributes") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("workspace" -> JsObject("attributes" -> JsObject()))
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
@@ -356,76 +474,82 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Get(testWorkspaces.workspace.path + "?fields=accessLevel,accessLevel") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject("accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString))
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
   it should "not return any attributes that aren't in the db" in withTestWorkspacesApiServices { services =>
-    Get(testWorkspaces.workspace.path + "?fields=workspace.attributes.description,workspace.attributes.tag:tags,workspace.attributes.library:orsp") ~>
+    Get(
+      testWorkspaces.workspace.path + "?fields=workspace.attributes.description,workspace.attributes.tag:tags,workspace.attributes.library:orsp"
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson.asJsObject
         val expected = JsObject(
           "workspace" -> JsObject(
             "attributes" -> JsObject("description" -> JsString("my description"))
           )
         )
-        assertResult(expected) { actual }
+        assertResult(expected)(actual)
       }
   }
 
   // START query param behavior tests
 
-  it should s"return 400 Bad Request for unknown fields value in querystring" in withTestWorkspacesApiServices { services =>
-    Get(testWorkspaces.workspace.path + "?fields=accessLevel,IntentionallyBadValueForUnitTest,AnotherBadOne") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should s"return 400 Bad Request for unknown fields value in querystring" in withTestWorkspacesApiServices {
+    services =>
+      Get(testWorkspaces.workspace.path + "?fields=accessLevel,IntentionallyBadValueForUnitTest,AnotherBadOne") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          val parsedResponse = responseAs[ErrorReport]
+          assertResult("Unrecognized field names: AnotherBadOne, IntentionallyBadValueForUnitTest") {
+            parsedResponse.message
+          }
         }
-        val parsedResponse = responseAs[ErrorReport]
-        assertResult("Unrecognized field names: AnotherBadOne, IntentionallyBadValueForUnitTest") {
-          parsedResponse.message
-        }
-      }
   }
 
-  it should s"return 400 Bad Request if fields param is specified multiple times" in withTestWorkspacesApiServices { services =>
-    Get(testWorkspaces.workspace.path + "?fields=accessLevel&fields=canShare,workspace.attributes") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should s"return 400 Bad Request if fields param is specified multiple times" in withTestWorkspacesApiServices {
+    services =>
+      Get(testWorkspaces.workspace.path + "?fields=accessLevel&fields=canShare,workspace.attributes") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          val parsedResponse = responseAs[ErrorReport]
+          assertResult("Parameter 'fields' may not be present multiple times.") {
+            parsedResponse.message
+          }
         }
-        val parsedResponse = responseAs[ErrorReport]
-        assertResult("Parameter 'fields' may not be present multiple times.") {
-          parsedResponse.message
-        }
-      }
   }
 
   // get-workspace-by-id delegates to get-workspace-by-name, so we test its option handling briefly, enough
   // to know we are passing the WorkspaceFieldSpecs along.
-  it should "include multiple keys simultaneously when getting a workspace by id" in withTestWorkspacesApiServices { services =>
-    Get(s"/workspaces/id/${testWorkspaces.workspace.workspaceId}" + "?fields=canShare,workspace.attributes,accessLevel") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-        val actual = responseAs[String].parseJson.asJsObject
-        val expected = JsObject(
-          "accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString),
-          "canShare" -> JsBoolean(fullWorkspaceResponse.canShare.get),
-          "workspace" -> JsObject(
-            "attributes" -> JsObject("a" -> JsString("x"), "description" -> JsString("my description"))
+  it should "include multiple keys simultaneously when getting a workspace by id" in withTestWorkspacesApiServices {
+    services =>
+      Get(
+        s"/workspaces/id/${testWorkspaces.workspace.workspaceId}" + "?fields=canShare,workspace.attributes,accessLevel"
+      ) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+          val actual = responseAs[String].parseJson.asJsObject
+          val expected = JsObject(
+            "accessLevel" -> JsString(fullWorkspaceResponse.accessLevel.get.toString),
+            "canShare" -> JsBoolean(fullWorkspaceResponse.canShare.get),
+            "workspace" -> JsObject(
+              "attributes" -> JsObject("a" -> JsString("x"), "description" -> JsString("my description"))
+            )
           )
-        )
-        assertResult(expected) { actual }
-      }
+          assertResult(expected)(actual)
+        }
   }
 
 }
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiLibraryPermissionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiLibraryPermissionsSpec.scala
@@ -32,31 +32,34 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
   // ==========================================
   // set up fixture data for the tests
   // ==========================================
-  case class LibraryPermissionUser(
-      curator: Boolean,
-      catalog: Boolean,
-      canShare: Boolean,
-      level: WorkspaceAccessLevel,
-      rawlsUser: RawlsUser) {
-  }
+  case class LibraryPermissionUser(curator: Boolean,
+                                   catalog: Boolean,
+                                   canShare: Boolean,
+                                   level: WorkspaceAccessLevel,
+                                   rawlsUser: RawlsUser
+  ) {}
 
-  def makeEmail(curator:Boolean, catalog:Boolean, canShare:Boolean, level: WorkspaceAccessLevel) =
+  def makeEmail(curator: Boolean, catalog: Boolean, canShare: Boolean, level: WorkspaceAccessLevel) =
     s"$level-curator:$curator-catalog:$catalog-canShare:$canShare"
 
-  def makeRawlsUser(level: WorkspaceAccessLevel, curator:Boolean=false, catalog:Boolean=false, canShare:Boolean=false) = {
+  def makeRawlsUser(level: WorkspaceAccessLevel,
+                    curator: Boolean = false,
+                    catalog: Boolean = false,
+                    canShare: Boolean = false
+  ) = {
     val email = makeEmail(curator, catalog, canShare, level)
     RawlsUser(UserInfo(RawlsUserEmail(email), OAuth2BearerToken("token"), 123, RawlsUserSubjectId(email)))
   }
 
   class LibraryPermissionTestData extends TestData {
 
-    val users:Seq[LibraryPermissionUser] = for {
-      curator <- Seq(true,false)
-      catalog <- Seq(true,false)
-      canShare <- Seq(true,false)
+    val users: Seq[LibraryPermissionUser] = for {
+      curator <- Seq(true, false)
+      catalog <- Seq(true, false)
+      canShare <- Seq(true, false)
       level <- Seq(WorkspaceAccessLevels.Owner, WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Read)
     } yield {
-      val rawlsUser = makeRawlsUser(level, curator=curator, catalog=catalog, canShare=canShare)
+      val rawlsUser = makeRawlsUser(level, curator = curator, catalog = catalog, canShare = canShare)
       LibraryPermissionUser(curator, catalog, canShare, level, rawlsUser)
     }
 
@@ -64,68 +67,101 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
 
     val wsUnpublishedName = WorkspaceName("myNamespace", "unpublishedWorkspace")
 
-    val unpublishedOwnerGroup = makeRawlsGroup(s"${wsUnpublishedName.name}-${wsUnpublishedName.name}-OWNER", users.filter(_.level == WorkspaceAccessLevels.Owner).map(_.rawlsUser:RawlsUserRef).toSet)
-    val unpublishedWriterGroup = makeRawlsGroup(s"${wsUnpublishedName.name}-${wsUnpublishedName.name}-WRITER", users.filter(_.level == WorkspaceAccessLevels.Write).map(_.rawlsUser:RawlsUserRef).toSet)
-    val unpublishedReaderGroup = makeRawlsGroup(s"${wsUnpublishedName.name}-${wsUnpublishedName.name}-READER", users.filter(_.level == WorkspaceAccessLevels.Read).map(_.rawlsUser:RawlsUserRef).toSet)
+    val unpublishedOwnerGroup = makeRawlsGroup(
+      s"${wsUnpublishedName.name}-${wsUnpublishedName.name}-OWNER",
+      users.filter(_.level == WorkspaceAccessLevels.Owner).map(_.rawlsUser: RawlsUserRef).toSet
+    )
+    val unpublishedWriterGroup = makeRawlsGroup(
+      s"${wsUnpublishedName.name}-${wsUnpublishedName.name}-WRITER",
+      users.filter(_.level == WorkspaceAccessLevels.Write).map(_.rawlsUser: RawlsUserRef).toSet
+    )
+    val unpublishedReaderGroup = makeRawlsGroup(
+      s"${wsUnpublishedName.name}-${wsUnpublishedName.name}-READER",
+      users.filter(_.level == WorkspaceAccessLevels.Read).map(_.rawlsUser: RawlsUserRef).toSet
+    )
 
-    val unpublishedWorkspace = Workspace(wsUnpublishedName.namespace, wsUnpublishedName.name, wsUnpublishedId.toString, "aBucket", Some("workflow-collection"), currentTime(), currentTime(), "testUser", Map.empty)
+    val unpublishedWorkspace = Workspace(
+      wsUnpublishedName.namespace,
+      wsUnpublishedName.name,
+      wsUnpublishedId.toString,
+      "aBucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty
+    )
 
-    def enableCurators(gcsDAO: GoogleServicesDAO ) = {
-      users.filter(_.curator).map(u=> gcsDAO.addLibraryCurator(u.rawlsUser.userEmail.value))
-    }
+    def enableCurators(gcsDAO: GoogleServicesDAO) =
+      users.filter(_.curator).map(u => gcsDAO.addLibraryCurator(u.rawlsUser.userEmail.value))
 
     override def save(): ReadWriteAction[Unit] = {
       import driver.api._
 
       DBIO.seq(
-        workspaceQuery.createOrUpdate(unpublishedWorkspace),
+        workspaceQuery.createOrUpdate(unpublishedWorkspace)
       )
     }
   }
 
   val libraryPermissionTestData = new LibraryPermissionTestData()
 
-  case class TestApiService(dataSource: SlickDataSource, user: String, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectivesWithUser
+  case class TestApiService(dataSource: SlickDataSource,
+                            user: String,
+                            gcsDAO: MockGoogleServicesDAO,
+                            gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectivesWithUser
 
-  def withApiServices[T](dataSource: SlickDataSource, libTest: LibraryPermissionTest)(testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(dataSource, libTest.user.userEmail.value, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO) {
+  def withApiServices[T](dataSource: SlickDataSource, libTest: LibraryPermissionTest)(
+    testCode: TestApiService => T
+  ): T = {
+    val apiService = new TestApiService(dataSource,
+                                        libTest.user.userEmail.value,
+                                        new MockGoogleServicesDAO("test"),
+                                        new MockGooglePubSubDAO
+    ) {
       override val samDAO = new MockSamDAO(dataSource) {
 
-        override def userHasAction(resourceTypeName: SamResourceTypeName, resourceId: String, action: SamResourceAction, userInfo: UserInfo): Future[Boolean] = {
+        override def userHasAction(resourceTypeName: SamResourceTypeName,
+                                   resourceId: String,
+                                   action: SamResourceAction,
+                                   userInfo: UserInfo
+        ): Future[Boolean] = {
           val result = action match {
-            case SamWorkspaceActions.catalog => libTest.catalog
+            case SamWorkspaceActions.catalog                                              => libTest.catalog
             case SamResourceAction(actionName) if actionName.startsWith("share_policy::") => libTest.canShare
-            case SamWorkspaceActions.own => libTest.accessLevel >= WorkspaceAccessLevels.Owner
+            case SamWorkspaceActions.own   => libTest.accessLevel >= WorkspaceAccessLevels.Owner
             case SamWorkspaceActions.write => libTest.accessLevel >= WorkspaceAccessLevels.Write
-            case SamWorkspaceActions.read => libTest.accessLevel >= WorkspaceAccessLevels.Read
-            case _ => true
+            case SamWorkspaceActions.read  => libTest.accessLevel >= WorkspaceAccessLevels.Read
+            case _                         => true
           }
           Future.successful(result)
         }
       }
     }
 
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withLibraryPermissionTestDataApiServicesAndUser[T](libTest: LibraryPermissionTest)(testCode: TestApiService => T): T = {
+  def withLibraryPermissionTestDataApiServicesAndUser[T](
+    libTest: LibraryPermissionTest
+  )(testCode: TestApiService => T): T =
     withCustomTestDatabase(libraryPermissionTestData) { dataSource: SlickDataSource =>
       withApiServices(dataSource, libTest) { services =>
         Await.result(Future.sequence(libraryPermissionTestData.enableCurators(services.gcsDAO)), Duration.Inf)
         testCode(services)
       }
     }
-  }
 
   trait MockUserInfoDirectivesWithUser extends UserInfoDirectives {
     val user: String
-    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] = {
+    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] =
       provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId(user)))
-    }
   }
 
   // ==========================================
@@ -133,8 +169,10 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
   // ==========================================
   val updatePublishValue = AttributeBoolean(true)
   val updatePublish: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(publishedFlag, updatePublishValue))
-  val updateDiscoverValue = AttributeValueList(Seq(AttributeString("one"),AttributeString("two")))
-  val updateDiscover: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(discoverableWSAttribute, updateDiscoverValue))
+  val updateDiscoverValue = AttributeValueList(Seq(AttributeString("one"), AttributeString("two")))
+  val updateDiscover: Seq[AttributeUpdateOperation] = Seq(
+    AddUpdateAttribute(discoverableWSAttribute, updateDiscoverValue)
+  )
   val updateLibName = AttributeName.withLibraryNS("foo")
   val updateLibValue = AttributeString("bar")
   val updateLibAttr: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(updateLibName, updateLibValue))
@@ -142,14 +180,17 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
   val updateLibValue2 = AttributeNumber(2)
   val updateLibAttr2: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(updateLibName2, updateLibValue2))
   val updateTagName = AttributeName.withTagsNS()
-  val updateTagValue = AttributeValueList(Seq(AttributeString("tag1"),AttributeString("tag2")))
+  val updateTagValue = AttributeValueList(Seq(AttributeString("tag1"), AttributeString("tag2")))
   val updateTagAttr: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(updateTagName, updateTagValue))
   val updateWsName = AttributeName.withDefaultNS("workspaceAttr")
   val updateWsValue = AttributeString("arbitrary workspace value")
   val updateWsAttr: Seq[AttributeUpdateOperation] = Seq(AddUpdateAttribute(updateWsName, updateWsValue))
 
   // reusable test util - called by every test
-  def testUpdateLibraryAttributes(payload: Seq[AttributeUpdateOperation], expectedStatusCode: StatusCode = StatusCodes.OK, ws: WorkspaceName = libraryPermissionTestData.wsUnpublishedName)(implicit services: TestApiService): Option[Workspace] = {
+  def testUpdateLibraryAttributes(payload: Seq[AttributeUpdateOperation],
+                                  expectedStatusCode: StatusCode = StatusCodes.OK,
+                                  ws: WorkspaceName = libraryPermissionTestData.wsUnpublishedName
+  )(implicit services: TestApiService): Option[Workspace] =
     withStatsD {
       Patch(ws.path + "/library", httpJson(payload)) ~> services.sealedInstrumentedRoutes ~>
         check {
@@ -171,115 +212,158 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
       val expected = expectedHttpRequestMetrics("patch", wsPathForRequestMetrics, expectedStatusCode.intValue, 1)
       assertSubsetOf(expected, capturedMetrics)
     }
-  }
 
   case class LibraryPermissionTest(
-                user: RawlsUser,
-                accessLevel: WorkspaceAccessLevel,
-                curator: Boolean = false,
-                catalog: Boolean = false,
-                canShare: Boolean = false,
-                workspaceName: WorkspaceName = libraryPermissionTestData.wsUnpublishedName,
-                publishedOnly: StatusCode = StatusCodes.Forbidden,
-                discoverOnly: StatusCode = StatusCodes.Forbidden,
-                publishedPlus: StatusCode = StatusCodes.BadRequest,
-                discoverPlus: StatusCode = StatusCodes.Forbidden,
-                multiLibrary: StatusCode = StatusCodes.Forbidden,
-                libraryPlusTags: StatusCode = StatusCodes.BadRequest,
-                libraryPlusWorkspace: StatusCode = StatusCodes.BadRequest,
-                workspaceOnly: StatusCode = StatusCodes.BadRequest
-              )
+    user: RawlsUser,
+    accessLevel: WorkspaceAccessLevel,
+    curator: Boolean = false,
+    catalog: Boolean = false,
+    canShare: Boolean = false,
+    workspaceName: WorkspaceName = libraryPermissionTestData.wsUnpublishedName,
+    publishedOnly: StatusCode = StatusCodes.Forbidden,
+    discoverOnly: StatusCode = StatusCodes.Forbidden,
+    publishedPlus: StatusCode = StatusCodes.BadRequest,
+    discoverPlus: StatusCode = StatusCodes.Forbidden,
+    multiLibrary: StatusCode = StatusCodes.Forbidden,
+    libraryPlusTags: StatusCode = StatusCodes.BadRequest,
+    libraryPlusWorkspace: StatusCode = StatusCodes.BadRequest,
+    workspaceOnly: StatusCode = StatusCodes.BadRequest
+  )
 
   // NB: re-publish case is handled in orchestration; we only need to check change-published here
 
   val tests = Seq(
     // when owner + curator, can do everything
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Owner, curator=true), WorkspaceAccessLevels.Owner,
-      curator=true,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Owner, curator = true),
+      WorkspaceAccessLevels.Owner,
+      curator = true,
       publishedOnly = StatusCodes.OK,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // owner but not curator: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Owner), WorkspaceAccessLevels.Owner,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Owner),
+      WorkspaceAccessLevels.Owner,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // owner + catalog: still can't change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Owner, catalog=true), WorkspaceAccessLevels.Owner,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Owner, catalog = true),
+      WorkspaceAccessLevels.Owner,
       catalog = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // owner + grant: still can't change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Owner, canShare=true), WorkspaceAccessLevels.Owner,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Owner, canShare = true),
+      WorkspaceAccessLevels.Owner,
       canShare = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // owner + grant + catalog: still can't change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Owner, canShare=true, catalog=true), WorkspaceAccessLevels.Owner,
-      canShare = true, catalog = true,
-      discoverOnly = StatusCodes.OK,
-      discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
-
-    // writer + curator: can only edit library attrs
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write, curator=true), WorkspaceAccessLevels.Write,
-      curator=true,
-      multiLibrary = StatusCodes.OK),
-    // plain-old writer: still can only edit library attributes
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write), WorkspaceAccessLevels.Write,
-      multiLibrary = StatusCodes.OK),
-    // writer + catalog: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write, catalog=true), WorkspaceAccessLevels.Write,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Owner, canShare = true, catalog = true),
+      WorkspaceAccessLevels.Owner,
+      canShare = true,
       catalog = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
+
+    // writer + curator: can only edit library attrs
+    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write, curator = true),
+                          WorkspaceAccessLevels.Write,
+                          curator = true,
+                          multiLibrary = StatusCodes.OK
+    ),
+    // plain-old writer: still can only edit library attributes
+    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write),
+                          WorkspaceAccessLevels.Write,
+                          multiLibrary = StatusCodes.OK
+    ),
+    // writer + catalog: everything except change published
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Write, catalog = true),
+      WorkspaceAccessLevels.Write,
+      catalog = true,
+      discoverOnly = StatusCodes.OK,
+      discoverPlus = StatusCodes.OK,
+      multiLibrary = StatusCodes.OK
+    ),
     // writer + grant: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write, canShare=true), WorkspaceAccessLevels.Write,
-      canShare=true,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Write, canShare = true),
+      WorkspaceAccessLevels.Write,
+      canShare = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // writer + grant + catalog: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Write, canShare=true, catalog=true), WorkspaceAccessLevels.Write,
-      canShare = true, catalog = true,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Write, canShare = true, catalog = true),
+      WorkspaceAccessLevels.Write,
+      canShare = true,
+      catalog = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
 
     // reader + curator: nothing
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read, curator=true), WorkspaceAccessLevels.Read,
-      curator=true),
+    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read, curator = true),
+                          WorkspaceAccessLevels.Read,
+                          curator = true
+    ),
     // plain-old reader: nothing
     LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read), WorkspaceAccessLevels.Read),
     // reader + catalog: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read,catalog=true), WorkspaceAccessLevels.Read,
-      catalog=true,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Read, catalog = true),
+      WorkspaceAccessLevels.Read,
+      catalog = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // reader + grant: change discoverability (but not other attrs)
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read, canShare=true), WorkspaceAccessLevels.Read,
-      canShare=true,
-      discoverOnly = StatusCodes.OK),
+    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read, canShare = true),
+                          WorkspaceAccessLevels.Read,
+                          canShare = true,
+                          discoverOnly = StatusCodes.OK
+    ),
     // reader + grant + catalog: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read, canShare=true, catalog=true), WorkspaceAccessLevels.Read,
-      canShare=true, catalog=true,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Read, canShare = true, catalog = true),
+      WorkspaceAccessLevels.Read,
+      canShare = true,
+      catalog = true,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK),
+      multiLibrary = StatusCodes.OK
+    ),
     // reader + curator + catalog: everything except change published
-    LibraryPermissionTest(makeRawlsUser(WorkspaceAccessLevels.Read, curator=true, catalog=true), WorkspaceAccessLevels.Read,
-      curator=true, catalog=true,
+    LibraryPermissionTest(
+      makeRawlsUser(WorkspaceAccessLevels.Read, curator = true, catalog = true),
+      WorkspaceAccessLevels.Read,
+      curator = true,
+      catalog = true,
       publishedOnly = StatusCodes.OK,
       discoverOnly = StatusCodes.OK,
       discoverPlus = StatusCodes.OK,
-      multiLibrary = StatusCodes.OK)
+      multiLibrary = StatusCodes.OK
+    )
   )
-
 
   tests foreach { testcrit =>
     val user = testcrit.user
@@ -289,7 +373,9 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
 
     behavior of s"Library attribute permissions for $testNameSuffix"
 
-    it should s"return ${testcrit.publishedOnly.value} when changing published flag as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.publishedOnly.value} when changing published flag as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updatePublish
       val ws = testUpdateLibraryAttributes(payload, testcrit.publishedOnly)(services)
       if (testcrit.publishedOnly == StatusCodes.OK) {
@@ -299,7 +385,9 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
       }
     }
 
-    it should s"return ${testcrit.discoverOnly.value} when changing discoverability list as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.discoverOnly.value} when changing discoverability list as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updateDiscover
       val ws = testUpdateLibraryAttributes(payload, testcrit.discoverOnly)(services)
       if (testcrit.discoverOnly == StatusCodes.OK) {
@@ -309,12 +397,16 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
       }
     }
 
-    it should s"return ${testcrit.publishedPlus.value} when changing published flag with another attr as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.publishedPlus.value} when changing published flag with another attr as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updatePublish ++ updateLibAttr
       testUpdateLibraryAttributes(payload, testcrit.publishedPlus)(services)
     }
 
-    it should s"return ${testcrit.discoverPlus.value} when changing discoverability list with another attr as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.discoverPlus.value} when changing discoverability list with another attr as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updateDiscover ++ updateLibAttr
       val ws = testUpdateLibraryAttributes(payload, testcrit.discoverPlus)(services)
       if (testcrit.discoverPlus == StatusCodes.OK) {
@@ -326,7 +418,9 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
         }
       }
     }
-    it should s"return ${testcrit.multiLibrary.value} when changing multiple standard library attrs as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.multiLibrary.value} when changing multiple standard library attrs as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       // tweak to make sure no state is persisted and that we (on some tests) check for unique values
       val uniqueLibName = AttributeName.withLibraryNS(UUID.randomUUID().toString)
       val uniqueLibValue = AttributeString(UUID.randomUUID().toString)
@@ -347,23 +441,27 @@ class WorkspaceApiLibraryPermissionsSpec extends ApiServiceSpec {
       }
     }
 
-    it should s"return ${testcrit.libraryPlusTags.value} when changing library attrs and tags as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.libraryPlusTags.value} when changing library attrs and tags as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updateLibAttr ++ updateTagAttr
       val ws = testUpdateLibraryAttributes(payload, testcrit.libraryPlusTags)(services)
     }
 
-    it should s"return ${testcrit.libraryPlusWorkspace.value} when changing library attrs and workspace attrs as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.libraryPlusWorkspace.value} when changing library attrs and workspace attrs as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updateLibAttr ++ updateWsAttr
       val ws = testUpdateLibraryAttributes(payload, testcrit.libraryPlusWorkspace)(services)
     }
 
-    it should s"return ${testcrit.workspaceOnly.value} when changing workspace attrs as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(testcrit) { services =>
+    it should s"return ${testcrit.workspaceOnly.value} when changing workspace attrs as $testNameSuffix" in withLibraryPermissionTestDataApiServicesAndUser(
+      testcrit
+    ) { services =>
       val payload = updateWsAttr
       val ws = testUpdateLibraryAttributes(payload, testcrit.workspaceOnly)(services)
     }
 
   }
-
-
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
@@ -19,38 +19,61 @@ import spray.json._
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 
-
 class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
   import driver.api._
 
   trait MockUserInfoDirectivesWithUser extends UserInfoDirectives {
     val user: String
-    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] = {
+    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] =
       // just return the cookie text as the common name
       user match {
-        case testData.userProjectOwner.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userProjectOwner.userSubjectId))
-        case testData.userOwner.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userOwner.userSubjectId))
-        case testData.userWriter.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userWriter.userSubjectId))
-        case testData.userReader.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userReader.userSubjectId))
-        case "no-access" => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212348")))
-        case _ => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349")))
+        case testData.userProjectOwner.userEmail.value =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userProjectOwner.userSubjectId)
+          )
+        case testData.userOwner.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userOwner.userSubjectId))
+        case testData.userWriter.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userWriter.userSubjectId))
+        case testData.userReader.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userReader.userSubjectId))
+        case "no-access" =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212348"))
+          )
+        case _ =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349"))
+          )
       }
-    }
   }
 
-  case class TestApiService(dataSource: SlickDataSource, user: String, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectivesWithUser
+  case class TestApiService(dataSource: SlickDataSource,
+                            user: String,
+                            gcsDAO: MockGoogleServicesDAO,
+                            gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectivesWithUser
 
-  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
+  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
     val apiService = new TestApiService(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
   class TestWorkspaces() extends TestData {
-    val userOwner = RawlsUser(UserInfo(testData.userOwner.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345")))
+    val userOwner = RawlsUser(
+      UserInfo(testData.userOwner.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212345")
+      )
+    )
 
     val billingProject = RawlsBillingProject(RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
 
@@ -59,10 +82,36 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     val workspace2Name = WorkspaceName(billingProject.projectName.value, "testworkspace2")
 
     val workspace1Id = UUID.randomUUID().toString
-    val workspace = makeWorkspaceWithUsers(billingProject, workspaceName.name, workspace1Id, "bucket1", Some(workspace1Id), testDate, testDate, "testUser", Map(AttributeName.withDefaultNS("a") -> AttributeString("x"), AttributeName.withDefaultNS("description") -> AttributeString("workspace one")), false)
+    val workspace = makeWorkspaceWithUsers(
+      billingProject,
+      workspaceName.name,
+      workspace1Id,
+      "bucket1",
+      Some(workspace1Id),
+      testDate,
+      testDate,
+      "testUser",
+      Map(AttributeName.withDefaultNS("a") -> AttributeString("x"),
+          AttributeName.withDefaultNS("description") -> AttributeString("workspace one")
+      ),
+      false
+    )
 
     val workspace2Id = UUID.randomUUID().toString
-    val workspace2 = makeWorkspaceWithUsers(billingProject, workspace2Name.name, workspace2Id, "bucket2", Some(workspace2Id), testDate, testDate, "testUser", Map(AttributeName.withDefaultNS("b") -> AttributeString("y"), AttributeName.withDefaultNS("description") -> AttributeString("workspace two")), false)
+    val workspace2 = makeWorkspaceWithUsers(
+      billingProject,
+      workspace2Name.name,
+      workspace2Id,
+      "bucket2",
+      Some(workspace2Id),
+      testDate,
+      testDate,
+      "testUser",
+      Map(AttributeName.withDefaultNS("b") -> AttributeString("y"),
+          AttributeName.withDefaultNS("description") -> AttributeString("workspace two")
+      ),
+      false
+    )
 
     val sample1 = Entity("sample1", "sample", Map.empty)
     val sample2 = Entity("sample2", "sample", Map.empty)
@@ -70,17 +119,46 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     val sample4 = Entity("sample4", "sample", Map.empty)
     val sample5 = Entity("sample5", "sample", Map.empty)
     val sample6 = Entity("sample6", "sample", Map.empty)
-    val sampleSet = Entity("sampleset", "sample_set", Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(
-      sample1.toReference,
-      sample2.toReference,
-      sample3.toReference
-    ))))
+    val sampleSet = Entity(
+      "sampleset",
+      "sample_set",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(
+            sample1.toReference,
+            sample2.toReference,
+            sample3.toReference
+          )
+        )
+      )
+    )
 
-    val methodConfig = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(workspaceName.namespace, "method-a", 1))
+    val methodConfig = MethodConfiguration(
+      "dsde",
+      "testConfig",
+      Some("Sample"),
+      None,
+      Map("param1" -> AttributeString("foo")),
+      Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")),
+      AgoraMethod(workspaceName.namespace, "method-a", 1)
+    )
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, workspaceName)
-    val submissionTemplate = createTestSubmission(workspace, methodConfig, sampleSet, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> testData.inputResolutions, sample2 -> testData.inputResolutions, sample3 -> testData.inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> testData.inputResolutions2, sample5 -> testData.inputResolutions2, sample6 -> testData.inputResolutions2))
+    val submissionTemplate = createTestSubmission(
+      workspace,
+      methodConfig,
+      sampleSet,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> testData.inputResolutions,
+          sample2 -> testData.inputResolutions,
+          sample3 -> testData.inputResolutions
+      ),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> testData.inputResolutions2,
+          sample5 -> testData.inputResolutions2,
+          sample6 -> testData.inputResolutions2
+      )
+    )
     val submissionSuccess = submissionTemplate.copy(
       submissionId = UUID.randomUUID().toString,
       status = SubmissionStatuses.Done,
@@ -102,85 +180,126 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
       workflows = submissionTemplate.workflows.map(_.copy(status = WorkflowStatuses.Running))
     )
 
-    override def save() = {
-      DBIO.seq(
-        rawlsBillingProjectQuery.create(billingProject),
-
-        workspaceQuery.createOrUpdate(workspace),
-        workspaceQuery.createOrUpdate(workspace2),
-
-        withWorkspaceContext(workspace) { ctx =>
-          DBIO.seq(
-            entityQuery.save(ctx, sample1),
-            entityQuery.save(ctx, sample2),
-            entityQuery.save(ctx, sample3),
-            entityQuery.save(ctx, sample4),
-            entityQuery.save(ctx, sample5),
-            entityQuery.save(ctx, sample6),
-            entityQuery.save(ctx, sampleSet),
-
-            methodConfigurationQuery.create(ctx, methodConfig),
-
-            submissionQuery.create(ctx, submissionSuccess),
-            submissionQuery.create(ctx, submissionFail),
-            submissionQuery.create(ctx, submissionRunning1),
-            submissionQuery.create(ctx, submissionRunning2)
-          )
-        }
-      ).withPinnedSession
-    }
+    override def save() =
+      DBIO
+        .seq(
+          rawlsBillingProjectQuery.create(billingProject),
+          workspaceQuery.createOrUpdate(workspace),
+          workspaceQuery.createOrUpdate(workspace2),
+          withWorkspaceContext(workspace) { ctx =>
+            DBIO.seq(
+              entityQuery.save(ctx, sample1),
+              entityQuery.save(ctx, sample2),
+              entityQuery.save(ctx, sample3),
+              entityQuery.save(ctx, sample4),
+              entityQuery.save(ctx, sample5),
+              entityQuery.save(ctx, sample6),
+              entityQuery.save(ctx, sampleSet),
+              methodConfigurationQuery.create(ctx, methodConfig),
+              submissionQuery.create(ctx, submissionSuccess),
+              submissionQuery.create(ctx, submissionFail),
+              submissionQuery.create(ctx, submissionRunning1),
+              submissionQuery.create(ctx, submissionRunning2)
+            )
+          }
+        )
+        .withPinnedSession
   }
 
   val testWorkspaces = new TestWorkspaces
 
-  def withTestWorkspacesApiServices[T](testCode: TestApiService => T): T = {
+  def withTestWorkspacesApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(testWorkspaces) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
+
+  "WorkspaceApi list-workspaces with fields param" should "return full response if no fields param" in withTestWorkspacesApiServices {
+    services =>
+      Get("/workspaces") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+
+          val dateTime = currentTime()
+          assertResult(
+            Set(
+              WorkspaceListResponse(
+                WorkspaceAccessLevels.Owner,
+                WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime),
+                                                         Option(Set.empty),
+                                                         true,
+                                                         Some(WorkspaceCloudPlatform.Gcp)
+                ),
+                Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
+                false
+              ),
+              WorkspaceListResponse(
+                WorkspaceAccessLevels.Owner,
+                WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime),
+                                                         Option(Set.empty),
+                                                         true,
+                                                         Some(WorkspaceCloudPlatform.Gcp)
+                ),
+                Option(WorkspaceSubmissionStats(None, None, 0)),
+                false
+              )
+            )
+          ) {
+            responseAs[Array[WorkspaceListResponse]]
+              .toSet[WorkspaceListResponse]
+              .map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
+          }
+        }
   }
 
+  it should "return full response if querystring exists but no fields param" in withTestWorkspacesApiServices {
+    services =>
+      Get("/workspaces?thisisnotfields=noitsnot") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
 
-  "WorkspaceApi list-workspaces with fields param" should "return full response if no fields param" in withTestWorkspacesApiServices { services =>
-    Get("/workspaces") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+          val dateTime = currentTime()
+          assertResult(
+            Set(
+              WorkspaceListResponse(
+                WorkspaceAccessLevels.Owner,
+                WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime),
+                                                         Option(Set.empty),
+                                                         true,
+                                                         Some(WorkspaceCloudPlatform.Gcp)
+                ),
+                Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
+                false
+              ),
+              WorkspaceListResponse(
+                WorkspaceAccessLevels.Owner,
+                WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime),
+                                                         Option(Set.empty),
+                                                         true,
+                                                         Some(WorkspaceCloudPlatform.Gcp)
+                ),
+                Option(WorkspaceSubmissionStats(None, None, 0)),
+                false
+              )
+            )
+          ) {
+            responseAs[Array[WorkspaceListResponse]]
+              .toSet[WorkspaceListResponse]
+              .map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
+          }
         }
-
-        val dateTime = currentTime()
-        assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), false),
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(None, None, 0)), false)
-        )) {
-          responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
-        }
-      }
-  }
-
-  it should "return full response if querystring exists but no fields param" in withTestWorkspacesApiServices { services =>
-    Get("/workspaces?thisisnotfields=noitsnot") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-
-        val dateTime = currentTime()
-        assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), false),
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(None, None, 0)), false)
-        )) {
-          responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
-        }
-      }
   }
 
   it should "filter response to a single key" in withTestWorkspacesApiServices { services =>
     Get("/workspaces?fields=accessLevel") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
         val expected = JsArray(
           JsObject("accessLevel" -> JsString(WorkspaceAccessLevels.Owner.toString)),
@@ -194,7 +313,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     Get("/workspaces?fields=accessLevel,public") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
         val expected = JsArray(
           JsObject(
@@ -214,7 +333,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     Get("/workspaces?fields=workspaceSubmissionStats,workspace.workspaceId,workspace.bucketName") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
         val expected = JsArray(
           JsObject(
@@ -224,7 +343,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
             ),
             "workspaceSubmissionStats" -> JsObject(
               "lastSuccessDate" -> JsString(testDate.toString),
-              "lastFailureDate" ->  JsString(testDate.toString),
+              "lastFailureDate" -> JsString(testDate.toString),
               "runningSubmissionsCount" -> JsNumber(2)
             )
           ),
@@ -246,7 +365,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     Get("/workspaces?fields=public,workspace.attributes") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
         val expected = JsArray(
           JsObject(
@@ -276,7 +395,7 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     Get("/workspaces?fields=public,workspace.attributes.description") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         val actual = responseAs[String].parseJson
         val expected = JsArray(
           JsObject(
@@ -305,11 +424,11 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     Get("/workspaces?fields=accessLevel,somethingNotRecognized,canShare") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.BadRequest) { status }
+        assertResult(StatusCodes.BadRequest)(status)
         val actual = responseAs[ErrorReport]
 
         // NB: field names in error response are alphabetized for deterministic behavior
-        assertResult("Unrecognized field names: canShare, somethingNotRecognized") { actual.message }
+        assertResult("Unrecognized field names: canShare, somethingNotRecognized")(actual.message)
       }
   }
 
@@ -317,10 +436,10 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     Get("/workspaces?fields=accessLevel&fields=public") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.BadRequest) { status }
+        assertResult(StatusCodes.BadRequest)(status)
         val actual = responseAs[ErrorReport]
 
-        assertResult("Parameter 'fields' may not be present multiple times.") { actual.message }
+        assertResult("Parameter 'fields' may not be present multiple times.")(actual.message)
       }
   }
 
@@ -336,16 +455,12 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
     * @param expected
     * @param actual
     */
-  def orderInsensitiveCompare(expected: JsArray, actual: Any): Unit = {
+  def orderInsensitiveCompare(expected: JsArray, actual: Any): Unit =
     actual match {
       case jsa: JsArray =>
-        jsa.elements should contain theSameElementsAs(expected.elements)
+        jsa.elements should contain theSameElementsAs (expected.elements)
       case x =>
         fail(s"actual value is of type ${x.getClass.getName}; expected JsArray.")
     }
 
-  }
-
-
 }
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -6,7 +6,15 @@ import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import bio.terra.workspace.model.JobReport.StatusEnum
-import bio.terra.workspace.model.{AzureContext, CreateCloudContextResult, CreateControlledAzureRelayNamespaceResult, JobReport, WorkspaceDescription, ErrorReport => _, _}
+import bio.terra.workspace.model.{
+  AzureContext,
+  CreateCloudContextResult,
+  CreateControlledAzureRelayNamespaceResult,
+  ErrorReport => _,
+  JobReport,
+  WorkspaceDescription,
+  _
+}
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import com.google.api.services.cloudresourcemanager.model.Project
 import io.opencensus.trace.Span
@@ -30,7 +38,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import spray.json.DefaultJsonProtocol._
-import spray.json.{JsObject, enrichAny}
+import spray.json.{enrichAny, JsObject}
 
 import java.util.UUID
 import scala.concurrent.duration.Duration
@@ -45,155 +53,218 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
   trait MockUserInfoDirectivesWithUser extends UserInfoDirectives {
     val user: String
-    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] = {
+    def requireUserInfo(span: Option[Span]): Directive1[UserInfo] =
       // just return the cookie text as the common name
       user match {
-        case testData.userProjectOwner.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userProjectOwner.userSubjectId))
-        case testData.userOwner.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userOwner.userSubjectId))
-        case testData.userWriter.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userWriter.userSubjectId))
-        case testData.userReader.userEmail.value => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userReader.userSubjectId))
-        case "no-access" => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212348")))
-        case _ => provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349")))
+        case testData.userProjectOwner.userEmail.value =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userProjectOwner.userSubjectId)
+          )
+        case testData.userOwner.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userOwner.userSubjectId))
+        case testData.userWriter.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userWriter.userSubjectId))
+        case testData.userReader.userEmail.value =>
+          provide(UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, testData.userReader.userSubjectId))
+        case "no-access" =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212348"))
+          )
+        case _ =>
+          provide(
+            UserInfo(RawlsUserEmail(user), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212349"))
+          )
       }
-    }
   }
 
-  case class TestApiService(dataSource: SlickDataSource, user: String, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectivesWithUser
+  case class TestApiService(dataSource: SlickDataSource,
+                            user: String,
+                            gcsDAO: MockGoogleServicesDAO,
+                            gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectivesWithUser
 
-  case class TestApiServiceCustomizableMockSam(dataSource: SlickDataSource, user: String, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(implicit override val executionContext: ExecutionContext) extends ApiServices with MockUserInfoDirectivesWithUser {
+  case class TestApiServiceCustomizableMockSam(dataSource: SlickDataSource,
+                                               user: String,
+                                               gcsDAO: MockGoogleServicesDAO,
+                                               gpsDAO: MockGooglePubSubDAO
+  )(implicit override val executionContext: ExecutionContext)
+      extends ApiServices
+      with MockUserInfoDirectivesWithUser {
     override val samDAO: CustomizableMockSamDAO = new CustomizableMockSamDAO(dataSource)
   }
 
-  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
+  def withApiServices[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
     val apiService = new TestApiService(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
   val userWriterNoCompute = RawlsUserEmail("writer-access-no-compute")
   val userWriterNoComputeOnProject = RawlsUserEmail("writer-access-no-compute-on-project")
 
-  def withApiServicesSecure[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
+  def withApiServicesSecure[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
     val apiService = new TestApiService(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO) {
       override val samDAO: MockSamDAO = new MockSamDAO(dataSource) {
-        override def userHasAction(resourceTypeName: SamResourceTypeName, resourceId: String, action: SamResourceAction, userInfo: UserInfo): Future[Boolean] = {
+        override def userHasAction(resourceTypeName: SamResourceTypeName,
+                                   resourceId: String,
+                                   action: SamResourceAction,
+                                   userInfo: UserInfo
+        ): Future[Boolean] = {
           val result = userInfo.userEmail match {
-            case testData.userOwner.userEmail => true
+            case testData.userOwner.userEmail        => true
             case testData.userProjectOwner.userEmail => true
-            case testData.userWriter.userEmail => Set(SamWorkspaceActions.read, SamWorkspaceActions.write, SamWorkspaceActions.compute, SamBillingProjectActions.launchBatchCompute).contains(action)
+            case testData.userWriter.userEmail =>
+              Set(SamWorkspaceActions.read,
+                  SamWorkspaceActions.write,
+                  SamWorkspaceActions.compute,
+                  SamBillingProjectActions.launchBatchCompute
+              ).contains(action)
             case `userWriterNoCompute` => Set(SamWorkspaceActions.read, SamWorkspaceActions.write).contains(action)
-            case `userWriterNoComputeOnProject` => Set(SamWorkspaceActions.read, SamWorkspaceActions.write, SamWorkspaceActions.compute).contains(action)
+            case `userWriterNoComputeOnProject` =>
+              Set(SamWorkspaceActions.read, SamWorkspaceActions.write, SamWorkspaceActions.compute).contains(action)
             case testData.userReader.userEmail => Set(SamWorkspaceActions.read).contains(action)
-            case _ => false
+            case _                             => false
           }
           Future.successful(result)
         }
       }
     }
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withApiServicesMockitoSam[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(dataSource, user, spy(new MockGoogleServicesDAO("test")), new MockGooglePubSubDAO) {
-      override val samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    }
-    try {
+  def withApiServicesMockitoSam[T](dataSource: SlickDataSource, user: String = testData.userOwner.userEmail.value)(
+    testCode: TestApiService => T
+  ): T = {
+    val apiService =
+      new TestApiService(dataSource, user, spy(new MockGoogleServicesDAO("test")), new MockGooglePubSubDAO) {
+        override val samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      }
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withTestDataApiServices[T](testCode: TestApiService => T): T = {
+  def withTestDataApiServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withTestDataApiServicesAndUser[T](user: String)(testCode: TestApiService => T): T = {
+  def withTestDataApiServicesAndUser[T](user: String)(testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServicesSecure(dataSource, user) { services =>
         testCode(services)
       }
     }
-  }
 
   def withApiServicesMockitoWSMDao[T](dataSource: SlickDataSource)(testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(dataSource, testData.userOwner.userEmail.value, spy(new MockGoogleServicesDAO("test")), new MockGooglePubSubDAO) {
+    val apiService = new TestApiService(dataSource,
+                                        testData.userOwner.userEmail.value,
+                                        spy(new MockGoogleServicesDAO("test")),
+                                        new MockGooglePubSubDAO
+    ) {
       override val workspaceManagerDAO: WorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
     }
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withTestDataApiServicesMockitoSam[T](testCode: TestApiService => T): T = {
+  def withTestDataApiServicesMockitoSam[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServicesMockitoSam(dataSource) { services =>
         testCode(services)
       }
     }
-  }
 
-  def withEmptyWorkspaceApiServices[T](user: String)(testCode: TestApiService => T): T = {
+  def withEmptyWorkspaceApiServices[T](user: String)(testCode: TestApiService => T): T =
     withCustomTestDatabase(new EmptyWorkspace) { dataSource: SlickDataSource =>
       withApiServices(dataSource, user)(testCode)
     }
-  }
 
-  def withLockedWorkspaceApiServices[T](user: String)(testCode: TestApiService => T): T = {
+  def withLockedWorkspaceApiServices[T](user: String)(testCode: TestApiService => T): T =
     withCustomTestDatabase(new LockedWorkspace) { dataSource: SlickDataSource =>
       withApiServicesSecure(dataSource, user)(testCode)
     }
-  }
 
-  def withApiServicesCustomizableMockSam[T](dataSource: SlickDataSource, user: String = testData.userProjectOwner.userEmail.value)(testCode: TestApiServiceCustomizableMockSam => T): T = {
-    val apiService = new TestApiServiceCustomizableMockSam(dataSource, user, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)
-    try {
+  def withApiServicesCustomizableMockSam[T](dataSource: SlickDataSource,
+                                            user: String = testData.userProjectOwner.userEmail.value
+  )(testCode: TestApiServiceCustomizableMockSam => T): T = {
+    val apiService = new TestApiServiceCustomizableMockSam(dataSource,
+                                                           user,
+                                                           new MockGoogleServicesDAO("test"),
+                                                           new MockGooglePubSubDAO
+    )
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  def withTestDataApiServicesCustomizableMockSam[T](testCode: TestApiServiceCustomizableMockSam => T): T = {
+  def withTestDataApiServicesCustomizableMockSam[T](testCode: TestApiServiceCustomizableMockSam => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withApiServicesCustomizableMockSam(dataSource)(testCode)
     }
-  }
 
-  def withEmptyDatabaseAndApiServices[T](testCode: TestApiService =>  T): T = {
+  def withEmptyDatabaseAndApiServices[T](testCode: TestApiService => T): T =
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withApiServicesMockitoGcsDao[T](testCode: TestApiService => T): T = {
-    withDefaultTestDatabase { dataSource: SlickDataSource => {
-      val apiService = new TestApiService(dataSource, testData.userProjectOwner.userEmail.value, mock[MockGoogleServicesDAO](RETURNS_SMART_NULLS), new MockGooglePubSubDAO)
-      try {
+  def withApiServicesMockitoGcsDao[T](testCode: TestApiService => T): T =
+    withDefaultTestDatabase { dataSource: SlickDataSource =>
+      val apiService = new TestApiService(dataSource,
+                                          testData.userProjectOwner.userEmail.value,
+                                          mock[MockGoogleServicesDAO](RETURNS_SMART_NULLS),
+                                          new MockGooglePubSubDAO
+      )
+      try
         testCode(apiService)
-      } finally {
+      finally
         apiService.cleanupSupervisor
-      }
     }
-    }
-  }
 
   class TestWorkspaces() extends TestData {
-    val userProjectOwner = RawlsUser(UserInfo(RawlsUserEmail("project-owner-access"), OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543210101")))
-    val userOwner = RawlsUser(UserInfo(testData.userOwner.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212345")))
-    val userWriter = RawlsUser(UserInfo(testData.userWriter.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212346")))
-    val userReader = RawlsUser(UserInfo(testData.userReader.userEmail, OAuth2BearerToken("token"), 123, RawlsUserSubjectId("123456789876543212347")))
+    val userProjectOwner = RawlsUser(
+      UserInfo(RawlsUserEmail("project-owner-access"),
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543210101")
+      )
+    )
+    val userOwner = RawlsUser(
+      UserInfo(testData.userOwner.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212345")
+      )
+    )
+    val userWriter = RawlsUser(
+      UserInfo(testData.userWriter.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212346")
+      )
+    )
+    val userReader = RawlsUser(
+      UserInfo(testData.userReader.userEmail,
+               OAuth2BearerToken("token"),
+               123,
+               RawlsUserSubjectId("123456789876543212347")
+      )
+    )
 
     val billingProject = RawlsBillingProject(RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
 
@@ -204,10 +275,32 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     val workspace3Name = WorkspaceName(billingProject.projectName.value, "testworkspace3")
 
     val workspace1Id = UUID.randomUUID().toString
-    val workspace = makeWorkspaceWithUsers(billingProject, workspaceName.name, workspace1Id, "bucket1", Some(workspace1Id), testDate, testDate, "testUser", Map(AttributeName.withDefaultNS("a") -> AttributeString("x")), false)
+    val workspace = makeWorkspaceWithUsers(
+      billingProject,
+      workspaceName.name,
+      workspace1Id,
+      "bucket1",
+      Some(workspace1Id),
+      testDate,
+      testDate,
+      "testUser",
+      Map(AttributeName.withDefaultNS("a") -> AttributeString("x")),
+      false
+    )
 
     val workspace2Id = UUID.randomUUID().toString
-    val workspace2 = makeWorkspaceWithUsers(billingProject, workspace2Name.name, workspace2Id, "bucket2", Some(workspace2Id), testDate, testDate, "testUser", Map(AttributeName.withDefaultNS("b") -> AttributeString("y")), false)
+    val workspace2 = makeWorkspaceWithUsers(
+      billingProject,
+      workspace2Name.name,
+      workspace2Id,
+      "bucket2",
+      Some(workspace2Id),
+      testDate,
+      testDate,
+      "testUser",
+      Map(AttributeName.withDefaultNS("b") -> AttributeString("y")),
+      false
+    )
 
     val sample1 = Entity("sample1", "sample", Map.empty)
     val sample2 = Entity("sample2", "sample", Map.empty)
@@ -215,17 +308,46 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     val sample4 = Entity("sample4", "sample", Map.empty)
     val sample5 = Entity("sample5", "sample", Map.empty)
     val sample6 = Entity("sample6", "sample", Map.empty)
-    val sampleSet = Entity("sampleset", "sample_set", Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(
-      sample1.toReference,
-      sample2.toReference,
-      sample3.toReference
-    ))))
+    val sampleSet = Entity(
+      "sampleset",
+      "sample_set",
+      Map(
+        AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(
+          Seq(
+            sample1.toReference,
+            sample2.toReference,
+            sample3.toReference
+          )
+        )
+      )
+    )
 
-    val methodConfig = MethodConfiguration("dsde", "testConfig", Some("Sample"), None, Map("param1"-> AttributeString("foo")), Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")), AgoraMethod(workspaceName.namespace, "method-a", 1))
+    val methodConfig = MethodConfiguration(
+      "dsde",
+      "testConfig",
+      Some("Sample"),
+      None,
+      Map("param1" -> AttributeString("foo")),
+      Map("out1" -> AttributeString("bar"), "out2" -> AttributeString("splat")),
+      AgoraMethod(workspaceName.namespace, "method-a", 1)
+    )
     val methodConfigName = MethodConfigurationName(methodConfig.name, methodConfig.namespace, workspaceName)
-    val submissionTemplate = createTestSubmission(workspace, methodConfig, sampleSet, WorkbenchEmail(userOwner.userEmail.value),
-      Seq(sample1, sample2, sample3), Map(sample1 -> testData.inputResolutions, sample2 -> testData.inputResolutions, sample3 -> testData.inputResolutions),
-      Seq(sample4, sample5, sample6), Map(sample4 -> testData.inputResolutions2, sample5 -> testData.inputResolutions2, sample6 -> testData.inputResolutions2))
+    val submissionTemplate = createTestSubmission(
+      workspace,
+      methodConfig,
+      sampleSet,
+      WorkbenchEmail(userOwner.userEmail.value),
+      Seq(sample1, sample2, sample3),
+      Map(sample1 -> testData.inputResolutions,
+          sample2 -> testData.inputResolutions,
+          sample3 -> testData.inputResolutions
+      ),
+      Seq(sample4, sample5, sample6),
+      Map(sample4 -> testData.inputResolutions2,
+          sample5 -> testData.inputResolutions2,
+          sample6 -> testData.inputResolutions2
+      )
+    )
     val submissionSuccess = submissionTemplate.copy(
       submissionId = UUID.randomUUID().toString,
       status = SubmissionStatuses.Done,
@@ -247,13 +369,11 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       workflows = submissionTemplate.workflows.map(_.copy(status = WorkflowStatuses.Running))
     )
 
-    override def save() = {
+    override def save() =
       DBIO.seq(
         rawlsBillingProjectQuery.create(billingProject),
-
         workspaceQuery.createOrUpdate(workspace),
         workspaceQuery.createOrUpdate(workspace2),
-
         withWorkspaceContext(workspace) { ctx =>
           DBIO.seq(
             entityQuery.save(ctx, sample1),
@@ -263,9 +383,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             entityQuery.save(ctx, sample5),
             entityQuery.save(ctx, sample6),
             entityQuery.save(ctx, sampleSet),
-
             methodConfigurationQuery.create(ctx, methodConfig),
-
             submissionQuery.create(ctx, submissionSuccess),
             submissionQuery.create(ctx, submissionFail),
             submissionQuery.create(ctx, submissionRunning1),
@@ -273,22 +391,19 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           )
         }
       )
-    }
   }
 
   val testWorkspaces = new TestWorkspaces
 
-  def withTestWorkspacesApiServices[T](testCode: TestApiService => T): T = {
+  def withTestWorkspacesApiServices[T](testCode: TestApiService => T): T =
     withCustomTestDatabase(testWorkspaces) { dataSource: SlickDataSource =>
       withApiServices(dataSource)(testCode)
     }
-  }
 
-  def withTestWorkspacesApiServicesAndUser[T](user: String)(testCode: TestApiService => T): T = {
+  def withTestWorkspacesApiServicesAndUser[T](user: String)(testCode: TestApiService => T): T =
     withCustomTestDatabase(testWorkspaces) { dataSource: SlickDataSource =>
       withApiServicesSecure(dataSource, user)(testCode)
     }
-  }
 
   "WorkspaceApi" should "return 201 for post to workspaces" in withTestDataApiServices { services =>
     val newWorkspace = WorkspaceRequest(
@@ -414,7 +529,12 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         assertResult(newWorkspace) {
           val ws = responseAs[WorkspaceDetails]
-          WorkspaceRequest(ws.namespace, ws.name, ws.attributes.getOrElse(Map()), Option(Set.empty), noWorkspaceOwner = Option(true))
+          WorkspaceRequest(ws.namespace,
+                           ws.name,
+                           ws.attributes.getOrElse(Map()),
+                           Option(Set.empty),
+                           noWorkspaceOwner = Option(true)
+          )
         }
         // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
         assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(newWorkspace.path))))) {
@@ -424,81 +544,113 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   private def toUserInfo(user: RawlsUser) = UserInfo(user.userEmail, OAuth2BearerToken(""), 0, user.userSubjectId)
-  private def populateBillingProjectPolicies(services: TestApiServiceCustomizableMockSam, workspace: Workspace = testData.workspace) = {
+  private def populateBillingProjectPolicies(services: TestApiServiceCustomizableMockSam,
+                                             workspace: Workspace = testData.workspace
+  ) = {
     val populateAcl = for {
       _ <- services.samDAO.registerUser(toUserInfo(testData.userProjectOwner))
 
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.billingProject, workspace.namespace, SamBillingProjectPolicyNames.owner,
-        SamPolicy(Set(WorkbenchEmail(testData.userProjectOwner.userEmail.value)), Set(SamBillingProjectActions.createWorkspace), Set(SamBillingProjectRoles.owner)), userInfo)
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.reader,
-        SamPolicy(Set(WorkbenchEmail(testData.userProjectOwner.userEmail.value)), Set(SamWorkspaceActions.read), Set(SamWorkspaceRoles.reader)), userInfo)
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.billingProject,
+        workspace.namespace,
+        SamBillingProjectPolicyNames.owner,
+        SamPolicy(Set(WorkbenchEmail(testData.userProjectOwner.userEmail.value)),
+                  Set(SamBillingProjectActions.createWorkspace),
+                  Set(SamBillingProjectRoles.owner)
+        ),
+        userInfo
+      )
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        workspace.workspaceId,
+        SamWorkspacePolicyNames.reader,
+        SamPolicy(Set(WorkbenchEmail(testData.userProjectOwner.userEmail.value)),
+                  Set(SamWorkspaceActions.read),
+                  Set(SamWorkspaceRoles.reader)
+        ),
+        userInfo
+      )
 
     } yield ()
 
     Await.result(populateAcl, Duration.Inf)
   }
 
-  it should "have an empty owner policy when creating a workspace with noWorkspaceOwner" in withTestDataApiServicesCustomizableMockSam { services =>
-    val newWorkspace = WorkspaceRequest(
-      namespace = testData.wsName.namespace,
-      name = "newWorkspace",
-      Map.empty,
-      noWorkspaceOwner = Option(true)
-    )
+  it should "have an empty owner policy when creating a workspace with noWorkspaceOwner" in withTestDataApiServicesCustomizableMockSam {
+    services =>
+      val newWorkspace = WorkspaceRequest(
+        namespace = testData.wsName.namespace,
+        name = "newWorkspace",
+        Map.empty,
+        noWorkspaceOwner = Option(true)
+      )
 
-    populateBillingProjectPolicies(services)
+      populateBillingProjectPolicies(services)
 
-    val expectedOwnerPolicyEmail = ""
+      val expectedOwnerPolicyEmail = ""
 
-    Post(s"/workspaces", httpJson(newWorkspace)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
+      Post(s"/workspaces", httpJson(newWorkspace)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
+          // check the workspace owner policy
+          assertResult(expectedOwnerPolicyEmail) {
+            val ws = runAndWait(workspaceQuery.findByName(newWorkspace.toWorkspaceName)).get
+            val policiesWithNameAndEmail = Await.result(
+              services.samDAO.listPoliciesForResource(SamResourceTypeNames.workspace, ws.workspaceId, userInfo),
+              Duration.Inf
+            )
+            val actualOwnerPolicyEmail =
+              policiesWithNameAndEmail.find(_.policyName == SamWorkspacePolicyNames.owner).get.email.value
+            actualOwnerPolicyEmail
+          }
         }
-        // check the workspace owner policy
-        assertResult(expectedOwnerPolicyEmail) {
-          val ws = runAndWait(workspaceQuery.findByName(newWorkspace.toWorkspaceName)).get
-          val policiesWithNameAndEmail = Await.result(services.samDAO.listPoliciesForResource(SamResourceTypeNames.workspace, ws.workspaceId, userInfo), Duration.Inf)
-          val actualOwnerPolicyEmail = policiesWithNameAndEmail.find(_.policyName == SamWorkspacePolicyNames.owner).get.email.value
-          actualOwnerPolicyEmail
-        }
-      }
   }
 
-  it should "return 403 for post to workspaces with noWorkspaceOwner without BP owner permissions" in withTestDataApiServicesMockitoSam { services =>
-    val newWorkspace = WorkspaceRequest(
-      namespace = testData.wsName.namespace,
-      name = "newWorkspace",
-      Map.empty,
-      noWorkspaceOwner = Option(true)
-    )
+  it should "return 403 for post to workspaces with noWorkspaceOwner without BP owner permissions" in withTestDataApiServicesMockitoSam {
+    services =>
+      val newWorkspace = WorkspaceRequest(
+        namespace = testData.wsName.namespace,
+        name = "newWorkspace",
+        Map.empty,
+        noWorkspaceOwner = Option(true)
+      )
 
-    // User has BP user role, but not owner role
-    when(services.samDAO.listUserRolesForResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-      ArgumentMatchers.eq(testData.billingProject.projectName.value),
-      any[UserInfo]
-    )).thenReturn(Future.successful(Set[SamResourceRole](SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.batchComputeUser)))
+      // User has BP user role, but not owner role
+      when(
+        services.samDAO.listUserRolesForResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(testData.billingProject.projectName.value),
+          any[UserInfo]
+        )
+      ).thenReturn(
+        Future.successful(
+          Set[SamResourceRole](SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.batchComputeUser)
+        )
+      )
 
-    // User has BP user permissions and therefore can create workspaces
-    when(services.samDAO.userHasAction(
-      ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-      ArgumentMatchers.eq(testData.billingProject.projectName.value),
-      ArgumentMatchers.eq(SamBillingProjectActions.createWorkspace),
-      any[UserInfo]
-    )).thenReturn(Future.successful(true))
+      // User has BP user permissions and therefore can create workspaces
+      when(
+        services.samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(testData.billingProject.projectName.value),
+          ArgumentMatchers.eq(SamBillingProjectActions.createWorkspace),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
-    Post(s"/workspaces", httpJson(newWorkspace)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden, responseAs[String]) {
-          status
+      Post(s"/workspaces", httpJson(newWorkspace)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden, responseAs[String]) {
+            status
+          }
+
+          val errorText = responseAs[ErrorReport].message
+          assert(errorText.contains(newWorkspace.namespace))
         }
-
-        val errorText = responseAs[ErrorReport].message
-        assert(errorText.contains(newWorkspace.namespace))
-      }
   }
 
   it should "get a workspace" in withTestWorkspacesApiServices { services =>
@@ -510,10 +662,30 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(Option(WorkspaceAccessLevels.Owner), Option(true), Option(true), Option(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), Option(WorkspaceBucketOptions(false)), Option(Set.empty), None)
-        ){
+          WorkspaceResponse(
+            Option(WorkspaceAccessLevels.Owner),
+            Option(true),
+            Option(true),
+            Option(true),
+            WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty),
+            Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
+            Option(WorkspaceBucketOptions(false)),
+            Option(Set.empty),
+            None
+          )
+        ) {
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, None)
+          WorkspaceResponse(
+            response.accessLevel,
+            response.canShare,
+            response.canCompute,
+            response.catalog,
+            response.workspace.copy(lastModified = dateTime),
+            response.workspaceSubmissionStats,
+            response.bucketOptions,
+            response.owners,
+            None
+          )
         }
       }
   }
@@ -527,10 +699,30 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
         val dateTime = currentTime()
         assertResult(
-          WorkspaceResponse(Option(WorkspaceAccessLevels.Owner), Option(true), Option(true), Option(true), WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty), Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), Option(WorkspaceBucketOptions(false)), Option(Set.empty), None)
-        ){
+          WorkspaceResponse(
+            Option(WorkspaceAccessLevels.Owner),
+            Option(true),
+            Option(true),
+            Option(true),
+            WorkspaceDetails(testWorkspaces.workspace.copy(lastModified = dateTime), Set.empty),
+            Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
+            Option(WorkspaceBucketOptions(false)),
+            Option(Set.empty),
+            None
+          )
+        ) {
           val response = responseAs[WorkspaceResponse]
-          WorkspaceResponse(response.accessLevel, response.canShare, response.canCompute, response.catalog, response.workspace.copy(lastModified = dateTime), response.workspaceSubmissionStats, response.bucketOptions, response.owners, None)
+          WorkspaceResponse(
+            response.accessLevel,
+            response.canShare,
+            response.canCompute,
+            response.catalog,
+            response.workspace.copy(lastModified = dateTime),
+            response.workspaceSubmissionStats,
+            response.bucketOptions,
+            response.owners,
+            None
+          )
         }
       }
   }
@@ -575,9 +767,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           status
         }
       }
-      assertResult(None) {
-        runAndWait(workspaceQuery.findByName(testData.workspace.toWorkspaceName))
-      }
+    assertResult(None) {
+      runAndWait(workspaceQuery.findByName(testData.workspace.toWorkspaceName))
+    }
   }
 
   it should "delete all entities when deleting a workspace" in withTestDataApiServices { services =>
@@ -607,8 +799,15 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     // check that length of result is > 0:
     withWorkspaceContext(testData.workspace) { workspaceContext =>
       assert {
-        runAndWait(methodConfigurationQuery.findActiveByName(workspaceContext.workspaceIdAsUUID, testData.agoraMethodConfig.namespace,
-          testData.agoraMethodConfig.name).length.result) > 0
+        runAndWait(
+          methodConfigurationQuery
+            .findActiveByName(workspaceContext.workspaceIdAsUUID,
+                              testData.agoraMethodConfig.namespace,
+                              testData.agoraMethodConfig.name
+            )
+            .length
+            .result
+        ) > 0
       }
     }
     // delete the workspace
@@ -622,8 +821,15 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     // now you should have no method configs listed
     withWorkspaceContext(testData.workspace) { workspaceContext =>
       assert {
-        runAndWait(methodConfigurationQuery.findActiveByName(workspaceContext.workspaceIdAsUUID, testData.agoraMethodConfig.namespace,
-          testData.agoraMethodConfig.name).length.result) == 0
+        runAndWait(
+          methodConfigurationQuery
+            .findActiveByName(workspaceContext.workspaceIdAsUUID,
+                              testData.agoraMethodConfig.namespace,
+                              testData.agoraMethodConfig.name
+            )
+            .length
+            .result
+        ) == 0
       }
     }
   }
@@ -651,148 +857,217 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "delete workspace and workflow collection sam resource when deleting a workspace" in withTestDataApiServicesMockitoSam { services =>
-    when(services.samDAO.userHasAction(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      ArgumentMatchers.eq(SamWorkspaceActions.delete),
-      any[UserInfo]
-    )).thenReturn(Future.successful(true))
+  it should "delete workspace and workflow collection sam resource when deleting a workspace" in withTestDataApiServicesMockitoSam {
+    services =>
+      when(
+        services.samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          ArgumentMatchers.eq(SamWorkspaceActions.delete),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      any[UserInfo]
-    )).thenReturn(Future.successful(()))
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(()))
 
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
-      ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
-      any[UserInfo]
-    )).thenReturn(Future.successful(()))
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
+          ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(()))
 
-    // mocking for deleting a google project
-    val petSAJson = "petJson"
-    val googleProjectId = testData.workspace.googleProjectId
-    when(services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful(Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId")))))
-    when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail)).thenReturn(Future.successful(petSAJson))
-    when(services.samDAO.listResourceChildren(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(googleProjectId.value, SamResourceTypeNames.googleProject.value))))
-    when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[UserInfo])).thenReturn(Future.successful()) // uses any[UserInfo] here since MockGoogleServicesDAO defaults to returning a different UserInfo
-    when(services.samDAO.deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful())
+      // mocking for deleting a google project
+      val petSAJson = "petJson"
+      val googleProjectId = testData.workspace.googleProjectId
+      when(
+        services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)
+      ).thenReturn(
+        Future.successful(
+          Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId")))
+        )
+      )
+      when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail))
+        .thenReturn(Future.successful(petSAJson))
+      when(services.samDAO.listResourceChildren(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo))
+        .thenReturn(
+          Future.successful(
+            Seq(SamFullyQualifiedResourceId(googleProjectId.value, SamResourceTypeNames.googleProject.value))
+          )
+        )
+      when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[UserInfo])).thenReturn(
+        Future.successful()
+      ) // uses any[UserInfo] here since MockGoogleServicesDAO defaults to returning a different UserInfo
+      when(services.samDAO.deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo))
+        .thenReturn(Future.successful())
 
-    Delete(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Accepted, responseAs[String]) {
-          status
+      Delete(testData.workspace.path) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Accepted, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    verify(services.samDAO).deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      any[UserInfo]
-    )
+      verify(services.samDAO).deleteResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(testData.workspace.workspaceId),
+        any[UserInfo]
+      )
 
-    verify(services.samDAO).deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
-      ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
-      any[UserInfo]
-    )
+      verify(services.samDAO).deleteResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
+        ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
+        any[UserInfo]
+      )
   }
 
-  it should "delete the google project in the workspace when deleting a workspace" in withTestDataApiServicesMockitoSam { services =>
-    when(services.samDAO.userHasAction(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      ArgumentMatchers.eq(SamWorkspaceActions.delete),
-      any[UserInfo]
-    )).thenReturn(Future.successful(true))
+  it should "delete the google project in the workspace when deleting a workspace" in withTestDataApiServicesMockitoSam {
+    services =>
+      when(
+        services.samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          ArgumentMatchers.eq(SamWorkspaceActions.delete),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      any[UserInfo]
-    )).thenReturn(Future.successful(()))
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(()))
 
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
-      ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
-      any[UserInfo]
-    )).thenReturn(Future.successful(()))
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
+          ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(()))
 
-    // mocking for deleting a google project
-    val petSAJson = "petJson"
-    val googleProjectId = testData.workspace.googleProjectId
-    when(services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful(Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId")))))
-    when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail)).thenReturn(Future.successful(petSAJson))
-    when(services.samDAO.listResourceChildren(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(googleProjectId.value, SamResourceTypeNames.googleProject.value))))
-    when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[UserInfo])).thenReturn(Future.successful()) // uses any[UserInfo] here since MockGoogleServicesDAO defaults to returning a different UserInfo
-    when(services.samDAO.deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful())
+      // mocking for deleting a google project
+      val petSAJson = "petJson"
+      val googleProjectId = testData.workspace.googleProjectId
+      when(
+        services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)
+      ).thenReturn(
+        Future.successful(
+          Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId")))
+        )
+      )
+      when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail))
+        .thenReturn(Future.successful(petSAJson))
+      when(services.samDAO.listResourceChildren(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo))
+        .thenReturn(
+          Future.successful(
+            Seq(SamFullyQualifiedResourceId(googleProjectId.value, SamResourceTypeNames.googleProject.value))
+          )
+        )
+      when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[UserInfo])).thenReturn(
+        Future.successful()
+      ) // uses any[UserInfo] here since MockGoogleServicesDAO defaults to returning a different UserInfo
+      when(services.samDAO.deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo))
+        .thenReturn(Future.successful())
 
-    Delete(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Accepted, responseAs[String]) {
-          status
+      Delete(testData.workspace.path) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Accepted, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    verify(services.samDAO).deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-      ArgumentMatchers.eq(googleProjectId.value),
-      any[UserInfo]
-    )
-    verify(services.gcsDAO).deleteGoogleProject(ArgumentMatchers.eq(googleProjectId))
+      verify(services.samDAO).deleteResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+        ArgumentMatchers.eq(googleProjectId.value),
+        any[UserInfo]
+      )
+      verify(services.gcsDAO).deleteGoogleProject(ArgumentMatchers.eq(googleProjectId))
   }
 
-  it should "tolerate a missing google-project Sam resource when deleting a workspace" in withTestDataApiServicesMockitoSam { services =>
-    when(services.samDAO.userHasAction(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      ArgumentMatchers.eq(SamWorkspaceActions.delete),
-      any[UserInfo]
-    )).thenReturn(Future.successful(true))
+  it should "tolerate a missing google-project Sam resource when deleting a workspace" in withTestDataApiServicesMockitoSam {
+    services =>
+      when(
+        services.samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          ArgumentMatchers.eq(SamWorkspaceActions.delete),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      any[UserInfo]
-    )).thenReturn(Future.successful(()))
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(()))
 
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
-      ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
-      any[UserInfo]
-    )).thenReturn(Future.successful(()))
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
+          ArgumentMatchers.eq(testData.workspace.workflowCollectionName.get),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(()))
 
-    // mocking for deleting a google project
-    val petSAJson = "petJson"
-    val googleProjectId = testData.workspace.googleProjectId
-    when(services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful(Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId")))))
-    when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail)).thenReturn(Future.successful(petSAJson))
-    when(services.samDAO.listResourceChildren(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)).thenReturn(Future.successful(Seq(SamFullyQualifiedResourceId(googleProjectId.value, SamResourceTypeNames.googleProject.value))))
-    when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[UserInfo])).thenReturn(Future.successful()) // uses any[UserInfo] here since MockGoogleServicesDAO defaults to returning a different UserInfo
-    when(services.samDAO.deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-      ArgumentMatchers.eq(googleProjectId.value),
-      any[UserInfo]
-    )).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"resource not found"))))
+      // mocking for deleting a google project
+      val petSAJson = "petJson"
+      val googleProjectId = testData.workspace.googleProjectId
+      when(
+        services.samDAO.listAllResourceMemberIds(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo)
+      ).thenReturn(
+        Future.successful(
+          Set(UserIdInfo(userInfo.userSubjectId.value, userInfo.userEmail.value, Option("googleSubId")))
+        )
+      )
+      when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail))
+        .thenReturn(Future.successful(petSAJson))
+      when(services.samDAO.listResourceChildren(SamResourceTypeNames.googleProject, googleProjectId.value, userInfo))
+        .thenReturn(
+          Future.successful(
+            Seq(SamFullyQualifiedResourceId(googleProjectId.value, SamResourceTypeNames.googleProject.value))
+          )
+        )
+      when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[UserInfo])).thenReturn(
+        Future.successful()
+      ) // uses any[UserInfo] here since MockGoogleServicesDAO defaults to returning a different UserInfo
+      when(
+        services.samDAO.deleteResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+          ArgumentMatchers.eq(googleProjectId.value),
+          any[UserInfo]
+        )
+      ).thenReturn(
+        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, s"resource not found")))
+      )
 
-    Delete(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Accepted, responseAs[String]) {
-          status
+      Delete(testData.workspace.path) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Accepted, responseAs[String]) {
+            status
+          }
         }
-      }
 
-    verify(services.samDAO).deleteResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-      ArgumentMatchers.eq(googleProjectId.value),
-      any[UserInfo]
-    )
-    verify(services.gcsDAO).deleteGoogleProject(ArgumentMatchers.eq(googleProjectId))
+      verify(services.samDAO).deleteResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+        ArgumentMatchers.eq(googleProjectId.value),
+        any[UserInfo]
+      )
+      verify(services.gcsDAO).deleteGoogleProject(ArgumentMatchers.eq(googleProjectId))
   }
 
   it should "delete an Azure workspace" in {
@@ -802,14 +1077,38 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext]))
           .thenReturn(new WorkspaceDescription().id(UUID.randomUUID()).azureContext(new AzureContext()))
         // Mock happy path workspaceCreate responses
-        when(services.workspaceManagerDAO.createAzureWorkspaceCloudContext(any[UUID], any[String], any[String], any[String], any[RawlsRequestContext]))
-          .thenReturn(new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED)))
-        when(services.workspaceManagerDAO.getWorkspaceCreateCloudContextResult(any[UUID], any[String], any[RawlsRequestContext]))
-          .thenReturn(new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED)))
+        when(
+          services.workspaceManagerDAO.createAzureWorkspaceCloudContext(any[UUID],
+                                                                        any[String],
+                                                                        any[String],
+                                                                        any[String],
+                                                                        any[RawlsRequestContext]
+          )
+        )
+          .thenReturn(
+            new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED))
+          )
+        when(
+          services.workspaceManagerDAO.getWorkspaceCreateCloudContextResult(any[UUID],
+                                                                            any[String],
+                                                                            any[RawlsRequestContext]
+          )
+        )
+          .thenReturn(
+            new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED))
+          )
         when(services.workspaceManagerDAO.createAzureRelay(any[UUID], any[String], any[RawlsRequestContext]))
-          .thenReturn(new CreateControlledAzureRelayNamespaceResult().jobReport(new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED)))
+          .thenReturn(
+            new CreateControlledAzureRelayNamespaceResult().jobReport(
+              new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED)
+            )
+          )
         when(services.workspaceManagerDAO.getCreateAzureRelayResult(any[UUID], any[String], any[RawlsRequestContext]))
-          .thenReturn(new CreateControlledAzureRelayNamespaceResult().jobReport(new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED)))
+          .thenReturn(
+            new CreateControlledAzureRelayNamespaceResult().jobReport(
+              new JobReport().id("fake_id").status(StatusEnum.SUCCEEDED)
+            )
+          )
         when(services.workspaceManagerDAO.createAzureStorageAccount(any[UUID], any[String], any[RawlsRequestContext]))
           .thenReturn(new CreatedControlledAzureStorage().resourceId(UUID.randomUUID()))
 
@@ -848,7 +1147,6 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
   // TODO - once workspace migration is complete and there are no more v1 workspaces or v1 billing projects, we can remove this https://broadworkbench.atlassian.net/browse/CA-1118
   it should "delete a v1 workspace" in withEmptyDatabaseAndApiServices { services =>
-
     val billingProject = RawlsBillingProject(RawlsBillingProjectName("v1-test-ns"), CreationStatuses.Ready, None, None)
     val v1Workspace = new Workspace(
       billingProject.projectName.value,
@@ -873,7 +1171,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     runAndWait(
       DBIO.seq(
         rawlsBillingProjectQuery.create(billingProject),
-        workspaceQuery.createOrUpdate(v1Workspace),
+        workspaceQuery.createOrUpdate(v1Workspace)
       )
     )
 
@@ -900,84 +1198,162 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
 
         val dateTime = currentTime()
-        assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)),  Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)), false),
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(None, None, 0)), false)
-        )) {
-          responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
+        assertResult(
+          Set(
+            WorkspaceListResponse(
+              WorkspaceAccessLevels.Owner,
+              WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime),
+                                                       Option(Set.empty),
+                                                       true,
+                                                       Some(WorkspaceCloudPlatform.Gcp)
+              ),
+              Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
+              false
+            ),
+            WorkspaceListResponse(
+              WorkspaceAccessLevels.Owner,
+              WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime),
+                                                       Option(Set.empty),
+                                                       true,
+                                                       Some(WorkspaceCloudPlatform.Gcp)
+              ),
+              Option(WorkspaceSubmissionStats(None, None, 0)),
+              false
+            )
+          )
+        ) {
+          responseAs[Array[WorkspaceListResponse]]
+            .toSet[WorkspaceListResponse]
+            .map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
         }
       }
   }
 
-  it should "list workspaces even when a Sam resourceId has an invalid UUID" in withTestDataApiServicesMockitoSam { services =>
-
+  it should "list workspaces even when a Sam resourceId has an invalid UUID" in withTestDataApiServicesMockitoSam {
+    services =>
       // override the call to Sam so that it returns non-uuid values in its resource id values
       // note the second item in the set has a non-UUID as its resourceId. That policy should be ignored silently.
       when(services.samDAO.getPoliciesForType(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any[UserInfo]))
-          .thenReturn(
-            Future.successful(Set(
-              SamResourceIdWithPolicyName(testData.workspace.workspaceId, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
-              SamResourceIdWithPolicyName("invalid-uuid-" + testData.workspaceSubmittedSubmission.workspaceId, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
-              SamResourceIdWithPolicyName(testData.workspaceFailedSubmission.workspaceId, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false)
-            ))
+        .thenReturn(
+          Future.successful(
+            Set(
+              SamResourceIdWithPolicyName(testData.workspace.workspaceId,
+                                          SamWorkspacePolicyNames.owner,
+                                          Set.empty,
+                                          Set.empty,
+                                          false
+              ),
+              SamResourceIdWithPolicyName("invalid-uuid-" + testData.workspaceSubmittedSubmission.workspaceId,
+                                          SamWorkspacePolicyNames.owner,
+                                          Set.empty,
+                                          Set.empty,
+                                          false
+              ),
+              SamResourceIdWithPolicyName(testData.workspaceFailedSubmission.workspaceId,
+                                          SamWorkspacePolicyNames.owner,
+                                          Set.empty,
+                                          Set.empty,
+                                          false
+              )
+            )
           )
+        )
 
       Get("/workspaces") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
 
-        val dateTime = currentTime()
-        assertResult(Set(
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testData.workspace.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(None, None, 8)), false),
-          WorkspaceListResponse(WorkspaceAccessLevels.Owner, WorkspaceDetails.fromWorkspaceAndOptions(testData.workspaceFailedSubmission.copy(lastModified = dateTime), Option(Set.empty), true,  Some(WorkspaceCloudPlatform.Gcp)), Option(WorkspaceSubmissionStats(None, Option(testDate), 0)), false),
-        )) {
-          responseAs[Array[WorkspaceListResponse]].toSet[WorkspaceListResponse].map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
+          val dateTime = currentTime()
+          assertResult(
+            Set(
+              WorkspaceListResponse(
+                WorkspaceAccessLevels.Owner,
+                WorkspaceDetails.fromWorkspaceAndOptions(testData.workspace.copy(lastModified = dateTime),
+                                                         Option(Set.empty),
+                                                         true,
+                                                         Some(WorkspaceCloudPlatform.Gcp)
+                ),
+                Option(WorkspaceSubmissionStats(None, None, 8)),
+                false
+              ),
+              WorkspaceListResponse(
+                WorkspaceAccessLevels.Owner,
+                WorkspaceDetails.fromWorkspaceAndOptions(
+                  testData.workspaceFailedSubmission.copy(lastModified = dateTime),
+                  Option(Set.empty),
+                  true,
+                  Some(WorkspaceCloudPlatform.Gcp)
+                ),
+                Option(WorkspaceSubmissionStats(None, Option(testDate), 0)),
+                false
+              )
+            )
+          ) {
+            responseAs[Array[WorkspaceListResponse]]
+              .toSet[WorkspaceListResponse]
+              .map(wslr => wslr.copy(workspace = wslr.workspace.copy(lastModified = dateTime)))
+          }
         }
-      }
   }
 
-  it should "return 404 Not Found on clone if the source workspace cannot be found" in withTestDataApiServices { services =>
-    val cloneSrc = testData.workspace.copy(name = "test_nonexistent_1")
-    val cloneDest = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_nonexistent_2", Map.empty)
-    Post(s"${cloneSrc.path}/clone", httpJson(cloneDest)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "return 404 Not Found on clone if the source workspace cannot be found" in withTestDataApiServices {
+    services =>
+      val cloneSrc = testData.workspace.copy(name = "test_nonexistent_1")
+      val cloneDest = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_nonexistent_2", Map.empty)
+      Post(s"${cloneSrc.path}/clone", httpJson(cloneDest)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
-    Get(testData.sample2.path(cloneDest)) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+      Get(testData.sample2.path(cloneDest)) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
-    Patch(testData.sample2.path(cloneDest), httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation))) ~>
-      sealRoute(services.entityRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+      Patch(
+        testData.sample2.path(cloneDest),
+        httpJson(
+          Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
+        )
+      ) ~>
+        sealRoute(services.entityRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 Bad Request on clone if the copyFilesWithPrefix is the empty string" in withTestDataApiServices { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, copyFilesWithPrefix = Some(""))
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+  it should "return 400 Bad Request on clone if the copyFilesWithPrefix is the empty string" in withTestDataApiServices {
+    services =>
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                           name = "test_copy",
+                                           Map.empty,
+                                           copyFilesWithPrefix = Some("")
+      )
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
   it should "return 200 on update workspace attributes" in withTestDataApiServices { services =>
-    Patch(testData.workspace.path, httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation))) ~>
+    Patch(
+      testData.workspace.path,
+      httpJson(
+        Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString("bang")): AttributeUpdateOperation)
+      )
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
@@ -988,7 +1364,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
       }
 
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
+    Patch(testData.workspace.path,
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -1017,73 +1395,87 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 on update with workspace attributes that specify list as value" in withTestDataApiServices { services =>
-    // we can't make this non-sensical json from our object hierarchy; we have to craft it by hand
-    val testPayload =
-      """
-        |[{
-        |    "op" : "AddUpdateAttribute",
-        |    "attributeName" : "something",
-        |    "addUpdateAttribute" : {
-        |      "itemsType" : "SomeValueNotExpected",
-        |      "items" : ["foo", "bar", "baz"]
-        |    }
-        |}]
+  it should "return 400 on update with workspace attributes that specify list as value" in withTestDataApiServices {
+    services =>
+      // we can't make this non-sensical json from our object hierarchy; we have to craft it by hand
+      val testPayload =
+        """
+          |[{
+          |    "op" : "AddUpdateAttribute",
+          |    "attributeName" : "something",
+          |    "addUpdateAttribute" : {
+          |      "itemsType" : "SomeValueNotExpected",
+          |      "items" : ["foo", "bar", "baz"]
+          |    }
+          |}]
       """.stripMargin
 
-    Patch(testData.workspace.path, httpJson(testPayload)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
+      Patch(testData.workspace.path, httpJson(testPayload)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 400 if the bucket location requested is in an invalid format" in withTestDataApiServices { services =>
-    val newWorkspace = WorkspaceRequest(
-      namespace = testData.wsName.namespace,
-      name = "newWorkspace",
-      attributes = Map.empty,
-      authorizationDomain = None,
-      bucketLocation = Option("EU")
-    )
+  it should "return 400 if the bucket location requested is in an invalid format" in withTestDataApiServices {
+    services =>
+      val newWorkspace = WorkspaceRequest(
+        namespace = testData.wsName.namespace,
+        name = "newWorkspace",
+        attributes = Map.empty,
+        authorizationDomain = None,
+        bucketLocation = Option("EU")
+      )
 
-    Post(s"/workspaces", httpJson(newWorkspace)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        val errorText = responseAs[ErrorReport].message
-        assert(status == StatusCodes.BadRequest)
-        assert(errorText.contains("Workspace bucket location must be a single region of format: [A-Za-z]+-[A-Za-z]+[0-9]+ or the default bucket location ('US')."))
-      }
+      Post(s"/workspaces", httpJson(newWorkspace)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          val errorText = responseAs[ErrorReport].message
+          assert(status == StatusCodes.BadRequest)
+          assert(
+            errorText.contains(
+              "Workspace bucket location must be a single region of format: [A-Za-z]+-[A-Za-z]+[0-9]+ or the default bucket location ('US')."
+            )
+          )
+        }
   }
 
-  it should "return 201 if the bucket location requested is the default bucket location" in withTestDataApiServices { services =>
-    val newWorkspace = WorkspaceRequest(
-      namespace = testData.wsName.namespace,
-      name = "newWorkspace",
-      attributes = Map.empty,
-      authorizationDomain = None,
-      bucketLocation = Option("US")
-    )
+  it should "return 201 if the bucket location requested is the default bucket location" in withTestDataApiServices {
+    services =>
+      val newWorkspace = WorkspaceRequest(
+        namespace = testData.wsName.namespace,
+        name = "newWorkspace",
+        attributes = Map.empty,
+        authorizationDomain = None,
+        bucketLocation = Option("US")
+      )
 
-    Post(s"/workspaces", httpJson(newWorkspace)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assert(status == StatusCodes.Created)
-      }
+      Post(s"/workspaces", httpJson(newWorkspace)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assert(status == StatusCodes.Created)
+        }
   }
 
   it should "concurrently update workspace attributes" in withTestDataApiServices { services =>
-    def generator(i: Int): ReadAction[Option[Workspace]] = {
-      Patch(testData.workspace.path, httpJson(Seq(AddUpdateAttribute(AttributeName.withDefaultNS("boo"), AttributeString(s"bang$i")): AttributeUpdateOperation))) ~>
+    def generator(i: Int): ReadAction[Option[Workspace]] =
+      Patch(testData.workspace.path,
+            httpJson(
+              Seq(
+                AddUpdateAttribute(AttributeName.withDefaultNS("boo"),
+                                   AttributeString(s"bang$i")
+                ): AttributeUpdateOperation
+              )
+            )
+      ) ~>
         sealRoute(services.workspaceRoutes) ~> check {
           assertResult(StatusCodes.OK, responseAs[String]) {
             status
           }
           workspaceQuery.findByName(testData.wsName)
         }
-    }
 
     runMultipleAndWait(10)(generator)
   }
@@ -1102,123 +1494,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           assert(copiedWorkspace.attributes == testData.workspace.attributes)
 
           withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
-            //Name, namespace, creation date, and owner might change, so this is all that remains.
-            assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
-              runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
-            }
-            assertResult(runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).toSet) {
-              runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext)).toSet
-            }
-          }
-        }
-
-        // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))) {
-          header("Location")
-        }
-      }
-  }
-
-  it should "clone a workspace and not try to copy over deleted method configs or hidden entities from the source" in withTestDataApiServices { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty)
-
-    // contains no references in/out, safe to hide
-    val entToDelete = testData.sample8
-    val mcToDelete = testData.agoraMethodConfig.toShort
-    withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
-      assert {
-        runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSeq.contains(entToDelete)
-      }
-      assert {
-          runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).contains(mcToDelete)
-      }
-
-      runAndWait(methodConfigurationQuery.delete(sourceWorkspaceContext, mcToDelete.namespace, mcToDelete.name))
-      runAndWait(entityQuery.hide(sourceWorkspaceContext, Seq(entToDelete.toReference)))
-
-      assert {
-        !runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSeq.contains(entToDelete)
-      }
-      assert {
-        !runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).contains(mcToDelete)
-      }
-    }
-
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
-        }
-
-        withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
-          val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
-          assert(copiedWorkspace.attributes == testData.workspace.attributes)
-
-          withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
             // Name, namespace, creation date, and owner might change, so this is all that remains.
-
-            val srcEnts = runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext))
-            val copiedEnts = runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext))
-            assertSameElements(srcEnts, copiedEnts)
-
-            val srcMCs = runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext))
-            val copiedMCs = runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext))
-            assertSameElements(srcMCs, copiedMCs)
-
-            assert {
-              ! copiedEnts.toSeq.contains(entToDelete)
-            }
-            assert {
-              ! copiedMCs.contains(mcToDelete)
-            }
-          }
-        }
-      }
-  }
-
-  it should "return 403 on clone workspace when adding invalid-namespace attributes" in withTestDataApiServices { services =>
-    val invalidAttrNamespace = "invalid"
-
-    val workspaceCopy = WorkspaceRequest(
-      namespace = testData.workspace.namespace,
-      name = "test_copy",
-      Map(AttributeName(invalidAttrNamespace, "attribute") -> AttributeString("foo"))
-    )
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden) {
-          status
-        }
-
-        val errorText = responseAs[ErrorReport].message
-        assert(errorText.contains(invalidAttrNamespace))
-      }
-  }
-
-  it should "return 201 on clone workspace when adding library-namespace attributes" in withTestDataApiServices { services =>
-    revokeCuratorRole(services)
-    val newAttr = AttributeName(AttributeName.libraryNamespace, "attribute") -> AttributeString("foo")
-
-    val workspaceCopy = WorkspaceRequest(
-      namespace = testData.workspace.namespace,
-      name = "test_copy",
-      Map(newAttr)
-    )
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
-        }
-
-        withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
-          val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
-          assert(copiedWorkspace.attributes == testData.workspace.attributes + newAttr)
-
-          withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
-            //Name, namespace, creation date, and owner might change, so this is all that remains.
             assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
               runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
             }
@@ -1229,45 +1505,175 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
 
         // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))) {
+        assertResult(
+          Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))
+        ) {
           header("Location")
         }
       }
   }
 
-  it should "return 201 on clone workspace with existing library-namespace attributes" in withTestDataApiServices { services =>
+  it should "clone a workspace and not try to copy over deleted method configs or hidden entities from the source" in withTestDataApiServices {
+    services =>
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty)
 
-    val updatedWorkspace = testData.workspace.copy(attributes = testData.workspace.attributes + (AttributeName(AttributeName.libraryNamespace, "attribute") -> AttributeString("foo")))
-    runAndWait(workspaceQuery.createOrUpdate(updatedWorkspace))
-
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty)
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
+      // contains no references in/out, safe to hide
+      val entToDelete = testData.sample8
+      val mcToDelete = testData.agoraMethodConfig.toShort
+      withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
+        assert {
+          runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSeq.contains(entToDelete)
+        }
+        assert {
+          runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).contains(mcToDelete)
         }
 
-        withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
-          val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
-          assert(copiedWorkspace.attributes == updatedWorkspace.attributes)
+        runAndWait(methodConfigurationQuery.delete(sourceWorkspaceContext, mcToDelete.namespace, mcToDelete.name))
+        runAndWait(entityQuery.hide(sourceWorkspaceContext, Seq(entToDelete.toReference)))
 
-          withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
-            //Name, namespace, creation date, and owner might change, so this is all that remains.
-            assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
-              runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
-            }
-            assertResult(runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).toSet) {
-              runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext)).toSet
+        assert {
+          !runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSeq.contains(entToDelete)
+        }
+        assert {
+          !runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).contains(mcToDelete)
+        }
+      }
+
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
+
+          withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
+            val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
+            assert(copiedWorkspace.attributes == testData.workspace.attributes)
+
+            withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
+              // Name, namespace, creation date, and owner might change, so this is all that remains.
+
+              val srcEnts = runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext))
+              val copiedEnts = runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext))
+              assertSameElements(srcEnts, copiedEnts)
+
+              val srcMCs = runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext))
+              val copiedMCs = runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext))
+              assertSameElements(srcMCs, copiedMCs)
+
+              assert {
+                !copiedEnts.toSeq.contains(entToDelete)
+              }
+              assert {
+                !copiedMCs.contains(mcToDelete)
+              }
             }
           }
         }
+  }
 
-        // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))) {
-          header("Location")
+  it should "return 403 on clone workspace when adding invalid-namespace attributes" in withTestDataApiServices {
+    services =>
+      val invalidAttrNamespace = "invalid"
+
+      val workspaceCopy = WorkspaceRequest(
+        namespace = testData.workspace.namespace,
+        name = "test_copy",
+        Map(AttributeName(invalidAttrNamespace, "attribute") -> AttributeString("foo"))
+      )
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden) {
+            status
+          }
+
+          val errorText = responseAs[ErrorReport].message
+          assert(errorText.contains(invalidAttrNamespace))
         }
-      }
+  }
+
+  it should "return 201 on clone workspace when adding library-namespace attributes" in withTestDataApiServices {
+    services =>
+      revokeCuratorRole(services)
+      val newAttr = AttributeName(AttributeName.libraryNamespace, "attribute") -> AttributeString("foo")
+
+      val workspaceCopy = WorkspaceRequest(
+        namespace = testData.workspace.namespace,
+        name = "test_copy",
+        Map(newAttr)
+      )
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
+
+          withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
+            val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
+            assert(copiedWorkspace.attributes == testData.workspace.attributes + newAttr)
+
+            withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
+              // Name, namespace, creation date, and owner might change, so this is all that remains.
+              assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
+                runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
+              }
+              assertResult(runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).toSet) {
+                runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext)).toSet
+              }
+            }
+          }
+
+          // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
+          assertResult(
+            Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))
+          ) {
+            header("Location")
+          }
+        }
+  }
+
+  it should "return 201 on clone workspace with existing library-namespace attributes" in withTestDataApiServices {
+    services =>
+      val updatedWorkspace =
+        testData.workspace.copy(attributes =
+          testData.workspace.attributes + (AttributeName(AttributeName.libraryNamespace,
+                                                         "attribute"
+          ) -> AttributeString("foo"))
+        )
+      runAndWait(workspaceQuery.createOrUpdate(updatedWorkspace))
+
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty)
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
+
+          withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
+            val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
+            assert(copiedWorkspace.attributes == updatedWorkspace.attributes)
+
+            withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
+              // Name, namespace, creation date, and owner might change, so this is all that remains.
+              assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
+                runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
+              }
+              assertResult(runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).toSet) {
+                runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext)).toSet
+              }
+            }
+          }
+
+          // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
+          assertResult(
+            Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))
+          ) {
+            header("Location")
+          }
+        }
   }
 
   it should "add attributes when cloning a workspace" in withTestDataApiServices { services =>
@@ -1284,8 +1690,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
 
     val newAtts = Map(
-      AttributeName.withDefaultNS("number") -> AttributeNumber(11),    // replaces an existing attribute
-      AttributeName.withDefaultNS("another") -> AttributeNumber(12)    // adds a new attribute
+      AttributeName.withDefaultNS("number") -> AttributeNumber(11), // replaces an existing attribute
+      AttributeName.withDefaultNS("another") -> AttributeNumber(12) // adds a new attribute
     )
 
     val workspaceCopyRealm = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy2", newAtts)
@@ -1307,7 +1713,11 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   }
 
   it should "clone a workspace with noWorkspaceOwner" in withTestDataApiServices { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, noWorkspaceOwner = Option(true))
+    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                         name = "test_copy",
+                                         Map.empty,
+                                         noWorkspaceOwner = Option(true)
+    )
     Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1319,7 +1729,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
 
           withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
-            //Name, namespace, creation date, and owner might change, so this is all that remains.
+            // Name, namespace, creation date, and owner might change, so this is all that remains.
             assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
               runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
             }
@@ -1330,79 +1740,108 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
 
         // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))) {
+        assertResult(
+          Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))
+        ) {
           header("Location")
         }
       }
   }
 
-  it should "have an empty owner policy when cloning a workspace with noWorkspaceOwner" in withTestDataApiServicesCustomizableMockSam { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, noWorkspaceOwner = Option(true))
-    populateBillingProjectPolicies(services)
-    val expectedOwnerPolicyEmail = ""
+  it should "have an empty owner policy when cloning a workspace with noWorkspaceOwner" in withTestDataApiServicesCustomizableMockSam {
+    services =>
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                           name = "test_copy",
+                                           Map.empty,
+                                           noWorkspaceOwner = Option(true)
+      )
+      populateBillingProjectPolicies(services)
+      val expectedOwnerPolicyEmail = ""
 
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
-        }
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
+          }
 
-        assertResult(expectedOwnerPolicyEmail) {
-          val ws = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
-          val policiesWithNameAndEmail = Await.result(services.samDAO.listPoliciesForResource(SamResourceTypeNames.workspace, ws.workspaceId, userInfo), Duration.Inf)
-          val actualOwnerPolicyEmail = policiesWithNameAndEmail.find(_.policyName == SamWorkspacePolicyNames.owner).get.email.value
-          actualOwnerPolicyEmail
+          assertResult(expectedOwnerPolicyEmail) {
+            val ws = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
+            val policiesWithNameAndEmail = Await.result(
+              services.samDAO.listPoliciesForResource(SamResourceTypeNames.workspace, ws.workspaceId, userInfo),
+              Duration.Inf
+            )
+            val actualOwnerPolicyEmail =
+              policiesWithNameAndEmail.find(_.policyName == SamWorkspacePolicyNames.owner).get.email.value
+            actualOwnerPolicyEmail
+          }
         }
-      }
   }
 
-  it should "return 403 for clone workspace with noWorkspaceOwner without BP owner permissions" in withTestDataApiServicesMockitoSam { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, noWorkspaceOwner = Option(true))
+  it should "return 403 for clone workspace with noWorkspaceOwner without BP owner permissions" in withTestDataApiServicesMockitoSam {
+    services =>
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                           name = "test_copy",
+                                           Map.empty,
+                                           noWorkspaceOwner = Option(true)
+      )
 
-    // User has read permissions on existing workspace
-    when(services.samDAO.userHasAction(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      ArgumentMatchers.eq(SamWorkspaceActions.read),
-      any[UserInfo]
-    )).thenReturn(Future.successful(true))
+      // User has read permissions on existing workspace
+      when(
+        services.samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          ArgumentMatchers.eq(SamWorkspaceActions.read),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
-    when(services.samDAO.getResourceAuthDomain(
-      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-      ArgumentMatchers.eq(testData.workspace.workspaceId),
-      any[UserInfo]
-    )).thenReturn(Future.successful(Seq.empty))
+      when(
+        services.samDAO.getResourceAuthDomain(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(Seq.empty))
 
-    // User has BP user role, but not owner role
-    when(services.samDAO.listUserRolesForResource(
-      ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-      ArgumentMatchers.eq(testData.billingProject.projectName.value),
-      any[UserInfo]
-    )).thenReturn(Future.successful(Set[SamResourceRole](SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.batchComputeUser)))
+      // User has BP user role, but not owner role
+      when(
+        services.samDAO.listUserRolesForResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(testData.billingProject.projectName.value),
+          any[UserInfo]
+        )
+      ).thenReturn(
+        Future.successful(
+          Set[SamResourceRole](SamBillingProjectRoles.workspaceCreator, SamBillingProjectRoles.batchComputeUser)
+        )
+      )
 
-    // User has BP user permissions and therefore can create workspaces
-    when(services.samDAO.userHasAction(
-      ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-      ArgumentMatchers.eq(testData.billingProject.projectName.value),
-      ArgumentMatchers.eq(SamBillingProjectActions.createWorkspace),
-      any[UserInfo]
-    )).thenReturn(Future.successful(true))
+      // User has BP user permissions and therefore can create workspaces
+      when(
+        services.samDAO.userHasAction(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(testData.billingProject.projectName.value),
+          ArgumentMatchers.eq(SamBillingProjectActions.createWorkspace),
+          any[UserInfo]
+        )
+      ).thenReturn(Future.successful(true))
 
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden, responseAs[String]) {
-          status
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden, responseAs[String]) {
+            status
+          }
+
+          val errorText = responseAs[ErrorReport].message
+          assert(errorText.contains(workspaceCopy.namespace))
         }
-
-        val errorText = responseAs[ErrorReport].message
-        assert(errorText.contains(workspaceCopy.namespace))
-      }
   }
 
   it should "return 409 Conflict on clone if the destination already exists" in withTestDataApiServices { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = testData.workspaceNoGroups.name, Map.empty)
+    val workspaceCopy =
+      WorkspaceRequest(namespace = testData.workspace.namespace, name = testData.workspaceNoGroups.name, Map.empty)
     Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1415,97 +1854,130 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
+  it should "clone workspace use different bucket location if bucketLocation is in request" in withApiServicesMockitoGcsDao {
+    services =>
+      val newBucketLocation = Option("us-terra1");
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                           name = "test_copy",
+                                           Map.empty,
+                                           bucketLocation = newBucketLocation
+      )
 
-  it should "clone workspace use different bucket location if bucketLocation is in request" in withApiServicesMockitoGcsDao { services =>
-    val newBucketLocation = Option("us-terra1");
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, bucketLocation = newBucketLocation)
+      // mock(ito) out the workspace creation
+      when(services.gcsDAO.testDMBillingAccountAccess(any[RawlsBillingAccountName])).thenReturn(Future.successful(true))
+      doReturn(
+        Future.successful(
+          new ProjectBillingInfo()
+            .setBillingAccountName(testData.workspace.currentBillingAccountOnGoogleProject.map(_.value).getOrElse(""))
+            .setProjectId(testData.workspace.googleProjectId.value)
+        ),
+        null
+      )
+        .when(services.gcsDAO)
+        .setBillingAccountName(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+                               any[RawlsBillingAccountName],
+                               any[Span]
+        )
+      when(services.gcsDAO.getGoogleProject(any[GoogleProjectId]))
+        .thenReturn(Future.successful(new Project().setProjectNumber(null)))
+      when(services.gcsDAO.labelSafeMap(any[Map[String, String]], any[String])).thenReturn(Map.empty[String, String])
+      when(services.gcsDAO.updateGoogleProject(any[GoogleProjectId], any[Project]))
+        .thenReturn(Future.successful(new Project()))
+      when(services.gcsDAO.removePolicyBindings(any[GoogleProjectId], any[Map[String, Set[String]]]))
+        .thenReturn(Future.successful(true))
+      when(services.gcsDAO.getGoogleProjectNumber(any[Project])).thenReturn(GoogleProjectNumber("GoogleProjectNumber"))
 
-    // mock(ito) out the workspace creation
-    when(services.gcsDAO.testDMBillingAccountAccess(any[RawlsBillingAccountName])).thenReturn(Future.successful(true))
-    doReturn(
-      Future.successful(
-        new ProjectBillingInfo()
-          .setBillingAccountName(testData.workspace.currentBillingAccountOnGoogleProject.map(_.value).getOrElse(""))
-          .setProjectId(testData.workspace.googleProjectId.value)),
-      null)
-      .when(services.gcsDAO).setBillingAccountName(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), any[RawlsBillingAccountName], any[Span])
-    when(services.gcsDAO.getGoogleProject(any[GoogleProjectId])).thenReturn(Future.successful(new Project().setProjectNumber(null)))
-    when(services.gcsDAO.labelSafeMap(any[Map[String, String]], any[String])).thenReturn(Map.empty[String, String])
-    when(services.gcsDAO.updateGoogleProject(any[GoogleProjectId], any[Project])).thenReturn(Future.successful(new Project()))
-    when(services.gcsDAO.removePolicyBindings(any[GoogleProjectId], any[Map[String, Set[String]]])).thenReturn(Future.successful(true))
-    when(services.gcsDAO.getGoogleProjectNumber(any[Project])).thenReturn(GoogleProjectNumber("GoogleProjectNumber"))
-
-    when(services.gcsDAO.setupWorkspace(
-      any[UserInfo],
-      ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
-      any[Map[WorkspaceAccessLevel, WorkbenchEmail]],
-      any[GcsBucketName],
-      any[Map[String, String]],
-      any[Span],
-      ArgumentMatchers.eq(newBucketLocation)))
-      .thenReturn(Future.successful(mock[GoogleWorkspaceInfo]))
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created, responseAs[String]) {
-          status
-        }
-
-        withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
-          val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
-          assert(copiedWorkspace.attributes == testData.workspace.attributes)
-
-          withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
-            //Name, namespace, creation date, and owner might change, so this is all that remains.
-            assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
-              runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
-            }
-            assertResult(runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).toSet) {
-              runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext)).toSet
-            }
+      when(
+        services.gcsDAO.setupWorkspace(
+          any[UserInfo],
+          ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+          any[Map[WorkspaceAccessLevel, WorkbenchEmail]],
+          any[GcsBucketName],
+          any[Map[String, String]],
+          any[Span],
+          ArgumentMatchers.eq(newBucketLocation)
+        )
+      )
+        .thenReturn(Future.successful(mock[GoogleWorkspaceInfo]))
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created, responseAs[String]) {
+            status
           }
-          verify(services.gcsDAO).setupWorkspace(
-            any[UserInfo],
-            ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
-            any[Map[WorkspaceAccessLevel, WorkbenchEmail]],
-            any[GcsBucketName],
-            any[Map[String, String]],
-            any[Span],
-            ArgumentMatchers.eq(newBucketLocation))
-        }
 
-        // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
-        assertResult(Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))) {
-          header("Location")
+          withWorkspaceContext(testData.workspace) { sourceWorkspaceContext =>
+            val copiedWorkspace = runAndWait(workspaceQuery.findByName(workspaceCopy.toWorkspaceName)).get
+            assert(copiedWorkspace.attributes == testData.workspace.attributes)
+
+            withWorkspaceContext(copiedWorkspace) { copiedWorkspaceContext =>
+              // Name, namespace, creation date, and owner might change, so this is all that remains.
+              assertResult(runAndWait(entityQuery.listActiveEntities(sourceWorkspaceContext)).toSet) {
+                runAndWait(entityQuery.listActiveEntities(copiedWorkspaceContext)).toSet
+              }
+              assertResult(runAndWait(methodConfigurationQuery.listActive(sourceWorkspaceContext)).toSet) {
+                runAndWait(methodConfigurationQuery.listActive(copiedWorkspaceContext)).toSet
+              }
+            }
+            verify(services.gcsDAO).setupWorkspace(
+              any[UserInfo],
+              ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+              any[Map[WorkspaceAccessLevel, WorkbenchEmail]],
+              any[GcsBucketName],
+              any[Map[String, String]],
+              any[Span],
+              ArgumentMatchers.eq(newBucketLocation)
+            )
+          }
+
+          // TODO: does not test that the path we return is correct.  Update this test in the future if we care about that
+          assertResult(
+            Some(Location(Uri("http", Uri.Authority(Uri.Host("example.com")), Uri.Path(workspaceCopy.path))))
+          ) {
+            header("Location")
+          }
         }
-      }
   }
 
-  it should "return 201 if the cloned bucket location requested is the default bucket location" in withTestDataApiServices { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, bucketLocation = Option("US"))
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assert(status == StatusCodes.Created)
-      }
+  it should "return 201 if the cloned bucket location requested is the default bucket location" in withTestDataApiServices {
+    services =>
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                           name = "test_copy",
+                                           Map.empty,
+                                           bucketLocation = Option("US")
+      )
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assert(status == StatusCodes.Created)
+        }
   }
 
-  it should "return 400 if the cloned bucket location requested is in an invalid format" in withTestDataApiServices { services =>
-    val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace, name = "test_copy", Map.empty, bucketLocation = Option("EU"))
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        val errorText = responseAs[ErrorReport].message
-        assert(status == StatusCodes.BadRequest)
-        assert(errorText.contains("Workspace bucket location must be a single region of format: [A-Za-z]+-[A-Za-z]+[0-9]+ or the default bucket location ('US')."))
-      }
+  it should "return 400 if the cloned bucket location requested is in an invalid format" in withTestDataApiServices {
+    services =>
+      val workspaceCopy = WorkspaceRequest(namespace = testData.workspace.namespace,
+                                           name = "test_copy",
+                                           Map.empty,
+                                           bucketLocation = Option("EU")
+      )
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          val errorText = responseAs[ErrorReport].message
+          assert(status == StatusCodes.BadRequest)
+          assert(
+            errorText.contains(
+              "Workspace bucket location must be a single region of format: [A-Za-z]+-[A-Za-z]+[0-9]+ or the default bucket location ('US')."
+            )
+          )
+        }
   }
 
   it should "return 200 when requesting an ACL from an existing workspace" in withTestDataApiServices { services =>
     Get(s"${testData.workspace.path}/acl") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
       }
   }
 
@@ -1514,7 +1986,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     Get(s"${nonExistent.path}/acl") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NotFound) { status }
+        assertResult(StatusCodes.NotFound)(status)
       }
   }
 
@@ -1522,21 +1994,22 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     Patch(s"${testData.workspace.path}/acl", httpJsonEmpty) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
       }
   }
 
-  it should "modifying a workspace acl should modify the workspace last modified date" in withTestDataApiServices { services =>
-    Patch(s"${testData.workspace.path}/acl", httpJsonEmpty) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-      }
-    Get(testData.workspace.path) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
-      }
+  it should "modifying a workspace acl should modify the workspace last modified date" in withTestDataApiServices {
+    services =>
+      Patch(s"${testData.workspace.path}/acl", httpJsonEmpty) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+        }
+      Get(testData.workspace.path) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertWorkspaceModifiedDate(status, responseAs[WorkspaceResponse].workspace.toWorkspace)
+        }
   }
 
   it should "return 404 when replacing an ACL on a non-existent workspace" in withTestDataApiServices { services =>
@@ -1544,7 +2017,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     Patch(s"${nonExistent.path}/acl", httpJsonEmpty) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NotFound) { status }
+        assertResult(StatusCodes.NotFound)(status)
       }
   }
 
@@ -1552,7 +2025,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     Get(s"${testData.workspace.path}/bucketOptions") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
         assertResult(WorkspaceBucketOptions(false)) {
           responseAs[WorkspaceBucketOptions]
         }
@@ -1563,7 +2036,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
   // Get Workspace requires READ access.  Accept if OWNER, WRITE, READ; Reject if NO ACCESS
 
-  it should "allow an project-owner-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(testData.userProjectOwner.userEmail.value) { services =>
+  it should "allow an project-owner-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(
+    testData.userProjectOwner.userEmail.value
+  ) { services =>
     Get(testWorkspaces.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1573,7 +2048,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow an owner-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(testData.userOwner.userEmail.value) { services =>
+  it should "allow an owner-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(
+    testData.userOwner.userEmail.value
+  ) { services =>
     Get(testWorkspaces.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1583,7 +2060,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow a write-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(testData.userWriter.userEmail.value) { services =>
+  it should "allow a write-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(
+    testData.userWriter.userEmail.value
+  ) { services =>
     Get(testWorkspaces.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1593,7 +2072,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow a read-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(testData.userReader.userEmail.value) { services =>
+  it should "allow a read-access user to get a workspace" in withTestWorkspacesApiServicesAndUser(
+    testData.userReader.userEmail.value
+  ) { services =>
     Get(testWorkspaces.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1603,30 +2084,36 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "not allow a no-access user to get a workspace" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
-    Get(testWorkspaces.workspace.path) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "not allow a no-access user to get a workspace" in withTestWorkspacesApiServicesAndUser("no-access") {
+    services =>
+      Get(testWorkspaces.workspace.path) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "not allow a no-access user to get a workspace by id" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
-    Get(s"/workspaces/id/${testWorkspaces.workspace.workspaceId}") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "not allow a no-access user to get a workspace by id" in withTestWorkspacesApiServicesAndUser("no-access") {
+    services =>
+      Get(s"/workspaces/id/${testWorkspaces.workspace.workspaceId}") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
   // Update Workspace requires WRITE access.  Accept if OWNER or WRITE; Reject if READ or NO ACCESS
 
-  it should "allow an project-owner-access user to update a workspace" in withTestDataApiServicesAndUser(testData.userProjectOwner.userEmail.value) { services =>
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
+  it should "allow an project-owner-access user to update a workspace" in withTestDataApiServicesAndUser(
+    testData.userProjectOwner.userEmail.value
+  ) { services =>
+    Patch(testData.workspace.path,
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -1635,7 +2122,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "check that an update to a workspace modifies the last modified date" in withTestDataApiServicesAndUser(testData.userProjectOwner.userEmail.value) { services =>
+  it should "check that an update to a workspace modifies the last modified date" in withTestDataApiServicesAndUser(
+    testData.userProjectOwner.userEmail.value
+  ) { services =>
     var mutableWorkspace: Workspace = testData.workspace.copy()
     Get(testData.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
@@ -1646,7 +2135,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         mutableWorkspace = responseAs[WorkspaceResponse].workspace.toWorkspace
       }
 
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
+    Patch(testData.workspace.path,
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -1664,8 +2155,12 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow an owner-access user to update a workspace" in withTestDataApiServicesAndUser(testData.userOwner.userEmail.value) { services =>
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
+  it should "allow an owner-access user to update a workspace" in withTestDataApiServicesAndUser(
+    testData.userOwner.userEmail.value
+  ) { services =>
+    Patch(testData.workspace.path,
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -1674,8 +2169,12 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow a write-access user to update a workspace" in withTestDataApiServicesAndUser(testData.userWriter.userEmail.value) { services =>
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
+  it should "allow a write-access user to update a workspace" in withTestDataApiServicesAndUser(
+    testData.userWriter.userEmail.value
+  ) { services =>
+    Patch(testData.workspace.path,
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.OK) {
@@ -1684,8 +2183,12 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "not allow a read-access user to update a workspace" in withTestDataApiServicesAndUser(testData.userReader.userEmail.value) { services =>
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
+  it should "not allow a read-access user to update a workspace" in withTestDataApiServicesAndUser(
+    testData.userReader.userEmail.value
+  ) { services =>
+    Patch(testData.workspace.path,
+          httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.Forbidden) {
@@ -1694,27 +2197,47 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "not allow a no-access user to update a workspace" in withTestDataApiServicesAndUser("no-access") { services =>
-    Patch(testData.workspace.path, httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+  it should "not allow a no-access user to update a workspace" in withTestDataApiServicesAndUser("no-access") {
+    services =>
+      Patch(testData.workspace.path,
+            httpJson(Seq(RemoveAttribute(AttributeName.withDefaultNS("boo")): AttributeUpdateOperation))
+      ) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
         }
-      }
   }
 
-  it should "not allow ACL updates with a member specified twice" in withTestDataApiServicesAndUser(testData.userOwner.userEmail.value) { services =>
-    Patch(s"${testData.workspace.path}/acl", httpJson(Seq(WorkspaceACLUpdate(testData.userProjectOwner.userEmail.value, WorkspaceAccessLevels.ProjectOwner, None), WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Read, None), WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Owner, None)))) ~>
+  it should "not allow ACL updates with a member specified twice" in withTestDataApiServicesAndUser(
+    testData.userOwner.userEmail.value
+  ) { services =>
+    Patch(
+      s"${testData.workspace.path}/acl",
+      httpJson(
+        Seq(
+          WorkspaceACLUpdate(testData.userProjectOwner.userEmail.value, WorkspaceAccessLevels.ProjectOwner, None),
+          WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Read, None),
+          WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Owner, None)
+        )
+      )
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.BadRequest ) { status }
+        assertResult(StatusCodes.BadRequest)(status)
       }
   }
 
-  it should "not allow an owner to grant compute permissions to reader" in withTestDataApiServicesAndUser("owner-access") { services =>
+  it should "not allow an owner to grant compute permissions to reader" in withTestDataApiServicesAndUser(
+    "owner-access"
+  ) { services =>
     import WorkspaceACLJsonSupport._
-    Patch(s"${testData.workspace.path}/acl", httpJson(Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Read, None, Option(true))))) ~>
+    Patch(s"${testData.workspace.path}/acl",
+          httpJson(
+            Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Read, None, Option(true)))
+          )
+    ) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest) {
@@ -1723,37 +2246,58 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "allow an owner to grant compute permissions to writer" in withTestDataApiServicesAndUser("owner-access") { services =>
-    // canCompute omitted defaults to true
-    Patch(s"${testData.workspace.path}/acl", httpJson(Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None, None)))) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-      }
+  it should "allow an owner to grant compute permissions to writer" in withTestDataApiServicesAndUser("owner-access") {
+    services =>
+      // canCompute omitted defaults to true
+      Patch(
+        s"${testData.workspace.path}/acl",
+        httpJson(Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None, None)))
+      ) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+        }
 
-    // canCompute explicitly set to false
-    Patch(s"${testData.workspace.path}/acl", httpJson(Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None, Option(false))))) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-      }
+      // canCompute explicitly set to false
+      Patch(
+        s"${testData.workspace.path}/acl",
+        httpJson(
+          Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None, Option(false)))
+        )
+      ) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+        }
 
-    // canCompute explicitly set to true
-    Patch(s"${testData.workspace.path}/acl", httpJson(Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None, Option(true))))) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-      }
+      // canCompute explicitly set to true
+      Patch(
+        s"${testData.workspace.path}/acl",
+        httpJson(
+          Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None, Option(true)))
+        )
+      ) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+        }
 
-    // canCompute explicitly set to true for owner has no effect
-    Patch(s"${testData.workspace.path}/acl", httpJson(Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Owner, None, Option(false))))) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) { status }
-      }
+      // canCompute explicitly set to true for owner has no effect
+      Patch(
+        s"${testData.workspace.path}/acl",
+        httpJson(
+          Seq(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Owner, None, Option(false)))
+        )
+      ) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK)(status)
+        }
   }
 
-  it should "return 204 for a user with read access on an unlocked workspace" in withTestDataApiServicesAndUser("reader-access") { services =>
+  it should "return 204 for a user with read access on an unlocked workspace" in withTestDataApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Get(s"${testData.workspace.path}/checkIamActionWithLock/read") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1763,7 +2307,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 403 for a reader testing the write action on an unlocked workspace" in withTestDataApiServicesAndUser("reader-access") { services =>
+  it should "return 403 for a reader testing the write action on an unlocked workspace" in withTestDataApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Get(s"${testData.workspace.path}/checkIamActionWithLock/write") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1773,7 +2319,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 204 for a reader testing the read action on a locked workspace" in withTestDataApiServicesAndUser("reader-access") { services =>
+  it should "return 204 for a reader testing the read action on a locked workspace" in withTestDataApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Get(s"${testData.workspaceLocked.path}/checkIamActionWithLock/read") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1783,7 +2331,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 204 for a writer testing the write action on an unlocked workspace" in withTestDataApiServicesAndUser("writer-access") { services =>
+  it should "return 204 for a writer testing the write action on an unlocked workspace" in withTestDataApiServicesAndUser(
+    "writer-access"
+  ) { services =>
     Get(s"${testData.workspace.path}/checkIamActionWithLock/write") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1793,7 +2343,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 403 for a writer testing the write action on a locked workspace" in withTestDataApiServicesAndUser("writer-access") { services =>
+  it should "return 403 for a writer testing the write action on a locked workspace" in withTestDataApiServicesAndUser(
+    "writer-access"
+  ) { services =>
     Get(s"${testData.workspaceLocked.path}/checkIamActionWithLock/write") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1806,24 +2358,28 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
   // End ACL-restriction Tests
 
   // Workspace Locking
-  it should "allow an owner to lock (and re-lock) the workspace" in withEmptyWorkspaceApiServices(testData.userOwner.userEmail.value) { services =>
+  it should "allow an owner to lock (and re-lock) the workspace" in withEmptyWorkspaceApiServices(
+    testData.userOwner.userEmail.value
+  ) { services =>
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
   }
 
-  it should "locking (and unlocking) a workspace should modify the workspace last modified date" in withEmptyWorkspaceApiServices(testData.userOwner.userEmail.value) { services =>
+  it should "locking (and unlocking) a workspace should modify the workspace last modified date" in withEmptyWorkspaceApiServices(
+    testData.userOwner.userEmail.value
+  ) { services =>
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
     Get(testData.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
@@ -1834,7 +2390,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
     Put(s"${testData.workspace.path}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
 
     Get(testData.workspace.path) ~>
@@ -1845,127 +2401,157 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
 
   }
 
-  it should "not allow anyone to write to a workspace when locked"  in withLockedWorkspaceApiServices(testData.userWriter.userEmail.value) { services =>
+  it should "not allow anyone to write to a workspace when locked" in withLockedWorkspaceApiServices(
+    testData.userWriter.userEmail.value
+  ) { services =>
     Patch(testData.workspace.path, httpJsonEmpty) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.Forbidden) { status }
+        assertResult(StatusCodes.Forbidden)(status)
       }
   }
 
-  it should "allow a reader to read a workspace, even when locked"  in withLockedWorkspaceApiServices(testData.userReader.userEmail.value) { services =>
+  it should "allow a reader to read a workspace, even when locked" in withLockedWorkspaceApiServices(
+    testData.userReader.userEmail.value
+  ) { services =>
     Get(testData.workspace.path) ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK) { status }
+        assertResult(StatusCodes.OK)(status)
       }
   }
 
-  it should "not allow an owner to lock a workspace with incomplete submissions" in withTestDataApiServicesAndUser(testData.userOwner.userEmail.value) { services =>
+  it should "not allow an owner to lock a workspace with incomplete submissions" in withTestDataApiServicesAndUser(
+    testData.userOwner.userEmail.value
+  ) { services =>
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.Conflict) { status }
+        assertResult(StatusCodes.Conflict)(status)
       }
   }
 
-  it should "not allow an owner to delete a locked workspace" in withLockedWorkspaceApiServices(testData.userOwner.userEmail.value) { services =>
+  it should "not allow an owner to delete a locked workspace" in withLockedWorkspaceApiServices(
+    testData.userOwner.userEmail.value
+  ) { services =>
     Delete(s"${testData.workspace.path}") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.Forbidden) { status }
+        assertResult(StatusCodes.Forbidden)(status)
       }
   }
 
-  it should "allow an owner to unlock the workspace (repeatedly)" in withEmptyWorkspaceApiServices(testData.userOwner.userEmail.value) { services =>
+  it should "allow an owner to unlock the workspace (repeatedly)" in withEmptyWorkspaceApiServices(
+    testData.userOwner.userEmail.value
+  ) { services =>
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
     Put(s"${testData.workspace.path}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
     Put(s"${testData.workspace.path}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
   }
 
-  it should "not allow a non-owner to lock or unlock the workspace" in withTestDataApiServicesAndUser(testData.userWriter.userEmail.value) { services =>
+  it should "not allow a non-owner to lock or unlock the workspace" in withTestDataApiServicesAndUser(
+    testData.userWriter.userEmail.value
+  ) { services =>
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.Forbidden) { status }
+        assertResult(StatusCodes.Forbidden)(status)
       }
     Put(s"${testData.workspace.path}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.Forbidden) { status }
+        assertResult(StatusCodes.Forbidden)(status)
       }
   }
 
-  it should "not allow a no-access user to infer the existence of the workspace by locking or unlocking" in withLockedWorkspaceApiServices("no-access") { services =>
+  it should "not allow a no-access user to infer the existence of the workspace by locking or unlocking" in withLockedWorkspaceApiServices(
+    "no-access"
+  ) { services =>
     Put(s"${testData.workspace.path}/lock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NotFound) { status }
+        assertResult(StatusCodes.NotFound)(status)
       }
     Put(s"${testData.workspace.path}/unlock") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NotFound) { status }
+        assertResult(StatusCodes.NotFound)(status)
       }
   }
 
-  it should "return 403 creating workspace in billing project with no access" in withTestDataApiServicesMockitoSam { services =>
-    val billingProjectName = testData.wsName.namespace.value
-    when(services.samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[UserInfo])).thenReturn(Future.successful(true))
-    when(services.samDAO.userHasAction(SamResourceTypeNames.billingProject, billingProjectName, SamBillingProjectActions.createWorkspace, userInfo)).thenReturn(Future.successful(false))
+  it should "return 403 creating workspace in billing project with no access" in withTestDataApiServicesMockitoSam {
+    services =>
+      val billingProjectName = testData.wsName.namespace.value
+      when(services.samDAO.userHasAction(any[SamResourceTypeName], any[String], any[SamResourceAction], any[UserInfo]))
+        .thenReturn(Future.successful(true))
+      when(
+        services.samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                      billingProjectName,
+                                      SamBillingProjectActions.createWorkspace,
+                                      userInfo
+        )
+      ).thenReturn(Future.successful(false))
 
-    val newWorkspace = WorkspaceRequest(
-      namespace = billingProjectName,
-      name = "newWorkspace",
-      Map.empty
-    )
+      val newWorkspace = WorkspaceRequest(
+        namespace = billingProjectName,
+        name = "newWorkspace",
+        Map.empty
+      )
 
-    Post(s"/workspaces", httpJson(newWorkspace)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Forbidden, responseAs[String]) {
-          status
+      Post(s"/workspaces", httpJson(newWorkspace)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Forbidden, responseAs[String]) {
+            status
+          }
         }
-      }
   }
 
-  it should "return 200 when a user can read a workspace bucket" in withTestDataApiServicesAndUser(testData.userReader.userEmail.value) { services =>
+  it should "return 200 when a user can read a workspace bucket" in withTestDataApiServicesAndUser(
+    testData.userReader.userEmail.value
+  ) { services =>
     Get(s"${testData.workspace.path}/checkBucketReadAccess") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.OK, responseAs[String]) { status }
+        assertResult(StatusCodes.OK, responseAs[String])(status)
       }
   }
 
-  it should "return 404 when a user can't read the bucket because they dont have workspace access" in withTestDataApiServicesAndUser("no-access") { services =>
+  it should "return 404 when a user can't read the bucket because they dont have workspace access" in withTestDataApiServicesAndUser(
+    "no-access"
+  ) { services =>
     Get(s"${testData.workspace.path}/checkBucketReadAccess") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NotFound) { status }
+        assertResult(StatusCodes.NotFound)(status)
       }
   }
 
-  it should "return 404 when requesting bucket size for a non-existent workspace" in withTestWorkspacesApiServicesAndUser("reader-access") { services =>
+  it should "return 404 when requesting bucket size for a non-existent workspace" in withTestWorkspacesApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Get(s"${testWorkspaces.workspace.copy(name = "DNE").path}/bucketUsage") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NotFound) { status }
+        assertResult(StatusCodes.NotFound)(status)
       }
   }
 
-  it should "return 404 when a no-access user requests bucket usage" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
+  it should "return 404 when a no-access user requests bucket usage" in withTestWorkspacesApiServicesAndUser(
+    "no-access"
+  ) { services =>
     Get(s"${testWorkspaces.workspace.path}/bucketUsage") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1975,7 +2561,9 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "not allow a reader-access user to request bucket usage" in withTestWorkspacesApiServicesAndUser("reader-access") { services =>
+  it should "not allow a reader-access user to request bucket usage" in withTestWorkspacesApiServicesAndUser(
+    "reader-access"
+  ) { services =>
     Get(s"${testWorkspaces.workspace.path}/bucketUsage") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -1985,8 +2573,10 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  for (access <- Seq("owner-access", "writer-access")) {
-    it should s"return 200 when workspace with $access requests bucket usage for an existing workspace" in withTestWorkspacesApiServicesAndUser(access) { services =>
+  for (access <- Seq("owner-access", "writer-access"))
+    it should s"return 200 when workspace with $access requests bucket usage for an existing workspace" in withTestWorkspacesApiServicesAndUser(
+      access
+    ) { services =>
       Get(s"${testWorkspaces.workspace.path}/bucketUsage") ~>
         sealRoute(services.workspaceRoutes) ~>
         check {
@@ -1998,65 +2588,68 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           }
         }
     }
-  }
 
-  it should "return the pending workspace file transfers for a recently cloned workspace" in withTestDataApiServices { services =>
-    val clonedWorkspaceName = WorkspaceName(testData.workspace.namespace, "test_copy")
-    val workspaceCopy = WorkspaceRequest(
-      namespace = clonedWorkspaceName.namespace,
-      name = clonedWorkspaceName.name,
-      attributes = Map.empty,
-      authorizationDomain = None,
-      copyFilesWithPrefix = Some("/notebooks"),
-      noWorkspaceOwner = None,
-      bucketLocation = None
-    )
-
-    Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.Created) {
-          status
-        }
-      }
-
-    val clonedWorkspaceResult = runAndWait(workspaceQuery.findByName(clonedWorkspaceName)).get
-    val expected = Seq(
-      PendingCloneWorkspaceFileTransfer(
-        clonedWorkspaceResult.workspaceIdAsUUID,
-        testData.workspace.bucketName,
-        clonedWorkspaceResult.bucketName,
-        workspaceCopy.copyFilesWithPrefix.get,
-        clonedWorkspaceResult.googleProjectId
+  it should "return the pending workspace file transfers for a recently cloned workspace" in withTestDataApiServices {
+    services =>
+      val clonedWorkspaceName = WorkspaceName(testData.workspace.namespace, "test_copy")
+      val workspaceCopy = WorkspaceRequest(
+        namespace = clonedWorkspaceName.namespace,
+        name = clonedWorkspaceName.name,
+        attributes = Map.empty,
+        authorizationDomain = None,
+        copyFilesWithPrefix = Some("/notebooks"),
+        noWorkspaceOwner = None,
+        bucketLocation = None
       )
-    )
 
-    Get(s"${clonedWorkspaceName.path}/fileTransfers") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+      Post(s"${testData.workspace.path}/clone", httpJson(workspaceCopy)) ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.Created) {
+            status
+          }
         }
-        assertResult(expected) {
-          responseAs[Seq[PendingCloneWorkspaceFileTransfer]]
+
+      val clonedWorkspaceResult = runAndWait(workspaceQuery.findByName(clonedWorkspaceName)).get
+      val expected = Seq(
+        PendingCloneWorkspaceFileTransfer(
+          clonedWorkspaceResult.workspaceIdAsUUID,
+          testData.workspace.bucketName,
+          clonedWorkspaceResult.bucketName,
+          workspaceCopy.copyFilesWithPrefix.get,
+          clonedWorkspaceResult.googleProjectId
+        )
+      )
+
+      Get(s"${clonedWorkspaceName.path}/fileTransfers") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(expected) {
+            responseAs[Seq[PendingCloneWorkspaceFileTransfer]]
+          }
         }
-      }
   }
 
-  it should "return no pending workspace file transfers for a workspace that already exists" in withTestDataApiServices { services =>
-    Get(s"${testData.workspace.path}/fileTransfers") ~>
-      sealRoute(services.workspaceRoutes) ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
+  it should "return no pending workspace file transfers for a workspace that already exists" in withTestDataApiServices {
+    services =>
+      Get(s"${testData.workspace.path}/fileTransfers") ~>
+        sealRoute(services.workspaceRoutes) ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult(Seq.empty) {
+            responseAs[Seq[PendingCloneWorkspaceFileTransfer]]
+          }
         }
-        assertResult(Seq.empty) {
-          responseAs[Seq[PendingCloneWorkspaceFileTransfer]]
-        }
-      }
   }
 
-  it should "require at least reader access on the workspace to query for active file transfers" in withTestWorkspacesApiServicesAndUser("no-access") { services =>
+  it should "require at least reader access on the workspace to query for active file transfers" in withTestWorkspacesApiServicesAndUser(
+    "no-access"
+  ) { services =>
     Get(s"${testWorkspaces.workspace.path}/fileTransfers") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
@@ -2066,32 +2659,55 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "prevent user without compute permission from creating submission" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    testCreateSubmission(dataSource, userWriterNoCompute, StatusCodes.Forbidden)
+  it should "prevent user without compute permission from creating submission" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      testCreateSubmission(dataSource, userWriterNoCompute, StatusCodes.Forbidden)
   }
 
-  it should "allow user with explicit compute permission to create submission" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    testCreateSubmission(dataSource, testData.userWriter.userEmail, StatusCodes.Created)
+  it should "allow user with explicit compute permission to create submission" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      testCreateSubmission(dataSource, testData.userWriter.userEmail, StatusCodes.Created)
   }
 
-  it should "allow user to create submission with workspace compute permission and no billing project compute permission" in withDefaultTestDatabase { dataSource: SlickDataSource =>
-    testCreateSubmission(dataSource, userWriterNoComputeOnProject, StatusCodes.Created)
+  it should "allow user to create submission with workspace compute permission and no billing project compute permission" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      testCreateSubmission(dataSource, userWriterNoComputeOnProject, StatusCodes.Created)
   }
 
-  private def testCreateSubmission(dataSource: SlickDataSource, userEmail: RawlsUserEmail, exectedStatus: StatusCode) = {
+  private def testCreateSubmission(dataSource: SlickDataSource, userEmail: RawlsUserEmail, exectedStatus: StatusCode) =
     withApiServicesSecure(dataSource, userEmail.value) { services =>
       val wsName = testData.wsName
-      val agoraMethodConf = MethodConfiguration("no_input", "dsde", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+      val agoraMethodConf = MethodConfiguration("no_input",
+                                                "dsde",
+                                                Some("Sample"),
+                                                None,
+                                                Map.empty,
+                                                Map.empty,
+                                                AgoraMethod("dsde", "no_input", 1)
+      )
       val dockstoreMethodConf =
-        MethodConfiguration("no_input_dockstore", "dsde", Some("Sample"), None, Map.empty, Map.empty, DockstoreMethod("dockstore-no-input-path", "dockstore-no-input-version"))
+        MethodConfiguration("no_input_dockstore",
+                            "dsde",
+                            Some("Sample"),
+                            None,
+                            Map.empty,
+                            Map.empty,
+                            DockstoreMethod("dockstore-no-input-path", "dockstore-no-input-version")
+        )
 
-      List(agoraMethodConf, dockstoreMethodConf).foreach(createSubmission(wsName, _, testData.sample1, None, services, exectedStatus))
+      List(agoraMethodConf, dockstoreMethodConf).foreach(
+        createSubmission(wsName, _, testData.sample1, None, services, exectedStatus)
+      )
     }
-  }
 
-  private def createSubmission(wsName: WorkspaceName, methodConf: MethodConfiguration,
-                               submissionEntity: Entity, submissionExpression: Option[String],
-                               services: TestApiService, expectedStatus: StatusCode, userComment: Option[String] = None): Option[String] = {
+  private def createSubmission(wsName: WorkspaceName,
+                               methodConf: MethodConfiguration,
+                               submissionEntity: Entity,
+                               submissionExpression: Option[String],
+                               services: TestApiService,
+                               expectedStatus: StatusCode,
+                               userComment: Option[String] = None
+  ): Option[String] = {
 
     Get(s"${wsName.path}/methodconfigs/${methodConf.namespace}/${methodConf.name}") ~>
       sealRoute(services.methodConfigRoutes) ~>
@@ -2131,22 +2747,23 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         if (expectedStatus == StatusCodes.Created) {
           val response = responseAs[SubmissionReport]
           Option(response.submissionId)
-        }
-        else None
+        } else None
       }
   }
 
-  it should "enable and disable RequesterPaysForLinkedServiceAccounts" in withTestDataApiServicesAndUser(testData.userWriter.userEmail.value) { services =>
+  it should "enable and disable RequesterPaysForLinkedServiceAccounts" in withTestDataApiServicesAndUser(
+    testData.userWriter.userEmail.value
+  ) { services =>
     Put(s"${testData.workspace.path}/enableRequesterPaysForLinkedServiceAccounts") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
 
     Put(s"${testData.workspace.path}/disableRequesterPaysForLinkedServiceAccounts") ~>
       sealRoute(services.workspaceRoutes) ~>
       check {
-        assertResult(StatusCodes.NoContent) { status }
+        assertResult(StatusCodes.NoContent)(status)
       }
   }
 
@@ -2158,10 +2775,24 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         withApiServicesSecure(dataSource, testData.userReader.userEmail.value) { servicesForReader =>
           val wsName = testData.wsName
           val userComment = Option("Comment for submission by workspace owner")
-          val agoraMethodConf = MethodConfiguration("no_input", "dsde", Some("Sample"), None, Map.empty, Map.empty, AgoraMethod("dsde", "no_input", 1))
+          val agoraMethodConf = MethodConfiguration("no_input",
+                                                    "dsde",
+                                                    Some("Sample"),
+                                                    None,
+                                                    Map.empty,
+                                                    Map.empty,
+                                                    AgoraMethod("dsde", "no_input", 1)
+          )
 
           // submission created by user with owner access
-          val submissionId = createSubmission(wsName, agoraMethodConf, testData.sample1, None, servicesForOwner, StatusCodes.Created, userComment).get
+          val submissionId = createSubmission(wsName,
+                                              agoraMethodConf,
+                                              testData.sample1,
+                                              None,
+                                              servicesForOwner,
+                                              StatusCodes.Created,
+                                              userComment
+          ).get
 
           // user with read access to workspace should be able to get submission details and read the user comment
           Get(s"${wsName.path}/submissions/$submissionId") ~>
@@ -2185,11 +2816,10 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             check {
               val response = responseAs[String]
               status should be(StatusCodes.Forbidden)
-              response should include ("insufficient permissions to perform operation on myNamespace/myWorkspace")
+              response should include("insufficient permissions to perform operation on myNamespace/myWorkspace")
             }
         }
       }
     }
   }
 }
-

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -9,8 +9,16 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig, MultiCloudWorkspaceManagerConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
-import org.broadinstitute.dsde.rawls.model.{MultiCloudWorkspaceRequest, SamBillingProjectActions, SamResourceTypeNames, Workspace, WorkspaceCloudPlatform, WorkspaceRequest, WorkspaceType}
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, verify, when}
+import org.broadinstitute.dsde.rawls.model.{
+  MultiCloudWorkspaceRequest,
+  SamBillingProjectActions,
+  SamResourceTypeNames,
+  Workspace,
+  WorkspaceCloudPlatform,
+  WorkspaceRequest,
+  WorkspaceType
+}
+import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -29,7 +37,16 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
   def activeMcWorkspaceConfig = MultiCloudWorkspaceConfig(
     multiCloudWorkspacesEnabled = true,
     Some(MultiCloudWorkspaceManagerConfig("fake_app_id", 60 seconds)),
-    Some(AzureConfig("fake_profile_id", "fake_tenant_id", "fake_sub_id", "fake_mrg_id", "fake_bp_id", "fake_group", "eastus")),
+    Some(
+      AzureConfig("fake_profile_id",
+                  "fake_tenant_id",
+                  "fake_sub_id",
+                  "fake_mrg_id",
+                  "fake_bp_id",
+                  "fake_group",
+                  "eastus"
+      )
+    )
   )
 
   it should "delegate legacy creation requests to WorkspaceService" in {
@@ -37,7 +54,11 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val config = MultiCloudWorkspaceConfig(ConfigFactory.load())
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      config,
+      workbenchMetricBaseName
     )(testContext)
     val workspaceRequest = WorkspaceRequest(
       "fake_billing_project",
@@ -50,13 +71,17 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     )
     val workspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
     when(workspaceService.createWorkspace(workspaceRequest, testContext)).thenReturn(
-      Future.successful(Workspace("fake", "fake", "fake", "fake", None,currentTime(), currentTime(),"fake", Map.empty))
+      Future.successful(
+        Workspace("fake", "fake", "fake", "fake", None, currentTime(), currentTime(), "fake", Map.empty)
+      )
     )
 
     val result = Await.result(mcWorkspaceService.createMultiCloudOrRawlsWorkspace(
-      workspaceRequest,
-      workspaceService
-    ), Duration.Inf)
+                                workspaceRequest,
+                                workspaceService
+                              ),
+                              Duration.Inf
+    )
 
     result.workspaceType shouldBe WorkspaceType.RawlsWorkspace
     verify(workspaceService, Mockito.times(1)).createWorkspace(workspaceRequest, testContext)
@@ -67,7 +92,11 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val config = MultiCloudWorkspaceConfig(ConfigFactory.load())
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      config,
+      workbenchMetricBaseName
     )(testContext)
     val workspaceRequest = WorkspaceRequest(
       "fake_mc_billing_project_name",
@@ -81,26 +110,32 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val workspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
 
     val result = Await.result(mcWorkspaceService.createMultiCloudOrRawlsWorkspace(
-      workspaceRequest,
-      workspaceService
-    ), Duration.Inf)
+                                workspaceRequest,
+                                workspaceService
+                              ),
+                              Duration.Inf
+    )
 
     result.workspaceType shouldBe WorkspaceType.McWorkspace
   }
 
-  it should "return forbidden if creating a workspace against a billing project that the user does not have the createWorkspace action for"  in {
+  it should "return forbidden if creating a workspace against a billing project that the user does not have the createWorkspace action for" in {
     val workspaceManagerDAO = new MockWorkspaceManagerDAO()
     val config = MultiCloudWorkspaceConfig(ConfigFactory.load())
     val samDAO = Mockito.spy(new MockSamDAO(slickDataSource))
     when(
-      samDAO.userHasAction(
-        SamResourceTypeNames.billingProject,
-        "fake_mc_billing_project_name",
-        SamBillingProjectActions.createWorkspace,
-        userInfo)
+      samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                           "fake_mc_billing_project_name",
+                           SamBillingProjectActions.createWorkspace,
+                           userInfo
+      )
     ).thenReturn(Future.successful(false))
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      config,
+      workbenchMetricBaseName
     )(testContext)
     val workspaceRequest = WorkspaceRequest(
       "fake_mc_billing_project_name",
@@ -115,9 +150,11 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
 
     val actual = intercept[RawlsExceptionWithErrorReport] {
       Await.result(mcWorkspaceService.createMultiCloudOrRawlsWorkspace(
-        workspaceRequest,
-        workspaceService
-      ), Duration.Inf)
+                     workspaceRequest,
+                     workspaceService
+                   ),
+                   Duration.Inf
+      )
     }
 
     actual.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
@@ -128,9 +165,18 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val config = MultiCloudWorkspaceConfig(multiCloudWorkspacesEnabled = false, None, None)
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, config, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      config,
+      workbenchMetricBaseName
     )(testContext)
-    val request = MultiCloudWorkspaceRequest("fake", "fake_name", Map.empty, cloudPlatform = WorkspaceCloudPlatform.Azure, "fake_region")
+    val request = MultiCloudWorkspaceRequest("fake",
+                                             "fake_name",
+                                             Map.empty,
+                                             cloudPlatform = WorkspaceCloudPlatform.Azure,
+                                             "fake_region"
+    )
 
     val actual = intercept[RawlsExceptionWithErrorReport] {
       mcWorkspaceService.createMultiCloudWorkspace(request)
@@ -145,10 +191,18 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     val workspaceManagerDAO = new MockWorkspaceManagerDAO()
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      activeMcWorkspaceConfig,
+      workbenchMetricBaseName
     )(testContext)
-    val request = MultiCloudWorkspaceRequest(
-      namespace, name, Map.empty, cloudPlatform = WorkspaceCloudPlatform.Azure, "fake_region")
+    val request = MultiCloudWorkspaceRequest(namespace,
+                                             name,
+                                             Map.empty,
+                                             cloudPlatform = WorkspaceCloudPlatform.Azure,
+                                             "fake_region"
+    )
 
     Await.result(mcWorkspaceService.createMultiCloudWorkspace(request), Duration.Inf)
     val thrown = intercept[RawlsExceptionWithErrorReport] {
@@ -162,51 +216,69 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
     //  Needed because the storage container takes the storage account ID as input.
     val storageAccountId = UUID.randomUUID()
     val customWsmDao = new MockWorkspaceManagerDAO() {
-      override def mockCreateAzureStorageAccountResult() = new CreatedControlledAzureStorage().
-        resourceId(storageAccountId).azureStorage(new AzureStorageResource())
+      override def mockCreateAzureStorageAccountResult() =
+        new CreatedControlledAzureStorage().resourceId(storageAccountId).azureStorage(new AzureStorageResource())
     }
     val workspaceManagerDAO = Mockito.spy(customWsmDao)
 
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      activeMcWorkspaceConfig,
+      workbenchMetricBaseName
     )(testContext)
     val namespace = "fake_ns" + UUID.randomUUID().toString
-    val request = new MultiCloudWorkspaceRequest(
-      namespace, "fake_name", Map.empty, cloudPlatform = WorkspaceCloudPlatform.Azure, "fake_region")
+    val request = new MultiCloudWorkspaceRequest(namespace,
+                                                 "fake_name",
+                                                 Map.empty,
+                                                 cloudPlatform = WorkspaceCloudPlatform.Azure,
+                                                 "fake_region"
+    )
 
     val result: Workspace = Await.result(mcWorkspaceService.createMultiCloudWorkspace(request), Duration.Inf)
 
     result.name shouldBe "fake_name"
     result.workspaceType shouldBe WorkspaceType.McWorkspace
     result.namespace shouldEqual namespace
-    Mockito.verify(workspaceManagerDAO).enableApplication(
-      ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-      ArgumentMatchers.eq("fake_app_id"),
-      ArgumentMatchers.eq(testContext)
-    )
-    Mockito.verify(workspaceManagerDAO).createAzureWorkspaceCloudContext(
-      ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-      ArgumentMatchers.eq("fake_tenant_id"),
-      ArgumentMatchers.eq("fake_mrg_id"),
-      ArgumentMatchers.eq("fake_sub_id"),
-      ArgumentMatchers.eq(testContext)
-    )
-    Mockito.verify(workspaceManagerDAO).createAzureRelay(
-      ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-      ArgumentMatchers.eq("fake_region"),
-      ArgumentMatchers.eq(testContext)
-    )
-    Mockito.verify(workspaceManagerDAO).createAzureStorageAccount(
-      ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-      ArgumentMatchers.eq("fake_region"),
-      ArgumentMatchers.eq(testContext)
-    )
-    Mockito.verify(workspaceManagerDAO).createAzureStorageContainer(
-      ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-      ArgumentMatchers.eq(storageAccountId),
-      ArgumentMatchers.eq(testContext)
-    )
+    Mockito
+      .verify(workspaceManagerDAO)
+      .enableApplication(
+        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq("fake_app_id"),
+        ArgumentMatchers.eq(testContext)
+      )
+    Mockito
+      .verify(workspaceManagerDAO)
+      .createAzureWorkspaceCloudContext(
+        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq("fake_tenant_id"),
+        ArgumentMatchers.eq("fake_mrg_id"),
+        ArgumentMatchers.eq("fake_sub_id"),
+        ArgumentMatchers.eq(testContext)
+      )
+    Mockito
+      .verify(workspaceManagerDAO)
+      .createAzureRelay(
+        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq("fake_region"),
+        ArgumentMatchers.eq(testContext)
+      )
+    Mockito
+      .verify(workspaceManagerDAO)
+      .createAzureStorageAccount(
+        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq("fake_region"),
+        ArgumentMatchers.eq(testContext)
+      )
+    Mockito
+      .verify(workspaceManagerDAO)
+      .createAzureStorageContainer(
+        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq(storageAccountId),
+        ArgumentMatchers.eq(testContext)
+      )
   }
 
   it should "fail on cloud context creation failure" in {
@@ -218,14 +290,23 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Test
   }
 
   def testAsyncCreationFailure(createCloudContestStatus: StatusEnum, createAzureRelayStatus: StatusEnum): Unit = {
-    val workspaceManagerDAO = MockWorkspaceManagerDAO.buildWithAsyncResults(createCloudContestStatus, createAzureRelayStatus)
+    val workspaceManagerDAO =
+      MockWorkspaceManagerDAO.buildWithAsyncResults(createCloudContestStatus, createAzureRelayStatus)
     val samDAO = new MockSamDAO(slickDataSource)
     val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource, workspaceManagerDAO, samDAO, activeMcWorkspaceConfig, workbenchMetricBaseName
+      slickDataSource,
+      workspaceManagerDAO,
+      samDAO,
+      activeMcWorkspaceConfig,
+      workbenchMetricBaseName
     )(testContext)
     val namespace = "fake_ns" + UUID.randomUUID().toString
-    val request = new MultiCloudWorkspaceRequest(
-      namespace, "fake_name", Map.empty, cloudPlatform = WorkspaceCloudPlatform.Azure, "fake_region")
+    val request = new MultiCloudWorkspaceRequest(namespace,
+                                                 "fake_name",
+                                                 Map.empty,
+                                                 cloudPlatform = WorkspaceCloudPlatform.Azure,
+                                                 "fake_region"
+    )
 
     intercept[WorkspaceManagerCreationFailureException] {
       Await.result(mcWorkspaceService.createMultiCloudWorkspace(request), Duration.Inf)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -61,9 +61,19 @@ import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.Try
 
-
 //noinspection NameBooleanParameters,TypeAnnotation,EmptyParenMethodAccessedAsParameterless,ScalaUnnecessaryParentheses,RedundantNewCaseClass,ScalaUnusedSymbol
-class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matchers with TestDriverComponent with RawlsTestUtils with Eventually with MockitoTestUtils with RawlsStatsDTestUtils with BeforeAndAfterAll with TableDrivenPropertyChecks with OptionValues {
+class WorkspaceServiceSpec
+    extends AnyFlatSpec
+    with ScalatestRouteTest
+    with Matchers
+    with TestDriverComponent
+    with RawlsTestUtils
+    with Eventually
+    with MockitoTestUtils
+    with RawlsStatsDTestUtils
+    with BeforeAndAfterAll
+    with TableDrivenPropertyChecks
+    with OptionValues {
   import driver.api._
 
   val workspace = Workspace(
@@ -90,13 +100,17 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     super.afterAll()
   }
 
-  //noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
-  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit val executionContext: ExecutionContext) extends WorkspaceApiService with MethodConfigApiService with SubmissionApiService with MockUserInfoDirectivesWithUser {
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends WorkspaceApiService
+      with MethodConfigApiService
+      with SubmissionApiService
+      with MockUserInfoDirectivesWithUser {
     val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
     lazy val workspaceService: WorkspaceService = workspaceServiceConstructor(ctx1)
     lazy val userService: UserService = userServiceConstructor(ctx1)
     val slickDataSource: SlickDataSource = dataSource
-
 
     def actorRefFactory = system
     val submissionTimeout = FiniteDuration(1, TimeUnit.MINUTES)
@@ -114,22 +128,36 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
     val testConf = ConfigFactory.load()
 
-    val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName), slickDataSource)
-    val submissionSupervisor = system.actorOf(SubmissionSupervisor.props(
-      executionServiceCluster,
-      new UncoordinatedDataSourceAccess(slickDataSource),
-      samDAO,
-      gcsDAO,
-      mockNotificationDAO,
-      gcsDAO.getBucketServiceAccountCredential,
-      SubmissionMonitorConfig(1 second, true, 20000, true),
-      workbenchMetricBaseName = "test"
-    ).withDispatcher("submission-monitor-dispatcher"))
+    val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(
+      new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
+      slickDataSource
+    )
+    val submissionSupervisor = system.actorOf(
+      SubmissionSupervisor
+        .props(
+          executionServiceCluster,
+          new UncoordinatedDataSourceAccess(slickDataSource),
+          samDAO,
+          gcsDAO,
+          mockNotificationDAO,
+          gcsDAO.getBucketServiceAccountCredential,
+          SubmissionMonitorConfig(1 second, true, 20000, true),
+          workbenchMetricBaseName = "test"
+        )
+        .withDispatcher("submission-monitor-dispatcher")
+    )
 
-    val servicePerimeterServiceConfig = ServicePerimeterServiceConfig(Map(ServicePerimeterName("theGreatBarrier") -> Seq(GoogleProjectNumber("555555"), GoogleProjectNumber("121212")),
-      ServicePerimeterName("anotherGoodName") -> Seq(GoogleProjectNumber("777777"), GoogleProjectNumber("343434"))), 1 second, 5 seconds)
+    val servicePerimeterServiceConfig = ServicePerimeterServiceConfig(
+      Map(
+        ServicePerimeterName("theGreatBarrier") -> Seq(GoogleProjectNumber("555555"), GoogleProjectNumber("121212")),
+        ServicePerimeterName("anotherGoodName") -> Seq(GoogleProjectNumber("777777"), GoogleProjectNumber("343434"))
+      ),
+      1 second,
+      5 seconds
+    )
     val servicePerimeterService = mock[ServicePerimeterService](RETURNS_SMART_NULLS)
-    when(servicePerimeterService.overwriteGoogleProjectsInPerimeter(any[ServicePerimeterName], any[DataAccess])).thenReturn(DBIO.successful(()))
+    when(servicePerimeterService.overwriteGoogleProjectsInPerimeter(any[ServicePerimeterName], any[DataAccess]))
+      .thenReturn(DBIO.successful(()))
 
     val billingProfileManagerDAO = mock[BillingProfileManagerDAOImpl](RETURNS_SMART_NULLS)
 
@@ -145,16 +173,20 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       servicePerimeterService,
       RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
       billingProfileManagerDAO
-    )_
+    ) _
 
     val genomicsServiceConstructor = GenomicsService.constructor(
       slickDataSource,
       gcsDAO
-    )_
+    ) _
 
     val bigQueryDAO = new MockGoogleBigQueryDAO
     val submissionCostService = new MockSubmissionCostService(
-      "fakeTableName", "fakeDatePartitionColumn", "fakeServiceProject", 31, bigQueryDAO
+      "fakeTableName",
+      "fakeDatePartitionColumn",
+      "fakeServiceProject",
+      31,
+      bigQueryDAO
     )
     val execServiceBatchSize = 3
     val maxActiveWorkflowsTotal = 10
@@ -165,16 +197,31 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       "us-central1"
     )
     val multiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(testConf)
-    override val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService = MultiCloudWorkspaceService.constructor(
-      dataSource, workspaceManagerDAO, samDAO, multiCloudWorkspaceConfig, workbenchMetricBaseName
-    )
+    override val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService =
+      MultiCloudWorkspaceService.constructor(
+        dataSource,
+        workspaceManagerDAO,
+        samDAO,
+        multiCloudWorkspaceConfig,
+        workbenchMetricBaseName
+      )
     lazy val mcWorkspaceService: MultiCloudWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx1)
 
     val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
-    val requesterPaysSetupService = new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
+    val requesterPaysSetupService =
+      new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
     val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
-    val entityManager = EntityManager.defaultEntityManager(dataSource, workspaceManagerDAO, dataRepoDAO, samDAO, bigQueryServiceFactory, DataRepoEntityProviderConfig(100, 10, 0), testConf.getBoolean("entityStatisticsCache.enabled"), workbenchMetricBaseName)
+    val entityManager = EntityManager.defaultEntityManager(
+      dataSource,
+      workspaceManagerDAO,
+      dataRepoDAO,
+      samDAO,
+      bigQueryServiceFactory,
+      DataRepoEntityProviderConfig(100, 10, 0),
+      testConf.getBoolean("entityStatisticsCache.enabled"),
+      workbenchMetricBaseName
+    )
 
     val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
     val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
@@ -186,7 +233,8 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       new HttpMethodRepoDAO(
         MethodRepoConfig[Agora.type](mockServer.mockServerBaseUrl, ""),
         MethodRepoConfig[Dockstore.type](mockServer.mockServerBaseUrl, ""),
-        workbenchMetricBaseName = workbenchMetricBaseName),
+        workbenchMetricBaseName = workbenchMetricBaseName
+      ),
       new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
       executionServiceCluster,
       execServiceBatchSize,
@@ -211,50 +259,48 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
       terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
       terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole"
-    )_
+    ) _
 
-    def cleanupSupervisor = {
+    def cleanupSupervisor =
       submissionSupervisor ! PoisonPill
-    }
   }
 
-  class TestApiServiceWithCustomSamDAO(dataSource: SlickDataSource, override val user: RawlsUser)(override implicit val executionContext: ExecutionContext) extends TestApiService(dataSource, user) {
+  class TestApiServiceWithCustomSamDAO(dataSource: SlickDataSource, override val user: RawlsUser)(implicit
+    override val executionContext: ExecutionContext
+  ) extends TestApiService(dataSource, user) {
     override val samDAO: CustomizableMockSamDAO = new CustomizableMockSamDAO(dataSource)
   }
 
-  def withTestDataServices[T](testCode: TestApiService => T): T = {
+  def withTestDataServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withServices(dataSource, testData.userOwner)(testCode)
     }
-  }
 
-  def withTestDataServicesCustomSamAndUser[T](user: RawlsUser)(testCode: TestApiServiceWithCustomSamDAO => T): T = {
+  def withTestDataServicesCustomSamAndUser[T](user: RawlsUser)(testCode: TestApiServiceWithCustomSamDAO => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withServicesCustomSam(dataSource, user)(testCode)
     }
-  }
 
-  def withTestDataServicesCustomSam[T](testCode: TestApiServiceWithCustomSamDAO => T): T = {
+  def withTestDataServicesCustomSam[T](testCode: TestApiServiceWithCustomSamDAO => T): T =
     withTestDataServicesCustomSamAndUser(testData.userOwner)(testCode)
-  }
 
   def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: (TestApiService) => T) = {
     val apiService = new TestApiService(dataSource, user)
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
-  private def withServicesCustomSam[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: (TestApiServiceWithCustomSamDAO) => T) = {
+  private def withServicesCustomSam[T](dataSource: SlickDataSource, user: RawlsUser)(
+    testCode: (TestApiServiceWithCustomSamDAO) => T
+  ) = {
     val apiService = new TestApiServiceWithCustomSamDAO(dataSource, user)
 
-    try {
+    try
       testCode(apiService)
-    } finally {
+    finally
       apiService.cleanupSupervisor
-    }
   }
 
   it should "retrieve ACLs" in withTestDataServicesCustomSam { services =>
@@ -262,10 +308,15 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
     val vComplete = Await.result(services.workspaceService.getACL(testData.workspace.toWorkspaceName), Duration.Inf)
 
-    assertResult(WorkspaceACL(Map(
-      testData.userOwner.userEmail.value -> AccessEntry(WorkspaceAccessLevels.Owner, false, true, true),
-      testData.userWriter.userEmail.value -> AccessEntry(WorkspaceAccessLevels.Write, false, false, true),
-      testData.userReader.userEmail.value -> AccessEntry(WorkspaceAccessLevels.Read, false, false, false)))) {
+    assertResult(
+      WorkspaceACL(
+        Map(
+          testData.userOwner.userEmail.value -> AccessEntry(WorkspaceAccessLevels.Owner, false, true, true),
+          testData.userWriter.userEmail.value -> AccessEntry(WorkspaceAccessLevels.Write, false, false, true),
+          testData.userReader.userEmail.value -> AccessEntry(WorkspaceAccessLevels.Read, false, false, false)
+        )
+      )
+    ) {
       vComplete
     }
   }
@@ -277,25 +328,72 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       _ <- services.samDAO.registerUser(toUserInfo(testData.userWriter))
       _ <- services.samDAO.registerUser(toUserInfo(testData.userReader))
 
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.owner,
-        SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set(SamWorkspaceActions.own, SamWorkspaceActions.write, SamWorkspaceActions.read), Set(SamWorkspaceRoles.owner)), userInfo)
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        workspace.workspaceId,
+        SamWorkspacePolicyNames.owner,
+        SamPolicy(
+          Set(WorkbenchEmail(testData.userOwner.userEmail.value)),
+          Set(SamWorkspaceActions.own, SamWorkspaceActions.write, SamWorkspaceActions.read),
+          Set(SamWorkspaceRoles.owner)
+        ),
+        userInfo
+      )
 
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.writer,
-        SamPolicy(Set(WorkbenchEmail(testData.userWriter.userEmail.value)), Set(SamWorkspaceActions.write, SamWorkspaceActions.read), Set(SamWorkspaceRoles.writer)), userInfo)
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        workspace.workspaceId,
+        SamWorkspacePolicyNames.writer,
+        SamPolicy(Set(WorkbenchEmail(testData.userWriter.userEmail.value)),
+                  Set(SamWorkspaceActions.write, SamWorkspaceActions.read),
+                  Set(SamWorkspaceRoles.writer)
+        ),
+        userInfo
+      )
 
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.reader,
-        SamPolicy(Set(WorkbenchEmail(testData.userReader.userEmail.value)), Set(SamWorkspaceActions.read), Set(SamWorkspaceRoles.reader)), userInfo)
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        workspace.workspaceId,
+        SamWorkspacePolicyNames.reader,
+        SamPolicy(Set(WorkbenchEmail(testData.userReader.userEmail.value)),
+                  Set(SamWorkspaceActions.read),
+                  Set(SamWorkspaceRoles.reader)
+        ),
+        userInfo
+      )
 
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.canCatalog,
-        SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set(SamWorkspaceActions.catalog), Set.empty), userInfo)
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.shareReader,
-        SamPolicy(Set.empty, Set.empty, Set.empty), userInfo)
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.shareWriter,
-        SamPolicy(Set.empty, Set.empty, Set.empty), userInfo)
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.canCompute,
-        SamPolicy(Set(WorkbenchEmail(testData.userWriter.userEmail.value)), Set.empty, Set.empty), userInfo)
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspacePolicyNames.projectOwner,
-        SamPolicy(Set.empty, Set.empty, Set.empty), userInfo)
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        workspace.workspaceId,
+        SamWorkspacePolicyNames.canCatalog,
+        SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set(SamWorkspaceActions.catalog), Set.empty),
+        userInfo
+      )
+      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace,
+                                           workspace.workspaceId,
+                                           SamWorkspacePolicyNames.shareReader,
+                                           SamPolicy(Set.empty, Set.empty, Set.empty),
+                                           userInfo
+      )
+      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace,
+                                           workspace.workspaceId,
+                                           SamWorkspacePolicyNames.shareWriter,
+                                           SamPolicy(Set.empty, Set.empty, Set.empty),
+                                           userInfo
+      )
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        workspace.workspaceId,
+        SamWorkspacePolicyNames.canCompute,
+        SamPolicy(Set(WorkbenchEmail(testData.userWriter.userEmail.value)), Set.empty, Set.empty),
+        userInfo
+      )
+      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace,
+                                           workspace.workspaceId,
+                                           SamWorkspacePolicyNames.projectOwner,
+                                           SamPolicy(Set.empty, Set.empty, Set.empty),
+                                           userInfo
+      )
     } yield ()
 
     Await.result(populateAcl, Duration.Inf)
@@ -308,23 +406,48 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val user2 = RawlsUser(RawlsUserSubjectId("obamaiscool2"), RawlsUserEmail("obama2@whitehouse.gov"))
 
     Await.result(for {
-      _ <- services.samDAO.registerUser(toUserInfo(user1))
-      _ <- services.samDAO.registerUser(toUserInfo(user2))
-    } yield (), Duration.Inf)
+                   _ <- services.samDAO.registerUser(toUserInfo(user1))
+                   _ <- services.samDAO.registerUser(toUserInfo(user2))
+                 } yield (),
+                 Duration.Inf
+    )
 
-    //add ACL
-    val aclAdd = Set(WorkspaceACLUpdate(user1.userEmail.value, WorkspaceAccessLevels.Owner, None), WorkspaceACLUpdate(user2.userEmail.value, WorkspaceAccessLevels.Read, Option(true)))
-    val aclAddResponse = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclAdd, false), Duration.Inf)
-    val responseFromAdd = WorkspaceACLUpdateResponseList(Set(WorkspaceACLUpdate(user1.userEmail.value, WorkspaceAccessLevels.Owner, Some(true), Some(true)), WorkspaceACLUpdate(user2.userEmail.value, WorkspaceAccessLevels.Read, Some(true), Some(false))), Set.empty, Set.empty)
+    // add ACL
+    val aclAdd = Set(
+      WorkspaceACLUpdate(user1.userEmail.value, WorkspaceAccessLevels.Owner, None),
+      WorkspaceACLUpdate(user2.userEmail.value, WorkspaceAccessLevels.Read, Option(true))
+    )
+    val aclAddResponse =
+      Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclAdd, false), Duration.Inf)
+    val responseFromAdd = WorkspaceACLUpdateResponseList(
+      Set(
+        WorkspaceACLUpdate(user1.userEmail.value, WorkspaceAccessLevels.Owner, Some(true), Some(true)),
+        WorkspaceACLUpdate(user2.userEmail.value, WorkspaceAccessLevels.Read, Some(true), Some(false))
+      ),
+      Set.empty,
+      Set.empty
+    )
 
     assertResult(responseFromAdd, aclAddResponse.toString) {
       aclAddResponse
     }
 
     services.samDAO.callsToAddToPolicy should contain theSameElementsAs Seq(
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.owner, user1.userEmail.value),
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.shareReader, user2.userEmail.value),
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.reader, user2.userEmail.value)
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.owner,
+       user1.userEmail.value
+      ),
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.shareReader,
+       user2.userEmail.value
+      ),
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.reader,
+       user2.userEmail.value
+      )
     )
     services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Seq.empty
   }
@@ -332,40 +455,85 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "update ACLs" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
-    //update ACL
+    // update ACL
     val aclUpdates = Set(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, None))
-    val aclUpdateResponse = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates, false), Duration.Inf)
-    val responseFromUpdate = WorkspaceACLUpdateResponseList(Set(WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, Some(false), Some(true))), Set.empty, Set.empty)
+    val aclUpdateResponse =
+      Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates, false),
+                   Duration.Inf
+      )
+    val responseFromUpdate = WorkspaceACLUpdateResponseList(
+      Set(
+        WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Write, Some(false), Some(true))
+      ),
+      Set.empty,
+      Set.empty
+    )
 
     assertResult(responseFromUpdate, "Update ACL shouldn't error") {
       aclUpdateResponse
     }
 
     services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Seq(
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.reader, testData.userReader.userEmail.value)
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.reader,
+       testData.userReader.userEmail.value
+      )
     )
     services.samDAO.callsToAddToPolicy should contain theSameElementsAs Seq(
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.writer, testData.userReader.userEmail.value),
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCompute, testData.userReader.userEmail.value),
-      (SamResourceTypeNames.billingProject, testData.workspace.namespace, SamBillingProjectPolicyNames.canComputeUser, testData.userReader.userEmail.value)
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.writer,
+       testData.userReader.userEmail.value
+      ),
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.canCompute,
+       testData.userReader.userEmail.value
+      ),
+      (SamResourceTypeNames.billingProject,
+       testData.workspace.namespace,
+       SamBillingProjectPolicyNames.canComputeUser,
+       testData.userReader.userEmail.value
+      )
     )
   }
 
   it should "remove ACLs" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
-    //remove ACL
+    // remove ACL
     val aclRemove = Set(WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.NoAccess, None))
-    val aclRemoveResponse = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclRemove, false), Duration.Inf)
-    val responseFromRemove = WorkspaceACLUpdateResponseList(Set(WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.NoAccess, Some(false), Some(false))), Set.empty, Set.empty)
+    val aclRemoveResponse =
+      Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclRemove, false),
+                   Duration.Inf
+      )
+    val responseFromRemove = WorkspaceACLUpdateResponseList(Set(
+                                                              WorkspaceACLUpdate(testData.userWriter.userEmail.value,
+                                                                                 WorkspaceAccessLevels.NoAccess,
+                                                                                 Some(false),
+                                                                                 Some(false)
+                                                              )
+                                                            ),
+                                                            Set.empty,
+                                                            Set.empty
+    )
 
     assertResult(responseFromRemove, "Remove ACL shouldn't error") {
       aclRemoveResponse
     }
 
     services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Seq(
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCompute, testData.userWriter.userEmail.value),
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.writer, testData.userWriter.userEmail.value)
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.canCompute,
+       testData.userWriter.userEmail.value
+      ),
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.writer,
+       testData.userWriter.userEmail.value
+      )
     )
     services.samDAO.callsToAddToPolicy should contain theSameElementsAs Seq.empty
   }
@@ -373,52 +541,91 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "remove requester pays appropriately when removing ACLs" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
-    runAndWait(workspaceRequesterPaysQuery.insertAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail, Set(BondServiceAccountEmail("foo@bar.com"))))
+    runAndWait(
+      workspaceRequesterPaysQuery.insertAllForUser(testData.workspace.toWorkspaceName,
+                                                   testData.userWriter.userEmail,
+                                                   Set(BondServiceAccountEmail("foo@bar.com"))
+      )
+    )
 
     val aclRemove = Set(WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.NoAccess, None))
-    Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclRemove, false), Duration.Inf)
+    Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclRemove, false),
+                 Duration.Inf
+    )
 
-    runAndWait(workspaceRequesterPaysQuery.listAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail)) shouldBe empty
+    runAndWait(
+      workspaceRequesterPaysQuery.listAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail)
+    ) shouldBe empty
   }
 
   it should "keep requester pays appropriately when changing ACLs" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
     val bondServiceAccountEmails = Set(BondServiceAccountEmail("foo@bar.com"))
-    runAndWait(workspaceRequesterPaysQuery.insertAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail, bondServiceAccountEmails))
+    runAndWait(
+      workspaceRequesterPaysQuery.insertAllForUser(testData.workspace.toWorkspaceName,
+                                                   testData.userWriter.userEmail,
+                                                   bondServiceAccountEmails
+      )
+    )
 
     val aclUpdate = Set(WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Owner, None))
-    Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdate, false), Duration.Inf)
+    Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdate, false),
+                 Duration.Inf
+    )
 
-    runAndWait(workspaceRequesterPaysQuery.listAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail)) should contain theSameElementsAs(bondServiceAccountEmails)
+    runAndWait(
+      workspaceRequesterPaysQuery.listAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail)
+    ) should contain theSameElementsAs bondServiceAccountEmails
   }
 
   it should "remove requester pays appropriately when changing ACLs" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
-    runAndWait(workspaceRequesterPaysQuery.insertAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail, Set(BondServiceAccountEmail("foo@bar.com"))))
+    runAndWait(
+      workspaceRequesterPaysQuery.insertAllForUser(testData.workspace.toWorkspaceName,
+                                                   testData.userWriter.userEmail,
+                                                   Set(BondServiceAccountEmail("foo@bar.com"))
+      )
+    )
 
     val aclUpdate = Set(WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Read, None))
-    Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdate, false), Duration.Inf)
+    Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdate, false),
+                 Duration.Inf
+    )
 
-    runAndWait(workspaceRequesterPaysQuery.listAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail)) shouldBe empty
+    runAndWait(
+      workspaceRequesterPaysQuery.listAllForUser(testData.workspace.toWorkspaceName, testData.userWriter.userEmail)
+    ) shouldBe empty
   }
 
   it should "return non-existent users during patch ACLs" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
     val aclUpdates = Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, None))
-    val vComplete = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates, false), Duration.Inf)
-    val responseFromUpdate = WorkspaceACLUpdateResponseList(Set.empty, Set.empty, Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, None)))
+    val vComplete =
+      Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates, false),
+                   Duration.Inf
+      )
+    val responseFromUpdate =
+      WorkspaceACLUpdateResponseList(Set.empty,
+                                     Set.empty,
+                                     Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, None))
+      )
 
     assertResult(responseFromUpdate, "Add ACL shouldn't error") {
       vComplete
     }
   }
 
-  it should "pass sam read action check for a user with read access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(testData.userReader) { services =>
+  it should "pass sam read action check for a user with read access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(
+    testData.userReader
+  ) { services =>
     populateWorkspacePolicies(services)
-    val rqComplete = Await.result(services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.read), Duration.Inf)
+    val rqComplete = Await.result(
+      services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.read),
+      Duration.Inf
+    )
     assertResult(true) {
       rqComplete
     }
@@ -426,52 +633,96 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
   it should "pass sam read action check for a user with read access in a locked workspace" in {
     withTestDataServicesCustomSam { services =>
-      populateWorkspacePolicies(services, testData.workspaceNoSubmissions) //can't lock a workspace with running submissions, which the default workspace has
-      Await.result(services.workspaceService.lockWorkspace(testData.workspaceNoSubmissions.toWorkspaceName), Duration.Inf)
+      populateWorkspacePolicies(services,
+                                testData.workspaceNoSubmissions
+      ) // can't lock a workspace with running submissions, which the default workspace has
+      Await.result(services.workspaceService.lockWorkspace(testData.workspaceNoSubmissions.toWorkspaceName),
+                   Duration.Inf
+      )
 
-      //generate a new workspace service with a reader user info so we can ask if a reader can access it
-      val readerWorkspaceService = services.workspaceServiceConstructor(RawlsRequestContext(UserInfo(testData.userReader.userEmail, OAuth2BearerToken("token"), 0, testData.userReader.userSubjectId)))
-      val rqComplete = Await.result(readerWorkspaceService.checkSamActionWithLock(testData.workspaceNoSubmissions.toWorkspaceName, SamWorkspaceActions.read), Duration.Inf)
+      // generate a new workspace service with a reader user info so we can ask if a reader can access it
+      val readerWorkspaceService = services.workspaceServiceConstructor(
+        RawlsRequestContext(
+          UserInfo(testData.userReader.userEmail, OAuth2BearerToken("token"), 0, testData.userReader.userSubjectId)
+        )
+      )
+      val rqComplete =
+        Await.result(readerWorkspaceService.checkSamActionWithLock(testData.workspaceNoSubmissions.toWorkspaceName,
+                                                                   SamWorkspaceActions.read
+                     ),
+                     Duration.Inf
+        )
       assertResult(true) {
         rqComplete
       }
     }
   }
 
-  it should "fail sam write action check for a user with read access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(testData.userReader) { services =>
+  it should "fail sam write action check for a user with read access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(
+    testData.userReader
+  ) { services =>
     populateWorkspacePolicies(services)
-    val rqComplete = Await.result(services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.write), Duration.Inf)
+    val rqComplete = Await.result(
+      services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.write),
+      Duration.Inf
+    )
     assertResult(false) {
       rqComplete
     }
   }
 
-  it should "pass sam write action check for a user with write access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(testData.userWriter) { services =>
+  it should "pass sam write action check for a user with write access in an unlocked workspace" in withTestDataServicesCustomSamAndUser(
+    testData.userWriter
+  ) { services =>
     populateWorkspacePolicies(services)
-    val rqComplete = Await.result(services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.write), Duration.Inf)
+    val rqComplete = Await.result(
+      services.workspaceService.checkSamActionWithLock(testData.workspace.toWorkspaceName, SamWorkspaceActions.write),
+      Duration.Inf
+    )
     assertResult(true) {
       rqComplete
     }
   }
 
-  //this is the important test!
-  it should "fail sam write action check for a user with write access in a locked workspace" in withTestDataServicesCustomSam { services =>
-    //first lock the workspace as the owner
-    populateWorkspacePolicies(services, testData.workspaceNoSubmissions) //can't lock a workspace with running submissions, which default workspace has
-    Await.result(services.workspaceService.lockWorkspace(testData.workspaceNoSubmissions.toWorkspaceName), Duration.Inf)
+  // this is the important test!
+  it should "fail sam write action check for a user with write access in a locked workspace" in withTestDataServicesCustomSam {
+    services =>
+      // first lock the workspace as the owner
+      populateWorkspacePolicies(services,
+                                testData.workspaceNoSubmissions
+      ) // can't lock a workspace with running submissions, which default workspace has
+      Await.result(services.workspaceService.lockWorkspace(testData.workspaceNoSubmissions.toWorkspaceName),
+                   Duration.Inf
+      )
 
-    //now as a writer, ask if we can write it. but it's locked!
-    val readerWorkspaceService = services.workspaceServiceConstructor(RawlsRequestContext(UserInfo(testData.userWriter.userEmail, OAuth2BearerToken("token"), 0, testData.userWriter.userSubjectId)))
-    val rqComplete = Await.result(readerWorkspaceService.checkSamActionWithLock(testData.workspaceNoSubmissions.toWorkspaceName, SamWorkspaceActions.write), Duration.Inf)
-    assertResult(false) {
-      rqComplete
-    }
+      // now as a writer, ask if we can write it. but it's locked!
+      val readerWorkspaceService = services.workspaceServiceConstructor(
+        RawlsRequestContext(
+          UserInfo(testData.userWriter.userEmail, OAuth2BearerToken("token"), 0, testData.userWriter.userSubjectId)
+        )
+      )
+      val rqComplete =
+        Await.result(readerWorkspaceService.checkSamActionWithLock(testData.workspaceNoSubmissions.toWorkspaceName,
+                                                                   SamWorkspaceActions.write
+                     ),
+                     Duration.Inf
+        )
+      assertResult(false) {
+        rqComplete
+      }
   }
 
   it should "invite a user to a workspace" in withTestDataServicesCustomSam { services =>
     val aclUpdates2 = Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, None))
-    val vComplete2 = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates2, true), Duration.Inf)
-    val responseFromUpdate2 = WorkspaceACLUpdateResponseList(Set.empty, Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, Some(true), Some(true))), Set.empty)
+    val vComplete2 =
+      Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates2, true),
+                   Duration.Inf
+      )
+    val responseFromUpdate2 = WorkspaceACLUpdateResponseList(
+      Set.empty,
+      Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, Some(true), Some(true))),
+      Set.empty
+    )
 
     assertResult(responseFromUpdate2, "Add ACL shouldn't error") {
       vComplete2
@@ -484,8 +735,13 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val populateAcl = for {
       _ <- services.samDAO.registerUser(toUserInfo(testData.userOwner))
 
-      _ <- services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCatalog,
-        SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set(SamWorkspaceActions.catalog), Set.empty), userInfo)
+      _ <- services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        testData.workspace.workspaceId,
+        SamWorkspacePolicyNames.canCatalog,
+        SamPolicy(Set(WorkbenchEmail(testData.userOwner.userEmail.value)), Set(SamWorkspaceActions.catalog), Set.empty),
+        userInfo
+      )
     } yield ()
 
     Await.result(populateAcl, Duration.Inf)
@@ -502,72 +758,105 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val user1 = RawlsUser(RawlsUserSubjectId("obamaiscool"), RawlsUserEmail("obama@whitehouse.gov"))
 
     Await.result(for {
-      _ <- services.samDAO.registerUser(toUserInfo(user1))
-    } yield (), Duration.Inf)
+                   _ <- services.samDAO.registerUser(toUserInfo(user1))
+                 } yield (),
+                 Duration.Inf
+    )
 
-    //add catalog perm
-    val catalogUpdateResponse = Await.result(services.workspaceService.updateCatalog(testData.workspace.toWorkspaceName,
-      Seq(WorkspaceCatalog("obama@whitehouse.gov", true))), Duration.Inf)
-    val expectedResponse = WorkspaceCatalogUpdateResponseList(Seq(WorkspaceCatalogResponse("obama@whitehouse.gov", true)), Seq.empty)
+    // add catalog perm
+    val catalogUpdateResponse =
+      Await.result(services.workspaceService.updateCatalog(testData.workspace.toWorkspaceName,
+                                                           Seq(WorkspaceCatalog("obama@whitehouse.gov", true))
+                   ),
+                   Duration.Inf
+      )
+    val expectedResponse =
+      WorkspaceCatalogUpdateResponseList(Seq(WorkspaceCatalogResponse("obama@whitehouse.gov", true)), Seq.empty)
 
     assertResult(expectedResponse) {
       catalogUpdateResponse
     }
 
-    //check result
+    // check result
     services.samDAO.callsToAddToPolicy should contain theSameElementsAs Seq(
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCatalog, user1.userEmail.value)
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.canCatalog,
+       user1.userEmail.value
+      )
     )
   }
 
   it should "remove catalog permissions" in withTestDataServicesCustomSam { services =>
     populateWorkspacePolicies(services)
 
-    //remove catalog perm
-    val catalogRemoveResponse = Await.result(services.workspaceService.updateCatalog(testData.workspace.toWorkspaceName,
-      Seq(WorkspaceCatalog(testData.userOwner.userEmail.value, false))), Duration.Inf)
+    // remove catalog perm
+    val catalogRemoveResponse = Await.result(
+      services.workspaceService.updateCatalog(testData.workspace.toWorkspaceName,
+                                              Seq(WorkspaceCatalog(testData.userOwner.userEmail.value, false))
+      ),
+      Duration.Inf
+    )
 
-    val expectedResponse = WorkspaceCatalogUpdateResponseList(Seq(WorkspaceCatalogResponse(testData.userOwner.userEmail.value, false)), Seq.empty)
+    val expectedResponse =
+      WorkspaceCatalogUpdateResponseList(Seq(WorkspaceCatalogResponse(testData.userOwner.userEmail.value, false)),
+                                         Seq.empty
+      )
 
     assertResult(expectedResponse) {
       catalogRemoveResponse
     }
 
-    //check result
+    // check result
     services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Seq(
-      (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCatalog, testData.userOwner.userEmail.value)
+      (SamResourceTypeNames.workspace,
+       testData.workspace.workspaceId,
+       SamWorkspacePolicyNames.canCatalog,
+       testData.userOwner.userEmail.value
+      )
     )
   }
 
   it should "lock a workspace with terminated submissions" in withTestDataServices { services =>
-    //check workspace is not locked
+    // check workspace is not locked
     assert(!testData.workspaceTerminatedSubmissions.isLocked)
 
-    val rqComplete = Await.result(services.workspaceService.lockWorkspace(testData.workspaceTerminatedSubmissions.toWorkspaceName), Duration.Inf)
+    val rqComplete =
+      Await.result(services.workspaceService.lockWorkspace(testData.workspaceTerminatedSubmissions.toWorkspaceName),
+                   Duration.Inf
+      )
 
     assertResult(true) {
       rqComplete
     }
 
-    val rqCompleteAgain = Await.result(services.workspaceService.lockWorkspace(testData.workspaceTerminatedSubmissions.toWorkspaceName), Duration.Inf)
+    val rqCompleteAgain =
+      Await.result(services.workspaceService.lockWorkspace(testData.workspaceTerminatedSubmissions.toWorkspaceName),
+                   Duration.Inf
+      )
 
     assertResult(false) {
       rqCompleteAgain
     }
 
-    //check workspace is locked
+    // check workspace is locked
     assert {
       runAndWait(workspaceQuery.findByName(testData.workspaceTerminatedSubmissions.toWorkspaceName)).head.isLocked
     }
   }
 
   it should "fail to lock a workspace with active submissions" in withTestDataServices { services =>
-    //check workspace is not locked
+    // check workspace is not locked
     assert(!testData.workspaceMixedSubmissions.isLocked)
 
-   val except: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-     Await.result(services.workspaceService.lockWorkspace(new WorkspaceName(testData.workspaceMixedSubmissions.namespace, testData.workspaceMixedSubmissions.name)), Duration.Inf)
-   }
+    val except: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        services.workspaceService.lockWorkspace(
+          new WorkspaceName(testData.workspaceMixedSubmissions.namespace, testData.workspaceMixedSubmissions.name)
+        ),
+        Duration.Inf
+      )
+    }
 
     assertResult(StatusCodes.Conflict) {
       except.errorReport.statusCode.get
@@ -581,245 +870,300 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   behavior of "deleteWorkspace"
 
   it should "delete a workspace with linked bond service account" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceNoSubmissions)) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
 
     // add a bond sa link
-    Await.result(services.requesterPaysSetupService.grantRequesterPaysToLinkedSAs(userInfo, testData.workspaceNoSubmissions), Duration.Inf)
+    Await.result(
+      services.requesterPaysSetupService.grantRequesterPaysToLinkedSAs(userInfo, testData.workspaceNoSubmissions),
+      Duration.Inf
+    )
 
-    //delete the workspace
+    // delete the workspace
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
 
     verify(services.workspaceManagerDAO, Mockito.atLeast(1)).deleteWorkspace(any[UUID], any[RawlsRequestContext])
 
-    //check that the workspace has been deleted
+    // check that the workspace has been deleted
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
-
 
   }
 
   it should "delete a workspace with no submissions" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceNoSubmissions)) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
 
-    //delete the workspace
+    // delete the workspace
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
 
     verify(services.workspaceManagerDAO, Mockito.atLeast(1)).deleteWorkspace(any[UUID], any[RawlsRequestContext])
 
-    //check that the workspace has been deleted
+    // check that the workspace has been deleted
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
 
-
   }
 
   it should "delete a workspace with succeeded submission" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceSuccessfulSubmission)) {
       runAndWait(workspaceQuery.findByName(testData.wsName4))
     }
 
-    //Check method configs to be deleted exist
-    assertResult(Vector(MethodConfigurationShort("testConfig2",Some("Sample"),AgoraMethod("myNamespace","method-a",1),"dsde"),
-      MethodConfigurationShort("testConfig1",Some("Sample"),AgoraMethod("ns-config","meth1",1),"ns"))) {
+    // Check method configs to be deleted exist
+    assertResult(
+      Vector(
+        MethodConfigurationShort("testConfig2", Some("Sample"), AgoraMethod("myNamespace", "method-a", 1), "dsde"),
+        MethodConfigurationShort("testConfig1", Some("Sample"), AgoraMethod("ns-config", "meth1", 1), "ns")
+      )
+    ) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceSuccessfulSubmission))
     }
 
-    //Check if submissions on workspace exist
+    // Check if submissions on workspace exist
     assertResult(List(testData.submissionSuccessful1)) {
       runAndWait(submissionQuery.list(testData.workspaceSuccessfulSubmission))
     }
 
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(20) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSuccessfulSubmission.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSuccessfulSubmission.workspaceId))
+          .length
+          .result
+      )
     }
 
-    //delete the workspace
+    // delete the workspace
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName4), Duration.Inf)
 
-    //check that the workspace has been deleted
+    // check that the workspace has been deleted
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName4))
     }
 
-    //check if method configs have been deleted
+    // check if method configs have been deleted
     assertResult(Vector()) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceSuccessfulSubmission))
     }
 
-    //Check if submissions on workspace have been deleted
+    // Check if submissions on workspace have been deleted
     assertResult(Vector()) {
       runAndWait(submissionQuery.list(testData.workspaceSuccessfulSubmission))
     }
 
-    //Check if entities on workspace have been deleted
+    // Check if entities on workspace have been deleted
     assertResult(0) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSuccessfulSubmission.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSuccessfulSubmission.workspaceId))
+          .length
+          .result
+      )
     }
   }
 
   it should "delete a workspace with failed submission" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceFailedSubmission)) {
       runAndWait(workspaceQuery.findByName(testData.wsName5))
     }
 
-    //Check method configs to be deleted exist
-    assertResult(Vector(MethodConfigurationShort("testConfig1",Some("Sample"),AgoraMethod("ns-config","meth1",1),"ns"))) {
+    // Check method configs to be deleted exist
+    assertResult(
+      Vector(MethodConfigurationShort("testConfig1", Some("Sample"), AgoraMethod("ns-config", "meth1", 1), "ns"))
+    ) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceFailedSubmission))
     }
 
-    //Check if submissions on workspace exist
+    // Check if submissions on workspace exist
     assertResult(List(testData.submissionFailed)) {
       runAndWait(submissionQuery.list(testData.workspaceFailedSubmission))
     }
 
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(20) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceFailedSubmission.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceFailedSubmission.workspaceId))
+          .length
+          .result
+      )
     }
 
-    //delete the workspace
+    // delete the workspace
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName5), Duration.Inf)
 
-    //check that the workspace has been deleted
+    // check that the workspace has been deleted
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName5))
     }
 
-    //check if method configs have been deleted
+    // check if method configs have been deleted
     assertResult(Vector()) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceFailedSubmission))
     }
 
-    //Check if submissions on workspace have been deleted
+    // Check if submissions on workspace have been deleted
     assertResult(Vector()) {
       runAndWait(submissionQuery.list(testData.workspaceFailedSubmission))
     }
 
-
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(0) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceFailedSubmission.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceFailedSubmission.workspaceId))
+          .length
+          .result
+      )
     }
   }
 
   it should "delete a workspace with submitted submission" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceSubmittedSubmission)) {
       runAndWait(workspaceQuery.findByName(testData.wsName6))
     }
 
-    //Check method configs to be deleted exist
-    assertResult(Vector(MethodConfigurationShort("testConfig1",Some("Sample"),AgoraMethod("ns-config","meth1",1),"ns"))) {
+    // Check method configs to be deleted exist
+    assertResult(
+      Vector(MethodConfigurationShort("testConfig1", Some("Sample"), AgoraMethod("ns-config", "meth1", 1), "ns"))
+    ) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceSubmittedSubmission))
     }
 
-    //Check if submissions on workspace exist
+    // Check if submissions on workspace exist
     assertResult(List(testData.submissionSubmitted)) {
       runAndWait(submissionQuery.list(testData.workspaceSubmittedSubmission))
     }
 
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(20) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSubmittedSubmission.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSubmittedSubmission.workspaceId))
+          .length
+          .result
+      )
     }
 
-    //delete the workspace
+    // delete the workspace
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName6), Duration.Inf)
 
-    //check that the workspace has been deleted
+    // check that the workspace has been deleted
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName6))
     }
 
-    //check if method configs have been deleted
+    // check if method configs have been deleted
     assertResult(Vector()) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceSubmittedSubmission))
     }
 
-    //Check if submissions on workspace have been deleted
+    // Check if submissions on workspace have been deleted
     assertResult(Vector()) {
       runAndWait(submissionQuery.list(testData.workspaceSubmittedSubmission))
     }
 
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(0) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSubmittedSubmission.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceSubmittedSubmission.workspaceId))
+          .length
+          .result
+      )
     }
   }
 
   it should "delete a workspace with mixed submissions" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceMixedSubmissions)) {
       runAndWait(workspaceQuery.findByName(testData.wsName7))
     }
 
-    //Check method configs to be deleted exist
-    assertResult(Vector(MethodConfigurationShort("testConfig1",Some("Sample"),AgoraMethod("ns-config","meth1",1),"ns"))) {
+    // Check method configs to be deleted exist
+    assertResult(
+      Vector(MethodConfigurationShort("testConfig1", Some("Sample"), AgoraMethod("ns-config", "meth1", 1), "ns"))
+    ) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceMixedSubmissions))
     }
 
-    //Check if submissions on workspace exist
+    // Check if submissions on workspace exist
     assertResult(2) {
       runAndWait(submissionQuery.list(testData.workspaceMixedSubmissions)).length
     }
 
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(20) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceMixedSubmissions.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceMixedSubmissions.workspaceId))
+          .length
+          .result
+      )
     }
 
-    //delete the workspace
+    // delete the workspace
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName7), Duration.Inf)
 
-    //check that the workspace has been deleted
+    // check that the workspace has been deleted
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName7))
     }
 
-    //check if method configs have been deleted
+    // check if method configs have been deleted
     assertResult(Vector()) {
       runAndWait(methodConfigurationQuery.listActive(testData.workspaceMixedSubmissions))
     }
 
-    //Check if submissions on workspace have been deleted
+    // Check if submissions on workspace have been deleted
     assertResult(Vector()) {
       runAndWait(submissionQuery.list(testData.workspaceMixedSubmissions))
     }
 
-    //Check if entities on workspace exist
+    // Check if entities on workspace exist
     assertResult(0) {
-      runAndWait(entityQuery.findActiveEntityByWorkspace(UUID.fromString(testData.workspaceMixedSubmissions.workspaceId)).length.result)
+      runAndWait(
+        entityQuery
+          .findActiveEntityByWorkspace(UUID.fromString(testData.workspaceMixedSubmissions.workspaceId))
+          .length
+          .result
+      )
     }
 
   }
 
   it should "handle 404s from Sam when deleting a workspace" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceNoSubmissions)) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
 
     when(
       services.samDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-        ArgumentMatchers.eq(testData.workspaceNoSubmissions.workspaceId), any[UserInfo])
+                                     ArgumentMatchers.eq(testData.workspaceNoSubmissions.workspaceId),
+                                     any[UserInfo]
+      )
     ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "404 from Sam"))))
 
     when(
-      services.samDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection), any[String], any[UserInfo])
+      services.samDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
+                                     any[String],
+                                     any[UserInfo]
+      )
     ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "404 from Sam"))))
 
-    //delete the workspace and verify it has been deleted
+    // delete the workspace and verify it has been deleted
     Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
@@ -827,14 +1171,16 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   }
 
   it should "fail if Sam throws a 403 in delete workspace" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceNoSubmissions)) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
 
     when(
       services.samDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-        ArgumentMatchers.eq(testData.workspaceNoSubmissions.workspaceId), any[UserInfo])
+                                     ArgumentMatchers.eq(testData.workspaceNoSubmissions.workspaceId),
+                                     any[UserInfo]
+      )
     ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "403 from Sam"))))
 
     val error = intercept[RawlsExceptionWithErrorReport] {
@@ -846,14 +1192,19 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   }
 
   it should "fail if Sam throws a 500 in delete workflowCollection" in withTestDataServices { services =>
-    //check that the workspace to be deleted exists
+    // check that the workspace to be deleted exists
     assertWorkspaceResult(Option(testData.workspaceNoSubmissions)) {
       runAndWait(workspaceQuery.findByName(testData.wsName3))
     }
 
     when(
-      services.samDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection), any[String], any[UserInfo])
-    ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "500 from Sam"))))
+      services.samDAO.deleteResource(ArgumentMatchers.eq(SamResourceTypeNames.workflowCollection),
+                                     any[String],
+                                     any[UserInfo]
+      )
+    ).thenReturn(
+      Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "500 from Sam")))
+    )
 
     val error = intercept[RawlsExceptionWithErrorReport] {
       Await.result(services.workspaceService.deleteWorkspace(testData.wsName3), Duration.Inf)
@@ -866,13 +1217,18 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "delete an Azure workspace" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
     val workspaceRequest = MultiCloudWorkspaceRequest(
-      testData.testProject1Name.value, workspaceName, Map.empty, WorkspaceCloudPlatform.Azure, "fake_region"
+      testData.testProject1Name.value,
+      workspaceName,
+      Map.empty,
+      WorkspaceCloudPlatform.Azure,
+      "fake_region"
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
-      new WorkspaceDescription().azureContext(new AzureContext()
-        .tenantId("fake_tenant_id")
-        .subscriptionId("fake_sub_id")
-        .resourceGroupId("fake_mrg_id")
+      new WorkspaceDescription().azureContext(
+        new AzureContext()
+          .tenantId("fake_tenant_id")
+          .subscriptionId("fake_sub_id")
+          .resourceGroupId("fake_mrg_id")
       )
     )
 
@@ -881,11 +1237,11 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       runAndWait(workspaceQuery.findByName(WorkspaceName(workspace.namespace, workspace.name))).map(_.toWorkspaceName)
     }
 
-    val deletedBucketName = Await.result(
-      services.workspaceService.deleteWorkspace(
-        WorkspaceName(workspace.namespace, workspace.name)
-      ),
-      Duration.Inf)
+    val deletedBucketName = Await.result(services.workspaceService.deleteWorkspace(
+                                           WorkspaceName(workspace.namespace, workspace.name)
+                                         ),
+                                         Duration.Inf
+    )
 
     deletedBucketName shouldBe None
     assertResult(None) {
@@ -896,7 +1252,6 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   behavior of "getTags"
 
   it should "return the correct tags from autocomplete" in withTestDataServices { services =>
-
     // when no tags, return empty set
     val res1 = Await.result(services.workspaceService.getTags(Some("notag")), Duration.Inf)
     assertResult(Vector.empty[WorkspaceTag]) {
@@ -904,14 +1259,25 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     }
 
     // add some tags
-    Await.result(services.workspaceService.updateWorkspace(testData.wsName,
-      Seq(AddListMember(AttributeName.withTagsNS, AttributeString("cancer")),
-        AddListMember(AttributeName.withTagsNS, AttributeString("cantaloupe")))), Duration.Inf)
+    Await.result(
+      services.workspaceService.updateWorkspace(
+        testData.wsName,
+        Seq(AddListMember(AttributeName.withTagsNS, AttributeString("cancer")),
+            AddListMember(AttributeName.withTagsNS, AttributeString("cantaloupe"))
+        )
+      ),
+      Duration.Inf
+    )
 
-    Await.result(services.workspaceService.updateWorkspace(testData.wsName7,
-      Seq(
-        AddListMember(AttributeName.withTagsNS, AttributeString("cantaloupe")),
-        AddListMember(AttributeName.withTagsNS, AttributeString("buffalo")))), Duration.Inf)
+    Await.result(
+      services.workspaceService.updateWorkspace(
+        testData.wsName7,
+        Seq(AddListMember(AttributeName.withTagsNS, AttributeString("cantaloupe")),
+            AddListMember(AttributeName.withTagsNS, AttributeString("buffalo"))
+        )
+      ),
+      Duration.Inf
+    )
 
     // searching for tag that doesn't exist should return empty set
     val res2 = Await.result(services.workspaceService.getTags(Some("notag")), Duration.Inf)
@@ -950,9 +1316,14 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     }
 
     // remove tags
-    Await.result(services.workspaceService.updateWorkspace(testData.wsName, Seq(RemoveAttribute(AttributeName.withTagsNS))), Duration.Inf)
-    Await.result(services.workspaceService.updateWorkspace(testData.wsName7, Seq(RemoveAttribute(AttributeName.withTagsNS))), Duration.Inf)
-
+    Await.result(
+      services.workspaceService.updateWorkspace(testData.wsName, Seq(RemoveAttribute(AttributeName.withTagsNS))),
+      Duration.Inf
+    )
+    Await.result(
+      services.workspaceService.updateWorkspace(testData.wsName7, Seq(RemoveAttribute(AttributeName.withTagsNS))),
+      Duration.Inf
+    )
 
     // make sure that tags no longer exists
     val res8 = Await.result(services.workspaceService.getTags(Some("aNc")), Duration.Inf)
@@ -964,22 +1335,35 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
   behavior of "maybeShareProjectComputePolicy"
 
-  for ((policyName, shouldShare) <- Seq((SamWorkspacePolicyNames.writer, false), (SamWorkspacePolicyNames.canCompute, true), (SamWorkspacePolicyNames.reader, false))) {
-    it should s"${if (!shouldShare) "not " else ""}share billing compute when workspace $policyName access granted" in withTestDataServicesCustomSam { services =>
-      val email = s"${UUID.randomUUID}@bar.com"
-      val results = Set((policyName, email))
-      Await.result(services.workspaceService.maybeShareProjectComputePolicy(results, testData.workspace.toWorkspaceName), Duration.Inf)
+  for (
+    (policyName, shouldShare) <- Seq((SamWorkspacePolicyNames.writer, false),
+                                     (SamWorkspacePolicyNames.canCompute, true),
+                                     (SamWorkspacePolicyNames.reader, false)
+    )
+  )
+    it should s"${if (!shouldShare) "not " else ""}share billing compute when workspace $policyName access granted" in withTestDataServicesCustomSam {
+      services =>
+        val email = s"${UUID.randomUUID}@bar.com"
+        val results = Set((policyName, email))
+        Await.result(
+          services.workspaceService.maybeShareProjectComputePolicy(results, testData.workspace.toWorkspaceName),
+          Duration.Inf
+        )
 
-      val expectedPolicyEntry = (SamResourceTypeNames.billingProject, testData.workspace.namespace, SamBillingProjectPolicyNames.canComputeUser, email)
-      if(shouldShare) {
-        services.samDAO.callsToAddToPolicy should contain theSameElementsAs(Set(expectedPolicyEntry))
-      } else {
-        services.samDAO.callsToAddToPolicy should contain theSameElementsAs(Set.empty)
-      }
+        val expectedPolicyEntry = (SamResourceTypeNames.billingProject,
+                                   testData.workspace.namespace,
+                                   SamBillingProjectPolicyNames.canComputeUser,
+                                   email
+        )
+        if (shouldShare) {
+          services.samDAO.callsToAddToPolicy should contain theSameElementsAs (Set(expectedPolicyEntry))
+        } else {
+          services.samDAO.callsToAddToPolicy should contain theSameElementsAs (Set.empty)
+        }
     }
-  }
 
-  val aclTestUser = UserInfo(RawlsUserEmail("acl-test-user"), OAuth2BearerToken(""), 0, RawlsUserSubjectId("acl-test-user-subject-id"))
+  val aclTestUser =
+    UserInfo(RawlsUserEmail("acl-test-user"), OAuth2BearerToken(""), 0, RawlsUserSubjectId("acl-test-user-subject-id"))
 
   def allWorkspaceAclUpdatePermutations(emailString: String): Seq[WorkspaceACLUpdate] = for {
     accessLevel <- WorkspaceAccessLevels.all
@@ -987,21 +1371,29 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     canCompute <- Set(Some(true), Some(false), None)
   } yield WorkspaceACLUpdate(emailString, accessLevel, canShare, canCompute)
 
-  def expectedPolicies(aclUpdate: WorkspaceACLUpdate): Either[StatusCode, Set[(SamResourceTypeName, SamResourcePolicyName)]] = {
+  def expectedPolicies(
+    aclUpdate: WorkspaceACLUpdate
+  ): Either[StatusCode, Set[(SamResourceTypeName, SamResourcePolicyName)]] =
     aclUpdate match {
       case WorkspaceACLUpdate(_, WorkspaceAccessLevels.ProjectOwner, _, _) => Left(StatusCodes.BadRequest)
-      case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Owner, _, _) => Right(Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.owner))
+      case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Owner, _, _) =>
+        Right(Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.owner))
 
       case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, canShare, canCompute) =>
         val canSharePolicy = canShare match {
           case None | Some(false) => Set.empty
-          case Some(true) => Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.shareWriter)
+          case Some(true)         => Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.shareWriter)
         }
         val canComputePolicy = canCompute match {
-          case None | Some(true) => Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.canCompute, SamResourceTypeNames.billingProject -> SamBillingProjectPolicyNames.canComputeUser)
+          case None | Some(true) =>
+            Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.canCompute,
+                SamResourceTypeNames.billingProject -> SamBillingProjectPolicyNames.canComputeUser
+            )
           case Some(false) => Set.empty
         }
-        Right(Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.writer) ++ canSharePolicy ++ canComputePolicy)
+        Right(
+          Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.writer) ++ canSharePolicy ++ canComputePolicy
+        )
 
       case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, canShare, canCompute) =>
         if (canCompute.contains(true)) {
@@ -1009,35 +1401,46 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
         } else {
           val canSharePolicy = canShare match {
             case None | Some(false) => Set.empty
-            case Some(true) => Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.shareReader)
+            case Some(true)         => Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.shareReader)
           }
           Right(Set(SamResourceTypeNames.workspace -> SamWorkspacePolicyNames.reader) ++ canSharePolicy)
         }
 
       case WorkspaceACLUpdate(_, WorkspaceAccessLevels.NoAccess, _, _) => Right(Set.empty)
     }
-  }
 
   behavior of "aclUpdate"
 
-  for (aclUpdate <- allWorkspaceAclUpdatePermutations(aclTestUser.userEmail.value)) {
+  for (aclUpdate <- allWorkspaceAclUpdatePermutations(aclTestUser.userEmail.value))
     it should s"add correct policies for $aclUpdate" in withTestDataServicesCustomSam { services =>
       Await.result(services.samDAO.registerUser(aclTestUser), Duration.Inf)
       populateWorkspacePolicies(services)
 
       val result = Try {
-        Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, Set(aclUpdate), inviteUsersNotFound = false), Duration.Inf)
+        Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName,
+                                                         Set(aclUpdate),
+                                                         inviteUsersNotFound = false
+                     ),
+                     Duration.Inf
+        )
       }
 
       (expectedPolicies(aclUpdate), result) match {
-        case (Left(statusCode), util.Failure(exception: RawlsExceptionWithErrorReport)) => assertResult(Some(statusCode), result.toString) {
-          exception.errorReport.statusCode
-        }
+        case (Left(statusCode), util.Failure(exception: RawlsExceptionWithErrorReport)) =>
+          assertResult(Some(statusCode), result.toString) {
+            exception.errorReport.statusCode
+          }
 
         case (Right(policies), util.Success(_)) =>
           val expectedAdds = policies.map {
-            case (SamResourceTypeNames.workspace, policyName) => (SamResourceTypeNames.workspace, testData.workspace.workspaceId, policyName, aclTestUser.userEmail.value)
-            case (SamResourceTypeNames.billingProject, policyName) => (SamResourceTypeNames.billingProject, testData.workspace.namespace, policyName, aclTestUser.userEmail.value)
+            case (SamResourceTypeNames.workspace, policyName) =>
+              (SamResourceTypeNames.workspace, testData.workspace.workspaceId, policyName, aclTestUser.userEmail.value)
+            case (SamResourceTypeNames.billingProject, policyName) =>
+              (SamResourceTypeNames.billingProject,
+               testData.workspace.namespace,
+               policyName,
+               aclTestUser.userEmail.value
+              )
             case _ => throw new Exception("make the compiler happy")
           }
 
@@ -1049,7 +1452,6 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
         case (_, r) => fail(r.toString)
       }
     }
-  }
 
   it should s"add correct policies for group" in withTestDataServicesCustomSam { services =>
     // setting the email to None is what a group looks like
@@ -1058,13 +1460,30 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
     val aclUpdate = WorkspaceACLUpdate(aclTestUser.userEmail.value, WorkspaceAccessLevels.Write)
 
-    val result = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, Set(aclUpdate), inviteUsersNotFound = false), Duration.Inf)
+    val result = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName,
+                                                                  Set(aclUpdate),
+                                                                  inviteUsersNotFound = false
+                              ),
+                              Duration.Inf
+    )
 
     withClue(result.toString) {
       services.samDAO.callsToAddToPolicy should contain theSameElementsAs Set(
-        (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.writer, aclTestUser.userEmail.value),
-        (SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCompute, aclTestUser.userEmail.value),
-        (SamResourceTypeNames.billingProject, testData.workspace.namespace, SamBillingProjectPolicyNames.canComputeUser, aclTestUser.userEmail.value)
+        (SamResourceTypeNames.workspace,
+         testData.workspace.workspaceId,
+         SamWorkspacePolicyNames.writer,
+         aclTestUser.userEmail.value
+        ),
+        (SamResourceTypeNames.workspace,
+         testData.workspace.workspaceId,
+         SamWorkspacePolicyNames.canCompute,
+         aclTestUser.userEmail.value
+        ),
+        (SamResourceTypeNames.billingProject,
+         testData.workspace.namespace,
+         SamBillingProjectPolicyNames.canComputeUser,
+         aclTestUser.userEmail.value
+        )
       )
       services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Set.empty
     }
@@ -1075,24 +1494,50 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     Await.result(services.samDAO.registerUser(aclTestUser), Duration.Inf)
 
     val aclUpdate = WorkspaceACLUpdate(aclTestUser.userEmail.value, WorkspaceAccessLevels.Write)
-    Await.result(services.samDAO.overwritePolicy(SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamWorkspacePolicyNames.canCatalog, SamPolicy(Set(WorkbenchEmail(aclUpdate.email)), Set.empty, Set(SamWorkspaceRoles.canCatalog)), userInfo), Duration.Inf)
-    val result = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, Set(aclUpdate), inviteUsersNotFound = false), Duration.Inf)
+    Await.result(
+      services.samDAO.overwritePolicy(
+        SamResourceTypeNames.workspace,
+        testData.workspace.workspaceId,
+        SamWorkspacePolicyNames.canCatalog,
+        SamPolicy(Set(WorkbenchEmail(aclUpdate.email)), Set.empty, Set(SamWorkspaceRoles.canCatalog)),
+        userInfo
+      ),
+      Duration.Inf
+    )
+    val result = Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName,
+                                                                  Set(aclUpdate),
+                                                                  inviteUsersNotFound = false
+                              ),
+                              Duration.Inf
+    )
 
     withClue(result.toString) {
       services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Set.empty
     }
   }
 
-
   def addEmailToPolicy(services: TestApiServiceWithCustomSamDAO, policyName: SamResourcePolicyName, email: String) = {
     val policy = services.samDAO.policies((SamResourceTypeNames.workspace, testData.workspace.workspaceId))(policyName)
     val updateMembers = policy.policy.memberEmails + WorkbenchEmail(email)
     val updatedPolicy = policy.copy(policy = policy.policy.copy(memberEmails = updateMembers))
-    services.samDAO.policies((SamResourceTypeNames.workspace, testData.workspace.workspaceId)).put(policyName, updatedPolicy)
+    services.samDAO
+      .policies((SamResourceTypeNames.workspace, testData.workspace.workspaceId))
+      .put(policyName, updatedPolicy)
   }
 
-  val testPolicyNames = Set(SamWorkspacePolicyNames.canCompute, SamWorkspacePolicyNames.writer, SamWorkspacePolicyNames.reader, SamWorkspacePolicyNames.owner, SamWorkspacePolicyNames.projectOwner, SamWorkspacePolicyNames.shareReader, SamWorkspacePolicyNames.shareWriter)
-  for(testPolicyName1 <- testPolicyNames; testPolicyName2 <- testPolicyNames if testPolicyName1 != testPolicyName2 && !(testPolicyName1 == SamWorkspacePolicyNames.shareReader && testPolicyName2 == SamWorkspacePolicyNames.shareWriter) && !(testPolicyName1 == SamWorkspacePolicyNames.shareWriter && testPolicyName2 == SamWorkspacePolicyNames.shareReader)) {
+  val testPolicyNames = Set(
+    SamWorkspacePolicyNames.canCompute,
+    SamWorkspacePolicyNames.writer,
+    SamWorkspacePolicyNames.reader,
+    SamWorkspacePolicyNames.owner,
+    SamWorkspacePolicyNames.projectOwner,
+    SamWorkspacePolicyNames.shareReader,
+    SamWorkspacePolicyNames.shareWriter
+  )
+  for (
+    testPolicyName1 <- testPolicyNames; testPolicyName2 <- testPolicyNames
+    if testPolicyName1 != testPolicyName2 && !(testPolicyName1 == SamWorkspacePolicyNames.shareReader && testPolicyName2 == SamWorkspacePolicyNames.shareWriter) && !(testPolicyName1 == SamWorkspacePolicyNames.shareWriter && testPolicyName2 == SamWorkspacePolicyNames.shareReader)
+  )
     it should s"remove $testPolicyName1 and $testPolicyName2" in withTestDataServicesCustomSam { services =>
       Await.result(services.samDAO.registerUser(aclTestUser), Duration.Inf)
       populateWorkspacePolicies(services)
@@ -1101,10 +1546,19 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       addEmailToPolicy(services, testPolicyName2, aclTestUser.userEmail.value)
 
       val result = Try {
-        Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, Set(WorkspaceACLUpdate(aclTestUser.userEmail.value, WorkspaceAccessLevels.NoAccess)), inviteUsersNotFound = false), Duration.Inf)
+        Await.result(
+          services.workspaceService.updateACL(
+            testData.workspace.toWorkspaceName,
+            Set(WorkspaceACLUpdate(aclTestUser.userEmail.value, WorkspaceAccessLevels.NoAccess)),
+            inviteUsersNotFound = false
+          ),
+          Duration.Inf
+        )
       }
 
-      if (testPolicyName1 == SamWorkspacePolicyNames.projectOwner || testPolicyName2 == SamWorkspacePolicyNames.projectOwner) {
+      if (
+        testPolicyName1 == SamWorkspacePolicyNames.projectOwner || testPolicyName2 == SamWorkspacePolicyNames.projectOwner
+      ) {
         val error = intercept[RawlsExceptionWithErrorReport] {
           result.get
         }
@@ -1114,16 +1568,26 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       } else {
         assert(result.isSuccess, result.toString)
         services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Set(
-          (SamResourceTypeNames.workspace, testData.workspace.workspaceId, testPolicyName1, aclTestUser.userEmail.value),
+          (SamResourceTypeNames.workspace,
+           testData.workspace.workspaceId,
+           testPolicyName1,
+           aclTestUser.userEmail.value
+          ),
           (SamResourceTypeNames.workspace, testData.workspace.workspaceId, testPolicyName2, aclTestUser.userEmail.value)
         )
         services.samDAO.callsToAddToPolicy should contain theSameElementsAs Set.empty
       }
 
     }
-  }
 
-  for(testPolicyName <- Set(SamWorkspacePolicyNames.writer, SamWorkspacePolicyNames.reader, SamWorkspacePolicyNames.owner); aclUpdate <- Set(WorkspaceAccessLevels.Read ,WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Owner).map(l => WorkspaceACLUpdate(aclTestUser.userEmail.value, l, canCompute = Some(false)))) {
+  for (
+    testPolicyName <- Set(SamWorkspacePolicyNames.writer,
+                          SamWorkspacePolicyNames.reader,
+                          SamWorkspacePolicyNames.owner
+    );
+    aclUpdate <- Set(WorkspaceAccessLevels.Read, WorkspaceAccessLevels.Write, WorkspaceAccessLevels.Owner)
+      .map(l => WorkspaceACLUpdate(aclTestUser.userEmail.value, l, canCompute = Some(false)))
+  )
     it should s"change $testPolicyName to $aclUpdate" in withTestDataServicesCustomSam { services =>
       Await.result(services.samDAO.registerUser(aclTestUser), Duration.Inf)
       populateWorkspacePolicies(services)
@@ -1131,7 +1595,12 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       addEmailToPolicy(services, testPolicyName, aclTestUser.userEmail.value)
 
       val result = Try {
-        Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, Set(aclUpdate), inviteUsersNotFound = false), Duration.Inf)
+        Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName,
+                                                         Set(aclUpdate),
+                                                         inviteUsersNotFound = false
+                     ),
+                     Duration.Inf
+        )
       }
 
       assert(result.isSuccess, result.toString)
@@ -1140,56 +1609,63 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
         services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Set.empty
         services.samDAO.callsToAddToPolicy should contain theSameElementsAs Set.empty
       } else {
-        services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Set((SamResourceTypeNames.workspace, testData.workspace.workspaceId, testPolicyName, aclTestUser.userEmail.value))
-        services.samDAO.callsToAddToPolicy should contain theSameElementsAs Set((SamResourceTypeNames.workspace, testData.workspace.workspaceId, SamResourcePolicyName(aclUpdate.accessLevel.toPolicyName.get), aclTestUser.userEmail.value))
+        services.samDAO.callsToRemoveFromPolicy should contain theSameElementsAs Set(
+          (SamResourceTypeNames.workspace, testData.workspace.workspaceId, testPolicyName, aclTestUser.userEmail.value)
+        )
+        services.samDAO.callsToAddToPolicy should contain theSameElementsAs Set(
+          (SamResourceTypeNames.workspace,
+           testData.workspace.workspaceId,
+           SamResourcePolicyName(aclUpdate.accessLevel.toPolicyName.get),
+           aclTestUser.userEmail.value
+          )
+        )
       }
     }
-  }
-
 
   "extractOperationIdsFromCromwellMetadata" should "parse workflow metadata" in {
-    val jsonString = """{
-                       |  "calls": {
-                       |    "hello_and_goodbye.goodbye": [
-                       |      {
-                       |        "attempt": 1,
-                       |        "backendLogs": {
-                       |          "log": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-goodbye/goodbye.log"
-                       |        },
-                       |        "backendStatus": "Success",
-                       |        "end": "2019-04-24T13:57:48.998Z",
-                       |        "executionStatus": "Done",
-                       |        "jobId": "operations/EN2siP2kLRinu-Wt-4-bqRQgw8Sszq0dKg9wcm9kdWN0aW9uUXVldWU",
-                       |        "shardIndex": -1,
-                       |        "start": "2019-04-24T13:56:22.387Z",
-                       |        "stderr": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-goodbye/goodbye-stderr.log",
-                       |        "stdout": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-goodbye/goodbye-stdout.log"
-                       |      }
-                       |    ],
-                       |    "hello_and_goodbye.hello": [
-                       |      {
-                       |        "attempt": 1,
-                       |        "backendLogs": {
-                       |          "log": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-hello/hello.log"
-                       |        },
-                       |        "backendStatus": "Success",
-                       |        "end": "2019-04-24T13:58:21.978Z",
-                       |        "executionStatus": "Done",
-                       |        "jobId": "operations/EKCsiP2kLRiu0qj_qdLFq8wBIMPErM6tHSoPcHJvZHVjdGlvblF1ZXVl",
-                       |        "shardIndex": -1,
-                       |        "start": "2019-04-24T13:56:22.387Z",
-                       |        "stderr": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-hello/hello-stderr.log",
-                       |        "stdout": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-hello/hello-stdout.log"
-                       |      }
-                       |    ]
-                       |  },
-                       |  "end": "2019-04-24T13:58:23.868Z",
-                       |  "id": "0d6768b7-73b3-41c4-b292-de743657c5db",
-                       |  "start": "2019-04-24T13:56:20.348Z",
-                       |  "status": "Succeeded",
-                       |  "workflowName": "sub.hello_and_goodbye",
-                       |  "workflowRoot": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/"
-                       |}""".stripMargin
+    val jsonString =
+      """{
+        |  "calls": {
+        |    "hello_and_goodbye.goodbye": [
+        |      {
+        |        "attempt": 1,
+        |        "backendLogs": {
+        |          "log": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-goodbye/goodbye.log"
+        |        },
+        |        "backendStatus": "Success",
+        |        "end": "2019-04-24T13:57:48.998Z",
+        |        "executionStatus": "Done",
+        |        "jobId": "operations/EN2siP2kLRinu-Wt-4-bqRQgw8Sszq0dKg9wcm9kdWN0aW9uUXVldWU",
+        |        "shardIndex": -1,
+        |        "start": "2019-04-24T13:56:22.387Z",
+        |        "stderr": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-goodbye/goodbye-stderr.log",
+        |        "stdout": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-goodbye/goodbye-stdout.log"
+        |      }
+        |    ],
+        |    "hello_and_goodbye.hello": [
+        |      {
+        |        "attempt": 1,
+        |        "backendLogs": {
+        |          "log": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-hello/hello.log"
+        |        },
+        |        "backendStatus": "Success",
+        |        "end": "2019-04-24T13:58:21.978Z",
+        |        "executionStatus": "Done",
+        |        "jobId": "operations/EKCsiP2kLRiu0qj_qdLFq8wBIMPErM6tHSoPcHJvZHVjdGlvblF1ZXVl",
+        |        "shardIndex": -1,
+        |        "start": "2019-04-24T13:56:22.387Z",
+        |        "stderr": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-hello/hello-stderr.log",
+        |        "stdout": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/call-main_workflow/sub.main_workflow/1cf452d0-f18c-4945-aaf4-779402e7b2aa/call-hello_and_goodbye/sub.hello_and_goodbye/0d6768b7-73b3-41c4-b292-de743657c5db/call-hello/hello-stdout.log"
+        |      }
+        |    ]
+        |  },
+        |  "end": "2019-04-24T13:58:23.868Z",
+        |  "id": "0d6768b7-73b3-41c4-b292-de743657c5db",
+        |  "start": "2019-04-24T13:56:20.348Z",
+        |  "status": "Succeeded",
+        |  "workflowName": "sub.hello_and_goodbye",
+        |  "workflowRoot": "gs://fc-2d8ada07-750f-4db8-88ab-307099d54a31/d25c4529-c247-41e0-99fb-1b8fade199d5/most_main_workflow/ccc3fdbe-3cf4-40cf-8a01-4ae77a5d3e5f/"
+        |}""".stripMargin
 
     import spray.json._
     val metadataJson = jsonString.parseJson.asJsObject
@@ -1202,36 +1678,62 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   behavior of "getTerminalStatusDate"
 
   // test getTerminalStatusDate
-  private val workflowFinishingTomorrow = testData.submissionMixed.workflows.head.copy(statusLastChangedDate = testDate.plusDays(1))
+  private val workflowFinishingTomorrow =
+    testData.submissionMixed.workflows.head.copy(statusLastChangedDate = testDate.plusDays(1))
   private val submissionMixedDates = testData.submissionMixed.copy(
     workflows = workflowFinishingTomorrow +: testData.submissionMixed.workflows.tail
   )
   private val getTerminalStatusDateTests = Table(
     ("description", "submission", "workflowId", "expectedOutput"),
     ("submission containing one completed workflow, no workflowId input",
-      testData.submissionSuccessful1, None, Option(testDate)),
+     testData.submissionSuccessful1,
+     None,
+     Option(testDate)
+    ),
     ("submission containing one completed workflow, with workflowId input",
-      testData.submissionSuccessful1, testData.submissionSuccessful1.workflows.head.workflowId, Option(testDate)),
+     testData.submissionSuccessful1,
+     testData.submissionSuccessful1.workflows.head.workflowId,
+     Option(testDate)
+    ),
     ("submission containing one completed workflow, with nonexistent workflowId input",
-      testData.submissionSuccessful1, Option("thisWorkflowIdDoesNotExist"), None),
+     testData.submissionSuccessful1,
+     Option("thisWorkflowIdDoesNotExist"),
+     None
+    ),
     ("submission containing several workflows with one finishing tomorrow, no workflowId input",
-      submissionMixedDates, None, Option(testDate.plusDays(1))),
+     submissionMixedDates,
+     None,
+     Option(testDate.plusDays(1))
+    ),
     ("submission containing several workflows, with workflowId input for workflow finishing tomorrow",
-      submissionMixedDates, submissionMixedDates.workflows.head.workflowId, Option(testDate.plusDays(1))),
+     submissionMixedDates,
+     submissionMixedDates.workflows.head.workflowId,
+     Option(testDate.plusDays(1))
+    ),
     ("submission containing several workflows, with workflowId input for workflow finishing today",
-      submissionMixedDates, submissionMixedDates.workflows(2).workflowId, Option(testDate)),
+     submissionMixedDates,
+     submissionMixedDates.workflows(2).workflowId,
+     Option(testDate)
+    ),
     ("submission containing several workflows, with workflowId input for workflow not finished",
-      submissionMixedDates, submissionMixedDates.workflows.last.workflowId, None),
-    ("aborted submission, no workflowId input",
-      testData.submissionAborted1, None, Option(testDate)),
+     submissionMixedDates,
+     submissionMixedDates.workflows.last.workflowId,
+     None
+    ),
+    ("aborted submission, no workflowId input", testData.submissionAborted1, None, Option(testDate)),
     ("aborted submission, with workflowId input",
-      testData.submissionAborted1, testData.submissionAborted1.workflows.head.workflowId, Option(testDate)),
-    ("in progress submission, no workflowId input",
-      testData.submissionSubmitted, None, None),
+     testData.submissionAborted1,
+     testData.submissionAborted1.workflows.head.workflowId,
+     Option(testDate)
+    ),
+    ("in progress submission, no workflowId input", testData.submissionSubmitted, None, None),
     ("in progress submission, with workflowId input",
-      testData.submissionSubmitted, testData.submissionSubmitted.workflows.head.workflowId, None),
+     testData.submissionSubmitted,
+     testData.submissionSubmitted.workflows.head.workflowId,
+     None
+    )
   )
-  forAll(getTerminalStatusDateTests) {(description, submission, workflowId, expectedOutput) =>
+  forAll(getTerminalStatusDateTests) { (description, submission, workflowId, expectedOutput) =>
     it should s"run getTerminalStatusDate test for $description" in {
       assertResult(WorkspaceService.getTerminalStatusDate(submission, workflowId))(expectedOutput)
     }
@@ -1241,17 +1743,41 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
   it should "return Unit when adding linked service accounts to workspace" in withTestDataServices { services =>
     withWorkspaceContext(testData.workspace) { ctx =>
-      val rqComplete = Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName), Duration.Inf)
+      val rqComplete =
+        Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName),
+                     Duration.Inf
+        )
       assertResult(()) {
         rqComplete
       }
     }
   }
 
-  it should "return a 404 ErrorReport when adding linked service accounts to workspace which does not exist" in withTestDataServices { services =>
+  it should "return a 404 ErrorReport when adding linked service accounts to workspace which does not exist" in withTestDataServices {
+    services =>
+      withWorkspaceContext(testData.workspace) { ctx =>
+        val error = intercept[RawlsExceptionWithErrorReport] {
+          Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(
+                         testData.workspace.toWorkspaceName.copy(name = "DNE")
+                       ),
+                       Duration.Inf
+          )
+        }
+        assertResult(Some(StatusCodes.NotFound)) {
+          error.errorReport.statusCode
+        }
+      }
+  }
+
+  it should "return a 404 ErrorReport when adding linked service accounts to workspace with no access" in withTestDataServicesCustomSamAndUser(
+    RawlsUser(RawlsUserSubjectId("no-access"), RawlsUserEmail("no-access"))
+  ) { services =>
+    populateWorkspacePolicies(services)
     withWorkspaceContext(testData.workspace) { ctx =>
       val error = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName.copy(name = "DNE")), Duration.Inf)
+        Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName),
+                     Duration.Inf
+        )
       }
       assertResult(Some(StatusCodes.NotFound)) {
         error.errorReport.statusCode
@@ -1259,23 +1785,15 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     }
   }
 
-  it should "return a 404 ErrorReport when adding linked service accounts to workspace with no access" in withTestDataServicesCustomSamAndUser(RawlsUser(RawlsUserSubjectId("no-access"), RawlsUserEmail("no-access"))) { services =>
+  it should "return a 403 Error Report when adding add linked service accounts to workspace with read access" in withTestDataServicesCustomSamAndUser(
+    testData.userReader
+  ) { services =>
     populateWorkspacePolicies(services)
     withWorkspaceContext(testData.workspace) { ctx =>
       val error = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName), Duration.Inf)
-      }
-      assertResult(Some(StatusCodes.NotFound)) {
-        error.errorReport.statusCode
-      }
-    }
-  }
-
-  it should "return a 403 Error Report when adding add linked service accounts to workspace with read access" in withTestDataServicesCustomSamAndUser(testData.userReader) { services =>
-    populateWorkspacePolicies(services)
-    withWorkspaceContext(testData.workspace) { ctx =>
-      val error = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName), Duration.Inf)
+        Await.result(services.workspaceService.enableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName),
+                     Duration.Inf
+        )
       }
       assertResult(Some(StatusCodes.Forbidden)) {
         error.errorReport.statusCode
@@ -1285,36 +1803,54 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
 
   it should "return Unit when removing linked service accounts from workspace" in withTestDataServices { services =>
     withWorkspaceContext(testData.workspace) { ctx =>
-      val rqComplete = Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName), Duration.Inf)
+      val rqComplete =
+        Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName),
+                     Duration.Inf
+        )
       assertResult(()) {
         rqComplete
       }
     }
   }
 
-  it should "return Unit when removing linked service accounts from workspace which does not exist" in withTestDataServices { services =>
-    withWorkspaceContext(testData.workspace) { ctx =>
-      val rqComplete = Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName.copy(name = "DNE")), Duration.Inf)
-      assertResult(()) {
-        rqComplete
+  it should "return Unit when removing linked service accounts from workspace which does not exist" in withTestDataServices {
+    services =>
+      withWorkspaceContext(testData.workspace) { ctx =>
+        val rqComplete = Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(
+                                        testData.workspace.toWorkspaceName.copy(name = "DNE")
+                                      ),
+                                      Duration.Inf
+        )
+        assertResult(()) {
+          rqComplete
+        }
       }
-    }
   }
 
-  it should "return Unit when removing linked service accounts from workspace with no access" in withTestDataServicesCustomSamAndUser(RawlsUser(RawlsUserSubjectId("no-access"), RawlsUserEmail("no-access"))) { services =>
+  it should "return Unit when removing linked service accounts from workspace with no access" in withTestDataServicesCustomSamAndUser(
+    RawlsUser(RawlsUserSubjectId("no-access"), RawlsUserEmail("no-access"))
+  ) { services =>
     populateWorkspacePolicies(services)
     withWorkspaceContext(testData.workspace) { ctx =>
-      val rqComplete = Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName), Duration.Inf)
+      val rqComplete =
+        Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName),
+                     Duration.Inf
+        )
       assertResult(()) {
         rqComplete
       }
     }
   }
 
-  it should "return Unit when removing linked service accounts from workspace with read access" in withTestDataServicesCustomSamAndUser(testData.userReader) { services =>
+  it should "return Unit when removing linked service accounts from workspace with read access" in withTestDataServicesCustomSamAndUser(
+    testData.userReader
+  ) { services =>
     populateWorkspacePolicies(services)
     withWorkspaceContext(testData.workspace) { ctx =>
-      val rqComplete = Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName), Duration.Inf)
+      val rqComplete =
+        Await.result(services.workspaceService.disableRequesterPaysForLinkedSAs(testData.workspace.toWorkspaceName),
+                     Duration.Inf
+        )
       assertResult(()) {
         rqComplete
       }
@@ -1356,8 +1892,10 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
       }
 
       val isPendingMigration = Await.result(services.slickDataSource.inTransaction { dataAccess =>
-        workspaces.traverse(dataAccess.workspaceMigrationQuery.isPendingMigration)
-      }, 30.seconds)
+                                              workspaces.traverse(dataAccess.workspaceMigrationQuery.isPendingMigration)
+                                            },
+                                            30.seconds
+      )
 
       every(isPendingMigration) shouldBe false
     }
@@ -1410,7 +1948,11 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "fail with 400 when the BillingProject is not Ready" in withTestDataServices { services =>
     (CreationStatuses.all - CreationStatuses.Ready).foreach { projectStatus =>
       // Update the BillingProject with the CreationStatus under test
-      runAndWait(slickDataSource.dataAccess.rawlsBillingProjectQuery.updateCreationStatus(testData.testProject1.projectName, projectStatus))
+      runAndWait(
+        slickDataSource.dataAccess.rawlsBillingProjectQuery.updateCreationStatus(testData.testProject1.projectName,
+                                                                                 projectStatus
+        )
+      )
 
       // Create a Workspace in the BillingProject
       val error = intercept[RawlsExceptionWithErrorReport] {
@@ -1433,117 +1975,134 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     error.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
   }
 
-  it should "fail with 500 if Billing Project does not have a Billing Account specified" in withTestDataServices { services =>
-    // Update BillingProject to wipe BillingAccount field.  Reload BillingProject and confirm that field is empty
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(testData.testProject1.projectName, billingAccount = None, testData.userOwner.userSubjectId)
-        updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
-      } yield updatedBillingProject.value.billingAccount shouldBe empty
-    }
-
-    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "banana_palooza", Map.empty)
-    val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    }
-    error.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
-  }
-
-  it should "fail with 403 and set the invalidBillingAcct field if Rawls does not have the required IAM permissions on the Google Billing Account" in withTestDataServices { services =>
-    // Preconditions: setup the BillingProject to have the BillingAccountName that will "fail" the permissions check in
-    // the MockGoogleServicesDAO.  Then confirm that the BillingProject.invalidBillingAccount field starts as FALSE
-
-    val billingAccountName = services.gcsDAO.inaccessibleBillingAccountName
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(testData.testProject1.projectName, billingAccountName.some, testData.userOwner.userSubjectId)
-        updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
-      } yield {
-        updatedBillingProject.value.billingAccount shouldBe defined
-        updatedBillingProject.value.invalidBillingAccount shouldBe false
+  it should "fail with 500 if Billing Project does not have a Billing Account specified" in withTestDataServices {
+    services =>
+      // Update BillingProject to wipe BillingAccount field.  Reload BillingProject and confirm that field is empty
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(
+            testData.testProject1.projectName,
+            billingAccount = None,
+            testData.userOwner.userSubjectId
+          )
+          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
+        } yield updatedBillingProject.value.billingAccount shouldBe empty
       }
-    }
 
-    // Make the call to createWorkspace and make sure it throws an exception with the correct StatusCode
-    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "whatever", Map.empty)
-    val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "banana_palooza", Map.empty)
+      val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      }
+      error.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
+  }
+
+  it should "fail with 403 and set the invalidBillingAcct field if Rawls does not have the required IAM permissions on the Google Billing Account" in withTestDataServices {
+    services =>
+      // Preconditions: setup the BillingProject to have the BillingAccountName that will "fail" the permissions check in
+      // the MockGoogleServicesDAO.  Then confirm that the BillingProject.invalidBillingAccount field starts as FALSE
+
+      val billingAccountName = services.gcsDAO.inaccessibleBillingAccountName
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(
+            testData.testProject1.projectName,
+            billingAccountName.some,
+            testData.userOwner.userSubjectId
+          )
+          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
+        } yield {
+          updatedBillingProject.value.billingAccount shouldBe defined
+          updatedBillingProject.value.invalidBillingAccount shouldBe false
+        }
+      }
+
+      // Make the call to createWorkspace and make sure it throws an exception with the correct StatusCode
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "whatever", Map.empty)
+      val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      }
+      error.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+
+      // Make sure that the BillingProject.invalidBillingAccount field was properly updated while attempting to create the
+      // Workspace
+      val persistedBillingProject =
+        runAndWait(slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name))
+      persistedBillingProject.value.invalidBillingAccount shouldBe true
+  }
+
+  it should "fail with 502 if Rawls is unable to retrieve the Google Project Number from Google for Workspace's Google Project" in withTestDataServices {
+    services =>
+      when(services.gcsDAO.getGoogleProject(any[GoogleProjectId]))
+        .thenReturn(Future.successful(new Project().setProjectNumber(null)))
+
+      val workspaceName = WorkspaceName(testData.testProject1Name.value, "whatever")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
+
+      val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      }
+
+      error.errorReport.statusCode shouldBe Some(StatusCodes.BadGateway)
+
+      val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
+      maybeWorkspace shouldBe None
+  }
+
+  it should "set the Billing Account on the Workspace's Google Project to match the Billing Project's Billing Account" in withTestDataServices {
+    services =>
+      val billingProject = testData.testProject1
+      val workspaceName = WorkspaceName(billingProject.projectName.value, "cool_workspace")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
+
       Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    }
-    error.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
 
-    // Make sure that the BillingProject.invalidBillingAccount field was properly updated while attempting to create the
-    // Workspace
-    val persistedBillingProject = runAndWait(slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name))
-    persistedBillingProject.value.invalidBillingAccount shouldBe true
-  }
-
-  it should "fail with 502 if Rawls is unable to retrieve the Google Project Number from Google for Workspace's Google Project" in withTestDataServices { services =>
-    when(services.gcsDAO.getGoogleProject(any[GoogleProjectId])).thenReturn(Future.successful(new Project().setProjectNumber(null)))
-
-    val workspaceName = WorkspaceName(testData.testProject1Name.value, "whatever")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
-
-    val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    }
-
-    error.errorReport.statusCode shouldBe Some(StatusCodes.BadGateway)
-
-    val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
-    maybeWorkspace shouldBe None
-  }
-
-  it should "set the Billing Account on the Workspace's Google Project to match the Billing Project's Billing Account" in withTestDataServices { services =>
-    val billingProject = testData.testProject1
-    val workspaceName = WorkspaceName(billingProject.projectName.value, "cool_workspace")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
-
-    Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-
-    // Project ID gets allocated when creating the Workspace, so we don't care what it is here.  We do care that
-    // whatever that Google Project is, we set the right Billing Account on it, which is the Billing Account specified
-    // in the Billing Project.  Additionally, only when creating a new Workspace, we can `force` the update (and ignore
-    // the "oldBillingAccount" value
-    verify(services.gcsDAO).setBillingAccountName(
-      any[GoogleProjectId],
-      ArgumentMatchers.eq(billingProject.billingAccount.get),
-      any[OpenCensusSpan]
-    )
-  }
-
-  it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>
-    doReturn(Future.failed(new Exception("failed")), null)
-      .when(services.gcsDAO)
-      .setBillingAccountName(
-        ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
-        ArgumentMatchers.eq(RawlsBillingAccountName("fakeBillingAcct")),
+      // Project ID gets allocated when creating the Workspace, so we don't care what it is here.  We do care that
+      // whatever that Google Project is, we set the right Billing Account on it, which is the Billing Account specified
+      // in the Billing Project.  Additionally, only when creating a new Workspace, we can `force` the update (and ignore
+      // the "oldBillingAccount" value
+      verify(services.gcsDAO).setBillingAccountName(
+        any[GoogleProjectId],
+        ArgumentMatchers.eq(billingProject.billingAccount.get),
         any[OpenCensusSpan]
       )
-
-    val workspaceName = WorkspaceName(testData.testProject1Name.value, "sad_workspace")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
-
-    intercept[Exception] {
-      Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    }
-
-    val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
-    maybeWorkspace shouldBe None
   }
 
-  it should "not try to modify the Service Perimeter if the Billing Project does not specify a Service Perimeter" in withTestDataServices { services =>
-    val newWorkspaceName = "space_for_workin"
-    val billingProject = testData.testProject1
+  it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices {
+    services =>
+      doReturn(Future.failed(new Exception("failed")), null)
+        .when(services.gcsDAO)
+        .setBillingAccountName(
+          ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+          ArgumentMatchers.eq(RawlsBillingAccountName("fakeBillingAcct")),
+          any[OpenCensusSpan]
+        )
 
-    // Pre-condition: make sure that the Billing Project we're adding the Workspace to DOES NOT specify a Service
-    // Perimeter
-    billingProject.servicePerimeter shouldBe empty
+      val workspaceName = WorkspaceName(testData.testProject1Name.value, "sad_workspace")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
 
-    val workspaceRequest = WorkspaceRequest(billingProject.projectName.value, newWorkspaceName, Map.empty)
-    Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      intercept[Exception] {
+        Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      }
 
-    // Verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was NOT called
-    verify(services.googleAccessContextManagerDAO, Mockito.never()).overwriteProjectsInServicePerimeter(any[ServicePerimeterName], any[Set[String]])
+      val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
+      maybeWorkspace shouldBe None
+  }
+
+  it should "not try to modify the Service Perimeter if the Billing Project does not specify a Service Perimeter" in withTestDataServices {
+    services =>
+      val newWorkspaceName = "space_for_workin"
+      val billingProject = testData.testProject1
+
+      // Pre-condition: make sure that the Billing Project we're adding the Workspace to DOES NOT specify a Service
+      // Perimeter
+      billingProject.servicePerimeter shouldBe empty
+
+      val workspaceRequest = WorkspaceRequest(billingProject.projectName.value, newWorkspaceName, Map.empty)
+      Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+
+      // Verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was NOT called
+      verify(services.googleAccessContextManagerDAO, Mockito.never())
+        .overwriteProjectsInServicePerimeter(any[ServicePerimeterName], any[Set[String]])
   }
 
   it should "claim a Google Project from Resource Buffering Service" in withTestDataServices { services =>
@@ -1555,94 +2114,123 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     verify(services.resourceBufferService).getGoogleProjectFromBuffer(any[ProjectPoolType], any[String])
   }
 
-  it should "Update a Google Project name after claiming a project from Resource Buffering Service" in withTestDataServices { services =>
-    val newWorkspaceNamespace = "short_-NS1"
-    val newWorkspaceName = "plus Long_ name to get past 30 chars since the google-project name is truncated at 30 chars and formatted as namespace--name"
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName(newWorkspaceNamespace), CreationStatuses.Ready, Option(RawlsBillingAccountName("fakeBillingAcct")), None)
-    runAndWait(rawlsBillingProjectQuery.create(billingProject))
-    val workspaceRequest = WorkspaceRequest(newWorkspaceNamespace, newWorkspaceName, Map.empty)
-    val captor = ArgumentCaptor.forClass(classOf[Project])
+  it should "Update a Google Project name after claiming a project from Resource Buffering Service" in withTestDataServices {
+    services =>
+      val newWorkspaceNamespace = "short_-NS1"
+      val newWorkspaceName =
+        "plus Long_ name to get past 30 chars since the google-project name is truncated at 30 chars and formatted as namespace--name"
+      val billingProject = RawlsBillingProject(RawlsBillingProjectName(newWorkspaceNamespace),
+                                               CreationStatuses.Ready,
+                                               Option(RawlsBillingAccountName("fakeBillingAcct")),
+                                               None
+      )
+      runAndWait(rawlsBillingProjectQuery.create(billingProject))
+      val workspaceRequest = WorkspaceRequest(newWorkspaceNamespace, newWorkspaceName, Map.empty)
+      val captor = ArgumentCaptor.forClass(classOf[Project])
 
-    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
 
-    verify(services.gcsDAO).updateGoogleProject(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), captor.capture())
-    val capturedProject = captor.getValue.asInstanceOf[Project] // Explicit cast needed since Scala type interference and capturing parameters with Mockito don't play nicely together here
+      verify(services.gcsDAO).updateGoogleProject(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+                                                  captor.capture()
+      )
+      val capturedProject =
+        captor.getValue
+          .asInstanceOf[Project] // Explicit cast needed since Scala type interference and capturing parameters with Mockito don't play nicely together here
 
-    val expectedProjectName = "short--NS1--plus Long- name to"
-    val actualProjectName = capturedProject.getName
-    actualProjectName shouldBe expectedProjectName
+      val expectedProjectName = "short--NS1--plus Long- name to"
+      val actualProjectName = capturedProject.getName
+      actualProjectName shouldBe expectedProjectName
   }
 
-  it should "Apply labels to a Google Project after claiming a project from Resource Buffering Service" in withTestDataServices { services =>
-    val newWorkspaceNamespace = "Long_Namespace---30-char-limit"
-    val newWorkspaceName = "Plus Long_ name to get past 63 chars since the labels are truncated at 63 chars"
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName(newWorkspaceNamespace), CreationStatuses.Ready, Option(RawlsBillingAccountName("fakeBillingAcct")), None)
-    runAndWait(rawlsBillingProjectQuery.create(billingProject))
-    val workspaceRequest = WorkspaceRequest(newWorkspaceNamespace, newWorkspaceName, Map.empty)
-    val captor = ArgumentCaptor.forClass(classOf[Project])
+  it should "Apply labels to a Google Project after claiming a project from Resource Buffering Service" in withTestDataServices {
+    services =>
+      val newWorkspaceNamespace = "Long_Namespace---30-char-limit"
+      val newWorkspaceName = "Plus Long_ name to get past 63 chars since the labels are truncated at 63 chars"
+      val billingProject = RawlsBillingProject(RawlsBillingProjectName(newWorkspaceNamespace),
+                                               CreationStatuses.Ready,
+                                               Option(RawlsBillingAccountName("fakeBillingAcct")),
+                                               None
+      )
+      runAndWait(rawlsBillingProjectQuery.create(billingProject))
+      val workspaceRequest = WorkspaceRequest(newWorkspaceNamespace, newWorkspaceName, Map.empty)
+      val captor = ArgumentCaptor.forClass(classOf[Project])
 
-    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
 
-    verify(services.gcsDAO).updateGoogleProject(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")), captor.capture())
-    val capturedProject = captor.getValue.asInstanceOf[Project] // Explicit cast needed since Scala type interference and capturing parameters with Mockito don't play nicely together here
+      verify(services.gcsDAO).updateGoogleProject(ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+                                                  captor.capture()
+      )
+      val capturedProject =
+        captor.getValue
+          .asInstanceOf[Project] // Explicit cast needed since Scala type interference and capturing parameters with Mockito don't play nicely together here
 
-    val expectedNewLabels = Map("workspacenamespace" -> "long_namespace---30-char-limit",
-      "workspacename" -> "plus-long_-name-to-get-past-63-chars-since-the-labels-are-trunc",
-      "workspaceid" -> workspace.workspaceId)
-    val numberOfLabelsFromBuffer = 3
-    val expectedLabelSize = numberOfLabelsFromBuffer + expectedNewLabels.size
-    val actualLabels = capturedProject.getLabels.asScala
+      val expectedNewLabels = Map(
+        "workspacenamespace" -> "long_namespace---30-char-limit",
+        "workspacename" -> "plus-long_-name-to-get-past-63-chars-since-the-labels-are-trunc",
+        "workspaceid" -> workspace.workspaceId
+      )
+      val numberOfLabelsFromBuffer = 3
+      val expectedLabelSize = numberOfLabelsFromBuffer + expectedNewLabels.size
+      val actualLabels = capturedProject.getLabels.asScala
 
-    actualLabels.size shouldBe expectedLabelSize
-    actualLabels should contain allElementsOf expectedNewLabels
+      actualLabels.size shouldBe expectedLabelSize
+      actualLabels should contain allElementsOf expectedNewLabels
   }
 
   // There is another test in WorkspaceComponentSpec that gets into more scenarios for selecting the right Workspaces
   // that should be within a Service Perimeter
-  "creating a Workspace in a Service Perimeter" should "attempt to overwrite the correct Service Perimeter" in withTestDataServices { services =>
-    // Use the WorkspaceServiceConfig to determine which static projects exist for which perimeter
-    val servicePerimeterName: ServicePerimeterName = services.servicePerimeterServiceConfig.staticProjectsInPerimeters.keys.head
-    val staticProjectNumbersInPerimeter: Set[String] = services.servicePerimeterServiceConfig.staticProjectsInPerimeters(servicePerimeterName).map(_.value).toSet
+  "creating a Workspace in a Service Perimeter" should "attempt to overwrite the correct Service Perimeter" in withTestDataServices {
+    services =>
+      // Use the WorkspaceServiceConfig to determine which static projects exist for which perimeter
+      val servicePerimeterName: ServicePerimeterName =
+        services.servicePerimeterServiceConfig.staticProjectsInPerimeters.keys.head
+      val staticProjectNumbersInPerimeter: Set[String] =
+        services.servicePerimeterServiceConfig.staticProjectsInPerimeters(servicePerimeterName).map(_.value).toSet
 
-    val billingProject1 = testData.testProject1
-    val billingProject2 = testData.testProject2
-    val billingProjects = Seq(billingProject1, billingProject2)
-    val workspacesPerProject = 2
+      val billingProject1 = testData.testProject1
+      val billingProject2 = testData.testProject2
+      val billingProjects = Seq(billingProject1, billingProject2)
+      val workspacesPerProject = 2
 
-    // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
-    // the Billing Projects and therefore in the Perimeter
-    val workspacesInPerimeter: Seq[Workspace] = billingProjects.flatMap { bp =>
-      runAndWait {
-        for {
-          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName, servicePerimeterName.some)
-          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
-        } yield updatedBillingProject.value.servicePerimeter.value shouldBe servicePerimeterName
+      // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
+      // the Billing Projects and therefore in the Perimeter
+      val workspacesInPerimeter: Seq[Workspace] = billingProjects.flatMap { bp =>
+        runAndWait {
+          for {
+            _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName,
+                                                                                            servicePerimeterName.some
+            )
+            updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
+          } yield updatedBillingProject.value.servicePerimeter.value shouldBe servicePerimeterName
+        }
+
+        (1 to workspacesPerProject).map { n =>
+          val workspace = testData.workspace.copy(
+            namespace = bp.projectName.value,
+            name = s"${bp.projectName.value}Workspace${n}",
+            workspaceId = UUID.randomUUID().toString,
+            googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString))
+          )
+          runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace))
+        }
       }
 
-      (1 to workspacesPerProject).map { n =>
-        val workspace = testData.workspace.copy(
-          namespace = bp.projectName.value,
-          name = s"${bp.projectName.value}Workspace${n}",
-          workspaceId = UUID.randomUUID().toString,
-          googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString)))
-        runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace))
-      }
-    }
+      // Test setup is done, now we're getting to the test
+      // Make a call to Create a new Workspace in the same Billing Project
+      val workspaceName = WorkspaceName(testData.testProject1Name.value, "cool_workspace")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
+      val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
 
-    // Test setup is done, now we're getting to the test
-    // Make a call to Create a new Workspace in the same Billing Project
-    val workspaceName = WorkspaceName(testData.testProject1Name.value, "cool_workspace")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
-    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      val servicePerimeterNameCaptor = captor[ServicePerimeterName]
+      // verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was called exactly once and capture
+      // the arguments passed to it so that we can verify that they were correct
+      verify(services.servicePerimeterService).overwriteGoogleProjectsInPerimeter(servicePerimeterNameCaptor.capture,
+                                                                                  any[DataAccess]
+      )
+      servicePerimeterNameCaptor.getValue shouldBe servicePerimeterName
 
-    val servicePerimeterNameCaptor = captor[ServicePerimeterName]
-    // verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was called exactly once and capture
-    // the arguments passed to it so that we can verify that they were correct
-    verify(services.servicePerimeterService).overwriteGoogleProjectsInPerimeter(servicePerimeterNameCaptor.capture, any[DataAccess])
-    servicePerimeterNameCaptor.getValue shouldBe servicePerimeterName
-
-    // verify that we set the folder for the perimeter
-    verify(services.gcsDAO).addProjectToFolder(ArgumentMatchers.eq(workspace.googleProjectId), any[String])
+      // verify that we set the folder for the perimeter
+      verify(services.gcsDAO).addProjectToFolder(ArgumentMatchers.eq(workspace.googleProjectId), any[String])
   }
 
   "cloneWorkspace" should "create a V2 Workspace" in withTestDataServices { services =>
@@ -1650,7 +2238,10 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val newWorkspaceName = "cloned_space"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
 
-    val workspace = Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+    val workspace =
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                   Duration.Inf
+      )
 
     workspace.name should be(newWorkspaceName)
     workspace.workspaceVersion should be(WorkspaceVersions.V2)
@@ -1662,12 +2253,21 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val baseWorkspace = testData.workspace
     val newWorkspaceName = "cloned_space"
     val copyFilesWithPrefix = "copy_me"
-    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty, copyFilesWithPrefix = Option(copyFilesWithPrefix))
+    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value,
+                                            newWorkspaceName,
+                                            Map.empty,
+                                            copyFilesWithPrefix = Option(copyFilesWithPrefix)
+    )
 
-    val workspace = Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+    val workspace =
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                   Duration.Inf
+      )
 
-    eventually (timeout = timeout(Span(10, Seconds))) {
-      runAndWait(slickDataSource.dataAccess.cloneWorkspaceFileTransferQuery.listPendingTransfers()).map(_.destWorkspaceId).contains(workspace.workspaceIdAsUUID) shouldBe true
+    eventually(timeout = timeout(Span(10, Seconds))) {
+      runAndWait(slickDataSource.dataAccess.cloneWorkspaceFileTransferQuery.listPendingTransfers())
+        .map(_.destWorkspaceId)
+        .contains(workspace.workspaceIdAsUUID) shouldBe true
     }
     workspace.name should be(newWorkspaceName)
     workspace.workspaceVersion should be(WorkspaceVersions.V2)
@@ -1680,7 +2280,9 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val workspaceRequest = WorkspaceRequest("nonexistent_namespace", "kermits_pond", Map.empty)
 
     val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                   Duration.Inf
+      )
     }
 
     error.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
@@ -1690,7 +2292,11 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "fail with 400 when the BillingProject is not Ready" in withTestDataServices { services =>
     (CreationStatuses.all - CreationStatuses.Ready).foreach { projectStatus =>
       // Update the BillingProject with the CreationStatus under test
-      runAndWait(slickDataSource.dataAccess.rawlsBillingProjectQuery.updateCreationStatus(testData.testProject1.projectName, projectStatus))
+      runAndWait(
+        slickDataSource.dataAccess.rawlsBillingProjectQuery.updateCreationStatus(testData.testProject1.projectName,
+                                                                                 projectStatus
+        )
+      )
 
       // Create a Workspace in the BillingProject
       val error = intercept[RawlsExceptionWithErrorReport] {
@@ -1703,118 +2309,145 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     }
   }
 
-  it should "fail with 500 if Billing Project does not have a Billing Account specified" in withTestDataServices { services =>
-    // Update BillingProject to wipe BillingAccount field.  Reload BillingProject and confirm that field is empty
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(testData.testProject1.projectName, billingAccount = None, testData.userOwner.userSubjectId)
-        updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
-      } yield updatedBillingProject.value.billingAccount shouldBe empty
-    }
+  it should "fail with 500 if Billing Project does not have a Billing Account specified" in withTestDataServices {
+    services =>
+      // Update BillingProject to wipe BillingAccount field.  Reload BillingProject and confirm that field is empty
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(
+            testData.testProject1.projectName,
+            billingAccount = None,
+            testData.userOwner.userSubjectId
+          )
+          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
+        } yield updatedBillingProject.value.billingAccount shouldBe empty
+      }
 
-    val baseWorkspace = testData.workspace
-    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "banana_palooza", Map.empty)
-    val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
-    }
-    error.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
+      val baseWorkspace = testData.workspace
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "banana_palooza", Map.empty)
+      val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                     Duration.Inf
+        )
+      }
+      error.errorReport.statusCode shouldBe Some(StatusCodes.InternalServerError)
   }
 
-  it should "fail with 403 and set the invalidBillingAcct field if Rawls does not have the required IAM permissions on the Google Billing Account" in withTestDataServices { services =>
-    // Preconditions: setup the BillingProject to have the BillingAccountName that will "fail" the permissions check in
-    // the MockGoogleServicesDAO.  Then confirm that the BillingProject.invalidBillingAccount field starts as FALSE
-    val billingAccountName = services.gcsDAO.inaccessibleBillingAccountName
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(testData.testProject1.projectName, billingAccountName.some, testData.userOwner.userSubjectId)
-        originalBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
-      } yield originalBillingProject.value.invalidBillingAccount shouldBe false
-    }
+  it should "fail with 403 and set the invalidBillingAcct field if Rawls does not have the required IAM permissions on the Google Billing Account" in withTestDataServices {
+    services =>
+      // Preconditions: setup the BillingProject to have the BillingAccountName that will "fail" the permissions check in
+      // the MockGoogleServicesDAO.  Then confirm that the BillingProject.invalidBillingAccount field starts as FALSE
+      val billingAccountName = services.gcsDAO.inaccessibleBillingAccountName
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateBillingAccount(
+            testData.testProject1.projectName,
+            billingAccountName.some,
+            testData.userOwner.userSubjectId
+          )
+          originalBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name)
+        } yield originalBillingProject.value.invalidBillingAccount shouldBe false
+      }
 
-    // Make the call to createWorkspace and make sure it throws an exception with the correct StatusCode
-    val baseWorkspace = testData.workspace
-    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "whatever", Map.empty)
-    val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
-    }
-    error.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+      // Make the call to createWorkspace and make sure it throws an exception with the correct StatusCode
+      val baseWorkspace = testData.workspace
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, "whatever", Map.empty)
+      val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                     Duration.Inf
+        )
+      }
+      error.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
 
-    // Make sure that the BillingProject.invalidBillingAccount field was properly updated while attempting to create the
-    // Workspace
-    val persistedBillingProject = runAndWait(slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name))
-    persistedBillingProject.value.invalidBillingAccount shouldBe true
+      // Make sure that the BillingProject.invalidBillingAccount field was properly updated while attempting to create the
+      // Workspace
+      val persistedBillingProject =
+        runAndWait(slickDataSource.dataAccess.rawlsBillingProjectQuery.load(testData.testProject1Name))
+      persistedBillingProject.value.invalidBillingAccount shouldBe true
   }
 
-  it should "fail with 502 if Rawls is unable to retrieve the Google Project Number from Google for Workspace's Google Project" in withTestDataServices { services =>
-    when(services.gcsDAO.getGoogleProject(any[GoogleProjectId])).thenReturn(Future.successful(new Project().setProjectNumber(null)))
+  it should "fail with 502 if Rawls is unable to retrieve the Google Project Number from Google for Workspace's Google Project" in withTestDataServices {
+    services =>
+      when(services.gcsDAO.getGoogleProject(any[GoogleProjectId]))
+        .thenReturn(Future.successful(new Project().setProjectNumber(null)))
 
-    val workspaceName = WorkspaceName(testData.testProject1Name.value, "whatever")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
+      val workspaceName = WorkspaceName(testData.testProject1Name.value, "whatever")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
 
-    val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    }
+      val error: RawlsExceptionWithErrorReport = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+      }
 
-    error.errorReport.statusCode shouldBe Some(StatusCodes.BadGateway)
+      error.errorReport.statusCode shouldBe Some(StatusCodes.BadGateway)
 
-    val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
-    maybeWorkspace shouldBe None
+      val maybeWorkspace = runAndWait(workspaceQuery.findByName(workspaceName))
+      maybeWorkspace shouldBe None
   }
 
-  it should "set the Billing Account on the Workspace's Google Project to match the Billing Project's Billing Account" in withTestDataServices { services =>
-    val destBillingProject = testData.testProject1
-    val destWorkspaceName = WorkspaceName(destBillingProject.projectName.value, "cool_workspace")
-    val workspaceRequest = WorkspaceRequest(destWorkspaceName.namespace, destWorkspaceName.name, Map.empty)
+  it should "set the Billing Account on the Workspace's Google Project to match the Billing Project's Billing Account" in withTestDataServices {
+    services =>
+      val destBillingProject = testData.testProject1
+      val destWorkspaceName = WorkspaceName(destBillingProject.projectName.value, "cool_workspace")
+      val workspaceRequest = WorkspaceRequest(destWorkspaceName.namespace, destWorkspaceName.name, Map.empty)
 
-    val baseWorkspace = testData.workspace
-    Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
-
-    // Project ID gets allocated when creating the Workspace, so we don't care what it is here.  We do care that
-    // we set the right Billing Account on it, which is the Billing Account specified by the Billing Project in the
-    // clone Workspace Request
-    verify(services.gcsDAO, times(1)).setBillingAccountName(
-      any[GoogleProjectId],
-      ArgumentMatchers.eq(destBillingProject.billingAccount.get),
-      any[OpenCensusSpan]
-    )
-  }
-
-  it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices { services =>
-    val baseWorkspace = testData.workspace
-    val destBillingProject = testData.testProject1
-    val clonedWorkspaceName = WorkspaceName(destBillingProject.projectName.value, "sad_workspace")
-    val cloneWorkspaceRequest = WorkspaceRequest(clonedWorkspaceName.namespace, clonedWorkspaceName.name, Map.empty)
-
-    doReturn(Future.failed(new Exception("Fake error from Google")), null)
-      .when(services.gcsDAO)
-      .setBillingAccountName(
-        ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
-        ArgumentMatchers.eq(RawlsBillingAccountName("fakeBillingAcct")),
-        any[OpenCensusSpan]
+      val baseWorkspace = testData.workspace
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                   Duration.Inf
       )
 
-    intercept[Exception] {
-      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, cloneWorkspaceRequest), Duration.Inf)
-    }
-
-    val maybeWorkspace = runAndWait(workspaceQuery.findByName(clonedWorkspaceName))
-    maybeWorkspace shouldBe None
+      // Project ID gets allocated when creating the Workspace, so we don't care what it is here.  We do care that
+      // we set the right Billing Account on it, which is the Billing Account specified by the Billing Project in the
+      // clone Workspace Request
+      verify(services.gcsDAO, times(1)).setBillingAccountName(
+        any[GoogleProjectId],
+        ArgumentMatchers.eq(destBillingProject.billingAccount.get),
+        any[OpenCensusSpan]
+      )
   }
 
-  it should "not try to modify the Service Perimeter if the Billing Project does not specify a Service Perimeter" in withTestDataServices { services =>
-    val baseWorkspace = testData.workspace
-    val newWorkspaceName = "space_for_workin"
-    val billingProject = testData.testProject1
+  it should "fail to create a database object when GoogleServicesDAO throws an exception when updating billing account" in withTestDataServices {
+    services =>
+      val baseWorkspace = testData.workspace
+      val destBillingProject = testData.testProject1
+      val clonedWorkspaceName = WorkspaceName(destBillingProject.projectName.value, "sad_workspace")
+      val cloneWorkspaceRequest = WorkspaceRequest(clonedWorkspaceName.namespace, clonedWorkspaceName.name, Map.empty)
 
-    // Pre-condition: make sure that the Billing Project we're adding the Workspace to DOES NOT specify a Service
-    // Perimeter
-    billingProject.servicePerimeter shouldBe empty
+      doReturn(Future.failed(new Exception("Fake error from Google")), null)
+        .when(services.gcsDAO)
+        .setBillingAccountName(
+          ArgumentMatchers.eq(GoogleProjectId("project-from-buffer")),
+          ArgumentMatchers.eq(RawlsBillingAccountName("fakeBillingAcct")),
+          any[OpenCensusSpan]
+        )
 
-    val workspaceRequest = WorkspaceRequest(billingProject.projectName.value, newWorkspaceName, Map.empty)
-    Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+      intercept[Exception] {
+        Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, cloneWorkspaceRequest),
+                     Duration.Inf
+        )
+      }
 
-    // Verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was NOT called
-    verify(services.googleAccessContextManagerDAO, Mockito.never()).overwriteProjectsInServicePerimeter(any[ServicePerimeterName], any[Set[String]])
+      val maybeWorkspace = runAndWait(workspaceQuery.findByName(clonedWorkspaceName))
+      maybeWorkspace shouldBe None
+  }
+
+  it should "not try to modify the Service Perimeter if the Billing Project does not specify a Service Perimeter" in withTestDataServices {
+    services =>
+      val baseWorkspace = testData.workspace
+      val newWorkspaceName = "space_for_workin"
+      val billingProject = testData.testProject1
+
+      // Pre-condition: make sure that the Billing Project we're adding the Workspace to DOES NOT specify a Service
+      // Perimeter
+      billingProject.servicePerimeter shouldBe empty
+
+      val workspaceRequest = WorkspaceRequest(billingProject.projectName.value, newWorkspaceName, Map.empty)
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                   Duration.Inf
+      )
+
+      // Verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was NOT called
+      verify(services.googleAccessContextManagerDAO, Mockito.never())
+        .overwriteProjectsInServicePerimeter(any[ServicePerimeterName], any[Set[String]])
   }
 
   it should "claim a Google Project from Resource Buffering Service" in withTestDataServices { services =>
@@ -1822,73 +2455,111 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     val newWorkspaceName = "cloned_space"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
 
-    val workspace = Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+    val workspace =
+      Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                   Duration.Inf
+      )
 
     verify(services.resourceBufferService).getGoogleProjectFromBuffer(any[ProjectPoolType], any[String])
   }
 
   // There is another test in WorkspaceComponentSpec that gets into more scenarios for selecting the right Workspaces
   // that should be within a Service Perimeter
-  "cloning a Workspace into a Service Perimeter" should "attempt to overwrite the correct Service Perimeter" in withTestDataServices { services =>
-    // Use the WorkspaceServiceConfig to determine which static projects exist for which perimeter
-    val servicePerimeterName: ServicePerimeterName = services.servicePerimeterServiceConfig.staticProjectsInPerimeters.keys.head
-    val staticProjectNumbersInPerimeter: Set[String] = services.servicePerimeterServiceConfig.staticProjectsInPerimeters(servicePerimeterName).map(_.value).toSet
+  "cloning a Workspace into a Service Perimeter" should "attempt to overwrite the correct Service Perimeter" in withTestDataServices {
+    services =>
+      // Use the WorkspaceServiceConfig to determine which static projects exist for which perimeter
+      val servicePerimeterName: ServicePerimeterName =
+        services.servicePerimeterServiceConfig.staticProjectsInPerimeters.keys.head
+      val staticProjectNumbersInPerimeter: Set[String] =
+        services.servicePerimeterServiceConfig.staticProjectsInPerimeters(servicePerimeterName).map(_.value).toSet
 
-    val billingProject1 = testData.testProject1
-    val billingProject2 = testData.testProject2
-    val billingProjects = Seq(billingProject1, billingProject2)
-    val workspacesPerProject = 2
+      val billingProject1 = testData.testProject1
+      val billingProject2 = testData.testProject2
+      val billingProjects = Seq(billingProject1, billingProject2)
+      val workspacesPerProject = 2
 
-    // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
-    // the Billing Projects and therefore in the Perimeter
-    val workspacesInPerimeter: Seq[Workspace] = billingProjects.flatMap { bp =>
-      runAndWait {
-        for {
-          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName, servicePerimeterName.some)
-          updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
-        } yield updatedBillingProject.value.servicePerimeter.value shouldBe servicePerimeterName
+      // Setup BillingProjects by updating their Service Perimeter fields, then pre-populate some Workspaces in each of
+      // the Billing Projects and therefore in the Perimeter
+      val workspacesInPerimeter: Seq[Workspace] = billingProjects.flatMap { bp =>
+        runAndWait {
+          for {
+            _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.updateServicePerimeter(bp.projectName,
+                                                                                            servicePerimeterName.some
+            )
+            updatedBillingProject <- slickDataSource.dataAccess.rawlsBillingProjectQuery.load(bp.projectName)
+          } yield updatedBillingProject.value.servicePerimeter.value shouldBe servicePerimeterName
+        }
+
+        (1 to workspacesPerProject).map { n =>
+          val workspace = testData.workspace.copy(
+            namespace = bp.projectName.value,
+            name = s"${bp.projectName.value}Workspace${n}",
+            workspaceId = UUID.randomUUID().toString,
+            googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString))
+          )
+          runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace))
+        }
       }
 
-      (1 to workspacesPerProject).map { n =>
-        val workspace = testData.workspace.copy(
-          namespace = bp.projectName.value,
-          name = s"${bp.projectName.value}Workspace${n}",
-          workspaceId = UUID.randomUUID().toString,
-          googleProjectNumber = Option(GoogleProjectNumber(UUID.randomUUID().toString)))
-        runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(workspace))
-      }
-    }
+      // Test setup is done, now we're getting to the test
+      // Make a call to Create a new Workspace in the same Billing Project
+      val baseWorkspace = testData.workspace
+      val workspaceName = WorkspaceName(testData.testProject1Name.value, "cool_workspace")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
+      val workspace =
+        Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest),
+                     Duration.Inf
+        )
 
-    // Test setup is done, now we're getting to the test
-    // Make a call to Create a new Workspace in the same Billing Project
-    val baseWorkspace = testData.workspace
-    val workspaceName = WorkspaceName(testData.testProject1Name.value, "cool_workspace")
-    val workspaceRequest = WorkspaceRequest(workspaceName.namespace, workspaceName.name, Map.empty)
-    val workspace = Await.result(services.workspaceService.cloneWorkspace(baseWorkspace.toWorkspaceName, workspaceRequest), Duration.Inf)
+      val servicePerimeterNameCaptor = captor[ServicePerimeterName]
+      // verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was called exactly once and capture
+      // the arguments passed to it so that we can verify that they were correct
+      verify(services.servicePerimeterService).overwriteGoogleProjectsInPerimeter(servicePerimeterNameCaptor.capture,
+                                                                                  any[DataAccess]
+      )
+      servicePerimeterNameCaptor.getValue shouldBe servicePerimeterName
 
-    val servicePerimeterNameCaptor = captor[ServicePerimeterName]
-    // verify that googleAccessContextManagerDAO.overwriteProjectsInServicePerimeter was called exactly once and capture
-    // the arguments passed to it so that we can verify that they were correct
-    verify(services.servicePerimeterService).overwriteGoogleProjectsInPerimeter(servicePerimeterNameCaptor.capture, any[DataAccess])
-    servicePerimeterNameCaptor.getValue shouldBe servicePerimeterName
-
-    // verify that we set the folder for the perimeter
-    verify(services.gcsDAO).addProjectToFolder(ArgumentMatchers.eq(workspace.googleProjectId), any[String])
+      // verify that we set the folder for the perimeter
+      verify(services.gcsDAO).addProjectToFolder(ArgumentMatchers.eq(workspace.googleProjectId), any[String])
   }
 
-  "getSpendReportTableName" should "return the correct fully formatted BigQuery table name if the spend report config is set" in withTestDataServices { services =>
-    val billingProjectName = RawlsBillingProjectName("test-project")
-    val billingProject = RawlsBillingProject(billingProjectName, CreationStatuses.Ready, None, None, None, None, None, false, Some(BigQueryDatasetName("bar")), Some(BigQueryTableName("baz")), Some(GoogleProject("foo")))
-    runAndWait(services.workspaceService.dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject))
+  "getSpendReportTableName" should "return the correct fully formatted BigQuery table name if the spend report config is set" in withTestDataServices {
+    services =>
+      val billingProjectName = RawlsBillingProjectName("test-project")
+      val billingProject = RawlsBillingProject(
+        billingProjectName,
+        CreationStatuses.Ready,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(BigQueryDatasetName("bar")),
+        Some(BigQueryTableName("baz")),
+        Some(GoogleProject("foo"))
+      )
+      runAndWait(services.workspaceService.dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject))
 
-    val result = Await.result(services.workspaceService.getSpendReportTableName(billingProjectName), Duration.Inf)
+      val result = Await.result(services.workspaceService.getSpendReportTableName(billingProjectName), Duration.Inf)
 
-    result shouldBe Some("foo.bar.baz")
+      result shouldBe Some("foo.bar.baz")
   }
 
   it should "return None if the spend report config is not set" in withTestDataServices { services =>
     val billingProjectName = RawlsBillingProjectName("test-project")
-    val billingProject = RawlsBillingProject(billingProjectName, CreationStatuses.Ready, None, None, None, None, None, false, None, None, None)
+    val billingProject = RawlsBillingProject(billingProjectName,
+                                             CreationStatuses.Ready,
+                                             None,
+                                             None,
+                                             None,
+                                             None,
+                                             None,
+                                             false,
+                                             None,
+                                             None,
+                                             None
+    )
     runAndWait(services.workspaceService.dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject))
 
     val result = Await.result(services.workspaceService.getSpendReportTableName(billingProjectName), Duration.Inf)
@@ -1896,14 +2567,15 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     result shouldBe None
   }
 
-  it should "throw a RawlsExceptionWithErrorReport if the billing project does not exist" in withTestDataServices { services =>
-    val billingProjectName = RawlsBillingProjectName("test-project")
+  it should "throw a RawlsExceptionWithErrorReport if the billing project does not exist" in withTestDataServices {
+    services =>
+      val billingProjectName = RawlsBillingProjectName("test-project")
 
-    val actual = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(services.workspaceService.getSpendReportTableName(billingProjectName), Duration.Inf)
-    }
+      val actual = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.getSpendReportTableName(billingProjectName), Duration.Inf)
+      }
 
-    actual.errorReport.statusCode.get shouldEqual StatusCodes.NotFound
+      actual.errorReport.statusCode.get shouldEqual StatusCodes.NotFound
   }
 
   behavior of "getWorkspace"
@@ -1911,14 +2583,17 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "get the details for a GCP workspace" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
     val workspaceRequest = WorkspaceRequest(
-      testData.testProject1Name.value, workspaceName, Map.empty
+      testData.testProject1Name.value,
+      workspaceName,
+      Map.empty
     )
     val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    val readWorkspace = Await.result(
-      services.workspaceService.getWorkspace(
-        WorkspaceName(workspace.namespace, workspace.name), WorkspaceFieldSpecs()
-      ),
-      Duration.Inf)
+    val readWorkspace = Await.result(services.workspaceService.getWorkspace(
+                                       WorkspaceName(workspace.namespace, workspace.name),
+                                       WorkspaceFieldSpecs()
+                                     ),
+                                     Duration.Inf
+    )
 
     val response = readWorkspace.convertTo[WorkspaceResponse]
 
@@ -1931,24 +2606,30 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
   it should "get the details of an Azure workspace" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
     val workspaceRequest = MultiCloudWorkspaceRequest(
-      testData.testProject1Name.value, workspaceName, Map.empty, WorkspaceCloudPlatform.Azure, "fake_region"
+      testData.testProject1Name.value,
+      workspaceName,
+      Map.empty,
+      WorkspaceCloudPlatform.Azure,
+      "fake_region"
     )
     val tenantId = UUID.randomUUID().toString
     val subId = UUID.randomUUID().toString
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
-      new WorkspaceDescription().azureContext(new AzureContext()
-        .tenantId(tenantId)
-        .subscriptionId(subId)
-        .resourceGroupId("fake_mrg_id")
+      new WorkspaceDescription().azureContext(
+        new AzureContext()
+          .tenantId(tenantId)
+          .subscriptionId(subId)
+          .resourceGroupId("fake_mrg_id")
       )
     )
 
     val workspace = Await.result(services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf)
-    val readWorkspace = Await.result(
-      services.workspaceService.getWorkspace(
-        WorkspaceName(workspace.namespace, workspace.name), WorkspaceFieldSpecs()
-      ),
-      Duration.Inf)
+    val readWorkspace = Await.result(services.workspaceService.getWorkspace(
+                                       WorkspaceName(workspace.namespace, workspace.name),
+                                       WorkspaceFieldSpecs()
+                                     ),
+                                     Duration.Inf
+    )
 
     val response = readWorkspace.convertTo[WorkspaceResponse]
 
@@ -1957,50 +2638,63 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     response.azureContext.get.managedResourceGroupId shouldEqual "fake_mrg_id"
   }
 
-  it should "return an error if an MC workspace is not present in workspace manager" in withTestDataServices { services =>
-    val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-    val workspaceRequest = MultiCloudWorkspaceRequest(
-      testData.testProject1Name.value, workspaceName, Map.empty, WorkspaceCloudPlatform.Azure, "fake_region"
-    )
-    // ApiException is a checked exception so we need to use thenAnswer rather than thenThrow
-    when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenAnswer(
-      _ => throw new ApiException(StatusCodes.NotFound.intValue, "not found")
-    )
-    val workspace = Await.result(
-      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf
-    )
+  it should "return an error if an MC workspace is not present in workspace manager" in withTestDataServices {
+    services =>
+      val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
+      val workspaceRequest = MultiCloudWorkspaceRequest(
+        testData.testProject1Name.value,
+        workspaceName,
+        Map.empty,
+        WorkspaceCloudPlatform.Azure,
+        "fake_region"
+      )
+      // ApiException is a checked exception so we need to use thenAnswer rather than thenThrow
+      when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenAnswer(_ =>
+        throw new ApiException(StatusCodes.NotFound.intValue, "not found")
+      )
+      val workspace = Await.result(
+        services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest),
+        Duration.Inf
+      )
 
-    val err = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        services.workspaceService.getWorkspace(
-          WorkspaceName(workspace.namespace, workspace.name), WorkspaceFieldSpecs()
-        ),
-        Duration.Inf)
-    }
+      val err = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(services.workspaceService.getWorkspace(
+                       WorkspaceName(workspace.namespace, workspace.name),
+                       WorkspaceFieldSpecs()
+                     ),
+                     Duration.Inf
+        )
+      }
 
-    withClue("MC workspace not present in WSM should result in 404") {
-      err.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
-    }
+      withClue("MC workspace not present in WSM should result in 404") {
+        err.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
+      }
   }
 
   it should "return an error if an MC workspace does not have an Azure context" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
     val workspaceRequest = MultiCloudWorkspaceRequest(
-      testData.testProject1Name.value, workspaceName, Map.empty, WorkspaceCloudPlatform.Azure, "fake_region"
+      testData.testProject1Name.value,
+      workspaceName,
+      Map.empty,
+      WorkspaceCloudPlatform.Azure,
+      "fake_region"
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
       new WorkspaceDescription() // no azureContext, should be an error
     )
     val workspace = Await.result(
-      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf
+      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest),
+      Duration.Inf
     )
 
     val err = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        services.workspaceService.getWorkspace(
-          WorkspaceName(workspace.namespace, workspace.name), WorkspaceFieldSpecs()
-        ),
-        Duration.Inf)
+      Await.result(services.workspaceService.getWorkspace(
+                     WorkspaceName(workspace.namespace, workspace.name),
+                     WorkspaceFieldSpecs()
+                   ),
+                   Duration.Inf
+      )
     }
 
     withClue("MC workspace with no azure context should result in not implemented") {
@@ -2008,130 +2702,197 @@ class WorkspaceServiceSpec extends AnyFlatSpec with ScalatestRouteTest with Matc
     }
   }
 
-  "listWorkspaces" should "list the correct cloud platform for Azure and Google workspaces" in withTestDataServices { services =>
-    val service = services.workspaceService
-    val workspaceId1 = UUID.randomUUID().toString
-    val workspaceId2 = UUID.randomUUID().toString
+  "listWorkspaces" should "list the correct cloud platform for Azure and Google workspaces" in withTestDataServices {
+    services =>
+      val service = services.workspaceService
+      val workspaceId1 = UUID.randomUUID().toString
+      val workspaceId2 = UUID.randomUUID().toString
 
-    // set up test data
-    val azureWorkspace = Workspace("test_namespace1", "name", workspaceId1, new DateTime(), new DateTime(), "testUser1", Map.empty)
-    val googleWorkspace = Workspace("test_namespace2", workspaceId2, workspaceId2, "aBucket", Some("workflow-collection"), new DateTime(), new DateTime(), "testUser2", Map.empty)
-    val azureWorkspaceDetails = WorkspaceDetails.fromWorkspaceAndOptions(azureWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Azure))
-    val googleWorkspaceDetails = WorkspaceDetails.fromWorkspaceAndOptions(googleWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Gcp))
-    val expected = List((azureWorkspaceDetails.workspaceId, azureWorkspaceDetails.cloudPlatform), (googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform))
+      // set up test data
+      val azureWorkspace =
+        Workspace("test_namespace1", "name", workspaceId1, new DateTime(), new DateTime(), "testUser1", Map.empty)
+      val googleWorkspace = Workspace("test_namespace2",
+                                      workspaceId2,
+                                      workspaceId2,
+                                      "aBucket",
+                                      Some("workflow-collection"),
+                                      new DateTime(),
+                                      new DateTime(),
+                                      "testUser2",
+                                      Map.empty
+      )
+      val azureWorkspaceDetails =
+        WorkspaceDetails.fromWorkspaceAndOptions(azureWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Azure))
+      val googleWorkspaceDetails =
+        WorkspaceDetails.fromWorkspaceAndOptions(googleWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Gcp))
+      val expected = List((azureWorkspaceDetails.workspaceId, azureWorkspaceDetails.cloudPlatform),
+                          (googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform)
+      )
 
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
-      } yield()
-    }
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
+        } yield ()
+      }
 
-    // mock external calls
-    when (service.workspaceManagerDAO.getWorkspace(azureWorkspace.workspaceIdAsUUID, services.ctx1)).thenReturn(
-      new WorkspaceDescription().azureContext(new AzureContext()))
-    when (service.workspaceManagerDAO.getWorkspace(googleWorkspace.workspaceIdAsUUID, services.ctx1)).thenReturn(
-      new WorkspaceDescription().gcpContext(new GcpContext())
-    )
-    when (service.samDAO.getPoliciesForType(SamResourceTypeNames.workspace, services.ctx1.userInfo)).thenReturn(
-      Future(Set(SamResourceIdWithPolicyName(workspaceId1, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
-        SamResourceIdWithPolicyName(workspaceId2, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false)
-      )))
+      // mock external calls
+      when(service.workspaceManagerDAO.getWorkspace(azureWorkspace.workspaceIdAsUUID, services.ctx1))
+        .thenReturn(new WorkspaceDescription().azureContext(new AzureContext()))
+      when(service.workspaceManagerDAO.getWorkspace(googleWorkspace.workspaceIdAsUUID, services.ctx1)).thenReturn(
+        new WorkspaceDescription().gcpContext(new GcpContext())
+      )
+      when(service.samDAO.getPoliciesForType(SamResourceTypeNames.workspace, services.ctx1.userInfo)).thenReturn(
+        Future(
+          Set(
+            SamResourceIdWithPolicyName(workspaceId1, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
+            SamResourceIdWithPolicyName(workspaceId2, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false)
+          )
+        )
+      )
 
-    // actually call listWorkspaces to get result it returns given the mocked calls you set up
-    val result = Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf).convertTo[Seq[WorkspaceListResponse]]
+      // actually call listWorkspaces to get result it returns given the mocked calls you set up
+      val result =
+        Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf).convertTo[Seq[WorkspaceListResponse]]
 
-    // verify that the result is what you expect it to be
-    result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
+      // verify that the result is what you expect it to be
+      result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
   }
 
-  "listWorkspaces" should "return an error if an MC workspace does not have a cloud context" in withTestDataServices { services =>
-    val service = services.workspaceService
-    val workspaceId1 = UUID.randomUUID().toString
-    val workspaceId2 = UUID.randomUUID().toString
+  "listWorkspaces" should "return an error if an MC workspace does not have a cloud context" in withTestDataServices {
+    services =>
+      val service = services.workspaceService
+      val workspaceId1 = UUID.randomUUID().toString
+      val workspaceId2 = UUID.randomUUID().toString
 
-    // set up test data
-    val azureWorkspace = Workspace("test_namespace1", "name", workspaceId1, new DateTime(), new DateTime(), "testUser1", Map.empty)
-    val googleWorkspace = Workspace("test_namespace2", workspaceId2, workspaceId2, "aBucket", Some("workflow-collection"), new DateTime(), new DateTime(), "testUser2", Map.empty)
+      // set up test data
+      val azureWorkspace =
+        Workspace("test_namespace1", "name", workspaceId1, new DateTime(), new DateTime(), "testUser1", Map.empty)
+      val googleWorkspace = Workspace("test_namespace2",
+                                      workspaceId2,
+                                      workspaceId2,
+                                      "aBucket",
+                                      Some("workflow-collection"),
+                                      new DateTime(),
+                                      new DateTime(),
+                                      "testUser2",
+                                      Map.empty
+      )
 
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
-      } yield()
-    }
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
+        } yield ()
+      }
 
-    when (service.workspaceManagerDAO.getWorkspace(azureWorkspace.workspaceIdAsUUID, services.ctx1)).thenReturn(
-      new WorkspaceDescription()) // no azureContext, should be an error
-    when (service.workspaceManagerDAO.getWorkspace(googleWorkspace.workspaceIdAsUUID, services.ctx1)).thenReturn(
-      new WorkspaceDescription().gcpContext(new GcpContext())
-    )
-    when (service.samDAO.getPoliciesForType(SamResourceTypeNames.workspace, services.ctx1.userInfo)).thenReturn(
-      Future(Set(SamResourceIdWithPolicyName(workspaceId1, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
-        SamResourceIdWithPolicyName(workspaceId2, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false))))
+      when(service.workspaceManagerDAO.getWorkspace(azureWorkspace.workspaceIdAsUUID, services.ctx1))
+        .thenReturn(new WorkspaceDescription()) // no azureContext, should be an error
+      when(service.workspaceManagerDAO.getWorkspace(googleWorkspace.workspaceIdAsUUID, services.ctx1)).thenReturn(
+        new WorkspaceDescription().gcpContext(new GcpContext())
+      )
+      when(service.samDAO.getPoliciesForType(SamResourceTypeNames.workspace, services.ctx1.userInfo)).thenReturn(
+        Future(
+          Set(
+            SamResourceIdWithPolicyName(workspaceId1, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
+            SamResourceIdWithPolicyName(workspaceId2, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false)
+          )
+        )
+      )
 
-    val err = intercept[RawlsException] {
+      val err = intercept[RawlsException] {
+        Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf)
+      }
+  }
+
+  "listWorkspaces" should "log a warning and filter out the workspace if getWorkspace throws an ApiException" in withTestDataServices {
+    services =>
+      val service = services.workspaceService
+      val workspaceId1 = UUID.randomUUID().toString
+      val workspaceId2 = UUID.randomUUID().toString
+
+      // set up test data
+      val azureWorkspace =
+        Workspace("test_namespace1", "name", workspaceId1, new DateTime(), new DateTime(), "testUser1", Map.empty)
+      val googleWorkspace = Workspace("test_namespace2",
+                                      workspaceId2,
+                                      workspaceId2,
+                                      "aBucket",
+                                      Some("workflow-collection"),
+                                      new DateTime(),
+                                      new DateTime(),
+                                      "testUser2",
+                                      Map.empty
+      )
+      val googleWorkspaceDetails =
+        WorkspaceDetails.fromWorkspaceAndOptions(googleWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Gcp))
+      val expected = List((googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform))
+
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
+        } yield ()
+      }
+
+      when(service.workspaceManagerDAO.getWorkspace(ArgumentMatchers.eq(azureWorkspace.workspaceIdAsUUID), any()))
+        .thenAnswer(_ => throw new ApiException(StatusCodes.NotFound.intValue, "not found"))
+      when(service.workspaceManagerDAO.getWorkspace(ArgumentMatchers.eq(googleWorkspace.workspaceIdAsUUID), any()))
+        .thenReturn(
+          new WorkspaceDescription().gcpContext(new GcpContext())
+        )
+      when(service.samDAO.getPoliciesForType(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any())).thenReturn(
+        Future(
+          Set(
+            SamResourceIdWithPolicyName(workspaceId1, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
+            SamResourceIdWithPolicyName(workspaceId2, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false)
+          )
+        )
+      )
+
+      val result =
+        Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf).convertTo[Seq[WorkspaceListResponse]]
+
+      result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
+  }
+
+  "getSubmissionMethodConfiguration" should "return the method configuration that was used to launch the submission" in withTestDataServices {
+    services =>
+      val workspaceName = testData.workspaceSuccessfulSubmission.toWorkspaceName
+      val originalMethodConfig = testData.agoraMethodConfig
+
+      // Overwrite the method configuration that was used for the submission. This forces it to generate a new version and soft-delete the old one
       Await.result(
-        service.listWorkspaces(WorkspaceFieldSpecs()),
-        Duration.Inf)
-    }
-  }
+        services.workspaceService.overwriteMethodConfiguration(
+          workspaceName,
+          originalMethodConfig.namespace,
+          originalMethodConfig.name,
+          originalMethodConfig.copy(inputs = Map("i1" -> AttributeString("input_updated")))
+        ),
+        Duration.Inf
+      )
 
-  "listWorkspaces" should "log a warning and filter out the workspace if getWorkspace throws an ApiException" in withTestDataServices { services =>
-    val service = services.workspaceService
-    val workspaceId1 = UUID.randomUUID().toString
-    val workspaceId2 = UUID.randomUUID().toString
+      val firstSubmission = Await.result(services.workspaceService.listSubmissions(workspaceName), Duration.Inf).head
 
-    // set up test data
-    val azureWorkspace = Workspace("test_namespace1", "name", workspaceId1, new DateTime(), new DateTime(), "testUser1", Map.empty)
-    val googleWorkspace = Workspace("test_namespace2", workspaceId2, workspaceId2, "aBucket", Some("workflow-collection"), new DateTime(), new DateTime(), "testUser2", Map.empty)
-    val googleWorkspaceDetails = WorkspaceDetails.fromWorkspaceAndOptions(googleWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Gcp))
-    val expected = List((googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform))
+      val result = Await.result(
+        services.workspaceService.getSubmissionMethodConfiguration(workspaceName, firstSubmission.submissionId),
+        Duration.Inf
+      )
 
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
-      } yield()
-    }
+      // None of the following attributes of a method config change when it is soft-deleted
+      assertResult(originalMethodConfig.namespace)(result.namespace)
+      assertResult(originalMethodConfig.inputs)(result.inputs)
+      assertResult(originalMethodConfig.outputs)(result.outputs)
+      assertResult(originalMethodConfig.prerequisites)(result.prerequisites)
+      assertResult(originalMethodConfig.methodConfigVersion)(result.methodConfigVersion)
+      assertResult(originalMethodConfig.methodRepoMethod)(result.methodRepoMethod)
+      assertResult(originalMethodConfig.rootEntityType)(result.rootEntityType)
 
-    when (service.workspaceManagerDAO.getWorkspace(ArgumentMatchers.eq(azureWorkspace.workspaceIdAsUUID), any())).thenAnswer(
-      _ => throw new ApiException(StatusCodes.NotFound.intValue, "not found"))
-    when (service.workspaceManagerDAO.getWorkspace(ArgumentMatchers.eq(googleWorkspace.workspaceIdAsUUID), any())).thenReturn(
-      new WorkspaceDescription().gcpContext(new GcpContext())
-    )
-    when (service.samDAO.getPoliciesForType(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any())).thenReturn(
-      Future(Set(SamResourceIdWithPolicyName(workspaceId1, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false),
-        SamResourceIdWithPolicyName(workspaceId2, SamWorkspacePolicyNames.owner, Set.empty, Set.empty, false))))
-
-    val result = Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf).convertTo[Seq[WorkspaceListResponse]]
-
-    result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
-  }
-
-  "getSubmissionMethodConfiguration" should "return the method configuration that was used to launch the submission" in withTestDataServices { services =>
-    val workspaceName = testData.workspaceSuccessfulSubmission.toWorkspaceName
-    val originalMethodConfig = testData.agoraMethodConfig
-
-    //Overwrite the method configuration that was used for the submission. This forces it to generate a new version and soft-delete the old one
-    Await.result(services.workspaceService.overwriteMethodConfiguration(workspaceName, originalMethodConfig.namespace, originalMethodConfig.name, originalMethodConfig.copy(inputs = Map("i1" -> AttributeString("input_updated")))), Duration.Inf)
-
-    val firstSubmission = Await.result(services.workspaceService.listSubmissions(workspaceName), Duration.Inf).head
-
-    val result = Await.result(services.workspaceService.getSubmissionMethodConfiguration(workspaceName, firstSubmission.submissionId), Duration.Inf)
-
-    //None of the following attributes of a method config change when it is soft-deleted
-    assertResult(originalMethodConfig.namespace) { result.namespace}
-    assertResult(originalMethodConfig.inputs) { result.inputs}
-    assertResult(originalMethodConfig.outputs) { result.outputs}
-    assertResult(originalMethodConfig.prerequisites) { result.prerequisites}
-    assertResult(originalMethodConfig.methodConfigVersion) { result.methodConfigVersion}
-    assertResult(originalMethodConfig.methodRepoMethod) { result.methodRepoMethod}
-    assertResult(originalMethodConfig.rootEntityType) { result.rootEntityType}
-
-    //The following attributes are modified when it is soft-deleted
-    assert(result.name.startsWith(originalMethodConfig.name)) //a random suffix is added in this case, should be something like "testConfig1_HoQyHjLZ"
-    assert(result.deleted)
-    assert(result.deletedDate.isDefined)
+      // The following attributes are modified when it is soft-deleted
+      assert(
+        result.name.startsWith(originalMethodConfig.name)
+      ) // a random suffix is added in this case, should be something like "testConfig1_HoQyHjLZ"
+      assert(result.deleted)
+      assert(result.deletedDate.isDefined)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -10,7 +10,11 @@ import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, WorkspaceAccessDeniedException}
+import org.broadinstitute.dsde.rawls.{
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  WorkspaceAccessDeniedException
+}
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
@@ -28,7 +32,6 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 
-
 /**
   * Unit tests kept separate from WorkspaceServiceSpec to separate true unit tests from tests requiring external resources
   */
@@ -37,44 +40,66 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
 
   val defaultRequestContext =
-    RawlsRequestContext(UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc")))
+    RawlsRequestContext(
+      UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+    )
 
   def workspaceServiceConstructor(
-                                   datasource: SlickDataSource = mock[SlickDataSource],
-                                   methodRepoDAO: MethodRepoDAO = mock[MethodRepoDAO],
-                                   cromiamDAO: ExecutionServiceDAO = mock[ExecutionServiceDAO],
-                                   executionServiceCluster: ExecutionServiceCluster = mock[ExecutionServiceCluster],
-                                   execServiceBatchSize: Int = 1,
-                                   workspaceManagerDAO: WorkspaceManagerDAO = mock[WorkspaceManagerDAO],
-                                   methodConfigResolver: MethodConfigResolver = mock[MethodConfigResolver],
-                                   gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO],
-                                   samDAO: SamDAO = mock[SamDAO],
-                                   notificationDAO: NotificationDAO = mock[NotificationDAO],
-                                   userServiceConstructor: RawlsRequestContext => UserService = _ => mock[UserService],
-                                   genomicsServiceConstructor: RawlsRequestContext => GenomicsService = _ => mock[GenomicsService],
-                                   maxActiveWorkflowsTotal: Int = 1,
-                                   maxActiveWorkflowsPerUser: Int = 1,
-                                   workbenchMetricBaseName: String = "",
-                                   submissionCostService: SubmissionCostService = mock[SubmissionCostService],
-                                   config: WorkspaceServiceConfig = mock[WorkspaceServiceConfig],
-                                   requesterPaysSetupService: RequesterPaysSetupService = mock[RequesterPaysSetupService],
-                                   entityManager: EntityManager = mock[EntityManager],
-                                   resourceBufferService: ResourceBufferService = mock[ResourceBufferService],
-                                   resourceBufferSaEmail: String = "",
-                                   servicePerimeterService: ServicePerimeterService = mock[ServicePerimeterService],
-                                   googleIamDao: GoogleIamDAO = mock[GoogleIamDAO],
-                                   terraBillingProjectOwnerRole: String = "",
-                                   terraWorkspaceCanComputeRole: String = "",
-                                   terraWorkspaceNextflowRole: String = ""): RawlsRequestContext => WorkspaceService = info =>
+    datasource: SlickDataSource = mock[SlickDataSource],
+    methodRepoDAO: MethodRepoDAO = mock[MethodRepoDAO],
+    cromiamDAO: ExecutionServiceDAO = mock[ExecutionServiceDAO],
+    executionServiceCluster: ExecutionServiceCluster = mock[ExecutionServiceCluster],
+    execServiceBatchSize: Int = 1,
+    workspaceManagerDAO: WorkspaceManagerDAO = mock[WorkspaceManagerDAO],
+    methodConfigResolver: MethodConfigResolver = mock[MethodConfigResolver],
+    gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO],
+    samDAO: SamDAO = mock[SamDAO],
+    notificationDAO: NotificationDAO = mock[NotificationDAO],
+    userServiceConstructor: RawlsRequestContext => UserService = _ => mock[UserService],
+    genomicsServiceConstructor: RawlsRequestContext => GenomicsService = _ => mock[GenomicsService],
+    maxActiveWorkflowsTotal: Int = 1,
+    maxActiveWorkflowsPerUser: Int = 1,
+    workbenchMetricBaseName: String = "",
+    submissionCostService: SubmissionCostService = mock[SubmissionCostService],
+    config: WorkspaceServiceConfig = mock[WorkspaceServiceConfig],
+    requesterPaysSetupService: RequesterPaysSetupService = mock[RequesterPaysSetupService],
+    entityManager: EntityManager = mock[EntityManager],
+    resourceBufferService: ResourceBufferService = mock[ResourceBufferService],
+    resourceBufferSaEmail: String = "",
+    servicePerimeterService: ServicePerimeterService = mock[ServicePerimeterService],
+    googleIamDao: GoogleIamDAO = mock[GoogleIamDAO],
+    terraBillingProjectOwnerRole: String = "",
+    terraWorkspaceCanComputeRole: String = "",
+    terraWorkspaceNextflowRole: String = ""
+  ): RawlsRequestContext => WorkspaceService = info =>
     WorkspaceService.constructor(
       datasource,
-      methodRepoDAO, cromiamDAO, executionServiceCluster, execServiceBatchSize, workspaceManagerDAO, methodConfigResolver,
-      gcsDAO, samDAO, notificationDAO, userServiceConstructor, genomicsServiceConstructor, maxActiveWorkflowsTotal,
-      maxActiveWorkflowsPerUser, workbenchMetricBaseName,
-      submissionCostService, config, requesterPaysSetupService, entityManager, resourceBufferService, resourceBufferSaEmail, servicePerimeterService,
-      googleIamDao, terraBillingProjectOwnerRole, terraWorkspaceCanComputeRole,
-      terraWorkspaceNextflowRole)(info)(mock[Materializer], scala.concurrent.ExecutionContext.global)
-
+      methodRepoDAO,
+      cromiamDAO,
+      executionServiceCluster,
+      execServiceBatchSize,
+      workspaceManagerDAO,
+      methodConfigResolver,
+      gcsDAO,
+      samDAO,
+      notificationDAO,
+      userServiceConstructor,
+      genomicsServiceConstructor,
+      maxActiveWorkflowsTotal,
+      maxActiveWorkflowsPerUser,
+      workbenchMetricBaseName,
+      submissionCostService,
+      config,
+      requesterPaysSetupService,
+      entityManager,
+      resourceBufferService,
+      resourceBufferSaEmail,
+      servicePerimeterService,
+      googleIamDao,
+      terraBillingProjectOwnerRole,
+      terraWorkspaceCanComputeRole,
+      terraWorkspaceNextflowRole
+    )(info)(mock[Materializer], scala.concurrent.ExecutionContext.global)
 
   "getWorkspaceById" should "return the workspace returned by getWorkspace(WorkspaceName) on success" in {
     val datasource = mock[SlickDataSource]
@@ -85,9 +110,13 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     // it will pass on literally any valid JsObject returned by getWorkspace
     val expected = new JsObject(Map("dummyKey" -> JsString("dummyVal")))
 
-    doReturn(Future.successful(expected)).when(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
+    doReturn(Future.successful(expected))
+      .when(service)
+      .getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
 
-    val result = Await.result(service.getWorkspaceById("c1e14bc7-cc7f-4710-a383-74370be3cba1", WorkspaceFieldSpecs()), Duration.Inf)
+    val result = Await.result(service.getWorkspaceById("c1e14bc7-cc7f-4710-a383-74370be3cba1", WorkspaceFieldSpecs()),
+                              Duration.Inf
+    )
     assertResult(expected)(result)
     verify(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
   }
@@ -97,11 +126,16 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     when(datasource.inTransaction[Any](any(), any())).thenReturn(Future.successful(List(("abc", "cba"))))
 
     val service = spy(workspaceServiceConstructor(datasource)(defaultRequestContext))
-    val exception = new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "A generic exception"))
-    doReturn(Future.failed(exception)).when(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
+    val exception =
+      new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "A generic exception"))
+    doReturn(Future.failed(exception))
+      .when(service)
+      .getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
 
     val result = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getWorkspaceById("c1e14bc7-cc7f-4710-a383-74370be3cba1", WorkspaceFieldSpecs()), Duration.Inf)
+      Await.result(service.getWorkspaceById("c1e14bc7-cc7f-4710-a383-74370be3cba1", WorkspaceFieldSpecs()),
+                   Duration.Inf
+      )
     }
 
     assertResult(exception)(result)
@@ -115,7 +149,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     val service = spy(workspaceServiceConstructor(datasource)(defaultRequestContext))
 
     doReturn(Future.failed(NoSuchWorkspaceException(WorkspaceName("abc", "123"))))
-      .when(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "123")), any(), any())
+      .when(service)
+      .getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "123")), any(), any())
 
     val workspaceId = "c1e14bc7-cc7f-4710-a383-74370be3cba1"
     val exception = intercept[NoSuchWorkspaceException] {
@@ -134,7 +169,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
 
     val service = spy(workspaceServiceConstructor(datasource)(defaultRequestContext))
     doReturn(Future.failed(WorkspaceAccessDeniedException(WorkspaceName("abc", "123"))))
-      .when(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "123")), any(), any())
+      .when(service)
+      .getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "123")), any(), any())
 
     val workspaceId = "c1e14bc7-cc7f-4710-a383-74370be3cba1"
     val exception = intercept[WorkspaceAccessDeniedException] {


### PR DESCRIPTION
We keep running into scalafmt check errors in otherwise small PRs, because scalafmt sees a file has changed and warns about its formatting. Then, the diff in the other PR is much bigger than it needs to be because we have to piggyback formatting changes into it.

#2002 is a good example: that PR should be a one-line change to an error message.

In this PR, I apply `sbt scalafmtAll` to the codebase, without any other changes. I hope that once we commit this, other PRs will run into fewer problems.