### PR TITLE
WOR-533

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -82,6 +82,9 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
       sourceWorkspaceId
     )
 
+  override def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport =
+    apiClientProvider.getJobsApi(ctx).retrieveJob(jobControlId)
+
   override def getCloneWorkspaceResult(workspaceId: UUID,
                                        jobControlId: String,
                                        ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 import bio.terra.common.tracing.JerseyTracingFilter
 import bio.terra.workspace.api.{
   ControlledAzureResourceApi,
+  JobsApi,
   LandingZonesApi,
   ResourceApi,
   UnauthenticatedApi,
@@ -21,6 +22,8 @@ import org.glassfish.jersey.client.ClientConfig
 trait WorkspaceManagerApiClientProvider {
   def getApiClient(ctx: RawlsRequestContext): ApiClient
 
+  def getJobsApi(ctx: RawlsRequestContext): JobsApi
+
   def getControlledAzureResourceApi(ctx: RawlsRequestContext): ControlledAzureResourceApi
 
   def getWorkspaceApplicationApi(ctx: RawlsRequestContext): WorkspaceApplicationApi
@@ -32,6 +35,7 @@ trait WorkspaceManagerApiClientProvider {
   def getResourceApi(ctx: RawlsRequestContext): ResourceApi
 
   def getUnauthenticatedApi(): UnauthenticatedApi
+
 }
 
 class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: String) extends WorkspaceManagerApiClientProvider {
@@ -62,6 +66,8 @@ class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: String) extend
 
   def getLandingZonesApi(ctx: RawlsRequestContext): LandingZonesApi =
     new LandingZonesApi(getApiClient(ctx))
+
+  def getJobsApi(ctx: RawlsRequestContext): JobsApi = new JobsApi(getApiClient(ctx))
 
   def getResourceApi(ctx: RawlsRequestContext): ResourceApi =
     new ResourceApi(getApiClient(ctx))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -27,6 +27,8 @@ trait WorkspaceManagerDAO {
                      location: Option[String] = None
   ): CloneWorkspaceResult
 
+  def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport
+
   def getCloneWorkspaceResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CloneWorkspaceResult
 
   def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -29,7 +29,10 @@ import org.broadinstitute.dsde.rawls.model.{CromwellBackend, RawlsRequestContext
 import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.AvroUpsertMonitorConfig
 import org.broadinstitute.dsde.rawls.monitor.migration.WorkspaceMigrationActor
 import org.broadinstitute.dsde.rawls.monitor.workspace.WorkspaceResourceMonitor
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.LandingZoneCreationStatusRunner
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.{
+  CloneWorkspaceContainerRunner,
+  LandingZoneCreationStatusRunner
+}
 import org.broadinstitute.dsde.rawls.util
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
@@ -405,7 +408,9 @@ object BootMonitors extends LazyLogging {
         dataSource,
         Map(
           JobType.AzureLandingZoneResult ->
-            new LandingZoneCreationStatusRunner(samDAO, workspaceManagerDAO, new BillingRepository(dataSource), gcsDAO)
+            new LandingZoneCreationStatusRunner(samDAO, workspaceManagerDAO, new BillingRepository(dataSource), gcsDAO),
+          JobType.CloneWorkspaceContainerResult ->
+            new CloneWorkspaceContainerRunner(samDAO, workspaceManagerDAO, dataSource, gcsDAO)
         )
       )
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -1,17 +1,10 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 
-import bio.terra.workspace.model.{CloneWorkspaceResult, JobReport}
+import bio.terra.workspace.model.{CloneControlledAzureStorageContainerResult, CloneWorkspaceResult, JobReport}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{
-  WorkspaceManagerResourceJobRunner,
-  WorkspaceManagerResourceMonitorRecord
-}
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
-  Complete,
-  Incomplete,
-  JobStatus
-}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{WorkspaceManagerResourceJobRunner, WorkspaceManagerResourceMonitorRecord}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, Incomplete, JobStatus}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
 import org.joda.time.DateTime
@@ -63,7 +56,7 @@ class CloneWorkspaceContainerRunner(
         logFailure(msg, Some(t))
         cloneFail(workspaceId, msg).map(_ => Incomplete)
       case Success(ctx) =>
-        Try(workspaceManagerDAO.getCloneWorkspaceResult(workspaceId, job.jobControlId.toString, ctx)) match {
+        Try(workspaceManagerDAO.getCloneAzureStorageContainerResult(workspaceId, job.jobControlId.toString, ctx)) match {
           case Success(result) => handleCloneResult(workspaceId, result)
           case Failure(t) =>
             val msg = s"Api call to get clone result from workspace manager failed with: ${t.getMessage}"
@@ -74,7 +67,7 @@ class CloneWorkspaceContainerRunner(
 
   }
 
-  def handleCloneResult(workspaceId: UUID, result: CloneWorkspaceResult)(implicit
+  def handleCloneResult(workspaceId: UUID, result: CloneControlledAzureStorageContainerResult)(implicit
     executionContext: ExecutionContext
   ): Future[JobStatus] = Option(result.getJobReport).map(_.getStatus) match {
     case Some(JobReport.StatusEnum.RUNNING) => Future.successful(Incomplete)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -47,18 +47,13 @@ class CloneWorkspaceContainerRunner(
         return Future.successful(Complete) // nothing more this runner can do with it
     }
 
-    val workspace = getWorkspace(workspaceId).map(_.getOrElse {
-      logFailure(s"no workspace found for workspace id: $workspaceId")
-      return Future.successful(Complete)
-    })
-
     val userEmail = job.userEmail match {
       case Some(email) => email
       case None =>
         val msg =
           s"Unable to update clone status for workspace $workspaceId because no user email set on monitoring job"
         logFailure(msg)
-        return workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Complete))
+        return cloneFail(workspaceId, msg).map(_ => Complete)
     }
 
     getUserCtx(userEmail).transformWith {
@@ -66,47 +61,59 @@ class CloneWorkspaceContainerRunner(
         val msg =
           s"Unable to retrieve clone workspace results for workspace $workspaceId: unable to retrieve request context for $userEmail"
         logFailure(msg, Some(t))
-        workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Incomplete))
+        cloneFail(workspaceId, msg).map(_ => Incomplete)
       case Success(ctx) =>
         Try(workspaceManagerDAO.getCloneWorkspaceResult(workspaceId, job.jobControlId.toString, ctx)) match {
-          case Success(result) => workspace.flatMap(handleCloneResult(_, result))
+          case Success(result) => handleCloneResult(workspaceId, result)
           case Failure(t) =>
             val msg = s"Api call to get clone result from workspace manager failed with: ${t.getMessage}"
             logFailure(msg, Some(t))
-            workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Incomplete))
+            cloneFail(workspaceId, msg).map(_ => Incomplete)
         }
     }
 
   }
 
-  def handleCloneResult(ws: Workspace, result: CloneWorkspaceResult)(implicit
+  def handleCloneResult(workspaceId: UUID, result: CloneWorkspaceResult)(implicit
     executionContext: ExecutionContext
   ): Future[JobStatus] = Option(result.getJobReport).map(_.getStatus) match {
     case Some(JobReport.StatusEnum.RUNNING) => Future.successful(Incomplete)
     case Some(JobReport.StatusEnum.SUCCEEDED) =>
       val completeTime = DateTime.parse(result.getJobReport.getCompleted)
-      cloneSuccess(ws, completeTime).map(_ => Complete)
+      cloneSuccess(workspaceId, completeTime).map(_ => Complete)
     // set the error, and indicate this runner is finished with the job
     case Some(JobReport.StatusEnum.FAILED) =>
       val msg = Option(result.getErrorReport)
         .map(_.getMessage)
         .getOrElse("Cloning failure Reported, but no errors returned")
-      cloneFail(ws, msg).map(_ => Complete)
+      cloneFail(workspaceId, msg).map(_ => Complete)
     case None =>
       val msg = Option(result.getErrorReport)
         .flatMap(report => Option(report.getMessage))
         .map(errorMessage => s"Cloning Failed: $errorMessage")
         .getOrElse("No job status or errors returned from workspace cloning")
-      cloneFail(ws, msg).map(_ => Complete)
+      cloneFail(workspaceId, msg).map(_ => Complete)
   }
 
-  def cloneSuccess(ws: Workspace, finishTime: DateTime): Future[Workspace] = {
-    val updatedWS = ws.copy(completedCloneWorkspaceFileTransfer = Some(finishTime))
-    dataSource.inTransaction(_.workspaceQuery.createOrUpdate(updatedWS))
-  }
+  def cloneSuccess(wsId: UUID, finishTime: DateTime)(implicit
+    executionContext: ExecutionContext
+  ): Future[Option[Workspace]] =
+    getWorkspace(wsId).flatMap {
+      case Some(workspace) =>
+        val updatedWS = workspace.copy(completedCloneWorkspaceFileTransfer = Some(finishTime))
+        dataSource.inTransaction(_.workspaceQuery.createOrUpdate(updatedWS)).map(Option(_))
+      case None => Future.successful(None) // TODO: log error
+    }
 
-  def cloneFail(ws: Workspace, message: String): Future[Workspace] =
-    dataSource.inTransaction(_.workspaceQuery.createOrUpdate(ws.copy(errorMessage = Some(message))))
+  def cloneFail(wsId: UUID, message: String)(implicit executionContext: ExecutionContext): Future[Option[Workspace]] =
+    getWorkspace(wsId).flatMap {
+      case Some(workspace) =>
+        dataSource
+          .inTransaction(_.workspaceQuery.createOrUpdate(workspace.copy(errorMessage = Some(message))))
+          .map(Option(_))
+      case None => Future.successful(None) // TODO: log error
+
+    }
 
   def getWorkspace(wsId: UUID): Future[Option[Workspace]] = dataSource.inTransaction { dataAccess =>
     dataAccess.workspaceQuery.findById(wsId.toString)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -34,7 +34,7 @@ class CloneWorkspaceContainerRunner(
   )(implicit executionContext: ExecutionContext): Future[JobStatus] = {
 
     def logFailure(msg: String, t: Option[Throwable] = None): Unit = {
-      val logMessage = s"CloneWorkspaceResult monitoring job with id ${job.jobControlId} failed: $msg"
+      val logMessage = s"CloneWorkspaceContainerResult monitoring job with id ${job.jobControlId} failed: $msg"
       t match {
         case Some(t) => logger.error(logMessage, t)
         case None    => logger.error(logMessage)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -66,14 +66,14 @@ class CloneWorkspaceContainerRunner(
         val msg =
           s"Unable to retrieve clone workspace results for workspace $workspaceId: unable to retrieve request context for $userEmail"
         logFailure(msg, Some(t))
-        return workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Complete))
+        workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Incomplete))
       case Success(ctx) =>
         Try(workspaceManagerDAO.getCloneWorkspaceResult(workspaceId, job.jobControlId.toString, ctx)) match {
           case Success(result) => workspace.flatMap(handleCloneResult(_, result))
           case Failure(t) =>
             val msg = s"Api call to get clone result from workspace manager failed with: ${t.getMessage}"
             logFailure(msg, Some(t))
-            return workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Incomplete))
+            workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Incomplete))
         }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -102,7 +102,7 @@ class CloneWorkspaceContainerRunner(
       case Some(workspace) =>
         val updatedWS = workspace.copy(completedCloneWorkspaceFileTransfer = Some(finishTime))
         dataSource.inTransaction(_.workspaceQuery.createOrUpdate(updatedWS)).map(Option(_))
-      case None => Future.successful(None) // TODO: log error
+      case None => Future.successful(None)
     }
 
   def cloneFail(wsId: UUID, message: String)(implicit executionContext: ExecutionContext): Future[Option[Workspace]] =
@@ -111,7 +111,7 @@ class CloneWorkspaceContainerRunner(
         dataSource
           .inTransaction(_.workspaceQuery.createOrUpdate(workspace.copy(errorMessage = Some(message))))
           .map(Option(_))
-      case None => Future.successful(None) // TODO: log error
+      case None => Future.successful(None)
 
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 
 import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.{CloneControlledAzureStorageContainerResult, CloneWorkspaceResult, JobReport}
+import bio.terra.workspace.model.JobReport
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -1,0 +1,123 @@
+package org.broadinstitute.dsde.rawls.monitor.workspace.runners
+
+import bio.terra.workspace.model.{CloneWorkspaceResult, JobReport}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  WorkspaceManagerResourceJobRunner,
+  WorkspaceManagerResourceMonitorRecord
+}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
+  Complete,
+  Incomplete,
+  JobStatus
+}
+import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
+import org.joda.time.DateTime
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class CloneWorkspaceContainerRunner(
+  samDAO: SamDAO,
+  workspaceManagerDAO: WorkspaceManagerDAO,
+  dataSource: SlickDataSource,
+  gcsDAO: GoogleServicesDAO
+) extends WorkspaceManagerResourceJobRunner
+    with LazyLogging {
+
+  override def apply(
+    job: WorkspaceManagerResourceMonitorRecord
+  )(implicit executionContext: ExecutionContext): Future[JobStatus] = {
+
+    def logFailure(msg: String, t: Option[Throwable] = None): Unit = {
+      val logMessage = s"CloneWorkspaceResult monitoring job with id ${job.jobControlId} failed: $msg"
+      t match {
+        case Some(t) => logger.error(logMessage, t)
+        case None    => logger.error(logMessage)
+      }
+    }
+
+    val workspaceId = job.workspaceId match {
+      case Some(name) => name
+      case None =>
+        logFailure("no workspace id set")
+        return Future.successful(Complete) // nothing more this runner can do with it
+    }
+
+    val workspace = getWorkspace(workspaceId).map(_.getOrElse {
+      logFailure(s"no workspace found for workspace id: $workspaceId")
+      return Future.successful(Complete)
+    })
+
+    val userEmail = job.userEmail match {
+      case Some(email) => email
+      case None =>
+        val msg =
+          s"Unable to update clone status for workspace $workspaceId because no user email set on monitoring job"
+        logFailure(msg)
+        return workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Complete))
+    }
+
+    getUserCtx(userEmail).transformWith {
+      case Failure(t) =>
+        val msg =
+          s"Unable to retrieve clone workspace results for workspace $workspaceId: unable to retrieve request context for $userEmail"
+        logFailure(msg, Some(t))
+        return workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Complete))
+      case Success(ctx) =>
+        Try(workspaceManagerDAO.getCloneWorkspaceResult(workspaceId, job.jobControlId.toString, ctx)) match {
+          case Success(result) => workspace.flatMap(handleCloneResult(_, result))
+          case Failure(t) =>
+            val msg = s"Api call to get clone result from workspace manager failed with: ${t.getMessage}"
+            logFailure(msg, Some(t))
+            return workspace.flatMap(ws => cloneFail(ws, msg).map(_ => Incomplete))
+        }
+    }
+
+  }
+
+  def handleCloneResult(ws: Workspace, result: CloneWorkspaceResult)(implicit
+    executionContext: ExecutionContext
+  ): Future[JobStatus] = Option(result.getJobReport).map(_.getStatus) match {
+    case Some(JobReport.StatusEnum.RUNNING) => Future.successful(Incomplete)
+    case Some(JobReport.StatusEnum.SUCCEEDED) =>
+      val completeTime = DateTime.parse(result.getJobReport.getCompleted)
+      cloneSuccess(ws, completeTime).map(_ => Complete)
+    // set the error, and indicate this runner is finished with the job
+    case Some(JobReport.StatusEnum.FAILED) =>
+      val completeTime = DateTime.parse(result.getJobReport.getCompleted)
+      val msg = Option(result.getErrorReport)
+        .map(_.getMessage)
+        .getOrElse("Cloning failure Reported, but no errors returned")
+      cloneFail(ws, msg, Some(completeTime)).map(_ => Complete)
+    case None =>
+      val msg = Option(result.getErrorReport)
+        .flatMap(report => Option(report.getMessage))
+        .map(errorMessage => s"Cloning Failed: $errorMessage")
+        .getOrElse("No job status or errors returned from workspace cloning")
+      cloneFail(ws, msg).map(_ => Complete)
+  }
+
+  def cloneSuccess(ws: Workspace, finishTime: DateTime): Future[Workspace] = {
+    val updatedWS = ws.copy(completedCloneWorkspaceFileTransfer = Some(finishTime))
+    dataSource.inTransaction(_.workspaceQuery.createOrUpdate(updatedWS))
+  }
+
+  def cloneFail(ws: Workspace, message: String, failTime: Option[DateTime] = None): Future[Workspace] = {
+    val updatedWS = ws.copy(errorMessage = Some(message), completedCloneWorkspaceFileTransfer = failTime)
+    dataSource.inTransaction(_.workspaceQuery.createOrUpdate(updatedWS))
+  }
+
+  def getWorkspace(wsId: UUID): Future[Option[Workspace]] = dataSource.inTransaction { dataAccess =>
+    dataAccess.workspaceQuery.findById(wsId.toString)
+  }
+
+  def getUserCtx(userEmail: String)(implicit executionContext: ExecutionContext): Future[RawlsRequestContext] = for {
+    petKey <- samDAO.getUserArbitraryPetServiceAccountKey(userEmail)
+    userInfo <- gcsDAO.getUserInfoUsingJson(petKey)
+  } yield RawlsRequestContext(userInfo)
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -11,7 +11,8 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
   Complete,
   Incomplete,
-  JobStatus
+  JobStatus,
+  JobType
 }
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
@@ -40,6 +41,9 @@ class CloneWorkspaceContainerRunner(
         case None    => logger.error(logMessage)
       }
     }
+
+    if (!job.jobType.equals(JobType.CloneWorkspaceContainerResult))
+      throw new IllegalArgumentException(s"${this.getClass.getSimpleName} called with invalid job type: ${job.jobType}")
 
     val workspaceId = job.workspaceId match {
       case Some(name) => name

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -50,6 +50,8 @@ class HttpWorkspaceManagerDAOSpec
 
     override def getResourceApi(ctx: RawlsRequestContext): ResourceApi = resourceApi
 
+    override def getJobsApi(ctx: RawlsRequestContext): JobsApi = ???
+
     override def getUnauthenticatedApi(): UnauthenticatedApi = ???
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -245,6 +245,8 @@ class MockWorkspaceManagerDAO(
                         ctx: RawlsRequestContext
   ): CreateLandingZoneResult = ???
 
+  override def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport = ???
+
   override def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult = ???
 
   def deleteLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): DeleteAzureLandingZoneResult = ???

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -5,6 +5,7 @@ import bio.terra.workspace.model.JobReport
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, Workspace}
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.{
@@ -52,6 +53,16 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
   behavior of "initial setup and basic requirements updating workspace container cloning status monitoring"
+
+  it should "throw an exception if called with a job type that is not CloneWorkspaceContainer" in {
+    val runner = new CloneWorkspaceContainerRunner(
+      mock[SamDAO],
+      mock[WorkspaceManagerDAO],
+      mock[SlickDataSource],
+      mock[GoogleServicesDAO]
+    )
+    intercept[IllegalArgumentException](runner(monitorRecord.copy(jobType = JobType.AzureLandingZoneResult)))
+  }
 
   it should "return a completed status if the workspace id is not set on the job" in {
     val runner = new CloneWorkspaceContainerRunner(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -1,0 +1,46 @@
+package org.broadinstitute.dsde.rawls.monitor.workspace.runners
+
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
+import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.monitorRecord
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext
+
+object CloneWorkspaceContainerRunnerSpec {
+  val userEmail: String = "user@email.com"
+  val workspaceId: UUID = UUID.randomUUID()
+
+  val monitorRecord: WorkspaceManagerResourceMonitorRecord =
+    WorkspaceManagerResourceMonitorRecord.forCloneWorkspaceContainer(
+      UUID.randomUUID(),
+      workspaceId,
+      RawlsUserEmail(userEmail)
+    )
+}
+
+class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSugar with Matchers with ScalaFutures {
+  implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
+
+  behavior of "initial setup and basic requirements updating workspace cloning status"
+
+  it should "return a completed status if the workspace id is None" in {
+    val runner = new CloneWorkspaceContainerRunner(
+      mock[SamDAO],
+      mock[WorkspaceManagerDAO],
+      mock[SlickDataSource],
+      mock[GoogleServicesDAO]
+    )
+    whenReady(runner(monitorRecord.copy(workspaceId = None)))(
+      _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
+    )
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -4,34 +4,54 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.monitorRecord
+import org.broadinstitute.dsde.rawls.model.{Attribute, AttributeName, RawlsUserEmail, Workspace}
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.{
+  monitorRecord,
+  userEmail,
+  workspace,
+  workspaceId
+}
+import org.joda.time.DateTime
+import org.mockito.{ArgumentMatchers, Mockito}
+import org.mockito.Mockito.{doAnswer, doReturn, spy, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 object CloneWorkspaceContainerRunnerSpec {
   val userEmail: String = "user@email.com"
   val workspaceId: UUID = UUID.randomUUID()
-
+  val wsCreatedDate: DateTime = DateTime.parse("2023-01-18T10:08:48.541-05:00")
   val monitorRecord: WorkspaceManagerResourceMonitorRecord =
     WorkspaceManagerResourceMonitorRecord.forCloneWorkspaceContainer(
       UUID.randomUUID(),
       workspaceId,
       RawlsUserEmail(userEmail)
     )
+
+  val workspace: Workspace = Workspace(
+    "test-ws-namespace",
+    "test-ws-name",
+    workspaceId.toString,
+    "test-bucket",
+    None,
+    wsCreatedDate,
+    wsCreatedDate,
+    "a_user",
+    Map()
+  )
 }
 
 class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSugar with Matchers with ScalaFutures {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
-  behavior of "initial setup and basic requirements updating workspace cloning status"
+  behavior of "initial setup and basic requirements updating workspace container cloning status monitoring"
 
-  it should "return a completed status if the workspace id is None" in {
+  it should "return a completed status if the workspace id is not set on the job" in {
     val runner = new CloneWorkspaceContainerRunner(
       mock[SamDAO],
       mock[WorkspaceManagerDAO],
@@ -42,5 +62,78 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
   }
+
+  it should "return a completed status if no workspace is found for the id" in {
+    val runner = spy(
+      new CloneWorkspaceContainerRunner(
+        mock[SamDAO],
+        mock[WorkspaceManagerDAO],
+        mock[SlickDataSource],
+        mock[GoogleServicesDAO]
+      )
+    )
+    // TODO: This needs an otherwise successful setup, up until the first use of the workspace
+    doReturn(Future.successful(None)).when(runner).getWorkspace(monitorRecord.workspaceId.get)
+    doReturn(Future.successful(new org.broadinstitute.dsde.workbench.client.sam.ApiException()))
+      .when(runner)
+      .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
+    whenReady(runner(monitorRecord))(
+      _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
+    )
+  }
+
+  it should "return a completed status if no user email is set on the job" in {
+    val runner = spy(
+      new CloneWorkspaceContainerRunner(
+        mock[SamDAO],
+        mock[WorkspaceManagerDAO],
+        mock[SlickDataSource],
+        mock[GoogleServicesDAO]
+      )
+    )
+    doReturn(Future.successful(Some(workspace)))
+      .when(runner)
+      .getWorkspace(ArgumentMatchers.eq(monitorRecord.workspaceId.get))
+    doAnswer(answer => Future.successful(answer.getArgument(0).asInstanceOf[Workspace]))
+      .when(runner)
+      .cloneFail(ArgumentMatchers.any(), ArgumentMatchers.any())
+
+    whenReady(runner(monitorRecord.copy(userEmail = None)))(
+      _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
+    )
+  }
+
+  it should "return Incomplete when the if the user context cannot be created" in {
+    val runner = spy(
+      new CloneWorkspaceContainerRunner(
+        mock[SamDAO],
+        mock[WorkspaceManagerDAO],
+        mock[SlickDataSource],
+        mock[GoogleServicesDAO]
+      )
+    )
+    doReturn(Future.successful(Some(workspace)))
+      .when(runner)
+      .getWorkspace(ArgumentMatchers.eq(monitorRecord.workspaceId.get))
+
+    doReturn(Future.failed(new org.broadinstitute.dsde.workbench.client.sam.ApiException()))
+      .when(runner)
+      .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
+    doAnswer { answer =>
+      val errorMessage = answer.getArgument(1).asInstanceOf[String]
+      errorMessage should include(workspaceId.toString)
+      errorMessage should include(userEmail)
+      Future.successful(answer.getArgument(0).asInstanceOf[Workspace])
+    }.when(runner).cloneFail(ArgumentMatchers.any(), ArgumentMatchers.any())
+
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    verify(runner).cloneFail(ArgumentMatchers.any(), ArgumentMatchers.any())
+  }
+
+  behavior of "handling the clone container report"
+
+  it should "set completedCloneWorkspaceFileTransfer on the workspace to the complete time in the report" in {}
+
+  it should "not set completedCloneWorkspaceFileTransfer on failures" in {}
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -115,6 +115,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     whenReady(runner(monitorRecord.copy(userEmail = None)))(
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
+    verify(runner).cloneFail(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any[ExecutionContext]())
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -1,17 +1,12 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 
-import bio.terra.workspace.model.{CloneWorkspaceResult, ErrorReport, JobReport}
+import bio.terra.workspace.model.{CloneControlledAzureStorageContainerResult, ErrorReport, JobReport}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, Workspace}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.{
-  monitorRecord,
-  userEmail,
-  workspace,
-  workspaceId
-}
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.{monitorRecord, userEmail, workspace, workspaceId}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{doAnswer, doReturn, spy, verify}
@@ -76,7 +71,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     val completedTime = "2023-01-16T10:08:48.541-05:00"
     val expectedTime = DateTime.parse(completedTime)
     val report = new JobReport().status(JobReport.StatusEnum.SUCCEEDED).completed(completedTime)
-    val cloneResult = new CloneWorkspaceResult().jobReport(report)
+    val cloneResult = new CloneControlledAzureStorageContainerResult().jobReport(report)
     doAnswer { answer =>
       val specifiedTime = answer.getArgument(1).asInstanceOf[DateTime]
       specifiedTime shouldBe expectedTime
@@ -155,7 +150,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     val completedTime = "2023-01-16T10:08:48.541-05:00"
     val expectedTime = DateTime.parse(completedTime)
     val report = new JobReport().status(JobReport.StatusEnum.SUCCEEDED).completed(completedTime)
-    val cloneResult = new CloneWorkspaceResult().jobReport(report)
+    val cloneResult = new CloneControlledAzureStorageContainerResult().jobReport(report)
     doAnswer { answer =>
       val specifiedTime = answer.getArgument(1).asInstanceOf[DateTime]
       specifiedTime shouldBe expectedTime
@@ -188,7 +183,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     val errorReport = new ErrorReport().message(wsmErrorMessage)
     val report = new JobReport().status(JobReport.StatusEnum.FAILED).completed(completedTime)
 
-    val cloneResult = new CloneWorkspaceResult().jobReport(report).errorReport(errorReport)
+    val cloneResult = new CloneControlledAzureStorageContainerResult().jobReport(report).errorReport(errorReport)
 
     doAnswer { answer =>
       val errorMessage = answer.getArgument(1).asInstanceOf[String]
@@ -217,7 +212,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     val errorReport = new ErrorReport().message(wsmErrorMessage)
     val report = new JobReport().status(JobReport.StatusEnum.FAILED).completed(completedTime)
 
-    val cloneResult = new CloneWorkspaceResult().jobReport(report).errorReport(errorReport)
+    val cloneResult = new CloneControlledAzureStorageContainerResult().jobReport(report).errorReport(errorReport)
 
     doAnswer { answer =>
       val errorMessage = answer.getArgument(1).asInstanceOf[String]
@@ -243,7 +238,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     )
     val completedTime = "2023-01-16T10:08:48.541-05:00"
     val report = new JobReport().status(JobReport.StatusEnum.FAILED).completed(completedTime)
-    val cloneResult = new CloneWorkspaceResult().jobReport(report)
+    val cloneResult = new CloneControlledAzureStorageContainerResult().jobReport(report)
 
     doAnswer { answer =>
       val errorMessage = answer.getArgument(1).asInstanceOf[String]
@@ -268,7 +263,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
       )
     )
 
-    val cloneResult = new CloneWorkspaceResult()
+    val cloneResult = new CloneControlledAzureStorageContainerResult()
 
     doAnswer { answer =>
       val errorMessage = answer.getArgument(1).asInstanceOf[String]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceCon
 }
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{doAnswer, doReturn, doThrow, spy, verify, when}
+import org.mockito.Mockito.{doAnswer, doReturn, spy, verify}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
Ticket: [WOR-533](https://broadworkbench.atlassian.net/browse/WOR-533)

Adding runner for CloneWorkspaceContainer jobs
Patterns are similar to those for LandingZoneCreationStatus
A bit of complexity in the tests was added because for the landing zone status, we have the `BillingRepository` to mock, making tests easy; but we don't have anything similar for workspaces. 
I considered adding something; but then I started looking at the workspace service, and the `WorkspaceSupport` trait, and thought better of it

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-533]: https://broadworkbench.atlassian.net/browse/WOR-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ