### PR TITLE
new tokens for each test [AJ-756]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -51,11 +51,8 @@ class RawlsApiSpec
 
   // We only want to see the users' workspaces so we can't be Project Owners
   val Seq(studentA, studentB) = UserPool.chooseStudents(2)
-  val studentAToken: AuthToken = studentA.makeAuthToken()
-  val studentBToken: AuthToken = studentB.makeAuthToken()
 
   val owner: Credentials = UserPool.chooseProjectOwner
-  val ownerAuthToken: AuthToken = owner.makeAuthToken()
 
   val billingAccountId: String = ServiceTestConfig.Projects.billingAccountId
 
@@ -148,7 +145,7 @@ class RawlsApiSpec
 
   "Rawls" - {
     "should retrieve sub-workflow metadata and outputs from Cromwell" taggedAs(MethodsTest) in {
-      implicit val token: AuthToken = studentBToken
+      implicit val token: AuthToken = studentB.makeAuthToken()
 
       // this will run scatterCount^levels workflows, so be careful if increasing these values!
       val topLevelMethod: Method = methodTree(levels = 3, scatterCount = 3)
@@ -248,7 +245,7 @@ class RawlsApiSpec
     }
 
     "should be able to create workspace and run sub-workflow tasks in non-US regions" taggedAs(MethodsTest) in {
-      implicit val token: AuthToken = studentBToken
+      implicit val token: AuthToken = studentB.makeAuthToken()
 
       // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)
@@ -476,7 +473,7 @@ class RawlsApiSpec
 //    Disabling this test until we decide what to do with it. See AP-177
 
     "should retrieve metadata with widely scattered sub-workflows in a short time" taggedAs(MethodsTest) ignore {
-      implicit val token: AuthToken = studentAToken
+      implicit val token: AuthToken = studentA.makeAuthToken()
 
       val scatterWidth = 500
 
@@ -572,7 +569,7 @@ class RawlsApiSpec
 
     "should label low security bucket" taggedAs(WorkspacesTest) in {
       implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 20 seconds)
-      implicit val token: AuthToken = studentAToken
+      implicit val token: AuthToken = studentA.makeAuthToken()
 
       withTemporaryBillingProject(billingAccountId, users = List(studentA.email).some) { projectName =>
         withWorkspace(projectName, "rawls-bucket-test") { workspaceName =>
@@ -586,7 +583,7 @@ class RawlsApiSpec
 
     "should label high security bucket" taggedAs(WorkspacesTest) in {
       implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 20 seconds)
-      implicit val token: AuthToken = studentAToken
+      implicit val token: AuthToken = studentA.makeAuthToken()
 
       withGroup("ad") { realmGroup =>
         withGroup("ad2") { realmGroup2 =>
@@ -610,7 +607,7 @@ class RawlsApiSpec
 
     "should have correct policies in Sam and IAM roles in Google when an unconstrained workspace is created" taggedAs(WorkspacesTest) in {
       implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 20 seconds)
-      implicit val token: AuthToken = ownerAuthToken
+      implicit val token: AuthToken = owner.makeAuthToken()
 
       withTemporaryBillingProject(billingAccountId) { projectName =>
         withWorkspace(projectName, s"unconstrained-workspace") { workspaceName =>
@@ -632,7 +629,7 @@ class RawlsApiSpec
 
     "should have correct policies in Sam and IAM roles in Google when a constrained workspace is created" taggedAs(WorkspacesTest) in {
       implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 20 seconds)
-      implicit val token: AuthToken = ownerAuthToken
+      implicit val token: AuthToken = owner.makeAuthToken()
 
       withTemporaryBillingProject(billingAccountId) { projectName =>
         withGroup("authDomain", List(owner.email)) { authDomain =>
@@ -654,7 +651,7 @@ class RawlsApiSpec
 
     "should clone a workspace and only copy files in the specified path" taggedAs(WorkspacesTest) in {
       implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 5 minutes)
-      implicit val token: AuthToken = studentAToken
+      implicit val token: AuthToken = studentA.makeAuthToken()
 
       withTemporaryBillingProject(billingAccountId, users = List(studentA.email).some) { projectName =>
         withWorkspace(projectName, "test-copy-files", Set.empty) { workspaceName =>
@@ -693,7 +690,7 @@ class RawlsApiSpec
     }
 
     "should support running workflows with private docker images" taggedAs(MethodsTest) in {
-      implicit val token: AuthToken = ownerAuthToken
+      implicit val token: AuthToken = owner.makeAuthToken()
 
       val privateMethod: Method = MethodData.SimpleMethod.copy(
         methodName = s"${UUID.randomUUID().toString()}-private_test_method",
@@ -757,7 +754,7 @@ class RawlsApiSpec
     }
 
     "should support running workflows with wdl structs" taggedAs(MethodsTest) in {
-      implicit val token: AuthToken = ownerAuthToken
+      implicit val token: AuthToken = owner.makeAuthToken()
 
       val privateMethod: Method = MethodData.SimpleMethod.copy(
         methodName = s"${UUID.randomUUID()}-wdl_struct_test_method",
@@ -931,7 +928,7 @@ class RawlsApiSpec
     }
 
     "should fail to launch a submission with a reserved output attribute" taggedAs(MethodsTest) in {
-      implicit val token: AuthToken = ownerAuthToken
+      implicit val token: AuthToken = owner.makeAuthToken()
 
       withTemporaryBillingProject(billingAccountId) { projectName =>
         withWorkspace(projectName, "rawls-wdl-struct") { workspaceName =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -356,7 +356,7 @@ class RawlsApiSpec
     }
 
     "should be able to run sub-workflow tasks in a cloned workspace in non-US regions" taggedAs(MethodsTest) in {
-      implicit val token: AuthToken = studentBToken
+      implicit val token: AuthToken = studentB.makeAuthToken()
 
       // this will create a method with a workflow containing 3 sub-workflows
       val topLevelMethod: Method = methodTree(levels = 2, scatterCount = 3)


### PR DESCRIPTION
Ticket: AJ-756

`RawlsApiSpec` generated tokens once at instantiation time, then reused them across tests. This has the possibility for tokens to time out, especially if tests are run serially and any test hits its 30-minute timeout.

This PR generates a fresh token for each test.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
