### PR TITLE
[WOR-686] Remove check against the alpha feature group when pulling billing profiles

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -317,7 +317,6 @@ object Boot extends IOApp with LazyLogging {
 
       val multiCloudWorkspaceConfig = MultiCloudWorkspaceConfig.apply(conf)
       val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
-        samDAO,
         new HttpBillingProfileManagerClientProvider(conf.getStringOption("billingProfileManager.baseUrl")),
         multiCloudWorkspaceConfig
       )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -4,17 +4,8 @@ import bio.terra.profile.model._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.ProjectRoles.ProjectRole
-import org.broadinstitute.dsde.rawls.model.{
-  AzureManagedAppCoordinates,
-  ErrorReport,
-  ProjectRoles,
-  RawlsBillingAccountName,
-  RawlsRequestContext,
-  SamResourceAction,
-  SamResourceTypeNames
-}
+import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, ErrorReport, ProjectRoles, RawlsBillingAccountName, RawlsRequestContext}
 
 import java.util.UUID
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -68,7 +68,6 @@ object BillingProfileManagerDAO {
  * for the purposes of testing Azure workspaces.
  */
 class BillingProfileManagerDAOImpl(
-  samDAO: SamDAO,
   apiClientProvider: BillingProfileManagerClientProvider,
   config: MultiCloudWorkspaceConfig
 ) extends BillingProfileManagerDAO
@@ -120,13 +119,6 @@ class BillingProfileManagerDAOImpl(
       return Future.successful(Seq())
     }
 
-    val azureConfig = config.azureConfig match {
-      case None =>
-        logger.warn("Multicloud workspaces enabled but no azure config setup, returning empty list of billing profiles")
-        return Future.successful(Seq())
-      case Some(value) => value
-    }
-
     val profileApi = apiClientProvider.getProfileApi(ctx)
 
     @tailrec
@@ -140,18 +132,7 @@ class BillingProfileManagerDAOImpl(
       }
     }
 
-    // NB until the BPM is live, we want to ensure user is in the alpha group
-    samDAO
-      .userHasAction(
-        SamResourceTypeNames.managedGroup,
-        azureConfig.alphaFeatureGroup,
-        SamResourceAction("use"),
-        ctx
-      )
-      .flatMap {
-        case true => Future.successful(callListProfiles())
-        case _    => Future.successful(Seq())
-      }
+    Future.successful(callListProfiles())
   }
 
   private def getProfileApiPolicy(samRole: ProjectRole): String =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -5,7 +5,13 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.model.ProjectRoles.ProjectRole
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, ErrorReport, ProjectRoles, RawlsBillingAccountName, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  ErrorReport,
+  ProjectRoles,
+  RawlsBillingAccountName,
+  RawlsRequestContext
+}
 
 import java.util.UUID
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -14,7 +14,7 @@ final case class MultiCloudWorkspaceConfig(multiCloudWorkspacesEnabled: Boolean,
 
 final case class MultiCloudWorkspaceManagerConfig(leonardoWsmApplicationId: String, pollTimeout: FiniteDuration)
 
-final case class AzureConfig(alphaFeatureGroup: String, landingZoneDefinition: String, landingZoneVersion: String)
+final case class AzureConfig(landingZoneDefinition: String, landingZoneVersion: String)
 
 case object MultiCloudWorkspaceConfig {
   def apply[T <: MultiCloudWorkspaceConfig](conf: Config): MultiCloudWorkspaceConfig = {
@@ -22,7 +22,6 @@ case object MultiCloudWorkspaceConfig {
       case Some(azc) =>
         Some(
           AzureConfig(
-            azc.getString("alphaFeatureGroup"),
             azc.getString("landingZoneDefinition"),
             azc.getString("landingZoneVersion")
           )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -73,35 +73,6 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     result.length should be(BillingProfileManagerDAO.BillingProfileRequestBatchSize + 1)
   }
 
-  it should "return no profiles if the user lacks permissions" in {
-    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
-      mock[BillingProfileManagerClientProvider],
-      new MultiCloudWorkspaceConfig(true, None, Some(azConfig))
-    )
-
-    Await.result(billingProfileManagerDAO.getAllBillingProfiles(testContext), Duration.Inf).isEmpty shouldBe true
-  }
-
-  it should "return no billing profiles if the feature flag is off" in {
-    val config = new MultiCloudWorkspaceConfig(false, None, None)
-    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
-      mock[BillingProfileManagerClientProvider],
-      config
-    )
-
-    Await.result(billingProfileManagerDAO.getAllBillingProfiles(testContext), Duration.Inf).isEmpty shouldBe true
-  }
-
-  it should "return no billing profiles if azure config is not set" in {
-    val config = new MultiCloudWorkspaceConfig(true, None, None)
-    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
-      mock[BillingProfileManagerClientProvider],
-      config
-    )
-
-    Await.result(billingProfileManagerDAO.getAllBillingProfiles(testContext), Duration.Inf).isEmpty shouldBe true
-  }
-
   behavior of "createBillingProfile"
 
   it should "fail when provided with Google billing account information" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -37,7 +37,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
   val azConfig: AzureConfig = AzureConfig(
-    "fake-alpha-feature-group",
     "fake-landing-zone-definition",
     "fake-landing-zone-version"
   )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -52,7 +52,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   val landingZoneDefinition = "fake-landing-zone-definition"
   val landingZoneVersion = "fake-landing-zone-version"
   val azConfig: AzureConfig = AzureConfig(
-    "fake-alpha-feature-group",
     landingZoneDefinition,
     landingZoneVersion
   )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -446,7 +446,6 @@ class SubmissionSpec(_system: ActorSystem)
       val servicePerimeterService = new ServicePerimeterService(slickDataSource, gcsDAO, servicePerimeterServiceConfig)
 
       val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
-        samDAO,
         mock[BillingProfileManagerClientProvider],
         new MultiCloudWorkspaceConfig(false, None, None)
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -50,7 +50,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     Some(MultiCloudWorkspaceManagerConfig("fake_app_id", 60 seconds)),
     Some(
       AzureConfig(
-        "fake_group",
         "fake-landing-zone-definition",
         "fake-landing-zone-version"
       )


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-686)
We were gating the availability of billing profiles by membership in the alpha-azure-feature-group Sam group. We need to remove this check for prod availability.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
