### PR TITLE
AJ-864: filter-by-column

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1560,6 +1560,11 @@ paths:
             enum:
               - and
               - or
+        - name: entityNameFilter
+          in: query
+          description: exact-match name of entity to return
+          schema:
+            type: string
         - name: fields
           in: query
           description: |

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1548,7 +1548,7 @@ paths:
               - desc
         - name: filterTerms
           in: query
-          description: Filter terms
+          description: terms to search for, using substring matching, in all attributes of an entity
           schema:
             type: string
         - name: filterOperator
@@ -1562,7 +1562,7 @@ paths:
               - or
         - name: entityNameFilter
           in: query
-          description: exact-match name of entity to return
+          description: exact-match name of entity to return. Mutually exclusive with the filterTerms parameter.
           schema:
             type: string
         - name: fields

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1548,7 +1548,7 @@ paths:
               - desc
         - name: filterTerms
           in: query
-          description: terms to search for, using substring matching, in all attributes of an entity
+          description: terms to search for, using substring matching, in all attributes of an entity. Mutually exclusive with the entityNameFilter and columnFilter parameters.
           schema:
             type: string
         - name: filterOperator
@@ -1562,7 +1562,12 @@ paths:
               - or
         - name: entityNameFilter
           in: query
-          description: exact-match name of entity to return. Mutually exclusive with the filterTerms parameter.
+          description: exact-match name of entity to return. Mutually exclusive with the filterTerms and columnFilter parameters.
+          schema:
+            type: string
+        - name: columnFilter
+          in: query
+          description: exact-match filter for a value in a single column, in the form columnName=string-to-match. Mutually exclusive with the filterTerms and entityNameFilter parameters.
           schema:
             type: string
         - name: fields

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1,18 +1,23 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
-import io.opencensus.trace.{Span, AttributeValue => OpenCensusAttributeValue}
+import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
-import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsFatalExceptionWithErrorReport, model}
+import org.broadinstitute.dsde.rawls.{
+  model,
+  RawlsException,
+  RawlsExceptionWithErrorReport,
+  RawlsFatalExceptionWithErrorReport
+}
 import slick.jdbc.{GetResult, JdbcProfile, SQLActionBuilder}
 
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 import scala.annotation.tailrec
+import scala.collection.immutable.TreeSeqMap
 import scala.language.postfixOps
 
 //noinspection TypeAnnotation
@@ -307,27 +312,19 @@ trait EntityComponent {
       }
 
       // the where clause for this query is filled in specific to the use case
-      def baseEntityAndAttributeSql(workspace: Workspace, desiredAttributes: Set[AttributeName] = Set.empty): String = baseEntityAndAttributeSql(
-        workspace.workspaceIdAsUUID, desiredAttributes
+      def baseEntityAndAttributeSql(workspace: Workspace): String = baseEntityAndAttributeSql(
+        workspace.workspaceIdAsUUID
       )
 
-      def baseEntityAndAttributeSql(workspaceId: UUID, desiredAttributes: Set[AttributeName] = Set.empty): String =
-        baseEntityAndAttributeSql(determineShard(workspaceId), desiredAttributes)
+      def baseEntityAndAttributeSql(workspaceId: UUID): String = baseEntityAndAttributeSql(determineShard(workspaceId))
 
-      private def baseEntityAndAttributeSql(shardId: ShardId, desiredAttributes: Set[AttributeName] = Set.empty): String = {
-        // TODO support optional attributes
-        val formattedAttributePairs =
-          desiredAttributes.map(attributeName => s"(${attributeName.namespace}, ${attributeName.name})").mkString(", ")
-        val whereClause = if (desiredAttributes.isEmpty) "" else s"where (a.namespace, a.name) in ($formattedAttributePairs)"
-
+      private def baseEntityAndAttributeSql(shardId: ShardId): String =
         s"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
           a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
           e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
           from ENTITY e
           left outer join ENTITY_ATTRIBUTE_$shardId a on a.owner_id = e.id and a.deleted = e.deleted
-          left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id
-          $whereClause"""
-      }
+          left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id"""
 
       // Active actions: only return entities and attributes with their deleted flag set to false
 
@@ -584,14 +581,12 @@ trait EntityComponent {
 
       def actionForTypeName(workspaceContext: Workspace,
                             entityType: String,
-                            entityName: String,
-                            desiredFields: Set[AttributeName]
-      ): ReadAction[Seq[EntityAndAttributesResult]] = {
+                            entityName: String
+      ): ReadAction[Seq[EntityAndAttributesResult]] =
         sql"""#${baseEntityAndAttributeSql(
-            workspaceContext, desiredFields
+            workspaceContext
           )} where e.name = ${entityName} and e.entity_type = ${entityType} and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
           .as[EntityAndAttributesResult]
-      }
 
       def actionForIds(workspaceId: UUID, entityIds: Set[Long]): ReadAction[Seq[EntityAndAttributesResult]] =
         if (entityIds.isEmpty) {
@@ -793,9 +788,8 @@ trait EntityComponent {
 
     // get a specific entity or set of entities: may include "hidden" deleted entities if not named "active"
 
-    def get(workspaceContext: Workspace, entityType: String, entityName: String,
-            desiredFields: Set[AttributeName] = Set.empty): ReadAction[Option[Entity]] =
-      EntityAndAttributesRawSqlQuery.actionForTypeName(workspaceContext, entityType, entityName, desiredFields) map (query =>
+    def get(workspaceContext: Workspace, entityType: String, entityName: String): ReadAction[Option[Entity]] =
+      EntityAndAttributesRawSqlQuery.actionForTypeName(workspaceContext, entityType, entityName) map (query =>
         unmarshalEntities(query)
       ) map (_.headOption)
 
@@ -872,19 +866,31 @@ trait EntityComponent {
     def loadSingleEntityForPage(workspaceContext: Workspace,
                                 entityType: String,
                                 entityName: String,
-                                entityQuery: model.EntityQuery
+                                entityQuery: model.EntityQuery,
+                                parentContext: RawlsRequestContext
     ): ReadWriteAction[(Int, Int, Iterable[Entity])] =
       for {
         unfilteredCount <- findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
-
-        desiredFields = entityQuery.fields.fields.getOrElse(Set.empty).map(AttributeName.fromDelimitedName)
-        optEntity <- get(workspaceContext, entityType, entityName, desiredFields)
+        optEntity <- get(workspaceContext, entityType, entityName)
       } yield
         if (optEntity.isEmpty) {
           // if we didn't find an entity of this name, nothing else to do
           (unfilteredCount, 0, Seq.empty)
         } else {
-          val page = optEntity.toSeq
+          // which fields does the user want to return?
+          // TODO: we'd ideally do the field-selection at the db level so we're not returning data from the db and then immediately discarding it
+          val desiredFields = entityQuery.fields.fields.getOrElse(Set.empty).map(AttributeName.fromDelimitedName)
+
+          val page = (if (desiredFields.nonEmpty) {
+                        optEntity.map { ent =>
+                          val filteredAttributes = ent.attributes.filter { case (attrName, _) =>
+                            desiredFields.contains(attrName)
+                          }
+                          ent.copy(attributes = filteredAttributes)
+                        }
+                      } else {
+                        optEntity
+                      }).toSeq
           (unfilteredCount, page.size, page)
         }
 
@@ -897,7 +903,7 @@ trait EntityComponent {
       // if entityNameFilter exists, retrieve that entity directly, else do the full query:
       entityQuery.entityNameFilter match {
         case Some(entityName) =>
-          loadSingleEntityForPage(workspaceContext, entityType, entityName, entityQuery)
+          loadSingleEntityForPage(workspaceContext, entityType, entityName, entityQuery, parentContext)
         case _ =>
           EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
                                                                    entityType,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -837,7 +837,7 @@ trait EntityComponent {
                        entityType: String,
                        entityQuery: model.EntityQuery,
                        parentContext: RawlsRequestContext
-                      ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
+    ): ReadWriteAction[(Int, Int, Iterable[Entity])] =
       // if entityNameFilter exists, retrieve that entity directly, else do the full query:
       entityQuery.entityNameFilter match {
         case Some(entityName) =>
@@ -848,12 +848,15 @@ trait EntityComponent {
             val page = optEntity.toSeq
             (unfilteredCount, page.size, page)
           }
-        case _ => EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
-          entityType, entityQuery, parentContext) map { case (unfilteredCount, filteredCount, pagination) =>
-          (unfilteredCount, filteredCount, unmarshalEntities(pagination))
-        }
+        case _ =>
+          EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
+                                                                   entityType,
+                                                                   entityQuery,
+                                                                   parentContext
+          ) map { case (unfilteredCount, filteredCount, pagination) =>
+            (unfilteredCount, filteredCount, unmarshalEntities(pagination))
+          }
       }
-    }
 
     // create or replace entities
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -312,18 +312,22 @@ trait EntityComponent {
       }
 
       // the where clause for this query is filled in specific to the use case
-      def baseEntityAndAttributeSql(workspace: Workspace, desiredAttributes: Set[AttributeName] = Set.empty): String =
+      def baseEntityAndAttributeSql(workspace: Workspace): String =
+        baseEntityAndAttributeSql(workspace, Set.empty)
+
+      def baseEntityAndAttributeSql(workspace: Workspace, desiredAttributes: Set[AttributeName]): String =
         baseEntityAndAttributeSql(
           workspace.workspaceIdAsUUID,
           desiredAttributes
         )
 
-      def baseEntityAndAttributeSql(workspaceId: UUID, desiredAttributes: Set[AttributeName] = Set.empty): String =
+      private def baseEntityAndAttributeSql(workspaceId: UUID): String =
+        baseEntityAndAttributeSql(workspaceId, Set.empty)
+
+      def baseEntityAndAttributeSql(workspaceId: UUID, desiredAttributes: Set[AttributeName]): String =
         baseEntityAndAttributeSql(determineShard(workspaceId), desiredAttributes)
 
-      private def baseEntityAndAttributeSql(shardId: ShardId,
-                                            desiredAttributes: Set[AttributeName] = Set.empty
-      ): String = {
+      private def baseEntityAndAttributeSql(shardId: ShardId, desiredAttributes: Set[AttributeName]): String = {
         // TODO support optional attributes
         val formattedAttributePairs =
           desiredAttributes.map(attributeName => s"(${attributeName.namespace}, ${attributeName.name})").mkString(", ")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -320,15 +320,13 @@ trait EntityComponent {
       private def baseEntityAndAttributeSql(workspaceId: UUID): String =
         baseEntityAndAttributeSql(determineShard(workspaceId))
 
-      private def baseEntityAndAttributeSql(shardId: ShardId): String = {
-
+      private def baseEntityAndAttributeSql(shardId: ShardId): String =
         s"""select e.id, e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date,
           a.id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
           e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
           from ENTITY e
           left outer join ENTITY_ATTRIBUTE_$shardId a on a.owner_id = e.id and a.deleted = e.deleted
           left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id"""
-      }
 
       // Active actions: only return entities and attributes with their deleted flag set to false
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -837,13 +837,12 @@ trait EntityComponent {
                        entityType: String,
                        entityQuery: model.EntityQuery,
                        parentContext: RawlsRequestContext
-    ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
-
-      // if entityNameFilter exists, call get-entity, else:
+                      ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
+      // if entityNameFilter exists, retrieve that entity directly, else do the full query:
       entityQuery.entityNameFilter match {
         case Some(entityName) =>
           for {
-            unfilteredCount <- findActiveEntityByType (workspaceContext.workspaceIdAsUUID, entityType).length.result
+            unfilteredCount <- findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
             optEntity <- get(workspaceContext, entityType, entityName)
           } yield {
             val page = optEntity.toSeq

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -465,24 +465,55 @@ trait EntityComponent {
           }
         }
 
+        val filterByColumn =
+          entityQuery.columnFilter match {
+            case None => sql""
+            case Some(columnFilter) =>
+              val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
+
+              sql""" and e.id in (
+                select filter_e.id
+                from ENTITY filter_e, ENTITY_ATTRIBUTE_#${shardId} filter_a
+                where filter_a.owner_id = filter_e.id
+                and filter_a.namespace = ${columnFilter.attributeName.namespace}
+                and filter_a.name = ${columnFilter.attributeName.name}
+                and COALESCE(filter_a.value_string, filter_a.value_number) = ${columnFilter.term}
+             )"""
+          }
+
         // additional joins-to-subquery to provide proper pagination
         val paginationJoin = concatSqlActions(
           sql""" join (""",
           paginationSubquery(workspaceContext.workspaceIdAsUUID, entityType, entityQuery.sortField),
           filterSql("and", "e"),
+          filterByColumn,
           order(""),
           sql" limit #${entityQuery.pageSize} offset #${(entityQuery.page - 1) * entityQuery.pageSize} ) p on p.id = e.id "
         )
 
         // standalone query to calculate the count of results that match our filter
-        def filteredCountQuery: ReadAction[Vector[Int]] = {
-          val filteredQuery =
-            sql"""select count(1) from ENTITY e
-                                   where e.deleted = 0
-                                   and e.entity_type = $entityType
-                                   and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """
-          concatSqlActions(filteredQuery, filterSql("and", "e")).as[Int]
-        }
+        def filteredCountQuery: ReadAction[Vector[Int]] =
+          entityQuery.columnFilter match {
+            case Some(columnFilter) =>
+              sql"""select count(1) from ENTITY e, ENTITY_ATTRIBUTE_#${determineShard(
+                  workspaceContext.workspaceIdAsUUID
+                )} a
+              where a.owner_id = e.id
+              and e.deleted = 0
+              and e.entity_type = $entityType
+              and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}
+              and a.namespace = ${columnFilter.attributeName.namespace}
+              and a.name = ${columnFilter.attributeName.name}
+              and COALESCE(a.value_string, a.value_number) = ${columnFilter.term}
+       """.as[Int]
+            case _ =>
+              val filteredQuery =
+                sql"""select count(1) from ENTITY e
+                where e.deleted = 0
+                and e.entity_type = $entityType
+                and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} """
+              concatSqlActions(filteredQuery, filterSql("and", "e")).as[Int]
+          }
 
         // the full query to generate the page of results, as requested by the user
         def pageQuery = {
@@ -535,7 +566,7 @@ trait EntityComponent {
             findActiveEntityByType(workspaceContext.workspaceIdAsUUID, entityType).length.result
           )
           filteredCount <-
-            if (entityQuery.filterTerms.isEmpty) {
+            if (entityQuery.filterTerms.isEmpty && entityQuery.columnFilter.isEmpty) {
               // if the query has no filter, then "filteredCount" and "unfilteredCount" will always be the same; no need to make another query
               DBIO.successful(Vector(unfilteredCount))
             } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -495,7 +495,7 @@ trait EntityComponent {
         def filteredCountQuery: ReadAction[Vector[Int]] =
           entityQuery.columnFilter match {
             case Some(columnFilter) =>
-              sql"""select count(1) from ENTITY e, ENTITY_ATTRIBUTE_#${determineShard(
+              sql"""select count(distinct(e.id)) from ENTITY e, ENTITY_ATTRIBUTE_#${determineShard(
                   workspaceContext.workspaceIdAsUUID
                 )} a
               where a.owner_id = e.id

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -43,8 +43,8 @@ trait EntityApiService extends UserInfoDirectives {
         path("workspaces" / Segment / Segment / "entityQuery" / Segment) {
           (workspaceNamespace, workspaceName, entityType) =>
             get {
-              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?) {
-                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator) =>
+              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?, 'entityNameFilter.?) {
+                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, entityNameFilter) =>
                   parameterSeq { allParams =>
                     val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
                       k -> Try(s.map(_.toInt))
@@ -67,7 +67,8 @@ trait EntityApiService extends UserInfoDirectives {
                         sortDirectionTry.get,
                         filterTerms,
                         operatorTry.get,
-                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
+                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                        entityNameFilter
                       )
                       complete {
                         entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -43,45 +43,61 @@ trait EntityApiService extends UserInfoDirectives {
         path("workspaces" / Segment / Segment / "entityQuery" / Segment) {
           (workspaceNamespace, workspaceName, entityType) =>
             get {
-              parameters('page.?, 'pageSize.?, 'sortField.?, 'sortDirection.?, 'filterTerms.?, 'filterOperator.?, 'entityNameFilter.?) {
-                (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, entityNameFilter) =>
-                  parameterSeq { allParams =>
-                    val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
-                      k -> Try(s.map(_.toInt))
-                    }
-                    val sortDirectionTry =
-                      sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
-                    val operatorTry =
-                      filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
+              parameters('page.?,
+                         'pageSize.?,
+                         'sortField.?,
+                         'sortDirection.?,
+                         'filterTerms.?,
+                         'filterOperator.?,
+                         'entityNameFilter.?
+              ) { (page, pageSize, sortField, sortDirection, filterTerms, filterOperator, entityNameFilter) =>
+                parameterSeq { allParams =>
+                  val toIntTries = Map("page" -> page, "pageSize" -> pageSize).map { case (k, s) =>
+                    k -> Try(s.map(_.toInt))
+                  }
+                  val sortDirectionTry =
+                    sortDirection.map(dir => Try(SortDirections.fromString(dir))).getOrElse(Success(Ascending))
+                  val operatorTry =
+                    filterOperator.map(op => Try(FilterOperators.fromString(op))).getOrElse(Success(And))
 
-                    val errors = toIntTries.collect {
+                  val filterValidation = if (filterTerms.isDefined && entityNameFilter.isDefined) {
+                    Seq(
+                      "filterTerms and entityNameFilter are mutually exclusive; you may specify only one or the other."
+                    )
+                  } else Seq.empty
+
+                  val errors = Seq(
+                    toIntTries.collect {
                       case (k, Failure(t))                 => s"$k must be a positive integer"
                       case (k, Success(Some(i))) if i <= 0 => s"$k must be a positive integer"
-                    } ++ (if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty)
+                    },
+                    if (sortDirectionTry.isFailure) Seq(sortDirectionTry.failed.get.getMessage) else Seq.empty,
+                    filterValidation
+                  ).flatten
 
-                    if (errors.isEmpty) {
-                      val entityQuery = EntityQuery(
-                        toIntTries("page").get.getOrElse(1),
-                        toIntTries("pageSize").get.getOrElse(10),
-                        sortField.getOrElse("name"),
-                        sortDirectionTry.get,
-                        filterTerms,
-                        operatorTry.get,
-                        WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
-                        entityNameFilter
+                  if (errors.isEmpty) {
+                    val entityQuery = EntityQuery(
+                      toIntTries("page").get.getOrElse(1),
+                      toIntTries("pageSize").get.getOrElse(10),
+                      sortField.getOrElse("name"),
+                      sortDirectionTry.get,
+                      filterTerms,
+                      operatorTry.get,
+                      WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                      entityNameFilter
+                    )
+                    complete {
+                      entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                  dataReference,
+                                                                  entityType,
+                                                                  entityQuery,
+                                                                  billingProject
                       )
-                      complete {
-                        entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                    dataReference,
-                                                                    entityType,
-                                                                    entityQuery,
-                                                                    billingProject
-                        )
-                      }
-                    } else {
-                      complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
                     }
+                  } else {
+                    complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
                   }
+                }
               }
             }
         } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -102,11 +102,18 @@ trait EntityApiService extends UserInfoDirectives {
                         entityNameFilter,
                         columnFilter.flatMap(_.toOption)
                       )
+                      complete {
+                        entityServiceConstructor(ctx).queryEntities(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                    dataReference,
+                                                                    entityType,
+                                                                    entityQuery,
+                                                                    billingProject
+                        )
+                      }
+                    } else {
+                      complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
                     }
-                  } else {
-                    complete(StatusCodes.BadRequest, ErrorReport(StatusCodes.BadRequest, errors.mkString(", ")))
                   }
-                }
               }
             }
         } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -4041,4 +4041,39 @@ class EntityApiServiceSpec extends ApiServiceSpec {
     assert(argumentCaptor.getValue)
   }
 
+  "createColumnFilter" should "return EntityColumnFilter from string" in {
+    val result = EntityApiService.createColumnFilter(Option("columnName=attributeValue"))
+    assertResult(Right(EntityColumnFilter(AttributeName("default", "columnName"), "attributeValue"))) {
+      result.get
+    }
+  }
+
+  it should "return EntityColumnFilter from string with domain" in {
+    val result = EntityApiService.createColumnFilter(Option("domain:columnName=attributeValue"))
+    assertResult(Right(EntityColumnFilter(AttributeName("domain", "columnName"), "attributeValue"))) {
+      result.get
+    }
+  }
+
+  it should "return error on incomplete filter" in {
+    val result = EntityApiService.createColumnFilter(Option("attributeValue"))
+    assertResult(Left(List("invalid input to the columnFilter parameter"))) {
+      result.get
+    }
+  }
+
+  it should "return error on incorrect filter" in {
+    val result = EntityApiService.createColumnFilter(Option("columnName=attribute=Value"))
+    assertResult(Left(List("invalid input to the columnFilter parameter"))) {
+      result.get
+    }
+  }
+
+  it should "return error on empty filter" in {
+    val result = EntityApiService.createColumnFilter(Option(""))
+    assertResult(Left(List("invalid input to the columnFilter parameter"))) {
+      result.get
+    }
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -3418,8 +3418,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       }
   }
 
-  it should "return 400 when specifying both filterTerms and entityNameFilter" in withPaginationTestDataApiServices {
-    services =>
+  // filter-by-name tests. All of these tests are read-only and use the same set of exemplar data, so we only create that data once:
+  withPaginationTestDataApiServices { services =>
+    it should "return 400 when specifying both filterTerms and entityNameFilter" in {
       Get(
         s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=foo&entityNameFilter=bar"
       ) ~>
@@ -3429,10 +3430,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             status
           }
         }
-  }
+    }
 
-  it should "return correct result when filtering by name on entity query" in withPaginationTestDataApiServices {
-    services =>
+    it should "return correct result when filtering by name on entity query" in {
       val entityNameFilter = "entity_99"
       val pageSize = paginationTestData.entities.size
       val expectedEntities = paginationTestData.entities
@@ -3459,10 +3459,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             responseAs[EntityQueryResponse]
           }
         }
-  }
+    }
 
-  it should "return zero results when filtering by an unknown name on entity query" in withPaginationTestDataApiServices {
-    services =>
+    it should "return zero results when filtering by an unknown name on entity query" in {
       val entityNameFilter = "entity_xyz"
       val pageSize = paginationTestData.entities.size
       val expectedEntities = Seq.empty
@@ -3487,6 +3486,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             responseAs[EntityQueryResponse]
           }
         }
+    }
   }
 
   // *********** START entityQuery field-selection tests

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -344,7 +344,8 @@ case class EntityQuery(page: Int,
                        sortDirection: SortDirections.SortDirection,
                        filterTerms: Option[String],
                        filterOperator: FilterOperators.FilterOperator = FilterOperators.And,
-                       fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs()
+                       fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs(),
+                       entityNameFilter: Option[String] = None
 )
 
 case class EntityQueryResultMetadata(unfilteredCount: Int, filteredCount: Int, filteredPageCount: Int)
@@ -1025,7 +1026,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val EntityTypeMetadataFormat: RootJsonFormat[EntityTypeMetadata] = jsonFormat3(EntityTypeMetadata)
 
-  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat7(EntityQuery)
+  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat8(EntityQuery)
 
   implicit val EntityQueryResultMetadataFormat: RootJsonFormat[EntityQueryResultMetadata] =
     jsonFormat3(EntityQueryResultMetadata)

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -338,6 +338,8 @@ object FilterOperators {
   def toSql(operator: FilterOperator): String = toString(operator)
 }
 
+case class EntityColumnFilter(attributeName: AttributeName, term: String)
+
 case class EntityQuery(page: Int,
                        pageSize: Int,
                        sortField: String,
@@ -345,7 +347,8 @@ case class EntityQuery(page: Int,
                        filterTerms: Option[String],
                        filterOperator: FilterOperators.FilterOperator = FilterOperators.And,
                        fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs(),
-                       entityNameFilter: Option[String] = None
+                       entityNameFilter: Option[String] = None,
+                       columnFilter: Option[EntityColumnFilter] = None
 )
 
 case class EntityQueryResultMetadata(unfilteredCount: Int, filteredCount: Int, filteredPageCount: Int)
@@ -1026,7 +1029,9 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val EntityTypeMetadataFormat: RootJsonFormat[EntityTypeMetadata] = jsonFormat3(EntityTypeMetadata)
 
-  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat8(EntityQuery)
+  implicit val EntityColumnFilterFormat: RootJsonFormat[EntityColumnFilter] = jsonFormat2(EntityColumnFilter)
+
+  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat9(EntityQuery)
 
   implicit val EntityQueryResultMetadataFormat: RootJsonFormat[EntityQueryResultMetadata] =
     jsonFormat3(EntityQueryResultMetadata)


### PR DESCRIPTION
Adds filter-by-column capability. I will make a separate PR to update Orch's swagger definitions once this merges.

---

David's performance tests:
* against workspace `davidan-bp-3/da-theiagen_anonymized_clone-6` in dev
* entityType `qxeuvwzusdwv` (32865 rows)
* filterTerms: `csrgy`
* columnFilter: `bbxqzvoxhhcu=csrgy`
* measured by running Rawls locally and capturing the execution time of the relevant SQL queries as reported by Slick

time, ms | filterTerms |   | columnFilter |  
-- | -- | -- | -- | --
  | count query | results query | count query | results query
run 1 | 74 | 669 | 74 | 292
run 2 | 73 | 691 | 75 | 290
run 3 | 72 | 649 | 74 | 278
run 4 | 72 | 665 | 75 | 284
run 5 | 72 | 662 | 69 | 277
avg | 72.6 | 667.2 | 73.4 | 284.2

---

Bria's performance tests:
30k rows:
Full table query: 300-1000ms
Filter term query: ~2000ms
Filter by column query: ~800ms

3k rows:
Full table query: ~300ms
Filter term query: ~400ms
Filter by column query: ~200-400ms

---

TODOs:
- [x] lots lots lots more tests, specifically around interactions with other features like field selection, sorting by columns other than "name", page size and offset; also need tests for filtering on values inside arrays
- [x] refactoring input validation out to a separate method
- [x] quantify, even manually/anecdotally, the latency impact of using columnFilter instead of filterTerms on a large table. We've added an additional subquery and I don't know how this impacts performance.
- [ ] update Orchestration's swagger definition to include the new query parameter, test it works via Orch

Note: the diff in this PR has a bunch of `scalafmt` changes; you might want to ignore whitespace in the diff