### PR TITLE
[WOR-728] make sure Leo app is enabled in cloned WSM workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -167,6 +167,12 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
       applicationId
     )
 
+  override def disableApplication(workspaceId: UUID,
+                                  applicationId: String,
+                                  ctx: RawlsRequestContext
+  ): WorkspaceApplicationDescription =
+    getWorkspaceApplicationApi(ctx).disableWorkspaceApplication(workspaceId, applicationId)
+
   override def createAzureStorageAccount(workspaceId: UUID,
                                          region: String,
                                          ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -67,6 +67,10 @@ trait WorkspaceManagerDAO {
                         applicationId: String,
                         ctx: RawlsRequestContext
   ): WorkspaceApplicationDescription
+  def disableApplication(workspaceId: UUID,
+                         applicationId: String,
+                         ctx: RawlsRequestContext
+  ): WorkspaceApplicationDescription
   def createAzureStorageAccount(workspaceId: UUID,
                                 region: String,
                                 ctx: RawlsRequestContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -281,6 +281,22 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                          getWorkspaceCloneStatus
           )
         }
+        _ <- traceWithParent("workspaceManagerDAO.disableLeo", parentContext) { context =>
+          Future(blocking {
+            workspaceManagerDAO.disableApplication(newWorkspace.workspaceIdAsUUID,
+                                                   wsmConfig.leonardoWsmApplicationId,
+                                                   context
+            )
+          })
+        }
+        _ <- traceWithParent("workspaceManagerDAO.reenableLeo", parentContext) { context =>
+          Future(blocking {
+            workspaceManagerDAO.enableApplication(newWorkspace.workspaceIdAsUUID,
+                                                  wsmConfig.leonardoWsmApplicationId,
+                                                  context
+            )
+          })
+        }
         _ = logger.info(
           s"Starting workspace storage container clone in WSM [workspaceId = ${newWorkspace.workspaceIdAsUUID}]"
         )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -219,6 +219,12 @@ class MockWorkspaceManagerDAO(
   ): WorkspaceApplicationDescription =
     new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
 
+  override def disableApplication(workspaceId: UUID,
+                                  applicationId: String,
+                                  ctx: RawlsRequestContext
+  ): WorkspaceApplicationDescription =
+    new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
+
   override def createAzureStorageAccount(workspaceId: UUID,
                                          region: String,
                                          ctx: RawlsRequestContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -717,6 +717,10 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
             }
           } yield {
             verify(mcWorkspaceService.workspaceManagerDAO, times(1))
+              .disableApplication(any(), any(), any())
+            verify(mcWorkspaceService.workspaceManagerDAO, times(1))
+              .enableApplication(any(), any(), any())
+            verify(mcWorkspaceService.workspaceManagerDAO, times(1))
               .cloneAzureStorageContainer(
                 equalTo(testData.azureWorkspace.workspaceIdAsUUID),
                 equalTo(clone.workspaceIdAsUUID),


### PR DESCRIPTION
Ticket: [WOR-728](https://broadworkbench.atlassian.net/browse/WOR-728)
WSM only half-enables applications in cloned workspaces. This is a workaround to tide us over while we work on the required WSM fix

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-728]: https://broadworkbench.atlassian.net/browse/WOR-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ