### PR TITLE
Add more error handling to cleanup resources (WOR-635).

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -37,6 +37,25 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   val userInfo: UserInfo =
     UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
   val testContext = RawlsRequestContext(userInfo)
+  val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
+  val billingProjectName = RawlsBillingProjectName("fake_name")
+  val createRequest = CreateRawlsV2BillingProjectFullRequest(
+    billingProjectName,
+    None,
+    None,
+    Some(coords)
+  )
+  val profileModel = new ProfileModel().id(UUID.randomUUID())
+  val landingZoneDefinition = "fake-landing-zone-definition"
+  val landingZoneVersion = "fake-landing-zone-version"
+  val azConfig: AzureConfig = AzureConfig(
+    "fake-alpha-feature-group",
+    "eastus",
+    landingZoneDefinition,
+    landingZoneVersion
+  )
+  val landingZoneId = UUID.randomUUID()
+  val landingZoneJobId = UUID.randomUUID()
 
   behavior of "validateBillingProjectCreationRequest"
 
@@ -46,27 +65,20 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             mock[HttpWorkspaceManagerDAO],
                                             mock[WorkspaceManagerResourceMonitorRecordDao]
     )
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
+    val gcpCreateRequest = CreateRawlsV2BillingProjectFullRequest(
+      billingProjectName,
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
       None
     )
 
     intercept[NotImplementedError] {
-      Await.result(bp.validateBillingProjectCreationRequest(createRequest, testContext), Duration.Inf)
+      Await.result(bp.validateBillingProjectCreationRequest(gcpCreateRequest, testContext), Duration.Inf)
     }
   }
 
   it should "fail when no matching managed app is found" in {
     val bpm = mock[BillingProfileManagerDAO]
-    val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
-      None,
-      None,
-      Some(coords)
-    )
     when(bpm.listManagedApps(coords.subscriptionId, false, testContext))
       .thenReturn(Seq())
     val bp = new BpmBillingProjectLifecycle(mock[BillingRepository],
@@ -82,13 +94,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
 
   it should "fail when BPM errors out" in {
     val bpm = mock[BillingProfileManagerDAO]
-    val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
-      None,
-      None,
-      Some(coords)
-    )
     when(bpm.listManagedApps(coords.subscriptionId, false, testContext))
       .thenThrow(new RuntimeException("failed"))
 
@@ -105,13 +110,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
 
   it should "succeed when a matching managed app is found" in {
     val bpm = mock[BillingProfileManagerDAO]
-    val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
-      None,
-      None,
-      Some(coords)
-    )
     when(bpm.listManagedApps(coords.subscriptionId, false, testContext))
       .thenReturn(
         Seq(
@@ -133,27 +131,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   behavior of "postCreationSteps"
 
   it should "store the landing zone ID and job creation ID and link the profile ID to the billing project record" in {
-    val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
-      None,
-      None,
-      Some(coords)
-    )
     val repo = mock[BillingRepository]
     val bpm = mock[BillingProfileManagerDAO]
-    val profileModel = new ProfileModel().id(UUID.randomUUID())
-
-    val landingZoneDefinition = "fake-landing-zone-definition"
-    val landingZoneVersion = "fake-landing-zone-version"
-    val azConfig: AzureConfig = AzureConfig(
-      "fake-alpha-feature-group",
-      "eastus",
-      landingZoneDefinition,
-      landingZoneVersion
-    )
-    val landingZoneId = UUID.randomUUID()
-    val landingZoneJobId = UUID.randomUUID()
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
 
     when(
@@ -199,13 +178,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   }
 
   it should "wrap exceptions thrown by synchronous calls in a Future" in {
-    val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
-      None,
-      None,
-      Some(coords)
-    )
     val bpm = mock[BillingProfileManagerDAO]
     val thrownExceptionMessage = "Exception from BPM"
     when(
@@ -232,26 +204,9 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     }
   }
 
-  it should "handle landing zone creation errors" in {
-    val coords = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      RawlsBillingProjectName("fake_name"),
-      None,
-      None,
-      Some(coords)
-    )
+  it should "handle landing zone creation errors and delete the billing profile" in {
     val repo = mock[BillingRepository]
     val bpm = mock[BillingProfileManagerDAO]
-    val profileModel = new ProfileModel().id(UUID.randomUUID())
-
-    val landingZoneDefinition = "fake-landing-zone-definition"
-    val landingZoneVersion = "fake-landing-zone-version"
-    val azConfig: AzureConfig = AzureConfig(
-      "fake-alpha-feature-group",
-      "eastus",
-      landingZoneDefinition,
-      landingZoneVersion
-    )
     val landingZoneErrorMessage = "Error from creating landing zone"
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     when(
@@ -266,7 +221,18 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     ).thenReturn(
       new CreateLandingZoneResult().errorReport(new ErrorReport().statusCode(500).message(landingZoneErrorMessage))
     )
-
+    when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(createRequest.projectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(profileModel.getId.toString)
+          )
+        )
+      )
+    )
     val bp =
       new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
     val result = bp.postCreationSteps(
@@ -277,18 +243,104 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     ScalaFutures.whenReady(result.failed) { exception =>
       exception shouldBe a[LandingZoneCreationException]
       assert(exception.getMessage.contains(landingZoneErrorMessage))
+      verify(bpm, Mockito.times(1)).deleteBillingProfile(profileModel.getId, testContext)
+    }
+  }
+
+  it should "handle landing zone unexpected errors and delete the billing profile" in {
+    val bpm = mock[BillingProfileManagerDAO]
+    val repo = mock[BillingRepository]
+    val unexpectedError = "Error from WSM"
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    when(
+      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
+                               ArgumentMatchers.eq(createRequest.billingInfo),
+                               ArgumentMatchers.eq(testContext)
+      )
+    )
+      .thenReturn(profileModel)
+    when(
+      workspaceManagerDAO.createLandingZone(landingZoneDefinition, landingZoneVersion, profileModel.getId, testContext)
+    ).thenThrow(new RuntimeException(unexpectedError))
+    when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(createRequest.projectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(profileModel.getId.toString)
+          )
+        )
+      )
+    )
+    val bp =
+      new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
+    val result = bp.postCreationSteps(
+      createRequest,
+      new MultiCloudWorkspaceConfig(true, None, Some(azConfig)),
+      testContext
+    )
+    ScalaFutures.whenReady(result.failed) { exception =>
+      exception shouldBe a[RuntimeException]
+      assert(exception.getMessage.contains(unexpectedError))
+      verify(bpm, Mockito.times(1)).deleteBillingProfile(profileModel.getId, testContext)
+    }
+  }
+
+  it should "handle errors after landing zone creation and delete resources" in {
+    val bpm = mock[BillingProfileManagerDAO]
+    val repo = mock[BillingRepository]
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    when(
+      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
+                               ArgumentMatchers.eq(createRequest.billingInfo),
+                               ArgumentMatchers.eq(testContext)
+      )
+    )
+      .thenReturn(profileModel)
+    when(
+      workspaceManagerDAO.createLandingZone(landingZoneDefinition, landingZoneVersion, profileModel.getId, testContext)
+    ).thenReturn(
+      new CreateLandingZoneResult()
+        .landingZoneId(landingZoneId)
+        .jobReport(new JobReport().id(landingZoneJobId.toString))
+    )
+    when(repo.updateLandingZoneId(createRequest.projectName, landingZoneId))
+      .thenReturn(Future.failed(new RuntimeException("Error from billing repo")))
+    when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(createRequest.projectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(profileModel.getId.toString)
+          )
+        )
+      )
+    )
+
+    val bp =
+      new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
+    val result = bp.postCreationSteps(
+      createRequest,
+      new MultiCloudWorkspaceConfig(true, None, Some(azConfig)),
+      testContext
+    )
+    ScalaFutures.whenReady(result.failed) { exception =>
+      exception shouldBe a[RuntimeException]
+      verify(bpm, Mockito.times(1)).deleteBillingProfile(profileModel.getId, testContext)
+      verify(workspaceManagerDAO, Mockito.times(1)).deleteLandingZone(landingZoneId, testContext)
     }
   }
 
   behavior of "preDeletionSteps"
 
   it should "error if the landing zone is still being created" in {
-    val billingProjectName = RawlsBillingProjectName("fake_name")
-
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.CreatingLandingZone))
     val landingZoneErrorMessage = "cannot be deleted because its landing zone is still being created"
-
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val bp =
@@ -305,8 +357,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   }
 
   it should "succeed if the landing zone and billing profiles id do not exist" in {
-    val billingProjectName = RawlsBillingProjectName("fake_name")
-
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
@@ -330,9 +380,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   }
 
   it should "delete the landing zone if the id exists" in {
-    val billingProjectName = RawlsBillingProjectName("fake_name")
-    val landingZoneId = UUID.randomUUID()
-
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(Some(landingZoneId.toString)))
@@ -357,13 +404,25 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   }
 
   it should "handle the landing zone error reports" in {
-    val billingProjectName = RawlsBillingProjectName("fake_name")
-    val landingZoneId = UUID.randomUUID()
+    val billingProfileId = profileModel.getId
     val landingZoneErrorMessage = "error from deleting landing zone"
 
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(Some(landingZoneId.toString)))
+    when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(Some(billingProfileId.toString)))
+    when(repo.getBillingProjectsWithProfile(Some(billingProfileId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(billingProjectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(billingProfileId.toString)
+          )
+        )
+      )
+    )
 
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
@@ -373,21 +432,23 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bp =
       new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
 
-    val result = bp.preDeletionSteps(
-      billingProjectName,
-      testContext
+    Await.result(bp.preDeletionSteps(
+                   billingProjectName,
+                   testContext
+                 ),
+                 Duration.Inf
     )
 
-    ScalaFutures.whenReady(result.failed) { exception =>
-      exception shouldBe a[BillingProjectDeletionException]
-      assert(exception.getMessage.contains(landingZoneErrorMessage))
-    }
+    verify(repo, Mockito.times(1)).getBillingProfileId(billingProjectName)
+    verify(repo, Mockito.times(1)).getBillingProjectsWithProfile(Some(billingProfileId))
+    verify(bpm, Mockito.times(1)).deleteBillingProfile(
+      ArgumentMatchers.eq(billingProfileId),
+      ArgumentMatchers.any()
+    )
   }
 
   it should "delete the billing profile if no other project references it" in {
-    val billingProfileId = UUID.randomUUID()
-    val billingProjectName = RawlsBillingProjectName(s"project_for_${billingProfileId}")
-
+    val billingProfileId = profileModel.getId
     val repo = mock[BillingRepository]
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
@@ -429,7 +490,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val billingProjectName = RawlsBillingProjectName("fake_name")
 
     val repo = mock[BillingRepository]
-    val billingProfileId = UUID.randomUUID()
+    val billingProfileId = profileModel.getId
     when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
     when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
     when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(Some(billingProfileId.toString)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -1794,7 +1794,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         })).flatten
         submissionList.forall(_.status == SubmissionStatuses.Done.toString) && submissionList.length == numSubmissions
       },
-      max = 30 seconds,
+      max = 60 seconds,
       interval = 1 second
     )
 


### PR DESCRIPTION
Ticket: <[WOR-635](https://broadworkbench.atlassian.net/browse/WOR-635)>

Adds more robustness in the Azure billing project creation/deletion so that we will clean up landing zones and billing profiles if at all possible. 

Note that WSM landing zone deletion code does not use the billing profile at all, so it is safe to delete the billing profile while landing zone deletion is underway.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
