### PR TITLE
[WOR-761] Azure workspaces should return canCompute as true for Writers

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -537,15 +537,14 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                                         userAccessLevel: WorkspaceAccessLevel,
                                         cloudPlatform: Option[WorkspaceCloudPlatform]
   ): Future[Boolean] =
-    if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
-    else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
-//    cloudPlatform match {
-//      case Some(WorkspaceCloudPlatform.Azure) =>
-//        Future.successful(userAccessLevel >= WorkspaceAccessLevels.Write)
-//      case _ =>
-//        if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
-//        else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
-//    }
+    cloudPlatform match {
+      case Some(WorkspaceCloudPlatform.Azure) =>
+        Future.successful(userAccessLevel >= WorkspaceAccessLevels.Write)
+      case _ if (userAccessLevel >= WorkspaceAccessLevels.Owner) =>
+          Future.successful(true)
+      case default =>
+          samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
+    }
 
   private def getUserSharePermissions(workspaceId: String,
                                       userAccessLevel: WorkspaceAccessLevel,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -540,10 +540,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     cloudPlatform match {
       case Some(WorkspaceCloudPlatform.Azure) =>
         Future.successful(userAccessLevel >= WorkspaceAccessLevels.Write)
-      case _ if (userAccessLevel >= WorkspaceAccessLevels.Owner) =>
-          Future.successful(true)
+      case _ if userAccessLevel >= WorkspaceAccessLevels.Owner =>
+        Future.successful(true)
       case default =>
-          samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
+        samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
     }
 
   private def getUserSharePermissions(workspaceId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -541,10 +541,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       case Some(WorkspaceCloudPlatform.Azure) =>
         Future.successful(userAccessLevel >= WorkspaceAccessLevels.Write)
       case _ =>
-        // Try to find test coverage
-        Future.successful(false)
-//        if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
-//        else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
+        if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+        else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
     }
 
   private def getUserSharePermissions(workspaceId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -537,13 +537,15 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                                         userAccessLevel: WorkspaceAccessLevel,
                                         cloudPlatform: Option[WorkspaceCloudPlatform]
   ): Future[Boolean] =
-    cloudPlatform match {
-      case Some(WorkspaceCloudPlatform.Azure) =>
-        Future.successful(userAccessLevel >= WorkspaceAccessLevels.Write)
-      case _ =>
-        if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
-        else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
-    }
+    if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+    else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
+//    cloudPlatform match {
+//      case Some(WorkspaceCloudPlatform.Azure) =>
+//        Future.successful(userAccessLevel >= WorkspaceAccessLevels.Write)
+//      case _ =>
+//        if (userAccessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+//        else samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
+//    }
 
   private def getUserSharePermissions(workspaceId: String,
                                       userAccessLevel: WorkspaceAccessLevel,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2862,67 +2862,67 @@ class WorkspaceServiceSpec
     response.workspace.cloudPlatform shouldBe Some(WorkspaceCloudPlatform.Azure)
   }
 
-  it should "return correct canCompute permission for Azure workspaces" in withTestDataServices { services =>
-    val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
-    val workspace = createAzureWorkspace(services, managedAppCoordinates)
-
-    // Create test user.
-    val testUser = RawlsUser(RawlsUserSubjectId("testuser"), RawlsUserEmail("test@user.com"))
-    val ctx = toRawlsRequestContext(testUser)
-
-    // Mock user being a reader only
-    val mockSamDAO = services.samDAO
-    val testUserWS = services.workspaceServiceConstructor(ctx)
-    when(
-      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
-    ).thenReturn(Future.successful(true))
-    when(
-      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
-    ).thenReturn(Future.successful(false))
-    when(
-      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
-    ).thenReturn(Future.successful(false))
-    when(
-      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-    )
-      .thenReturn(Future.successful(Set(SamWorkspaceRoles.reader)))
-
-    val readerWorkspace =
-      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
-    val readerResponse = readerWorkspace.convertTo[WorkspaceResponse]
-    readerResponse.canCompute.get shouldEqual false
-    readerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Read
-
-    // Now change mocks to be a writer.
-    when(
-      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
-    ).thenReturn(Future.successful(true))
-    when(
-      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-    )
-      .thenReturn(Future.successful(Set(SamWorkspaceRoles.writer, SamWorkspaceRoles.reader)))
-
-    val writerWorkspace =
-      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
-    val writerResponse = writerWorkspace.convertTo[WorkspaceResponse]
-    writerResponse.canCompute.get shouldEqual true
-    writerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Write
-
-    // Now change mocks to be an owner.
-    when(
-      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
-    ).thenReturn(Future.successful(true))
-    when(
-      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-    )
-      .thenReturn(Future.successful(Set(SamWorkspaceRoles.owner)))
-
-    val ownerWorkspace =
-      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
-    val ownerResponse = ownerWorkspace.convertTo[WorkspaceResponse]
-    ownerResponse.canCompute.get shouldEqual true
-    ownerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Owner
-  }
+//  it should "return correct canCompute permission for Azure workspaces" in withTestDataServices { services =>
+//    val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
+//    val workspace = createAzureWorkspace(services, managedAppCoordinates)
+//
+//    // Create test user.
+//    val testUser = RawlsUser(RawlsUserSubjectId("testuser"), RawlsUserEmail("test@user.com"))
+//    val ctx = toRawlsRequestContext(testUser)
+//
+//    // Mock user being a reader only
+//    val mockSamDAO = services.samDAO
+//    val testUserWS = services.workspaceServiceConstructor(ctx)
+//    when(
+//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
+//    ).thenReturn(Future.successful(true))
+//    when(
+//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
+//    ).thenReturn(Future.successful(false))
+//    when(
+//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
+//    ).thenReturn(Future.successful(false))
+//    when(
+//      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+//    )
+//      .thenReturn(Future.successful(Set(SamWorkspaceRoles.reader)))
+//
+//    val readerWorkspace =
+//      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
+//    val readerResponse = readerWorkspace.convertTo[WorkspaceResponse]
+//    readerResponse.canCompute.get shouldEqual false
+//    readerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Read
+//
+//    // Now change mocks to be a writer.
+//    when(
+//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
+//    ).thenReturn(Future.successful(true))
+//    when(
+//      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+//    )
+//      .thenReturn(Future.successful(Set(SamWorkspaceRoles.writer, SamWorkspaceRoles.reader)))
+//
+//    val writerWorkspace =
+//      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
+//    val writerResponse = writerWorkspace.convertTo[WorkspaceResponse]
+//    writerResponse.canCompute.get shouldEqual true
+//    writerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Write
+//
+//    // Now change mocks to be an owner.
+//    when(
+//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
+//    ).thenReturn(Future.successful(true))
+//    when(
+//      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+//    )
+//      .thenReturn(Future.successful(Set(SamWorkspaceRoles.owner)))
+//
+//    val ownerWorkspace =
+//      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
+//    val ownerResponse = ownerWorkspace.convertTo[WorkspaceResponse]
+//    ownerResponse.canCompute.get shouldEqual true
+//    ownerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Owner
+//  }
 
   it should "return an error if an MC workspace is not present in workspace manager" in withTestDataServices {
     services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2862,67 +2862,67 @@ class WorkspaceServiceSpec
     response.workspace.cloudPlatform shouldBe Some(WorkspaceCloudPlatform.Azure)
   }
 
-//  it should "return correct canCompute permission for Azure workspaces" in withTestDataServices { services =>
-//    val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
-//    val workspace = createAzureWorkspace(services, managedAppCoordinates)
-//
-//    // Create test user.
-//    val testUser = RawlsUser(RawlsUserSubjectId("testuser"), RawlsUserEmail("test@user.com"))
-//    val ctx = toRawlsRequestContext(testUser)
-//
-//    // Mock user being a reader only
-//    val mockSamDAO = services.samDAO
-//    val testUserWS = services.workspaceServiceConstructor(ctx)
-//    when(
-//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
-//    ).thenReturn(Future.successful(true))
-//    when(
-//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
-//    ).thenReturn(Future.successful(false))
-//    when(
-//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
-//    ).thenReturn(Future.successful(false))
-//    when(
-//      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-//    )
-//      .thenReturn(Future.successful(Set(SamWorkspaceRoles.reader)))
-//
-//    val readerWorkspace =
-//      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
-//    val readerResponse = readerWorkspace.convertTo[WorkspaceResponse]
-//    readerResponse.canCompute.get shouldEqual false
-//    readerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Read
-//
-//    // Now change mocks to be a writer.
-//    when(
-//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
-//    ).thenReturn(Future.successful(true))
-//    when(
-//      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-//    )
-//      .thenReturn(Future.successful(Set(SamWorkspaceRoles.writer, SamWorkspaceRoles.reader)))
-//
-//    val writerWorkspace =
-//      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
-//    val writerResponse = writerWorkspace.convertTo[WorkspaceResponse]
-//    writerResponse.canCompute.get shouldEqual true
-//    writerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Write
-//
-//    // Now change mocks to be an owner.
-//    when(
-//      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
-//    ).thenReturn(Future.successful(true))
-//    when(
-//      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
-//    )
-//      .thenReturn(Future.successful(Set(SamWorkspaceRoles.owner)))
-//
-//    val ownerWorkspace =
-//      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
-//    val ownerResponse = ownerWorkspace.convertTo[WorkspaceResponse]
-//    ownerResponse.canCompute.get shouldEqual true
-//    ownerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Owner
-//  }
+  it should "return correct canCompute permission for Azure workspaces" in withTestDataServices { services =>
+    val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
+    val workspace = createAzureWorkspace(services, managedAppCoordinates)
+
+    // Create test user.
+    val testUser = RawlsUser(RawlsUserSubjectId("testuser"), RawlsUserEmail("test@user.com"))
+    val ctx = toRawlsRequestContext(testUser)
+
+    // Mock user being a reader only
+    val mockSamDAO = services.samDAO
+    val testUserWS = services.workspaceServiceConstructor(ctx)
+    when(
+      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx)
+    ).thenReturn(Future.successful(true))
+    when(
+      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
+    ).thenReturn(Future.successful(false))
+    when(
+      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
+    ).thenReturn(Future.successful(false))
+    when(
+      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+    )
+      .thenReturn(Future.successful(Set(SamWorkspaceRoles.reader)))
+
+    val readerWorkspace =
+      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
+    val readerResponse = readerWorkspace.convertTo[WorkspaceResponse]
+    readerResponse.canCompute.get shouldEqual false
+    readerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Read
+
+    // Now change mocks to be a writer.
+    when(
+      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx)
+    ).thenReturn(Future.successful(true))
+    when(
+      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+    )
+      .thenReturn(Future.successful(Set(SamWorkspaceRoles.writer, SamWorkspaceRoles.reader)))
+
+    val writerWorkspace =
+      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
+    val writerResponse = writerWorkspace.convertTo[WorkspaceResponse]
+    writerResponse.canCompute.get shouldEqual true
+    writerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Write
+
+    // Now change mocks to be an owner.
+    when(
+      mockSamDAO.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.own, ctx)
+    ).thenReturn(Future.successful(true))
+    when(
+      mockSamDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx)
+    )
+      .thenReturn(Future.successful(Set(SamWorkspaceRoles.owner)))
+
+    val ownerWorkspace =
+      Await.result(testUserWS.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs()), Duration.Inf)
+    val ownerResponse = ownerWorkspace.convertTo[WorkspaceResponse]
+    ownerResponse.canCompute.get shouldEqual true
+    ownerResponse.accessLevel.get shouldEqual WorkspaceAccessLevels.Owner
+  }
 
   it should "return an error if an MC workspace is not present in workspace manager" in withTestDataServices {
     services =>


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-761)

Note that there is integration (swatomation) test coverage for the Google case.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
