### PR TITLE
[AJ-659] add default value for new ignoreEmptyColumns submission column

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -125,4 +125,5 @@
     <include file="changesets/20220929_create_workspace_manager_resource_monitor_record.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20221020_alter_migration_retries_fk.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20221011_add_ignore_empty_outputs.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20221027_add_default_ignore_empty_outputs.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20221027_add_default_ignore_empty_outputs.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20221027_add_default_ignore_empty_outputs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="add_empty_columns" author="jsafer" logicalFilePath="dummy">
+        <addDefaultValue tableName="SUBMISSION" columnName="IGNORE_EMPTY_OUTPUTS" columnDataType="BOOLEAN"
+                         defaultValueBoolean="false" />
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20221027_add_default_ignore_empty_outputs.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20221027_add_default_ignore_empty_outputs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet id="add_empty_columns" author="jsafer" logicalFilePath="dummy">
-        <addDefaultValue tableName="SUBMISSION" columnName="IGNORE_EMPTY_OUTPUTS" columnDataType="BOOLEAN"
-                         defaultValueBoolean="false" />
+        <addNotNullConstraint tableName="SUBMISSION" columnName="IGNORE_EMPTY_OUTPUTS" columnDataType="BOOLEAN"
+                              defaultNullValue="false"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-659
Liquibase change to put a default value for ignoreEmptyOutputs to fix handling of existing columns

See test failure ticket: https://broadworkbench.atlassian.net/browse/QA-2033

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
