### PR TITLE
[WOR-741] add new owners to pet-creator policy too

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
@@ -117,9 +117,11 @@ class MultiCloudWorkspaceAclManager(workspaceManagerDAO: WorkspaceManagerDAO,
     workspaceName: WorkspaceName,
     ctx: RawlsRequestContext
   ): Future[Unit] = {
-    val newWriterEmails = policyAdditions.collect { case (SamWorkspacePolicyNames.writer, email) => email }
+    val newPetCreatorEmails = policyAdditions.collect {
+      case (SamWorkspacePolicyNames.writer | SamWorkspacePolicyNames.owner, email) => email
+    }
 
-    if (newWriterEmails.isEmpty) {
+    if (newPetCreatorEmails.isEmpty) {
       Future.successful()
     } else {
       for {
@@ -143,7 +145,7 @@ class MultiCloudWorkspaceAclManager(workspaceManagerDAO: WorkspaceManagerDAO,
             )
           )
         _ <- Future
-          .traverse(newWriterEmails) { email =>
+          .traverse(newPetCreatorEmails) { email =>
             Future(
               billingProfileManagerDAO
                 .addProfilePolicyMember(UUID.fromString(workspaceBillingProfileId),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
@@ -49,7 +49,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
       ExecutionContext.global
     )
 
-  "maybeShareWorkspaceNamespaceCompute" should "add new writers to the pet-creator billing profile policy" in {
+  "maybeShareWorkspaceNamespaceCompute" should "add new writers and owners to the pet-creator billing profile policy" in {
     val policyAdditions = Set(
       (SamWorkspacePolicyNames.writer, "writer1@example.com"),
       (SamWorkspacePolicyNames.writer, "writer2@example.com"),
@@ -103,7 +103,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
     )
 
     policyAdditions.foreach {
-      case (SamWorkspacePolicyNames.writer, email) =>
+      case (SamWorkspacePolicyNames.writer | SamWorkspacePolicyNames.owner, email) =>
         verify(mockBpmDAO).addProfilePolicyMember(ArgumentMatchers.eq(billingProfileId),
                                                   ArgumentMatchers.eq(ProfilePolicy.PetCreator),
                                                   ArgumentMatchers.eq(email),


### PR DESCRIPTION
Ticket: [WOR-741](https://broadworkbench.atlassian.net/browse/WOR-741)
* add new workspace owners to pet-creator policy also

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-741]: https://broadworkbench.atlassian.net/browse/WOR-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ