### PR TITLE
Revert "[SU-171] Remove Rawls implementation of GooglePubSubDAO, use …

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -70,7 +70,7 @@
         <appender-ref ref="Sentry" />
     </logger>
 
-    <logger name="org.broadinstitute.dsde.workbench.google.HttpGooglePubSubDAO" level="debug" additivity="false">
+    <logger name="org.broadinstitute.dsde.rawls.google.HttpGooglePubSubDAO" level="debug" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -30,7 +30,7 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.{DrsHubResolver, MarthaResolver}
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
-import org.broadinstitute.dsde.rawls.google.HttpGoogleAccessContextManagerDAO
+import org.broadinstitute.dsde.rawls.google.{HttpGoogleAccessContextManagerDAO, HttpGooglePubSubDAO}
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.wdlparsing.{CachingWDLParser, NonCachingWDLParser, WDLParser}
 import org.broadinstitute.dsde.rawls.model._
@@ -52,14 +52,8 @@ import org.broadinstitute.dsde.rawls.workspace.{
 }
 import org.broadinstitute.dsde.workbench.dataaccess.PubSubNotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.Json
-import org.broadinstitute.dsde.workbench.google.{
-  GoogleCredentialModes,
-  HttpGoogleBigQueryDAO,
-  HttpGoogleIamDAO,
-  HttpGooglePubSubDAO
-}
+import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleBigQueryDAO, HttpGoogleIamDAO}
 import org.broadinstitute.dsde.workbench.google2._
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
 import org.http4s.Uri
@@ -191,18 +185,20 @@ object Boot extends IOApp with LazyLogging {
       )
 
       val pubSubDAO = new HttpGooglePubSubDAO(
+        clientEmail,
+        pathToPem,
         appName,
-        googleCredentialMode = GoogleCredentialModes.Pem(WorkbenchEmail(clientEmail), new java.io.File(pathToPem)),
-        workbenchMetricBaseName = metricsPrefix,
-        serviceProject
+        serviceProject,
+        workbenchMetricBaseName = metricsPrefix
       )
 
       // Import service uses a different project for its pubsub topic
       val importServicePubSubDAO = new HttpGooglePubSubDAO(
+        clientEmail,
+        pathToPem,
         appName,
-        googleCredentialMode = GoogleCredentialModes.Pem(WorkbenchEmail(clientEmail), new java.io.File(pathToPem)),
-        workbenchMetricBaseName = metricsPrefix,
-        conf.getString("avroUpsertMonitor.updateImportStatusPubSubProject")
+        conf.getString("avroUpsertMonitor.updateImportStatusPubSubProject"),
+        workbenchMetricBaseName = metricsPrefix
       )
 
       val importServiceDAO = new HttpImportServiceDAO(conf.getString("avroUpsertMonitor.server"))
@@ -285,8 +281,16 @@ object Boot extends IOApp with LazyLogging {
       val requesterPaysRole = gcsConfig.getString("requesterPaysRole")
       val projectTemplate = ProjectTemplate(projectOwners, projectEditors)
 
+      val notificationPubSubDAO = new org.broadinstitute.dsde.workbench.google.HttpGooglePubSubDAO(
+        clientEmail,
+        pathToPem,
+        appName,
+        serviceProject,
+        workbenchMetricBaseName = metricsPrefix
+      )
+
       val notificationDAO = new PubSubNotificationDAO(
-        pubSubDAO,
+        notificationPubSubDAO,
         gcsConfig.getString("notifications.topicName")
       )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -11,6 +11,8 @@ import fs2.concurrent.SignallingRef
 import io.circe.fs2._
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.entities.EntityService
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ImportStatuses.ImportStatus
 import org.broadinstitute.dsde.rawls.model.{
@@ -30,8 +32,6 @@ import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.{
 }
 import org.broadinstitute.dsde.rawls.util.AuthUtil
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
-import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.model.{UserInfo => _, _}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsResolver
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityService
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
 import org.broadinstitute.dsde.rawls.jobexec.{
   MethodConfigResolver,
   SubmissionMonitorConfig,
@@ -35,7 +36,7 @@ import org.broadinstitute.dsde.rawls.monitor.workspace.runners.{
 import org.broadinstitute.dsde.rawls.util
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
-import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GooglePubSubDAO}
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, GoogleStorageTransferService}
 import spray.json._
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/HealthMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/HealthMonitor.scala
@@ -9,10 +9,10 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.Subsystems._
 import org.broadinstitute.dsde.rawls.model.{StatusCheckResponse, SubsystemStatus}
 import org.broadinstitute.dsde.rawls.monitor.HealthMonitor._
-import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
 
 import java.util.concurrent.TimeoutException
 import scala.Option

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -5,6 +5,8 @@ import akka.testkit.TestKit
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.rawls.dataaccess._
 import slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.MessageRequest
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
   AddUpdateAttribute,
   AttributeUpdateOperation,
@@ -39,8 +41,6 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.broadinstitute.dsde.rawls.entities.EntityService
-import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.MessageRequest
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 
 import java.util.UUID
 import java.util.concurrent.TimeUnit

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/HealthMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/HealthMonitorSpec.scala
@@ -10,11 +10,10 @@ import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.google.{GooglePubSubDAO, MockGooglePubSubDAO}
 import org.broadinstitute.dsde.rawls.model.Subsystems._
 import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, StatusCheckResponse, SubsystemStatus}
 import org.broadinstitute.dsde.rawls.monitor.HealthMonitor._
-import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.{
   ActiveSubmissionFormat,
   WorkflowQueueStatusByUserResponseFormat
@@ -12,7 +13,6 @@ import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport.RawlsBillingProje
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{AttributeReferenceFormat, WorkspaceDetailsFormat}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import spray.json.DefaultJsonProtocol._
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -29,6 +29,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponentWithFla
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, SubmissionSupervisor}
 import org.broadinstitute.dsde.rawls.metrics.{InstrumentationDirectives, RawlsInstrumented, RawlsStatsDTestUtils}
 import org.broadinstitute.dsde.rawls.mock._
@@ -55,7 +56,7 @@ import org.broadinstitute.dsde.rawls.workspace.{
   WorkspaceService
 }
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGooglePubSubDAO}
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.mockito.Mockito.RETURNS_SMART_NULLS

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceSpec.scala
@@ -8,10 +8,10 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   RawlsBillingProjectRecord,
   ReadAction
 }
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.rawls.{model, RawlsExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.{ArgumentMatcher, ArgumentMatchers}
 import org.mockito.ArgumentMatchers._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -10,11 +10,11 @@ import org.broadinstitute.dsde.rawls.billing.{
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{RawlsBillingProjectRecord, ReadAction}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
 import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadWriteAction, TestData}
 import org.broadinstitute.dsde.rawls.entities.EntityService
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
@@ -14,7 +15,6 @@ import org.broadinstitute.dsde.rawls.model.SortDirections.{Ascending, Descending
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import spray.json.DefaultJsonProtocol._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/MethodConfigApiServiceSpec.scala
@@ -8,10 +8,10 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import org.broadinstitute.dsde.rawls.dataaccess.MockCromwellSwaggerClient.makeBadWorkflowDescription
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.scalatest.concurrent.ScalaFutures
 import spray.json.DefaultJsonProtocol._
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/NotificationsApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/NotificationsApiServiceSpec.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.rawls.webservice
 
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.dataaccess.{MockGoogleServicesDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.ExecutionContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -5,10 +5,10 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestData
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.StandardUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -6,11 +6,11 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.dataaccess.{MockGoogleServicesDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.DataReferenceModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/StatusApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/StatusApiServiceSpec.scala
@@ -7,6 +7,7 @@ import bio.terra.profile.model.SystemStatus
 import com.google.api.services.directory.model.Group
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.rawls.dataaccess.{MockGoogleServicesDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.StatusJsonSupport.StatusCheckResponseFormat
 import org.broadinstitute.dsde.rawls.model.Subsystems._
 import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, StatusCheckResponse, SubsystemStatus}
@@ -14,7 +15,6 @@ import org.broadinstitute.dsde.rawls.monitor.HealthMonitor
 import org.broadinstitute.dsde.rawls.monitor.HealthMonitor.CheckAll
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.mockito.Mockito.when
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiMetadataParamsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiMetadataParamsSpec.scala
@@ -3,10 +3,10 @@ package org.broadinstitute.dsde.rawls.webservice
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.MetadataParamsFormat
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -10,12 +10,12 @@ import akka.testkit.TestProbe
 import org.apache.commons.lang3.RandomStringUtils
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadWriteAction, TestData, WorkflowAuditStatusRecord}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.jobexec.WorkflowSubmissionActor
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/UserApiServiceSpec.scala
@@ -6,13 +6,13 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.CreatingBillingProjectMonitor
 import org.broadinstitute.dsde.rawls.monitor.CreatingBillingProjectMonitor.CheckDone
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.duration.Duration

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -8,10 +8,10 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestData
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import spray.json._
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiLibraryPermissionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiLibraryPermissionsSpec.scala
@@ -7,13 +7,13 @@ import akka.http.scaladsl.server.Directives._
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadWriteAction, TestData}
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import spray.json.DefaultJsonProtocol._
 
 import java.util.UUID

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
@@ -8,10 +8,10 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestData
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import spray.json.DefaultJsonProtocol._
 import spray.json._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadAction, TestData}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.mock.{CustomizableMockSamDAO, MockSamDAO}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
@@ -23,7 +24,6 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, RawlsWorkspaceAclManager}
-import org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/GooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/GooglePubSubDAO.scala
@@ -1,0 +1,73 @@
+package org.broadinstitute.dsde.rawls.google
+
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.services.pubsub.model.Topic
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO._
+
+import scala.collection.Map
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Created by dvoet on 12/7/16.
+ */
+object GooglePubSubDAO {
+  sealed trait AckStatus
+
+  case object MessageAcknowledged extends AckStatus
+  case object MessageNotAcknowledged extends AckStatus
+
+  sealed trait HandledStatus
+
+  case object MessageHandled extends HandledStatus
+  case object MessageNotHandled extends HandledStatus
+  case object NoMessage extends HandledStatus
+
+  case class PubSubMessage(ackId: String, contents: String, attributes: Map[String, String] = Map.empty)
+  case class MessageRequest(text: String, attributes: Map[String, String] = Map.empty)
+
+}
+
+trait GooglePubSubDAO {
+  implicit val executionContext: ExecutionContext
+
+  def createTopic(topicName: String): Future[Boolean]
+
+  def deleteTopic(topicName: String): Future[Boolean]
+
+  def getTopic(topicName: String)(implicit executionContext: ExecutionContext): Future[Option[Topic]]
+
+  def createSubscription(topicName: String, subscriptionName: String, ackDeadlineSeconds: Option[Int]): Future[Boolean]
+
+  def deleteSubscription(subscriptionName: String): Future[Boolean]
+
+  def publishMessages(topicName: String, messages: scala.collection.immutable.Seq[MessageRequest]): Future[Unit]
+
+  def acknowledgeMessages(subscriptionName: String,
+                          messages: scala.collection.immutable.Seq[PubSubMessage]
+  ): Future[Unit]
+
+  def acknowledgeMessagesById(subscriptionName: String, ackIds: scala.collection.immutable.Seq[String]): Future[Unit]
+
+  def pullMessages(subscriptionName: String, maxMessages: Int): Future[scala.collection.immutable.Seq[PubSubMessage]]
+
+  def withMessage(subscriptionName: String)(op: (String) => Future[AckStatus]): Future[HandledStatus] =
+    withMessages(subscriptionName, 1) {
+      case Seq(msg) => op(msg)
+      case _        => throw new RawlsException(s"Unable to process message from subscription ${subscriptionName}")
+    }
+
+  def withMessages(subscriptionName: String, maxMessages: Int)(
+    op: (scala.collection.immutable.Seq[String]) => Future[AckStatus]
+  ): Future[HandledStatus] =
+    pullMessages(subscriptionName, maxMessages) flatMap {
+      case Seq() => Future.successful(NoMessage)
+      case messages =>
+        op(messages.map(msg => msg.contents)) flatMap {
+          case MessageAcknowledged    => acknowledgeMessages(subscriptionName, messages).map(_ => MessageHandled)
+          case MessageNotAcknowledged => Future.successful(MessageNotHandled)
+        }
+    }
+
+  def getPubSubServiceAccountCredential: Credential
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/HttpGooglePubSubDAO.scala
@@ -1,0 +1,154 @@
+package org.broadinstitute.dsde.rawls.google
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.http.HttpResponseException
+import com.google.api.client.json.gson.GsonFactory
+import com.google.api.services.pubsub.model._
+import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO._
+import org.broadinstitute.dsde.rawls.metrics.GoogleInstrumentedService
+import org.broadinstitute.dsde.rawls.util.FutureSupport
+
+import scala.concurrent._
+import scala.jdk.CollectionConverters._
+
+/**
+ * Created by mbemis on 5/6/16.
+ */
+
+class HttpGooglePubSubDAO(clientEmail: String,
+                          pemFile: String,
+                          appName: String,
+                          serviceProject: String,
+                          override val workbenchMetricBaseName: String
+)(implicit val system: ActorSystem, implicit val executionContext: ExecutionContext)
+    extends FutureSupport
+    with GoogleUtilities
+    with GooglePubSubDAO {
+
+  val pubSubScopes = Seq(PubsubScopes.PUBSUB)
+
+  val httpTransport = GoogleNetHttpTransport.newTrustedTransport
+  val jsonFactory = GsonFactory.getDefaultInstance
+
+  private val characterEncoding = "UTF-8"
+  implicit val service = GoogleInstrumentedService.PubSub
+
+  override def createTopic(topicName: String) =
+    retryWithRecoverWhen500orGoogleError { () =>
+      executeGoogleRequest(getPubSubDirectory.projects().topics().create(topicToFullPath(topicName), new Topic()))
+      true
+    } {
+      case t: HttpResponseException if t.getStatusCode == 409 => false
+    }
+
+  override def deleteTopic(topicName: String): Future[Boolean] =
+    retryWithRecoverWhen500orGoogleError { () =>
+      executeGoogleRequest(getPubSubDirectory.projects().topics().delete(topicToFullPath(topicName)))
+      true
+    } {
+      case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => false
+    }
+
+  override def getTopic(topicName: String)(implicit executionContext: ExecutionContext): Future[Option[Topic]] =
+    retryWithRecoverWhen500orGoogleError { () =>
+      Option(executeGoogleRequest(getPubSubDirectory.projects().topics().get(topicToFullPath(topicName))))
+    } {
+      case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
+    }
+
+  override def createSubscription(topicName: String, subscriptionName: String, ackDeadlineSeconds: Option[Int] = None) =
+    retryWithRecoverWhen500orGoogleError { () =>
+      val subscription = new Subscription().setTopic(topicToFullPath(topicName))
+      ackDeadlineSeconds.map { secs =>
+        subscription.setAckDeadlineSeconds(secs)
+      }
+      executeGoogleRequest(
+        getPubSubDirectory.projects().subscriptions().create(subscriptionToFullPath(subscriptionName), subscription)
+      )
+      true
+    } {
+      case t: HttpResponseException if t.getStatusCode == 409 => false
+    }
+
+  override def deleteSubscription(subscriptionName: String): Future[Boolean] =
+    retryWithRecoverWhen500orGoogleError { () =>
+      executeGoogleRequest(
+        getPubSubDirectory.projects().subscriptions().delete(subscriptionToFullPath(subscriptionName))
+      )
+      true
+    } {
+      case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => false
+    }
+
+  override def publishMessages(topicName: String, messages: scala.collection.immutable.Seq[MessageRequest]) = {
+    logger.debug(s"publishing to google pubsub topic $topicName, messages [${messages.mkString(", ")}]")
+    Future
+      .traverse(messages.grouped(1000)) { messageBatch =>
+        retryWhen500orGoogleError { () =>
+          val pubsubMessages = messageBatch.map(messageRequest =>
+            new PubsubMessage()
+              .encodeData(messageRequest.text.getBytes(characterEncoding))
+              .setAttributes(messageRequest.attributes.asJava)
+          )
+          val pubsubRequest = new PublishRequest().setMessages(pubsubMessages.asJava)
+          executeGoogleRequest(
+            getPubSubDirectory.projects().topics().publish(topicToFullPath(topicName), pubsubRequest)
+          )
+        }
+      }
+      .map(_ => ())
+  }
+
+  override def acknowledgeMessages(subscriptionName: String, messages: scala.collection.immutable.Seq[PubSubMessage]) =
+    acknowledgeMessagesById(subscriptionName, messages.map(_.ackId))
+
+  override def acknowledgeMessagesById(subscriptionName: String, ackIds: scala.collection.immutable.Seq[String]) =
+    retryWhen500orGoogleError { () =>
+      val ackRequest = new AcknowledgeRequest().setAckIds(ackIds.asJava)
+      executeGoogleRequest(
+        getPubSubDirectory.projects().subscriptions().acknowledge(subscriptionToFullPath(subscriptionName), ackRequest)
+      )
+    }
+
+  override def pullMessages(subscriptionName: String,
+                            maxMessages: Int
+  ): Future[scala.collection.immutable.Seq[PubSubMessage]] =
+    retryWhen500orGoogleError { () =>
+      val pullRequest = new PullRequest()
+        .setReturnImmediately(true)
+        .setMaxMessages(maxMessages) // won't keep the connection open if there's no msgs available
+      val messages = executeGoogleRequest(
+        getPubSubDirectory.projects().subscriptions().pull(subscriptionToFullPath(subscriptionName), pullRequest)
+      ).getReceivedMessages
+      if (messages == null)
+        scala.collection.immutable.Seq.empty
+      else
+        messages.asScala.toList.map { message =>
+          val messageBody = Option(message.getMessage.decodeData()).map(new String(_, characterEncoding)).getOrElse("")
+          PubSubMessage(message.getAckId, messageBody, message.getMessage.getAttributes.asScala.toMap)
+        }
+    }
+
+  def topicToFullPath(topicName: String) = s"projects/${serviceProject}/topics/${topicName}"
+  def subscriptionToFullPath(subscriptionName: String) = s"projects/${serviceProject}/subscriptions/${subscriptionName}"
+
+  def getPubSubDirectory =
+    new Pubsub.Builder(httpTransport, jsonFactory, getPubSubServiceAccountCredential)
+      .setApplicationName(appName)
+      .build()
+
+  def getPubSubServiceAccountCredential: Credential =
+    new GoogleCredential.Builder()
+      .setTransport(httpTransport)
+      .setJsonFactory(jsonFactory)
+      .setServiceAccountId(clientEmail)
+      .setServiceAccountScopes(pubSubScopes.asJava) // grant pub sub powers
+      .setServiceAccountPrivateKeyFromPemFile(new java.io.File(pemFile))
+      .build()
+
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/rawls/google/MockGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/rawls/google/MockGooglePubSubDAO.scala
@@ -1,0 +1,123 @@
+package org.broadinstitute.dsde.rawls.google
+
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
+import com.google.api.services.pubsub.model.Topic
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.{MessageRequest, PubSubMessage}
+
+import java.util
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
+import java.util.{Collections, UUID}
+import scala.collection.{mutable, _}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Created by dvoet on 12/7/16.
+ */
+class MockGooglePubSubDAO extends GooglePubSubDAO {
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
+
+  val topics: concurrent.Map[String, mutable.Set[Subscription]] =
+    new ConcurrentHashMap[String, mutable.Set[Subscription]]().asScala
+  val subscriptionsByName = collection.concurrent.TrieMap.empty[String, Subscription]
+
+  val messageLog = new ConcurrentLinkedQueue[String]
+  val acks = new ConcurrentLinkedQueue[String]
+
+  def logMessage(topic: String, message: String) = messageLog.add(s"$topic|$message")
+  def receivedMessage(topic: String, message: String, count: Int = 1) =
+    messageLog.toArray.filter(_ == s"$topic|$message").size == count
+
+  override def createTopic(topicName: String): Future[Boolean] = {
+    val initialCount = topics.size
+    topics += (topicName -> Collections.synchronizedSet(new util.HashSet[Subscription]()).asScala)
+    Future.successful(topics.size != initialCount)
+  }
+
+  override def pullMessages(subscriptionName: String,
+                            maxMessages: Int
+  ): Future[scala.collection.immutable.Seq[PubSubMessage]] = Future {
+    val subscription =
+      subscriptionsByName.getOrElse(subscriptionName,
+                                    throw new RawlsException(s"no subscription named $subscriptionName")
+      )
+    (0 until maxMessages).map(_ => Option(subscription.queue.poll())).collect { case Some(message) =>
+      PubSubMessage(UUID.randomUUID().toString, message.text, message.attributes)
+    }
+  }
+
+  override def acknowledgeMessages(subscriptionName: String,
+                                   messages: scala.collection.immutable.Seq[PubSubMessage]
+  ): Future[Unit] = Future.successful(messages.foreach(m => acks.add(m.ackId)))
+
+  override def acknowledgeMessagesById(subscriptionName: String,
+                                       ackIds: scala.collection.immutable.Seq[String]
+  ): Future[Unit] = Future.successful(ackIds.foreach(acks.add))
+
+  override def publishMessages(topicName: String,
+                               messages: scala.collection.immutable.Seq[MessageRequest]
+  ): Future[Unit] = Future {
+    val subscriptions = topics.getOrElse(topicName, throw new RawlsException(s"no topic named $topicName"))
+    messages.foreach(message => logMessage(topicName, message.text))
+    for {
+      sub <- subscriptions
+      message <- messages
+    } yield sub.queue.add(message)
+  }
+
+  override def getPubSubServiceAccountCredential: Credential = getPreparedMockGoogleCredential()
+
+  override def deleteSubscription(subscriptionName: String): Future[Boolean] = Future {
+    subscriptionsByName.get(subscriptionName) match {
+      case None =>
+        false
+
+      case Some(subscription) =>
+        topics(subscription.topic) -= subscription
+        subscriptionsByName -= subscriptionName
+        true
+    }
+  }
+
+  override def deleteTopic(topicName: String): Future[Boolean] = Future {
+    val startingLength = topics.size
+    topics -= topicName
+    startingLength != topics.size
+  }
+
+  override def createSubscription(topicName: String,
+                                  subscriptionName: String,
+                                  ackDeadlineSeconds: Option[Int] = None
+  ): Future[Boolean] = Future {
+    if (!topics.contains(topicName)) throw new RawlsException(s"no topic named $topicName")
+    if (subscriptionsByName.contains(subscriptionName)) {
+      false
+    } else {
+      val subscription = Subscription(subscriptionName, topicName, new ConcurrentLinkedQueue[MessageRequest]())
+      topics(topicName) += subscription
+      subscriptionsByName += subscriptionName -> subscription
+      true
+    }
+  }
+
+  def getPreparedMockGoogleCredential(): MockGoogleCredential = {
+    val credential = new MockGoogleCredential.Builder().build()
+    credential.setAccessToken(MockGoogleCredential.ACCESS_TOKEN)
+//    credential.setRefreshToken(token)
+    credential.setExpiresInSeconds(1000000L) // make sure not to refresh this token
+    credential
+  }
+
+  override def getTopic(topicName: String)(implicit executionContext: ExecutionContext): Future[Option[Topic]] =
+    Future {
+      if (topics.contains(topicName)) {
+        val topic = new Topic
+        topic.setName(topicName)
+        Some(topic)
+      } else None
+    }
+
+  case class Subscription(name: String, topic: String, queue: ConcurrentLinkedQueue[MessageRequest])
+}

--- a/google/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGooglePubSubDAOSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/rawls/integrationtest/HttpGooglePubSubDAOSpec.scala
@@ -1,0 +1,130 @@
+package org.broadinstitute.dsde.rawls.integrationtest
+
+/**
+ * Created by mbemis on 5/10/16.
+ */
+
+import akka.actor.ActorSystem
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
+import com.google.api.client.json.gson.GsonFactory
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.MessageRequest
+import org.broadinstitute.dsde.rawls.google.{GooglePubSubDAO, HttpGooglePubSubDAO}
+import org.broadinstitute.dsde.rawls.metrics.StatsDTestUtils
+import org.broadinstitute.dsde.rawls.util.{MockitoTestUtils, Retry}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{File, StringReader}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class HttpGooglePubSubDAOSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with Retry
+    with LazyLogging
+    with Eventually
+    with MockitoTestUtils
+    with StatsDTestUtils {
+  implicit val system = ActorSystem("HttpGooglePubSubDAOSpec")
+
+  val etcConf = ConfigFactory.load()
+  val jenkinsConf = ConfigFactory.parseFile(new File("jenkins.conf"))
+  val gcsConfig = jenkinsConf.withFallback(etcConf).getConfig("gcs")
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  val gpsDAO = new HttpGooglePubSubDAO(
+    GoogleClientSecrets
+      .load(GsonFactory.getDefaultInstance, new StringReader(gcsConfig.getString("secrets")))
+      .getDetails
+      .get("client_email")
+      .toString,
+    gcsConfig.getString("pathToPem"),
+    gcsConfig.getString("appName"),
+    gcsConfig.getString("serviceProject"),
+    workbenchMetricBaseName
+  )
+
+  val defaultTopicName = "integration-tests"
+  val defaultSubscriptionName = "test-subscription"
+
+  override def beforeAll() = {
+    super.beforeAll()
+    // if this test ever fails, there will likely be some leftover garbage. clean it up first
+    // cleanup uses Await.ready because we don't care what the result is, just that it happened
+    Await.ready(gpsDAO.deleteSubscription(defaultSubscriptionName), Duration.Inf)
+    Await.ready(gpsDAO.deleteTopic(defaultTopicName), Duration.Inf)
+
+    Await.result(gpsDAO.createTopic(defaultTopicName), Duration.Inf)
+    Await.result(gpsDAO.createSubscription(defaultTopicName, defaultSubscriptionName), Duration.Inf)
+  }
+
+  override def afterAll() = {
+    super.afterAll()
+    Await.result(gpsDAO.deleteSubscription(defaultSubscriptionName), Duration.Inf)
+    Await.result(gpsDAO.deleteTopic(defaultTopicName), Duration.Inf)
+  }
+
+  "HttpGooglePubSubDAOSpec" should "do all of the things" in {
+    // publish a few messages to the topic
+    val messages = List(MessageRequest("test-1"))
+    Await.result(gpsDAO.publishMessages(defaultTopicName, messages), Duration.Inf)
+
+    Await.result(
+      gpsDAO.withMessage(defaultSubscriptionName) { msg =>
+        assertResult(true) {
+          messages.contains(msg)
+        }
+        Future.successful(GooglePubSubDAO.MessageAcknowledged)
+      },
+      Duration.Inf
+    )
+  }
+
+  it should "submit more than 1000 messages" in {
+    // publish a lot of messages to the topic
+    val numMessages = 2877
+    val messages = List.fill(numMessages)(MessageRequest("foo"))
+    Await.result(gpsDAO.publishMessages(defaultTopicName, messages), Duration.Inf)
+
+    while (
+      Await.result(gpsDAO.withMessages(defaultSubscriptionName, numMessages) { msgs =>
+                     Future.successful(GooglePubSubDAO.MessageAcknowledged)
+                   },
+                   Duration.Inf
+      ) != GooglePubSubDAO.NoMessage
+    ) {}
+  }
+
+  it should "gracefully handle there being no messages in the queue" in {
+    Await.result(gpsDAO.withMessage(defaultSubscriptionName) { msg =>
+                   assertResult(None) {
+                     msg
+                   }
+                   Future.successful(GooglePubSubDAO.MessageNotAcknowledged)
+                 },
+                 Duration.Inf
+    )
+  }
+
+  it should "do all of the things with multiple messages" in {
+    // publish a few messages to the topic
+    val messages = List("test-1", "test-2", "test-3", "test-4", "test-5").map(MessageRequest(_))
+    Await.result(gpsDAO.publishMessages(defaultTopicName, messages), Duration.Inf)
+
+    Await.result(gpsDAO.withMessages(defaultSubscriptionName, 5) { msg =>
+                   assertResult(messages) {
+                     msg
+                   }
+                   Future.successful(GooglePubSubDAO.MessageAcknowledged)
+                 },
+                 Duration.Inf
+    )
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,6 +48,7 @@ object Dependencies {
   val googleIamCredentials: ModuleID =        excludeGuavaJDK5("com.google.apis"        % "google-api-services-iamcredentials"        % ("v1-rev20211203-" + googleV))
 
   val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev20230119-" + googleV)
+  val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev20230112-" + googleV)
   val googleDeploymentManager: ModuleID = "com.google.apis"   % "google-api-services-deploymentmanager" % ("v2-rev20220908-" + googleV)
   val accessContextManager: ModuleID =    "com.google.apis"   % "google-api-services-accesscontextmanager" % ("v1-rev20230109-" + googleV)
   val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "31.1-jre"
@@ -81,10 +82,10 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "df84a1e"
+  val workbenchLibsHash = "46d1df6"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.23-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.22-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.3-a79c7f9" //See SU-278 for why this version deviates from workbenchLibsHash
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"
@@ -181,6 +182,7 @@ object Dependencies {
     googleIam,
     googleIamCredentials,
     googleCompute,
+    googlePubSub,
     googleDeploymentManager,
     googleGuava
   )


### PR DESCRIPTION
…workbench-libs instead (#1937)"

This reverts commit 399eac474aab19a8a02cf1b5a52feb50b6aeb595.

Ticket: <Link to Jira ticket>
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
