### PR TITLE
[WOR-641] Limit sam to http1.1

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -7,7 +7,7 @@ import bio.terra.common.tracing.OkHttpClientTracingInterceptor
 import com.google.api.client.auth.oauth2.Credential
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.trace.{Span, Tracing}
-import okhttp3.{Interceptor, Response}
+import okhttp3.{Interceptor, Protocol, Response}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, Retry}
@@ -48,7 +48,7 @@ class HttpSamDAO(baseSamServiceURL: String, serviceAccountCreds: Credential, tim
         .addInterceptor(new OkHttpClientTracingInterceptor(Tracing.getTracer))
     )
 
-    val samApiClient = new ApiClient(okHttpClientWithTracingBuilder.build())
+    val samApiClient = new ApiClient(okHttpClientWithTracingBuilder.protocols(Seq(Protocol.HTTP_1_1).asJava).build())
     samApiClient.setBasePath(samServiceURL)
     samApiClient.setAccessToken(ctx.userInfo.accessToken.token)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-641

We continue to see instances of connection resets during tests. My hypothesis is that this may be an issue with the HTTP/2 exchange between sam <--> rawls. This PR sets the protocol to HTTP/1.1 to see if that helps. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
