### PR TITLE
[WOR-576] Replace "say" with "echo" to work around git-secrets installation issue 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Secrets check
         run: |
-          ln -s "$(which echo)" say
+          sudo ln -s "$(which echo)" say
           ./minnie-kenny.sh --force
           git secrets --scan-history
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Secrets check
         run: |
-          sudo ln -s "$(which echo)" say
+          sudo ln -s "$(which echo)" /usr/local/bin/say
           ./minnie-kenny.sh --force
           git secrets --scan-history
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-576

git has deleted `say`. The [PR](https://github.com/awslabs/git-secrets/pull/221) to fix the issue in git-secrets has not been merged. When it is merged, we can update the commit we use to pick up the change and delete this workaround.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
