### PR TITLE
[WOR-721] limit SnapshotService and EntityService to v2 workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -1,23 +1,35 @@
 package org.broadinstitute.dsde.rawls.entities
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException
+}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityCopyDefinition, EntityQuery, ErrorReport, SamResourceTypeNames, SamWorkspaceActions, UserInfo, WorkspaceName, _}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  Entity,
+  EntityCopyDefinition,
+  EntityQuery,
+  ErrorReport,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  WorkspaceName,
+  _
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.AttributeUpdateOperationException
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
-import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -5,31 +5,14 @@ import akka.http.scaladsl.model.{StatusCodes, Uri}
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
-import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{
-  DataEntityException,
-  DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException,
-  EntityNotFoundException
-}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{
-  AttributeEntityReference,
-  Entity,
-  EntityCopyDefinition,
-  EntityQuery,
-  ErrorReport,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
-  UserInfo,
-  WorkspaceName,
-  _
-}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityCopyDefinition, EntityQuery, ErrorReport, SamResourceTypeNames, SamWorkspaceActions, UserInfo, WorkspaceName, _}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.AttributeUpdateOperationException
@@ -68,9 +51,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
   def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[Entity] =
     withAttributeNamespaceCheck(entity) {
       for {
-        workspaceContext <- getWorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.write,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
+        workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                                SamWorkspaceActions.write,
+                                                                Some(WorkspaceAttributeSpecs(all = false))
         )
         entityManager <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
         result <- entityManager.createEntity(entity)
@@ -83,9 +66,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                 dataReference: Option[DataReferenceName],
                 billingProject: Option[GoogleProjectId]
   ): Future[Entity] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
@@ -110,9 +93,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                    operations: Seq[AttributeUpdateOperation]
   ): Future[Entity] =
     withAttributeNamespaceCheck(operations.map(_.name)) {
-      getWorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+      getV2WorkspaceContextAndPermissions(workspaceName,
+                                          SamWorkspaceActions.write,
+                                          Some(WorkspaceAttributeSpecs(all = false))
       ) flatMap { workspaceContext =>
         dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
           withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
@@ -144,9 +127,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                      dataReference: Option[DataReferenceName],
                      billingProject: Option[GoogleProjectId]
   ): Future[Set[AttributeEntityReference]] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
@@ -167,9 +150,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                            dataReference: Option[DataReferenceName],
                            billingProject: Option[GoogleProjectId]
   ) =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
@@ -195,9 +178,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                              entityType: String,
                              attributeNames: Set[AttributeName]
   ): Future[Unit] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         dataAccess
@@ -213,9 +196,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
@@ -267,9 +250,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
           )
       }
 
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         for {
@@ -286,9 +269,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                          entityName: String,
                          expression: String
   ): Future[Seq[AttributeValue]] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
@@ -330,9 +313,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                          billingProject: Option[GoogleProjectId],
                          useCache: Boolean
   ): Future[Map[String, EntityTypeMetadata]] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
@@ -345,9 +328,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def listEntities(workspaceName: WorkspaceName, entityType: String): Future[Seq[Entity]] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         traceDBIOWithParent("countActiveEntitiesOfType", ctx) { countContext =>
@@ -387,9 +370,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
       )
     }
 
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
@@ -406,13 +389,13 @@ class EntityService(protected val ctx: RawlsRequestContext,
                    uri: Uri,
                    linkExistingEntities: Boolean
   ): Future[EntityCopyResponse] =
-    getWorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { destWorkspaceContext =>
-      getWorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,
-                                        SamWorkspaceActions.read,
+    getV2WorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
+                                        SamWorkspaceActions.write,
                                         Some(WorkspaceAttributeSpecs(all = false))
+    ) flatMap { destWorkspaceContext =>
+      getV2WorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,
+                                          SamWorkspaceActions.read,
+                                          Some(WorkspaceAttributeSpecs(all = false))
       ) flatMap { sourceWorkspaceContext =>
         dataSource.inTransaction { dataAccess =>
           for {
@@ -447,9 +430,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                   dataReference: Option[DataReferenceName],
                                   billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
       for {
@@ -483,9 +466,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                       attributeRenameRequest: AttributeRename
   ): Future[Int] =
     withAttributeNamespaceCheck(Seq(attributeRenameRequest.newAttributeName)) {
-      getWorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+      getV2WorkspaceContextAndPermissions(workspaceName,
+                                          SamWorkspaceActions.write,
+                                          Some(WorkspaceAttributeSpecs(all = false))
       ) flatMap { workspaceContext =>
         def validateNewAttributeName(dataAccess: DataAccess,
                                      workspaceContext: Workspace,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -13,7 +13,6 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   SamWorkspaceActions,
   SnapshotListResponse,
-  UserInfo,
   WorkspaceAttributeSpecs,
   WorkspaceName
 }
@@ -45,9 +44,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     with LazyLogging {
 
   def createSnapshot(workspaceName: WorkspaceName, snapshot: NamedDataRepoSnapshot): Future[DataRepoSnapshotResource] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { workspaceContext =>
       val wsid = workspaceContext.workspaceIdAsUUID // to avoid UUID parsing multiple times
       // create the stub workspace in WSM if it does not already exist
@@ -68,9 +67,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
   def getSnapshot(workspaceName: WorkspaceName, referenceId: String): Future[DataRepoSnapshotResource] = {
     val referenceUuid = validateSnapshotId(referenceId)
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, referenceUuid, ctx)
       Future.successful(ref)
@@ -78,9 +77,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
   }
 
   def getSnapshotByName(workspaceName: WorkspaceName, referenceName: String): Future[DataRepoSnapshotResource] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).flatMap { workspaceContext =>
       val ref = workspaceManagerDAO.getDataRepoSnapshotReferenceByName(workspaceContext.workspaceIdAsUUID,
                                                                        DataReferenceName(referenceName),
@@ -133,9 +132,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
                          limit: Int,
                          referencedSnapshotId: Option[UUID] = None
   ): Future[SnapshotListResponse] =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.read,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).map { workspaceContext =>
       referencedSnapshotId match {
         case None     => retrieveSnapshotReferences(workspaceContext.workspaceIdAsUUID, offset, limit)
@@ -196,9 +195,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
                      updateInfo: UpdateDataRepoSnapshotReferenceRequestBody
   ): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).map { workspaceContext =>
       // check that snapshot exists before updating it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)
@@ -222,9 +221,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
 
   def deleteSnapshot(workspaceName: WorkspaceName, snapshotId: String): Future[Unit] = {
     val snapshotUuid = validateSnapshotId(snapshotId)
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.write,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    getV2WorkspaceContextAndPermissions(workspaceName,
+                                        SamWorkspaceActions.write,
+                                        Some(WorkspaceAttributeSpecs(all = false))
     ).map { workspaceContext =>
       // check that snapshot exists before deleting it. If the snapshot does not exist, the GET attempt will throw a 404
       workspaceManagerDAO.getDataRepoSnapshotReference(workspaceContext.workspaceIdAsUUID, snapshotUuid, ctx)


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
