### PR TITLE
multiple updates in batchUpsert [AJ-677]

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -35,7 +35,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import scala.collection.immutable.Map
 import scala.concurrent.ExecutionContext
 
 class LocalEntityProviderSpec

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -334,11 +334,11 @@ class LocalEntityProviderSpec
         val multiUpsert = Seq(
           EntityUpdateDefinition("myname",
                                  "mytype",
-                                 Seq(AddUpdateAttribute(AttributeName.withDefaultNS("one"), AttributeNumber(1)))
+                                 Seq(AddUpdateAttribute(AttributeName.withDefaultNS("one"), AttributeString("111")))
           ),
           EntityUpdateDefinition("myname",
                                  "mytype",
-                                 Seq(AddUpdateAttribute(AttributeName.withDefaultNS("two"), AttributeNumber(2)))
+                                 Seq(AddUpdateAttribute(AttributeName.withDefaultNS("two"), AttributeString("222")))
           )
         )
         val writes = localEntityProvider.batchUpsertEntities(multiUpsert).futureValue
@@ -353,11 +353,20 @@ class LocalEntityProviderSpec
         actual.results.size shouldBe 1
         actual.results.head shouldBe Entity("myname",
                                             "mytype",
-                                            Map(AttributeName.withDefaultNS("one") -> AttributeNumber(1),
-                                                AttributeName.withDefaultNS("two") -> AttributeNumber(2)
+                                            Map(AttributeName.withDefaultNS("one") -> AttributeString("111"),
+                                                AttributeName.withDefaultNS("two") -> AttributeString("222")
                                             )
         )
 
+        val withAllAttrs = runAndWait(
+          dataSource.dataAccess.entityQueryWithInlineAttributes
+            .findEntityByName(localEntityProviderTestData.workspace.workspaceIdAsUUID, "mytype", "myname")
+            .result
+        )
+
+        withAllAttrs.size shouldBe 1
+        val allAttrs = withAllAttrs.head.allAttributeValues.getOrElse("")
+        allAttrs shouldBe "myname 111 222"
     }
 
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-677

This error was caused because the batchUpsert logic attempted to detect which of the entities in the request payload already existed. Pre-existing entities were updated, and non-pre-existing entities were inserted.

However, if a given entity was in the request payload more than once, but did not pre-exist, this logic generated two inserts. The second of these inserts would fail on a MySQL unique-constraint violation.

This PR updates the logic (which is annoyingly complex) to treat these repeated entities as an insert followed by updates.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
