### PR TITLE
AJ-242: list-all-entities streams

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -73,6 +73,15 @@ data-source {
   }
 }
 
+slick {
+  # batchSize is used for writes, to group inserts/updates
+  # this must be explicitly utilized via custom business logic
+  batchSize = 2000
+  # fetchSize is used during Slick streaming to set the size of pages
+  # this must be explicitly set via withStatementParameters
+  fetchSize = 5000
+}
+
 wdl-parsing {
   # number of parsed WDLs to cache
   cache-max-size = 7500

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -24,7 +24,10 @@ object AttributeTempTableType extends Enumeration {
 
 class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit executionContext: ExecutionContext)
     extends LazyLogging {
-  val dataAccess = new DataAccessComponent(databaseConfig.profile, databaseConfig.config.getInt("batchSize"))
+  val batchSize = databaseConfig.config.getInt("batchSize")
+  val fetchSize = databaseConfig.config.getInt("fetchSize")
+
+  val dataAccess = new DataAccessComponent(databaseConfig.profile, batchSize, fetchSize)
 
   val database = databaseConfig.db
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -32,7 +32,8 @@ trait DataAccess
   this: DriverComponent =>
 
   val driver: JdbcProfile
-  val batchSize: Int
+  val batchSize: Int // used for writes to group inserts/updates; must be explicitly utilized via custom business logic
+  val fetchSize: Int // used during Slick streaming to set the size of pages; must be explicitly set via withStatementParameters
 
   import driver.api._
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessComponent.scala
@@ -4,6 +4,7 @@ import slick.jdbc.JdbcProfile
 
 import scala.concurrent.ExecutionContext
 
-class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int)(implicit val executionContext: ExecutionContext)
-    extends DriverComponent
+class DataAccessComponent(val driver: JdbcProfile, val batchSize: Int, val fetchSize: Int)(implicit
+  val executionContext: ExecutionContext
+) extends DriverComponent
     with DataAccess

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponent.scala
@@ -13,7 +13,8 @@ import scala.concurrent.ExecutionContext
 
 trait DriverComponent extends StringValidationUtils {
   val driver: JdbcProfile
-  val batchSize: Int
+  val batchSize: Int // used for writes to group inserts/updates; must be explicitly utilized via custom business logic
+  val fetchSize: Int // used during Slick streaming to set the size of pages; must be explicitly set via withStatementParameters
   implicit val executionContext: ExecutionContext
   implicit override val errorReportSource = ErrorReportSource("rawls")
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -64,6 +64,12 @@ case class EntityRecordWithInlineAttributes(id: Long,
                                             deletedDate: Option[Timestamp]
 ) extends EntityRecordBase
 
+// result structure from entity and attribute list raw sql
+case class EntityAndAttributesResult(entityRecord: EntityRecord,
+                                     attributeRecord: Option[EntityAttributeRecord],
+                                     refEntityRecord: Option[EntityRecord]
+)
+
 object EntityComponent {
   // the length of the all_attribute_values column, which is TEXT, -1 becaue i'm nervous
   val allAttributeValuesColumnSize = 65534
@@ -224,12 +230,6 @@ trait EntityComponent {
 
     type EntityQuery = Query[EntityTable, EntityRecord, Seq]
     type EntityAttributeQuery = Query[EntityAttributeTable, EntityAttributeRecord, Seq]
-
-    // result structure from entity and attribute list raw sql
-    case class EntityAndAttributesResult(entityRecord: EntityRecord,
-                                         attributeRecord: Option[EntityAttributeRecord],
-                                         refEntityRecord: Option[EntityRecord]
-    )
 
     // Raw queries - used when querying for multiple AttributeEntityReferences
 
@@ -1432,12 +1432,12 @@ trait EntityComponent {
       Entity(entityRecord.name, entityRecord.entityType, attributes)
 
     def unmarshalEntities(
-      entityAttributeRecords: Seq[entityQuery.EntityAndAttributesResult]
+      entityAttributeRecords: Seq[EntityAndAttributesResult]
     ): Seq[Entity] =
       unmarshalEntitiesWithIds(entityAttributeRecords).map { case (_, entity) => entity }
 
     def unmarshalEntitiesWithIds(
-      entityAttributeRecords: Seq[entityQuery.EntityAndAttributesResult]
+      entityAttributeRecords: Seq[EntityAndAttributesResult]
     ): Seq[(Long, Entity)] = {
       val allEntityRecords = entityAttributeRecords.map(_.entityRecord).distinct
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -342,6 +342,8 @@ trait EntityComponent {
       ): SqlStreamingAction[Seq[EntityAndAttributesResult], EntityAndAttributesResult, Read] =
         concatSqlActions(listTypeSql(workspaceContext, entityType), sql" order by e.id").as[EntityAndAttributesResult]
 
+      // TODO: if only used by tests, can this be removed?
+      // currently only used by listActiveEntitiesOfType, which is only used by tests
       def activeActionForType(workspaceContext: Workspace,
                               entityType: String
       ): ReadAction[Seq[EntityAndAttributesResult]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -478,7 +478,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
     val pipeline = dbSource
-      .map(x => AttrAccum(Seq(x), None)) // transform EntityAndAttributesResult to AttrAccum
+      .map(entityAndAttributesResult =>
+        AttrAccum(Seq(entityAndAttributesResult), None)
+      ) // transform EntityAndAttributesResult to AttrAccum
       .via(new EntityCollector()) // execute the business logic to accumulate attributes and emit entities
       .collect { // "flatten" the stream to only emit entities
         case AttrAccum(_, Some(entity)) => entity

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.webservice
 
+import akka.http.scaladsl.common.{EntityStreamingSupport, JsonEntityStreamingSupport}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.BadRequest
@@ -237,6 +238,8 @@ trait EntityApiService extends UserInfoDirectives {
           path("workspaces" / Segment / Segment / "entities" / Segment) {
             (workspaceNamespace, workspaceName, entityType) =>
               get {
+                // if any other APIs adopt streaming, move this implicit val higher up in the EntityApiService trait
+                implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()
                 complete {
                   entityServiceConstructor(ctx).listEntities(WorkspaceName(workspaceNamespace, workspaceName),
                                                              entityType

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -34,7 +34,12 @@ backRawls = true
 
 mysql {
   driver = "slick.driver.MySQLDriver$"
+  # batchSize is used for writes, to group inserts/updates
+  # this must be explicitly utilized via custom business logic
   batchSize = 5000
+  # fetchSize is used during Slick streaming to set the size of pages
+  # this must be explicitly set via withStatementParameters
+  fetchSize = 5000
   host = "localhost"
   port = 3310
   db {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -74,6 +74,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
   override val driver: JdbcProfile = DbResource.dataConfig.profile
   override val batchSize: Int = DbResource.dataConfig.config.getInt("batchSize")
+  override val fetchSize: Int = DbResource.dataConfig.config.getInt("fetchSize")
   val slickDataSource = DbResource.dataSource
 
   val userInfo = UserInfo(RawlsUserEmail("owner-access"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -3,11 +3,16 @@ package org.broadinstitute.dsde.rawls.entities
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
-import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  EntityAndAttributesResult,
+  EntityAttributeRecord,
+  EntityRecord,
+  TestDriverComponent
+}
 import org.broadinstitute.dsde.rawls.dataaccess.{
   GoogleBigQueryServiceFactory,
   MockBigQueryServiceFactory,
@@ -54,10 +59,11 @@ import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice.EntityApiService
 import org.broadinstitute.dsde.rawls.workspace.{AttributeNotFoundException, AttributeUpdateOperationException}
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.UUID
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.concurrent.{Await, ExecutionContext}
 
@@ -68,6 +74,7 @@ class EntityServiceSpec
     with TestDriverComponent
     with RawlsTestUtils
     with Eventually
+    with ScalaFutures
     with MockitoTestUtils
     with RawlsStatsDTestUtils
     with BeforeAndAfterAll {
@@ -443,4 +450,106 @@ class EntityServiceSpec
       ex.errorReport.message shouldBe "Can't find attribute name non-existent-attribute"
       ex.errorReport.statusCode shouldBe Some(StatusCodes.NotFound)
   }
+
+  // all following tests can use the same exemplar data, no need to re-create it for each unit test
+  withTestDataServices { services =>
+    // helper methods for these tests
+    val workspaceId = UUID.randomUUID()
+    val entityRecordProto = EntityRecord(1, "my-name", "my-type", workspaceId, 1, false, None)
+    val entityAttributeRecordProto =
+      EntityAttributeRecord(1, 1, "default", "attrname", None, None, None, None, None, None, None, false, None)
+
+    "EntityService.gatherEntities" should "handle empty list" in {
+      val input = Source.empty[EntityAndAttributesResult]
+      val actual = services.entityService.gatherEntities(input).runWith(Sink.seq).futureValue
+
+      assertResult(0, "actual result should be empty")(actual.size)
+    }
+
+    it should "handle single-entity list" in {
+      val input = Source.fromIterator[EntityAndAttributesResult](() =>
+        Seq(
+          EntityAndAttributesResult(
+            entityRecordProto,
+            Option(entityAttributeRecordProto.copy(name = "first", valueString = Option("foo"))),
+            None
+          ),
+          EntityAndAttributesResult(
+            entityRecordProto,
+            Option(entityAttributeRecordProto.copy(name = "second", valueString = Option("bar"))),
+            None
+          )
+        ).iterator
+      )
+
+      val actual = services.entityService.gatherEntities(input).runWith(Sink.seq).futureValue
+
+      assertResult(
+        Seq(
+          Entity("my-name",
+                 "my-type",
+                 Map(AttributeName.withDefaultNS("first") -> AttributeString("foo"),
+                     AttributeName.withDefaultNS("second") -> AttributeString("bar")
+                 )
+          )
+        ),
+        "actual result should have one entity"
+      )(actual)
+    }
+
+    it should "handle multiple-entity list" in {
+      val input = Source.fromIterator[EntityAndAttributesResult](() =>
+        Seq(
+          EntityAndAttributesResult(
+            entityRecordProto,
+            Option(entityAttributeRecordProto.copy(name = "first", valueString = Option("foo"))),
+            None
+          ),
+          EntityAndAttributesResult(
+            entityRecordProto,
+            Option(entityAttributeRecordProto.copy(name = "second", valueString = Option("bar"))),
+            None
+          ),
+          EntityAndAttributesResult(
+            entityRecordProto.copy(id = 2, name = "entity-two"),
+            Option(entityAttributeRecordProto.copy(name = "first", valueString = Option("baz"))),
+            None
+          ),
+          EntityAndAttributesResult(
+            entityRecordProto.copy(id = 3, name = "entity-three"),
+            Option(entityAttributeRecordProto.copy(name = "more", valueNumber = Option(34))),
+            None
+          ),
+          EntityAndAttributesResult(
+            entityRecordProto.copy(id = 3, name = "entity-three"),
+            Option(entityAttributeRecordProto.copy(name = "moremore", valueNumber = Option(45))),
+            None
+          )
+        ).iterator
+      )
+
+      val actual = services.entityService.gatherEntities(input).runWith(Sink.seq).futureValue
+
+      assertResult(
+        Seq(
+          Entity("my-name",
+                 "my-type",
+                 Map(AttributeName.withDefaultNS("first") -> AttributeString("foo"),
+                     AttributeName.withDefaultNS("second") -> AttributeString("bar")
+                 )
+          ),
+          Entity("entity-two", "my-type", Map(AttributeName.withDefaultNS("first") -> AttributeString("baz"))),
+          Entity("entity-three",
+                 "my-type",
+                 Map(AttributeName.withDefaultNS("more") -> AttributeNumber(34),
+                     AttributeName.withDefaultNS("moremore") -> AttributeNumber(45)
+                 )
+          )
+        ),
+        "actual result should have three entities"
+      )(actual)
+    }
+
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -507,8 +507,8 @@ class EntityServiceSpec
           ),
           EntityAndAttributesResult(
             entityRecordProto,
-            Option(entityAttributeRecordProto.copy(name = "second", valueString = Option("bar"))),
-            None
+            Option(entityAttributeRecordProto.copy(name = "second", valueEntityRef = Option(999))),
+            Option(entityRecordProto.copy(id = 999, entityType = "referenced-type", name = "referenced-entity"))
           ),
           EntityAndAttributesResult(
             entityRecordProto.copy(id = 2, name = "entity-two"),
@@ -522,8 +522,8 @@ class EntityServiceSpec
           ),
           EntityAndAttributesResult(
             entityRecordProto.copy(id = 3, name = "entity-three"),
-            Option(entityAttributeRecordProto.copy(name = "moremore", valueNumber = Option(45))),
-            None
+            Option(entityAttributeRecordProto.copy(name = "moremore", valueEntityRef = Option(999))),
+            Option(entityRecordProto.copy(id = 999, entityType = "referenced-type", name = "referenced-entity"))
           )
         ).iterator
       )
@@ -532,18 +532,24 @@ class EntityServiceSpec
 
       assertResult(
         Seq(
-          Entity("my-name",
-                 "my-type",
-                 Map(AttributeName.withDefaultNS("first") -> AttributeString("foo"),
-                     AttributeName.withDefaultNS("second") -> AttributeString("bar")
-                 )
+          Entity(
+            "my-name",
+            "my-type",
+            Map(
+              AttributeName.withDefaultNS("first") -> AttributeString("foo"),
+              AttributeName.withDefaultNS("second") -> AttributeEntityReference("referenced-type", "referenced-entity")
+            )
           ),
           Entity("entity-two", "my-type", Map(AttributeName.withDefaultNS("first") -> AttributeString("baz"))),
-          Entity("entity-three",
-                 "my-type",
-                 Map(AttributeName.withDefaultNS("more") -> AttributeNumber(34),
-                     AttributeName.withDefaultNS("moremore") -> AttributeNumber(45)
-                 )
+          Entity(
+            "entity-three",
+            "my-type",
+            Map(
+              AttributeName.withDefaultNS("more") -> AttributeNumber(34),
+              AttributeName.withDefaultNS("moremore") -> AttributeEntityReference("referenced-type",
+                                                                                  "referenced-entity"
+              )
+            )
           )
         ),
         "actual result should have three entities"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -259,7 +259,6 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           }
         }
 
-        implicit val actorSystem = ActorSystem() // needed for stream materialization below
         exemplarTypes foreach { typeUnderTest =>
           s"should list all entities only for target type [$typeUnderTest]" in withTestDataServices { services =>
             // save exemplar data


### PR DESCRIPTION
Adds JSON streaming for list-all-entities, and removes the `pageSizeLimit` cap on how many entities can be returned from this API. Obsoletes #1536 and #1670.

Requires broadinstitute/firecloud-develop#3253.

`EntityService` and `EntityServiceSpec` contain the important changes in this PR. Most of the rest of the files are syntax/compatibility changes that should have no real effect.

Non-automated testing shows that:
* time to first byte is significantly faster for large data tables and equivalent for small data tables
* time to complete the request is slower for large data tables and equivalent for small data tables
* memory usage does not spike for large data tables

TODOs:
- [x] refactor `EntityService.listEntities` to better support unit tests
- [ ] (maybe) remove test-only SQL query methods - _do this in a follow-on PR to keep PRs managable_
- [x] review code for any refactoring
- [x] perf test
- [x] memory test

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
