### PR TITLE
test iam permissions instead of diagnostic bucket read

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.12.3"
 
   val workbenchLibsHash = "fbb79d0"
-  val workbenchServiceTestHash = "6b83810" // Differs from workbench libs because serviceTest has newer changes we depend on
+  val workbenchServiceTestHash = "46d1df6" // Differs from workbench libs because serviceTest has newer changes we depend on
   val serviceTestV = s"2.0-${workbenchServiceTestHash}"
   val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.24-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -5,13 +5,12 @@ object Dependencies {
 
   val akkaV         = "2.6.8"
   val akkaHttpV     = "10.2.0"
-  val jacksonV      = "2.12.3"
+  val jacksonV      = "2.14.1"
 
-  val workbenchLibsHash = "fbb79d0"
-  val workbenchServiceTestHash = "46d1df6" // Differs from workbench libs because serviceTest has newer changes we depend on
-  val serviceTestV = s"2.0-${workbenchServiceTestHash}"
-  val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.24-${workbenchLibsHash}"
+  val workbenchLibsHash = "1174fb6"
+  val serviceTestV = s"2.0-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.22-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.5-${workbenchLibsHash}"
 

--- a/automation/project/plugins.sbt
+++ b/automation/project/plugins.sbt
@@ -1,0 +1,1 @@
+addDependencyTreePlugin

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -474,6 +474,8 @@ object Boot extends IOApp with LazyLogging {
         terraBillingProjectOwnerRole = gcsConfig.getString("terraBillingProjectOwnerRole"),
         terraWorkspaceCanComputeRole = gcsConfig.getString("terraWorkspaceCanComputeRole"),
         terraWorkspaceNextflowRole = gcsConfig.getString("terraWorkspaceNextflowRole"),
+        terraBucketReaderRole = gcsConfig.getString("terraBucketReaderRole"),
+        terraBucketWriterRole = gcsConfig.getString("terraBucketWriterRole"),
         new RawlsWorkspaceAclManager(samDAO),
         new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, slickDataSource)
       )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -51,17 +51,17 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def getGoogleProject(googleProject: GoogleProjectId): Future[Project]
 
   /** Mark all objects in the bucket for deletion, then attempts to delete the bucket from Google Cloud Storage.
-    *
-    * The bucket's lifecycle rule is set to delete any objects older than 0 days. This
-    * effectively marks all objects in the bucket for deletion the next time GCS inspects the bucket (up to 24 hours
-    * later at the time of this writing; see [[https://cloud.google.com/storage/docs/lifecycle#behavior]]).
-    * Bucket deletion will not Rawls will periodically retry the bucket deletion until it succeeds.
-    *
-    * This strategy is inspired by [[http://blog.iangsy.com/2014/04/google-cloud-storage-deleting-full.html]].
-    *
-    * @param bucketName the name of the bucket to delete
-    * @return true if the bucket was deleted, false if not
-    */
+   *
+   * The bucket's lifecycle rule is set to delete any objects older than 0 days. This
+   * effectively marks all objects in the bucket for deletion the next time GCS inspects the bucket (up to 24 hours
+   * later at the time of this writing; see [[https://cloud.google.com/storage/docs/lifecycle#behavior]]).
+   * Bucket deletion will not Rawls will periodically retry the bucket deletion until it succeeds.
+   *
+   * This strategy is inspired by [[http://blog.iangsy.com/2014/04/google-cloud-storage-deleting-full.html]].
+   *
+   * @param bucketName the name of the bucket to delete
+   * @return true if the bucket was deleted, false if not
+   */
   def deleteBucket(bucketName: String): Future[Boolean]
 
   def isAdmin(userEmail: String): Future[Boolean]
@@ -77,37 +77,37 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def getGoogleGroup(groupName: String)(implicit executionContext: ExecutionContext): Future[Option[Group]]
 
   /**
-    * Returns the most recent daily storage usage information for a bucket in bytes. The information comes from daily
-    * storage logs reported in byte-hours over a 24-hour period, which is divided by 24 to obtain usage in bytes.
-    * Queries the objects in a bucket and calculates the total usage (bytes).
-    *
-    * Note: maxResults is used for integration testing of multi-page queries. While it could potentially be used for
-    * performance tuning, it would be better to build that into the service instead of giving the caller a dial to mess
-    * with. For that reason, the maxResults parameter should be removed in favor of extracting the creation of Storage
-    * objects from the service implementation to enable test doubles to be injected.
-    *
-    * @param googleProject the name of the project that owns the bucket
-    * @param bucketName    the name of the bucket to query
-    * @param maxResults    (optional) the page size to use when fetching objects
-    * @return the size in bytes of the data stored in the bucket
-    */
+   * Returns the most recent daily storage usage information for a bucket in bytes. The information comes from daily
+   * storage logs reported in byte-hours over a 24-hour period, which is divided by 24 to obtain usage in bytes.
+   * Queries the objects in a bucket and calculates the total usage (bytes).
+   *
+   * Note: maxResults is used for integration testing of multi-page queries. While it could potentially be used for
+   * performance tuning, it would be better to build that into the service instead of giving the caller a dial to mess
+   * with. For that reason, the maxResults parameter should be removed in favor of extracting the creation of Storage
+   * objects from the service implementation to enable test doubles to be injected.
+   *
+   * @param googleProject the name of the project that owns the bucket
+   * @param bucketName    the name of the bucket to query
+   * @param maxResults    (optional) the page size to use when fetching objects
+   * @return the size in bytes of the data stored in the bucket
+   */
   def getBucketUsage(googleProject: GoogleProjectId,
                      bucketName: String,
                      maxResults: Option[Long] = None
   ): Future[BucketUsageResponse]
 
   /**
-    * Gets a Google bucket.
-    *
-    * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
-    * is because this method is used for health monitoring, and we want health checks to use a
-    * different execution context (thread pool) than user-facing operations.
-    *
-    * @param bucketName       the bucket name
-    * @param executionContext the execution context to use for aysnc operations
-    * @param userProject the project to be billed - optional. If None, defaults to the bucket's project
-    * @return optional Google bucket
-    */
+   * Gets a Google bucket.
+   *
+   * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
+   * is because this method is used for health monitoring, and we want health checks to use a
+   * different execution context (thread pool) than user-facing operations.
+   *
+   * @param bucketName       the bucket name
+   * @param executionContext the execution context to use for aysnc operations
+   * @param userProject      the project to be billed - optional. If None, defaults to the bucket's project
+   * @return optional Google bucket
+   */
   def getBucket(bucketName: String, userProject: Option[GoogleProjectId])(implicit
     executionContext: ExecutionContext
   ): Future[Either[String, Bucket]]
@@ -139,15 +139,15 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def testDMBillingAccountAccess(billingAccountName: RawlsBillingAccountName): Future[Boolean]
 
   /**
-    * Lists Google billing accounts using the billing service account.
-    *
-    * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
-    * is because this method is used for health monitoring, and we want health checks to use a
-    * different execution context (thread pool) than user-facing operations.
-    *
-    * @param executionContext the execution context to use for aysnc operations
-    * @return sequence of RawlsBillingAccounts
-    */
+   * Lists Google billing accounts using the billing service account.
+   *
+   * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
+   * is because this method is used for health monitoring, and we want health checks to use a
+   * different execution context (thread pool) than user-facing operations.
+   *
+   * @param executionContext the execution context to use for aysnc operations
+   * @return sequence of RawlsBillingAccounts
+   */
   def listBillingAccountsUsingServiceCredential(implicit
     executionContext: ExecutionContext
   ): Future[Seq[RawlsBillingAccount]]
@@ -179,15 +179,15 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def getGenomicsOperation(jobId: String): Future[Option[JsObject]]
 
   /**
-    * Checks that a query can be performed against the genomics api.
-    *
-    * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
-    * is because this method is used for health monitoring, and we want health checks to use a
-    * different execution context (thread pool) than user-facing operations.
-    *
-    * @param executionContext the execution context to use for aysnc operations
-    * @return sequence of Google operations
-    */
+   * Checks that a query can be performed against the genomics api.
+   *
+   * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
+   * is because this method is used for health monitoring, and we want health checks to use a
+   * different execution context (thread pool) than user-facing operations.
+   *
+   * @param executionContext the execution context to use for aysnc operations
+   * @return sequence of Google operations
+   */
   def checkGenomicsOperationsHealth(implicit executionContext: ExecutionContext): Future[Boolean]
 
   def toGoogleGroupName(groupName: RawlsGroupName): String
@@ -203,14 +203,14 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def getBucketDetails(bucket: String, project: GoogleProjectId): Future[WorkspaceBucketOptions]
 
   /**
-    * The project creation process is now mostly handled by Deployment Manager.
-    *
-    * - First, we call Deployment Manager, telling it to kick off its template and create the new project. This gives us back
-    * an operation that needs to be polled.
-    *
-    * - Polling is handled by CreatingBillingProjectMonitor. Once the deployment is completed, CBPM deletes the deployment, as
-    * there is a per-project limit on number of deployments, and then marks the project as fully created.
-    */
+   * The project creation process is now mostly handled by Deployment Manager.
+   *
+   * - First, we call Deployment Manager, telling it to kick off its template and create the new project. This gives us back
+   * an operation that needs to be polled.
+   *
+   * - Polling is handled by CreatingBillingProjectMonitor. Once the deployment is completed, CBPM deletes the deployment, as
+   * there is a per-project limit on number of deployments, and then marks the project as fully created.
+   */
   def createProject(googleProject: GoogleProjectId,
                     billingAccount: RawlsBillingAccount,
                     dmTemplatePath: String,
@@ -225,15 +225,15 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   ): Future[RawlsBillingProjectOperationRecord]
 
   /**
-    *
-    */
+   *
+   */
   def cleanupDMProject(googleProject: GoogleProjectId): Future[Unit]
 
   /**
-    * Removes the IAM policies from the project's existing policies
-    *
-    * @return true if the policy was actually changed
-    */
+   * Removes the IAM policies from the project's existing policies
+   *
+   * @return true if the policy was actually changed
+   */
   def removePolicyBindings(googleProject: GoogleProjectId,
                            policiesToRemove: Map[String, Set[String]]
   ): Future[Boolean] = updatePolicyBindings(googleProject) { existingPolicies =>
@@ -248,10 +248,10 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   }
 
   /**
-    * Adds the IAM policies to the project's existing policies
-    *
-    * @return true if the policy was actually changed
-    */
+   * Adds the IAM policies to the project's existing policies
+   *
+   * @return true if the policy was actually changed
+   */
   def addPolicyBindings(googleProject: GoogleProjectId, policiesToAdd: Map[String, Set[String]]): Future[Boolean] =
     updatePolicyBindings(googleProject) { existingPolicies =>
       // |+| is a semigroup: it combines a map's keys by combining their values' members instead of replacing them
@@ -260,23 +260,23 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
     }
 
   /**
-    * Internal function to update project IAM bindings.
-    *
-    * @param googleProject  google project id
-    * @param updatePolicies function (existingPolicies => updatedPolicies). May return policies with no members
-    *                       which will be handled appropriately when sent to google.
-    * @return true if google was called to update policies, false otherwise
-    */
+   * Internal function to update project IAM bindings.
+   *
+   * @param googleProject  google project id
+   * @param updatePolicies function (existingPolicies => updatedPolicies). May return policies with no members
+   *                       which will be handled appropriately when sent to google.
+   * @return true if google was called to update policies, false otherwise
+   */
   protected def updatePolicyBindings(googleProject: GoogleProjectId)(
     updatePolicies: Map[String, Set[String]] => Map[String, Set[String]]
   ): Future[Boolean]
 
   /**
-    *
-    * @param bucketName
-    * @param readers emails of users to be granted read access
-    * @return bucket name
-    */
+   *
+   * @param bucketName
+   * @param readers emails of users to be granted read access
+   * @return bucket name
+   */
   def grantReadAccess(bucketName: String, readers: Set[WorkbenchEmail]): Future[String]
 
   def pollOperation(operationId: OperationId): Future[OperationStatus]
@@ -292,45 +292,48 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def getUserInfoUsingJson(saKey: String): Future[UserInfo]
 
   /**
-    * Convert a string to a legal gcp label text, with an optional prefix
-    * See: https://cloud.google.com/compute/docs/labeling-resources#restrictions
-    *
-    * @param s
-    * @param prefix defaults to "fc-"
-    * @return
-    */
+   * Convert a string to a legal gcp label text, with an optional prefix
+   * See: https://cloud.google.com/compute/docs/labeling-resources#restrictions
+   *
+   * @param s
+   * @param prefix defaults to "fc-"
+   * @return
+   */
   def labelSafeString(s: String, prefix: String = "fc-"): String =
     prefix + s.toLowerCase.replaceAll("[^a-z0-9\\-_]", "-").take(63)
 
   /**
-    * Convert a map of labels to legal gcp label text. Runs [[labelSafeString]] on all keys and values in the map.
-    * @param m Map of label key value pairs
-    * @param prefix defaults to "fc-"
-    * @return
-    */
+   * Convert a map of labels to legal gcp label text. Runs [[labelSafeString]] on all keys and values in the map.
+   *
+   * @param m      Map of label key value pairs
+   * @param prefix defaults to "fc-"
+   * @return
+   */
   def labelSafeMap(m: Map[String, String], prefix: String = "fc-"): Map[String, String] = m.map { case (key, value) =>
     labelSafeString(key, prefix) -> labelSafeString(value, prefix)
   }
 
   /**
-    * Valid text for google project name.
-    *
-    * "The optional user-assigned display name of the Project. It must be 4 to 30 characters. Allowed
-    * characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote,
-    * space, and exclamation point."
-    *
-    * For more info see: https://cloud.google.com/resource-manager/reference/rest/v1/projects
-    * @param name
-    * @return
-    */
+   * Valid text for google project name.
+   *
+   * "The optional user-assigned display name of the Project. It must be 4 to 30 characters. Allowed
+   * characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote,
+   * space, and exclamation point."
+   *
+   * For more info see: https://cloud.google.com/resource-manager/reference/rest/v1/projects
+   *
+   * @param name
+   * @return
+   */
   def googleProjectNameSafeString(name: String): String =
     name.replaceAll("[^a-zA-Z0-9\\-'\" !]", "-").take(30)
 
   /**
-    * Handles getting the google project number from the google [[Project]]
-    * @param googleProject
-    * @return GoogleProjectNumber
-    */
+   * Handles getting the google project number from the google [[Project]]
+   *
+   * @param googleProject
+   * @return GoogleProjectNumber
+   */
   def getGoogleProjectNumber(googleProject: Project): GoogleProjectNumber = googleProject.getProjectNumber match {
     case null =>
       throw new RawlsExceptionWithErrorReport(
@@ -348,15 +351,20 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
   def testBillingAccountAccess(billingAccount: RawlsBillingAccountName, userInfo: UserInfo): Future[Boolean]
 
   /**
-    * Returns location of a regional bucket. If the bucket's location type is `multi-region`, it returns None
-
-    * @param bucketName       the bucket name
-    * @param userProject - the project to be billed - optional. If None, defaults to the bucket's project
-    * @return optional Google bucket region
-    */
+   * Returns location of a regional bucket. If the bucket's location type is `multi-region`, it returns None
+   *
+   * @param bucketName  the bucket name
+   * @param userProject - the project to be billed - optional. If None, defaults to the bucket's project
+   * @return optional Google bucket region
+   */
   def getRegionForRegionalBucket(bucketName: String, userProject: Option[GoogleProjectId]): Future[Option[String]]
 
   def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]]
+
+  def testBucketIam(bucketName: String, petKey: String, permissions: Set[String])(implicit
+    executionContext: ExecutionContext
+  ): Future[Boolean] =
+    Future.successful(true)
 }
 
 object GoogleApiTypes {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.auth.oauth2.Credential
-import com.google.api.services.admin.directory.model.Group
+import com.google.api.services.directory.model.Group
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.google.api.services.storage.model.{Bucket, BucketAccessControl, StorageObject}
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, IamPermission}
 import spray.json.JsObject
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -361,10 +361,13 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
 
   def getComputeZonesForRegion(googleProject: GoogleProjectId, region: String): Future[List[String]]
 
-  def testBucketIam(bucketName: String, petKey: String, permissions: Set[String])(implicit
-    executionContext: ExecutionContext
-  ): Future[Boolean] =
-    Future.successful(true)
+  def testSAGoogleBucketIam(bucketName: GcsBucketName, saKey: String, permissions: Set[IamPermission])(implicit
+                                                                                                        executionContext: ExecutionContext
+  ): Future[Set[IamPermission]]
+
+  def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
+                                                                                                      executionContext: ExecutionContext
+  ): Future[Set[IamPermission]]
 }
 
 object GoogleApiTypes {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SamModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SamModel.scala
@@ -35,6 +35,8 @@ object SamWorkspaceRoles {
   val shareReader = SamResourceRole("share-reader")
   val canCompute = SamResourceRole("can-compute")
   val canCatalog = SamResourceRole("can-catalog")
+
+  val rolesContainingWritePermissions = Set(SamWorkspaceRoles.owner, SamWorkspaceRoles.writer, SamWorkspaceRoles.projectOwner)
 }
 
 object SamBillingProjectRoles {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -199,7 +199,7 @@ trait WorkspaceApiService extends UserInfoDirectives {
           get {
             complete {
               workspaceServiceConstructor(ctx)
-                .checkBucketReadAccess(WorkspaceName(workspaceNamespace, workspaceName))
+                .checkWorkspaceCloudPermissions(WorkspaceName(workspaceNamespace, workspaceName))
                 .map(_ => StatusCodes.OK)
             }
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2668,11 +2668,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       iamResults <- gcsDAO.testBucketIam(
         workspace.bucketName,
         petKey,
-        Set("resourcemanager.projects.get",
-            "resourcemanager.projects.list",
-            "storage.buckets.get",
-            "storage.objects.get",
-            "storage.objects.list"
+        Set(
+          "storage.buckets.get",
+          "storage.objects.get",
+          "storage.objects.list"
         )
       )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2661,7 +2661,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
        If the user has write access, we need to use the pet for this workspace's project in order to get accurate results.
        */
-  def checkBucketReadAccess(workspaceName: WorkspaceName): Future[Unit] =
+  def checkWorkspaceCloudPermissions(workspaceName: WorkspaceName): Future[Unit] =
     for {
       workspace <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -10,7 +10,7 @@ import cats.{Applicative, ApplicativeThrow, MonadThrow}
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.startSpanWithParent
-import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span, Status}
+import io.opencensus.trace.{Span, Status, AttributeValue => OpenCensusAttributeValue}
 import org.broadinstitute.dsde.rawls._
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import slick.jdbc.TransactionIsolation
@@ -45,7 +45,7 @@ import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.model.Notifications.{WorkspaceName => NotificationWorkspaceName}
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, IamPermission}
 import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
 import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol._
@@ -89,6 +89,8 @@ object WorkspaceService {
                   terraBillingProjectOwnerRole: String,
                   terraWorkspaceCanComputeRole: String,
                   terraWorkspaceNextflowRole: String,
+                  terraBucketReaderRole: String,
+                  terraBucketWriterRole: String,
                   rawlsWorkspaceAclManager: RawlsWorkspaceAclManager,
                   multiCloudWorkspaceAclManager: MultiCloudWorkspaceAclManager
   )(
@@ -122,6 +124,8 @@ object WorkspaceService {
       terraBillingProjectOwnerRole,
       terraWorkspaceCanComputeRole,
       terraWorkspaceNextflowRole,
+      terraBucketReaderRole,
+      terraBucketWriterRole,
       rawlsWorkspaceAclManager,
       multiCloudWorkspaceAclManager
     )
@@ -192,6 +196,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                        terraBillingProjectOwnerRole: String,
                        terraWorkspaceCanComputeRole: String,
                        terraWorkspaceNextflowRole: String,
+                       terraBucketReaderRole: String,
+                       terraBucketWriterRole: String,
                        rawlsWorkspaceAclManager: RawlsWorkspaceAclManager,
                        multiCloudWorkspaceAclManager: MultiCloudWorkspaceAclManager
 )(implicit protected val executionContext: ExecutionContext)
@@ -2616,83 +2622,83 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       )
     }
 
+  private def getGoogleBucketPermissionsFromRoles(workspaceRoles: Set[SamResourceRole]): Future[Set[IamPermission]] = {
+    val googleRole = if (workspaceRoles.intersect(SamWorkspaceRoles.rolesContainingWritePermissions).nonEmpty) {
+      // workspace project owner, owner and writer have terraBucketWriterRole
+      Option(terraBucketWriterRole)
+    } else if (workspaceRoles.contains(SamWorkspaceRoles.reader)) {
+      // workspace reader has terraBucketReaderRole
+      Option(terraBucketReaderRole)
+    } else None
+
+    getPermissionsFromRoles(googleRole.toSet)
+  }
+
+  private def getGoogleProjectPermissionsFromRoles(workspaceRoles: Set[SamResourceRole]): Future[Set[IamPermission]] = {
+    val googleRoles = workspaceRoles.flatMap {
+      case SamWorkspaceRoles.projectOwner => Set(terraBillingProjectOwnerRole, terraWorkspaceCanComputeRole, terraWorkspaceNextflowRole)
+      case SamWorkspaceRoles.owner | SamWorkspaceRoles.canCompute => Set(terraWorkspaceCanComputeRole, terraWorkspaceNextflowRole)
+      case _ => Set.empty
+    }
+
+    getPermissionsFromRoles(googleRoles)
+  }
+
+  private def getPermissionsFromRoles(googleRoles: Set[String]) = {
+    Future.traverse(googleRoles) { googleRole =>
+      googleIamDao.getOrganizationCustomRole(googleRole)
+    }.map(_.flatten.flatMap(_.getIncludedPermissions.asScala.map(IamPermission)))
+  }
+
   /*
-   If the user only has read access, check the bucket using the default pet.
-   If the user has a higher level of access, check the bucket using the pet for this workspace's project.
+       If the user only has read access, check the bucket using the default pet.
+       If the user has a higher level of access, check the bucket using the pet for this workspace's project.
 
-   We use the default pet when possible because the default pet is created in a per-user shell project, i.e. not in
-     this workspace's project. This prevents proliferation of service accounts within this workspace's project. For
-     FireCloud's common read-only public workspaces, this is an important safeguard; else those common projects
-     would constantly hit limits on the number of allowed service accounts.
+       We use the default pet when possible because the default pet is created in a per-user shell project, i.e. not in
+         this workspace's project. This prevents proliferation of service accounts within this workspace's project. For
+         FireCloud's common read-only public workspaces, this is an important safeguard; else those common projects
+         would constantly hit limits on the number of allowed service accounts.
 
-   If the user has write access, we need to use the pet for this workspace's project in order to get accurate results.
-   */
+       If the user has write access, we need to use the pet for this workspace's project in order to get accurate results.
+       */
   def checkBucketReadAccess(workspaceName: WorkspaceName): Future[Unit] =
     for {
-      (workspace, maxAccessLevel) <- getWorkspaceContextAndPermissions(workspaceName,
-                                                                       SamWorkspaceActions.read
-      ) flatMap { workspaceContext =>
-        dataSource.inTransaction { dataAccess =>
-          DBIO.from(getMaximumAccessLevel(workspaceContext.workspaceIdAsUUID.toString)).map { accessLevel =>
-            (workspaceContext, accessLevel)
-          }
-        }
+      workspace <- getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read)
+
+      _ <- workspace.workspaceType match {
+        case WorkspaceType.McWorkspace => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotImplemented, "not implemented for McWorkspace")))
+        case WorkspaceType.RawlsWorkspace => Future.successful(())
       }
 
-//      _ <- workspace.workspaceType match {
-//        case WorkspaceType.McWorkspace => Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotImplemented, "not implemented for McWorkspace")))
-//        case WorkspaceType.RawlsWorkspace => Future.successful(())
-//      }
-//      List(
-//      billingProjectOwnerPolicyEmail -> Set(terraBillingProjectOwnerRole,
-//      terraWorkspaceCanComputeRole,
-//      terraWorkspaceNextflowRole
-//      ),
-//      policyEmailsByName(SamWorkspacePolicyNames.owner) -> Set(terraWorkspaceCanComputeRole,
-//      terraWorkspaceNextflowRole
-//      ),
-//      policyEmailsByName(SamWorkspacePolicyNames.canCompute) -> Set(terraWorkspaceCanComputeRole,
-//      terraWorkspaceNextflowRole
-//      )
-      // project owner - organizations/$ORG_ID/roles/terraBucketWriter
-      // workspace owner - organizations/$ORG_ID/roles/terraBucketWriter
-      // workspace writer - organizations/$ORG_ID/roles/terraBucketWriter
-      // workspace reader - organizations/$ORG_ID/roles/terraBucketReader
+      workspaceRoles <- samDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceIdAsUUID.toString, ctx)
 
       petKey <-
-        if (maxAccessLevel >= WorkspaceAccessLevels.Write)
+        if (workspaceRoles.intersect(SamWorkspaceRoles.rolesContainingWritePermissions).nonEmpty)
           samDAO.getPetServiceAccountKeyForUser(workspace.googleProjectId, ctx.userInfo.userEmail)
         else
           samDAO.getDefaultPetServiceAccountKeyForUser(ctx)
 
-      iamResults <- gcsDAO.testBucketIam(
-        workspace.bucketName,
+      // google api will error if any permission starts with something other than "storage."
+      expectedGoogleBucketPermissions <- getGoogleBucketPermissionsFromRoles(workspaceRoles).map(_.filter(_.value.startsWith("storage.")))
+      expectedGoogleProjectPermissions <- getGoogleProjectPermissionsFromRoles(workspaceRoles).map(_.filterNot(_.value.startsWith("resourcemanager.")))
+
+      bucketIamResults <- gcsDAO.testSAGoogleBucketIam(
+        GcsBucketName(workspace.bucketName),
         petKey,
-        Set(
-          "storage.buckets.get",
-          "storage.objects.get",
-          "storage.objects.list"
-        )
+        expectedGoogleBucketPermissions
       )
+      projectIamResults <- gcsDAO.testSAGoogleProjectIam(GoogleProject(workspace.googleProjectId.value), petKey, expectedGoogleProjectPermissions)
 
-      accessToken <- gcsDAO.getAccessTokenUsingJson(petKey)
+      missingBucketPermissions = expectedGoogleBucketPermissions -- bucketIamResults
+      missingProjectPermissions = expectedGoogleProjectPermissions -- projectIamResults
 
-      (petEmail, petSubjectId) = petKey.parseJson match {
-        case JsObject(fields) =>
-          (RawlsUserEmail(fields("client_email").toString), RawlsUserSubjectId(fields("client_id").toString))
-        case _ => throw new RawlsException("pet service account key was not a json object")
+      _ <- if (missingBucketPermissions.nonEmpty || missingProjectPermissions.nonEmpty) {
+        val petEmail = petKey.parseJson.asJsObject().fields.getOrElse("client_email", JsString("UNKNOWN"))
+        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, s"${petEmail.toString()} missing permissions [${missingProjectPermissions.mkString(",")}] on google project ${workspace.googleProjectId.value}, missing permissions [${missingBucketPermissions.mkString(",")}] on google bucket ${workspace.bucketName} for workspace ${workspace.toWorkspaceName.toString}")))
+      } else {
+        Future.successful(())
       }
-
-      resultsForPet <- gcsDAO.diagnosticBucketRead(UserInfo(petEmail, OAuth2BearerToken(accessToken), 60, petSubjectId),
-                                                   workspace.bucketName
-      )
-    } yield resultsForPet match {
-      case None =>
-        logger.info("checkBucketReadAccess: diagnosticBucketRead true, testBucketIam " + iamResults)
-      case Some(report) =>
-        logger.info("checkBucketReadAccess: diagnosticBucketRead false, testBucketIam " + iamResults)
-        throw new RawlsExceptionWithErrorReport(report)
-    }
+    } yield ()
 
   def checkSamActionWithLock(workspaceName: WorkspaceName, samAction: SamResourceAction): Future[Boolean] = {
     val wsCtxFuture = dataSource.inTransaction { dataAccess =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3444,6 +3444,13 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           s"Internal bucket for workspace `${workspaceRequest.name}` in namespace `${workspaceRequest.namespace}` was created in region `$location`."
         )
       )
+
+      // proactively create pet service account for user to start propagation of IAM
+      _ <- traceDBIOWithParent("samDAO.getPetServiceAccountKeyForUser", parentContext)(childContext =>
+        DBIO.from(
+          samDAO.getPetServiceAccountKeyForUser(savedWorkspace.googleProjectId, ctx.userInfo.userEmail)
+        )
+      )
     } yield savedWorkspace
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -26,7 +26,7 @@ import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecuti
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, verify, when}
+import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
@@ -551,17 +551,23 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   it should "build billing project policies that always include the creator as an owner" in {
     val user1Email = "user1@foo.bar"
     val user2Email = "user2@foo.bar"
-    val membersToAdd = Set(ProjectAccessUpdate(user1Email, ProjectRoles.Owner), ProjectAccessUpdate(user2Email, ProjectRoles.User))
+    val membersToAdd =
+      Set(ProjectAccessUpdate(user1Email, ProjectRoles.Owner), ProjectAccessUpdate(user2Email, ProjectRoles.User))
 
     val resultingPolicies = BillingProjectOrchestrator.buildBillingProjectPolicies(membersToAdd, testContext)
 
-    //Validate owner policy
-    assert(resultingPolicies(SamBillingProjectPolicyNames.owner).memberEmails.contains(WorkbenchEmail(userInfo.userEmail.value)))
+    // Validate owner policy
+    assert(
+      resultingPolicies(SamBillingProjectPolicyNames.owner).memberEmails
+        .contains(WorkbenchEmail(userInfo.userEmail.value))
+    )
     assert(resultingPolicies(SamBillingProjectPolicyNames.owner).memberEmails.contains(WorkbenchEmail(user1Email)))
     assert(resultingPolicies(SamBillingProjectPolicyNames.owner).memberEmails.size == 2)
 
-    //Validate user (workspaceCreator) policy
-    assert(resultingPolicies(SamBillingProjectPolicyNames.workspaceCreator).memberEmails.contains(WorkbenchEmail(user2Email)))
+    // Validate user (workspaceCreator) policy
+    assert(
+      resultingPolicies(SamBillingProjectPolicyNames.workspaceCreator).memberEmails.contains(WorkbenchEmail(user2Email))
+    )
     assert(resultingPolicies(SamBillingProjectPolicyNames.workspaceCreator).memberEmails.size == 1)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
-import com.google.api.services.admin.directory.model.Group
+import com.google.api.services.directory.model.Group
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.google.api.services.storage.model.{Bucket, BucketAccessControl, StorageObject}
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.google.{AccessContextManagerDAO, MockGoogle
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, IamPermission}
 import org.joda.time.DateTime
 import spray.json._
 
@@ -323,4 +323,8 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
     Future.successful(billingAccount)
   }
+
+  override def testSAGoogleBucketIam(bucketName: GcsBucketName, saKey: String, permissions: Set[IamPermission])(implicit executionContext: ExecutionContext): Future[Set[IamPermission]] = Future.successful(permissions)
+
+  override def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit executionContext: ExecutionContext): Future[Set[IamPermission]] = Future.successful(permissions)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -531,6 +531,8 @@ class SubmissionSpec(_system: ActorSystem)
         terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
         terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
         terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
+        terraBucketReaderRole = "fakeTerraBucketReaderRole",
+        terraBucketWriterRole = "fakeTerraBucketWriterRole",
         new RawlsWorkspaceAclManager(samDAO),
         new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
       ) _

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -341,6 +341,8 @@ trait ApiServiceSpec
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
       terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
       terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
+      terraBucketReaderRole = "fakeTerraBucketReaderRole",
+      terraBucketWriterRole = "fakeTerraBucketWriterRole",
       rawlsWorkspaceAclManager,
       multiCloudWorkspaceAclManager
     ) _

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/StatusApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/StatusApiServiceSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import bio.terra.profile.model.SystemStatus
-import com.google.api.services.admin.directory.model.Group
+import com.google.api.services.directory.model.Group
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.rawls.dataaccess.{MockGoogleServicesDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -264,6 +264,8 @@ class WorkspaceServiceSpec
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
       terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",
       terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole",
+      terraBucketReaderRole = "fakeTerraBucketReaderRole",
+      terraBucketWriterRole = "fakeTerraBucketWriterRole",
       rawlsWorkspaceAclManager,
       multiCloudWorkspaceAclManager
     ) _

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -93,6 +93,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     terraBillingProjectOwnerRole: String = "",
     terraWorkspaceCanComputeRole: String = "",
     terraWorkspaceNextflowRole: String = "",
+    terraBucketReaderRole: String = "",
+    terraBucketWriterRole: String = "",
     billingProfileManagerDAO: BillingProfileManagerDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS),
     aclManagerDatasource: SlickDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS)
   ): RawlsRequestContext => WorkspaceService = info =>
@@ -123,6 +125,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
       terraBillingProjectOwnerRole,
       terraWorkspaceCanComputeRole,
       terraWorkspaceNextflowRole,
+      terraBucketReaderRole,
+      terraBucketWriterRole,
       new RawlsWorkspaceAclManager(samDAO),
       new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, aclManagerDatasource)
     )(info)(mock[Materializer], scala.concurrent.ExecutionContext.global)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,6 @@ object Dependencies {
   val slickV = "3.4.1"
 
   val googleV = "2.0.0"
-  val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
@@ -48,7 +47,7 @@ object Dependencies {
   val googleIam: ModuleID =                   excludeGuavaJDK5("com.google.apis"        % "google-api-services-iam"                   % ("v1-rev20230105-" + googleV))
   val googleIamCredentials: ModuleID =        excludeGuavaJDK5("com.google.apis"        % "google-api-services-iamcredentials"        % ("v1-rev20211203-" + googleV))
 
-  val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev72-" + olderGoogleV)
+  val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev20230119-" + googleV)
   val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20230112-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2-rev20220908-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,7 +95,7 @@ object Dependencies {
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model"  % workbenchModelV
   val workbenchGoogle: ModuleID =       "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV
   val workbenchGoogleMocks: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests"
-  val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll(ExclusionRule("org.apache.arrow"), ExclusionRule("io.netty"))
+  val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
   val workbenchGoogle2Tests: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests"
   val workbenchNotifications: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll(excludeWorkbenchGoogle)
   val workbenchOauth2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,7 +95,7 @@ object Dependencies {
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model"  % workbenchModelV
   val workbenchGoogle: ModuleID =       "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV
   val workbenchGoogleMocks: ModuleID =  "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV % "test" classifier "tests"
-  val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V
+  val workbenchGoogle2: ModuleID =      "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V excludeAll(ExclusionRule("org.apache.arrow"), ExclusionRule("io.netty"))
   val workbenchGoogle2Tests: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V % "test" classifier "tests"
   val workbenchNotifications: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll(excludeWorkbenchGoogle)
   val workbenchOauth2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,10 +49,7 @@ object Dependencies {
   val googleIamCredentials: ModuleID =        excludeGuavaJDK5("com.google.apis"        % "google-api-services-iamcredentials"        % ("v1-rev20210326-" + googleV))
 
   val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev72-" + olderGoogleV)
-  val googleAdminDirectory: ModuleID =    "com.google.apis"   % "google-api-services-admin-directory"   % ("directory_v1-rev53-" + olderGoogleV)
-  val googlePlus: ModuleID =              "com.google.apis"   % "google-api-services-plus"              % ("v1-rev381-" + olderGoogleV)
   val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20210322-" + googleV)
-  val googleServicemanagement: ModuleID = "com.google.apis"   % "google-api-services-servicemanagement" % ("v1-rev20210604-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
@@ -85,10 +82,10 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "f7103bc"
+  val workbenchLibsHash = "46d1df6"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.21-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.22-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.3-a79c7f9" //See SU-278 for why this version deviates from workbenchLibsHash
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"
@@ -185,10 +182,7 @@ object Dependencies {
     googleIam,
     googleIamCredentials,
     googleCompute,
-    googleAdminDirectory,
-    googlePlus,
     googlePubSub,
-    googleServicemanagement,
     googleDeploymentManager,
     googleGuava
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaHttpV = "10.2.9"
   val slickV = "3.4.1"
 
-  val googleV = "1.31.0"
+  val googleV = "2.0.0"
   val olderGoogleV = "1.20.0"   // TODO why do we have two google versions?  GAWB-2149
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
@@ -40,17 +40,17 @@ object Dependencies {
   val cromwellClient: ModuleID =    "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP"
 
   val googleApiClient: ModuleID =             excludeGuavaJDK5("com.google.api-client"  % "google-api-client"                         % googleV)
-  val googleCloudBilling: ModuleID =          excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudbilling"          % ("v1-rev20210322-" + googleV))
-  val googleGenomics: ModuleID =              excludeGuavaJDK5("com.google.apis"        % "google-api-services-genomics"              % ("v2alpha1-rev20210605-" + googleV))
-  val googleLifeSciences: ModuleID =          excludeGuavaJDK5("com.google.apis"        % "google-api-services-lifesciences"          % ("v2beta-rev20210527-" + googleV))
-  val googleStorage: ModuleID =               excludeGuavaJDK5("com.google.apis"        % "google-api-services-storage"               % ("v1-rev20210127-" + googleV))
-  val googleCloudResourceManager: ModuleID =  excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudresourcemanager"  % ("v1-rev20210613-" + googleV))
-  val googleIam: ModuleID =                   excludeGuavaJDK5("com.google.apis"        % "google-api-services-iam"                   % ("v1-rev20210211-" + googleV))
-  val googleIamCredentials: ModuleID =        excludeGuavaJDK5("com.google.apis"        % "google-api-services-iamcredentials"        % ("v1-rev20210326-" + googleV))
+  val googleCloudBilling: ModuleID =          excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudbilling"          % ("v1-rev20220908-" + googleV))
+  val googleGenomics: ModuleID =              excludeGuavaJDK5("com.google.apis"        % "google-api-services-genomics"              % ("v2alpha1-rev20220913-" + googleV))
+  val googleLifeSciences: ModuleID =          excludeGuavaJDK5("com.google.apis"        % "google-api-services-lifesciences"          % ("v2beta-rev20220916-" + googleV))
+  val googleStorage: ModuleID =               excludeGuavaJDK5("com.google.apis"        % "google-api-services-storage"               % ("v1-rev20220705-" + googleV))
+  val googleCloudResourceManager: ModuleID =  excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudresourcemanager"  % ("v1-rev20220828-" + googleV))
+  val googleIam: ModuleID =                   excludeGuavaJDK5("com.google.apis"        % "google-api-services-iam"                   % ("v1-rev20230105-" + googleV))
+  val googleIamCredentials: ModuleID =        excludeGuavaJDK5("com.google.apis"        % "google-api-services-iamcredentials"        % ("v1-rev20211203-" + googleV))
 
   val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev72-" + olderGoogleV)
-  val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20210322-" + googleV)
-  val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2beta-rev20210311-" + googleV)
+  val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20230112-" + googleV)
+  val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2-rev20220908-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
   // metrics4-scala and metrics3-statsd are pulled in by workbench-metrics, which is pulled in by

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,6 +50,7 @@ object Dependencies {
   val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev20230119-" + googleV)
   val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20230112-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2-rev20220908-" + googleV)
+  val accessContextManager: ModuleID =    "com.google.apis"   % "google-api-services-accesscontextmanager" % ("v1-rev20230109-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
 
   // metrics4-scala and metrics3-statsd are pulled in by workbench-metrics, which is pulled in by
@@ -104,8 +105,6 @@ object Dependencies {
   val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.6-${workbenchLibsHash}"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.14.1"
-
-  val accessContextManager = "com.google.apis" % "google-api-services-accesscontextmanager" % "v1-rev20220620-1.32.1"
 
   // should we prefer jakarta over javax.xml?
   def excludeJakartaActivationApi = ExclusionRule("jakarta.activation", "jakarta.activation-api")

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -17,6 +17,8 @@ object Merging {
     case "logback.xml" => MergeStrategy.first
     case x if x.endsWith("kotlin-stdlib.kotlin_module") => MergeStrategy.first
     case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
+    case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.concat
+    case x if x.endsWith("arrow-git.properties") => MergeStrategy.concat
     case x => oldStrategy(x)
   }
 }

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,6 +15,8 @@ object Merging {
     case PathList("javax", "ws", "rs", _ @ _*) => MergeStrategy.first
     case "version.conf" => MergeStrategy.concat
     case "logback.xml" => MergeStrategy.first
+    case x if x.endsWith("kotlin-stdlib.kotlin_module") => MergeStrategy.first
+    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
     case x => oldStrategy(x)
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-746

3 general changes

1. update `workbenchServiceTestHash` to pull in changes to polling of workspace permissions
2. a bunch of library updates triggered by conflicts when pulling a new workbench-libs google version
3. the purpose of this PR - change how we check the user's google permissions from attempting to read a bucket to checking their expected permissions on bucket and project. Based on the roles of the user in sam, figure out which custom roles the user should have, look up the permissions for each, then use the `testIamPermission` api on bucket and project.

Some tech debt here is that the function and api is still named `checkBucketReadAccess`. The function is now more wholistic. Changing the api is a bigger deal. I hope the reviewer will forgive this in light of the tech debt payment made in library cleanup.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
