### PR TITLE
[WOR-678] Add users to pet-creator policy on billing profile when added to workspace

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -476,7 +476,7 @@ object Boot extends IOApp with LazyLogging {
         terraWorkspaceCanComputeRole = gcsConfig.getString("terraWorkspaceCanComputeRole"),
         terraWorkspaceNextflowRole = gcsConfig.getString("terraWorkspaceNextflowRole"),
         new RawlsWorkspaceAclManager(samDAO),
-        new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+        new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, slickDataSource)
       )
 
       val entityServiceConstructor: RawlsRequestContext => EntityService = EntityService.constructor(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -10,6 +10,7 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.api.client.http.HttpResponseException
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.config.DeploymentManagerConfig
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -722,7 +723,7 @@ class UserService(
           case Some(billingProfileId) =>
             billingProfileManagerDAO.addProfilePolicyMember(
               UUID.fromString(billingProfileId),
-              projectAccessUpdate.role,
+              ProfilePolicy.fromProjectRole(projectAccessUpdate.role),
               projectAccessUpdate.email,
               ctx
             )
@@ -764,7 +765,7 @@ class UserService(
           case Some(billingProfileId) =>
             billingProfileManagerDAO.deleteProfilePolicyMember(
               UUID.fromString(billingProfileId),
-              projectAccessUpdate.role,
+              ProfilePolicy.fromProjectRole(projectAccessUpdate.role),
               projectAccessUpdate.email,
               ctx
             )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
@@ -8,7 +8,19 @@ import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{AccessEntry, ErrorReport, ProjectRoles, RawlsBillingProjectName, RawlsRequestContext, SamResourcePolicyName, SamWorkspacePolicyNames, Workspace, WorkspaceACL, WorkspaceAccessLevels, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{
+  AccessEntry,
+  ErrorReport,
+  ProjectRoles,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamResourcePolicyName,
+  SamWorkspacePolicyNames,
+  Workspace,
+  WorkspaceACL,
+  WorkspaceAccessLevels,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import java.util.UUID

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
@@ -119,7 +119,9 @@ class MultiCloudWorkspaceAclManager(workspaceManagerDAO: WorkspaceManagerDAO,
   ): Future[Unit] = {
     val newWriterEmails = policyAdditions.collect { case (SamWorkspacePolicyNames.writer, email) => email }
 
-    if (newWriterEmails.nonEmpty) {
+    if (newWriterEmails.isEmpty) {
+      Future.successful()
+    } else {
       for {
         workspaceBillingProject <- dataSource.inTransaction(
           _.rawlsBillingProjectQuery.load(RawlsBillingProjectName(workspaceName.namespace))
@@ -152,6 +154,6 @@ class MultiCloudWorkspaceAclManager(workspaceManagerDAO: WorkspaceManagerDAO,
             )
           }
       } yield ()
-    } else Future.successful()
+    }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAclManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAclManager.scala
@@ -35,16 +35,16 @@ trait WorkspaceAclManager {
                            ctx: RawlsRequestContext
   ): Future[Unit]
 
+  def maybeShareWorkspaceNamespaceCompute(
+    policyAdditions: Set[(SamResourcePolicyName, String)],
+    workspaceName: WorkspaceName,
+    ctx: RawlsRequestContext
+  ): Future[Unit]
+
   def isUserPending(userEmail: String, ctx: RawlsRequestContext): Future[Boolean] =
     samDAO.getUserIdInfo(userEmail, ctx).map {
       case SamDAO.User(x)  => x.googleSubjectId.isEmpty
       case SamDAO.NotUser  => false
       case SamDAO.NotFound => true
     }
-
-  def maybeShareWorkspaceNamespaceCompute(
-    policyAdditions: Set[(SamResourcePolicyName, String)],
-    workspaceName: WorkspaceName,
-    ctx: RawlsRequestContext
-  ): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAclManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceAclManager.scala
@@ -1,7 +1,13 @@
 package org.broadinstitute.dsde.rawls.workspace
 
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
-import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, SamResourcePolicyName, Workspace, WorkspaceACL}
+import org.broadinstitute.dsde.rawls.model.{
+  RawlsRequestContext,
+  SamResourcePolicyName,
+  Workspace,
+  WorkspaceACL,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import java.util.UUID
@@ -35,4 +41,10 @@ trait WorkspaceAclManager {
       case SamDAO.NotUser  => false
       case SamDAO.NotFound => true
     }
+
+  def maybeShareWorkspaceNamespaceCompute(
+    policyAdditions: Set[(SamResourcePolicyName, String)],
+    workspaceName: WorkspaceName,
+    ctx: RawlsRequestContext
+  ): Future[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1410,7 +1410,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
               revokeRequesterPaysForLinkedSAs(workspace, policyRemovals, policyAdditions)
             } else Future.successful()
 
-          _ <- maybeShareProjectComputePolicy(policyAdditions, workspaceName)
+          _ <- workspaceAclManager.maybeShareWorkspaceNamespaceCompute(policyAdditions, workspaceName, ctx)
         } yield {
           val (invites, updates) = aclChanges.partition(acl => userToInvite.contains(acl.email))
           sendACLUpdateNotifications(workspaceName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.api.{AzureApi, ProfileApi}
 import bio.terra.profile.model._
 import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.{
@@ -250,12 +251,12 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     )
     when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
 
-    billingProfileManagerDAO.addProfilePolicyMember(profileId, ProjectRoles.Owner, memberEmail, testContext)
+    billingProfileManagerDAO.addProfilePolicyMember(profileId, ProfilePolicy.Owner, memberEmail, testContext)
     verify(profileApi).addProfilePolicyMember(memberRequest, profileId, "owner")
 
     reset(profileApi)
 
-    billingProfileManagerDAO.addProfilePolicyMember(profileId, ProjectRoles.User, memberEmail, testContext)
+    billingProfileManagerDAO.addProfilePolicyMember(profileId, ProfilePolicy.User, memberEmail, testContext)
     verify(profileApi).addProfilePolicyMember(memberRequest, profileId, "user")
   }
 
@@ -274,12 +275,12 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     )
     when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
 
-    billingProfileManagerDAO.deleteProfilePolicyMember(profileId, ProjectRoles.Owner, memberEmail, testContext)
+    billingProfileManagerDAO.deleteProfilePolicyMember(profileId, ProfilePolicy.Owner, memberEmail, testContext)
     verify(profileApi).deleteProfilePolicyMember(profileId, "owner", memberEmail)
 
     reset(profileApi)
 
-    billingProfileManagerDAO.deleteProfilePolicyMember(profileId, ProjectRoles.User, memberEmail, testContext)
+    billingProfileManagerDAO.deleteProfilePolicyMember(profileId, ProfilePolicy.User, memberEmail, testContext)
     verify(profileApi).deleteProfilePolicyMember(profileId, "user", memberEmail)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -533,7 +533,7 @@ class SubmissionSpec(_system: ActorSystem)
         terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
         terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
         new RawlsWorkspaceAclManager(samDAO),
-        new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+        new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
       ) _
       lazy val workspaceService: WorkspaceService = workspaceServiceConstructor(testContext)
       try

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -8,12 +8,13 @@ import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.typesafe.config.{Config, ConfigFactory}
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.config.DeploymentManagerConfig
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, WorkspaceManagerResourceMonitorRecord}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, _}
+import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.mockito.ArgumentMatchers
@@ -1463,7 +1464,7 @@ class UserServiceSpec
       // Expect BPM mock to have been called
       verify(bpmDAO).addProfilePolicyMember(
         billingProfileId,
-        ProjectRoles.User,
+        ProfilePolicy.User,
         userEmail,
         testContext
       )
@@ -1513,7 +1514,7 @@ class UserServiceSpec
       // Expect BPM mock to have been called
       verify(bpmDAO).addProfilePolicyMember(
         billingProfileId,
-        ProjectRoles.Owner,
+        ProfilePolicy.Owner,
         ownerEmail,
         testContext
       )
@@ -1547,7 +1548,7 @@ class UserServiceSpec
       when(
         bpmDAO.addProfilePolicyMember(
           billingProfileId,
-          ProjectRoles.Owner,
+          ProfilePolicy.Owner,
           ownerEmail,
           testContext
         )
@@ -1610,7 +1611,7 @@ class UserServiceSpec
       // Expect BPM mock to have been called
       verify(bpmDAO).deleteProfilePolicyMember(
         billingProfileId,
-        ProjectRoles.User,
+        ProfilePolicy.User,
         userEmail,
         testContext
       )
@@ -1660,7 +1661,7 @@ class UserServiceSpec
       // Expect BPM mock to have been called
       verify(bpmDAO).deleteProfilePolicyMember(
         billingProfileId,
-        ProjectRoles.Owner,
+        ProfilePolicy.Owner,
         ownerEmail,
         testContext
       )
@@ -1694,7 +1695,7 @@ class UserServiceSpec
       when(
         bpmDAO.deleteProfilePolicyMember(
           billingProfileId,
-          ProjectRoles.Owner,
+          ProfilePolicy.Owner,
           ownerEmail,
           testContext
         )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -310,7 +310,7 @@ trait ApiServiceSpec
     val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
     val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
-    val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+    val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
 
     override val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -131,7 +131,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       }
       // these need to be overridden to use the new samDAO
       override val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
-      override val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+      override val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
     }
     try
       testCode(apiService)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
@@ -1,0 +1,111 @@
+package org.broadinstitute.dsde.rawls.workspace
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.model.{
+  CreationStatuses,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamWorkspacePolicyNames,
+  UserInfo,
+  WorkspaceName
+}
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util.UUID
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.language.postfixOps
+
+class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTestUtils {
+
+  val defaultRequestContext: RawlsRequestContext =
+    RawlsRequestContext(
+      UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+    )
+
+  def multiCloudWorkspaceAclManagerConstructor(
+    workspaceManagerDAO: WorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+    samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
+    billingProfileManagerDAO: BillingProfileManagerDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS),
+    dataSource: SlickDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
+  ): WorkspaceAclManager =
+    new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)(
+      ExecutionContext.global
+    )
+
+  "maybeShareWorkspaceNamespaceCompute" should "add new writers to the pet-creator billing profile policy" in {
+    val policyAdditions = Set(
+      (SamWorkspacePolicyNames.writer, "writer1@example.com"),
+      (SamWorkspacePolicyNames.writer, "writer2@example.com"),
+      (SamWorkspacePolicyNames.owner, "owner@example.com"),
+      (SamWorkspacePolicyNames.reader, "reader@example.com")
+    )
+    val spendProfileId = UUID.randomUUID()
+
+    val mockDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
+    when(mockDataSource.inTransaction[Option[RawlsBillingProject]](any(), any())).thenReturn(
+      Future.successful(
+        Option(
+          RawlsBillingProject(
+            RawlsBillingProjectName("fake-project"),
+            CreationStatuses.Ready,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+            Option(spendProfileId.toString),
+            None
+          )
+        )
+      )
+    )
+
+    val mockBpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+    doNothing()
+      .when(mockBpmDAO)
+      .addProfilePolicyMember(ArgumentMatchers.eq(spendProfileId),
+                              ArgumentMatchers.eq(ProfilePolicy.PetCreator),
+                              any(),
+                              any()
+      )
+
+    val multiCloudWorkspaceAclManager =
+      multiCloudWorkspaceAclManagerConstructor(billingProfileManagerDAO = mockBpmDAO, dataSource = mockDataSource)
+
+    Await.result(
+      multiCloudWorkspaceAclManager.maybeShareWorkspaceNamespaceCompute(policyAdditions,
+                                                                        WorkspaceName("doesntmatter", "dontcare"),
+                                                                        defaultRequestContext
+      ),
+      5 seconds
+    )
+
+    policyAdditions.foreach {
+      case (SamWorkspacePolicyNames.writer, email) =>
+        verify(mockBpmDAO).addProfilePolicyMember(ArgumentMatchers.eq(spendProfileId),
+                                                  ArgumentMatchers.eq(ProfilePolicy.PetCreator),
+                                                  ArgumentMatchers.eq(email),
+                                                  any()
+        )
+      case (_, email) =>
+        verify(mockBpmDAO, times(0)).addProfilePolicyMember(any(), any(), ArgumentMatchers.eq(email), any())
+    }
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/RawlsWorkspaceAclManagerUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/RawlsWorkspaceAclManagerUnitTests.scala
@@ -1,0 +1,96 @@
+package org.broadinstitute.dsde.rawls.workspace
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
+import org.broadinstitute.dsde.rawls.model.{
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamBillingProjectPolicyNames,
+  SamResourcePolicyName,
+  SamResourceTypeNames,
+  SamWorkspacePolicyNames,
+  UserInfo,
+  WorkspaceName
+}
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.language.postfixOps
+
+class RawlsWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTestUtils {
+  val defaultRequestContext: RawlsRequestContext =
+    RawlsRequestContext(
+      UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
+    )
+  val defaultWorkspaceName: WorkspaceName = WorkspaceName("fake_namespace", "fake_name")
+
+  def rawlsWorkspaceAclManagerConstructor(samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)): WorkspaceAclManager =
+    new RawlsWorkspaceAclManager(
+      samDAO
+    )(ExecutionContext.global)
+
+  def verifyCorrectSamInteractions(policyAdditions: Set[(SamResourcePolicyName, String)], samDAO: SamDAO): Unit =
+    policyAdditions.foreach {
+      case (SamWorkspacePolicyNames.canCompute, email) =>
+        verify(samDAO).addUserToPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(defaultWorkspaceName.namespace),
+          ArgumentMatchers.eq(SamBillingProjectPolicyNames.canComputeUser),
+          ArgumentMatchers.eq(email),
+          any()
+        )
+      case (_, email) =>
+        verify(samDAO, times(0)).addUserToPolicy(any(), any(), any(), ArgumentMatchers.eq(email), any())
+    }
+
+  "maybeShareWorkspaceNamespaceCompute" should "add new can-compute workspace users to the can-compute billing project policy" in {
+    val policyAdditions = Set(
+      (SamWorkspacePolicyNames.canCompute, "computer1@example.com"),
+      (SamWorkspacePolicyNames.canCompute, "computer2@example.com"),
+      (SamWorkspacePolicyNames.writer, "writer@example.com"),
+      (SamWorkspacePolicyNames.owner, "owner@example.com"),
+      (SamWorkspacePolicyNames.reader, "reader@example.com")
+    )
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.addUserToPolicy(any(), any(), any(), any(), any())).thenReturn(Future.successful())
+
+    val workspaceAclManager = rawlsWorkspaceAclManagerConstructor(samDAO)
+    Await.result(
+      workspaceAclManager.maybeShareWorkspaceNamespaceCompute(policyAdditions,
+                                                              defaultWorkspaceName,
+                                                              defaultRequestContext
+      ),
+      5 seconds
+    )
+
+    verifyCorrectSamInteractions(policyAdditions, samDAO)
+  }
+
+  it should "tolerate the can-compute policy not existing on the billing project" in {
+    val policyAdditions = Set(
+      (SamWorkspacePolicyNames.canCompute, "computer@example.com")
+    )
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.addUserToPolicy(any(), any(), any(), any(), any()))
+      .thenReturn(Future.failed(new Exception("can-compute policy not found")))
+
+    val workspaceAclManager = rawlsWorkspaceAclManagerConstructor(samDAO)
+    Await.result(
+      workspaceAclManager.maybeShareWorkspaceNamespaceCompute(policyAdditions,
+                                                              defaultWorkspaceName,
+                                                              defaultRequestContext
+      ),
+      5 seconds
+    )
+
+    verifyCorrectSamInteractions(policyAdditions, samDAO)
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -230,7 +230,7 @@ class WorkspaceServiceSpec
     val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
     val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
-    val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+    val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
 
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
@@ -278,7 +278,7 @@ class WorkspaceServiceSpec
 
     // these need to be overridden to use the new samDAO
     override val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
-    override val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+    override val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
   }
 
   def withTestDataServices[T](testCode: TestApiService => T): T =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -7,7 +7,6 @@ import bio.terra.workspace.model.{IamRole, RoleBinding, RoleBindingList}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
@@ -18,16 +17,10 @@ import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{
-  NoSuchWorkspaceException,
-  RawlsExceptionWithErrorReport,
-  UserDisabledException,
-  WorkspaceAccessDeniedException
-}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, UserDisabledException, WorkspaceAccessDeniedException}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.rawls.QueryMatcher
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers._
@@ -42,7 +35,6 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
-import scala.reflect.runtime.universe.typeOf
 
 /**
   * Unit tests kept separate from WorkspaceServiceSpec to separate true unit tests from tests requiring external resources

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -17,7 +17,12 @@ import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, UserDisabledException, WorkspaceAccessDeniedException}
+import org.broadinstitute.dsde.rawls.{
+  NoSuchWorkspaceException,
+  RawlsExceptionWithErrorReport,
+  UserDisabledException,
+  WorkspaceAccessDeniedException
+}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.stream.Materializer
 import bio.terra.workspace.model.{IamRole, RoleBinding, RoleBindingList}
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -16,12 +17,7 @@ import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{
-  NoSuchWorkspaceException,
-  RawlsExceptionWithErrorReport,
-  UserDisabledException,
-  WorkspaceAccessDeniedException
-}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport, UserDisabledException, WorkspaceAccessDeniedException}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
@@ -91,7 +87,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     googleIamDao: GoogleIamDAO = mock[GoogleIamDAO](RETURNS_SMART_NULLS),
     terraBillingProjectOwnerRole: String = "",
     terraWorkspaceCanComputeRole: String = "",
-    terraWorkspaceNextflowRole: String = ""
+    terraWorkspaceNextflowRole: String = "",
+    billingProfileManagerDAO: BillingProfileManagerDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
   ): RawlsRequestContext => WorkspaceService = info =>
     WorkspaceService.constructor(
       datasource,
@@ -121,7 +118,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
       terraWorkspaceCanComputeRole,
       terraWorkspaceNextflowRole,
       new RawlsWorkspaceAclManager(samDAO),
-      new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO)
+      new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, datasource)
     )(info)(mock[Materializer], scala.concurrent.ExecutionContext.global)
 
   "getWorkspaceById" should "return the workspace returned by getWorkspace(WorkspaceName) on success" in {


### PR DESCRIPTION
Ticket: [WOR-678](https://broadworkbench.atlassian.net/browse/WOR-678)


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-678]: https://broadworkbench.atlassian.net/browse/WOR-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ