### PR TITLE
Better error message for method-config-doesnt-exist when creating a submission [AJ-395]

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -435,7 +435,6 @@ trait ExecutionJsonSupport extends JsonSupport {
 
   implicit val SubmissionFormat = jsonFormat17(Submission)
 
-
   implicit val SubmissionRetryFormat = jsonFormat1(SubmissionRetry)
 
   implicit val SubmissionReportFormat = jsonFormat7(SubmissionReport)
@@ -534,25 +533,23 @@ object WorkflowStatuses {
 
 object SubmissionRetryStatuses {
   sealed trait RetryStatus extends RawlsEnumeration[RetryStatus] {
-    def filterWorkflows(workflows: Seq[Workflow]) = {
+    def filterWorkflows(workflows: Seq[Workflow]) =
       this match {
-        case RetryFailed => workflows.filter(wf => wf.status.equals(Failed))
-        case RetryAborted => workflows.filter(wf => wf.status.equals(Aborted))
+        case RetryFailed           => workflows.filter(wf => wf.status.equals(Failed))
+        case RetryAborted          => workflows.filter(wf => wf.status.equals(Aborted))
         case RetryFailedAndAborted => workflows.filter(wf => wf.status.equals(Failed) || wf.status.equals(Aborted))
       }
-    }
     override def toString = getClass.getSimpleName.stripSuffix("$")
     override def withName(name: String) = SubmissionRetryStatuses.withName(name)
   }
 
-  def withName(name: String): RetryStatus = {
+  def withName(name: String): RetryStatus =
     name match {
-      case "Failed" => RetryFailed
-      case "Aborted" => RetryAborted
+      case "Failed"           => RetryFailed
+      case "Aborted"          => RetryAborted
       case "FailedAndAborted" => RetryFailedAndAborted
-      case _ => throw new RawlsException(s"invalid WorkflowStatus [${name}]")
+      case _                  => throw new RawlsException(s"invalid WorkflowStatus [${name}]")
     }
-  }
 
   case object RetryFailed extends RetryStatus
   case object RetryAborted extends RetryStatus


### PR DESCRIPTION
When creating a submission, provide a more helpful error message if the method config for that submission cannot be found. The retry-submission feature in AJ-395 makes it significantly more likely for end users to run into this case: they could be retrying an older submission whose config has already been superseded.

Before:
![Screenshot 8-29-2022 at 04 13 PM](https://user-images.githubusercontent.com/6041577/187487791-ed9dc309-5e3f-412e-9650-ce83c0e70cfc.png)

After:
![Screenshot 8-29-2022 at 04 15 PM](https://user-images.githubusercontent.com/6041577/187487784-d60ef4da-7a90-433e-acd0-72dc414a59fe.png)
