### PR TITLE
Use LZ storage account for workspace storage container (WOR-511).

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions :+ rawlsModelExclusion:_*)
 
-  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.441-SNAPSHOT"
+  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.459-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32" // scala-steward:off (must match TDR)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -191,19 +191,26 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     )
   }
 
-  def createAzureStorageContainer(workspaceId: UUID, storageAccountId: UUID, ctx: RawlsRequestContext) =
+  def createAzureStorageContainer(workspaceId: UUID, storageAccountId: Option[UUID], ctx: RawlsRequestContext) = {
+    val storageContainerCreationParameters = storageAccountId match {
+      case Some(_) =>
+        new AzureStorageContainerCreationParameters()
+          .storageContainerName(s"sc-${workspaceId}")
+          .storageAccountId(storageAccountId.get)
+      case None =>
+        new AzureStorageContainerCreationParameters()
+          .storageContainerName(s"sc-${workspaceId}")
+    }
+
     getControlledAzureResourceApi(ctx).createAzureStorageContainer(
       new CreateControlledAzureStorageContainerRequestBody()
         .common(
           createCommonFields(s"sc-${workspaceId}").cloningInstructions(CloningInstructionsEnum.DEFINITION)
         )
-        .azureStorageContainer(
-          new AzureStorageContainerCreationParameters()
-            .storageContainerName(s"sc-${workspaceId}")
-            .storageAccountId(storageAccountId)
-        ),
+        .azureStorageContainer(storageContainerCreationParameters),
       workspaceId
     )
+  }
 
   override def getRoles(workspaceId: UUID, ctx: RawlsRequestContext) = getWorkspaceApi(ctx).getRoles(workspaceId)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -70,8 +70,18 @@ trait WorkspaceManagerDAO {
                                 region: String,
                                 ctx: RawlsRequestContext
   ): CreatedControlledAzureStorage
+
+  /**
+    * Creates an Azure storage container in the workspace.
+    *
+    * @param workspaceId the UUID of the workspace
+    * @param storageAccountId optional UUID of a storage account resource. If not specified, the storage
+    *                         account from the workspace's landing zone will be used
+    * @param ctx Raws context
+    * @return the response from workspace manager
+    */
   def createAzureStorageContainer(workspaceId: UUID,
-                                  storageAccountId: UUID,
+                                  storageAccountId: Option[UUID],
                                   ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -9,8 +9,8 @@ import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.{
   AzureManagedAppCoordinates,
   ErrorReport,
@@ -18,13 +18,12 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   SamBillingProjectActions,
   SamResourceTypeNames,
-  UserInfo,
   Workspace,
   WorkspaceCloudPlatform,
   WorkspaceRequest
 }
-import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceWithParent}
 import org.broadinstitute.dsde.rawls.util.Retry
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceWithParent}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.joda.time.DateTime
 import slick.jdbc.TransactionIsolation
@@ -231,14 +230,12 @@ class MultiCloudWorkspaceService(ctx: RawlsRequestContext,
       azureRelayCreateResult <- traceWithParent("createAzureRelayInWSM", parentContext)(_ =>
         Future(workspaceManagerDAO.createAzureRelay(workspaceId, workspaceRequest.region, ctx))
       )
-      // Create storage account before polling on relay because it takes ~45 seconds to create a relay
-      _ = logger.info(s"Creating Azure storage account in WSM [workspaceId = ${workspaceId}]")
-      storageAccountResult <- traceWithParent("createStorageAccount", parentContext)(_ =>
-        Future(workspaceManagerDAO.createAzureStorageAccount(workspaceId, workspaceRequest.region, ctx))
+      // Create storage container before polling on relay because it takes ~45 seconds to create a relay
+      containerResult <- traceWithParent("createStorageContainer", parentContext)(_ =>
+        Future(workspaceManagerDAO.createAzureStorageContainer(workspaceId, None, ctx))
       )
-      _ = logger.info(s"Creating Azure storage container in WSM [workspaceId = ${workspaceId}]")
-      _ <- traceWithParent("createStorageContainer", parentContext)(_ =>
-        Future(workspaceManagerDAO.createAzureStorageContainer(workspaceId, storageAccountResult.getResourceId, ctx))
+      _ = logger.info(
+        s"Created Azure storage container in WSM [workspaceId = ${workspaceId}, containerId = ${containerResult.getResourceId}]"
       )
       relayJobControlId = azureRelayCreateResult.getJobReport.getId
       _ = logger.info(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -109,17 +109,30 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
 
   behavior of "createAzureStorageContainer"
 
-  it should "call the WSM controlled azure resource API" in {
+  it should "call the WSM controlled azure resource API with a SA id" in {
     val controlledAzureResourceApi = mock[ControlledAzureResourceApi]
     val wsmDao =
       new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
 
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
     val storageAccountId = UUID.randomUUID()
-    wsmDao.createAzureStorageContainer(workspaceId, storageAccountId, testContext)
+    wsmDao.createAzureStorageContainer(workspaceId, Some(storageAccountId), testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "sc-" + workspaceId
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe storageAccountId
+    assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon, CloningInstructionsEnum.DEFINITION)
+  }
+
+  it should "call the WSM controlled azure resource API without a SA id" in {
+    val controlledAzureResourceApi = mock[ControlledAzureResourceApi]
+    val wsmDao =
+      new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
+
+    val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
+    wsmDao.createAzureStorageContainer(workspaceId, None, testContext)
+    verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
+    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "sc-" + workspaceId
+    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe null
     assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon, CloningInstructionsEnum.DEFINITION)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -179,7 +179,7 @@ class MockWorkspaceManagerDAO(
     mockCreateAzureStorageAccountResult()
 
   override def createAzureStorageContainer(workspaceId: UUID,
-                                           storageAccountId: UUID,
+                                           storageAccountId: Option[UUID],
                                            ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer =
     mockCreateAzureStorageContainerResult()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.user
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.{CloudPlatform => BPMCloudPlatform, ProfileModel}
-import bio.terra.workspace.model.{AzureLandingZone, AzureLandingZoneResult, JobReport}
+import bio.terra.workspace.model.{AzureLandingZoneDetails, AzureLandingZoneResult, JobReport}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.typesafe.config.{Config, ConfigFactory}
@@ -16,10 +16,9 @@ import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManage
 import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, _}
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
-import org.mockito.{ArgumentMatchers, Mockito}
-import org.mockito.ArgumentMatchers.{any, contains}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
-import org.mockito.verification.VerificationMode
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -1354,7 +1353,7 @@ class UserServiceSpec
     val wsmDao = mock[WorkspaceManagerDAO]
     val lzId = UUID.randomUUID()
     val landingZoneResult = new AzureLandingZoneResult()
-      .landingZone(new AzureLandingZone().id(lzId))
+      .landingZone(new AzureLandingZoneDetails().id(lzId))
       .jobReport(new JobReport().status(JobReport.StatusEnum.SUCCEEDED))
     when(
       wsmDao.getCreateAzureLandingZoneResult(ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
@@ -1393,7 +1392,7 @@ class UserServiceSpec
     val wsmDao = mock[WorkspaceManagerDAO]
     val lzId = UUID.randomUUID()
     val landingZoneResult = new AzureLandingZoneResult()
-      .landingZone(new AzureLandingZone().id(lzId))
+      .landingZone(new AzureLandingZoneDetails().id(lzId))
       .jobReport(new JobReport().status(JobReport.StatusEnum.RUNNING))
     when(
       wsmDao.getCreateAzureLandingZoneResult(ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
@@ -1510,7 +1509,7 @@ class UserServiceSpec
 
     val wsmDao = mock[WorkspaceManagerDAO]
     val lzId = UUID.randomUUID()
-    val landingZoneResult = new AzureLandingZoneResult().landingZone(new AzureLandingZone().id(lzId))
+    val landingZoneResult = new AzureLandingZoneResult().landingZone(new AzureLandingZoneDetails().id(lzId))
     when(
       wsmDao.getCreateAzureLandingZoneResult(ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
                                              ArgumentMatchers.any()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
   def excludeBroadWorkbench = ExclusionRule("org.broadinstitute.dsde.workbench")
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.441-SNAPSHOT")
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.459-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.22-SNAPSHOT")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-511

Logging from creating a workspace with this code change:

````
rawls [INFO] [19:13:19.152] [scala-execution-context-global-78] o.b.d.r.w.MultiCloudWorkspaceService - Created Azure storage container in WSM [workspaceId = 1e94fe51-af40-4b57-957f-68155504e224, containerId = 4fbaa44a-11a5-418e-88e1-1e8173103e44]
````
And running https://github.com/DataBiosphere/terra-ui/pull/3522 locally (note "lz" prefix),

![image](https://user-images.githubusercontent.com/484484/202281950-e5a96269-28c8-4030-a516-161c7a8fcc1e.png)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
