### PR TITLE
[WOR-631] Remove Alpha_Spend_Report_Users, feature available to all users

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -14,7 +14,6 @@ import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithE
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito.{doReturn, spy, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -549,40 +548,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         ),
         Duration.Inf
       )
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
-  }
-
-  it should "throw an exception when user is not in alpha group" in {
-    val samDAO = mock[SamDAO]
-    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
-    when(
-      samDAO.userHasAction(
-        ArgumentMatchers.eq(SamResourceTypeNames.managedGroup),
-        ArgumentMatchers.eq("Alpha_Spend_Report_Users"),
-        ArgumentMatchers.eq(SamResourceAction("use")),
-        ArgumentMatchers.eq(testContext)
-      )
-    ).thenReturn(Future.successful(false))
-
-    val service = new SpendReportingService(
-      testContext,
-      mock[SlickDataSource],
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
-      samDAO,
-      spendReportingServiceConfig
-    )
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        service.getSpendForBillingProject(billingProject.projectName,
-                                          DateTime.now().minusDays(1),
-                                          DateTime.now(),
-                                          Set.empty
-        ),
-        Duration.Inf
-      )
-      fail("action was run without an exception being thrown")
     }
     e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-631 with information in [parent ticket](https://broadworkbench.atlassian.net/browse/WOR-468). 

Removes the check on the alpha group for returning spend report data.

Related to https://github.com/DataBiosphere/terra-ui/pull/3520 and https://github.com/broadinstitute/terra-helmfile/pull/3580 (monolith release must proceed those tickets merging).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
