### PR TITLE
[WOR-675] Enable Autoclass on new workspace buckets

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -254,7 +254,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
             traceId = Option(traceId),
             bucketPolicyOnlyEnabled = true,
             logBucket = Option(GcsBucketName(GoogleServicesDAO.getStorageLogsBucketName(googleProject))),
-            location = bucketLocation
+            location = bucketLocation,
+            autoclassEnabled = true
           )
           .compile
           .drain

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/WorkspaceMigrationActorSpec.scala
@@ -785,7 +785,8 @@ class WorkspaceMigrationActorSpec extends AnyFlatSpecLike with Matchers with Eve
                                     logBucket: Option[GcsBucketName],
                                     retryConfig: RetryConfig,
                                     location: Option[String],
-                                    bucketTargetOptions: List[Storage.BucketTargetOption]
+                                    bucketTargetOptions: List[Storage.BucketTargetOption],
+                                    autoclassEnabled: Boolean
           ): fs2.Stream[IO, Unit] =
             fs2.Stream.raiseError[IO](error)
         }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,10 +82,10 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "46d1df6"
+  val workbenchLibsHash = "3de88b23-SNAP"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.22-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.23-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "a78f6e9"
+  val workbenchLibsHash = "db348ae"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.23-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "3de88b23-SNAP"
+  val workbenchLibsHash = "a78f6e9"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.23-${workbenchLibsHash}"


### PR DESCRIPTION
Ticket: [WOR-675](https://broadworkbench.atlassian.net/browse/WOR-675)
- enable autoclass on all new workspace buckets
- see workbench-libs PR https://github.com/broadinstitute/workbench-libs/pull/1278

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-675]: https://broadworkbench.atlassian.net/browse/WOR-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ