### PR TITLE
Log all encountered exceptions, and throw original exception to user (WOR-650)

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -69,7 +69,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
       _ = logger.info(s"Created billing project record, running post-creation steps [name=${billingProjectName.value}]")
       creationStatus <- billingProjectLifecycle.postCreationSteps(createProjectRequest, config, ctx).recoverWith {
         case t: Throwable =>
-          logger.error(s"Error in post-creation steps for billing project [name=${billingProjectName.value}]")
+          logger.error(s"Error in post-creation steps for billing project [name=${billingProjectName.value}]", t)
           rollbackCreateV2BillingProjectInternal(createProjectRequest).map(throw t)
       }
       _ = logger.info(s"Post-creation steps succeeded, setting billing project status [status=$creationStatus]")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -219,3 +219,6 @@ class GoogleBillingAccountAccessException(errorReport: ErrorReport) extends Rawl
 class LandingZoneCreationException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
 
 class BillingProjectDeletionException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
+
+class BillingProjectCreationException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
+

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -221,4 +221,3 @@ class LandingZoneCreationException(errorReport: ErrorReport) extends RawlsExcept
 class BillingProjectDeletionException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
 
 class BillingProjectCreationException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
-

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -219,5 +219,3 @@ class GoogleBillingAccountAccessException(errorReport: ErrorReport) extends Rawl
 class LandingZoneCreationException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
 
 class BillingProjectDeletionException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
-
-class BillingProjectCreationException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -144,7 +144,7 @@ class BpmBillingProjectLifecycle(
             // Log the exception that prevented cleanup from completing, but do not throw it so original
             // cause of billing project failure is shown to user.
             logger.warn(
-              s"Unable to delete billing profile zone with ID ${profileModel.getId} for BPM-backed billing project ${projectName.value}.",
+              s"Unable to delete billing profile with ID ${profileModel.getId} for BPM-backed billing project ${projectName.value}.",
               cleanupError
             )
           } >> Future.failed(t)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -134,10 +134,12 @@ class BpmBillingProjectLifecycle(
             )
             _ <- billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
           } yield CreationStatuses.CreatingLandingZone).recoverWith { case t: Throwable =>
+            logger.warn("Billing project creation failed, cleaning up landing zone")
             cleanupLandingZone(landingZone.getLandingZoneId, projectName, ctx) >> Future.failed(t)
           }
         }
         .recoverWith { case t: Throwable =>
+          logger.warn("Billing project creation failed, cleaning up billing profile")
           cleanupBillingProfile(profileModel.getId, projectName, ctx) >> Future.failed(t)
         }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -135,7 +135,10 @@ class BpmBillingProjectLifecycle(
             _ <- billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
           } yield CreationStatuses.CreatingLandingZone).recoverWith { case t: Throwable =>
             logger.error("Billing project creation failed, cleaning up landing zone")
-            cleanupLandingZone(landingZone.getLandingZoneId, projectName, ctx) >> Future.failed(t)
+            Option(landingZone.getLandingZoneId) match {
+              case Some(landingZoneId) => cleanupLandingZone(landingZoneId, projectName, ctx) >> Future.failed(t)
+              case _                   => Future.failed(t)
+            }
           }
         }
         .recoverWith { case t: Throwable =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -140,10 +140,12 @@ class BpmBillingProjectLifecycle(
         }
         .recoverWith { case t: Throwable =>
           logger.error("Billing project creation failed, cleaning up billing profile")
-          cleanupBillingProfile(profileModel.getId, projectName, ctx).recover { case t: Throwable =>
+          cleanupBillingProfile(profileModel.getId, projectName, ctx).recover { case cleanupError: Throwable =>
+            // Log the exception that prevented cleanup from completing, but do not throw it so original
+            // cause of billing project failure is shown to user.
             logger.warn(
               s"Unable to delete billing profile zone with ID ${profileModel.getId} for BPM-backed billing project ${projectName.value}.",
-              t
+              cleanupError
             )
           } >> Future.failed(t)
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -134,12 +134,12 @@ class BpmBillingProjectLifecycle(
             )
             _ <- billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
           } yield CreationStatuses.CreatingLandingZone).recoverWith { case t: Throwable =>
-            logger.warn("Billing project creation failed, cleaning up landing zone")
+            logger.error("Billing project creation failed, cleaning up landing zone", t)
             cleanupLandingZone(landingZone.getLandingZoneId, projectName, ctx) >> Future.failed(t)
           }
         }
         .recoverWith { case t: Throwable =>
-          logger.warn("Billing project creation failed, cleaning up billing profile")
+          logger.error("Billing project creation failed, cleaning up billing profile", t)
           cleanupBillingProfile(profileModel.getId, projectName, ctx) >> Future.failed(t)
         }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -145,7 +145,7 @@ class BpmBillingProjectLifecycle(
               s"Unable to delete billing profile zone with ID ${profileModel.getId} for BPM-backed billing project ${projectName.value}.",
               t
             )
-          } >> Future.failed(new BillingProjectCreationException(RawlsErrorReport(InternalServerError, t)))
+          } >> Future.failed(t)
         }
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -134,10 +134,13 @@ class BpmBillingProjectLifecycle(
             )
             _ <- billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
           } yield CreationStatuses.CreatingLandingZone).recoverWith { case t: Throwable =>
-            logger.error("Billing project creation failed, cleaning up landing zone")
             Option(landingZone.getLandingZoneId) match {
-              case Some(landingZoneId) => cleanupLandingZone(landingZoneId, projectName, ctx) >> Future.failed(t)
-              case _                   => Future.failed(t)
+              case Some(landingZoneId) =>
+                logger.error("Billing project creation failed, cleaning up landing zone")
+                cleanupLandingZone(landingZoneId, projectName, ctx) >> Future.failed(t)
+              case _ =>
+                logger.error("Billing project creation failed, no landing zone to clean up")
+                Future.failed(t)
             }
           }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -28,6 +28,7 @@ import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.sql.SQLSyntaxErrorException
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -392,7 +393,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful(Some("fake-id")))
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
     when(billingProjectLifecycle.preDeletionSteps(billingProjectName, testContext)).thenReturn(
-      Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "Failed")))
+      Future.failed(new SQLSyntaxErrorException("failed"))
     )
 
     val bpo = new BillingProjectOrchestrator(
@@ -404,7 +405,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       mock[MultiCloudWorkspaceConfig]
     )
 
-    intercept[RawlsExceptionWithErrorReport] {
+    intercept[SQLSyntaxErrorException] {
       Await.result(bpo.deleteBillingProjectV2(billingProjectName), Duration.Inf)
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -27,6 +27,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.{a, convertToAnyShouldWrapper}
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.sql.SQLException
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -275,6 +276,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       new CreateLandingZoneResult()
         .landingZoneId(landingZoneId)
     )
+    when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
+      .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
@@ -362,6 +365,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         .landingZoneId(landingZoneId)
         .jobReport(new JobReport().id(landingZoneJobId.toString))
     )
+    when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
+      .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
     when(repo.updateLandingZoneId(createRequest.projectName, landingZoneId))
       .thenReturn(Future.failed(new RuntimeException(billingRepoError)))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
@@ -386,6 +391,60 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     ScalaFutures.whenReady(result.failed) { exception =>
       exception shouldBe a[RuntimeException]
+      assert(exception.getMessage.contains(billingRepoError))
+      verify(bpm, Mockito.times(1)).deleteBillingProfile(profileModel.getId, testContext)
+      verify(workspaceManagerDAO, Mockito.times(1)).deleteLandingZone(landingZoneId, testContext)
+    }
+  }
+
+  it should "return the original error if resource deletion also errors" in {
+    val bpm = mock[BillingProfileManagerDAO]
+    val repo = mock[BillingRepository]
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    val billingRepoError = "SQLException from billing repository"
+    when(
+      bpm.createBillingProfile(createRequest.projectName.value, createRequest.billingInfo, testContext)
+    )
+      .thenReturn(profileModel)
+    // Throw exception when deleting profile during cleanup code.
+    when(bpm.deleteBillingProfile(profileModel.getId, testContext))
+      .thenThrow(new RuntimeException("BPM profile deletion"))
+    when(
+      workspaceManagerDAO.createLandingZone(landingZoneDefinition, landingZoneVersion, profileModel.getId, testContext)
+    ).thenReturn(
+      new CreateLandingZoneResult()
+        .landingZoneId(landingZoneId)
+        .jobReport(new JobReport().id(landingZoneJobId.toString))
+    )
+    // Deletion of landing zone during cleanup does not error.
+    when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
+      .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
+    // Exception thrown after creation of billing profile and landing zone.
+    // This exception should be visible to the user.
+    when(repo.updateLandingZoneId(createRequest.projectName, landingZoneId))
+      .thenReturn(Future.failed(new SQLException(billingRepoError)))
+    when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
+      Future.successful(
+        Seq(
+          RawlsBillingProject(createRequest.projectName,
+                              CreationStatuses.Ready,
+                              None,
+                              None,
+                              billingProfileId = Some(profileModel.getId.toString)
+          )
+        )
+      )
+    )
+
+    val bp =
+      new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, mock[WorkspaceManagerResourceMonitorRecordDao])
+    val result = bp.postCreationSteps(
+      createRequest,
+      new MultiCloudWorkspaceConfig(true, None, Some(azConfig)),
+      testContext
+    )
+    ScalaFutures.whenReady(result.failed) { exception =>
+      exception shouldBe a[SQLException]
       assert(exception.getMessage.contains(billingRepoError))
       verify(bpm, Mockito.times(1)).deleteBillingProfile(profileModel.getId, testContext)
       verify(workspaceManagerDAO, Mockito.times(1)).deleteLandingZone(landingZoneId, testContext)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-650

This changes some of the error handling/logging around deletion and creation of Azure-backed billing projects. It increases logging to make sure that we have logged information for all the different things that may have gone wrong, and it makes sure that the error shown to the user is the one that caused billing project creation to fail, instead of potentially being an exception thrown during cleanup.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
