### PR TITLE
[WOR-625] Wire up WSM Cloning Operations in Rawls

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -8,6 +8,7 @@ import cats.implicits.{catsSyntaxFlatMapOps, toTraverseOps}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.HttpWorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
@@ -127,10 +128,11 @@ class BpmBillingProjectLifecycle(
             )
             _ <- billingRepository.updateLandingZoneId(createProjectRequest.projectName, landingZone.getLandingZoneId)
             _ <- resourceMonitorRecordDao.create(
-              UUID.fromString(jobReport.getId),
-              JobType.AzureLandingZoneResult,
-              projectName.value,
-              ctx.userInfo.userEmail
+              WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
+                UUID.fromString(jobReport.getId),
+                projectName,
+                ctx.userInfo.userEmail
+              )
             )
             _ <- billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
           } yield CreationStatuses.CreatingLandingZone).recoverWith { case t: Throwable =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -9,7 +9,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.HttpWorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.rawls.model.{

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceManagerResourceMonitorRecordDao.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceManagerResourceMonitorRecordDao.scala
@@ -1,39 +1,22 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsUserEmail}
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
 
-import java.sql.Timestamp
-import java.time.Instant
-import java.util.UUID
 import scala.concurrent.Future
 
-class WorkspaceManagerResourceMonitorRecordDao(val dataSource: SlickDataSource) {
-
-  def create(jobRecordId: UUID, jobType: JobType, billingProjectName: String, userEmail: RawlsUserEmail): Future[Unit] =
-    create(
-      WorkspaceManagerResourceMonitorRecord(
-        jobRecordId,
-        jobType,
-        None,
-        Some(billingProjectName),
-        Some(userEmail.value),
-        Timestamp.from(Instant.now())
-      )
-    )
+case class WorkspaceManagerResourceMonitorRecordDao(dataSource: SlickDataSource) {
 
   def create(job: WorkspaceManagerResourceMonitorRecord): Future[Unit] =
     dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.create(job))
 
   def selectAll(): Future[Seq[WorkspaceManagerResourceMonitorRecord]] =
-    dataSource.inTransaction(dataAccess => dataAccess.WorkspaceManagerResourceMonitorRecordQuery.getRecords)
+    dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.getRecords)
 
   def selectByBillingProject(name: RawlsBillingProjectName): Future[Seq[WorkspaceManagerResourceMonitorRecord]] =
     dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.selectByBillingProject(name))
 
-  def delete(job: WorkspaceManagerResourceMonitorRecord): Future[Boolean] = dataSource.inTransaction { dataAccess =>
-    dataAccess.WorkspaceManagerResourceMonitorRecordQuery.delete(job)
-  }
+  def delete(job: WorkspaceManagerResourceMonitorRecord): Future[Boolean] =
+    dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.delete(job))
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -110,6 +110,9 @@ trait WorkspaceManagerResourceMonitorRecordComponent {
     def selectByBillingProject(name: RawlsBillingProjectName): ReadAction[Seq[WorkspaceManagerResourceMonitorRecord]] =
       query.filter(_.billingProjectId === name.value).result
 
+    def selectByWorkspaceId(workspaceId: UUID): ReadAction[Seq[WorkspaceManagerResourceMonitorRecord]] =
+      query.filter(_.workspaceId === workspaceId).result
+
     def getRecords: ReadAction[Seq[WorkspaceManagerResourceMonitorRecord]] = query.result
 
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -2,10 +2,11 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobStatus
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
-import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsUserEmail}
 import slick.lifted.ProvenShape
 
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,21 +14,51 @@ object WorkspaceManagerResourceMonitorRecord {
   object JobType extends SlickEnum {
     type JobType = Value
     val AzureLandingZoneResult: Value = Value("AzureLandingZoneResult")
+    val CloneWorkspaceResult: Value = Value("CloneWorkspaceResult")
   }
 
-  implicit sealed class JobStatus(val complete: Boolean)
+  implicit sealed class JobStatus(val isDone: Boolean)
 
   case object Complete extends JobStatus(true)
 
   case object Incomplete extends JobStatus(false)
+
+  def forAzureLandingZone(jobRecordId: UUID,
+                          billingProjectName: RawlsBillingProjectName,
+                          userEmail: RawlsUserEmail
+  ): WorkspaceManagerResourceMonitorRecord =
+    WorkspaceManagerResourceMonitorRecord(
+      jobRecordId,
+      JobType.AzureLandingZoneResult,
+      workspaceId = None,
+      Some(billingProjectName.value),
+      Some(userEmail.value),
+      Timestamp.from(Instant.now())
+    )
+
+  def forCloneWorkspace(jobRecordId: UUID,
+                        workspaceId: UUID,
+                        userEmail: RawlsUserEmail
+  ): WorkspaceManagerResourceMonitorRecord =
+    WorkspaceManagerResourceMonitorRecord(
+      jobRecordId,
+      JobType.CloneWorkspaceResult,
+      workspaceId = Some(workspaceId),
+      billingProjectId = None,
+      userEmail = Some(userEmail.value),
+      Timestamp.from(Instant.now())
+    )
 }
 
 trait WorkspaceManagerResourceJobRunner {
-  val jobType: JobType
-  // Returns true if this runner is finished with the job
-  def run(job: WorkspaceManagerResourceMonitorRecord)(implicit executionContext: ExecutionContext): Future[JobStatus]
+  // Returns Some(Outcome) if the job has completed
+  def apply(job: WorkspaceManagerResourceMonitorRecord)(implicit
+    executionContext: ExecutionContext
+  ): Future[JobStatus]
 }
 
+// Avoid constructing directly - prefer one of the smart constructors in the
+// companion object to ensure persisted state is well defined.
 final case class WorkspaceManagerResourceMonitorRecord(
   jobControlId: UUID,
   jobType: JobType,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -75,7 +75,7 @@ trait WorkspaceManagerResourceMonitorRecordComponent {
 
   class WorkspaceManagerResourceMonitorRecordTable(tag: Tag)
       extends Table[WorkspaceManagerResourceMonitorRecord](tag, "WORKSPACE_MANAGER_RESOURCE_MONITOR_RECORD") {
-    def jobControlId: Rep[UUID] = column[UUID]("JOB_CONTROL_ID", O.PrimaryKey)
+    def jobControlId: Rep[String] = column[String]("JOB_CONTROL_ID", O.PrimaryKey)
 
     def jobType: Rep[JobType] = column[JobType]("JOB_TYPE")
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -28,7 +28,7 @@ object WorkspaceManagerResourceMonitorRecord {
                           userEmail: RawlsUserEmail
   ): WorkspaceManagerResourceMonitorRecord =
     WorkspaceManagerResourceMonitorRecord(
-      jobRecordId.toString,
+      jobRecordId,
       JobType.AzureLandingZoneResult,
       workspaceId = None,
       Some(billingProjectName.value),
@@ -36,7 +36,7 @@ object WorkspaceManagerResourceMonitorRecord {
       Timestamp.from(Instant.now())
     )
 
-  def forCloneWorkspace(jobRecordId: String,
+  def forCloneWorkspace(jobRecordId: UUID,
                         workspaceId: UUID,
                         userEmail: RawlsUserEmail
   ): WorkspaceManagerResourceMonitorRecord =
@@ -60,7 +60,7 @@ trait WorkspaceManagerResourceJobRunner {
 // Avoid constructing directly - prefer one of the smart constructors in the
 // companion object to ensure persisted state is well defined.
 final case class WorkspaceManagerResourceMonitorRecord(
-  jobControlId: String,
+  jobControlId: UUID,
   jobType: JobType,
   workspaceId: Option[UUID],
   billingProjectId: Option[String],
@@ -75,7 +75,7 @@ trait WorkspaceManagerResourceMonitorRecordComponent {
 
   class WorkspaceManagerResourceMonitorRecordTable(tag: Tag)
       extends Table[WorkspaceManagerResourceMonitorRecord](tag, "WORKSPACE_MANAGER_RESOURCE_MONITOR_RECORD") {
-    def jobControlId: Rep[String] = column[String]("JOB_CONTROL_ID", O.PrimaryKey)
+    def jobControlId: Rep[UUID] = column[UUID]("JOB_CONTROL_ID", O.PrimaryKey)
 
     def jobType: Rep[JobType] = column[JobType]("JOB_TYPE")
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -28,7 +28,7 @@ object WorkspaceManagerResourceMonitorRecord {
                           userEmail: RawlsUserEmail
   ): WorkspaceManagerResourceMonitorRecord =
     WorkspaceManagerResourceMonitorRecord(
-      jobRecordId,
+      jobRecordId.toString,
       JobType.AzureLandingZoneResult,
       workspaceId = None,
       Some(billingProjectName.value),
@@ -36,7 +36,7 @@ object WorkspaceManagerResourceMonitorRecord {
       Timestamp.from(Instant.now())
     )
 
-  def forCloneWorkspace(jobRecordId: UUID,
+  def forCloneWorkspace(jobRecordId: String,
                         workspaceId: UUID,
                         userEmail: RawlsUserEmail
   ): WorkspaceManagerResourceMonitorRecord =
@@ -60,7 +60,7 @@ trait WorkspaceManagerResourceJobRunner {
 // Avoid constructing directly - prefer one of the smart constructors in the
 // companion object to ensure persisted state is well defined.
 final case class WorkspaceManagerResourceMonitorRecord(
-  jobControlId: UUID,
+  jobControlId: String,
   jobType: JobType,
   workspaceId: Option[UUID],
   billingProjectId: Option[String],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -76,7 +76,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
       new CloneWorkspaceRequest()
         .destinationWorkspaceId(workspaceId)
         .displayName(displayName)
-        .spendProfile(spendProfile.toString)
+        .spendProfile(spendProfile.getId.toString)
         .azureContext(
           new AzureContext()
             .tenantId(spendProfile.getTenantId.toString)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.api.{ReferencedGcpResourceApi, ResourceApi, WorkspaceApi}
 import bio.terra.workspace.client.ApiClient
 import bio.terra.workspace.model._
@@ -67,10 +68,24 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def cloneWorkspace(sourceWorkspaceId: UUID,
                               workspaceId: UUID,
                               displayName: String,
-                              spendProfileId: UUID,
-                              location: String,
-                              ctx: RawlsRequestContext
-  ): CloneWorkspaceResult = ???
+                              spendProfile: ProfileModel,
+                              ctx: RawlsRequestContext,
+                              location: Option[String]
+  ): CloneWorkspaceResult =
+    getWorkspaceApi(ctx).cloneWorkspace(
+      new CloneWorkspaceRequest()
+        .destinationWorkspaceId(workspaceId)
+        .displayName(displayName)
+        .spendProfile(spendProfile.toString)
+        .azureContext(
+          new AzureContext()
+            .tenantId(spendProfile.getTenantId.toString)
+            .subscriptionId(spendProfile.getSubscriptionId.toString)
+            .resourceGroupId(spendProfile.getManagedResourceGroupId)
+        )
+        .location(location.orNull),
+      sourceWorkspaceId
+    )
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                                 azureTenantId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -64,6 +64,14 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
         .stage(WorkspaceStageModel.MC_WORKSPACE)
     )
 
+  override def cloneWorkspace(sourceWorkspaceId: UUID,
+                              workspaceId: UUID,
+                              displayName: String,
+                              spendProfileId: UUID,
+                              location: String,
+                              ctx: RawlsRequestContext
+  ): CloneWorkspaceResult = ???
+
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                                 azureTenantId: String,
                                                 azureResourceGroupId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -26,7 +26,7 @@ object WorkspaceManagerDAO {
     val byteBuffer = ByteBuffer.allocate(16)
     byteBuffer.putLong(uuid.getMostSignificantBits)
     byteBuffer.putLong(uuid.getLeastSignificantBits)
-    base64Url().encode(byteBuffer.array())
+    base64Url().omitPadding().encode(byteBuffer.array())
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -13,6 +13,8 @@ import scala.util.Try
 
 object WorkspaceManagerDAO {
 
+  // Remove/Move into ShortUUID after [PF-1268]
+
   /** @see bio.terra.stairway.ShortUUID#get() */
   def decodeShortUuid(shortUuid: String): Option[UUID] =
     Try {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
+import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, RawlsRequestContext}
@@ -21,9 +22,9 @@ trait WorkspaceManagerDAO {
   def cloneWorkspace(sourceWorkspaceId: UUID,
                      workspaceId: UUID,
                      displayName: String,
-                     spendProfileId: UUID,
-                     location: String,
-                     ctx: RawlsRequestContext
+                     spendProfile: ProfileModel,
+                     ctx: RawlsRequestContext,
+                     location: Option[String] = None
   ): CloneWorkspaceResult
 
   def createAzureWorkspaceCloudContext(workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -3,10 +3,32 @@ package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
+import com.google.common.io.BaseEncoding.base64Url
 import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, RawlsRequestContext}
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, WorkbenchEmail}
 
+import java.nio.ByteBuffer
 import java.util.UUID
+import scala.util.Try
+
+object WorkspaceManagerDAO {
+
+  /** @see bio.terra.stairway.ShortUUID#get() */
+  def decodeShortUuid(shortUuid: String): Option[UUID] =
+    Try {
+      val bytes = ByteBuffer.wrap(base64Url.decode(shortUuid))
+      val hi = bytes.getLong(0)
+      val lo = bytes.getLong(8)
+      new UUID(hi, lo)
+    }.toOption
+
+  def encodeShortUUID(uuid: UUID): String = {
+    val byteBuffer = ByteBuffer.allocate(16)
+    byteBuffer.putLong(uuid.getMostSignificantBits)
+    byteBuffer.putLong(uuid.getLeastSignificantBits)
+    base64Url().encode(byteBuffer.array())
+  }
+}
 
 trait WorkspaceManagerDAO {
   val errorReportSource = ErrorReportSource("WorkspaceManager")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -17,6 +17,15 @@ trait WorkspaceManagerDAO {
                                       spendProfileId: String,
                                       ctx: RawlsRequestContext
   ): CreatedWorkspace
+
+  def cloneWorkspace(sourceWorkspaceId: UUID,
+                     workspaceId: UUID,
+                     displayName: String,
+                     spendProfileId: UUID,
+                     location: String,
+                     ctx: RawlsRequestContext
+  ): CloneWorkspaceResult
+
   def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                        azureTenantId: String,
                                        azureResourceGroupId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/RawlsInstrumented.scala
@@ -125,6 +125,15 @@ trait RawlsInstrumented extends WorkbenchInstrumented {
       .asCounter("count")
 
   /**
+    * Counts the total number of cloned 'Workspace Manager'-managed workspaces.
+    */
+  protected def clonedMultiCloudWorkspaceCounter: Counter =
+    ExpandedMetricBuilder
+      .expand(AggregationMetricKey, "cloned_mc_workspaces")
+      .transient()
+      .asCounter("count")
+
+  /**
     * A histogram to track the number of entities in each cloned workspace.
     */
   protected def clonedWorkspaceEntityHistogram: Histogram =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -16,6 +16,8 @@ import org.broadinstitute.dsde.rawls.coordination.{
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsResolver
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceJobRunner
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
@@ -398,12 +400,17 @@ object BootMonitors extends LazyLogging {
     samDAO: SamDAO,
     workspaceManagerDAO: WorkspaceManagerDAO,
     gcsDAO: GoogleServicesDAO
-  ) = {
-    val jobRunners: List[WorkspaceManagerResourceJobRunner] = List(
-      new LandingZoneCreationStatusRunner(samDAO, workspaceManagerDAO, new BillingRepository(dataSource), gcsDAO)
+  ) =
+    system.actorOf(
+      WorkspaceResourceMonitor.props(
+        config,
+        dataSource,
+        Map(
+          JobType.AzureLandingZoneResult ->
+            new LandingZoneCreationStatusRunner(samDAO, workspaceManagerDAO, new BillingRepository(dataSource), gcsDAO)
+        )
+      )
     )
-    system.actorOf(WorkspaceResourceMonitor.props(config, dataSource, jobRunners))
-  }
 
   private def startWorkspaceMigrationActor(system: ActorSystem,
                                            config: Config,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -15,9 +15,7 @@ import org.broadinstitute.dsde.rawls.coordination.{
 }
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsResolver
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceJobRunner
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
@@ -92,7 +92,7 @@ case class WorkspaceResourceMonitor(
     */
   def runJob(job: WorkspaceManagerResourceMonitorRecord): Future[JobStatus] =
     for {
-      status <- jobRunners.getOrElse(job.jobType, NoopJobRunner)(job).recover { case t: Throwable =>
+      status <- jobRunners.getOrElse(job.jobType, AlwaysIncompleteJobRunner)(job).recover { case t: Throwable =>
         logger.warn(
           "Failure monitoring WSM job " +
             s"[ jobId = ${job.jobControlId}" +
@@ -110,7 +110,7 @@ case class WorkspaceResourceMonitor(
     } yield status
 }
 
-case object NoopJobRunner extends WorkspaceManagerResourceJobRunner {
+case object AlwaysIncompleteJobRunner extends WorkspaceManagerResourceJobRunner {
   override def apply(job: WorkspaceManagerResourceMonitorRecord)(implicit
     executionContext: ExecutionContext
   ): Future[JobStatus] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceJobRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceJobRunner.scala
@@ -1,3 +1,0 @@
-package org.broadinstitute.dsde.rawls.monitor.workspace.runners
-
-case class CloneWorkspaceJobRunner()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceJobRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceJobRunner.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.rawls.monitor.workspace.runners
+
+case class CloneWorkspaceJobRunner()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
@@ -28,10 +28,7 @@ class LandingZoneCreationStatusRunner(
   gcsDAO: GoogleServicesDAO
 ) extends WorkspaceManagerResourceJobRunner
     with LazyLogging {
-
-  override val jobType: JobType = JobType.AzureLandingZoneResult
-
-  override def run(
+  override def apply(
     job: WorkspaceManagerResourceMonitorRecord
   )(implicit executionContext: ExecutionContext): Future[JobStatus] = {
     val billingProjectName = job.billingProjectId match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
@@ -3,19 +3,17 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 import bio.terra.workspace.model.JobReport
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.billing.BillingRepository
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
   Complete,
   Incomplete,
-  JobStatus,
-  JobType
+  JobStatus
 }
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   WorkspaceManagerResourceJobRunner,
   WorkspaceManagerResourceMonitorRecord
 }
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.model.{CreationStatuses, RawlsBillingProjectName, RawlsRequestContext}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -4,17 +4,12 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.profile.model.{CloudPlatform, ProfileModel}
 import bio.terra.workspace.model.JobReport.StatusEnum
-import bio.terra.workspace.model.{
-  CloneWorkspaceResult,
-  CreateCloudContextResult,
-  CreateControlledAzureRelayNamespaceResult
-}
+import bio.terra.workspace.model.{CreateCloudContextResult, CreateControlledAzureRelayNamespaceResult}
 import cats.Apply
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   DataAccess,
   ReadWriteAction,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -259,18 +259,17 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       // to avoid naming conflicts - we'll erase it should the clone request to WSM fail.
       (newWorkspace, cloneResult) <- createNewWorkspaceContext().flatMap { newWorkspace =>
         traceWithParent("workspaceManagerDAO.cloneWorkspace", parentContext) { context =>
-          Future
-            .successful((newWorkspace, _: CloneWorkspaceResult))
-            .ap(Future(blocking {
-              workspaceManagerDAO.cloneWorkspace(
-                sourceWorkspace.workspaceIdAsUUID,
-                newWorkspace.workspaceIdAsUUID,
-                request.name,
-                profile.getId,
-                request.bucketLocation.getOrElse(""),
-                context
-              )
-            }))
+          Future(blocking {
+            workspaceManagerDAO.cloneWorkspace(
+              sourceWorkspace.workspaceIdAsUUID,
+              newWorkspace.workspaceIdAsUUID,
+              request.name,
+              profile.getId,
+              request.bucketLocation.getOrElse(""),
+              context
+            )
+          })
+            .map((newWorkspace, _))
         }.recoverWith { case t: Throwable =>
           logger.warn(
             "Clone workspace request to workspace manager failed for " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -287,7 +287,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       // hand off monitoring the clone job to the resource monitor
       _ <- WorkspaceManagerResourceMonitorRecordDao(dataSource).create(
         WorkspaceManagerResourceMonitorRecord.forCloneWorkspace(
-          UUID.fromString(cloneResult.getJobReport.getId),
+          cloneResult.getJobReport.getId,
           newWorkspace.workspaceIdAsUUID,
           parentContext.userInfo.userEmail
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -275,7 +275,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         dataSource.inTransaction(_.workspaceQuery.delete(newWorkspace.toWorkspaceName)) >> Future.failed(t)
       }
 
-      _ = clonedWorkspaceCounter.inc()
+      _ = clonedMultiCloudWorkspaceCounter.inc()
       _ = logger.info(
         "Created workspace record and clone job for azure workspace " +
           s"[ workspaceId=${newWorkspace.workspaceId}" +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -277,9 +277,10 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             s"]",
           t
         )
-        dataSource.inTransaction(_.workspaceQuery.delete(newWorkspace.toWorkspaceName)) *> Future.failed(t)
+        dataSource.inTransaction(_.workspaceQuery.delete(newWorkspace.toWorkspaceName)) >> Future.failed(t)
       }
 
+      _ = clonedWorkspaceCounter.inc()
       _ = logger.info(
         "Created workspace record and clone job for azure workspace " +
           s"[ workspaceId=${newWorkspace.workspaceId}" +

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
-import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, WorkspaceManagerResourceMonitorRecord}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.model.{
   CreationStatuses,
@@ -133,7 +133,13 @@ class BillingRepositorySpec extends AnyFlatSpec with TestDriverComponent {
     val userEmail = RawlsUserEmail("user@email.com")
     Await.result(repo.createBillingProject(billingProject), Duration.Inf)
     Await.result(
-      wsmRecordDao.create(jobId, JobType.AzureLandingZoneResult, billingProject.projectName.value, userEmail),
+      wsmRecordDao.create(
+        WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
+          jobId,
+          billingProject.projectName,
+          userEmail
+        )
+      ),
       Duration.Inf
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -182,7 +182,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     verify(wsmResouceRecordDao, Mockito.times(1))
       .create(argThat { (job: WorkspaceManagerResourceMonitorRecord) =>
         job.jobType == JobType.AzureLandingZoneResult &&
-        job.jobControlId == landingZoneJobId.toString &&
+        job.jobControlId == landingZoneJobId &&
         job.billingProjectId.contains(createRequest.projectName.value)
       })
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -6,6 +6,7 @@ import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZon
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.HttpWorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{
@@ -156,10 +157,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val wsmResouceRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
     when(
       wsmResouceRecordDao.create(
-        landingZoneJobId,
-        JobType.AzureLandingZoneResult,
-        createRequest.projectName.value,
-        testContext.userInfo.userEmail
+        WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
+          landingZoneJobId,
+          createRequest.projectName,
+          testContext.userInfo.userEmail
+        )
       )
     ).thenReturn(Future.successful())
     val bp = new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, wsmResouceRecordDao)
@@ -181,10 +183,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, landingZoneId)
     verify(repo, Mockito.times(1)).setBillingProfileId(createRequest.projectName, profileModel.getId)
     verify(wsmResouceRecordDao, Mockito.times(1)).create(
-      landingZoneJobId,
-      JobType.AzureLandingZoneResult,
-      createRequest.projectName.value,
-      testContext.userInfo.userEmail
+      WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
+        landingZoneJobId,
+        createRequest.projectName,
+        testContext.userInfo.userEmail
+      )
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -7,7 +7,6 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.HttpWorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{
   AzureManagedAppCoordinates,
@@ -21,7 +20,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsUserSubjectId,
   UserInfo
 }
-import org.mockito.Mockito.{verify, when}
+import org.mockito.Mockito.{doReturn, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -155,15 +154,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.setBillingProfileId(createRequest.projectName, profileModel.getId)).thenReturn(Future.successful(1))
 
     val wsmResouceRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
-    when(
-      wsmResouceRecordDao.create(
-        WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
-          landingZoneJobId,
-          createRequest.projectName,
-          testContext.userInfo.userEmail
-        )
-      )
-    ).thenReturn(Future.successful())
+
+    doReturn(Future.successful())
+      .when(wsmResouceRecordDao)
+      .create(org.mockito.ArgumentMatchers.any())
+
     val bp = new BpmBillingProjectLifecycle(repo, bpm, workspaceManagerDAO, wsmResouceRecordDao)
 
     assertResult(CreationStatuses.CreatingLandingZone) {
@@ -182,13 +177,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, landingZoneId)
     verify(repo, Mockito.times(1)).setBillingProfileId(createRequest.projectName, profileModel.getId)
-    verify(wsmResouceRecordDao, Mockito.times(1)).create(
-      WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
-        landingZoneJobId,
-        createRequest.projectName,
-        testContext.userInfo.userEmail
-      )
-    )
+    verify(wsmResouceRecordDao, Mockito.times(1)).create(org.mockito.ArgumentMatchers.any())
   }
 
   it should "wrap exceptions thrown by synchronous calls in a Future" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -201,4 +201,12 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
                                                    ArgumentMatchers.eq(landingZoneId)
     )
   }
+
+  behavior of "encode/decode ShortUuid"
+  it should "encode and decode the ShortUUID to the same value" in {
+    val uuid = UUID.randomUUID()
+    val encoded = WorkspaceManagerDAO.encodeShortUUID(uuid)
+    val decoded = WorkspaceManagerDAO.decodeShortUuid(encoded)
+    decoded shouldBe Some(uuid)
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -1,19 +1,12 @@
 package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.stairway.ShortUUID
-import bio.terra.workspace.api.{
-  ControlledAzureResourceApi,
-  LandingZonesApi,
-  UnauthenticatedApi,
-  WorkspaceApi,
-  WorkspaceApplicationApi
-}
+import bio.terra.workspace.api._
 import bio.terra.workspace.client.ApiClient
 import bio.terra.workspace.model._
-import org.broadinstitute.dsde.rawls.TestExecutionContext
-import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.ArgumentMatchers
@@ -24,19 +17,17 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext
 
-class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with MockitoSugar with MockitoTestUtils {
+class HttpWorkspaceManagerDAOSpec
+    extends AnyFlatSpec
+    with Matchers
+    with MockitoSugar
+    with MockitoTestUtils
+    with TestDriverComponent {
+
   implicit val actorSystem: ActorSystem = ActorSystem("HttpWorkspaceManagerDAOSpec")
-  implicit val executionContext: ExecutionContext = new TestExecutionContext()
 
   val workspaceId = UUID.randomUUID()
-  val userInfo = UserInfo(RawlsUserEmail("owner-access"),
-                          OAuth2BearerToken("token"),
-                          123,
-                          RawlsUserSubjectId("123456789876543212345")
-  )
-  val testContext = RawlsRequestContext(userInfo)
 
   def getApiClientProvider(workspaceApplicationApi: WorkspaceApplicationApi = mock[WorkspaceApplicationApi],
                            controlledAzureResourceApi: ControlledAzureResourceApi = mock[ControlledAzureResourceApi],
@@ -201,6 +192,35 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
     verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
                                                    ArgumentMatchers.eq(landingZoneId)
     )
+  }
+
+  behavior of "clone"
+  it should "call the WSM workspace API" in {
+    val workspaceApi = mock[WorkspaceApi]
+    val wsmDao = new HttpWorkspaceManagerDAO(getApiClientProvider(workspaceApi = workspaceApi))
+
+    val expectedRequest = new CloneWorkspaceRequest()
+      .displayName("my-workspace-clone")
+      .destinationWorkspaceId(workspaceId)
+      .spendProfile(testData.azureBillingProfile.getId.toString)
+      .location("the-moon")
+      .azureContext(
+        new AzureContext()
+          .tenantId(testData.azureBillingProfile.getTenantId.toString)
+          .subscriptionId(testData.azureBillingProfile.getSubscriptionId.toString)
+          .resourceGroupId(testData.azureBillingProfile.getManagedResourceGroupId)
+      )
+
+    wsmDao.cloneWorkspace(
+      testData.azureWorkspace.workspaceIdAsUUID,
+      workspaceId,
+      "my-workspace-clone",
+      testData.azureBillingProfile,
+      testContext,
+      Some("the-moon")
+    )
+
+    verify(workspaceApi).cloneWorkspace(expectedRequest, testData.azureWorkspace.workspaceIdAsUUID)
   }
 
   behavior of "encode/decode ShortUuid"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import bio.terra.stairway.ShortUUID
 import bio.terra.workspace.api.{
   ControlledAzureResourceApi,
   LandingZonesApi,
@@ -203,10 +204,18 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
   }
 
   behavior of "encode/decode ShortUuid"
-  it should "encode and decode the ShortUUID to the same value" in {
+  it should "encode and decode a UUID to the same value" in {
     val uuid = UUID.randomUUID()
     val encoded = WorkspaceManagerDAO.encodeShortUUID(uuid)
     val decoded = WorkspaceManagerDAO.decodeShortUuid(encoded)
     decoded shouldBe Some(uuid)
+  }
+
+  it should "encode and decode a Short UUID to the same value" in {
+    val shortUuid = ShortUUID.get()
+    val decoded = WorkspaceManagerDAO.decodeShortUuid(shortUuid)
+    decoded shouldBe defined
+    val encoded = WorkspaceManagerDAO.encodeShortUUID(decoded.get)
+    encoded shouldBe shortUuid
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.mock
 
 import akka.http.scaladsl.model.StatusCodes
+import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport.StatusEnum
 import bio.terra.workspace.model._
@@ -55,14 +56,14 @@ class MockWorkspaceManagerDAO(
   override def cloneWorkspace(sourceWorkspaceId: UUID,
                               workspaceId: UUID,
                               displayName: String,
-                              spendProfileId: UUID,
-                              location: String,
-                              ctx: RawlsRequestContext
+                              spendProfile: ProfileModel,
+                              ctx: RawlsRequestContext,
+                              location: Option[String]
   ): CloneWorkspaceResult = {
     val clonedWorkspace = new ClonedWorkspace()
       .sourceWorkspaceId(sourceWorkspaceId)
       .destinationWorkspaceId(workspaceId)
-      .destinationUserFacingId(displayName)
+      .destinationUserFacingId(UUID.randomUUID().toString)
 
     val jobReport = new JobReport()
       .id(UUID.randomUUID().toString)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.mock
 
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.profile.model.ProfileModel
+import bio.terra.stairway.ShortUUID
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport.StatusEnum
 import bio.terra.workspace.model._
@@ -65,8 +66,10 @@ class MockWorkspaceManagerDAO(
       .destinationWorkspaceId(workspaceId)
       .destinationUserFacingId(UUID.randomUUID().toString)
 
+    // Currently have no way of specifying a job id to wsm for this route and
+    // a base64 url-encoded "short" UUID is generated instead.
     val jobReport = new JobReport()
-      .id(UUID.randomUUID().toString)
+      .id(ShortUUID.get())
       .status(StatusEnum.RUNNING)
 
     new CloneWorkspaceResult()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -52,6 +52,27 @@ class MockWorkspaceManagerDAO(
   override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
+  override def cloneWorkspace(sourceWorkspaceId: UUID,
+                              workspaceId: UUID,
+                              displayName: String,
+                              spendProfileId: UUID,
+                              location: String,
+                              ctx: RawlsRequestContext
+  ): CloneWorkspaceResult = {
+    val clonedWorkspace = new ClonedWorkspace()
+      .sourceWorkspaceId(sourceWorkspaceId)
+      .destinationWorkspaceId(workspaceId)
+      .destinationUserFacingId(displayName)
+
+    val jobReport = new JobReport()
+      .id(UUID.randomUUID().toString)
+      .status(StatusEnum.RUNNING)
+
+    new CloneWorkspaceResult()
+      .workspace(clonedWorkspace)
+      .jobReport(jobReport)
+  }
+
   override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit = ()
 
   override def createDataRepoSnapshotReference(workspaceId: UUID,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitorSpec.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   WorkspaceManagerResourceJobRunner,
   WorkspaceManagerResourceMonitorRecord
 }
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsUserEmail}
 import org.broadinstitute.dsde.rawls.monitor.workspace.WorkspaceResourceMonitor.CheckDone
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{doReturn, spy, verify, when}
@@ -35,21 +36,15 @@ class WorkspaceResourceMonitorSpec extends AnyFlatSpec with Matchers with Mockit
   behavior of "WorkspaceResourceMonitor.checkJobs"
 
   it should "return a CheckDone message with the number of uncompleted jobs" in {
-    val job0 = new WorkspaceManagerResourceMonitorRecord(
+    val job0 = WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
       UUID.randomUUID(),
-      JobType.AzureLandingZoneResult,
-      None,
-      Some("bpId1"),
-      None,
-      Timestamp.from(Instant.now())
+      RawlsBillingProjectName("bpId1"),
+      RawlsUserEmail("simply-sausages@gmail.com")
     )
-    val job1 = new WorkspaceManagerResourceMonitorRecord(
+    val job1 = WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
       UUID.randomUUID(),
-      JobType.AzureLandingZoneResult,
-      None,
-      Some("bpId1"),
-      None,
-      Timestamp.from(Instant.now())
+      RawlsBillingProjectName("bpId1"),
+      RawlsUserEmail("simply-sausages@gmail.com")
     )
     val jobDao = mock[WorkspaceManagerResourceMonitorRecordDao]
     when(jobDao.selectAll()).thenReturn(Future.successful(Seq(job0, job1)))
@@ -63,13 +58,10 @@ class WorkspaceResourceMonitorSpec extends AnyFlatSpec with Matchers with Mockit
   behavior of "WorkspaceResourceMonitor.runJob"
 
   it should "delete a job after it completes successfully" in {
-    val job = new WorkspaceManagerResourceMonitorRecord(
+    val job = WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
       UUID.randomUUID(),
-      JobType.AzureLandingZoneResult,
-      None,
-      Some("bpId"),
-      None,
-      Timestamp.from(Instant.now())
+      RawlsBillingProjectName("bpId1"),
+      RawlsUserEmail("simply-sausages@gmail.com")
     )
 
     val jobDao = mock[WorkspaceManagerResourceMonitorRecordDao]
@@ -93,13 +85,10 @@ class WorkspaceResourceMonitorSpec extends AnyFlatSpec with Matchers with Mockit
   }
 
   it should "mark any jobs that doesnt have a registered handler as incomplete" in {
-    val job = new WorkspaceManagerResourceMonitorRecord(
+    val job = WorkspaceManagerResourceMonitorRecord.forAzureLandingZone(
       UUID.randomUUID(),
-      JobType.AzureLandingZoneResult,
-      None,
-      Some("bpId"),
-      None,
-      Timestamp.from(Instant.now())
+      RawlsBillingProjectName("bpId1"),
+      RawlsUserEmail("simply-sausages@gmail.com")
     )
 
     val jobDao = mock[WorkspaceManagerResourceMonitorRecordDao]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitorSpec.scala
@@ -54,8 +54,8 @@ class WorkspaceResourceMonitorSpec extends AnyFlatSpec with Matchers with Mockit
     val jobDao = mock[WorkspaceManagerResourceMonitorRecordDao]
     when(jobDao.selectAll()).thenReturn(Future.successful(Seq(job0, job1)))
     val monitor = spy(new WorkspaceResourceMonitor(jobDao, Map.empty))
-    doReturn(Future.successful(true)).when(monitor).runJob(ArgumentMatchers.eq(job0))
-    doReturn(Future.successful(false)).when(monitor).runJob(ArgumentMatchers.eq(job1))
+    doReturn(Future.successful(Complete)).when(monitor).runJob(ArgumentMatchers.eq(job0))
+    doReturn(Future.successful(Incomplete)).when(monitor).runJob(ArgumentMatchers.eq(job1))
 
     Await.result(monitor.checkJobs(), Duration.Inf) shouldBe CheckDone(1)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
@@ -47,7 +47,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       mock[BillingRepository],
       mock[GoogleServicesDAO]
     )
-    whenReady(runner.apply(monitorRecord.copy(billingProjectId = None)))(
+    whenReady(runner(monitorRecord.copy(billingProjectId = None)))(
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
   }
@@ -72,7 +72,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       billingRepository,
       mock[GoogleServicesDAO]
     )
-    whenReady(runner.apply(monitorRecord.copy(userEmail = None)))(
+    whenReady(runner(monitorRecord.copy(userEmail = None)))(
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
 
@@ -111,7 +111,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       .when(runner)
       .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
@@ -145,7 +145,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
@@ -180,7 +180,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
@@ -207,7 +207,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
     // since no methods are defined on the mock billing repository, any calls will throw an exception
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
   }
 
   it should "update the project as Errored and return a completed status when the job is marked as failed" in {
@@ -240,7 +240,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
@@ -274,7 +274,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
@@ -310,7 +310,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     val ctx = mock[RawlsRequestContext]
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
@@ -47,7 +47,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       mock[BillingRepository],
       mock[GoogleServicesDAO]
     )
-    whenReady(runner.run(monitorRecord.copy(billingProjectId = None)))(
+    whenReady(runner.apply(monitorRecord.copy(billingProjectId = None)))(
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
   }
@@ -72,7 +72,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       billingRepository,
       mock[GoogleServicesDAO]
     )
-    whenReady(runner.run(monitorRecord.copy(userEmail = None)))(
+    whenReady(runner.apply(monitorRecord.copy(userEmail = None)))(
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
 
@@ -111,7 +111,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       .when(runner)
       .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
@@ -145,7 +145,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
@@ -180,7 +180,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
@@ -207,7 +207,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
     // since no methods are defined on the mock billing repository, any calls will throw an exception
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
   }
 
   it should "update the project as Errored and return a completed status when the job is marked as failed" in {
@@ -240,7 +240,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
@@ -274,7 +274,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
@@ -310,7 +310,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     val ctx = mock[RawlsRequestContext]
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner.run(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
+    whenReady(runner.apply(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
@@ -128,7 +128,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     val wsmExceptionMessage = "looking for this to be reported in the billing project message"
     when(
       wsmDao.getCreateAzureLandingZoneResult(
-        ArgumentMatchers.eq(monitorRecord.jobControlId),
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
         ArgumentMatchers.any()
       )
     ).thenAnswer(_ => throw new bio.terra.workspace.client.ApiException(404, wsmExceptionMessage))
@@ -167,7 +167,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     val wsmDao = mock[WorkspaceManagerDAO]
     when(
       wsmDao.getCreateAzureLandingZoneResult(
-        ArgumentMatchers.eq(monitorRecord.jobControlId),
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
         ArgumentMatchers.any()
       )
     ).thenReturn(landingZoneResult)
@@ -201,7 +201,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       .jobReport(new JobReport().status(JobReport.StatusEnum.RUNNING))
     when(
       wsmDao.getCreateAzureLandingZoneResult(
-        ArgumentMatchers.eq(monitorRecord.jobControlId),
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
         ArgumentMatchers.any()
       )
     ).thenReturn(landingZoneResult)
@@ -222,7 +222,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       .errorReport(new bio.terra.workspace.model.ErrorReport().message(failureMessage))
     when(
       wsmDao.getCreateAzureLandingZoneResult(
-        ArgumentMatchers.eq(monitorRecord.jobControlId),
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
         ArgumentMatchers.any()
       )
     ).thenReturn(landingZoneResult)
@@ -261,7 +261,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     val landingZoneResult = new AzureLandingZoneResult().landingZone(new AzureLandingZoneDetails().id(lzId))
     when(
       wsmDao.getCreateAzureLandingZoneResult(
-        ArgumentMatchers.eq(monitorRecord.jobControlId),
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
         ArgumentMatchers.any()
       )
     ).thenReturn(landingZoneResult)
@@ -292,7 +292,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       .errorReport(new bio.terra.workspace.model.ErrorReport().message(failureMessage))
     when(
       wsmDao.getCreateAzureLandingZoneResult(
-        ArgumentMatchers.eq(monitorRecord.jobControlId),
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
         ArgumentMatchers.any()
       )
     ).thenReturn(landingZoneResult)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -435,7 +435,10 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
                   Map.empty
                 )
               )
-            } yield fail(),
+            } yield fail(
+              "cloneMultiCloudWorkspace does not fail when a workspace " +
+                "with the same name already exists."
+            ),
             Duration.Inf
           )
         }
@@ -532,8 +535,8 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
 
   it should
     "clone an azure workspace" +
-    "& create a new workspace record" +
-    "& create a new job for the workspace manager resource monitor" in
+    " & create a new workspace record" +
+    " & create a new job for the workspace manager resource monitor" in
     withEmptyTestDatabase {
       withMockedMultiCloudWorkspaceService { mcWorkspaceService =>
         val cloneName = WorkspaceName(testData.azureWorkspace.namespace, "kifflom")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -416,29 +416,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     runTest(mcWorkspaceService)
   }
 
-  it should "not permit cloning azure workspace storage into anything other than the `defaultRegion`" in
-    withMockedMultiCloudWorkspaceService { mcWorkspaceService =>
-      val result = intercept[RawlsExceptionWithErrorReport] {
-        Await.result(
-          mcWorkspaceService.cloneMultiCloudWorkspace(
-            mock[WorkspaceService](RETURNS_SMART_NULLS),
-            testData.azureWorkspace.toWorkspaceName,
-            WorkspaceRequest(
-              testData.azureBillingProjectName.value,
-              UUID.randomUUID().toString,
-              Map.empty,
-              bucketLocation = Some("the-moon")
-            )
-          ),
-          Duration.Inf
-        )
-      }
-
-      result.errorReport.statusCode.value shouldBe StatusCodes.BadRequest
-      result.errorReport.message should
-        include(mcWorkspaceService.multiCloudWorkspaceConfig.azureConfig.get.defaultRegion)
-    }
-
   it should "fail if the destination workspace already exists" in
     withEmptyTestDatabase {
       withMockedMultiCloudWorkspaceService { mcWorkspaceService =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,7 +124,7 @@ object Dependencies {
   // "Terra Common Lib" Exclusions:
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.459-SNAPSHOT")
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.515-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.57-SNAPSHOT")


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/WOR-625 Call WSM to initiate the workspace clone
Hand off monitoring WSM job to the WorkspaceResourceMonitor (todo [WOR-553] extend support for CloneWorkspace job types)
Add "smart constructors" to `WorkspaceManagerResourceMonitorRecord` so we supply all the fields required for each job type.

I haven't added integration tests - i feel there are other things to implement before that (ie tracking the clone job in wsm), not least that that sort of end-to-end test would be too long running for PR tests and to stay on-top of any drooled state.
This may be a bit controversial, but either wsm's implementation is correct or it isnt and I don't believe here is that right place to test that.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-553]: https://broadworkbench.atlassian.net/browse/WOR-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WOR-625]: https://broadworkbench.atlassian.net/browse/WOR-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ