### PR TITLE
WOR-595

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -614,7 +614,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     workspaceChildren <- samDAO
       .listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
       .map(
-        // a workspace may have a single child, if that child is the google project
+        // a workspace may have a single child, if that child is the google project: this is deleted as part of the normal process
         _.filter(c =>
           c.resourceTypeName != SamResourceTypeNames.googleProject.value || workspace.googleProjectId.value != c.resourceId
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.workspace
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.Materializer
 import bio.terra.workspace.client.ApiException
@@ -610,11 +610,34 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       } yield ()
     }
 
+  def assertNoChildrenBlockingWorkspaceDeletion(workspace: Workspace): Future[Unit] = for {
+    workspaceChildren <- samDAO
+      .listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+      .map(
+        // a workspace may have a single child, if that child is the google project
+        _.filter(c =>
+          c.resourceTypeName != SamResourceTypeNames.googleProject.value || workspace.googleProjectId.value != c.resourceId
+        )
+      )
+    googleProjectChildren <-
+      samDAO.listResourceChildren(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx)
+    blockingChildren = workspaceChildren.toList ::: googleProjectChildren.toList
+  } yield
+    if (!blockingChildren.isEmpty) {
+      val reports =
+        blockingChildren.map(r => ErrorReport(s"Blocking resource: ${r.resourceTypeName} resource ${r.resourceId}"))
+      throw RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "Workspace deletion blocked by child resources", reports)
+      )
+    }
+
   private def deleteWorkspaceInternal(workspaceContext: Workspace,
                                       maybeMcWorkspace: Option[WorkspaceDescription],
                                       parentContext: RawlsRequestContext
   ): Future[Option[String]] =
     for {
+      _ <- assertNoChildrenBlockingWorkspaceDeletion(workspaceContext)
+
       _ <- traceWithParent("requesterPaysSetupService.revokeAllUsersFromWorkspace", parentContext)(_ =>
         requesterPaysSetupService.revokeAllUsersFromWorkspace(workspaceContext) recoverWith { case t: Throwable =>
           logger.warn(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -896,7 +896,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       when(
         services.samDAO.listResourceChildren(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-        ArgumentMatchers.eq(testData.workspace.workspaceId),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
           any[RawlsRequestContext]()
         )
       ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -893,7 +893,20 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Some(SamUserStatusResponse(userInfo.userSubjectId.value, userInfo.userEmail.value, enabled = true))
         )
       )
-
+      when(
+        services.samDAO.listResourceChildren(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[RawlsRequestContext]()
+        )
+      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
+      when(
+        services.samDAO.listResourceChildren(
+          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+          ArgumentMatchers.eq(testData.workspace.googleProjectId.value),
+          any[RawlsRequestContext]()
+        )
+      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
       when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),
@@ -975,7 +988,20 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Some(SamUserStatusResponse(userInfo.userSubjectId.value, userInfo.userEmail.value, enabled = true))
         )
       )
-
+      when(
+        services.samDAO.listResourceChildren(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[RawlsRequestContext]()
+        )
+      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
+      when(
+        services.samDAO.listResourceChildren(
+          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+          ArgumentMatchers.eq(testData.workspace.googleProjectId.value),
+          any[RawlsRequestContext]()
+        )
+      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
       when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),
@@ -1052,7 +1078,20 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Some(SamUserStatusResponse(userInfo.userSubjectId.value, userInfo.userEmail.value, enabled = true))
         )
       )
-
+      when(
+        services.samDAO.listResourceChildren(
+          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+          ArgumentMatchers.eq(testData.workspace.workspaceId),
+          any[RawlsRequestContext]()
+        )
+      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
+      when(
+        services.samDAO.listResourceChildren(
+          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
+          ArgumentMatchers.eq(testData.workspace.googleProjectId.value),
+          any[RawlsRequestContext]()
+        )
+      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
       when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -30,6 +30,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.Futures.whenReady
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import spray.json.{JsObject, JsString}
@@ -51,6 +52,18 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     RawlsRequestContext(
       UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
     )
+
+  val workspace = Workspace(
+    "test-namespace",
+    "test-name",
+    "aWorkspaceId",
+    "aBucket",
+    Some("workflow-collection"),
+    new DateTime(),
+    new DateTime(),
+    "test",
+    Map.empty
+  )
 
   def workspaceServiceConstructor(
     datasource: SlickDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS),
@@ -132,7 +145,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     verify(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
   }
 
-  "getWorkspaceById" should "return the exception thrown by getWorkspace(WorkspaceName) on failure" in {
+  it should "return the exception thrown by getWorkspace(WorkspaceName) on failure" in {
     val datasource = mock[SlickDataSource]
     when(datasource.inTransaction[Any](any(), any())).thenReturn(Future.successful(List(("abc", "cba"))))
 
@@ -153,7 +166,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     verify(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "cba")), any(), any())
   }
 
-  "getWorkspaceById" should "return an exception without the workspace name when getWorkspace(WorkspaceName) is not found" in {
+  it should "return an exception without the workspace name when getWorkspace(WorkspaceName) is not found" in {
     val workspaceFields: Future[Seq[(String, String)]] = Future.successful(List(("abc", "123")))
     val datasource = mock[SlickDataSource]
     when(datasource.inTransaction[Any](any(), any())).thenReturn(workspaceFields)
@@ -173,7 +186,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     verify(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "123")), any(), any())
   }
 
-  "getWorkspaceById" should "return an exception without the workspace name when getWorkspace(WorkspaceName) fails access checks" in {
+  it should "return an exception without the workspace name when getWorkspace(WorkspaceName) fails access checks" in {
     val workspaceFields: Future[Seq[(String, String)]] = Future.successful(List(("abc", "123")))
     val datasource = mock[SlickDataSource]
     when(datasource.inTransaction[Any](any(), any())).thenReturn(workspaceFields)
@@ -194,7 +207,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     verify(service).getWorkspace(ArgumentMatchers.eq(WorkspaceName("abc", "123")), any(), any())
   }
 
-  "getWorkspaceById" should "return an exception with the workspaceId when no workspace is found in the initial query" in {
+  it should "return an exception with the workspaceId when no workspace is found in the initial query" in {
     val datasource = mock[SlickDataSource]
     when(datasource.inTransaction[Any](any(), any())).thenReturn(Future.successful(List()))
 
@@ -208,7 +221,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     assert(exception.workspace == workspaceId)
   }
 
-  "getWorkspace" should "return an unauthorized error if the user is disabled" in {
+  it should "return an unauthorized error if the user is disabled" in {
     val datasource = mock[SlickDataSource]
     when(datasource.inTransaction[Any](any(), any())).thenReturn(Future.successful(List()))
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
@@ -225,6 +238,111 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     }
 
     exception.errorReport.statusCode shouldBe Some(StatusCodes.Unauthorized)
+  }
+
+  "assertNoChildrenBlockingWorkspaceDeletion" should "not error if the only child is the google project" in {
+    val samDAO = mock[SamDAO]
+    when(samDAO.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, defaultRequestContext))
+      .thenReturn(
+        Future(
+          Seq(
+            SamFullyQualifiedResourceId(workspace.googleProjectId.value, SamResourceTypeNames.googleProject.value)
+          )
+        )
+      )
+    when(
+      samDAO.listResourceChildren(
+        SamResourceTypeNames.googleProject,
+        workspace.googleProjectId.value,
+        defaultRequestContext
+      )
+    )
+      .thenReturn(Future(Seq()))
+    val workspaceService = workspaceServiceConstructor(samDAO = samDAO)(defaultRequestContext)
+
+    Await.result(workspaceService.assertNoChildrenBlockingWorkspaceDeletion(workspace), Duration.Inf) shouldBe ()
+  }
+
+  it should "error if the workspace google project has a child resource" in {
+    val samDAO = mock[SamDAO]
+    when(samDAO.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, defaultRequestContext))
+      .thenReturn(Future(Seq()))
+    when(
+      samDAO.listResourceChildren(
+        SamResourceTypeNames.googleProject,
+        workspace.googleProjectId.value,
+        defaultRequestContext
+      )
+    )
+      .thenReturn(Future(Seq(SamFullyQualifiedResourceId("some-child", SamResourceTypeNames.googleProject.value))))
+    val workspaceService = workspaceServiceConstructor(samDAO = samDAO)(defaultRequestContext)
+
+    val error = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(workspaceService.assertNoChildrenBlockingWorkspaceDeletion(workspace), Duration.Inf)
+    }
+
+    error.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+    error.errorReport.message shouldBe "Workspace deletion blocked by child resources"
+    error.errorReport.causes.size shouldBe 1
+  }
+
+  it should "error if the workspace has a child resource besides it's google project" in {
+    val samDAO = mock[SamDAO]
+    when(samDAO.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, defaultRequestContext))
+      .thenReturn(
+        Future(
+          Seq(
+            SamFullyQualifiedResourceId(workspace.googleProjectId.value, SamResourceTypeNames.googleProject.value)
+          )
+        )
+      )
+    when(
+      samDAO.listResourceChildren(
+        SamResourceTypeNames.googleProject,
+        workspace.googleProjectId.value,
+        defaultRequestContext
+      )
+    )
+      .thenReturn(Future(Seq(SamFullyQualifiedResourceId("some-child", SamResourceTypeNames.googleProject.value))))
+    val workspaceService = workspaceServiceConstructor(samDAO = samDAO)(defaultRequestContext)
+
+    val error = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(workspaceService.assertNoChildrenBlockingWorkspaceDeletion(workspace), Duration.Inf)
+    }
+
+    error.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+    error.errorReport.message shouldBe "Workspace deletion blocked by child resources"
+    error.errorReport.causes.size shouldBe 1
+  }
+
+  it should "return an error for each blocking child resource in the error report" in {
+    val samDAO = mock[SamDAO]
+    when(samDAO.listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, defaultRequestContext))
+      .thenReturn(
+        Future(
+          Seq(
+            SamFullyQualifiedResourceId(workspace.googleProjectId.value, SamResourceTypeNames.googleProject.value),
+            SamFullyQualifiedResourceId("another-resource", SamResourceTypeNames.googleProject.value)
+          )
+        )
+      )
+    when(
+      samDAO.listResourceChildren(
+        SamResourceTypeNames.googleProject,
+        workspace.googleProjectId.value,
+        defaultRequestContext
+      )
+    )
+      .thenReturn(Future(Seq(SamFullyQualifiedResourceId("some-child", SamResourceTypeNames.googleProject.value))))
+    val workspaceService = workspaceServiceConstructor(samDAO = samDAO)(defaultRequestContext)
+
+    val error = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(workspaceService.assertNoChildrenBlockingWorkspaceDeletion(workspace), Duration.Inf)
+    }
+
+    error.errorReport.statusCode.get shouldBe StatusCodes.BadRequest
+    error.errorReport.message shouldBe "Workspace deletion blocked by child resources"
+    error.errorReport.causes.size shouldBe 2
   }
 
   def mockWsmForAclTests(ownerEmail: String = "owner@example.com",


### PR DESCRIPTION
Ticket: [WOR-595](https://broadworkbench.atlassian.net/browse/WOR-595)

Adds a check prior to workspace deletion that throw an error if there are child resources blocking deletion

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
