### PR TITLE
WOR-746 add wait before running workflow

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.workbench.config.ServiceTestConfig.FireCloud
 import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBillingProject
 import org.broadinstitute.dsde.workbench.fixture.WorkspaceFixtures
-import org.broadinstitute.dsde.workbench.service.Rawls
+import org.broadinstitute.dsde.workbench.service.{Orchestration, Rawls}
 import org.broadinstitute.dsde.workbench.service.util.Tags
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
@@ -209,6 +209,9 @@ class SnapshotAPISpec
             "deleted" -> false,
             "dataReferenceName" -> snapshotName
           )
+
+          Orchestration.workspaces.waitForBucketReadAccess(billingProject, workspaceName)
+
           Rawls.postRequest(
             uri = createMethodConfigUrl.toString(),
             content = createMethodConfigPayload)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-746

this test is running a workflow and needs to wait for cloud IAM to propagate

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
