### PR TITLE
PROD-750: Add heartbeat and liveness checks to submission monitor

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -135,11 +135,11 @@ class SubmissionMonitorActor(val workspaceName: WorkspaceName,
       checkCurrentWorkflowStatusCounts(true) pipeTo parent
     case SubmissionMonitorHeartbeat =>
       val secondsSinceLastMonitorPass = OffsetDateTime.now().toEpochSecond - lastMonitorPass.toEpochSecond
-      logger.debug(s"submission monitor heartbeat. Last monitor pass (or actor startup): ${lastMonitorPass} ($secondsSinceLastMonitorPass ago)")
+      logger.debug(s"submission monitor heartbeat for ${submissionId}. Last monitor pass (or actor startup): ${lastMonitorPass} ($secondsSinceLastMonitorPass ago)")
       val safetyMargin = (config.submissionPollInterval.toSeconds * 10)
       if (secondsSinceLastMonitorPass > safetyMargin) {
         // This will cause the actor to crash, this situation will be logged and recorded in sentry, and the actor will be restarted by the supervisor:
-        self ! Status.Failure(new Exception(s"Time since last monitor pass (${secondsSinceLastMonitorPass seconds}) exceeds allowed safety margin (10 x submissionPollInterval = 10 x ${config.submissionPollInterval.toSeconds} seconds = ${safetyMargin} seconds)"))
+        self ! Status.Failure(new Exception(s"Submission ${submissionId}: Time since last monitor pass (${secondsSinceLastMonitorPass seconds}) exceeds allowed safety margin (10 x submissionPollInterval = 10 x ${config.submissionPollInterval.toSeconds} seconds = ${safetyMargin} seconds)"))
       } else {
         scheduleHeartbeat()
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -153,12 +153,8 @@ class SubmissionMonitorActor(val workspaceName: WorkspaceName,
       )
       val safetyMargin = config.submissionPollInterval.toSeconds * 10
       if (secondsSinceLastMonitorPass > safetyMargin) {
-        // This will cause the actor to crash, this situation will be logged and recorded in sentry, and the actor will be restarted by the supervisor:
-        self ! Status.Failure(
-          new Exception(
-            s"Submission ${submissionId}: Time since last monitor pass (${secondsSinceLastMonitorPass seconds}) exceeds allowed safety margin (10 x submissionPollInterval = 10 x ${config.submissionPollInterval.toSeconds} seconds = ${safetyMargin} seconds)"
-          )
-        )
+        // This won't cause anything to happen, other than this detectable and alertable error message:
+        logger.error(s"Submission ${submissionId}: Time since last monitor pass (${secondsSinceLastMonitorPass seconds}) exceeds allowed safety margin (10 x submissionPollInterval = 10 x ${config.submissionPollInterval.toSeconds} seconds = ${safetyMargin} seconds). Perhaps try using innotop (see rawls playbook) to work out what's going on.")
       } else {
         scheduleHeartbeat()
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -154,7 +154,9 @@ class SubmissionMonitorActor(val workspaceName: WorkspaceName,
       val safetyMargin = config.submissionPollInterval.toSeconds * 10
       if (secondsSinceLastMonitorPass > safetyMargin) {
         // This won't cause anything to happen, other than this detectable and alertable error message:
-        logger.error(s"Submission ${submissionId}: Time since last monitor pass (${secondsSinceLastMonitorPass seconds}) exceeds allowed safety margin (10 x submissionPollInterval = 10 x ${config.submissionPollInterval.toSeconds} seconds = ${safetyMargin} seconds). Perhaps try using innotop (see rawls playbook) to work out what's going on.")
+        logger.error(
+          s"Submission ${submissionId}: Time since last monitor pass (${secondsSinceLastMonitorPass seconds}) exceeds allowed safety margin (10 x submissionPollInterval = 10 x ${config.submissionPollInterval.toSeconds} seconds = ${safetyMargin} seconds). Perhaps try using innotop (see rawls playbook) to work out what's going on."
+        )
       } else {
         scheduleHeartbeat()
       }


### PR DESCRIPTION
Per PROD-650, we're still not sure **why** the submission monitor actor is getting jammed up, but we do think we know which function it's happening in (technically, which function gets run but then doesn't log that it completed, and doesn't get triggered again - at least not for a very long time). So - we can at least catch the situation when it happens and log it. ~And since we're there, we might as well restart the actor too~.

This should:
- Let us count how often this is happening
- Give us sentry alerts every time this happens
- ~Give the monitor a chance to reset its state by being killed and restarted~