### PR TITLE
Stop sending AzureContext on workspace creation and cloning (WOR-682).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -88,9 +88,6 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     getWorkspaceApi(ctx).getCloneWorkspaceResult(workspaceId, jobControlId)
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
-                                                azureTenantId: String,
-                                                azureResourceGroupId: String,
-                                                azureSubscriptionId: String,
                                                 ctx: RawlsRequestContext
   ): CreateCloudContextResult = {
     val jobControlId = UUID.randomUUID().toString

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -77,12 +77,6 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
         .destinationWorkspaceId(workspaceId)
         .displayName(displayName)
         .spendProfile(spendProfile.getId.toString)
-        .azureContext(
-          new AzureContext()
-            .tenantId(spendProfile.getTenantId.toString)
-            .subscriptionId(spendProfile.getSubscriptionId.toString)
-            .resourceGroupId(spendProfile.getManagedResourceGroupId)
-        )
         .location(location.orNull),
       sourceWorkspaceId
     )
@@ -100,14 +94,9 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                 ctx: RawlsRequestContext
   ): CreateCloudContextResult = {
     val jobControlId = UUID.randomUUID().toString
-    val azureContext = new AzureContext()
-      .tenantId(azureTenantId)
-      .subscriptionId(azureSubscriptionId)
-      .resourceGroupId(azureResourceGroupId)
     getWorkspaceApi(ctx).createCloudContext(new CreateCloudContextRequest()
                                               .cloudPlatform(CloudPlatform.AZURE)
-                                              .jobControl(new JobControl().id(jobControlId))
-                                              .azureContext(azureContext),
+                                              .jobControl(new JobControl().id(jobControlId)),
                                             workspaceId
     )
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -30,6 +30,7 @@ trait WorkspaceManagerDAO {
   def getCloneWorkspaceResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CloneWorkspaceResult
 
   def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult
+
   def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                            jobControlId: String,
                                            ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -29,12 +29,7 @@ trait WorkspaceManagerDAO {
 
   def getCloneWorkspaceResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CloneWorkspaceResult
 
-  def createAzureWorkspaceCloudContext(workspaceId: UUID,
-                                       azureTenantId: String,
-                                       azureResourceGroupId: String,
-                                       azureSubscriptionId: String,
-                                       ctx: RawlsRequestContext
-  ): CreateCloudContextResult
+  def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult
   def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                            jobControlId: String,
                                            ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -127,11 +127,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                     workspaceRequest.name,
                     workspaceRequest.attributes,
                     WorkspaceCloudPlatform.Azure,
-                    AzureManagedAppCoordinates(
-                      profileModel.getTenantId,
-                      profileModel.getSubscriptionId,
-                      profileModel.getManagedResourceGroupId
-                    ),
                     profileModel.getId.toString
                   ),
                   s
@@ -394,9 +389,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       .getOrElse(throw new RawlsException("WSM app config not present"))
 
     val spendProfileId = workspaceRequest.billingProfileId
-    val azureTenantId = workspaceRequest.managedAppCoordinates.tenantId.toString
-    val azureSubscriptionId = workspaceRequest.managedAppCoordinates.subscriptionId.toString
-    val azureResourceGroupId = workspaceRequest.managedAppCoordinates.managedResourceGroupId
 
     val workspaceId = UUID.randomUUID
     for {
@@ -410,12 +402,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       _ = logger.info(s"Creating cloud context in WSM [workspaceId = ${workspaceId}]")
       cloudContextCreateResult <- traceWithParent("createAzureCloudContextInWSM", parentContext)(_ =>
         Future(
-          workspaceManagerDAO.createAzureWorkspaceCloudContext(workspaceId,
-                                                               azureTenantId,
-                                                               azureResourceGroupId,
-                                                               azureSubscriptionId,
-                                                               ctx
-          )
+          workspaceManagerDAO.createAzureWorkspaceCloudContext(workspaceId, ctx)
         )
       )
       jobControlId = cloudContextCreateResult.getJobReport.getId

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -245,12 +245,6 @@ class HttpWorkspaceManagerDAOSpec
       .destinationWorkspaceId(workspaceId)
       .spendProfile(testData.azureBillingProfile.getId.toString)
       .location("the-moon")
-      .azureContext(
-        new AzureContext()
-          .tenantId(testData.azureBillingProfile.getTenantId.toString)
-          .subscriptionId(testData.azureBillingProfile.getSubscriptionId.toString)
-          .resourceGroupId(testData.azureBillingProfile.getManagedResourceGroupId)
-      )
 
     wsmDao.cloneWorkspace(
       testData.azureWorkspace.workspaceIdAsUUID,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -205,12 +205,8 @@ class MockWorkspaceManagerDAO(
   ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
-  override def createAzureWorkspaceCloudContext(workspaceId: UUID,
-                                                azureTenantId: String,
-                                                azureResourceGroupId: String,
-                                                azureSubscriptionId: String,
-                                                ctx: RawlsRequestContext
-  ): CreateCloudContextResult = mockInitialCreateAzureCloudContextResult()
+  override def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult =
+    mockInitialCreateAzureCloudContextResult()
 
   override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                                     jobControlId: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -13,7 +13,6 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMo
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.McWorkspace
 import org.broadinstitute.dsde.rawls.model.{
-  AzureManagedAppCoordinates,
   ErrorReport,
   MultiCloudWorkspaceRequest,
   RawlsBillingProject,
@@ -340,9 +339,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       .verify(workspaceManagerDAO)
       .createAzureWorkspaceCloudContext(
         ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-        ArgumentMatchers.eq(tenantId.toString),
-        ArgumentMatchers.eq("fake_mrg_id"),
-        ArgumentMatchers.eq(subscriptionId.toString),
         ArgumentMatchers.eq(testContext)
       )
     Mockito

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -264,7 +264,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       "fake_name",
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      mock[AzureManagedAppCoordinates],
       "fake_billingProjectId"
     )
 
@@ -291,7 +290,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       s"fake-name-${UUID.randomUUID().toString}",
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake"),
       "fake_billingProjectId"
     )
 
@@ -324,7 +322,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       "fake_name",
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      AzureManagedAppCoordinates(tenantId, subscriptionId, "fake_mrg_id"),
       "fake_billingProjectId"
     )
     val result: Workspace = Await.result(mcWorkspaceService.createMultiCloudWorkspace(request), Duration.Inf)
@@ -376,7 +373,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       "fake_name",
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "managed_resource_group_id"),
       "fake_billingProjectId"
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -230,7 +230,8 @@ class WorkspaceServiceSpec
     val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
     val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
-    val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
+    val multiCloudWorkspaceAclManager =
+      new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
 
     val workspaceServiceConstructor = WorkspaceService.constructor(
       slickDataSource,
@@ -278,7 +279,8 @@ class WorkspaceServiceSpec
 
     // these need to be overridden to use the new samDAO
     override val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
-    override val multiCloudWorkspaceAclManager = new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
+    override val multiCloudWorkspaceAclManager =
+      new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
   }
 
   def withTestDataServices[T](testCode: TestApiService => T): T =
@@ -1228,13 +1230,11 @@ class WorkspaceServiceSpec
 
   it should "delete an Azure workspace" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-    val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
     val workspaceRequest = MultiCloudWorkspaceRequest(
       testData.testProject1Name.value,
       workspaceName,
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      managedAppCoordinates,
       "fake_billingProjectId"
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
@@ -2668,7 +2668,6 @@ class WorkspaceServiceSpec
       workspaceName,
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      managedAppCoordinates,
       "fake_billingProjectId"
     )
 
@@ -2700,13 +2699,11 @@ class WorkspaceServiceSpec
   it should "return an error if an MC workspace is not present in workspace manager" in withTestDataServices {
     services =>
       val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-      val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
       val workspaceRequest = MultiCloudWorkspaceRequest(
         testData.testProject1Name.value,
         workspaceName,
         Map.empty,
         WorkspaceCloudPlatform.Azure,
-        managedAppCoordinates,
         "fake_billingProjectId"
       )
       // ApiException is a checked exception so we need to use thenAnswer rather than thenThrow
@@ -2734,13 +2731,11 @@ class WorkspaceServiceSpec
 
   it should "return an error if an MC workspace does not have an Azure context" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-    val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
     val workspaceRequest = MultiCloudWorkspaceRequest(
       testData.testProject1Name.value,
       workspaceName,
       Map.empty,
       WorkspaceCloudPlatform.Azure,
-      managedAppCoordinates,
       "fake_billingProjectId"
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -150,7 +150,6 @@ case class MultiCloudWorkspaceRequest(
   name: String,
   attributes: AttributeMap,
   cloudPlatform: WorkspaceCloudPlatform,
-  managedAppCoordinates: AzureManagedAppCoordinates,
   billingProfileId: String
 ) extends Attributable {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
@@ -1031,7 +1030,7 @@ class WorkspaceJsonSupport extends JsonSupport {
     jsonFormat3(AzureManagedAppCoordinates)
 
   implicit val MultiCloudWorkspaceRequestFormat: RootJsonFormat[MultiCloudWorkspaceRequest] =
-    jsonFormat6(MultiCloudWorkspaceRequest)
+    jsonFormat5(MultiCloudWorkspaceRequest)
 
   implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat7(WorkspaceRequest)
 


### PR DESCRIPTION
Ticket: [WOR-682](https://broadworkbench.atlassian.net/browse/WOR-682)

WSM [ignores](https://github.com/DataBiosphere/terra-workspace-manager/blob/fed3185e5babac58eebf9dc90d5eaab32a9156f5/service/src/main/java/bio/terra/workspace/service/workspace/flight/create/azure/CreateDbAzureCloudContextFinishStep.java#L36) the managed app coordinates when creating the cloud context if BPM is enabled… which it always is now.

By removing these optional arguments now, there will not be a compatibility issue when https://github.com/DataBiosphere/terra-workspace-manager/pull/1003 is ultimately merged.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-682]: https://broadworkbench.atlassian.net/browse/WOR-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ