### PR TITLE
[PPWM-105] Fix Workspace Deletion Failure Post-Migration

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -123,4 +123,5 @@
     <include file="changesets/20220802_add_entity_type_normalization.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220810_separate_iam_and_transfer_jobs.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20220929_create_workspace_manager_resource_monitor_record.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221020_alter_migration_retries_fk.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20221020_alter_migration_retries_fk.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20221020_alter_migration_retries_fk.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="ehigham" id="ALTER_V1_WORKSPACE_MIGRATION_RETRIES_FK">
+        <comment>
+            [PPWM-105] The `FK_V1_WORKSPACE_MIGRATION_HISTORY_MIGRATION_ID` foreign key constraint
+            prevents users from deleting their workspaces if those workspaces were migrated from
+            v1 workspaces and that migration had a retry.
+        </comment>
+        <dropForeignKeyConstraint constraintName="FK_V1_WORKSPACE_MIGRATION_HISTORY_MIGRATION_ID"
+                                  baseTableName="V1_WORKSPACE_MIGRATION_RETRIES"/>
+        <addForeignKeyConstraint baseColumnNames="MIGRATION_ID"
+                                 baseTableName="V1_WORKSPACE_MIGRATION_RETRIES"
+                                 constraintName="FK_V1_WORKSPACE_MIGRATION_HISTORY_MIGRATION_ID"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 onUpdate="CASCADE"
+                                 onDelete="CASCADE"
+                                 referencedColumnNames="id"
+                                 referencedTableName="V1_WORKSPACE_MIGRATION_HISTORY"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/PPWM-105 Foreign key on `V1_WORKSPACE_MIGRATION_RETIRES` table prevented workspaces from being deleted post migration. Update constraint to lift this.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
