### PR TITLE
AJ-862: filter by name

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1560,6 +1560,11 @@ paths:
             enum:
               - and
               - or
+        - name: entityNameFilter
+          in: query
+          description: exact-match name of entity to return
+          schema:
+            type: string
         - name: fields
           in: query
           description: |

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1548,7 +1548,7 @@ paths:
               - desc
         - name: filterTerms
           in: query
-          description: Filter terms
+          description: terms to search for, using substring matching, in all attributes of an entity
           schema:
             type: string
         - name: filterOperator
@@ -1562,7 +1562,7 @@ paths:
               - or
         - name: entityNameFilter
           in: query
-          description: exact-match name of entity to return
+          description: exact-match name of entity to return. Mutually exclusive with the filterTerms parameter.
           schema:
             type: string
         - name: fields

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -837,7 +837,7 @@ trait EntityComponent {
                        entityType: String,
                        entityQuery: model.EntityQuery,
                        parentContext: RawlsRequestContext
-                      ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
+    ): ReadWriteAction[(Int, Int, Iterable[Entity])] =
       // if entityNameFilter exists, retrieve that entity directly, else do the full query:
       entityQuery.entityNameFilter match {
         case Some(entityName) =>
@@ -848,12 +848,15 @@ trait EntityComponent {
             val page = optEntity.toSeq
             (unfilteredCount, page.size, page)
           }
-        case _ => EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
-          entityType, entityQuery, parentContext) map { case (unfilteredCount, filteredCount, pagination) =>
-          (unfilteredCount, filteredCount, unmarshalEntities(pagination))
-        }
+        case _ =>
+          EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
+                                                                   entityType,
+                                                                   entityQuery,
+                                                                   parentContext
+          ) map { case (unfilteredCount, filteredCount, pagination) =>
+            (unfilteredCount, filteredCount, unmarshalEntities(pagination))
+          }
       }
-    }
 
     // create or replace entities
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -312,18 +312,22 @@ trait EntityComponent {
       }
 
       // the where clause for this query is filled in specific to the use case
-      def baseEntityAndAttributeSql(workspace: Workspace, desiredAttributes: Set[AttributeName] = Set.empty): String =
+      def baseEntityAndAttributeSql(workspace: Workspace): String =
+        baseEntityAndAttributeSql(workspace, Set.empty)
+
+      def baseEntityAndAttributeSql(workspace: Workspace, desiredAttributes: Set[AttributeName]): String =
         baseEntityAndAttributeSql(
           workspace.workspaceIdAsUUID,
           desiredAttributes
         )
 
-      def baseEntityAndAttributeSql(workspaceId: UUID, desiredAttributes: Set[AttributeName] = Set.empty): String =
+      private def baseEntityAndAttributeSql(workspaceId: UUID): String =
+        baseEntityAndAttributeSql(workspaceId, Set.empty)
+
+      def baseEntityAndAttributeSql(workspaceId: UUID, desiredAttributes: Set[AttributeName]): String =
         baseEntityAndAttributeSql(determineShard(workspaceId), desiredAttributes)
 
-      private def baseEntityAndAttributeSql(shardId: ShardId,
-                                            desiredAttributes: Set[AttributeName] = Set.empty
-      ): String = {
+      private def baseEntityAndAttributeSql(shardId: ShardId, desiredAttributes: Set[AttributeName]): String = {
         // TODO support optional attributes
         val formattedAttributePairs =
           desiredAttributes.map(attributeName => s"(${attributeName.namespace}, ${attributeName.name})").mkString(", ")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -320,15 +320,13 @@ trait EntityComponent {
       private def baseEntityAndAttributeSql(workspaceId: UUID): String =
         baseEntityAndAttributeSql(determineShard(workspaceId))
 
-      private def baseEntityAndAttributeSql(shardId: ShardId): String = {
-
+      private def baseEntityAndAttributeSql(shardId: ShardId): String =
         s"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
           a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
           e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
           from ENTITY e
           left outer join ENTITY_ATTRIBUTE_$shardId a on a.owner_id = e.id and a.deleted = e.deleted
           left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id"""
-      }
 
       // Active actions: only return entities and attributes with their deleted flag set to false
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -837,13 +837,12 @@ trait EntityComponent {
                        entityType: String,
                        entityQuery: model.EntityQuery,
                        parentContext: RawlsRequestContext
-    ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
-
-      // if entityNameFilter exists, call get-entity, else:
+                      ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
+      // if entityNameFilter exists, retrieve that entity directly, else do the full query:
       entityQuery.entityNameFilter match {
         case Some(entityName) =>
           for {
-            unfilteredCount <- findActiveEntityByType (workspaceContext.workspaceIdAsUUID, entityType).length.result
+            unfilteredCount <- findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
             optEntity <- get(workspaceContext, entityType, entityName)
           } yield {
             val page = optEntity.toSeq

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -565,8 +565,8 @@ trait EntityComponent {
 
         concatSqlActions(
           sql"""#${baseEntityAndAttributeSql(
-            workspaceContext
-          )} where e.name = ${entityName} and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""",
+              workspaceContext
+            )} where e.name = ${entityName} and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""",
           attributesFilter
         ).as[EntityAndAttributesResult]
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -43,8 +43,8 @@ trait EntityApiService extends UserInfoDirectives {
         path("workspaces" / Segment / Segment / "entityQuery" / Segment) {
           (workspaceNamespace, workspaceName, entityType) =>
             get {
-              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?) {
-                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator) =>
+              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?, 'entityNameFilter.?) {
+                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, entityNameFilter) =>
                   parameterSeq { allParams =>
                     val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
                       k -> Try(s.map(_.toInt))
@@ -67,7 +67,8 @@ trait EntityApiService extends UserInfoDirectives {
                         sortDirectionTry.get,
                         filterTerms,
                         operatorTry.get,
-                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
+                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                        entityNameFilter
                       )
                       complete {
                         entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -43,45 +43,61 @@ trait EntityApiService extends UserInfoDirectives {
         path("workspaces" / Segment / Segment / "entityQuery" / Segment) {
           (workspaceNamespace, workspaceName, entityType) =>
             get {
-              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?, 'entityNameFilter.?) {
-                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, entityNameFilter) =>
-                  parameterSeq { allParams =>
-                    val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
-                      k -> Try(s.map(_.toInt))
-                    }
-                    val sortDirectionTry =
-                      sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
-                    val operatorTry =
-                      filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
+              parameters('page.?,
+                         'pageSize.?,
+                         'sortField.?,
+                         'sortDirection.?,
+                         'filterTerms.?,
+                         'filterOperator.?,
+                         'entityNameFilter.?
+              ) { (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, entityNameFilter) =>
+                parameterSeq { allParams =>
+                  val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
+                    k -> Try(s.map(_.toInt))
+                  }
+                  val sortDirectionTry =
+                    sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
+                  val operatorTry =
+                    filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
 
-                    val errors = toIntTries.collect {
+                  val filterValidation = if (filterTerms.isDefined && entityNameFilter.isDefined) {
+                    Seq(
+                      "filterTerms and entityNameFilter are mutually exclusive; you may specify only one or the other."
+                    )
+                  } else Seq.empty
+
+                  val errors = Seq(
+                    toIntTries.collect {
                       case (k, Failure(t))                 => s"$k must be a positive integer"
                       case (k, Success(Some(i))) if i <= 0 => s"$k must be a positive integer"
-                    } ++ (if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty)
+                    },
+                    if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty,
+                    filterValidation
+                  ).flatten
 
-                    if (errors.isEmpty) {
-                      val entityQuery = EntityQuery(
-                        toIntTries("page").get.getOrElse(1),
-                        toIntTries("pageSize").get.getOrElse(10),
-                        sortField.getOrElse("name"),
-                        sortDirectionTry.get,
-                        filterTerms,
-                        operatorTry.get,
-                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
-                        entityNameFilter
+                  if (errors.isEmpty) {
+                    val entityQuery = EntityQuery(
+                      toIntTries("page").get.getOrElse(1),
+                      toIntTries("pageSize").get.getOrElse(10),
+                      sortField.getOrElse("name"),
+                      sortDirectionTry.get,
+                      filterTerms,
+                      operatorTry.get,
+                      WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                      entityNameFilter
+                    )
+                    complete {
+                      entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                  dataReference,
+                                                                  entityType,
+                                                                  entityQuery,
+                                                                  billingProject
                       )
-                      complete {
-                        entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                    dataReference,
-                                                                    entityType,
-                                                                    entityQuery,
-                                                                    billingProject
-                        )
-                      }
-                    } else {
-                      complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
                     }
+                  } else {
+                    complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
                   }
+                }
               }
             }
         } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -1491,6 +1491,39 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
+  it should "return only the selected attributes" in withDefaultTestDatabase {
+    withWorkspaceContext(testData.workspace) { context =>
+      val testAttribute1 = AttributeName.withDefaultNS("attr1") -> AttributeString("val1")
+      val testAttribute2 = AttributeName.withDefaultNS("attr2") -> AttributeString("val2")
+      val testAttribute3 = AttributeName.withDefaultNS("attr3") -> AttributeString("val3")
+      val testAttribute4 = AttributeName.withDefaultNS("attr4") -> AttributeString("val4")
+
+      val entityToSave = Entity(
+        "testName",
+        "testType",
+        Map(testAttribute1, testAttribute2, testAttribute3, testAttribute4)
+      )
+
+      runAndWait(entityQuery.save(context, entityToSave))
+
+      val result = runAndWait(entityQuery.get(
+        context,
+        entityToSave.entityType,
+        entityToSave.name,
+        Set(testAttribute1._1, testAttribute3._1)
+      ))
+
+      assert(result.isDefined)
+      val resAttributeNames = result.get.attributes.keys
+
+      assert(resAttributeNames.exists(_.equalsIgnoreCase(testAttribute1._1)),
+        "Attribute 1 should be returned by the filter query")
+      assert(resAttributeNames.exists(_.equalsIgnoreCase(testAttribute3._1)),
+        "Attribute 3 should be returned by the filter query")
+      resAttributeNames.size shouldBe 2
+    }
+  }
+
   it should "select the all_attribute_values column when using entityQueryWithInlineAttributes and not otherwise" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
       val hasAttrs = Entity(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -1506,20 +1506,24 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       runAndWait(entityQuery.save(context, entityToSave))
 
-      val result = runAndWait(entityQuery.get(
-        context,
-        entityToSave.entityType,
-        entityToSave.name,
-        Set(testAttribute1._1, testAttribute3._1)
-      ))
+      val result = runAndWait(
+        entityQuery.get(
+          context,
+          entityToSave.entityType,
+          entityToSave.name,
+          Set(testAttribute1._1, testAttribute3._1)
+        )
+      )
 
       assert(result.isDefined)
       val resAttributeNames = result.get.attributes.keys
 
       assert(resAttributeNames.exists(_.equalsIgnoreCase(testAttribute1._1)),
-        "Attribute 1 should be returned by the filter query")
+             "Attribute 1 should be returned by the filter query"
+      )
       assert(resAttributeNames.exists(_.equalsIgnoreCase(testAttribute3._1)),
-        "Attribute 3 should be returned by the filter query")
+             "Attribute 3 should be returned by the filter query"
+      )
       resAttributeNames.size shouldBe 2
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -3418,8 +3418,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 when specifying both filterTerms and entityNameFilter" in withPaginationTestDataApiServices {
-    services =>
+  // filter-by-name tests. All of these tests are read-only and use the same set of exemplar data, so we only create that data once:
+  withPaginationTestDataApiServices { services =>
+    it should "return 400 when specifying both filterTerms and entityNameFilter" in {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=foo&entityNameFilter=bar"
       ) ~>
@@ -3429,10 +3430,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             status
           }
         }
-  }
+    }
 
-  it should "return correct result when filtering by name on entity query" in withPaginationTestDataApiServices {
-    services =>
+    it should "return correct result when filtering by name on entity query" in {
       val entityNameFilter = "entity_99"
       val pageSize = paginationTestData.entities.size
       val expectedEntities = paginationTestData.entities
@@ -3459,10 +3459,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             responseAs[EntityQueryResponse]
           }
         }
-  }
+    }
 
-  it should "return zero results when filtering by an unknown name on entity query" in withPaginationTestDataApiServices {
-    services =>
+    it should "return zero results when filtering by an unknown name on entity query" in {
       val entityNameFilter = "entity_xyz"
       val pageSize = paginationTestData.entities.size
       val expectedEntities = Seq.empty
@@ -3487,6 +3486,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             responseAs[EntityQueryResponse]
           }
         }
+    }
   }
 
   // *********** START entityQuery field-selection tests

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -344,7 +344,8 @@ case class EntityQuery(page: Int,
                        sortDirection: SortDirections.SortDirection,
                        filterTerms: Option[String],
                        filterOperator: FilterOperators.FilterOperator = FilterOperators.And,
-                       fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs()
+                       fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs(),
+                       entityNameFilter: Option[String] = None
 )
 
 case class EntityQueryResultMetadata(unfilteredCount: Int, filteredCount: Int, filteredPageCount: Int)
@@ -1025,7 +1026,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val EntityTypeMetadataFormat: RootJsonFormat[EntityTypeMetadata] = jsonFormat3(EntityTypeMetadata)
 
-  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat7(EntityQuery)
+  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat8(EntityQuery)
 
   implicit val EntityQueryResultMetadataFormat: RootJsonFormat[EntityQueryResultMetadata] =
     jsonFormat3(EntityQueryResultMetadata)


### PR DESCRIPTION
adds filter-by-name capability to the `entityQuery` API. This will allow users (once UI adopts this feature) to search for e.g. a sample_id in a sample table and return the one row they are looking for.

Performance on a 30k row anonymized table: https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/da_theiagen_anonymized_clone/data

```
30k rows:
Full table query: 3200-3400ms
Entity name exact match query: 1200ms

300 rows:
Full table query: 1200ms
Entity name exact match query: 1200ms
```

remaining TODOs:
- [x] quantify, even manually/anecdotally, the latency impact of using `entityNameFilter` instead of `filterTerms` on a large table
- [x] ensure Jenkins automation tests pass
- [ ] update Orchestration's swagger definition to include the new query parameter, test it works via Orch