### PR TITLE
AJ-242: list-all-entities streaming tweaks: logging, exception handling, test-only method organization

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -330,24 +330,15 @@ trait EntityComponent {
 
       // Active actions: only return entities and attributes with their deleted flag set to false
 
-      private def listTypeSql(workspaceContext: Workspace, entityType: String) =
-        sql"""#${baseEntityAndAttributeSql(workspaceContext)}
-        where e.deleted = false
-        and e.entity_type = ${entityType}
-        and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
-
       // almost the same as "activeActionForType" except 1) adds a sort by e.id; 2) returns a stream
       def activeStreamForType(workspaceContext: Workspace,
                               entityType: String
       ): SqlStreamingAction[Seq[EntityAndAttributesResult], EntityAndAttributesResult, Read] =
-        concatSqlActions(listTypeSql(workspaceContext, entityType), sql" order by e.id").as[EntityAndAttributesResult]
-
-      // TODO: if only used by tests, can this be removed?
-      // currently only used by listActiveEntitiesOfType, which is only used by tests
-      def activeActionForType(workspaceContext: Workspace,
-                              entityType: String
-      ): ReadAction[Seq[EntityAndAttributesResult]] =
-        listTypeSql(workspaceContext, entityType).as[EntityAndAttributesResult]
+        sql"""#${baseEntityAndAttributeSql(workspaceContext)}
+                where e.deleted = false
+                and e.entity_type = ${entityType}
+                and e.workspace_id = ${workspaceContext.workspaceIdAsUUID} order by e.id"""
+          .as[EntityAndAttributesResult]
 
       def activeActionForRefs(workspaceContext: Workspace,
                               entityRefs: Set[AttributeEntityReference]
@@ -579,11 +570,6 @@ trait EntityComponent {
           concatSqlActions(baseSelect, entityIdSql, sql")").as[EntityAndAttributesResult]
         }
 
-      def actionForWorkspace(workspaceContext: Workspace): ReadAction[Seq[EntityAndAttributesResult]] =
-        sql"""#${baseEntityAndAttributeSql(
-            workspaceContext
-          )} where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}""".as[EntityAndAttributesResult]
-
       def batchHide(workspaceContext: Workspace, entities: Seq[AttributeEntityReference]): ReadWriteAction[Seq[Int]] = {
         val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
         // get unique suffix for renaming
@@ -727,6 +713,35 @@ trait EntityComponent {
           """
     }
 
+    /*
+      These methods are only used by unit tests.
+      They return full, materialized result sets without streaming, and these result sets can be
+      quite large in real-world usage. Do not use those methods in user-facing runtime code.
+     */
+    object UnitTestHelpers extends RawSqlQuery {
+
+      val driver: JdbcProfile = EntityComponent.this.driver
+
+      def listActiveEntitiesOfType(workspaceContext: Workspace,
+                                   entityType: String
+      ): ReadAction[TraversableOnce[Entity]] =
+        sql"""#${EntityAndAttributesRawSqlQuery.baseEntityAndAttributeSql(workspaceContext)}
+        where e.deleted = false
+        and e.entity_type = ${entityType}
+        and e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
+          .as[EntityAndAttributesResult](EntityAndAttributesRawSqlQuery.getEntityAndAttributesResult)
+          .map(query => unmarshalEntities(query))
+
+      // includes "deleted" hidden entities
+      def listEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
+        sql"""#${EntityAndAttributesRawSqlQuery.baseEntityAndAttributeSql(
+            workspaceContext
+          )} where e.workspace_id = ${workspaceContext.workspaceIdAsUUID}"""
+          .as[EntityAndAttributesResult](EntityAndAttributesRawSqlQuery.getEntityAndAttributesResult)
+          .map(query => unmarshalEntities(query))
+
+    }
+
     // Slick queries
 
     // Active queries: only return entities and attributes with their deleted flag set to false
@@ -802,23 +817,11 @@ trait EntityComponent {
     def listActiveEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
       EntityAndAttributesRawSqlQuery.activeActionForWorkspace(workspaceContext) map (query => unmarshalEntities(query))
 
-    // includes "deleted" hidden entities
-    // Note: currently only used by tests?
-    def listEntities(workspaceContext: Workspace): ReadAction[TraversableOnce[Entity]] =
-      EntityAndAttributesRawSqlQuery.actionForWorkspace(workspaceContext) map (query => unmarshalEntities(query))
-
     // almost the same as "listActiveEntitiesOfType" except 1) does not unmarshal entities; 2) returns a stream
     def streamActiveEntityAttributesOfType(workspaceContext: Workspace,
                                            entityType: String
     ): SqlStreamingAction[Seq[EntityAndAttributesResult], EntityAndAttributesResult, Read] =
       EntityAndAttributesRawSqlQuery.activeStreamForType(workspaceContext, entityType)
-
-    // TODO: if only used by tests, can this be removed?
-    // currently only used by tests
-    def listActiveEntitiesOfType(workspaceContext: Workspace, entityType: String): ReadAction[TraversableOnce[Entity]] =
-      EntityAndAttributesRawSqlQuery.activeActionForType(workspaceContext, entityType) map (query =>
-        unmarshalEntities(query)
-      )
 
     def getEntityTypesWithCounts(workspaceId: UUID): ReadAction[Map[String, Int]] =
       findActiveEntityByWorkspace(workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -376,7 +376,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * @param dbSource the Source of attributes, typically from a database stream
     * @return a Source of entities constructed from the attributes
     */
-  def gatherEntities(dbSource: Source[EntityAndAttributesResult, NotUsed]): Source[Entity, NotUsed] = {
+  def gatherEntities(
+    dbSource: Source[EntityAndAttributesResult, NotUsed]
+  ): Source[Try[Entity], NotUsed] = {
     // interim classes used while iterating through the stream, allows us to accumulate attributes
     // until ready to emit an entity
     trait AttributeStreamElement
@@ -413,12 +415,20 @@ class EntityService(protected val ctx: RawlsRequestContext,
           val newAccum = prev.accum ++ curr.accum
           AttrAccum(newAccum, None)
 
-        // midstream, we notice that the current entity is DIFFERENT from the previous entity.
+        // midstream, we notice that the current entity's id is greater than the previous entity's id.
         // take all the attributes we have gathered for the previous entity,
         // marshal them into an Entity object, emit that Entity, and start a new accumulator
         // for the new/current entity
-        case (prev: AttrAccum, curr: AttrAccum) if prev.accum.head.entityRecord.id != curr.accum.head.entityRecord.id =>
+        case (prev: AttrAccum, curr: AttrAccum) if prev.accum.head.entityRecord.id < curr.accum.head.entityRecord.id =>
           entityFinished(prev.accum, curr.accum)
+
+        // midstream, we notice that the current entity's id is LESS than the previous entity's id.
+        // this breaks the assumption that entities are ordered by their ids ascending, and indicates a coding
+        // error. Throw an exception.
+        case (prev: AttrAccum, curr: AttrAccum) if prev.accum.head.entityRecord.id > curr.accum.head.entityRecord.id =>
+          throw new RawlsException(
+            "Unexpected internal error; the previous results may be incomplete. Cause: entity source input is in unexpected order."
+          )
 
         // if current is empty but previous is not, it means the stream has finished.
         // Marshal and output the final Entity.
@@ -483,7 +493,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
       ) // transform EntityAndAttributesResult to AttrAccum
       .via(new EntityCollector()) // execute the business logic to accumulate attributes and emit entities
       .collect { // "flatten" the stream to only emit entities
-        case AttrAccum(_, Some(entity)) => entity
+        case AttrAccum(_, Some(entity)) => Success(entity)
+      }
+      .log("gatherEntities")
+      .addAttributes(
+        Attributes.logLevels(onElement = Attributes.LogLevels.Debug,
+                             onFinish = Attributes.LogLevels.Info,
+                             onFailure = Attributes.LogLevels.Error
+        )
+      )
+      .recover { case e: Exception =>
+        Failure(RawlsExceptionWithErrorReport(e.getMessage))
       }
 
     Source.fromGraph(pipeline) // return a Source, which akka-http natively knows how to stream to the caller

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -376,9 +376,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     * @param dbSource the Source of attributes, typically from a database stream
     * @return a Source of entities constructed from the attributes
     */
-  def gatherEntities(
-    dbSource: Source[EntityAndAttributesResult, NotUsed]
-  ): Source[Entity, NotUsed] = {
+  def gatherEntities(dbSource: Source[EntityAndAttributesResult, NotUsed]): Source[Entity, NotUsed] = {
     // interim classes used while iterating through the stream, allows us to accumulate attributes
     // until ready to emit an entity
     trait AttributeStreamElement

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -1450,9 +1450,10 @@ class AttributeComponentSpec
       withClue(s"should have saved exactly $parallelism entities")(saveFailures shouldBe empty)
 
       // query all entities for workspace (odd)
-      val actualEntitiesOdd = runAndWait(entityQuery.listActiveEntitiesOfType(workspaceOdd, entityType))
+      val actualEntitiesOdd = runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(workspaceOdd, entityType))
       // query all entities for workspace (even)
-      val actualEntitiesEven = runAndWait(entityQuery.listActiveEntitiesOfType(workspaceEven, entityType))
+      val actualEntitiesEven =
+        runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(workspaceEven, entityType))
 
       // validate save counts entities
       val expectedCountOdd = Math.ceil(parallelism.toDouble / 2d)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -17,7 +17,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   // entity and attribute counts, regardless of deleted status
   def countEntitiesAttrs(workspace: Workspace): (Int, Int) = {
-    val ents = runAndWait(entityQuery.listEntities(workspace))
+    val ents = runAndWait(entityQuery.UnitTestHelpers.listEntities(workspace))
     (ents.size, ents.map(_.attributes.size).sum)
   }
 
@@ -919,7 +919,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     )
 
     withWorkspaceContext(constantData.workspace) { context =>
-      assertSameElements(expected, runAndWait(entityQuery.listActiveEntitiesOfType(context, "Sample")))
+      assertSameElements(expected, runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context, "Sample")))
     }
   }
 
@@ -1149,8 +1149,13 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         )
         runAndWait(entityQuery.save(context2, x2_updated))
 
-        assert(runAndWait(entityQuery.listActiveEntitiesOfType(context2, "SampleSet")).toList.contains(x1))
-        assert(runAndWait(entityQuery.listActiveEntitiesOfType(context2, "SampleSet")).toList.contains(x2_updated))
+        assert(
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context2, "SampleSet")).toList.contains(x1)
+        )
+        assert(
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context2, "SampleSet")).toList
+            .contains(x2_updated)
+        )
 
         // note: we're copying FROM workspace2 INTO workspace
         assertResult(Seq.empty) {
@@ -1165,8 +1170,13 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         )
 
         // verify it was actually copied into the workspace
-        assert(runAndWait(entityQuery.listActiveEntitiesOfType(context1, "SampleSet")).toList.contains(x1))
-        assert(runAndWait(entityQuery.listActiveEntitiesOfType(context1, "SampleSet")).toList.contains(x2_updated))
+        assert(
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context1, "SampleSet")).toList.contains(x1)
+        )
+        assert(
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context1, "SampleSet")).toList
+            .contains(x2_updated)
+        )
       }
     }
   }
@@ -1220,7 +1230,9 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         )
 
         // verify it was actually copied into the workspace
-        assertSameElements(allEntities, runAndWait(entityQuery.listActiveEntitiesOfType(context1, "test")).toSet)
+        assertSameElements(allEntities,
+                           runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context1, "test")).toSet
+        )
       }
     }
 
@@ -1243,7 +1255,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
       // verify that it wasn't copied into the workspace again
       assert(
-        runAndWait(entityQuery.listActiveEntitiesOfType(context, "Sample")).toList
+        runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context, "Sample")).toList
           .filter(entity => entity == testData.sample1)
           .size == 1
       )
@@ -1269,21 +1281,21 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         runAndWait(entityQuery.save(context3, sample1))
 
         assertResult(List()) {
-          runAndWait(entityQuery.listActiveEntitiesOfType(context2, "sample")).toList
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context2, "sample")).toList
         }
 
         assertResult(List(participant1)) {
-          runAndWait(entityQuery.listActiveEntitiesOfType(context2, "participant")).toList
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context2, "participant")).toList
         }
 
         runAndWait(entityQuery.checkAndCopyEntities(context3, context2, "sample", Seq("sample1"), true, testContext))
 
         assertResult(List(sample1)) {
-          runAndWait(entityQuery.listActiveEntitiesOfType(context2, "sample")).toList
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context2, "sample")).toList
         }
 
         assertResult(List(participant1)) {
-          runAndWait(entityQuery.listActiveEntitiesOfType(context2, "participant")).toList
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context2, "participant")).toList
         }
 
       }
@@ -1377,7 +1389,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
 
   it should "delete an entity type and return the total number of rows deleted (hidden)" in withDefaultTestDatabase {
     withWorkspaceContext(testData.workspace) { context =>
-      val sampleCount = runAndWait(entityQuery.listActiveEntitiesOfType(context, "sample")).iterator.size
+      val sampleCount =
+        runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context, "sample")).iterator.size
 
       assertResult(sampleCount) {
         runAndWait(entityQuery.hideType(context, "sample"))
@@ -1598,7 +1611,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     )
     runAndWait(entityQuery.save(context, entitiesToSave))
 
-    assume(runAndWait(entityQuery.listEntities(context)).size == 5,
+    assume(runAndWait(entityQuery.UnitTestHelpers.listEntities(context)).size == 5,
            "filteredCount tests did not set up fixtures correctly"
     )
 
@@ -1616,7 +1629,7 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
           withWorkspaceContext(emptyWorkspace.workspace) { context =>
             caseSensitivityFixtures(context)
 
-            assume(runAndWait(entityQuery.listEntities(context)).size == 5,
+            assume(runAndWait(entityQuery.UnitTestHelpers.listEntities(context)).size == 5,
                    "filteredCount tests did not set up fixtures correctly, within first test"
             )
             val unfilteredQuery = EntityQuery(1, 1, sortKey, sortDir, None)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -305,7 +305,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
       // Check in db if entities are there
       withWorkspaceContext(testData.workspace) { context =>
         eventually(Timeout(scaled(timeout)), Interval(scaled(interval))) {
-          val entitiesOfType = runAndWait(entityQuery.listActiveEntitiesOfType(context, entityType))
+          val entitiesOfType = runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(context, entityType))
           assertResult(upsertQuantity)(entitiesOfType.size)
           upsertRange(upsertQuantity) foreach { idx =>
             val name = s"avro-entity-$idx"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -491,7 +491,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
 
   // entity and attribute counts, regardless of deleted status
   def countEntitiesAttrs(workspace: Workspace): (Int, Int) = {
-    val ents = runAndWait(entityQuery.listEntities(testData.workspace))
+    val ents = runAndWait(entityQuery.UnitTestHelpers.listEntities(testData.workspace))
     (ents.size, ents.map(_.attributes.size).sum)
   }
 
@@ -856,7 +856,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
             status
           }
           assertResult(Seq.empty) {
-            runAndWait(entityQuery.listActiveEntitiesOfType(testData.workspace, "typeToDelete")).toSeq
+            runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(testData.workspace, "typeToDelete")).toSeq
           }
         }
 
@@ -900,7 +900,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           responseAs[String].contains("50")
         }
         assertResult(true) {
-          runAndWait(entityQuery.listActiveEntitiesOfType(testData.workspace, "typeToDelete")).iterator.nonEmpty
+          runAndWait(
+            entityQuery.UnitTestHelpers.listActiveEntitiesOfType(testData.workspace, "typeToDelete")
+          ).iterator.nonEmpty
         }
       }
 
@@ -1514,7 +1516,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           status
         }
 
-        val dbSamples = runAndWait(entityQuery.listActiveEntitiesOfType(constantData.workspace, "Sample"))
+        val dbSamples =
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(constantData.workspace, "Sample"))
         assertSameElements(responseAs[Array[Entity]], expected)
         assertSameElements(dbSamples, expected)
       }
@@ -1549,7 +1552,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           status
         }
 
-        val dbSamples = runAndWait(entityQuery.listActiveEntitiesOfType(constantData.workspace, "Sample"))
+        val dbSamples =
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(constantData.workspace, "Sample"))
         assertSameElements(responseAs[Array[Entity]], expected :+ newSample)
         assertSameElements(dbSamples, expected :+ newSample)
       }
@@ -1569,7 +1573,8 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           status
         }
 
-        val dbSamples = runAndWait(entityQuery.listActiveEntitiesOfType(constantData.workspace, "Sample"))
+        val dbSamples =
+          runAndWait(entityQuery.UnitTestHelpers.listActiveEntitiesOfType(constantData.workspace, "Sample"))
         assertSameElements(responseAs[Array[Entity]], expected)
         assertSameElements(dbSamples, expected)
       }


### PR DESCRIPTION
Follow-on work to #2247 

This PR adds:
* consolidation/organization of `EntityComponent` methods that are only used in unit tests
* additional logging for the list-all-entities stream
    * by default, logs when the upstream/downstream finishes and in case of an exception
    * has a clear place (`onElement`) to enable logging for each element in the stream if a developer wants to do so
* additional error-handling
    * adds a `recover` for the stream to output exception messages to the caller before shutting down the stream
    * adds a safety check for out-of-order input to the stream

This is what exception info at the end of the response looks like:
![Screenshot 3-2-2023 at 02 09 PM](https://user-images.githubusercontent.com/6041577/222527922-0cfa2684-c5b9-4afa-84ee-4ab429f1a8d9.png)

And here's the extra logging in the typical success case:
```
rawls [INFO] [19:15:06.514] [rawls-akka.actor.default-dispatcher-14] akka.stream.Materializer - [gatherEntities] Downstream finished, cause: SubscriptionWithCancelException$StageWasCompleted$: null
rawls [INFO] [19:15:07.076] [rawls-akka.actor.default-dispatcher-5] akka.stream.Materializer - [gatherEntities] Upstream finished.
```


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
