### PR TITLE
[WOR-641] Pull in latest Sam client to get updated okhttp dep

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/StatusModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/StatusModel.scala
@@ -18,8 +18,18 @@ case class StatusCheckResponse(
 
 object Subsystems {
   val AllSubsystems =
-    Set(Agora, Cromwell, Database, GoogleBilling, GoogleBuckets, GoogleGenomics, GoogleGroups, GooglePubSub, Sam,
-      BillingProfileManager, WorkspaceManager)
+    Set(Agora,
+        Cromwell,
+        Database,
+        GoogleBilling,
+        GoogleBuckets,
+        GoogleGenomics,
+        GoogleGroups,
+        GooglePubSub,
+        Sam,
+        BillingProfileManager,
+        WorkspaceManager
+    )
   // CriticalSubsystems are those that will trigger rawls to report down
   val CriticalSubsystems = Set(Database, GoogleGroups, Sam)
   val GoogleSubsystems = Set(GoogleBilling, GoogleBuckets, GoogleGenomics, GoogleGroups, GooglePubSub)
@@ -32,19 +42,19 @@ object Subsystems {
 
   def withName(name: String): Subsystem =
     name match {
-      case "Agora"          => Agora
-      case "Cromwell"       => Cromwell
-      case "Database"       => Database
-      case "GoogleBilling"  => GoogleBilling
-      case "GoogleBuckets"  => GoogleBuckets
-      case "GoogleGenomics" => GoogleGenomics
-      case "GoogleGroups"   => GoogleGroups
-      case "GooglePubSub"   => GooglePubSub
-      case "Mongo"          => Mongo
-      case "Sam"            => Sam
-      case "BillingProfileManager"       => BillingProfileManager
-      case "WorkspaceManager" => WorkspaceManager
-      case _                => throw new RawlsException(s"invalid Subsystem [$name]")
+      case "Agora"                 => Agora
+      case "Cromwell"              => Cromwell
+      case "Database"              => Database
+      case "GoogleBilling"         => GoogleBilling
+      case "GoogleBuckets"         => GoogleBuckets
+      case "GoogleGenomics"        => GoogleGenomics
+      case "GoogleGroups"          => GoogleGroups
+      case "GooglePubSub"          => GooglePubSub
+      case "Mongo"                 => Mongo
+      case "Sam"                   => Sam
+      case "BillingProfileManager" => BillingProfileManager
+      case "WorkspaceManager"      => WorkspaceManager
+      case _                       => throw new RawlsException(s"invalid Subsystem [$name]")
     }
 
   case object Agora extends Subsystem

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.57-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.63-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-00feed1")
+  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-f554115")
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"
   val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2"


### PR DESCRIPTION
## Why
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-641)
[Related Sam PR (merged)](https://github.com/broadinstitute/sam/pull/921)

We are seeing intermittent failures with our AuthDomain integration tests. Logs show an okhttp client error at the time of failure. I pushed an upgrade to the okhttp client in Sam, which in turn included that upgrade in it's latest published Sam client version.

## This PR
* Pulls in the new Sam client with the upgraded okhtttp client
* Fixes various scalafmt issues

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
