### PR TITLE
Aj 582 clone snapshot references along with workspace

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -431,6 +431,13 @@ object Boot extends IOApp with LazyLogging {
           metricsPrefix
         )
 
+      val snapshotServiceConstructor: RawlsRequestContext => SnapshotService = SnapshotService.constructor(
+        slickDataSource,
+        samDAO,
+        workspaceManagerDAO,
+        conf.getString("dataRepo.terraInstanceName")
+      )
+
       val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService = WorkspaceService.constructor(
         slickDataSource,
         methodRepoDAO,
@@ -457,7 +464,8 @@ object Boot extends IOApp with LazyLogging {
         googleIamDao = appDependencies.httpGoogleIamDAO,
         terraBillingProjectOwnerRole = gcsConfig.getString("terraBillingProjectOwnerRole"),
         terraWorkspaceCanComputeRole = gcsConfig.getString("terraWorkspaceCanComputeRole"),
-        terraWorkspaceNextflowRole = gcsConfig.getString("terraWorkspaceNextflowRole")
+        terraWorkspaceNextflowRole = gcsConfig.getString("terraWorkspaceNextflowRole"),
+        snapshotServiceConstructor
       )
 
       val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(
@@ -468,13 +476,6 @@ object Boot extends IOApp with LazyLogging {
         conf.getInt("entities.pageSizeLimit")
       )
 
-      val snapshotServiceConstructor: RawlsRequestContext => SnapshotService = SnapshotService.constructor(
-        slickDataSource,
-        samDAO,
-        workspaceManagerDAO,
-        conf.getString("dataRepo.terraInstanceName")
-      )
-
       val spendReportingBigQueryService =
         appDependencies.bigQueryServiceFactory.getServiceFromJson(bqJsonCreds,
                                                                   GoogleProject(gcsConfig.getString("serviceProject"))
@@ -483,7 +484,7 @@ object Boot extends IOApp with LazyLogging {
         gcsConfig.getString("billingExportTableName"),
         gcsConfig.getString("billingExportTimePartitionColumn"),
         gcsConfig.getConfig("spendReporting").getInt("maxDateRange"),
-        metricsPrefix,
+        metricsPrefix
       )
 
       val spendReportingServiceConstructor: RawlsRequestContext => SpendReportingService =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -207,12 +207,14 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                destinationWorkspaceId: UUID,
                                name: String,
                                ctx: RawlsRequestContext
-  ): Unit = {
+  ): DataRepoSnapshotResource = {
     val requestBody = new CloneReferencedResourceRequestBody()
       .name(name)
-      .cloningInstructions(CloningInstructionsEnum.NOTHING)
+      .cloningInstructions(CloningInstructionsEnum.REFERENCE)
       .destinationWorkspaceId(destinationWorkspaceId)
-    getReferencedGcpResourceApi(ctx).cloneGcpDataRepoSnapshotReference(requestBody, sourceWorkspaceId, snapshotId)
+    getReferencedGcpResourceApi(ctx)
+      .cloneGcpDataRepoSnapshotReference(requestBody, sourceWorkspaceId, snapshotId)
+      .getResource()
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -201,4 +201,18 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
         ),
       workspaceId
     )
+
+  def cloneSnapshotByReference(sourceWorkspaceId: UUID,
+                               snapshotId: UUID,
+                               destinationWorkspaceId: UUID,
+                               name: String,
+                               ctx: RawlsRequestContext
+  ): Unit = {
+    val requestBody = new CloneReferencedResourceRequestBody()
+      .name(name)
+      .cloningInstructions(CloningInstructionsEnum.NOTHING)
+      .destinationWorkspaceId(destinationWorkspaceId)
+    getReferencedGcpResourceApi(ctx).cloneGcpDataRepoSnapshotReference(requestBody, sourceWorkspaceId, snapshotId)
+  }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -55,6 +55,14 @@ trait WorkspaceManagerDAO {
                                           limit: Int,
                                           ctx: RawlsRequestContext
   ): ResourceList
+
+  def cloneSnapshotByReference(sourceWorkspaceId: UUID,
+                               snapshotId: UUID,
+                               destinationWorkspaceId: UUID,
+                               name: String,
+                               ctx: RawlsRequestContext
+  ): Unit
+
   def enableApplication(workspaceId: UUID,
                         applicationId: String,
                         ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -61,7 +61,7 @@ trait WorkspaceManagerDAO {
                                destinationWorkspaceId: UUID,
                                name: String,
                                ctx: RawlsRequestContext
-  ): Unit
+  ): DataRepoSnapshotResource
 
   def enableApplication(workspaceId: UUID,
                         applicationId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -66,6 +66,21 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       Future.successful(snapshotRef)
     }
 
+  def cloneSnapshotByReference(sourceWorkspaceId: UUID,
+                               targetWorkspaceId: UUID,
+                               snapshot: DataRepoSnapshotResource
+  ): DataRepoSnapshotResource = {
+    if (!workspaceStubExists(targetWorkspaceId, ctx)) {
+      workspaceManagerDAO.createWorkspace(targetWorkspaceId, ctx)
+    }
+    workspaceManagerDAO.cloneSnapshotByReference(sourceWorkspaceId,
+                                                 snapshot.getMetadata().getResourceId(),
+                                                 targetWorkspaceId,
+                                                 snapshot.getMetadata().getName(),
+                                                 ctx
+    )
+  }
+
   def getSnapshot(workspaceName: WorkspaceName, referenceId: String): Future[DataRepoSnapshotResource] = {
     val referenceUuid = validateSnapshotId(referenceId)
     getWorkspaceContextAndPermissions(workspaceName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1075,20 +1075,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                                                         dataAccess,
                                                         s1
                                 ) { destWorkspaceContext =>
-                                  // TODO: Without limit to make sure all snapshots are fetched
-                                  val snapshotResponse: Future[SnapshotListResponse] = snapshotServiceConstructor(s1)
-                                    .enumerateSnapshots(
-                                      sourceWorkspaceContext.toWorkspaceName,
-                                      0,
-                                      100
-                                    )
-                                  for {
-                                    snapshots <- snapshotResponse
-                                    snapshot <- snapshots.gcpDataRepoSnapshots
-                                  } snapshotServiceConstructor(s1).cloneSnapshotByReference(
+                                  snapshotServiceConstructor(s1).cloneAllSnapshotsByReference(
                                     sourceWorkspaceContext.workspaceIdAsUUID,
-                                    destWorkspaceContext.workspaceIdAsUUID,
-                                    snapshot
+                                    sourceWorkspaceContext.toWorkspaceName,
+                                    destWorkspaceContext.workspaceIdAsUUID
                                   )
 
                                   dataAccess.entityQuery

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1,10 +1,13 @@
 package org.broadinstitute.dsde.rawls.workspace
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.Materializer
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.{ResourceDescription, WorkspaceDescription}
+import cats.MonadThrow
 import cats.implicits._
+import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.startSpanWithParent
 import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span, Status}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1078,11 +1078,13 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                                       100,
                                       ctx
                                     )
-                                    .getResources()
+                                    .getResources
                                   for (resource <- resources.asScala)
                                     workspaceManagerDAO.cloneSnapshotByReference(
                                       sourceWorkspaceContext.workspaceIdAsUUID,
-                                      resource.getMetadata().getResourceId(),
+                                      UUID.fromString(
+                                        resource.getResourceAttributes.getGcpDataRepoSnapshot.getSnapshot
+                                      ),
                                       destWorkspaceContext.workspaceIdAsUUID,
                                       resource.getMetadata().getName(),
                                       ctx

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -25,6 +25,7 @@ import org.broadinstitute.dsde.rawls.model.SubmissionRetryStatuses.RetryAborted
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
+import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
@@ -490,6 +491,13 @@ class SubmissionSpec(_system: ActorSystem)
         workbenchMetricBaseName
       )
 
+      val snapshotServiceConstructor = SnapshotService.constructor(
+        slickDataSource,
+        samDAO,
+        workspaceManagerDAO,
+        "terra-data-repo-url"
+      ) _
+
       val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
       val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
       val resourceBufferService = new ResourceBufferService(resourceBufferDAO, resourceBufferConfig)
@@ -525,7 +533,8 @@ class SubmissionSpec(_system: ActorSystem)
         googleIamDao = new MockGoogleIamDAO,
         terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
         terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
-        terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole"
+        terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
+        snapshotServiceConstructor
       ) _
       lazy val workspaceService: WorkspaceService = workspaceServiceConstructor(testContext)
       try

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -141,13 +141,12 @@ class MockWorkspaceManagerDAO(
                                         name: String,
                                         ctx: RawlsRequestContext
   ): DataRepoSnapshotResource =
-//    val refToClone = getDataRepoSnapshotReference(sourceWorkspaceId, snapshotId, ctx)
     createDataRepoSnapshotReference(destinationWorkspaceId,
                                     snapshotId,
                                     DataReferenceName(name),
                                     None,
                                     "foo",
-                                    CloningInstructionsEnum.NOTHING,
+                                    CloningInstructionsEnum.REFERENCE,
                                     ctx
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -135,6 +135,22 @@ class MockWorkspaceManagerDAO(
     if (references.contains(workspaceId, referenceId))
       references -= ((workspaceId, referenceId))
 
+  override def cloneSnapshotByReference(sourceWorkspaceId: UUID,
+                                        snapshotId: UUID,
+                                        destinationWorkspaceId: UUID,
+                                        name: String,
+                                        ctx: RawlsRequestContext
+  ): Unit =
+//    val refToClone = getDataRepoSnapshotReference(sourceWorkspaceId, snapshotId, ctx)
+    createDataRepoSnapshotReference(destinationWorkspaceId,
+                                    snapshotId,
+                                    DataReferenceName(name),
+                                    None,
+                                    "foo",
+                                    CloningInstructionsEnum.NOTHING,
+                                    ctx
+    )
+
   override def createWorkspaceWithSpendProfile(workspaceId: UUID,
                                                displayName: String,
                                                spendProfileId: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -140,7 +140,7 @@ class MockWorkspaceManagerDAO(
                                         destinationWorkspaceId: UUID,
                                         name: String,
                                         ctx: RawlsRequestContext
-  ): Unit =
+  ): DataRepoSnapshotResource =
 //    val refToClone = getDataRepoSnapshotReference(sourceWorkspaceId, snapshotId, ctx)
     createDataRepoSnapshotReference(destinationWorkspaceId,
                                     snapshotId,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -140,15 +140,20 @@ class MockWorkspaceManagerDAO(
                                         destinationWorkspaceId: UUID,
                                         name: String,
                                         ctx: RawlsRequestContext
-  ): DataRepoSnapshotResource =
-    createDataRepoSnapshotReference(destinationWorkspaceId,
-                                    snapshotId,
-                                    DataReferenceName(name),
-                                    None,
-                                    "foo",
-                                    CloningInstructionsEnum.REFERENCE,
-                                    ctx
-    )
+  ): DataRepoSnapshotResource = {
+    val snap: DataRepoSnapshotResource = references.get(sourceWorkspaceId, snapshotId).get
+    val metadata = new ResourceMetadata()
+      .name(name)
+      .resourceId(snapshotId)
+      .resourceType(ResourceType.DATA_REPO_SNAPSHOT)
+      .stewardshipType(StewardshipType.REFERENCED)
+      .workspaceId(destinationWorkspaceId)
+      .cloningInstructions(CloningInstructionsEnum.NOTHING)
+    val snapshot = new DataRepoSnapshotResource().metadata(metadata).attributes(snap.getAttributes())
+    references.put((destinationWorkspaceId, snapshotId), snapshot)
+    mockReferenceResponse(destinationWorkspaceId, snapshotId)
+
+  }
 
   override def createWorkspaceWithSpendProfile(workspaceId: UUID,
                                                displayName: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -232,7 +232,8 @@ trait ApiServiceSpec
     ) _
 
     val spendReportingBigQueryService = bigQueryServiceFactory.getServiceFromJson("json", GoogleProject("test-project"))
-    val spendReportingServiceConfig = SpendReportingServiceConfig("fakeTableName", "fakeTimePartitionColumn", 90, "test.metrics")
+    val spendReportingServiceConfig =
+      SpendReportingServiceConfig("fakeTableName", "fakeTimePartitionColumn", 90, "test.metrics")
     override val spendReportingConstructor = SpendReportingService.constructor(
       slickDataSource,
       spendReportingBigQueryService,
@@ -318,7 +319,8 @@ trait ApiServiceSpec
       googleIamDao = new MockGoogleIamDAO,
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
       terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
-      terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole"
+      terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
+      snapshotServiceConstructor
     ) _
 
     override val multiCloudWorkspaceServiceConstructor = MultiCloudWorkspaceService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2267,12 +2267,10 @@ class WorkspaceServiceSpec
   it should "clone snapshots-by-reference" in withTestDataServices { services =>
     val baseWorkspace = testData.workspace
     // Make sure base workspace has a snapshot by reference
-    val snapshotId = UUID.randomUUID()
-
     Await.result(
       services.snapshotService.createSnapshot(
         baseWorkspace.toWorkspaceName,
-        NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), snapshotId)
+        NamedDataRepoSnapshot(DataReferenceName("foo"), Option(DataReferenceDescriptionField("foo")), UUID.randomUUID())
       ),
       Duration.Inf
     )
@@ -2294,7 +2292,10 @@ class WorkspaceServiceSpec
     val newSnapshots =
       Await.result(services.snapshotService.enumerateSnapshots(workspace.toWorkspaceName, 0, 100), Duration.Inf)
 
-    newSnapshots.gcpDataRepoSnapshots(0).getAttributes().getSnapshot() shouldEqual snapshotId.toString()
+    newSnapshots.gcpDataRepoSnapshots(0).getAttributes().getSnapshot() shouldEqual snapshotList
+      .gcpDataRepoSnapshots(0)
+      .getAttributes()
+      .getSnapshot()
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -183,6 +183,13 @@ class WorkspaceServiceSpec
       gcsDAO
     ) _
 
+    val snapshotServiceConstructor = SnapshotService.constructor(
+      slickDataSource,
+      samDAO,
+      workspaceManagerDAO,
+      "terra-data-repo-url"
+    ) _
+
     val bigQueryDAO = new MockGoogleBigQueryDAO
     val submissionCostService = new MockSubmissionCostService(
       "fakeTableName",
@@ -262,7 +269,8 @@ class WorkspaceServiceSpec
       googleIamDao = new MockGoogleIamDAO,
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
       terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
-      terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole"
+      terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
+      snapshotServiceConstructor
     ) _
 
     def cleanupSupervisor =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -12,14 +12,10 @@ import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
+import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{
-  NoSuchWorkspaceException,
-  RawlsExceptionWithErrorReport,
-  UserDisabledException,
-  WorkspaceAccessDeniedException
-}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, UserDisabledException, WorkspaceAccessDeniedException}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.mockito.ArgumentMatchers
@@ -72,7 +68,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     googleIamDao: GoogleIamDAO = mock[GoogleIamDAO],
     terraBillingProjectOwnerRole: String = "",
     terraWorkspaceCanComputeRole: String = "",
-    terraWorkspaceNextflowRole: String = ""
+    terraWorkspaceNextflowRole: String = "",
+    snapshotServiceConstructor: RawlsRequestContext => SnapshotService = _ => mock[SnapshotService]
   ): RawlsRequestContext => WorkspaceService = info =>
     WorkspaceService.constructor(
       datasource,
@@ -100,7 +97,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
       googleIamDao,
       terraBillingProjectOwnerRole,
       terraWorkspaceCanComputeRole,
-      terraWorkspaceNextflowRole
+      terraWorkspaceNextflowRole,
+      snapshotServiceConstructor
     )(info)(mock[Materializer], scala.concurrent.ExecutionContext.global)
 
   "getWorkspaceById" should "return the workspace returned by getWorkspace(WorkspaceName) on success" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -15,7 +15,12 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, UserDisabledException, WorkspaceAccessDeniedException}
+import org.broadinstitute.dsde.rawls.{
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  UserDisabledException,
+  WorkspaceAccessDeniedException
+}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.mockito.ArgumentMatchers


### PR DESCRIPTION
[AJ-582 Cloning a workspace also clones snapshots-by-reference](https://broadworkbench.atlassian.net/browse/AJ-582)
Cloning workspaces previously ignored snapshot-by-references.  This PR includes them.  
Note: If the user of the newly cloned workspace does not have permission to view the snapshot, then it will still appear in the workspace, but the user will be unable to view any data, as below:
<img width="1418" alt="Screen Shot 2022-09-29 at 1 34 36 PM" src="https://user-images.githubusercontent.com/5884792/193107383-f03226ac-0567-489b-a661-79cd822c8bec.png">
Also, this specifically deals exclusively with GCP resources, so expanding beyond that will need further work.   I'm guessing that can be a follow-on ticket when the time comes.
The clone workspace API in Firecloud Orchestration calls the rawlsDao, so i believe no further work should be required there.
This PR is half-draft as it does not address the case of very large numbers of snapshots in one workspace, but I am putting it out for comment while I think about that.