### PR TITLE
WX-854 Use supported Terra region in test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -247,7 +247,7 @@ class RawlsApiSpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) ignore in {
+    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will create a method with a workflow containing 3 sub-workflows

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -253,10 +253,10 @@ class RawlsApiSpec
       // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
 
-      val europeNorth1ZonesPrefix = "europe-north1-"
+      val northAmericaNortheast1ZonesPrefix = "northamerica-northeast1-"
 
       withTemporaryBillingProject(billingAccountId, users = List(studentB.email).some) { projectName =>
-        withWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("europe-north1")) { workspaceName =>
+        withWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("northamerica-northeast1")) { workspaceName =>
           withCleanUp {
             Orchestration.methodConfigurations.createMethodConfigInWorkspace(
               projectName, workspaceName,
@@ -310,14 +310,14 @@ class RawlsApiSpec
               }
             }
 
-            // Get sub-workflow ids and check the `zones` in workflow options belong to `europe-north1` region
+            // Get sub-workflow ids and check the `zones` in workflow options belong to `northamerica-northeast1` region
             val subWorkflowIds: List[String] = eventually {
               val rootWorkflowMetadata = Rawls.submissions.getWorkflowMetadata(projectName, workspaceName, submissionId, rootWorkflowId)
               val workflowOptions = parseWorkflowOptionsFromMetadata(rootWorkflowMetadata)
               val subWorkflowIds = parseSubWorkflowIdsFromMetadata(rootWorkflowMetadata)
 
               withClue(getWorkflowResponse(projectName, workspaceName, submissionId, rootWorkflowId)) {
-                workflowOptions should include (europeNorth1ZonesPrefix)
+                workflowOptions should include (northAmericaNortheast1ZonesPrefix)
 
                 subWorkflowIds should not be (empty)
                 subWorkflowIds.length shouldBe(3)
@@ -345,14 +345,14 @@ class RawlsApiSpec
             // For each call in the sub-workflows, check
             //   - the zones for each job that were determined by Cromwell and
             //   - the worker assigned for the tasks
-            // belong to `europe-north1`
+            // belong to `northamerica-northeast1`
             val callZones = subWorkflowCallMetadata map { parseRuntimeAttributeKeyFromCallMetadata(_, "zones") }
             val workerAssignedExecEvents = subWorkflowCallMetadata flatMap { parseWorkerAssignedExecEventsFromCallMetadata }
 
-            callZones foreach { _.split(",") foreach { zone => zone should startWith (europeNorth1ZonesPrefix) } }
+            callZones foreach { _.split(",") foreach { zone => zone should startWith (northAmericaNortheast1ZonesPrefix) } }
 
             workerAssignedExecEvents should not be (empty)
-            workerAssignedExecEvents foreach { event => event should include (europeNorth1ZonesPrefix) }
+            workerAssignedExecEvents foreach { event => event should include (northAmericaNortheast1ZonesPrefix) }
           }
         }
       }(owner.makeAuthToken(billingScopes))
@@ -364,11 +364,11 @@ class RawlsApiSpec
       // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
 
-      val europeNorth1ZonesPrefix = "europe-north1-"
+      val northAmericaNortheast1ZonesPrefix = "northamerica-northeast1-"
 
       withTemporaryBillingProject(billingAccountId, users = List(studentB.email).some) { projectName =>
         // `withClonedWorkspace()` will create a new workspace, clone it and run the workflow in the cloned workspace
-        withClonedWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("europe-north1")) { workspaceName =>
+        withClonedWorkspace(projectName, "rawls-subworkflows-in-regions", bucketLocation = Option("northamerica-northeast1")) { workspaceName =>
           withCleanUp {
             // `withClonedWorkspace()` appends `_clone` to the original workspace. Check that workspace returned is actually a clone
             workspaceName should include ("_clone")
@@ -425,14 +425,14 @@ class RawlsApiSpec
               }
             }
 
-            // Get sub-workflow ids and check the `zones` in workflow options belong to `europe-north1` region
+            // Get sub-workflow ids and check the `zones` in workflow options belong to `northamerica-northeast1` region
             val subWorkflowIds: List[String] = eventually {
               val rootWorkflowMetadata = Rawls.submissions.getWorkflowMetadata(projectName, workspaceName, submissionId, rootWorkflowId)
               val workflowOptions = parseWorkflowOptionsFromMetadata(rootWorkflowMetadata)
               val subWorkflowIds = parseSubWorkflowIdsFromMetadata(rootWorkflowMetadata)
 
               withClue(getWorkflowResponse(projectName, workspaceName, submissionId, rootWorkflowId)) {
-                workflowOptions should include (europeNorth1ZonesPrefix)
+                workflowOptions should include (northAmericaNortheast1ZonesPrefix)
 
                 subWorkflowIds should not be (empty)
                 subWorkflowIds.length shouldBe(3)
@@ -460,14 +460,14 @@ class RawlsApiSpec
             // For each call in the sub-workflows, check
             //   - the zones for each job that were determined by Cromwell and
             //   - the worker assigned for the tasks
-            // belong to `europe-north1`
+            // belong to `northamerica-northeast1`
             val callZones = subWorkflowCallMetadata map { parseRuntimeAttributeKeyFromCallMetadata(_, "zones") }
             val workerAssignedExecEvents = subWorkflowCallMetadata flatMap { parseWorkerAssignedExecEventsFromCallMetadata }
 
-            callZones foreach { _.split(",") foreach { zone => zone should startWith (europeNorth1ZonesPrefix) } }
+            callZones foreach { _.split(",") foreach { zone => zone should startWith (northAmericaNortheast1ZonesPrefix) } }
 
             workerAssignedExecEvents should not be (empty)
-            workerAssignedExecEvents foreach { event => event should include (europeNorth1ZonesPrefix) }
+            workerAssignedExecEvents foreach { event => event should include (northAmericaNortheast1ZonesPrefix) }
           }
         }
       }(owner.makeAuthToken(billingScopes))

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -147,7 +147,7 @@ class RawlsApiSpec
   }
 
   "Rawls" - {
-    "should retrieve sub-workflow metadata and outputs from Cromwell" ignore taggedAs(MethodsTest) in {
+    "should retrieve sub-workflow metadata and outputs from Cromwell" taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will run scatterCount^levels workflows, so be careful if increasing these values!
@@ -247,7 +247,7 @@ class RawlsApiSpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should be able to create workspace and run sub-workflow tasks in non-US regions" ignore taggedAs(MethodsTest) in {
+    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) ignore in {
       implicit val token: AuthToken = studentBToken
 
       // this will create a method with a workflow containing 3 sub-workflows
@@ -475,7 +475,7 @@ class RawlsApiSpec
 
 //    Disabling this test until we decide what to do with it. See AP-177
 
-    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) {
+    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) ignore {
       implicit val token: AuthToken = studentAToken
 
       val scatterWidth = 500

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -247,7 +247,7 @@ class RawlsApiSpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) in {
+    "should be able to create workspace and run sub-workflow tasks in non-US regions" ignore taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will create a method with a workflow containing 3 sub-workflows
@@ -475,7 +475,7 @@ class RawlsApiSpec
 
 //    Disabling this test until we decide what to do with it. See AP-177
 
-    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) ignore {
+    "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) {
       implicit val token: AuthToken = studentAToken
 
       val scatterWidth = 500

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -147,7 +147,7 @@ class RawlsApiSpec
   }
 
   "Rawls" - {
-    "should retrieve sub-workflow metadata and outputs from Cromwell" taggedAs(MethodsTest) in {
+    "should retrieve sub-workflow metadata and outputs from Cromwell" ignore taggedAs(MethodsTest) in {
       implicit val token: AuthToken = studentBToken
 
       // this will run scatterCount^levels workflows, so be careful if increasing these values!


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/WX-854)

These tests started failing because when trying to run the workflow, we couldn't write to the bucket. This changes the region to one supported by Terra.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
