### PR TITLE
[WOR-679] Revert "WOR-595 (#2153)"

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.rawls.workspace
 
-import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.Materializer
 import bio.terra.workspace.client.ApiException
@@ -624,34 +624,11 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       } yield ()
     }
 
-  def assertNoChildrenBlockingWorkspaceDeletion(workspace: Workspace): Future[Unit] = for {
-    workspaceChildren <- samDAO
-      .listResourceChildren(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-      .map(
-        // a workspace may have a single child, if that child is the google project: this is deleted as part of the normal process
-        _.filter(c =>
-          c.resourceTypeName != SamResourceTypeNames.googleProject.value || workspace.googleProjectId.value != c.resourceId
-        )
-      )
-    googleProjectChildren <-
-      samDAO.listResourceChildren(SamResourceTypeNames.googleProject, workspace.googleProjectId.value, ctx)
-    blockingChildren = workspaceChildren.toList ::: googleProjectChildren.toList
-  } yield
-    if (!blockingChildren.isEmpty) {
-      val reports =
-        blockingChildren.map(r => ErrorReport(s"Blocking resource: ${r.resourceTypeName} resource ${r.resourceId}"))
-      throw RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.BadRequest, "Workspace deletion blocked by child resources", reports)
-      )
-    }
-
   private def deleteWorkspaceInternal(workspaceContext: Workspace,
                                       maybeMcWorkspace: Option[WorkspaceDescription],
                                       parentContext: RawlsRequestContext
   ): Future[Option[String]] =
     for {
-      _ <- assertNoChildrenBlockingWorkspaceDeletion(workspaceContext)
-
       _ <- traceWithParent("requesterPaysSetupService.revokeAllUsersFromWorkspace", parentContext)(_ =>
         requesterPaysSetupService.revokeAllUsersFromWorkspace(workspaceContext) recoverWith { case t: Throwable =>
           logger.warn(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -902,20 +902,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Some(SamUserStatusResponse(userInfo.userSubjectId.value, userInfo.userEmail.value, enabled = true))
         )
       )
-      when(
-        services.samDAO.listResourceChildren(
-          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-          ArgumentMatchers.eq(testData.workspace.workspaceId),
-          any[RawlsRequestContext]()
-        )
-      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
-      when(
-        services.samDAO.listResourceChildren(
-          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-          ArgumentMatchers.eq(testData.workspace.googleProjectId.value),
-          any[RawlsRequestContext]()
-        )
-      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
+
       when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),
@@ -997,20 +984,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Some(SamUserStatusResponse(userInfo.userSubjectId.value, userInfo.userEmail.value, enabled = true))
         )
       )
-      when(
-        services.samDAO.listResourceChildren(
-          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-          ArgumentMatchers.eq(testData.workspace.workspaceId),
-          any[RawlsRequestContext]()
-        )
-      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
-      when(
-        services.samDAO.listResourceChildren(
-          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-          ArgumentMatchers.eq(testData.workspace.googleProjectId.value),
-          any[RawlsRequestContext]()
-        )
-      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
+
       when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),
@@ -1087,20 +1061,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Some(SamUserStatusResponse(userInfo.userSubjectId.value, userInfo.userEmail.value, enabled = true))
         )
       )
-      when(
-        services.samDAO.listResourceChildren(
-          ArgumentMatchers.eq(SamResourceTypeNames.workspace),
-          ArgumentMatchers.eq(testData.workspace.workspaceId),
-          any[RawlsRequestContext]()
-        )
-      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
-      when(
-        services.samDAO.listResourceChildren(
-          ArgumentMatchers.eq(SamResourceTypeNames.googleProject),
-          ArgumentMatchers.eq(testData.workspace.googleProjectId.value),
-          any[RawlsRequestContext]()
-        )
-      ).thenReturn(Future(Seq[SamFullyQualifiedResourceId]()))
+
       when(
         services.samDAO.deleteResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),


### PR DESCRIPTION
This reverts commit dd16dffd49ec4967d297490f8de23f0515e1a3e5.

Ticket: [WOR-679](https://broadworkbench.atlassian.net/browse/WOR-679)
* workspace deletion currently fails with the error message ```You may not perform any of [LIST_CHILDREN] on google-project/terra-dev-8c41eed5``` 
* [This Sam PR](https://github.com/broadinstitute/sam/pull/922) appears to not have worked correctly because workspace owners do not have the `list_children` on `google-project` resources as they should. Root cause is TBD

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
