### PR TITLE
Limit WorkspaceService, EntityService, and SnapshotService to V2 workspaces (WOR-721).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -3,7 +3,12 @@ package org.broadinstitute.dsde.rawls.billing
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProject, RawlsBillingProjectName, WorkspaceVersions}
+import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  WorkspaceVersions
+}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 
 import java.util.UUID

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
-
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProject, RawlsBillingProjectName}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProject, RawlsBillingProjectName, WorkspaceVersions}
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
@@ -93,15 +92,25 @@ class BillingRepository(dataSource: SlickDataSource) {
 
   def failUnlessHasNoWorkspaces(projectName: RawlsBillingProjectName)(implicit ec: ExecutionContext): Future[Unit] =
     dataSource.inTransaction { dataAccess =>
-      dataAccess.workspaceQuery.countByNamespace(projectName) map { count =>
-        if (count == 0) ()
-        else
+      for {
+        workspaces <- dataAccess.workspaceQuery.listWorkspacesByNamespace(projectName)
+        (v1Workspaces, v2Workspaces) = workspaces.partition(ws => ws.workspaceVersion == WorkspaceVersions.V1)
+        _ = v2Workspaces map { _ =>
           throw new RawlsExceptionWithErrorReport(
             ErrorReport(
               StatusCodes.BadRequest,
               "Project cannot be deleted because it contains workspaces."
             )
           )
-      }
+        }
+        _ = v1Workspaces map { _ =>
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              "Project cannot be deleted because it contains v1 workspaces. Contact support for help."
+            )
+          )
+        }
+      } yield {}
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -348,6 +348,9 @@ trait WorkspaceComponent {
     ): ReadAction[Seq[Workspace]] =
       loadWorkspaces(findV2WorkspacesByIdsQuery(workspaceIds), attributeSpecs)
 
+    def listWorkspacesByNamespace(namespaceName: RawlsBillingProjectName): ReadAction[Seq[Workspace]] =
+      loadWorkspaces(findByNamespaceQuery(namespaceName))
+
     def countByNamespace(namespaceName: RawlsBillingProjectName): ReadAction[Int] =
       findByNamespaceQuery(namespaceName).size.result
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -348,9 +348,6 @@ trait WorkspaceComponent {
     ): ReadAction[Seq[Workspace]] =
       loadWorkspaces(findV2WorkspacesByIdsQuery(workspaceIds), attributeSpecs)
 
-    def listWorkspacesByNamespace(namespaceName: RawlsBillingProjectName): ReadAction[Seq[Workspace]] =
-      loadWorkspaces(findByNamespaceQuery(namespaceName))
-
     def countByNamespace(namespaceName: RawlsBillingProjectName): ReadAction[Int] =
       findByNamespaceQuery(namespaceName).size.result
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -326,6 +326,11 @@ trait WorkspaceComponent {
     ): ReadAction[Option[Workspace]] =
       loadWorkspace(findByNameQuery(workspaceName), attributeSpecs)
 
+    def findV2WorkspaceByName(workspaceName: WorkspaceName,
+                              attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+    ): ReadAction[Option[Workspace]] =
+      loadWorkspace(findV2WorkspaceByNameQuery(workspaceName), attributeSpecs)
+
     def findById(workspaceId: String): ReadAction[Option[Workspace]] =
       loadWorkspace(findByIdQuery(UUID.fromString(workspaceId)))
 
@@ -338,8 +343,10 @@ trait WorkspaceComponent {
     ): ReadAction[Seq[Workspace]] =
       loadWorkspaces(findByIdsQuery(workspaceIds), attributeSpecs)
 
-    def listByNamespaces(namespaceNames: Seq[RawlsBillingProjectName]): ReadAction[Seq[Workspace]] =
-      loadWorkspaces(findByNamespacesQuery(namespaceNames))
+    def listV2WorkspacesByIds(workspaceIds: Seq[UUID],
+                              attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+    ): ReadAction[Seq[Workspace]] =
+      loadWorkspaces(findV2WorkspacesByIdsQuery(workspaceIds), attributeSpecs)
 
     def countByNamespace(namespaceName: RawlsBillingProjectName): ReadAction[Int] =
       findByNamespaceQuery(namespaceName).size.result
@@ -373,6 +380,9 @@ trait WorkspaceComponent {
 
     def getWorkspaceId(workspaceName: WorkspaceName): ReadAction[Option[UUID]] =
       uniqueResult(workspaceQuery.findByNameQuery(workspaceName).result).map(x => x.map(_.id))
+
+    def getV2WorkspaceId(workspaceName: WorkspaceName): ReadAction[Option[UUID]] =
+      uniqueResult(workspaceQuery.findV2WorkspaceByNameQuery(workspaceName).result).map(x => x.map(_.id))
 
     /**
       * Lists all workspaces with a particular attribute name/value pair.
@@ -513,8 +523,16 @@ trait WorkspaceComponent {
     private def findByNameQuery(workspaceName: WorkspaceName): WorkspaceQueryType =
       filter(rec => (rec.namespace === workspaceName.namespace) && (rec.name === workspaceName.name))
 
+    private def findV2WorkspaceByNameQuery(workspaceName: WorkspaceName): WorkspaceQueryType =
+      filter(rec =>
+        (rec.namespace === workspaceName.namespace) && (rec.name === workspaceName.name) && (rec.workspaceVersion === WorkspaceVersions.V2.value)
+      )
+
     def findByIdQuery(workspaceId: UUID): WorkspaceQueryType =
       workspaceQuery.withWorkspaceId(workspaceId)
+
+    def findV2WorkspaceByIdQuery(workspaceId: UUID): WorkspaceQueryType =
+      workspaceQuery.withWorkspaceId(workspaceId).withVersion(WorkspaceVersions.V2)
 
     def findByIdAndRecordVersionQuery(workspaceId: UUID, recordVersion: Long): WorkspaceQueryType =
       filter(w => w.id === workspaceId && w.recordVersion === recordVersion)
@@ -522,11 +540,11 @@ trait WorkspaceComponent {
     def findByIdsQuery(workspaceIds: Seq[UUID]): WorkspaceQueryType =
       filter(_.id.inSetBind(workspaceIds))
 
+    def findV2WorkspacesByIdsQuery(workspaceIds: Seq[UUID]): WorkspaceQueryType =
+      filter(w => w.id.inSetBind(workspaceIds) && w.workspaceVersion === WorkspaceVersions.V2.value)
+
     private def findByNamespaceQuery(namespaceName: RawlsBillingProjectName): WorkspaceQueryType =
       workspaceQuery.withBillingProject(namespaceName)
-
-    private def findByNamespacesQuery(namespaceNames: Seq[RawlsBillingProjectName]): WorkspaceQueryType =
-      filter(_.namespace.inSetBind(namespaceNames.map(_.value)))
 
     private def loadWorkspace(lookup: WorkspaceQueryType,
                               attributeSpecs: Option[WorkspaceAttributeSpecs] = None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -13,7 +13,6 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   SamWorkspaceActions,
   SnapshotListResponse,
-  UserInfo,
   WorkspaceAttributeSpecs,
   WorkspaceName
 }
@@ -45,9 +44,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     with LazyLogging {
 
   def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataRepoSnapshotResource] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { workspaceContext =>
       val wsid = workspaceContext.workspaceIdAsUUID // to avoid UUID parsing multiple times
       // create the stub workspace in WSM if it does not already exist
@@ -68,9 +67,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
   def getSnapshot(workspaceName: WorkspaceName, referenceId: String): Future[DataRepoSnapshotResource] = {
     val referenceUuid = validateSnapshotId(referenceId)
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceUuid, ctx)
       Future.successful(ref)
@@ -78,9 +77,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
   }
 
   def getSnapshotByName(workspaceName: WorkspaceName, referenceName: String): Future[DataRepoSnapshotResource] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReferenceByName(workspaceContext.workspaceIdAsUUID,
                                                                        DataReferenceName(referenceName),
@@ -133,9 +132,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
                          limit: Int,
                          referencedSnapshotId: Option[UUID] = None
   ): Future[SnapshotListResponse] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).map { workspaceContext =>
       referencedSnapshotId match {
         case None     => retrieveSnapshotReferences(workspaceContext.workspaceIdAsUUID, offset, limit)
@@ -196,9 +195,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
                      updateInfo: UpdateDataRepoSnapshotReferenceRequestBody
   ): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).map { workspaceContext =>
       // check that snapshot exists before updating it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)
@@ -222,9 +221,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
   def deleteSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).map { workspaceContext =>
       // check that snapshot exists before deleting it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.{McWorkspace, RawlsWorkspace}
 import org.broadinstitute.dsde.rawls.model.{
-  AzureManagedAppCoordinates,
   ErrorReport,
   MultiCloudWorkspaceRequest,
   RawlsBillingProject,
@@ -194,7 +193,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                destWorkspaceRequest: WorkspaceRequest
   ): Future[Workspace] =
     for {
-      sourceWs <- getWorkspaceContextAndPermissions(sourceWorkspaceName, SamWorkspaceActions.read)
+      sourceWs <- getV2WorkspaceContextAndPermissions(sourceWorkspaceName, SamWorkspaceActions.read)
       billingProject <- getBillingProjectContext(RawlsBillingProjectName(destWorkspaceRequest.namespace))
       _ <- requireCreateWorkspaceAction(billingProject.projectName)
       billingProfileOpt <- getBillingProfile(billingProject)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -572,9 +572,11 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       .getPolicy(SamResourceTypeNames.workspace, workspaceId, SamWorkspacePolicyNames.owner, ctx)
       .map(_.memberEmails)
 
+  // Do not limit workspace deletion to V2 workspaces so that we can clean up old V1 workspaces as needed.
+  // Possibly create a counter when this is called on a v1 workspace?
   def deleteWorkspace(workspaceName: WorkspaceName): Future[Option[String]] =
-    traceWithParent("getV2WorkspaceContextAndPermissions", ctx)(_ =>
-      getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.delete) flatMap { workspace =>
+    traceWithParent("getWorkspaceContextAndPermissions", ctx)(_ =>
+      getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.delete) flatMap { workspace =>
         traceWithParent("maybeLoadMCWorkspace", ctx)(_ => maybeLoadMcWorkspace(workspace)) flatMap { maybeMcWorkspace =>
           traceWithParent("deleteWorkspaceInternal", ctx)(s1 =>
             deleteWorkspaceInternal(workspace, maybeMcWorkspace, s1)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -573,7 +573,6 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       .map(_.memberEmails)
 
   // Do not limit workspace deletion to V2 workspaces so that we can clean up old V1 workspaces as needed.
-  // Possibly create a counter when this is called on a v1 workspace?
   def deleteWorkspace(workspaceName: WorkspaceName): Future[Option[String]] =
     traceWithParent("getWorkspaceContextAndPermissions", ctx)(_ =>
       getWorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.delete) flatMap { workspace =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -75,6 +75,10 @@ class WorkspaceComponentSpec
       runAndWait(workspaceQuery.listV2WorkspacesByIds(Seq(workspaceId)))
     }
 
+    assertWorkspaceResult(Seq(workspace)) {
+      runAndWait(workspaceQuery.listWorkspacesByNamespace(RawlsBillingProjectName(workspace.namespace)))
+    }
+
     assertWorkspaceResult(Option(workspace)) {
       runAndWait(workspaceQuery.findByName(workspace.toWorkspaceName))
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -55,6 +55,10 @@ class WorkspaceComponentSpec
       runAndWait(workspaceQuery.findByName(workspace.toWorkspaceName))
     }
 
+    assertResult(None) {
+      runAndWait(workspaceQuery.findV2WorkspaceByName(workspace.toWorkspaceName))
+    }
+
     assertWorkspaceResult(workspace) {
       runAndWait(workspaceQuery.createOrUpdate(workspace))
     }
@@ -67,8 +71,24 @@ class WorkspaceComponentSpec
       runAndWait(workspaceQuery.listByIds(Seq(workspaceId)))
     }
 
+    assertWorkspaceResult(Seq(workspace)) {
+      runAndWait(workspaceQuery.listV2WorkspacesByIds(Seq(workspaceId)))
+    }
+
     assertWorkspaceResult(Option(workspace)) {
       runAndWait(workspaceQuery.findByName(workspace.toWorkspaceName))
+    }
+
+    assertWorkspaceResult(Option(workspace)) {
+      runAndWait(workspaceQuery.findV2WorkspaceByName(workspace.toWorkspaceName))
+    }
+
+    assertResult(Option(UUID.fromString(workspace.workspaceId))) {
+      runAndWait(workspaceQuery.getWorkspaceId(workspace.toWorkspaceName))
+    }
+
+    assertResult(Option(UUID.fromString(workspace.workspaceId))) {
+      runAndWait(workspaceQuery.getV2WorkspaceId(workspace.toWorkspaceName))
     }
 
     assertResult(1) {
@@ -93,6 +113,10 @@ class WorkspaceComponentSpec
       runAndWait(workspaceQuery.findByName(workspace.toWorkspaceName))
     }
 
+    assertWorkspaceResult(Option(updatedWorkspace)) {
+      runAndWait(workspaceQuery.findV2WorkspaceByName(workspace.toWorkspaceName))
+    }
+
     assertResult(true) {
       runAndWait(workspaceQuery.delete(workspace.toWorkspaceName))
     }
@@ -103,6 +127,10 @@ class WorkspaceComponentSpec
 
     assertResult(None) {
       runAndWait(workspaceQuery.findByName(workspace.toWorkspaceName))
+    }
+
+    assertResult(None) {
+      runAndWait(workspaceQuery.findV2WorkspaceByName(workspace.toWorkspaceName))
     }
 
     assertResult(false) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -75,10 +75,6 @@ class WorkspaceComponentSpec
       runAndWait(workspaceQuery.listV2WorkspacesByIds(Seq(workspaceId)))
     }
 
-    assertWorkspaceResult(Seq(workspace)) {
-      runAndWait(workspaceQuery.listWorkspacesByNamespace(RawlsBillingProjectName(workspace.namespace)))
-    }
-
     assertWorkspaceResult(Option(workspace)) {
       runAndWait(workspaceQuery.findByName(workspace.toWorkspaceName))
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.mock
 
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
 
 import java.util.concurrent.ConcurrentLinkedDeque
 import scala.collection.concurrent.TrieMap
@@ -182,7 +182,7 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
   ): Future[Set[UserIdInfo]] = Future.successful(Set.empty)
 
   override def getAccessInstructions(groupName: WorkbenchGroupName, ctx: RawlsRequestContext): Future[Option[String]] =
-    ???
+    Future(None)
 
   override def listResourceChildren(resourceTypeName: SamResourceTypeName,
                                     resourceId: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.webservice
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
@@ -11,6 +12,7 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.CreatingBillingProjectMonitor
 import org.broadinstitute.dsde.rawls.monitor.CreatingBillingProjectMonitor.CheckDone
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.duration.Duration
@@ -137,6 +139,8 @@ class UserApiServiceSpec extends ApiServiceSpec {
       sealRoute(services.userRoutes) ~>
       check {
         assertResult(StatusCodes.BadRequest)(status)
+        val responseString = Unmarshal(response.entity).to[String].futureValue
+        assert(responseString.contains("Project cannot be deleted because it contains workspaces."))
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -37,7 +37,6 @@ import org.scalatest.{Assertion, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar.mock
 
 import java.util.UUID
-import scala.collection.immutable.Map
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
@@ -411,11 +410,11 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
 
     doReturn(Future.successful(testData.azureWorkspace))
       .when(mcWorkspaceService)
-      .getWorkspaceContext(equalTo(testData.azureWorkspace.toWorkspaceName), any())
+      .getV2WorkspaceContext(equalTo(testData.azureWorkspace.toWorkspaceName), any())
 
     doReturn(Future.successful(testData.workspace))
       .when(mcWorkspaceService)
-      .getWorkspaceContext(equalTo(testData.workspace.toWorkspaceName), any())
+      .getV2WorkspaceContext(equalTo(testData.workspace.toWorkspaceName), any())
 
     runTest(mcWorkspaceService)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -38,7 +38,7 @@ import org.broadinstitute.dsde.rawls.webservice._
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers._
@@ -123,7 +123,7 @@ class WorkspaceServiceSpec
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
 
     val notificationTopic = "test-notification-topic"
-    val notificationDAO = new PubSubNotificationDAO(gpsDAO, notificationTopic)
+    val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))
 
     val testConf = ConfigFactory.load()
 
@@ -2634,6 +2634,81 @@ class WorkspaceServiceSpec
       }
 
       actual.errorReport.statusCode.get shouldEqual StatusCodes.NotFound
+  }
+
+  behavior of "sendChangeNotifications"
+
+  it should "send a workspace changed notification to all users" in withTestDataServices { services =>
+    val service = services.workspaceService
+    when(
+      service.samDAO.listAllResourceMemberIds(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                                              ArgumentMatchers.eq(testData.workspace.workspaceId),
+                                              any()
+      )
+    ).thenReturn(
+      Future(
+        Set(
+          UserIdInfo(
+            "User1Id",
+            "user1@foo.com",
+            Some("googleUser1Id")
+          ),
+          UserIdInfo(
+            "User2Id",
+            "user2@foo.com",
+            Some("googleUser2Id")
+          )
+        )
+      )
+    )
+
+    val notificationCaptor = captor[Set[Notifications.WorkspaceChangedNotification]]
+
+    val numSent = Await.result(service.sendChangeNotifications(testData.workspace.toWorkspaceName), Duration.Inf)
+
+    verify(services.notificationDAO, times(1)).fireAndForgetNotifications(notificationCaptor.capture)(
+      ArgumentMatchers.any()
+    )
+    notificationCaptor.getValue.size shouldBe 2
+    val firstNotification = notificationCaptor.getValue.head
+    firstNotification.recipientUserId.value shouldEqual "googleUser1Id"
+    firstNotification.workspaceName shouldEqual Notifications.WorkspaceName(testData.workspace.namespace,
+                                                                            testData.workspace.name
+    )
+    val secondNotification = notificationCaptor.getValue.tail.head
+    secondNotification.recipientUserId.value shouldEqual "googleUser2Id"
+    secondNotification.workspaceName shouldEqual Notifications.WorkspaceName(testData.workspace.namespace,
+                                                                             testData.workspace.name
+    )
+
+    numSent shouldBe "2"
+  }
+
+  behavior of "getAccessInstructions"
+
+  it should "return instructions from Sam" in withTestDataServices { services =>
+    val service = services.workspaceService
+
+    when(
+      service.samDAO.getResourceAuthDomain(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                                           ArgumentMatchers.eq(testData.workspace.workspaceId),
+                                           any()
+      )
+    ).thenReturn(Future(Seq("domain1", "domain2")))
+
+    when(service.samDAO.getAccessInstructions(ArgumentMatchers.eq(WorkbenchGroupName("domain1")), any()))
+      .thenReturn(Future(Some("instruction1")))
+
+    when(service.samDAO.getAccessInstructions(ArgumentMatchers.eq(WorkbenchGroupName("domain2")), any()))
+      .thenReturn(Future(Some("instruction2")))
+
+    val instructions = Await.result(service.getAccessInstructions(testData.workspace.toWorkspaceName), Duration.Inf)
+
+    instructions.length shouldBe 2
+    instructions.head.groupName shouldBe "domain1"
+    instructions.head.instructions shouldBe "instruction1"
+    instructions.tail.head.groupName shouldBe "domain2"
+    instructions.tail.head.instructions shouldBe "instruction2"
   }
 
   behavior of "getWorkspace"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-721

This PR changes `WorkspaceService` so that it generally only returns/accepts v2 workspaces. I say _generally_ because there are the following exceptions:

1. The delete endpoint continues to accept v1 workspaces for the purpose of cleaning up old workspaces (do we want to add logging or a counter if it is called with a v1 workspace?).
2. Admin endpoints have not been limited to v2 workspaces.
3. [getMethodInputsOutputs](https://github.com/broadinstitute/rawls/blob/00060a63a7a5fd65ce8b2e09c5d0bbf219bf7a39/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala#L2020), which does not seem to be based on a workspace.
4. [workflowQueueStatus](https://github.com/broadinstitute/rawls/blob/00060a63a7a5fd65ce8b2e09c5d0bbf219bf7a39/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala#L2588), which does not seem to be based on a workspace.
5. [getGenomicsOperationV2](https://github.com/broadinstitute/rawls/blob/00060a63a7a5fd65ce8b2e09c5d0bbf219bf7a39/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala#L2766). This is called with a workspaceId, but it immediately calls into cromiam. **I do not know how this endpoint is being used.**
6. Methods that are based on billingProjects instead of workspaces (`createGoogleProject`, `setProjectBillingAccount`, `setupGoogleProjectIam`, `renameAndLabelProject`, `getSpendReportTableName`). Note that these are mostly used by the migration actor.

With these change, the v1 workspace I'm on ("rtitle test") does not show in the workspace list, cannot be directly accessed, and does not contribute tags to the tags filter select. I do get an error about a persistent disk needing to be migrated because "rtitle test" has a disk… that's because the Leo disk API is returning the disk, and yet no workspace that is returned from the `getList` method has a googleProject account matching the disk's. I will next be looking into Leo.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
