### PR TITLE
WOR-697, clone container during clone workspace operation

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -14,7 +14,7 @@ object WorkspaceManagerResourceMonitorRecord {
   object JobType extends SlickEnum {
     type JobType = Value
     val AzureLandingZoneResult: Value = Value("AzureLandingZoneResult")
-    val CloneWorkspaceResult: Value = Value("CloneWorkspaceResult")
+    val CloneWorkspaceContainerResult: Value = Value("CloneWorkspaceContainerResult")
   }
 
   implicit sealed class JobStatus(val isDone: Boolean)
@@ -36,13 +36,13 @@ object WorkspaceManagerResourceMonitorRecord {
       Timestamp.from(Instant.now())
     )
 
-  def forCloneWorkspace(jobRecordId: UUID,
-                        workspaceId: UUID,
-                        userEmail: RawlsUserEmail
+  def forCloneWorkspaceContainer(jobRecordId: UUID,
+                                 workspaceId: UUID,
+                                 userEmail: RawlsUserEmail
   ): WorkspaceManagerResourceMonitorRecord =
     WorkspaceManagerResourceMonitorRecord(
       jobRecordId,
-      JobType.CloneWorkspaceResult,
+      JobType.CloneWorkspaceContainerResult,
       workspaceId = Some(workspaceId),
       billingProjectId = None,
       userEmail = Some(userEmail.value),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -227,6 +227,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def cloneAzureStorageContainer(sourceWorkspaceId: UUID,
                                           destinationWorkspaceId: UUID,
                                           sourceContainerId: UUID,
+                                          destinationContainerName: String,
                                           cloningInstructions: CloningInstructionsEnum,
                                           ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult = {
@@ -234,6 +235,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     getControlledAzureResourceApi(ctx).cloneAzureStorageContainer(
       new CloneControlledAzureStorageContainerRequest()
         .destinationWorkspaceId(destinationWorkspaceId)
+        .name(destinationContainerName)
         .cloningInstructions(cloningInstructions)
         .jobControl(new JobControl().id(jobControlId)),
       sourceWorkspaceId,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -217,7 +217,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     getControlledAzureResourceApi(ctx).createAzureStorageContainer(
       new CreateControlledAzureStorageContainerRequestBody()
         .common(
-          createCommonFields(storageContainerName).cloningInstructions(CloningInstructionsEnum.DEFINITION)
+          createCommonFields(storageContainerName).cloningInstructions(CloningInstructionsEnum.NOTHING)
         )
         .azureStorageContainer(storageContainerCreationParameters),
       workspaceId

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -28,7 +28,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     new ReferencedGcpResourceApi(getApiClient(ctx))
 
   private def getResourceApi(ctx: RawlsRequestContext): ResourceApi =
-    new ResourceApi(getApiClient(ctx))
+    apiClientProvider.getResourceApi(ctx)
 
   private def getWorkspaceApplicationApi(ctx: RawlsRequestContext) =
     apiClientProvider.getWorkspaceApplicationApi(ctx)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -204,24 +204,19 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                            storageAccountId: Option[UUID],
                                            ctx: RawlsRequestContext
   ) = {
-    val storageContainerCreationParameters = storageAccountId match {
-      case Some(_) =>
-        new AzureStorageContainerCreationParameters()
-          .storageContainerName(storageContainerName)
-          .storageAccountId(storageAccountId.get)
-      case None =>
-        new AzureStorageContainerCreationParameters()
-          .storageContainerName(storageContainerName)
-    }
+    val creationParams =
+      new AzureStorageContainerCreationParameters()
+        .storageContainerName(storageContainerName)
+        .storageAccountId(storageAccountId.orNull)
 
-    getControlledAzureResourceApi(ctx).createAzureStorageContainer(
-      new CreateControlledAzureStorageContainerRequestBody()
-        .common(
-          createCommonFields(storageContainerName).cloningInstructions(CloningInstructionsEnum.NOTHING)
-        )
-        .azureStorageContainer(storageContainerCreationParameters),
-      workspaceId
-    )
+    val requestBody = new CreateControlledAzureStorageContainerRequestBody()
+      .common(
+        createCommonFields(storageContainerName).cloningInstructions(CloningInstructionsEnum.NOTHING)
+      )
+      .azureStorageContainer(creationParams)
+
+    getControlledAzureResourceApi(ctx)
+      .createAzureStorageContainer(requestBody, workspaceId)
   }
 
   override def cloneAzureStorageContainer(sourceWorkspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
@@ -4,6 +4,7 @@ import bio.terra.common.tracing.JerseyTracingFilter
 import bio.terra.workspace.api.{
   ControlledAzureResourceApi,
   LandingZonesApi,
+  ResourceApi,
   UnauthenticatedApi,
   WorkspaceApi,
   WorkspaceApplicationApi
@@ -27,6 +28,8 @@ trait WorkspaceManagerApiClientProvider {
   def getWorkspaceApi(ctx: RawlsRequestContext): WorkspaceApi
 
   def getLandingZonesApi(ctx: RawlsRequestContext): LandingZonesApi
+
+  def getResourceApi(ctx: RawlsRequestContext): ResourceApi
 
   def getUnauthenticatedApi(): UnauthenticatedApi
 }
@@ -59,6 +62,9 @@ class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: String) extend
 
   def getLandingZonesApi(ctx: RawlsRequestContext): LandingZonesApi =
     new LandingZonesApi(getApiClient(ctx))
+
+  def getResourceApi(ctx: RawlsRequestContext): ResourceApi =
+    new ResourceApi(getApiClient(ctx))
 
   override def getUnauthenticatedApi(): UnauthenticatedApi = {
     val client: ApiClient = new ApiClient()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -83,7 +83,7 @@ trait WorkspaceManagerDAO {
     * @param storageContainerName the name of the new container
     * @param storageAccountId optional UUID of a storage account resource. If not specified, the storage
     *                         account from the workspace's landing zone will be used
-    * @param ctx Raws context
+    * @param ctx Rawls context
     * @return the response from workspace manager
     */
   def createAzureStorageContainer(workspaceId: UUID,
@@ -92,6 +92,20 @@ trait WorkspaceManagerDAO {
                                   ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer
 
+  /**
+    * Clone the storage container from one workspace to another.
+    *
+    * @param sourceWorkspaceId the UUID of the source workspace
+    * @param destinationWorkspaceId the UUID of the destination workspace
+    * @param sourceContainerId the UUID of the source container to clone
+    * @param destinationContainerName the name for the created container in the destination workspace
+    * @param cloningInstructions the cloning instructions to use. Note that this will override the cloning
+    *                            instructions of the source container for the purposes of this cloning operation;
+    *                            however, the cloned container's cloning instructions will be the same as the
+    *                            original source container's.
+    * @param Rawls context
+    * @return the response from workspace manager
+    */
   def cloneAzureStorageContainer(sourceWorkspaceId: UUID,
                                  destinationWorkspaceId: UUID,
                                  sourceContainerId: UUID,
@@ -100,11 +114,28 @@ trait WorkspaceManagerDAO {
                                  ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult
 
+  /**
+    * Get the job result from a storage container clone operation.
+    *
+    * @param workspaceId the UUID of the workspace that is being cloned into
+    * @param jobId the jobID of the container clone operation
+    * @param Rawls context
+    * @return the response from workspace manager
+    */
   def getCloneAzureStorageContainerResult(workspaceId: UUID,
                                           jobId: String,
                                           ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult
 
+  /**
+    * Get the storage containers for the specified workspace.
+    *
+    * @param workspaceId the UUID of the workspace
+    * @param offset starting index
+    * @param limit number to return
+    * @param Rawls context
+    * @return the response from workspace manager
+    */
   def enumerateStorageContainers(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList
 
   def getRoles(workspaceId: UUID, ctx: RawlsRequestContext): RoleBindingList

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -3,34 +3,10 @@ package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
-import com.google.common.io.BaseEncoding.base64Url
 import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, RawlsRequestContext}
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, WorkbenchEmail}
 
-import java.nio.ByteBuffer
 import java.util.UUID
-import scala.util.Try
-
-object WorkspaceManagerDAO {
-
-  // Remove/Move into ShortUUID after [PF-1268]
-
-  /** @see bio.terra.stairway.ShortUUID#get() */
-  def decodeShortUuid(shortUuid: String): Option[UUID] =
-    Try {
-      val bytes = ByteBuffer.wrap(base64Url.decode(shortUuid))
-      val hi = bytes.getLong(0)
-      val lo = bytes.getLong(8)
-      new UUID(hi, lo)
-    }.toOption
-
-  def encodeShortUUID(uuid: UUID): String = {
-    val byteBuffer = ByteBuffer.allocate(16)
-    byteBuffer.putLong(uuid.getMostSignificantBits)
-    byteBuffer.putLong(uuid.getLeastSignificantBits)
-    base64Url().omitPadding().encode(byteBuffer.array())
-  }
-}
 
 trait WorkspaceManagerDAO {
   val errorReportSource = ErrorReportSource("WorkspaceManager")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -104,15 +104,31 @@ trait WorkspaceManagerDAO {
     * Creates an Azure storage container in the workspace.
     *
     * @param workspaceId the UUID of the workspace
+    * @param storageContainerName the name of the new container
     * @param storageAccountId optional UUID of a storage account resource. If not specified, the storage
     *                         account from the workspace's landing zone will be used
     * @param ctx Raws context
     * @return the response from workspace manager
     */
   def createAzureStorageContainer(workspaceId: UUID,
+                                  storageContainerName: String,
                                   storageAccountId: Option[UUID],
                                   ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer
+
+  def cloneAzureStorageContainer(sourceWorkspaceId: UUID,
+                                 destinationWorkspaceId: UUID,
+                                 sourceContainerId: UUID,
+                                 cloningInstructions: CloningInstructionsEnum,
+                                 ctx: RawlsRequestContext
+  ): CloneControlledAzureStorageContainerResult
+
+  def getCloneAzureStorageContainerResult(workspaceId: UUID,
+                                          jobId: String,
+                                          ctx: RawlsRequestContext
+  ): CloneControlledAzureStorageContainerResult
+
+  def enumerateStorageContainers(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList
 
   def getRoles(workspaceId: UUID, ctx: RawlsRequestContext): RoleBindingList
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -95,6 +95,7 @@ trait WorkspaceManagerDAO {
   def cloneAzureStorageContainer(sourceWorkspaceId: UUID,
                                  destinationWorkspaceId: UUID,
                                  sourceContainerId: UUID,
+                                 destinationContainerName: String,
                                  cloningInstructions: CloningInstructionsEnum,
                                  ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -4,15 +4,19 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.profile.model.{CloudPlatform, ProfileModel}
 import bio.terra.workspace.model.JobReport.StatusEnum
-import bio.terra.workspace.model.{CloneWorkspaceResult, CreateCloudContextResult}
+import bio.terra.workspace.model._
 import cats.Apply
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  DataAccess,
+  ReadWriteAction,
+  WorkspaceManagerResourceMonitorRecord
+}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.{McWorkspace, RawlsWorkspace}
@@ -38,6 +42,7 @@ import slick.jdbc.TransactionIsolation
 import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.language.postfixOps
 import scala.util.{Success, Try}
 
@@ -58,6 +63,9 @@ object MultiCloudWorkspaceService {
       dataSource,
       workbenchMetricBaseName
     )
+
+  def getStorageContainerName(workspaceId: UUID): String = s"sc-${workspaceId}"
+
 }
 
 /**
@@ -252,7 +260,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       // to avoid naming conflicts - we'll erase it should the clone request to WSM fail.
       newWorkspace <- createNewWorkspaceRecord()
 
-      _ <- (for {
+      containerCloneResult <- (for {
         cloneResult <- traceWithParent("workspaceManagerDAO.cloneWorkspace", parentContext) { context =>
           Future(blocking {
             workspaceManagerDAO.cloneWorkspace(
@@ -278,7 +286,14 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                          getWorkspaceCloneStatus
           )
         }
-      } yield ()).recoverWith { t: Throwable =>
+        _ = logger.info(
+          s"Starting workspace storage container clone in WSM [workspaceId = ${newWorkspace.workspaceIdAsUUID}]"
+        )
+        containerCloneResult <- traceWithParent("workspaceManagerDAO.cloneAzureStorageContainer", parentContext) {
+          context =>
+            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID, newWorkspace.workspaceIdAsUUID, context)
+        }
+      } yield containerCloneResult).recoverWith { t: Throwable =>
         logger.warn(
           "Clone workspace request to workspace manager failed for " +
             s"[ sourceWorkspaceName='${sourceWorkspace.toWorkspaceName}'" +
@@ -293,39 +308,60 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         "Created azure workspace " +
           s"[ workspaceId='${newWorkspace.workspaceId}'" +
           s", workspaceName='${newWorkspace.toWorkspaceName}'" +
-          //  s", cloneJobReportId='${cloneResult.getJobReport.getId}'" + WOR-697
+          s", containerCloneJobReportId='${containerCloneResult.getJobReport.getId}'" +
           s"]"
       )
 
-      // We can't specify the jobId to WSM at the time of writing and
-      // a 22-character base64url-encoded short-UUID is generated instead.
-      // Commented out until WOR-697
-//      jobId = WorkspaceManagerDAO.decodeShortUuid(cloneResult.getJobReport.getId).getOrElse {
-//        // If this happens we're in trouble. Our database needs a UUID but whatever WSM gave us
-//        // was not something we know how to convert into a UUID. I don't think we should delete the
-//        // workspace record but I'm not going to write an elaborate error handler to clean this up,
-//        // instead favouring PF-1269 as a better solution.
-//        val message =
-//          "Job report id returned by WSM when creating workspace clone was not a ShortUUID " +
-//            s"[ workspaceName='${newWorkspace.toWorkspaceName}'" +
-//            s", workspaceId='${newWorkspace.workspaceId}'" +
-//            s", jobId='${cloneResult.getJobReport.getId}' " +
-//            s"]"
-//
-//        logger.error(message)
-//        throw RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, message))
-//      }
-//
-//      // hand off monitoring the clone job to the resource monitor
-//      _ <- WorkspaceManagerResourceMonitorRecordDao(dataSource).create(
-//        WorkspaceManagerResourceMonitorRecord.forCloneWorkspace(
-//          jobId,
-//          newWorkspace.workspaceIdAsUUID,
-//          parentContext.userInfo.userEmail
-//        )
-//      )
+      // hand off monitoring the clone job to the resource monitor
+      _ <- WorkspaceManagerResourceMonitorRecordDao(dataSource).create(
+        WorkspaceManagerResourceMonitorRecord.forCloneWorkspace(
+          UUID.fromString(containerCloneResult.getJobReport.getId),
+          newWorkspace.workspaceIdAsUUID,
+          parentContext.userInfo.userEmail
+        )
+      )
 
     } yield newWorkspace
+  }
+
+  def cloneWorkspaceStorageContainer(sourceWorkspaceId: UUID,
+                                     destinationWorkspaceId: UUID,
+                                     ctx: RawlsRequestContext
+  ): Future[CloneControlledAzureStorageContainerResult] = {
+
+    val expectedContainerName = getStorageContainerName(sourceWorkspaceId)
+    val allContainers =
+      workspaceManagerDAO.enumerateStorageContainers(sourceWorkspaceId, 0, 200, ctx).getResources.asScala
+    val sharedAccessContainers = allContainers.filter(resource =>
+      resource.getMetadata.getControlledResourceMetadata.getAccessScope == AccessScope.SHARED_ACCESS
+    )
+    if (sharedAccessContainers.size > 1) {
+      logger.warn(
+        s"Workspace being cloned has multiple shared access containers [ workspaceId='${sourceWorkspaceId}' ]"
+      )
+    }
+    val container = sharedAccessContainers.find(resource => resource.getMetadata.getName == expectedContainerName)
+    container match {
+      case Some(_) =>
+        Future(blocking {
+          workspaceManagerDAO.cloneAzureStorageContainer(
+            sourceWorkspaceId,
+            destinationWorkspaceId,
+            container.get.getMetadata.getResourceId,
+            CloningInstructionsEnum.RESOURCE,
+            ctx
+          )
+        })
+      case None =>
+        Future.failed(
+          RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.InternalServerError,
+              s"Workspace ${sourceWorkspaceId} does not have the expected storage container ${expectedContainerName}."
+            )
+          )
+        )
+    }
   }
 
   /**
@@ -411,13 +447,17 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         Future(workspaceManagerDAO.enableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, ctx))
       )
       containerResult <- traceWithParent("createStorageContainer", parentContext)(_ =>
-        Future(workspaceManagerDAO.createAzureStorageContainer(workspaceId, None, ctx))
+        Future(
+          workspaceManagerDAO.createAzureStorageContainer(workspaceId, getStorageContainerName(workspaceId), None, ctx)
+        )
       )
       _ = logger.info(
         s"Created Azure storage container in WSM [workspaceId = ${workspaceId}, containerId = ${containerResult.getResourceId}]"
       )
     } yield savedWorkspace
   }
+
+  private def getStorageContainerName(workspaceId: UUID): String = s"sc-${workspaceId}"
 
   private def getCloudContextCreationStatus(workspaceId: UUID,
                                             jobControlId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -329,7 +329,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                      ctx: RawlsRequestContext
   ): Future[CloneControlledAzureStorageContainerResult] = {
 
-    val expectedContainerName = getStorageContainerName(sourceWorkspaceId)
+    val expectedContainerName = MultiCloudWorkspaceService.getStorageContainerName(sourceWorkspaceId)
     val allContainers =
       workspaceManagerDAO.enumerateStorageContainers(sourceWorkspaceId, 0, 200, ctx).getResources.asScala
     val sharedAccessContainers = allContainers.filter(resource =>
@@ -348,7 +348,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             sourceWorkspaceId,
             destinationWorkspaceId,
             container.get.getMetadata.getResourceId,
-            getStorageContainerName(destinationWorkspaceId),
+            MultiCloudWorkspaceService.getStorageContainerName(destinationWorkspaceId),
             CloningInstructionsEnum.RESOURCE,
             ctx
           )
@@ -449,7 +449,12 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       )
       containerResult <- traceWithParent("createStorageContainer", parentContext)(_ =>
         Future(
-          workspaceManagerDAO.createAzureStorageContainer(workspaceId, getStorageContainerName(workspaceId), None, ctx)
+          workspaceManagerDAO.createAzureStorageContainer(
+            workspaceId,
+            MultiCloudWorkspaceService.getStorageContainerName(workspaceId),
+            None,
+            ctx
+          )
         )
       )
       _ = logger.info(
@@ -457,8 +462,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       )
     } yield savedWorkspace
   }
-
-  private def getStorageContainerName(workspaceId: UUID): String = s"sc-${workspaceId}"
 
   private def getCloudContextCreationStatus(workspaceId: UUID,
                                             jobControlId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -348,6 +348,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             sourceWorkspaceId,
             destinationWorkspaceId,
             container.get.getMetadata.getResourceId,
+            getStorageContainerName(destinationWorkspaceId),
             CloningInstructionsEnum.RESOURCE,
             ctx
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -314,7 +314,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
 
       // hand off monitoring the clone job to the resource monitor
       _ <- WorkspaceManagerResourceMonitorRecordDao(dataSource).create(
-        WorkspaceManagerResourceMonitorRecord.forCloneWorkspace(
+        WorkspaceManagerResourceMonitorRecord.forCloneWorkspaceContainer(
           UUID.fromString(containerCloneResult.getJobReport.getId),
           newWorkspace.workspaceIdAsUUID,
           parentContext.userInfo.userEmail
@@ -330,6 +330,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
   ): Future[CloneControlledAzureStorageContainerResult] = {
 
     val expectedContainerName = MultiCloudWorkspaceService.getStorageContainerName(sourceWorkspaceId)
+    // Using limit of 200 to be safe, but we expect at most a handful of storage containers.
     val allContainers =
       workspaceManagerDAO.enumerateStorageContainers(sourceWorkspaceId, 0, 200, ctx).getResources.asScala
     val sharedAccessContainers = allContainers.filter(resource =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -100,9 +100,9 @@ class HttpWorkspaceManagerDAOSpec
 
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
     val storageAccountId = UUID.randomUUID()
-    wsmDao.createAzureStorageContainer(workspaceId, Some(storageAccountId), testContext)
+    wsmDao.createAzureStorageContainer(workspaceId, "containerName", Some(storageAccountId), testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
-    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "sc-" + workspaceId
+    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "containerName"
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe storageAccountId
     assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon, CloningInstructionsEnum.NOTHING)
   }
@@ -113,9 +113,9 @@ class HttpWorkspaceManagerDAOSpec
       new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
 
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
-    wsmDao.createAzureStorageContainer(workspaceId, None, testContext)
+    wsmDao.createAzureStorageContainer(workspaceId, "containerName", None, testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
-    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "sc-" + workspaceId
+    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "containerName"
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe null
     assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon, CloningInstructionsEnum.NOTHING)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -68,9 +68,10 @@ class HttpWorkspaceManagerDAOSpec
 
   def assertControlledResourceCommonFields(commonFields: ControlledResourceCommonFields,
                                            expectedCloningInstructions: CloningInstructionsEnum =
-                                             CloningInstructionsEnum.NOTHING
+                                             CloningInstructionsEnum.NOTHING,
+                                           expectedNameSuffix: String = workspaceId.toString
   ): Unit = {
-    commonFields.getName should endWith(workspaceId.toString)
+    commonFields.getName should endWith(expectedNameSuffix)
     commonFields.getCloningInstructions shouldBe expectedCloningInstructions
     commonFields.getAccessScope shouldBe AccessScope.SHARED_ACCESS
     commonFields.getManagedBy shouldBe ManagedBy.USER
@@ -100,24 +101,31 @@ class HttpWorkspaceManagerDAOSpec
 
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
     val storageAccountId = UUID.randomUUID()
-    wsmDao.createAzureStorageContainer(workspaceId, "containerName", Some(storageAccountId), testContext)
+    val containerName = "containerName"
+    wsmDao.createAzureStorageContainer(workspaceId, containerName, Some(storageAccountId), testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
-    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "containerName"
+    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe containerName
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe storageAccountId
-    assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon, CloningInstructionsEnum.NOTHING)
+    assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon,
+                                         CloningInstructionsEnum.NOTHING,
+                                         containerName
+    )
   }
 
   it should "call the WSM controlled azure resource API without a SA id" in {
     val controlledAzureResourceApi = mock[ControlledAzureResourceApi]
     val wsmDao =
       new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
-
+    val containerName = "containerName"
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
-    wsmDao.createAzureStorageContainer(workspaceId, "containerName", None, testContext)
+    wsmDao.createAzureStorageContainer(workspaceId, containerName, None, testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
-    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe "containerName"
+    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe containerName
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe null
-    assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon, CloningInstructionsEnum.NOTHING)
+    assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon,
+                                         CloningInstructionsEnum.NOTHING,
+                                         containerName
+    )
   }
 
   behavior of "getRoles"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
 import akka.actor.ActorSystem
-import bio.terra.stairway.ShortUUID
 import bio.terra.workspace.api._
 import bio.terra.workspace.client.ApiClient
 import bio.terra.workspace.model._
@@ -214,21 +213,5 @@ class HttpWorkspaceManagerDAOSpec
     )
 
     verify(workspaceApi).cloneWorkspace(expectedRequest, testData.azureWorkspace.workspaceIdAsUUID)
-  }
-
-  behavior of "encode/decode ShortUuid"
-  it should "encode and decode a UUID to the same value" in {
-    val uuid = UUID.randomUUID()
-    val encoded = WorkspaceManagerDAO.encodeShortUUID(uuid)
-    val decoded = WorkspaceManagerDAO.decodeShortUuid(encoded)
-    decoded shouldBe Some(uuid)
-  }
-
-  it should "encode and decode a Short UUID to the same value" in {
-    val shortUuid = ShortUUID.get()
-    val decoded = WorkspaceManagerDAO.decodeShortUuid(shortUuid)
-    decoded shouldBe defined
-    val encoded = WorkspaceManagerDAO.encodeShortUUID(decoded.get)
-    encoded shouldBe shortUuid
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -75,6 +75,7 @@ class MockWorkspaceManagerDAO(
   override def cloneAzureStorageContainer(sourceWorkspaceId: UUID,
                                           destinationWorkspaceId: UUID,
                                           sourceContainerId: UUID,
+                                          destinationContainerName: String,
                                           cloningInstructions: CloningInstructionsEnum,
                                           ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -64,7 +64,7 @@ class MockWorkspaceManagerDAO(
     // Currently have no way of specifying a job id to wsm for this route and
     // a base64 url-encoded "short" UUID is generated instead.
     val jobReport = new JobReport()
-      .id(ShortUUID.get()) // TODO: remove ShortUIID conversion code?
+      .id(ShortUUID.get())
       .status(StatusEnum.RUNNING)
 
     new CloneWorkspaceResult()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -64,13 +64,50 @@ class MockWorkspaceManagerDAO(
     // Currently have no way of specifying a job id to wsm for this route and
     // a base64 url-encoded "short" UUID is generated instead.
     val jobReport = new JobReport()
-      .id(ShortUUID.get())
+      .id(ShortUUID.get()) // TODO: remove ShortUIID conversion code?
       .status(StatusEnum.RUNNING)
 
     new CloneWorkspaceResult()
       .workspace(clonedWorkspace)
       .jobReport(jobReport)
   }
+
+  override def cloneAzureStorageContainer(sourceWorkspaceId: UUID,
+                                          destinationWorkspaceId: UUID,
+                                          sourceContainerId: UUID,
+                                          cloningInstructions: CloningInstructionsEnum,
+                                          ctx: RawlsRequestContext
+  ): CloneControlledAzureStorageContainerResult = {
+
+    val clonedStorageContainer = new ClonedControlledAzureStorageContainer()
+      .sourceWorkspaceId(sourceWorkspaceId)
+      .sourceResourceId(sourceContainerId)
+      .effectiveCloningInstructions(cloningInstructions)
+      .storageContainer(mockCreateAzureStorageContainerResult())
+
+    val jobReport = new JobReport()
+      .id(UUID.randomUUID().toString)
+      .status(StatusEnum.RUNNING)
+
+    new CloneControlledAzureStorageContainerResult()
+      .container(clonedStorageContainer)
+      .jobReport(jobReport)
+  }
+
+  def getCloneAzureStorageContainerResult(workspaceId: UUID,
+                                          jobId: String,
+                                          ctx: RawlsRequestContext
+  ): CloneControlledAzureStorageContainerResult = {
+
+    val jobReport = new JobReport()
+      .id(jobId)
+      .status(StatusEnum.RUNNING)
+    new CloneControlledAzureStorageContainerResult()
+      .jobReport(jobReport)
+  }
+
+  def enumerateStorageContainers(workspaceId: UUID, offset: Int, limit: Int, ctx: RawlsRequestContext): ResourceList =
+    new ResourceList()
 
   override def getCloneWorkspaceResult(workspaceId: UUID,
                                        jobControlId: String,
@@ -192,6 +229,7 @@ class MockWorkspaceManagerDAO(
     mockCreateAzureStorageAccountResult()
 
   override def createAzureStorageContainer(workspaceId: UUID,
+                                           storageContainerName: String,
                                            storageAccountId: Option[UUID],
                                            ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -3,11 +3,13 @@ package org.broadinstitute.dsde.rawls.workspace
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.workspace.model.JobReport.StatusEnum
+import bio.terra.workspace.model._
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig, MultiCloudWorkspaceManagerConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.McWorkspace
 import org.broadinstitute.dsde.rawls.model.{
@@ -350,6 +352,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       .verify(workspaceManagerDAO)
       .createAzureStorageContainer(
         ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq(MultiCloudWorkspaceService.getStorageContainerName(UUID.fromString(result.workspaceId))),
         ArgumentMatchers.eq(None),
         ArgumentMatchers.eq(testContext)
       )
@@ -513,7 +516,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
           )
         ).thenAnswer((_: InvocationOnMock) => MockWorkspaceManagerDAO.getCloneWorkspaceResult(StatusEnum.FAILED))
 
-        val result = intercept[WorkspaceManagerCreationFailureException] {
+        intercept[WorkspaceManagerCreationFailureException] {
           Await.result(
             mcWorkspaceService.cloneMultiCloudWorkspace(
               mock[WorkspaceService](RETURNS_SMART_NULLS),
@@ -527,6 +530,95 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
             Duration.Inf
           )
         }
+
+        // fail if the workspace exists
+        val clone = Await.result(
+          slickDataSource.inTransaction(_.workspaceQuery.findByName(cloneName)),
+          Duration.Inf
+        )
+
+        clone shouldBe empty
+      }
+    }
+
+  it should "not create a workspace record if the workspace has no storage containers" in
+    withEmptyTestDatabase {
+      withMockedMultiCloudWorkspaceService { mcWorkspaceService =>
+        val cloneName = WorkspaceName(testData.azureWorkspace.namespace, "kifflom")
+        // workspaceManagerDAO returns an empty ResourceList by default for enumerateStorageContainers
+
+        val actual = intercept[RawlsExceptionWithErrorReport] {
+          Await.result(
+            mcWorkspaceService.cloneMultiCloudWorkspace(
+              mock[WorkspaceService](RETURNS_SMART_NULLS),
+              testData.azureWorkspace.toWorkspaceName,
+              WorkspaceRequest(
+                cloneName.namespace,
+                cloneName.name,
+                Map.empty
+              )
+            ),
+            Duration.Inf
+          )
+        }
+
+        assert(actual.errorReport.message.contains("does not have the expected storage container"))
+
+        verify(mcWorkspaceService.workspaceManagerDAO, never())
+          .cloneAzureStorageContainer(any(), any(), any, any(), any())
+
+        // fail if the workspace exists
+        val clone = Await.result(
+          slickDataSource.inTransaction(_.workspaceQuery.findByName(cloneName)),
+          Duration.Inf
+        )
+
+        clone shouldBe empty
+      }
+    }
+
+  it should "not create a workspace record if there is no storage container with the correct name" in
+    withEmptyTestDatabase {
+      withMockedMultiCloudWorkspaceService { mcWorkspaceService =>
+        val cloneName = WorkspaceName(testData.azureWorkspace.namespace, "kifflom")
+
+        when(
+          mcWorkspaceService.workspaceManagerDAO.enumerateStorageContainers(
+            equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+            any(),
+            any(),
+            any()
+          )
+        ).thenAnswer((_: InvocationOnMock) =>
+          new ResourceList().addResourcesItem(
+            new ResourceDescription().metadata(
+              new ResourceMetadata()
+                .resourceId(UUID.randomUUID())
+                .name("not the correct name")
+                .controlledResourceMetadata(new ControlledResourceMetadata().accessScope(AccessScope.SHARED_ACCESS))
+            )
+          )
+        )
+
+        val actual = intercept[RawlsExceptionWithErrorReport] {
+          Await.result(
+            mcWorkspaceService.cloneMultiCloudWorkspace(
+              mock[WorkspaceService](RETURNS_SMART_NULLS),
+              testData.azureWorkspace.toWorkspaceName,
+              WorkspaceRequest(
+                cloneName.namespace,
+                cloneName.name,
+                Map.empty
+              )
+            ),
+            Duration.Inf
+          )
+        }
+
+        assert(actual.errorReport.message.contains("does not have the expected storage container"))
+
+        verify(mcWorkspaceService.workspaceManagerDAO, never())
+          .cloneAzureStorageContainer(any(), any(), any, any(), any())
 
         // fail if the workspace exists
         val clone = Await.result(
@@ -580,11 +672,28 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
 
   it should
     "clone an azure workspace" +
-    " & create a new workspace record" in
-    // " & create a new job for the workspace manager resource monitor" in
+    " & create a new workspace record" +
+    " & create a new job for the workspace manager resource monitor" in
     withEmptyTestDatabase {
       withMockedMultiCloudWorkspaceService { mcWorkspaceService =>
         val cloneName = WorkspaceName(testData.azureWorkspace.namespace, "kifflom")
+        when(
+          mcWorkspaceService.workspaceManagerDAO.enumerateStorageContainers(
+            equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+            any(),
+            any(),
+            any()
+          )
+        ).thenAnswer((_: InvocationOnMock) =>
+          new ResourceList().addResourcesItem(
+            new ResourceDescription().metadata(
+              new ResourceMetadata()
+                .resourceId(UUID.randomUUID())
+                .name(MultiCloudWorkspaceService.getStorageContainerName(testData.azureWorkspace.workspaceIdAsUUID))
+                .controlledResourceMetadata(new ControlledResourceMetadata().accessScope(AccessScope.SHARED_ACCESS))
+            )
+          )
+        )
         Await.result(
           for {
             _ <- slickDataSource.inTransaction(_.rawlsBillingProjectQuery.create(testData.azureBillingProject))
@@ -597,30 +706,35 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
                 Map.empty
               )
             )
-
             _ = clone.toWorkspaceName shouldBe cloneName
             _ = clone.workspaceType shouldBe McWorkspace
 
-//            To be added back with WOR-697
-//            jobs <- slickDataSource.inTransaction { access =>
-//              for {
-//                // the newly cloned workspace should be persisted
-//                clone_ <- access.workspaceQuery.findByName(cloneName)
-//                _ = clone_.value.workspaceId shouldBe clone.workspaceId
-//
-//                // a new resource monitor job should be created
-//                jobs <- access.WorkspaceManagerResourceMonitorRecordQuery
-//                  .selectByWorkspaceId(clone.workspaceIdAsUUID)
-//              } yield jobs
-            //           }
-          } yield clone.completedCloneWorkspaceFileTransfer shouldBe None
-//            jobs.size shouldBe 1
-//            jobs.head.jobType shouldBe JobType.CloneWorkspaceResult
-//            jobs.head.workspaceId.value.toString shouldBe clone.workspaceId
-          ,
+            jobs <- slickDataSource.inTransaction { access =>
+              for {
+                // the newly cloned workspace should be persisted
+                clone_ <- access.workspaceQuery.findByName(cloneName)
+                _ = clone_.value.workspaceId shouldBe clone.workspaceId
+
+                // a new resource monitor job should be created
+                jobs <- access.WorkspaceManagerResourceMonitorRecordQuery
+                  .selectByWorkspaceId(clone.workspaceIdAsUUID)
+              } yield jobs
+            }
+          } yield {
+            clone.completedCloneWorkspaceFileTransfer shouldBe None
+            jobs.size shouldBe 1
+            jobs.head.jobType shouldBe JobType.CloneWorkspaceResult
+            jobs.head.workspaceId.value.toString shouldBe clone.workspaceId
+          },
           Duration.Inf
         )
+        verify(mcWorkspaceService.workspaceManagerDAO, times(1))
+          .cloneAzureStorageContainer(any(),
+                                      any(),
+                                      any,
+                                      equalTo(CloningInstructionsEnum.RESOURCE),
+                                      any()
+          ) shouldBe null // expects an assertion to be returned
       }
     }
-
 }


### PR DESCRIPTION
[Ticket: WOR-697 <Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/WOR-697)
<Put notes here to help reviewer understand this PR>

This issues the call to clone the container for the Azure workspace clone operation. Note that it is against https://github.com/broadinstitute/rawls/pull/2179.

The container still does not clone due to https://github.com/DataBiosphere/terra-workspace-manager/pull/992 not being merged, but we are calling the WSM clone API:

```
rawls [INFO] [14:53:31.207] [scala-execution-context-global-74] o.b.d.r.w.MultiCloudWorkspaceService - Starting workspace storage container clone in WSM [workspaceId = f679c6fb-7217-4578-a696-a9a1b1979266]
rawls [INFO] [14:53:31.762] [scala-execution-context-global-74] o.b.d.r.w.MultiCloudWorkspaceService - Created azure workspace [ workspaceId='f679c6fb-7217-4578-a696-a9a1b1979266', workspaceName='CARDec13Work/CARAzureCopyInstructions copy11', containerCloneJobReportId='3ba98ab3-3a50-48fc-9b8c-3102e71ca556']
```
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
