### PR TITLE
[WOR-667] Delete Azure workspace if creation fails partway through

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.workspace
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.profile.model.{CloudPlatform, ProfileModel}
+import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport.StatusEnum
 import bio.terra.workspace.model._
 import cats.Apply
@@ -121,13 +122,8 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             .traverse { _ =>
               traceWithParent("createMultiCloudWorkspace", parentContext) { s =>
                 createMultiCloudWorkspace(
-                  MultiCloudWorkspaceRequest(
-                    workspaceRequest.namespace,
-                    workspaceRequest.name,
-                    workspaceRequest.attributes,
-                    WorkspaceCloudPlatform.Azure,
-                    profileModel.getId.toString
-                  ),
+                  workspaceRequest,
+                  profileModel,
                   s
                 )
               }
@@ -233,33 +229,19 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
 
     val wsmConfig = multiCloudWorkspaceConfig.workspaceManager
       .getOrElse(throw new RawlsException("WSM app config not present"))
-
-    def createNewWorkspaceRecord(): Future[Workspace] =
-      dataSource.inTransaction { access =>
-        for {
-          _ <- failIfWorkspaceExists(request.toWorkspaceName)
-          workspaceId = UUID.randomUUID()
-          newWorkspace <- createMultiCloudWorkspaceInDatabase(
-            workspaceId.toString,
-            request.toWorkspaceName,
-            request.attributes,
-            access,
-            parentContext
-          )
-        } yield newWorkspace
-      }
+    val workspaceId = UUID.randomUUID()
 
     for {
       // The call to WSM is asynchronous. Before we fire it off, allocate a new workspace record
       // to avoid naming conflicts - we'll erase it should the clone request to WSM fail.
-      newWorkspace <- createNewWorkspaceRecord()
+      newWorkspace <- createNewWorkspaceRecord(workspaceId, request, parentContext)
 
       containerCloneResult <- (for {
         cloneResult <- traceWithParent("workspaceManagerDAO.cloneWorkspace", parentContext) { context =>
           Future(blocking {
             workspaceManagerDAO.cloneWorkspace(
               sourceWorkspaceId = sourceWorkspace.workspaceIdAsUUID,
-              workspaceId = newWorkspace.workspaceIdAsUUID,
+              workspaceId = workspaceId,
               displayName = request.name,
               spendProfile = profile,
               context
@@ -268,10 +250,10 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         }
         jobControlId = cloneResult.getJobReport.getId
         _ = logger.info(
-          s"Polling on workspace clone in WSM [workspaceId = ${newWorkspace.workspaceIdAsUUID}, jobControlId = ${jobControlId}]"
+          s"Polling on workspace clone in WSM [workspaceId = ${workspaceId}, jobControlId = ${jobControlId}]"
         )
         _ <- traceWithParent("workspaceManagerDAO.getWorkspaceCloneStatus", parentContext) { context =>
-          pollWMCreation(newWorkspace.workspaceIdAsUUID,
+          pollWMCreation(workspaceId,
                          jobControlId,
                          context,
                          2 seconds,
@@ -282,26 +264,20 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         }
         _ <- traceWithParent("workspaceManagerDAO.disableLeo", parentContext) { context =>
           Future(blocking {
-            workspaceManagerDAO.disableApplication(newWorkspace.workspaceIdAsUUID,
-                                                   wsmConfig.leonardoWsmApplicationId,
-                                                   context
-            )
+            workspaceManagerDAO.disableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, context)
           })
         }
         _ <- traceWithParent("workspaceManagerDAO.reenableLeo", parentContext) { context =>
           Future(blocking {
-            workspaceManagerDAO.enableApplication(newWorkspace.workspaceIdAsUUID,
-                                                  wsmConfig.leonardoWsmApplicationId,
-                                                  context
-            )
+            workspaceManagerDAO.enableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, context)
           })
         }
         _ = logger.info(
-          s"Starting workspace storage container clone in WSM [workspaceId = ${newWorkspace.workspaceIdAsUUID}]"
+          s"Starting workspace storage container clone in WSM [workspaceId = ${workspaceId}]"
         )
         containerCloneResult <- traceWithParent("workspaceManagerDAO.cloneAzureStorageContainer", parentContext) {
           context =>
-            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID, newWorkspace.workspaceIdAsUUID, context)
+            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID, workspaceId, context)
         }
       } yield containerCloneResult).recoverWith { t: Throwable =>
         logger.warn(
@@ -326,7 +302,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       _ <- WorkspaceManagerResourceMonitorRecordDao(dataSource).create(
         WorkspaceManagerResourceMonitorRecord.forCloneWorkspaceContainer(
           UUID.fromString(containerCloneResult.getJobReport.getId),
-          newWorkspace.workspaceIdAsUUID,
+          workspaceId,
           parentContext.userInfo.userEmail
         )
       )
@@ -383,7 +359,8 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     * @param parentSpan       OpenCensus span
     * @return Future containing the created Workspace's information
     */
-  def createMultiCloudWorkspace(workspaceRequest: MultiCloudWorkspaceRequest,
+  def createMultiCloudWorkspace(workspaceRequest: WorkspaceRequest,
+                                profile: ProfileModel,
                                 parentContext: RawlsRequestContext = ctx
   ): Future[Workspace] = {
     if (!multiCloudWorkspaceConfig.multiCloudWorkspacesEnabled) {
@@ -391,24 +368,30 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     }
 
     traceWithParent("createMultiCloudWorkspace", parentContext)(s1 =>
-      createWorkspace(workspaceRequest, s1) andThen { case Success(_) =>
+      createWorkspace(workspaceRequest, profile, s1) andThen { case Success(_) =>
         createdMultiCloudWorkspaceCounter.inc()
       }
     )
   }
 
-  private def createWorkspace(workspaceRequest: MultiCloudWorkspaceRequest,
+  private def createWorkspace(workspaceRequest: WorkspaceRequest,
+                              profile: ProfileModel,
                               parentContext: RawlsRequestContext
   ): Future[Workspace] = {
     val wsmConfig = multiCloudWorkspaceConfig.workspaceManager
       .getOrElse(throw new RawlsException("WSM app config not present"))
 
-    val spendProfileId = workspaceRequest.billingProfileId
-
-    val workspaceId = UUID.randomUUID
-    for {
+    val spendProfileId = profile.getId.toString
+    val workspaceId = UUID.randomUUID()
+    (for {
       _ <- requireCreateWorkspaceAction(RawlsBillingProjectName(workspaceRequest.namespace))
-      _ <- dataSource.inTransaction(_ => failIfWorkspaceExists(workspaceRequest.toWorkspaceName))
+
+      _ = logger.info(s"Creating workspace record")
+      savedWorkspace <- traceWithParent("saveMultiCloudWorkspaceToDB", parentContext)(_ =>
+        createNewWorkspaceRecord(workspaceId, workspaceRequest, parentContext)
+      )
+
+      _ = logger.info(s"Creating workspace in WSM [workspaceId = ${workspaceId}]")
       _ <- traceWithParent("createMultiCloudWorkspaceInWSM", parentContext)(_ =>
         Future(
           workspaceManagerDAO.createWorkspaceWithSpendProfile(workspaceId, workspaceRequest.name, spendProfileId, ctx)
@@ -432,20 +415,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                        getCloudContextCreationStatus
         )
       )
-      _ = logger.info(s"Creating workspace record [workspaceId = ${workspaceId}]")
-      savedWorkspace: Workspace <- traceWithParent("saveMultiCloudWorkspaceToDB", parentContext)(_ =>
-        dataSource.inTransaction(
-          dataAccess =>
-            createMultiCloudWorkspaceInDatabase(
-              workspaceId.toString,
-              workspaceRequest.toWorkspaceName,
-              workspaceRequest.attributes,
-              dataAccess,
-              parentContext
-            ),
-          TransactionIsolation.ReadCommitted
-        )
-      )
+
       _ = logger.info(s"Enabling leonardo app in WSM [workspaceId = ${workspaceId}]")
       _ <- traceWithParent("enableLeoInWSM", parentContext)(_ =>
         Future(workspaceManagerDAO.enableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, ctx))
@@ -463,7 +433,17 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       _ = logger.info(
         s"Created Azure storage container in WSM [workspaceId = ${workspaceId}, containerId = ${containerResult.getResourceId}]"
       )
-    } yield savedWorkspace
+    } yield savedWorkspace).recoverWith { case e: ApiException =>
+      logger.info(s"Error creating workspace ${workspaceRequest.toWorkspaceName} [workspaceId = ${workspaceId}]", e)
+      for {
+        _ <- Future(workspaceManagerDAO.deleteWorkspace(workspaceId, ctx))
+        _ <- dataSource.inTransaction(_.workspaceQuery.delete(workspaceRequest.toWorkspaceName))
+      } yield throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.InternalServerError,
+                    s"Error creating workspace ${workspaceRequest.toWorkspaceName}. Please try again."
+        )
+      )
+    }
   }
 
   private def getCloudContextCreationStatus(workspaceId: UUID,
@@ -525,6 +505,23 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
           jobControlId
         )
       case Right(_) => ()
+    }
+
+  private def createNewWorkspaceRecord(workspaceId: UUID,
+                                       request: WorkspaceRequest,
+                                       parentContext: RawlsRequestContext
+  ): Future[Workspace] =
+    dataSource.inTransaction { access =>
+      for {
+        _ <- failIfWorkspaceExists(request.toWorkspaceName)
+        newWorkspace <- createMultiCloudWorkspaceInDatabase(
+          workspaceId.toString,
+          request.toWorkspaceName,
+          request.attributes,
+          access,
+          parentContext
+        )
+      } yield newWorkspace
     }
 
   private def createMultiCloudWorkspaceInDatabase(workspaceId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -23,13 +23,11 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.{McWorkspace, RawlsWorkspace}
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
-  MultiCloudWorkspaceRequest,
   RawlsBillingProject,
   RawlsBillingProjectName,
   RawlsRequestContext,
   SamWorkspaceActions,
   Workspace,
-  WorkspaceCloudPlatform,
   WorkspaceName,
   WorkspaceRequest
 }
@@ -37,7 +35,6 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, tra
 import org.broadinstitute.dsde.rawls.util.{Retry, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.joda.time.DateTime
-import slick.jdbc.TransactionIsolation
 
 import java.util.UUID
 import scala.concurrent.duration._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -383,7 +383,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     (for {
       _ <- requireCreateWorkspaceAction(RawlsBillingProjectName(workspaceRequest.namespace))
 
-      _ = logger.info(s"Creating workspace record")
+      _ = logger.info(s"Creating workspace record [workspaceId = ${workspaceId}")
       savedWorkspace <- traceWithParent("saveMultiCloudWorkspaceToDB", parentContext)(_ =>
         createNewWorkspaceRecord(workspaceId, workspaceRequest, parentContext)
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -15,14 +15,12 @@ import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.McWorkspace
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
-  MultiCloudWorkspaceRequest,
   RawlsBillingProject,
   RawlsBillingProjectName,
   RawlsRequestContext,
   SamBillingProjectActions,
   SamResourceTypeNames,
   Workspace,
-  WorkspaceCloudPlatform,
   WorkspaceName,
   WorkspaceRequest,
   WorkspaceType

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -4,6 +4,7 @@ import akka.actor.PoisonPill
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.{AzureContext, GcpContext, WorkspaceDescription}
 import cats.implicits.{catsSyntaxOptionId, toTraverseOps}
@@ -1232,12 +1233,10 @@ class WorkspaceServiceSpec
 
   it should "delete an Azure workspace" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-    val workspaceRequest = MultiCloudWorkspaceRequest(
+    val workspaceRequest = WorkspaceRequest(
       testData.testProject1Name.value,
       workspaceName,
-      Map.empty,
-      WorkspaceCloudPlatform.Azure,
-      "fake_billingProjectId"
+      Map.empty
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
       new WorkspaceDescription().azureContext(
@@ -1248,7 +1247,10 @@ class WorkspaceServiceSpec
       )
     )
 
-    val workspace = Await.result(services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf)
+    val workspace = Await.result(
+      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest, new ProfileModel().id(UUID.randomUUID())),
+      Duration.Inf
+    )
     assertResult(Option(workspace.toWorkspaceName)) {
       runAndWait(workspaceQuery.findByName(WorkspaceName(workspace.namespace, workspace.name))).map(_.toWorkspaceName)
     }
@@ -1268,12 +1270,10 @@ class WorkspaceServiceSpec
   it should "not delete the rawls Azure workspace when WSM errors out for an azure workspace" in withTestDataServices {
     services =>
       val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-      val workspaceRequest = MultiCloudWorkspaceRequest(
+      val workspaceRequest = WorkspaceRequest(
         testData.testProject1Name.value,
         workspaceName,
-        Map.empty,
-        WorkspaceCloudPlatform.Azure,
-        "fake_billingProjectId"
+        Map.empty
       )
       when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
         new WorkspaceDescription().azureContext(
@@ -1288,7 +1288,11 @@ class WorkspaceServiceSpec
       )
 
       val workspace =
-        Await.result(services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf)
+        Await.result(services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest,
+                                                                           new ProfileModel().id(UUID.randomUUID())
+                     ),
+                     Duration.Inf
+        )
       assertResult(Option(workspace.toWorkspaceName)) {
         runAndWait(workspaceQuery.findByName(WorkspaceName(workspace.namespace, workspace.name))).map(_.toWorkspaceName)
       }
@@ -1307,12 +1311,10 @@ class WorkspaceServiceSpec
 
   it should "delete the rawls workspace when WSM returns 404" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-    val workspaceRequest = MultiCloudWorkspaceRequest(
+    val workspaceRequest = WorkspaceRequest(
       testData.testProject1Name.value,
       workspaceName,
-      Map.empty,
-      WorkspaceCloudPlatform.Azure,
-      "fake_billingProjectId"
+      Map.empty
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
       new WorkspaceDescription().azureContext(
@@ -1326,7 +1328,10 @@ class WorkspaceServiceSpec
       throw new ApiException(404, "not found")
     )
 
-    val workspace = Await.result(services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf)
+    val workspace = Await.result(
+      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest, new ProfileModel().id(UUID.randomUUID())),
+      Duration.Inf
+    )
     assertResult(Option(workspace.toWorkspaceName)) {
       runAndWait(workspaceQuery.findByName(WorkspaceName(workspace.namespace, workspace.name))).map(_.toWorkspaceName)
     }
@@ -2816,12 +2821,10 @@ class WorkspaceServiceSpec
   it should "get the details of an Azure workspace" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
     val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
-    val workspaceRequest = MultiCloudWorkspaceRequest(
+    val workspaceRequest = WorkspaceRequest(
       testData.testProject1Name.value,
       workspaceName,
-      Map.empty,
-      WorkspaceCloudPlatform.Azure,
-      "fake_billingProjectId"
+      Map.empty
     )
 
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
@@ -2833,7 +2836,10 @@ class WorkspaceServiceSpec
       )
     )
 
-    val workspace = Await.result(services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest), Duration.Inf)
+    val workspace = Await.result(
+      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest, new ProfileModel().id(UUID.randomUUID())),
+      Duration.Inf
+    )
     val readWorkspace = Await.result(services.workspaceService.getWorkspace(
                                        WorkspaceName(workspace.namespace, workspace.name),
                                        WorkspaceFieldSpecs()
@@ -2852,19 +2858,19 @@ class WorkspaceServiceSpec
   it should "return an error if an MC workspace is not present in workspace manager" in withTestDataServices {
     services =>
       val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-      val workspaceRequest = MultiCloudWorkspaceRequest(
+      val workspaceRequest = WorkspaceRequest(
         testData.testProject1Name.value,
         workspaceName,
-        Map.empty,
-        WorkspaceCloudPlatform.Azure,
-        "fake_billingProjectId"
+        Map.empty
       )
       // ApiException is a checked exception so we need to use thenAnswer rather than thenThrow
       when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenAnswer(_ =>
         throw new ApiException(StatusCodes.NotFound.intValue, "not found")
       )
       val workspace = Await.result(
-        services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest),
+        services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest,
+                                                              new ProfileModel().id(UUID.randomUUID())
+        ),
         Duration.Inf
       )
 
@@ -2884,18 +2890,16 @@ class WorkspaceServiceSpec
 
   it should "return an error if an MC workspace does not have an Azure context" in withTestDataServices { services =>
     val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
-    val workspaceRequest = MultiCloudWorkspaceRequest(
+    val workspaceRequest = WorkspaceRequest(
       testData.testProject1Name.value,
       workspaceName,
-      Map.empty,
-      WorkspaceCloudPlatform.Azure,
-      "fake_billingProjectId"
+      Map.empty
     )
     when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
       new WorkspaceDescription() // no azureContext, should be an error
     )
     val workspace = Await.result(
-      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest),
+      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest, new ProfileModel().id(UUID.randomUUID())),
       Duration.Inf
     )
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -145,18 +145,6 @@ object WorkspaceVersions {
     )
 }
 
-case class MultiCloudWorkspaceRequest(
-  namespace: String,
-  name: String,
-  attributes: AttributeMap,
-  cloudPlatform: WorkspaceCloudPlatform,
-  billingProfileId: String
-) extends Attributable {
-  def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
-  def briefName: String = toWorkspaceName.toString
-  def path: String = toWorkspaceName.path
-}
-
 case class WorkspaceRequest(
   namespace: String,
   name: String,
@@ -1028,9 +1016,6 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val AzureManagedAppCoordinatesFormat: RootJsonFormat[AzureManagedAppCoordinates] =
     jsonFormat3(AzureManagedAppCoordinates)
-
-  implicit val MultiCloudWorkspaceRequestFormat: RootJsonFormat[MultiCloudWorkspaceRequest] =
-    jsonFormat5(MultiCloudWorkspaceRequest)
 
   implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat7(WorkspaceRequest)
 


### PR DESCRIPTION
Ticket: [WOR-667](https://broadworkbench.atlassian.net/browse/WOR-667)
- Catch exceptions from WSM when orchestrating calls required to create an Azure workspace so that we can rollback workspace creation if one of the calls fails.
- Move creation of workspace record in Rawls earlier in the createAzureWorkspace process
- Remove `MultiCloudWorkspaceRequest` -- this lets us share code more easily between `cloneWorkspace` and `createWorkspace` and this case class wasn't being used for very much at this point.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-667]: https://broadworkbench.atlassian.net/browse/WOR-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ