### PR TITLE
Make methods private if they can be (WOR-721).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -532,8 +532,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
 
   private def getUserSharePermissions(workspaceId: String,
-                              userAccessLevel: WorkspaceAccessLevel,
-                              accessLevelToShareWith: WorkspaceAccessLevel
+                                      userAccessLevel: WorkspaceAccessLevel,
+                                      accessLevelToShareWith: WorkspaceAccessLevel
   ): Future[Boolean] =
     if (userAccessLevel < WorkspaceAccessLevels.Read) Future.successful(false)
     else if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
@@ -2249,12 +2249,12 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
 
   private def saveSubmission(workspaceContext: Workspace,
-                     submissionId: UUID,
-                     submissionRequest: SubmissionRequest,
-                     submissionRoot: String,
-                     submissionParameters: Seq[SubmissionValidationEntityInputs],
-                     workflowFailureMode: Option[WorkflowFailureMode],
-                     header: SubmissionValidationHeader
+                             submissionId: UUID,
+                             submissionRequest: SubmissionRequest,
+                             submissionRoot: String,
+                             submissionParameters: Seq[SubmissionValidationEntityInputs],
+                             workflowFailureMode: Option[WorkflowFailureMode],
+                             header: SubmissionValidationHeader
   ): Future[Submission] =
     dataSource.inTransaction { dataAccess =>
       val (successes, failures) = submissionParameters.partition { entityInputs =>
@@ -2325,9 +2325,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
 
   private def logAndCreateDbSubmission(workspaceContext: Workspace,
-                               submissionId: UUID,
-                               submission: Submission,
-                               dataAccess: DataAccess
+                                       submissionId: UUID,
+                                       submission: Submission,
+                                       dataAccess: DataAccess
   ): ReadWriteAction[Submission] = {
     // implicitly passed to SubmissionComponent.create
     implicit val subStatusCounter = submissionStatusCounter(workspaceMetricBuilder(workspaceContext.toWorkspaceName))
@@ -3030,7 +3030,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     }
 
   private def failUnlessBillingAccountHasAccess(billingProject: RawlsBillingProject,
-                                        parentContext: RawlsRequestContext = ctx
+                                                parentContext: RawlsRequestContext = ctx
   ): Future[Unit] =
     traceWithParent("updateAndGetBillingAccountAccess", parentContext) { s =>
       updateAndGetBillingAccountAccess(billingProject, s).map { hasAccess =>
@@ -3053,7 +3053,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     * FALSE
     */
   private def updateAndGetBillingAccountAccess(billingProject: RawlsBillingProject,
-                                       parentContext: RawlsRequestContext
+                                               parentContext: RawlsRequestContext
   ): Future[Boolean] =
     for {
       billingAccountName <- billingProject.billingAccount

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -625,7 +625,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       } yield ()
     }
 
-  private def assertNoGoogleChildrenBlockingWorkspaceDeletion(workspace: Workspace): Future[Unit] = for {
+  def assertNoGoogleChildrenBlockingWorkspaceDeletion(workspace: Workspace): Future[Unit] = for {
     _ <- ApplicativeThrow[Future].raiseWhen(workspace.googleProjectId.value.isEmpty) {
       RawlsExceptionWithErrorReport(
         ErrorReport(


### PR DESCRIPTION
In preparation for some filtering of workspaces (filtering out V1 workspaces) in WOR-721, reduce the public API of `WorkspaceService`.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
