### PR TITLE
[WOR-683] Don't check google children on deletion for Azure workspaces.

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -363,7 +363,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     }
 
     error.errorReport.statusCode.get shouldBe StatusCodes.InternalServerError
-    error.errorReport.message shouldBe "Cannot call this method on a workspace with no googleProjectId"
+    assert(error.errorReport.message contains "with no googleProjectId")
   }
 
   def mockWsmForAclTests(ownerEmail: String = "owner@example.com",


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-683

This fixes an issue that was recently introduced in https://github.com/broadinstitute/rawls/pull/2153

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-683]: https://broadworkbench.atlassian.net/browse/WOR-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ