### PR TITLE
[SU-278] Consistent versioning for workbench-notifications

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,6 @@ object Dependencies {
   val workbenchLibsHash = "46d1df6"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
-  val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.22-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,7 @@ object Dependencies {
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.23-${workbenchLibsHash}"
-  val workbenchNotificationsV = s"0.3-a79c7f9" //See SU-278 for why this version deviates from workbenchLibsHash
+  val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"
 


### PR DESCRIPTION
I originally used an inconsistent version here to avoid having to resolve a bunch of other changing dependencies before the Azure Jan 25th launch. Since then, the dependency headaches have been resolved so this workaround is unnecessary and can be cleaned up.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
