### PR TITLE
AJ-864: enable column filter on primary key; remove name filter

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1548,7 +1548,7 @@ paths:
               - desc
         - name: filterTerms
           in: query
-          description: terms to search for, using substring matching, in all attributes of an entity. Mutually exclusive with the entityNameFilter and columnFilter parameters.
+          description: terms to search for, using substring matching, in all attributes of an entity. Mutually exclusive with the columnFilter parameter.
           schema:
             type: string
         - name: filterOperator
@@ -1560,14 +1560,9 @@ paths:
             enum:
               - and
               - or
-        - name: entityNameFilter
-          in: query
-          description: exact-match name of entity to return. Mutually exclusive with the filterTerms and columnFilter parameters.
-          schema:
-            type: string
         - name: columnFilter
           in: query
-          description: exact-match filter for a value in a single column, in the form columnName=string-to-match. Mutually exclusive with the filterTerms and entityNameFilter parameters.
+          description: exact-match filter for a value in a single column, in the form columnName=string-to-match. Mutually exclusive with the filterTerms parameter.
           schema:
             type: string
         - name: fields

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -929,11 +929,10 @@ trait EntityComponent {
                        entityQuery: model.EntityQuery,
                        parentContext: RawlsRequestContext
     ): ReadWriteAction[(Int, Int, Iterable[Entity])] = {
-      // look for either an entityNameFilter or a columnFilter that specifies the primary key for this entityType;
-      // such a columnFilter is equivalent to an entityNameFilter.
-      val nameFilter: Option[String] = (entityQuery.entityNameFilter, entityQuery.columnFilter) match {
-        case (Some(nameFilter), _) => Option(nameFilter)
-        case (_, Some(colFilter))
+      // look for a columnFilter that specifies the primary key for this entityType;
+      // such a columnFilter means we are filtering by name and can greatly simplify the underlying query.
+      val nameFilter: Option[String] = entityQuery.columnFilter match {
+        case Some(colFilter)
             if colFilter.attributeName == AttributeName.withDefaultNS(
               entityType + Attributable.entityIdAttributeSuffix
             ) =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -3426,9 +3426,9 @@ class EntityApiServiceSpec extends ApiServiceSpec {
   // filter-by-name and filter-by-column tests. All of these tests are read-only and use the same set of exemplar data,
   // so we only create that data once:
   withPaginationTestDataApiServices { services =>
-    it should "return 400 when specifying both filterTerms and entityNameFilter" in {
+    it should "return 400 when specifying both filterTerms and columnFilter" in {
       Get(
-        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=foo&entityNameFilter=bar"
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?filterTerms=foo&columnFilter=bar%3Dbaz"
       ) ~>
         sealRoute(services.entityRoutes) ~>
         check {
@@ -3445,7 +3445,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         .filter(e => e.name == entityNameFilter)
         .sortBy(_.name)
       Get(
-        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&entityNameFilter=$entityNameFilter"
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=${paginationTestData.entityType}_id%3D$entityNameFilter"
       ) ~>
         sealRoute(services.entityRoutes) ~>
         check {
@@ -3454,7 +3454,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           }
           assertResult(
             EntityQueryResponse(
-              defaultQuery.copy(pageSize = pageSize, entityNameFilter = Option(entityNameFilter)),
+              defaultQuery.copy(
+                pageSize = pageSize,
+                columnFilter = Option(
+                  EntityColumnFilter(AttributeName.fromDelimitedName(s"${paginationTestData.entityType}_id"),
+                                     entityNameFilter
+                  )
+                )
+              ),
               EntityQueryResultMetadata(paginationTestData.numEntities,
                                         expectedEntities.size,
                                         calculateNumPages(expectedEntities.size, pageSize)
@@ -3472,7 +3479,7 @@ class EntityApiServiceSpec extends ApiServiceSpec {
       val pageSize = paginationTestData.entities.size
       val expectedEntities = Seq.empty
       Get(
-        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&entityNameFilter=$entityNameFilter"
+        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?pageSize=$pageSize&columnFilter=${paginationTestData.entityType}_id%3D$entityNameFilter"
       ) ~>
         sealRoute(services.entityRoutes) ~>
         check {
@@ -3481,7 +3488,14 @@ class EntityApiServiceSpec extends ApiServiceSpec {
           }
           assertResult(
             EntityQueryResponse(
-              defaultQuery.copy(pageSize = pageSize, entityNameFilter = Option(entityNameFilter)),
+              defaultQuery.copy(
+                pageSize = pageSize,
+                columnFilter = Option(
+                  EntityColumnFilter(AttributeName.fromDelimitedName(s"${paginationTestData.entityType}_id"),
+                                     entityNameFilter
+                  )
+                )
+              ),
               EntityQueryResultMetadata(paginationTestData.numEntities,
                                         expectedEntities.size,
                                         calculateNumPages(expectedEntities.size, pageSize)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiServiceSpec.scala
@@ -3802,17 +3802,6 @@ class EntityApiServiceSpec extends ApiServiceSpec {
         }
     }
 
-    it should "return 400 when column filter specifies a non-existent column" in {
-      Get(
-        s"${paginationTestData.workspace.path}/entityQuery/${paginationTestData.entityType}?columnFilter=this-attribute-does-not-exist%3D99"
-      ) ~>
-        sealRoute(services.entityRoutes) ~>
-        check {
-          assertResult(StatusCodes.BadRequest) {
-            status
-          }
-        }
-    }
   }
 
   // *********** START entityQuery field-selection tests

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -347,7 +347,6 @@ case class EntityQuery(page: Int,
                        filterTerms: Option[String],
                        filterOperator: FilterOperators.FilterOperator = FilterOperators.And,
                        fields: WorkspaceFieldSpecs = WorkspaceFieldSpecs(),
-                       entityNameFilter: Option[String] = None,
                        columnFilter: Option[EntityColumnFilter] = None
 )
 
@@ -1031,7 +1030,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val EntityColumnFilterFormat: RootJsonFormat[EntityColumnFilter] = jsonFormat2(EntityColumnFilter)
 
-  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat9(EntityQuery)
+  implicit val EntityQueryFormat: RootJsonFormat[EntityQuery] = jsonFormat8(EntityQuery)
 
   implicit val EntityQueryResultMetadataFormat: RootJsonFormat[EntityQueryResultMetadata] =
     jsonFormat3(EntityQueryResultMetadata)


### PR DESCRIPTION
Enhancement to #2239 and #2240:

* if the user specifies the id column `${entityType}_id` in `columnFilter`, treat it exactly the same as if the user specified an entity name in the now-deleted `entityNameFilter`
* remove `entityNameFilter`

This consolidates two query parameters into one, simplifying the API slightly, and allows the `${entityType}_id` pseudo-column to function exactly the same as other columns. This should simplify UI development.