### PR TITLE
WM-1493: Revert "Update out of date dependencies (#2119)"

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -247,7 +247,7 @@ class RawlsApiSpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) ignore in {
+    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will create a method with a workflow containing 3 sub-workflows

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -253,10 +253,10 @@ class RawlsApiSpec
       // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
 
-      val europeNorth1ZonesPrefix = "europe-north1-"
+      val northAmericaNortheast1ZonesPrefix = "northamerica-northeast1-"
 
       withTemporaryBillingProject(billingAccountId, users = List(studentB.email).some) { projectName =>
-        withWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("europe-north1")) { workspaceName =>
+        withWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("northamerica-northeast1")) { workspaceName =>
           withCleanUp {
             Orchestration.methodConfigurations.createMethodConfigInWorkspace(
               projectName, workspaceName,
@@ -310,14 +310,14 @@ class RawlsApiSpec
               }
             }
 
-            // Get sub-workflow ids and check the `zones` in workflow options belong to `europe-north1` region
+            // Get sub-workflow ids and check the `zones` in workflow options belong to `northamerica-northeast1` region
             val subWorkflowIds: List[String] = eventually {
               val rootWorkflowMetadata = Rawls.submissions.getWorkflowMetadata(projectName, workspaceName, submissionId, rootWorkflowId)
               val workflowOptions = parseWorkflowOptionsFromMetadata(rootWorkflowMetadata)
               val subWorkflowIds = parseSubWorkflowIdsFromMetadata(rootWorkflowMetadata)
 
               withClue(getWorkflowResponse(projectName, workspaceName, submissionId, rootWorkflowId)) {
-                workflowOptions should include (europeNorth1ZonesPrefix)
+                workflowOptions should include (northAmericaNortheast1ZonesPrefix)
 
                 subWorkflowIds should not be (empty)
                 subWorkflowIds.length shouldBe(3)
@@ -345,14 +345,14 @@ class RawlsApiSpec
             // For each call in the sub-workflows, check
             //   - the zones for each job that were determined by Cromwell and
             //   - the worker assigned for the tasks
-            // belong to `europe-north1`
+            // belong to `northamerica-northeast1`
             val callZones = subWorkflowCallMetadata map { parseRuntimeAttributeKeyFromCallMetadata(_, "zones") }
             val workerAssignedExecEvents = subWorkflowCallMetadata flatMap { parseWorkerAssignedExecEventsFromCallMetadata }
 
-            callZones foreach { _.split(",") foreach { zone => zone should startWith (europeNorth1ZonesPrefix) } }
+            callZones foreach { _.split(",") foreach { zone => zone should startWith (northAmericaNortheast1ZonesPrefix) } }
 
             workerAssignedExecEvents should not be (empty)
-            workerAssignedExecEvents foreach { event => event should include (europeNorth1ZonesPrefix) }
+            workerAssignedExecEvents foreach { event => event should include (northAmericaNortheast1ZonesPrefix) }
           }
         }
       }(owner.makeAuthToken(billingScopes))
@@ -364,11 +364,11 @@ class RawlsApiSpec
       // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
 
-      val europeNorth1ZonesPrefix = "europe-north1-"
+      val northAmericaNortheast1ZonesPrefix = "northamerica-northeast1-"
 
       withTemporaryBillingProject(billingAccountId, users = List(studentB.email).some) { projectName =>
         // `withClonedWorkspace()` will create a new workspace, clone it and run the workflow in the cloned workspace
-        withClonedWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("europe-north1")) { workspaceName =>
+        withClonedWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("northamerica-northeast1")) { workspaceName =>
           withCleanUp {
             // `withClonedWorkspace()` appends `_clone` to the original workspace. Check that workspace returned is actually a clone
             workspaceName should include ("_clone")
@@ -425,14 +425,14 @@ class RawlsApiSpec
               }
             }
 
-            // Get sub-workflow ids and check the `zones` in workflow options belong to `europe-north1` region
+            // Get sub-workflow ids and check the `zones` in workflow options belong to `northamerica-northeast1` region
             val subWorkflowIds: List[String] = eventually {
               val rootWorkflowMetadata = Rawls.submissions.getWorkflowMetadata(projectName, workspaceName, submissionId, rootWorkflowId)
               val workflowOptions = parseWorkflowOptionsFromMetadata(rootWorkflowMetadata)
               val subWorkflowIds = parseSubWorkflowIdsFromMetadata(rootWorkflowMetadata)
 
               withClue(getWorkflowResponse(projectName, workspaceName, submissionId, rootWorkflowId)) {
-                workflowOptions should include (europeNorth1ZonesPrefix)
+                workflowOptions should include (northAmericaNortheast1ZonesPrefix)
 
                 subWorkflowIds should not be (empty)
                 subWorkflowIds.length shouldBe(3)
@@ -460,14 +460,14 @@ class RawlsApiSpec
             // For each call in the sub-workflows, check
             //   - the zones for each job that were determined by Cromwell and
             //   - the worker assigned for the tasks
-            // belong to `europe-north1`
+            // belong to `northamerica-northeast1`
             val callZones = subWorkflowCallMetadata map { parseRuntimeAttributeKeyFromCallMetadata(_, "zones") }
             val workerAssignedExecEvents = subWorkflowCallMetadata flatMap { parseWorkerAssignedExecEventsFromCallMetadata }
 
-            callZones foreach { _.split(",") foreach { zone => zone should startWith (europeNorth1ZonesPrefix) } }
+            callZones foreach { _.split(",") foreach { zone => zone should startWith (northAmericaNortheast1ZonesPrefix) } }
 
             workerAssignedExecEvents should not be (empty)
-            workerAssignedExecEvents foreach { event => event should include (europeNorth1ZonesPrefix) }
+            workerAssignedExecEvents foreach { event => event should include (northAmericaNortheast1ZonesPrefix) }
           }
         }
       }(owner.makeAuthToken(billingScopes))

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -147,7 +147,7 @@ class RawlsApiSpec
   }
 
   "Rawls" - {
-    "should retrieve sub-workflow metadata and outputs from Cromwell" ignore taggedAs(MethodsTest) in {
+    "should retrieve sub-workflow metadata and outputs from Cromwell" taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will run scatterCount^levels workflows, so be careful if increasing these values!
@@ -247,7 +247,7 @@ class RawlsApiSpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should be able to create workspace and run sub-workflow tasks in non-US regions" ignore taggedAs(MethodsTest) in {
+    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) ignore in {
       implicit val token: AuthToken = studentBToken
 
       // this will create a method with a workflow containing 3 sub-workflows
@@ -475,7 +475,7 @@ class RawlsApiSpec
 
 //    Disabling this test until we decide what to do with it. See AP-177
 
-    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) {
+    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) ignore {
       implicit val token: AuthToken = studentAToken
 
       val scatterWidth = 500

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -247,7 +247,7 @@ class RawlsApiSpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) in {
+    "should be able to create workspace and run sub-workflow tasks in non-US regions" ignore taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will create a method with a workflow containing 3 sub-workflows
@@ -475,7 +475,7 @@ class RawlsApiSpec
 
 //    Disabling this test until we decide what to do with it. See AP-177
 
-    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) ignore {
+    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) {
       implicit val token: AuthToken = studentAToken
 
       val scatterWidth = 500

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -147,7 +147,7 @@ class RawlsApiSpec
   }
 
   "Rawls" - {
-    "should retrieve sub-workflow metadata and outputs from Cromwell" taggedAs(MethodsTest) in {
+    "should retrieve sub-workflow metadata and outputs from Cromwell" ignore taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will run scatterCount^levels workflows, so be careful if increasing these values!

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -4,9 +4,8 @@ import _root_.slick.dbio.DBIOAction
 import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.model.{AttributeName, _}
-import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsTestUtils}
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils, model}
 
-import java.sql.SQLException
 import java.util.UUID
 
 /**
@@ -543,7 +542,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // now attempt to calculate attr names and types, with a timeout of 1 second
       withClue("This test is potentially flaky, failures should be reviewed: ") {
-        intercept[java.sql.SQLException] {
+        intercept[MySQLTimeoutException] {
           runAndWait(entityQuery.getAttrNamesAndEntityTypes(context.workspaceIdAsUUID, 1))
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -4,7 +4,7 @@ import _root_.slick.dbio.DBIOAction
 import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.model.{AttributeName, _}
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils, model}
+import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsTestUtils}
 
 import java.util.UUID
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.9"
-  val slickV = "3.4.1"
+  val slickV = "3.3.3"
 
   val googleV = "1.31.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
@@ -18,9 +18,6 @@ object Dependencies {
 
   val excludeBouncyCastle =     ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
   val excludeProtobufJavalite = ExclusionRule(organization = "com.google.protobuf", name = "protobuf-javalite")
-
-  val excludePostgresql =       ExclusionRule("org.postgresql", "postgresql")
-  val excludeSnakeyaml =        ExclusionRule("org.yaml", "snakeyaml")
 
   val akkaActor: ModuleID =             "com.typesafe.akka" %% "akka-actor"               % akkaV
   val akkaActorTyped: ModuleID =        "com.typesafe.akka" %% "akka-actor-typed"         % akkaV
@@ -82,8 +79,20 @@ object Dependencies {
   val ficus: ModuleID =           "com.iheart"                    %% "ficus"                % "1.5.2"
   val apacheCommonsIO: ModuleID = "commons-io"                    % "commons-io"            % "2.11.0"
   val antlrParser: ModuleID =     "org.antlr"                     % "antlr4-runtime"        % "4.8-1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
-  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
+
+  /* mysql-connector-java > 8.0.22 is incompatible with liquibase-core < 4.3.1. See:
+      - https://github.com/liquibase/liquibase/issues/1639
+      - https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-23.html
+     the end result of this incompatibility is that attempting to run Rawls' liquibase on an already-initialized database
+     will throw an error "java.lang.ClassCastException: class java.time.LocalDateTime cannot be cast to class java.lang.String".
+     This only occurs on already-initialized databases; it does not happen when liquibase is run the first time on an
+     empty DB.
+
+     The behavior change in mysql-connector-java between 8.0.22 and 8.0.23 needs to be assessed to see if it will cause
+     any issues elsewhere in Rawls before upgrading.
+   */
+  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.22"
+  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "3.10.3"
 
   val workbenchLibsHash = "f7103bc"
 
@@ -121,8 +130,7 @@ object Dependencies {
   def excludeOpenCensus = ExclusionRule("io.opencensus")
   def excludeGoogleFindBugs = ExclusionRule("com.google.code.findbugs")
   def excludeBroadWorkbench = ExclusionRule("org.broadinstitute.dsde.workbench")
-  // "Terra Common Lib" Exclusions:
-  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml)
+  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench)
 
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.459-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,4 +10,3 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addDependencyTreePlugin


### PR DESCRIPTION
This reverts commit a3e63e0d9e0b2009bc62f57339e56e1f413cf5a2 to check whether it re-enables rawls deployment tests, and therefore releases