### PR TITLE
Delete unreferenced BPM billing profile on project deletion (WOR-577).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -8,16 +8,12 @@ import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.rawls.model.{
   AzureManagedAppCoordinates,
-  CreationStatuses,
   ErrorReport,
   ProjectRoles,
   RawlsBillingAccountName,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
   RawlsRequestContext,
   SamResourceAction,
-  SamResourceTypeNames,
-  UserInfo
+  SamResourceTypeNames
 }
 
 import java.util.UUID
@@ -33,6 +29,8 @@ trait BillingProfileManagerDAO {
                            billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates],
                            ctx: RawlsRequestContext
   ): ProfileModel
+
+  def deleteBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit
 
   def listManagedApps(subscriptionId: UUID, ctx: RawlsRequestContext): Seq[AzureManagedAppModel]
 
@@ -105,6 +103,9 @@ class BillingProfileManagerDAOImpl(
 
   def getBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Option[ProfileModel] =
     Option(apiClientProvider.getProfileApi(ctx).getProfile(billingProfileId))
+
+  override def deleteBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =
+    apiClientProvider.getProfileApi(ctx).deleteProfile(billingProfileId)
 
   def getAllBillingProfiles(ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[ProfileModel]] = {
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -33,6 +33,9 @@ class BillingRepository(dataSource: SlickDataSource) {
   def getBillingProjects(projectNames: Set[RawlsBillingProjectName]): Future[Seq[RawlsBillingProject]] =
     dataSource.inTransaction(_.rawlsBillingProjectQuery.getBillingProjects(projectNames))
 
+  def getBillingProjectsWithProfile(billingProfileId: Option[UUID]): Future[Seq[RawlsBillingProject]] =
+    dataSource.inTransaction(_.rawlsBillingProjectQuery.getBillingProjectsWithProfile(billingProfileId))
+
   def getBillingProfileId(
     projectName: RawlsBillingProjectName
   )(implicit executionContext: ExecutionContext): Future[Option[String]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -316,6 +316,9 @@ trait RawlsBillingProjectComponent {
     def getBillingProjects(projectNames: Set[RawlsBillingProjectName]): ReadAction[Seq[RawlsBillingProject]] =
       rawlsBillingProjectQuery.withProjectNames(projectNames).read
 
+    def getBillingProjectsWithProfile(billingProfileId: Option[UUID]): ReadAction[Seq[RawlsBillingProject]] =
+      rawlsBillingProjectQuery.withBillingProfileId(billingProfileId).read
+
     def getBillingProjectDetails(
       projectNames: Seq[RawlsBillingProjectName]
     ): ReadAction[Map[String, (CreationStatuses.CreationStatus, Option[String])]] =
@@ -378,6 +381,9 @@ trait RawlsBillingProjectComponent {
 
     def withProjectNames(projectNames: Iterable[RawlsBillingProjectName]): RawlsBillingProjectQuery =
       query.filter(_.projectName.inSetBind(projectNames.map(_.value)))
+
+    def withBillingProfileId(billingProfileId: Option[UUID]): RawlsBillingProjectQuery =
+      query.filter(_.billingProfileId === billingProfileId.map(_.value))
 
     def withBillingAccount(billingAccount: Option[RawlsBillingAccountName]): RawlsBillingProjectQuery =
       query.filter(_.billingAccount === billingAccount.map(_.value))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -8,24 +8,17 @@ import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceCon
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.{
   AzureManagedAppCoordinates,
-  CreationStatuses,
   ProjectRoles,
   RawlsBillingAccountName,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
-  SamBillingProjectActions,
-  SamBillingProjectRoles,
   SamResourceAction,
   SamResourceTypeNames,
-  SamRolesAndActions,
-  SamUserResource,
   UserInfo
 }
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{reset, times, verify, when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar
@@ -161,6 +154,24 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
     assertResult(expectedProfile)(profile)
     verify(profileApi, times(1)).createProfile(ArgumentMatchers.any[CreateProfileRequest])
+  }
+
+  behavior of "deleteBillingProfile"
+
+  it should "call BPM's delete method" in {
+    val profileId = UUID.randomUUID()
+
+    val provider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)
+    val profileApi = mock[ProfileApi](RETURNS_SMART_NULLS)
+    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
+      mock[SamDAO],
+      provider,
+      MultiCloudWorkspaceConfig(true, None, Some(azConfig))
+    )
+    when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
+
+    billingProfileManagerDAO.deleteBillingProfile(profileId, testContext)
+    verify(profileApi).deleteProfile(profileId)
   }
 
   behavior of "listManagedApps"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
@@ -179,11 +179,13 @@ class BillingRepositorySpec extends AnyFlatSpec with TestDriverComponent {
     val repo = new BillingRepository(slickDataSource)
     val firstProject = makeBillingProject()
     val secondProject = makeBillingProject()
+    val projectWithDifferentBP = makeBillingProject()
     val billingProfileId = UUID.fromString(firstProject.billingProfileId.get)
 
     Await.result(repo.createBillingProject(firstProject), Duration.Inf)
     Await.result(repo.createBillingProject(secondProject), Duration.Inf)
     Await.result(repo.setBillingProfileId(secondProject.projectName, billingProfileId), Duration.Inf)
+    Await.result(repo.createBillingProject(projectWithDifferentBP), Duration.Inf)
 
     val projectNames = Await.result(repo.getBillingProjectsWithProfile(Some(billingProfileId)), Duration.Inf).map {
       _.projectName

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
@@ -1,9 +1,8 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
-
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.model.{
   CreationStatuses,
   CromwellBackend,
@@ -15,6 +14,8 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.contain
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import java.util.UUID
 import scala.concurrent.Await
@@ -184,10 +185,11 @@ class BillingRepositorySpec extends AnyFlatSpec with TestDriverComponent {
     Await.result(repo.createBillingProject(secondProject), Duration.Inf)
     Await.result(repo.setBillingProfileId(secondProject.projectName, billingProfileId), Duration.Inf)
 
-    val projects = Await.result(repo.getBillingProjectsWithProfile(Some(billingProfileId)), Duration.Inf)
-    assertResult(2)(projects.length)
-    assertResult(firstProject.projectName)(projects.head.projectName)
-    assertResult(secondProject.projectName)(projects.tail.head.projectName)
+    val projectNames = Await.result(repo.getBillingProjectsWithProfile(Some(billingProfileId)), Duration.Inf).map {
+      _.projectName
+    }
+    assertResult(2)(projectNames.length)
+    projectNames should contain theSameElementsAs Seq(firstProject.projectName, secondProject.projectName)
   }
 
   it should "return return an empty Seq if no billing profile ID specified" in withDefaultTestDatabase {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -417,7 +417,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                  Duration.Inf
     )
 
-    verify(bpm, Mockito.times(1)).deleteBillingProfile(billingProfileId, testContext)
+    verify(bpm, Mockito.times(1)).deleteBillingProfile(ArgumentMatchers.any(), ArgumentMatchers.any())
   }
 
   it should "not delete the billing profile if other projects reference it" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.rawls.model.{
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
   RawlsBillingAccountName,
+  RawlsBillingProject,
   RawlsBillingProjectName,
   RawlsRequestContext,
   RawlsUserEmail,
@@ -303,12 +304,13 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     }
   }
 
-  it should "succeed if the landing zone id does not exist" in {
+  it should "succeed if the landing zone billing profiles id do not exist" in {
     val billingProjectName = RawlsBillingProjectName("fake_name")
 
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
+    when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(None))
 
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
@@ -321,6 +323,10 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                  ),
                  Duration.Inf
     )
+
+    verify(workspaceManagerDAO, Mockito.times(0))
+      .deleteLandingZone(ArgumentMatchers.any[UUID], ArgumentMatchers.eq(testContext))
+    verify(bpm, Mockito.times(0)).deleteBillingProfile(ArgumentMatchers.any[UUID], ArgumentMatchers.eq(testContext))
   }
 
   it should "delete the landing zone if the id exists" in {
@@ -330,6 +336,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(Some(landingZoneId.toString)))
+    // Mock no associated billing profile to delete
+    when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(None))
 
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
@@ -374,5 +382,83 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       exception shouldBe a[BillingProjectDeletionException]
       assert(exception.getMessage.contains(landingZoneErrorMessage))
     }
+  }
+
+  it should "delete the billing profile if no other project references it" in {
+    val billingProjectName = RawlsBillingProjectName("fake_name")
+
+    val repo = mock[BillingRepository]
+    val billingProfileId = UUID.randomUUID()
+    when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
+    when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
+    when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(Some(billingProfileId.toString)))
+    when(repo.getBillingProjectsWithProfile(Some(billingProfileId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(billingProjectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(billingProfileId.toString)
+          )
+        )
+      )
+    )
+
+    val bpm = mock[BillingProfileManagerDAO]
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    val bp =
+      new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
+
+    Await.result(bp.preDeletionSteps(
+                   billingProjectName,
+                   testContext
+                 ),
+                 Duration.Inf
+    )
+
+    verify(bpm, Mockito.times(1)).deleteBillingProfile(billingProfileId, testContext)
+  }
+
+  it should "not delete the billing profile if other projects reference it" in {
+    val billingProjectName = RawlsBillingProjectName("fake_name")
+
+    val repo = mock[BillingRepository]
+    val billingProfileId = UUID.randomUUID()
+    when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
+    when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
+    when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(Some(billingProfileId.toString)))
+    when(repo.getBillingProjectsWithProfile(Some(billingProfileId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(billingProjectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(billingProfileId.toString)
+          ),
+          RawlsBillingProject(RawlsBillingProjectName("other_billing_project"),
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(billingProfileId.toString)
+          )
+        )
+      )
+    )
+
+    val bpm = mock[BillingProfileManagerDAO]
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    val bp =
+      new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
+
+    Await.result(bp.preDeletionSteps(
+                   billingProjectName,
+                   testContext
+                 ),
+                 Duration.Inf
+    )
+
+    verify(bpm, Mockito.times(0)).deleteBillingProfile(billingProfileId, testContext)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -304,7 +304,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     }
   }
 
-  it should "succeed if the landing zone billing profiles id do not exist" in {
+  it should "succeed if the landing zone and billing profiles id do not exist" in {
     val billingProjectName = RawlsBillingProjectName("fake_name")
 
     val repo = mock[BillingRepository]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -385,10 +385,10 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   }
 
   it should "delete the billing profile if no other project references it" in {
-    val billingProjectName = RawlsBillingProjectName("fake_name")
+    val billingProfileId = UUID.randomUUID()
+    val billingProjectName = RawlsBillingProjectName(s"project_for_${billingProfileId}")
 
     val repo = mock[BillingRepository]
-    val billingProfileId = UUID.randomUUID()
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
     when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(Some(billingProfileId.toString)))
@@ -418,8 +418,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
 
     verify(repo, Mockito.times(1)).getBillingProfileId(billingProjectName)
-    verify(repo, Mockito.times(1)).getBillingProjectsWithProfile(ArgumentMatchers.any())
-    verify(bpm, Mockito.times(1)).deleteBillingProfile(ArgumentMatchers.any(), ArgumentMatchers.any())
+    verify(repo, Mockito.times(1)).getBillingProjectsWithProfile(Some(billingProfileId))
+    verify(bpm, Mockito.times(1)).deleteBillingProfile(
+      ArgumentMatchers.eq(billingProfileId),
+      ArgumentMatchers.any()
+    )
   }
 
   it should "not delete the billing profile if other projects reference it" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -417,6 +417,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                  Duration.Inf
     )
 
+    verify(repo, Mockito.times(1)).getBillingProfileId(billingProjectName)
+    verify(repo, Mockito.times(1)).getBillingProjectsWithProfile(ArgumentMatchers.any())
     verify(bpm, Mockito.times(1)).deleteBillingProfile(ArgumentMatchers.any(), ArgumentMatchers.any())
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-577
This change allows Terra managed app deployments to be reused once the Rawls billing project is deleted (through Swagger/curl).

Log output from manual testing:

````
rawls [INFO] [16:24:22.710] [scala-execution-context-global-56] o.b.d.r.b.BpmBillingProjectLifecycle - Deleting BPM-backed billing project RawlsBillingProjectName(CARNov7), initiated deletion of landing zone a30683c0-0cb7-42f3-94fc-8ce4a701c087 with jobID b6084e84-b353-42b4-9f88-ed08620d9fe2
rawls [INFO] [16:24:23.676] [scala-execution-context-global-56] o.b.d.r.b.BpmBillingProjectLifecycle - Deleting BPM-backed billing project RawlsBillingProjectName(CARNov7), deleting billing profile record aa3e1d57-94c1-45e8-a83a-30bb6e4bfbb4
````


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
