### PR TITLE
[SU-284] Endpoint for batch updating billing project members + email invites

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -401,6 +401,44 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
+    patch:
+      tags:
+        - billing_v2
+      summary: batch update members of billing project
+      description: batch update members of billing project. only owners may perform this action.
+      operationId: batchUpdateBillingProjectMembersV2
+      parameters:
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
+        - name: inviteUsersNotFound
+          in: query
+          description: true to invite unregistered users, false to ignore
+          required: true
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        description: billing project access updates
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/BatchProjectAccessUpdate'
+      responses:
+        204:
+          description: No Content
+        403:
+          description: You must be a project owner to alter the members of a project
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        409:
+          description: You have specified a member that does not exist in the system. Use the inviteUsersNotFound query param to invite them
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}/spendReport:
     get:
       tags:
@@ -5652,6 +5690,22 @@ components:
           role:
             description: the role to modify for the specified member
             $ref: '#/components/schemas/ProjectRole'
+    BatchProjectAccessUpdate:
+        required:
+          - membersToAdd
+          - membersToRemove
+        type: object
+        properties:
+          membersToAdd:
+            description: The list of members to add to the billing project
+            type: array
+            items:
+              $ref: '#/components/schemas/ProjectAccessUpdate'
+          membersToRemove:
+            description: The list of members to remove from the billing project
+            type: array
+            items:
+              $ref: '#/components/schemas/ProjectAccessUpdate'
     SpendReport:
       required:
         - spendDetails

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -357,7 +357,8 @@ object Boot extends IOApp with LazyLogging {
           servicePerimeterService,
           RawlsBillingAccountName(gcsConfig.getString("adminRegisterBillingAccountId")),
           billingProfileManagerDAO,
-          workspaceManagerDAO
+          workspaceManagerDAO,
+          notificationDAO
         )
 
       val maxActiveWorkflowsTotal =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -124,6 +124,8 @@ case class RawlsBillingProjectTransfer(project: String, bucket: String, newOwner
 
 case class ProjectAccessUpdate(email: String, role: ProjectRole)
 
+case class BatchProjectAccessUpdate(membersToAdd: Set[ProjectAccessUpdate], membersToRemove: Set[ProjectAccessUpdate])
+
 object ProjectRoles {
   sealed trait ProjectRole extends RawlsEnumeration[ProjectRole] {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
@@ -284,6 +286,8 @@ class UserAuthJsonSupport extends JsonSupport {
   implicit val SyncReportFormat: RootJsonFormat[SyncReport] = jsonFormat2(SyncReport)
 
   implicit val ProjectAccessUpdateFormat: RootJsonFormat[ProjectAccessUpdate] = jsonFormat2(ProjectAccessUpdate)
+
+  implicit val BatchProjectAccessUpdateFormat: RootJsonFormat[BatchProjectAccessUpdate] = jsonFormat2(BatchProjectAccessUpdate)
 
   implicit val CreateRawlsBillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsBillingProjectFullRequest] =
     jsonFormat6(CreateRawlsBillingProjectFullRequest)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -287,7 +287,9 @@ class UserAuthJsonSupport extends JsonSupport {
 
   implicit val ProjectAccessUpdateFormat: RootJsonFormat[ProjectAccessUpdate] = jsonFormat2(ProjectAccessUpdate)
 
-  implicit val BatchProjectAccessUpdateFormat: RootJsonFormat[BatchProjectAccessUpdate] = jsonFormat2(BatchProjectAccessUpdate)
+  implicit val BatchProjectAccessUpdateFormat: RootJsonFormat[BatchProjectAccessUpdate] = jsonFormat2(
+    BatchProjectAccessUpdate
+  )
 
   implicit val CreateRawlsBillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsBillingProjectFullRequest] =
     jsonFormat6(CreateRawlsBillingProjectFullRequest)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -789,10 +789,10 @@ class UserService(
       val membersToAdd = batchProjectAccessUpdate.membersToAdd
       val membersToRemove = batchProjectAccessUpdate.membersToRemove
 
-      collectMissingUsers(membersToAdd.map(_.email), ctx) flatMap { membersToInvite =>
-        if (membersToInvite.isEmpty || inviteUsersNotFound) {
+      collectMissingUsers(membersToAdd.map(_.email), ctx) flatMap { missingUsers =>
+        if (missingUsers.isEmpty || inviteUsersNotFound) {
           for {
-            invites <- Future.traverse(membersToInvite) { invite =>
+            invites <- Future.traverse(missingUsers) { invite =>
               samDAO.inviteUser(invite, ctx).map { _ =>
                 Notifications.BillingProjectInvitedNotification(
                   WorkbenchEmail(invite),
@@ -811,7 +811,7 @@ class UserService(
         } else
           Future.failed(
             new RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.Conflict, s"Users ${membersToInvite.mkString(",")} have not signed up for Terra")
+              ErrorReport(StatusCodes.Conflict, s"Users ${missingUsers.mkString(",")} have not signed up for Terra")
             )
           )
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -816,7 +816,7 @@ class UserService(
         } else
           Future.failed(
             new RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.Conflict, s"Users ${membersToInvite.mkString(",")} not found in Sam")
+              ErrorReport(StatusCodes.Conflict, s"Users ${membersToInvite.mkString(",")} have not signed up for Terra")
             )
           )
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -24,12 +24,7 @@ import org.broadinstitute.dsde.rawls.user.UserService._
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, RoleSupport, UserUtils, UserWiths}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, StringValidationUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
-import org.broadinstitute.dsde.workbench.model.{
-  Notifications,
-  WorkbenchEmail,
-  WorkbenchExceptionWithErrorReport,
-  WorkbenchUserId
-}
+import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryTableName, GoogleProject}
 
 import java.net.URLEncoder

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -159,15 +159,20 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
                     userServiceConstructor(ctx).getBillingProjectMembers(RawlsBillingProjectName(projectId))
                   }
                 } ~
-                patch {
-                  parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound =>
-                    entity(as[BatchProjectAccessUpdate]) { batchProjectAccessUpdate =>
-                      complete {
-                        userServiceConstructor(ctx).batchUpdateBillingProjectMembers(RawlsBillingProjectName(projectId), batchProjectAccessUpdate, inviteUsersNotFound.getOrElse("false").toBoolean).map(_ => StatusCodes.NoContent -> None)
+                  patch {
+                    parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound =>
+                      entity(as[BatchProjectAccessUpdate]) { batchProjectAccessUpdate =>
+                        complete {
+                          userServiceConstructor(ctx)
+                            .batchUpdateBillingProjectMembers(RawlsBillingProjectName(projectId),
+                                                              batchProjectAccessUpdate,
+                                                              inviteUsersNotFound.getOrElse("false").toBoolean
+                            )
+                            .map(_ => StatusCodes.NoContent -> None)
+                        }
                       }
                     }
                   }
-                }
               } ~
                 // these routes are for adding/removing users from projects
                 path(Segment / Segment) { (workbenchRole, userEmail) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -158,6 +158,15 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
                   complete {
                     userServiceConstructor(ctx).getBillingProjectMembers(RawlsBillingProjectName(projectId))
                   }
+                } ~
+                patch {
+                  parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound =>
+                    entity(as[BatchProjectAccessUpdate]) { batchProjectAccessUpdate =>
+                      complete {
+                        userServiceConstructor(ctx).batchUpdateBillingProjectMembers(RawlsBillingProjectName(projectId), batchProjectAccessUpdate, inviteUsersNotFound.getOrElse("false").toBoolean).map(_ => StatusCodes.NoContent -> None)
+                      }
+                    }
+                  }
                 }
               } ~
                 // these routes are for adding/removing users from projects

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -324,7 +324,11 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(billingAccount)
   }
 
-  override def testSAGoogleBucketIam(bucketName: GcsBucketName, saKey: String, permissions: Set[IamPermission])(implicit executionContext: ExecutionContext): Future[Set[IamPermission]] = Future.successful(permissions)
+  override def testSAGoogleBucketIam(bucketName: GcsBucketName, saKey: String, permissions: Set[IamPermission])(implicit
+    executionContext: ExecutionContext
+  ): Future[Set[IamPermission]] = Future.successful(permissions)
 
-  override def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit executionContext: ExecutionContext): Future[Set[IamPermission]] = Future.successful(permissions)
+  override def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
+    executionContext: ExecutionContext
+  ): Future[Set[IamPermission]] = Future.successful(permissions)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -462,7 +462,8 @@ class SubmissionSpec(_system: ActorSystem)
         servicePerimeterService,
         RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
         billingProfileManagerDAO,
-        mock[WorkspaceManagerDAO]
+        mock[WorkspaceManagerDAO],
+        mock[NotificationDAO]
       ) _
 
       val genomicsServiceConstructor = GenomicsService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.user
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.profile.model.{CloudPlatform => BPMCloudPlatform, ProfileModel}
+import bio.terra.profile.model.{ProfileModel, CloudPlatform => BPMCloudPlatform}
 import bio.terra.workspace.model.{AzureLandingZoneDetails, AzureLandingZoneResult, JobReport}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, Work
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
+import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -108,7 +109,8 @@ class UserServiceSpec
       workspaceManagerDao,
       bpmDAO,
       billingRepository.getOrElse(new BillingRepository(dataSource)),
-      workspaceMonitorRecordDao.getOrElse(new WorkspaceManagerResourceMonitorRecordDao(dataSource))
+      workspaceMonitorRecordDao.getOrElse(new WorkspaceManagerResourceMonitorRecordDao(dataSource)),
+      mock[NotificationDAO]
     )
 
   // 204 when project exists without perimeter and user is owner of project and has right permissions on service-perimeter

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -231,7 +231,8 @@ trait ApiServiceSpec
       servicePerimeterService,
       RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
       billingProfileManagerDAO,
-      mock[WorkspaceManagerDAO]
+      mock[WorkspaceManagerDAO],
+      mock[NotificationDAO]
     ) _
 
     override val snapshotServiceConstructor = SnapshotService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -608,6 +608,148 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
         }
   }
 
+  "PATCH /billing/v2/{projectName}/members" should "return 204 when all members exist" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("project")
+
+      when(
+        services.samDAO.addUserToPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          any[SamResourcePolicyName],
+          any[String],
+          ArgumentMatchers.argThat(userInfoEq(testContext))
+        )
+      ).thenReturn(
+        Future.successful()
+      )
+
+      when(services.samDAO.getUserIdInfo(any(), any())).thenReturn(
+        Future.successful(SamDAO.User(UserIdInfo("fake_user_id", "user@example.com", Option("fake_google_subject_id"))))
+      )
+
+      Patch(
+        s"/billing/v2/${project.projectName.value}/members",
+        BatchProjectAccessUpdate(Set(ProjectAccessUpdate("user1@test.edu", ProjectRoles.Owner),
+                                     ProjectAccessUpdate("user2@test.edu", ProjectRoles.User)
+                                 ),
+                                 Set.empty
+        )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+        }
+  }
+
+  it should "return 409 when trying to add a member that does not exist and inviteUsersNotFound=false" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("project")
+
+      when(
+        services.samDAO.addUserToPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          any[SamResourcePolicyName],
+          any[String],
+          ArgumentMatchers.argThat(userInfoEq(testContext))
+        )
+      ).thenReturn(
+        Future.successful()
+      )
+
+      when(services.samDAO.getUserIdInfo(any(), any())).thenReturn(
+        Future.successful(SamDAO.NotFound)
+      )
+
+      Patch(
+        s"/billing/v2/${project.projectName.value}/members",
+        BatchProjectAccessUpdate(Set(ProjectAccessUpdate("user1@test.edu", ProjectRoles.Owner),
+                                     ProjectAccessUpdate("user2@test.edu", ProjectRoles.User)
+                                 ),
+                                 Set.empty
+        )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.Conflict) {
+            status
+          }
+        }
+  }
+
+  it should "return 204 when trying to add a member that does not exist and inviteUsersNotFound=true" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("project")
+
+      when(
+        services.samDAO.addUserToPolicy(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          any[SamResourcePolicyName],
+          any[String],
+          ArgumentMatchers.argThat(userInfoEq(testContext))
+        )
+      ).thenReturn(
+        Future.successful()
+      )
+
+      when(services.samDAO.getUserIdInfo(any(), any())).thenReturn(
+        Future.successful(SamDAO.NotFound)
+      )
+
+      when(services.samDAO.inviteUser(any(), any())).thenReturn(
+        Future.successful()
+      )
+
+      Patch(
+        s"/billing/v2/${project.projectName.value}/members?inviteUsersNotFound=true",
+        BatchProjectAccessUpdate(Set(ProjectAccessUpdate("user1@test.edu", ProjectRoles.Owner),
+                                     ProjectAccessUpdate("user2@test.edu", ProjectRoles.User)
+                                 ),
+                                 Set.empty
+        )
+      ) ~>
+        sealRoute(services.billingRoutesV2) ~>
+        check {
+          assertResult(StatusCodes.NoContent) {
+            status
+          }
+        }
+
+      verify(services.samDAO, times(2)).inviteUser(any(), any())
+  }
+
+  it should "return 403 with non-owner role" in withEmptyDatabaseAndApiServices { services =>
+    val project = createProject("project")
+
+    when(
+      services.samDAO.userHasAction(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(project.projectName.value),
+        ArgumentMatchers.eq(SamBillingProjectActions.alterPolicies),
+        ArgumentMatchers.argThat(userInfoEq(testContext))
+      )
+    ).thenReturn(Future.successful(false))
+
+    Patch(
+      s"/billing/v2/${project.projectName.value}/members",
+      BatchProjectAccessUpdate(Set(ProjectAccessUpdate("user1@test.edu", ProjectRoles.Owner),
+                                   ProjectAccessUpdate("user2@test.edu", ProjectRoles.User)
+                               ),
+                               Set.empty
+      )
+    ) ~>
+      sealRoute(services.billingRoutesV2) ~>
+      check {
+        assertResult(StatusCodes.Forbidden) {
+          status
+        }
+      }
+  }
+
   "GET /billing/v2/{projectName}" should "return 200 with owner role" in withEmptyDatabaseAndApiServices { services =>
     val project = createProject("project")
     when(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -172,7 +172,8 @@ class WorkspaceServiceSpec
       servicePerimeterService,
       RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
       billingProfileManagerDAO,
-      mock[WorkspaceManagerDAO]
+      mock[WorkspaceManagerDAO],
+      mock[NotificationDAO]
     ) _
 
     val genomicsServiceConstructor = GenomicsService.constructor(


### PR DESCRIPTION
This PR adds a new endpoint to batch update the members of a billing project. Currently users have to be added one by one which can be a painful UX, and using a managed group isn't always the best option.

This PR also implements the new billing project email invite / pending access for unregistered users.

Ticket: https://broadworkbench.atlassian.net/browse/SU-284

This also relates to https://broadworkbench.atlassian.net/browse/WOR-601



---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[SUP-758]: https://broadworkbench.atlassian.net/browse/SUP-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ