### PR TITLE
Add delay in launching workflows in non-US region tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -269,6 +269,10 @@ class RawlsApiSpec
 
             Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
 
+            // sleep for 10 minutes to ensure write permissions on the bucket are propagated.
+            // See https://broadworkbench.atlassian.net/browse/WM-1599
+            Thread.sleep(600000)
+
             val start = System.currentTimeMillis()
 
             val submissionId = Rawls.submissions.launchWorkflow(
@@ -383,6 +387,10 @@ class RawlsApiSpec
             // See https://github.com/broadinstitute/workbench-libs/pull/61 and https://broadinstitute.atlassian.net/browse/GAWB-3327
 
             Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
+
+            // sleep for 10 minutes to ensure write permissions on the bucket are propagated.
+            // See https://broadworkbench.atlassian.net/browse/WM-1599
+            Thread.sleep(600000)
 
             val start = System.currentTimeMillis()
 


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
