### PR TITLE
Delete relay WorkspaceManagerDAO methods (WOR-607).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -151,31 +151,10 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
       applicationId
     )
 
-  def createAzureRelay(workspaceId: UUID,
-                       region: String,
-                       ctx: RawlsRequestContext
-  ): CreateControlledAzureRelayNamespaceResult = {
-    val jobControlId = UUID.randomUUID().toString
-    getControlledAzureResourceApi(ctx).createAzureRelayNamespace(
-      new CreateControlledAzureRelayNamespaceRequestBody()
-        .common(
-          createCommonFields(s"relay-${workspaceId}")
-        )
-        .azureRelayNamespace(
-          new AzureRelayNamespaceCreationParameters().namespaceName(s"relay-ns-${workspaceId}").region(region)
-        )
-        .jobControl(new JobControl().id(jobControlId)),
-      workspaceId
-    )
-  }
-
-  def getCreateAzureRelayResult(workspaceId: UUID,
-                                jobControlId: String,
+  def createAzureStorageAccount(workspaceId: UUID,
+                                region: String,
                                 ctx: RawlsRequestContext
-  ): CreateControlledAzureRelayNamespaceResult =
-    getControlledAzureResourceApi(ctx).getCreateAzureRelayNamespaceResult(workspaceId, jobControlId)
-
-  def createAzureStorageAccount(workspaceId: UUID, region: String, ctx: RawlsRequestContext) = {
+  ): CreatedControlledAzureStorage = {
     // Storage account names must be unique and 3-24 characters in length, numbers and lowercase letters only.
     val prefix = workspaceId.toString.substring(0, workspaceId.toString.indexOf("-"))
     val suffix = workspaceId.toString.substring(workspaceId.toString.lastIndexOf("-") + 1)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -59,14 +59,6 @@ trait WorkspaceManagerDAO {
                         applicationId: String,
                         ctx: RawlsRequestContext
   ): WorkspaceApplicationDescription
-  def createAzureRelay(workspaceId: UUID,
-                       region: String,
-                       ctx: RawlsRequestContext
-  ): CreateControlledAzureRelayNamespaceResult
-  def getCreateAzureRelayResult(workspaceId: UUID,
-                                jobControlId: String,
-                                ctx: RawlsRequestContext
-  ): CreateControlledAzureRelayNamespaceResult
   def createAzureStorageAccount(workspaceId: UUID,
                                 region: String,
                                 ctx: RawlsRequestContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -84,21 +84,6 @@ class HttpWorkspaceManagerDAOSpec extends AnyFlatSpec with Matchers with Mockito
     commonFields.getManagedBy shouldBe ManagedBy.USER
   }
 
-  behavior of "createAzureRelay"
-
-  it should "call the WSM controlled azure resource API" in {
-    val controlledAzureResourceApi = mock[ControlledAzureResourceApi]
-    val wsmDao =
-      new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
-
-    val relayArgumentCaptor = captor[CreateControlledAzureRelayNamespaceRequestBody]
-    wsmDao.createAzureRelay(workspaceId, "arlington", testContext)
-    verify(controlledAzureResourceApi).createAzureRelayNamespace(relayArgumentCaptor.capture, any[UUID])
-    relayArgumentCaptor.getValue.getAzureRelayNamespace.getRegion shouldBe "arlington"
-    relayArgumentCaptor.getValue.getAzureRelayNamespace.getNamespaceName should endWith(workspaceId.toString)
-    assertControlledResourceCommonFields(relayArgumentCaptor.getValue.getCommon)
-  }
-
   behavior of "createAzureStorageAccount"
 
   it should "call the WSM controlled azure resource API" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -37,10 +37,6 @@ class MockWorkspaceManagerDAO(
   def mockInitialCreateAzureCloudContextResult() =
     MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.RUNNING)
   def mockCreateAzureCloudContextResult() = createCloudContextResult
-  def mockInitialAzureRelayNamespaceResult() =
-    MockWorkspaceManagerDAO.getCreateControlledAzureRelayNamespaceResult(StatusEnum.RUNNING)
-  def mockAzureRelayNamespaceResult() =
-    MockWorkspaceManagerDAO.getCreateControlledAzureRelayNamespaceResult(StatusEnum.SUCCEEDED)
   def mockCreateAzureStorageAccountResult() =
     new CreatedControlledAzureStorage().resourceId(UUID.randomUUID()).azureStorage(new AzureStorageResource())
   def mockCreateAzureStorageContainerResult() = new CreatedControlledAzureStorageContainer()
@@ -159,18 +155,6 @@ class MockWorkspaceManagerDAO(
   ): WorkspaceApplicationDescription =
     new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
 
-  override def createAzureRelay(workspaceId: UUID,
-                                region: String,
-                                ctx: RawlsRequestContext
-  ): CreateControlledAzureRelayNamespaceResult =
-    mockInitialAzureRelayNamespaceResult()
-
-  override def getCreateAzureRelayResult(workspaceId: UUID,
-                                         jobControlId: String,
-                                         ctx: RawlsRequestContext
-  ): CreateControlledAzureRelayNamespaceResult =
-    mockAzureRelayNamespaceResult()
-
   override def createAzureStorageAccount(workspaceId: UUID,
                                          region: String,
                                          ctx: RawlsRequestContext
@@ -205,9 +189,6 @@ class MockWorkspaceManagerDAO(
 object MockWorkspaceManagerDAO {
   def getCreateCloudContextResult(status: StatusEnum): CreateCloudContextResult =
     new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(status))
-
-  def getCreateControlledAzureRelayNamespaceResult(status: StatusEnum): CreateControlledAzureRelayNamespaceResult =
-    new CreateControlledAzureRelayNamespaceResult().jobReport(new JobReport().id("relay_fake_id").status(status))
 
   def buildWithAsyncCloudContextResult(createCloudContextStatus: StatusEnum) =
     new MockWorkspaceManagerDAO(


### PR DESCRIPTION
Creating a separate PR for removing the interface methods to WorkspaceManager. This will make it easier for someone to revive them in the future if desired (will rebase against develop after https://github.com/broadinstitute/rawls/pull/2168 merges).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
