### PR TITLE
[WOR-644] Tag Sentry events for billing project creation failures

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -63,7 +63,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
   def createBillingProjectV2(createProjectRequest: CreateRawlsV2BillingProjectFullRequest): Future[Unit] = {
     def tagAndCaptureSentryEvent(e: Throwable): Unit = {
       val sentryEvent = new SentryEvent()
-      sentryEvent.setTag("team", "workspaces")
+      sentryEvent.setTag("component", "billing")
       sentryEvent.setThrowable(e)
       Sentry.captureEvent(sentryEvent)
       throw e

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -1,7 +1,11 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.StatusCodes.ServerError
+import bio.terra.profile.client.{ApiException => BpmApiException}
+import bio.terra.workspace.client.{ApiException => WsmApiException}
 import com.typesafe.scalalogging.LazyLogging
+import io.sentry.{Sentry, SentryEvent}
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.model.{
@@ -57,15 +61,22 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
    * Creates a "v2" billing project, using either Azure managed app coordinates or a Google Billing Account
    */
   def createBillingProjectV2(createProjectRequest: CreateRawlsV2BillingProjectFullRequest): Future[Unit] = {
+    def tagAndCaptureSentryEvent(e: Throwable): Unit = {
+      val sentryEvent = new SentryEvent()
+      sentryEvent.setTag("team", "workspaces")
+      sentryEvent.setThrowable(e)
+      Sentry.captureEvent(sentryEvent)
+      throw e
+    }
+
     val billingProjectLifecycle = createProjectRequest.billingInfo match {
       case Left(_)  => googleBillingProjectLifecycle
       case Right(_) => bpmBillingProjectLifecycle
     }
     val billingProjectName = createProjectRequest.projectName
 
-    for {
+    (for {
       _ <- validateBillingProjectName(createProjectRequest.projectName.value)
-
       _ = logger.info(s"Validating billing project creation request [name=${billingProjectName.value}]")
       _ <- billingProjectLifecycle.validateBillingProjectCreationRequest(createProjectRequest, ctx)
 
@@ -84,7 +95,14 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
         creationStatus,
         None
       )
-    } yield {}
+    } yield {}).recover {
+      case e: RawlsExceptionWithErrorReport =>
+        e.errorReport.statusCode.collect { case _: ServerError =>
+          tagAndCaptureSentryEvent(e)
+        }
+      case wsmException: WsmApiException if wsmException.getCode >= 500 => tagAndCaptureSentryEvent(wsmException)
+      case bpmException: BpmApiException if bpmException.getCode >= 500 => tagAndCaptureSentryEvent(bpmException)
+    }
   }
 
   private def rollbackCreateV2BillingProjectInternal(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -97,8 +97,10 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
       )
     } yield {}).recover {
       case e: RawlsExceptionWithErrorReport =>
-        e.errorReport.statusCode.collect { case _: ServerError =>
-          tagAndCaptureSentryEvent(e)
+        e.errorReport.statusCode.collect {
+          case _: ServerError =>
+            tagAndCaptureSentryEvent(e)
+          case _ => throw e
         }
       case wsmException: WsmApiException if wsmException.getCode >= 500 => tagAndCaptureSentryEvent(wsmException)
       case bpmException: BpmApiException if bpmException.getCode >= 500 => tagAndCaptureSentryEvent(bpmException)


### PR DESCRIPTION
Ticket: [WOR-644](https://broadworkbench.atlassian.net/browse/WOR-644)

- Add custom tag to server exceptions thrown during billing project creation (includes any landing zone or billing profile failures).
- Alerts will be configured in Sentry to notify the #dsp-workspaces-alerts channel when issues with the Workspaces team tag are seen. See this test exception I set up in dev as an example - https://broad-institute.sentry.io/alerts/rules/firecloud-dev/13984611/details/

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-644]: https://broadworkbench.atlassian.net/browse/WOR-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ