### PR TITLE
WOR-779 update rawls spend report api to call bpm for azure billing projects

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -507,14 +507,6 @@ object Boot extends IOApp with LazyLogging {
         metricsPrefix
       )
 
-      val spendReportingServiceConstructor: RawlsRequestContext => SpendReportingService =
-        SpendReportingService.constructor(
-          slickDataSource,
-          spendReportingBigQueryService,
-          samDAO,
-          spendReportingServiceConfig
-        )
-
       val workspaceManagerResourceMonitorRecordDao = new WorkspaceManagerResourceMonitorRecordDao(slickDataSource)
       val billingRepository = new BillingRepository(slickDataSource)
       val billingProjectOrchestratorConstructor: RawlsRequestContext => BillingProjectOrchestrator =
@@ -531,6 +523,16 @@ object Boot extends IOApp with LazyLogging {
           ),
           workspaceManagerResourceMonitorRecordDao,
           multiCloudWorkspaceConfig
+        )
+
+      val spendReportingServiceConstructor: RawlsRequestContext => SpendReportingService =
+        SpendReportingService.constructor(
+          slickDataSource,
+          spendReportingBigQueryService,
+          billingRepository,
+          billingProfileManagerDAO,
+          samDAO,
+          spendReportingServiceConfig
         )
 
       val service = new RawlsApiServiceImpl(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import bio.terra.common.tracing.JerseyTracingFilter
-import bio.terra.profile.api.{AzureApi, ProfileApi, UnauthenticatedApi}
+import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi, UnauthenticatedApi}
 import bio.terra.profile.client.ApiClient
 import io.opencensus.trace.Tracing
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
@@ -18,6 +18,8 @@ trait BillingProfileManagerClientProvider {
   def getAzureApi(ctx: RawlsRequestContext): AzureApi
 
   def getProfileApi(ctx: RawlsRequestContext): ProfileApi
+
+  def getSpendReportingApi(ctx: RawlsRequestContext): SpendReportingApi
 
   def getUnauthenticatedApi(): UnauthenticatedApi
 }
@@ -44,6 +46,9 @@ class HttpBillingProfileManagerClientProvider(baseBpmUrl: Option[String]) extend
 
   override def getProfileApi(ctx: RawlsRequestContext): ProfileApi =
     new ProfileApi(getApiClient(ctx))
+
+  override def getSpendReportingApi(ctx: RawlsRequestContext): SpendReportingApi =
+    new SpendReportingApi(getApiClient(ctx))
 
   private def basePath =
     baseBpmUrl.getOrElse(throw new NotImplementedError("Billing profile manager path not configured"))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -214,12 +214,12 @@ class BillingProfileManagerDAOImpl(
         )
     catch {
       case ex: ApiException =>
-        if (ex.getCode == StatusCodes.BadRequest.intValue) {
-          val bpmErrorMessageJson = ex.getMessage.parseJson
-          val bpmErrorMessage = bpmErrorMessageJson.convertTo[BpmAzureReportErrorMessage]
-          throw new BpmAzureSpendReportBadRequest(bpmErrorMessage.message)
-        } else {
-          throw new BpmAzureSpendReportApiException(ex.getMessage, ex)
+        ex.getCode match {
+          case StatusCodes.BadRequest.intValue =>
+            val bpmErrorMessageJson = ex.getMessage.parseJson
+            val bpmErrorMessage = bpmErrorMessageJson.convertTo[BpmAzureReportErrorMessage]
+            throw new BpmAzureSpendReportBadRequest(bpmErrorMessage.message)
+          case _ => throw new BpmAzureSpendReportApiException(ex.getMessage, ex)
         }
       case ex: Exception => throw new BpmAzureSpendReportApiException(ex.getMessage, ex)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext
 }
 
-import java.util.UUID
+import java.util.{Date, UUID}
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
@@ -52,6 +52,12 @@ trait BillingProfileManagerDAO {
   ): Unit
 
   def getStatus(): SystemStatus
+
+  def getAzureSpendReport(billingProfileId: UUID,
+                          spendReportStartDate: Date,
+                          spendReportEndDate: Date,
+                          ctx: RawlsRequestContext
+  )(implicit ec: ExecutionContext): Future[SpendReport]
 }
 
 class ManagedAppNotFoundException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
@@ -173,4 +179,19 @@ class BillingProfileManagerDAOImpl(
       )
 
   override def getStatus(): SystemStatus = apiClientProvider.getUnauthenticatedApi().serviceStatus()
+
+  def getAzureSpendReport(billingProfileId: UUID,
+                          spendReportStartDate: Date,
+                          spendReportEndDate: Date,
+                          ctx: RawlsRequestContext
+  )(implicit ec: ExecutionContext): Future[SpendReport] =
+    Future.apply(
+      apiClientProvider
+        .getSpendReportingApi(ctx)
+        .getSpendReport(
+          billingProfileId,
+          spendReportStartDate,
+          spendReportEndDate
+        )
+    )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -15,16 +15,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsBillingAccountName,
   RawlsRequestContext
 }
-import spray.json.{
-  DefaultJsonProtocol,
-  DeserializationException,
-  JsArray,
-  JsNumber,
-  JsObject,
-  JsString,
-  JsValue,
-  RootJsonFormat
-}
+import spray.json.DefaultJsonProtocol
 
 import java.util.{Date, UUID}
 import scala.annotation.tailrec
@@ -32,7 +23,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 
 case class BpmAzureReportErrorMessage(message: String, statusCode: Int)
-//object BpmAzureReportErrorMessage
 
 object BpmAzureReportErrorMessageJsonProtocol extends DefaultJsonProtocol {
   implicit val bpmAzureReportErrorMessageFormat = jsonFormat2(BpmAzureReportErrorMessage.apply)
@@ -40,23 +30,6 @@ object BpmAzureReportErrorMessageJsonProtocol extends DefaultJsonProtocol {
 
 import spray.json._
 import BpmAzureReportErrorMessageJsonProtocol._
-
-//object BpmAzureReportErrorMessageProtocol extends DefaultJsonProtocol {
-//  implicit object BpmAzureReportErrorMessageJsonFormat extends RootJsonFormat[BpmAzureReportErrorMessage] {
-//    def write(error: BpmAzureReportErrorMessage) =
-//      JsObject(
-//        "message" -> JsString(error.message),
-//        "statusCode" -> JsString(error.statusCode.toString)
-//      )
-//
-//    def read(value: JsValue): BpmAzureReportErrorMessage =
-//      value.asJsObject.getFields("message", "statusCode") match {
-//        case Seq(JsString(message), JsNumber(statusCode)) =>
-//          BpmAzureReportErrorMessage(message, statusCode.intValue)
-//        case _ => throw DeserializationException("Could not deserialize to BpmAzureReportErrorMessage")
-//      }
-//  }
-//}
 
 /**
  * Common interface for Billing Profile Manager operations

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -66,6 +66,7 @@ trait BillingProfileManagerDAO {
   def getStatus(): SystemStatus
 
   @throws(classOf[BpmAzureSpendReportBadRequest])
+  @throws(classOf[BpmAzureSpendReportApiException])
   def getAzureSpendReport(billingProfileId: UUID,
                           spendReportStartDate: Date,
                           spendReportEndDate: Date,
@@ -76,6 +77,7 @@ trait BillingProfileManagerDAO {
 class ManagedAppNotFoundException(errorReport: ErrorReport) extends RawlsExceptionWithErrorReport(errorReport)
 
 class BpmAzureSpendReportBadRequest(message: String) extends Exception(message)
+class BpmAzureSpendReportApiException(message: String, cause: Throwable = null) extends Exception(message, cause)
 
 object BillingProfileManagerDAO {
   val BillingProfileRequestBatchSize = 1000
@@ -196,6 +198,7 @@ class BillingProfileManagerDAOImpl(
   override def getStatus(): SystemStatus = apiClientProvider.getUnauthenticatedApi().serviceStatus()
 
   @throws(classOf[BpmAzureSpendReportBadRequest])
+  @throws(classOf[BpmAzureSpendReportApiException])
   def getAzureSpendReport(billingProfileId: UUID,
                           spendReportStartDate: Date,
                           spendReportEndDate: Date,
@@ -216,8 +219,8 @@ class BillingProfileManagerDAOImpl(
           val bpmErrorMessage = bpmErrorMessageJson.convertTo[BpmAzureReportErrorMessage]
           throw new BpmAzureSpendReportBadRequest(bpmErrorMessage.message)
         } else {
-          throw ex
+          throw new BpmAzureSpendReportApiException(ex.getMessage, ex)
         }
+      case ex: Exception => throw new BpmAzureSpendReportApiException(ex.getMessage, ex)
     }
-
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -77,7 +77,9 @@ object SpendReportingAggregation {
           srRange.getCredits,
           srRange.getCurrency,
           Option.when(srRange.getStartTime != null)(DateTime.parse(srRange.getStartTime)),
-          Option.when(srRange.getEndTime != null)(DateTime.parse(srRange.getEndTime))
+          Option.when(srRange.getEndTime != null)(DateTime.parse(srRange.getEndTime)),
+          category =
+            Option.when(srRange.getCategory != null)(TerraSpendCategories.withName(srRange.getCategory.toString))
         )
       )
       .toList

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -38,7 +38,8 @@ object SpendReportingResultsConvertor {
         spendReportingForDateRange.getCredits,
         spendReportingForDateRange.getCurrency,
         Option.empty,
-        Option.empty
+        Option.empty,
+        category = Option.apply(TerraSpendCategories.withName(spendReportingForDateRange.getCategory.toString))
       )
 
     // TODO: implement apply for SpendReportingAggregation?!

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -38,7 +38,7 @@ object SpendReportingResultsConvertor {
         spendReportingForDateRange.getCurrency,
         Option.empty,
         Option.empty,
-        category = Option.apply(TerraSpendCategories.withName(spendReportingForDateRange.getCategory.toString))
+        category = Option(TerraSpendCategories.withName(spendReportingForDateRange.getCategory.toString))
       )
 
     def mapSpendReportingAggregation(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -37,8 +37,8 @@ object SpendReportingResultsConvertor {
         spendReportingForDateRange.getCost,
         spendReportingForDateRange.getCredits,
         spendReportingForDateRange.getCurrency,
-        Option.apply(DateTime.parse(spendReportingForDateRange.getStartTime)),
-        Option.apply(DateTime.parse(spendReportingForDateRange.getEndTime))
+        Option.empty,
+        Option.empty
       )
 
     // TODO: implement apply for SpendReportingAggregation?!

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -29,7 +29,6 @@ case class SpendReportingResults(spendDetails: Seq[SpendReportingAggregation], s
 object SpendReportingResultsConvertor {
   def apply(spendReport: SpendReport): SpendReportingResults = {
 
-    // TODO: implement apply for SpendReportingAggregation?!
     def mapSpendReportingForDateRange(
       spendReportingForDateRange: bio.terra.profile.model.SpendReportingForDateRange
     ): SpendReportingForDateRange =
@@ -42,7 +41,6 @@ object SpendReportingResultsConvertor {
         category = Option.apply(TerraSpendCategories.withName(spendReportingForDateRange.getCategory.toString))
       )
 
-    // TODO: implement apply for SpendReportingAggregation?!
     def mapSpendReportingAggregation(
       spendReportingAggregation: bio.terra.profile.model.SpendReportingAggregation
     ): SpendReportingAggregation = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -37,10 +37,9 @@ object SpendReportingResults {
                 srRange.getCost,
                 srRange.getCredits,
                 srRange.getCurrency,
-                Option.when(srRange.getStartTime != null)(DateTime.parse(srRange.getStartTime)),
-                Option.when(srRange.getEndTime != null)(DateTime.parse(srRange.getEndTime)),
-                category =
-                  Option.when(srRange.getCategory != null)(TerraSpendCategories.withName(srRange.getCategory.toString))
+                Option(srRange.getStartTime).map(DateTime.parse),
+                Option(srRange.getEndTime).map(DateTime.parse),
+                category = Option(srRange.getCategory).map(v => TerraSpendCategories.withName(v.toString))
               )
             )
             .toSeq
@@ -52,12 +51,8 @@ object SpendReportingResults {
       spendReport.getSpendSummary.getCost,
       spendReport.getSpendSummary.getCredits,
       spendReport.getSpendSummary.getCurrency,
-      Option.when(spendReport.getSpendSummary.getStartTime != null)(
-        DateTime.parse(spendReport.getSpendSummary.getStartTime)
-      ),
-      Option.when(spendReport.getSpendSummary.getEndTime != null)(
-        DateTime.parse(spendReport.getSpendSummary.getEndTime)
-      )
+      Option(spendReport.getSpendSummary.getStartTime).map(DateTime.parse),
+      Option(spendReport.getSpendSummary.getEndTime).map(DateTime.parse)
     )
 
     SpendReportingResults(spendDetails, spendSummary)
@@ -76,10 +71,9 @@ object SpendReportingAggregation {
           srRange.getCost,
           srRange.getCredits,
           srRange.getCurrency,
-          Option.when(srRange.getStartTime != null)(DateTime.parse(srRange.getStartTime)),
-          Option.when(srRange.getEndTime != null)(DateTime.parse(srRange.getEndTime)),
-          category =
-            Option.when(srRange.getCategory != null)(TerraSpendCategories.withName(srRange.getCategory.toString))
+          Option(srRange.getStartTime).map(DateTime.parse),
+          Option(srRange.getEndTime).map(DateTime.parse),
+          category = Option(srRange.getCategory).map(v => TerraSpendCategories.withName(v.toString))
         )
       )
       .toList
@@ -110,15 +104,9 @@ object SpendReportingForDateRange {
       spendReportingForDateRange.getCost,
       spendReportingForDateRange.getCredits,
       spendReportingForDateRange.getCurrency,
-      Option.when(spendReportingForDateRange.getStartTime != null)(
-        DateTime.parse(spendReportingForDateRange.getStartTime)
-      ),
-      Option.when(spendReportingForDateRange.getEndTime != null)(
-        DateTime.parse(spendReportingForDateRange.getEndTime)
-      ),
-      category = Option.when(spendReportingForDateRange.getCategory != null)(
-        TerraSpendCategories.withName(spendReportingForDateRange.getCategory.toString)
-      )
+      Option(spendReportingForDateRange.getStartTime).map(DateTime.parse),
+      Option(spendReportingForDateRange.getEndTime).map(DateTime.parse),
+      category = Option(spendReportingForDateRange.getCategory).map(v => TerraSpendCategories.withName(v.toString))
     )
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -26,7 +26,7 @@ case class SpendReportingAggregationKeyWithSub(key: SpendReportingAggregationKey
 
 case class SpendReportingResults(spendDetails: Seq[SpendReportingAggregation], spendSummary: SpendReportingForDateRange)
 
-object SpendReportingResults {
+object SpendReportingResultsConvertor {
   def apply(spendReport: SpendReport): SpendReportingResults = {
 
     // TODO: implement apply for SpendReportingAggregation?!

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -10,7 +10,7 @@ import nl.grons.metrics4.scala.{Counter, Histogram}
 import org.broadinstitute.dsde.rawls.billing.{
   BillingProfileManagerDAO,
   BillingRepository,
-  BpmAzureSpendReportBadRequest
+  BpmAzureSpendReportApiException
 }
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
@@ -340,8 +340,8 @@ class SpendReportingService(
         SpendReportingResults(spendReport)
       }
       .recoverWith {
-        case ex: BpmAzureSpendReportBadRequest =>
-          Future.failed(RawlsExceptionWithErrorReport(StatusCodes.BadRequest, ex.getMessage))
+        case ex: BpmAzureSpendReportApiException =>
+          Future.failed(RawlsExceptionWithErrorReport(ex.statusCode, ex.getMessage))
         case ex: Exception =>
           Future.failed(RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex)))
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -334,10 +334,10 @@ class SpendReportingService(
     end: DateTime
   ): Future[SpendReportingResults] =
     try {
-      val spendReport =
+      val spendReport: bio.terra.profile.model.SpendReport =
         bpmDao.getAzureSpendReport(UUID.fromString(billingProfileId), start.toDate, end.toDate, ctx)
 
-      Future.successful(SpendReportingResultsConvertor(spendReport))
+      Future.successful(SpendReportingResults(spendReport))
     } catch {
       case ex: BpmAzureSpendReportBadRequest =>
         throw RawlsExceptionWithErrorReport(StatusCodes.BadRequest, ex.getMessage)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -341,5 +341,6 @@ class SpendReportingService(
     } catch {
       case ex: BpmAzureSpendReportBadRequest =>
         throw RawlsExceptionWithErrorReport(StatusCodes.BadRequest, ex.getMessage)
+      case ex: Exception => throw RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex))
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -314,9 +314,7 @@ class SpendReportingService(
       billingProject <- billingRepository.getBillingProject(project)
 
       report <- getReportData(billingProject.get, project, start, end, aggregations)
-
-      result = report
-    } yield result
+    } yield report
 
   private def getReportData(billingProject: RawlsBillingProject,
                             project: RawlsBillingProjectName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -88,7 +88,7 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
                   ) { (startDate, endDate, aggregationKeyParameters) =>
                     complete {
                       spendReportingConstructor(ctx).getSpendForBillingProject(
-                        projectId,
+                        RawlsBillingProjectName(projectId),
                         startDate,
                         endDate.plusDays(1).minusMillis(1),
                         aggregationKeyParameters.toSet

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -87,9 +87,6 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
                       .repeated
                   ) { (startDate, endDate, aggregationKeyParameters) =>
                     complete {
-                      // Q: is it ok to place this code here -> userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId))
-                      // to get billing project info and pass it downstream or inject userService into spendReporting Service?
-
                       spendReportingConstructor(ctx).getSpendForBillingProject(
                         projectId,
                         startDate,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -87,8 +87,11 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
                       .repeated
                   ) { (startDate, endDate, aggregationKeyParameters) =>
                     complete {
+                      // Q: is it ok to place this code here -> userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId))
+                      // to get billing project info and pass it downstream or inject userService into spendReporting Service?
+
                       spendReportingConstructor(ctx).getSpendForBillingProject(
-                        RawlsBillingProjectName(projectId),
+                        projectId,
                         startDate,
                         endDate.plusDays(1).minusMillis(1),
                         aggregationKeyParameters.toSet

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -310,16 +310,6 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
   behavior of "BpmAzureReportErrorMessageJsonProtocol"
 
-  it should "serialize BpmAzureReportErrorMessage into json" in {
-    val bpmError = BpmAzureReportErrorMessage("customError", 400)
-    val jsObject: JsValue = bpmError.toJson
-
-    jsObject shouldNot equal(null)
-
-    // jsObject.fields should contain key "message"
-    // jsObject.fields should contain key "statusCode"
-  }
-
   it should "deserialize json into BpmAzureReportErrorMessage" in {
     val bpmError = BpmAzureReportErrorMessage("customError", 400).toJson
     val value = bpmError.convertTo[BpmAzureReportErrorMessage]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -93,7 +93,7 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
   it should "successfully convert empty SpendReport" in {
     val emptySpendReport = TestData.buildBPMEmptyReport
 
-    val result = SpendReportingResultsConvertor(emptySpendReport)
+    val result = SpendReportingResults(emptySpendReport)
 
     result shouldNot equal(null)
   }
@@ -106,7 +106,7 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost, CategoryEnum.STORAGE -> storageCost)
     val someReport = TestData.someBPMNonEmptyReport(from, to, categoriesCosts)
 
-    val result = SpendReportingResultsConvertor(someReport)
+    val result = SpendReportingResults(someReport)
 
     result shouldNot equal(null)
     result.spendSummary shouldNot equal(null)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -131,6 +131,6 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     storageDetails.get shouldNot equal(null)
     storageDetails.get.cost shouldBe storageCost.toString()
     storageDetails.get.credits shouldBe TestData.defaultCredits
-    computeDetails.get.currency shouldBe TestData.defaultCurrency
+    storageDetails.get.currency shouldBe TestData.defaultCurrency
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.model
 
 import bio.terra.profile.model.SpendReport
+import bio.terra.profile.model.SpendReportingForDateRange.CategoryEnum
 import bio.terra.profile.model.{SpendReportingForDateRange => SpendReportingForDateRangeBPM}
 import bio.terra.profile.model.{SpendReportingAggregation => SpendReportingAggregationBPM}
 import org.joda.time.DateTime
@@ -13,6 +14,9 @@ import scala.jdk.CollectionConverters._
 
 class SpendReportingModelSpec extends AnyFlatSpecLike {
   object TestData {
+    val defaultCurrency = "USD"
+    val defaultCredits = "0" // always 0 for Azure
+
     def buildBPMEmptyReport: SpendReport = {
       // some period
       val from = DateTime.now().minusMonths(2)
@@ -37,15 +41,24 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
         )
     }
 
-    def someBPMNonEmptyReport(from: DateTime, to: DateTime, costs: Seq[BigDecimal]): SpendReport = {
-      val currency = "USD"
+    def someBPMNonEmptyReport(from: DateTime, to: DateTime, costs: Map[CategoryEnum, BigDecimal]): SpendReport = {
       val categoriesCosts = costs
-        .map(cost => buildSpendReportingForDateRange(cost.toString(), currency, null, null, null))
-        .asJava
+        .map(costPerCategoryKvp =>
+          buildSpendReportingForDateRange(costPerCategoryKvp._2.toString,
+                                          defaultCurrency,
+                                          costPerCategoryKvp._1,
+                                          null,
+                                          null
+          )
+        )
+        .asJavaCollection
+        .stream()
+        .toList
+
       new SpendReport()
         .spendSummary(
-          buildSpendReportingForDateRange(costs.sum.toString(),
-                                          currency,
+          buildSpendReportingForDateRange(costs.values.sum.toString(),
+                                          defaultCurrency,
                                           null,
                                           from.toString(ISODateTimeFormat.date()),
                                           to.toString(ISODateTimeFormat.date())
@@ -68,7 +81,7 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     ): SpendReportingForDateRangeBPM =
       new SpendReportingForDateRangeBPM()
         .cost(cost)
-        .credits("0")
+        .credits(defaultCredits)
         .currency(currency)
         .category(category)
         .startTime(from)
@@ -90,16 +103,34 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     val to = DateTime.now().plusMonths(1)
     val computeCost: BigDecimal = 100.20
     val storageCost: BigDecimal = 54.32
-    val categoriesCosts = Seq(computeCost, storageCost)
+    val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost, CategoryEnum.STORAGE -> storageCost)
     val someReport = TestData.someBPMNonEmptyReport(from, to, categoriesCosts)
 
     val result = SpendReportingResultsConvertor(someReport)
 
     result shouldNot equal(null)
     result.spendSummary shouldNot equal(null)
-    result.spendSummary.cost shouldBe categoriesCosts.sum.toString()
+    result.spendSummary.cost shouldBe categoriesCosts.values.sum.toString()
     result.spendDetails shouldNot equal(null)
     result.spendDetails(0) shouldNot equal(null)
     result.spendDetails(0).spendData should have size categoriesCosts.size
+
+    val computeDetails = result
+      .spendDetails(0)
+      .spendData
+      .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.Compute))
+    computeDetails.get shouldNot equal(null)
+    computeDetails.get.cost shouldBe computeCost.toString()
+    computeDetails.get.credits shouldBe TestData.defaultCredits
+    computeDetails.get.currency shouldBe TestData.defaultCurrency
+
+    val storageDetails = result
+      .spendDetails(0)
+      .spendData
+      .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.Storage))
+    storageDetails.get shouldNot equal(null)
+    storageDetails.get.cost shouldBe storageCost.toString()
+    storageDetails.get.credits shouldBe TestData.defaultCredits
+    computeDetails.get.currency shouldBe TestData.defaultCurrency
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -15,7 +15,7 @@ import scala.jdk.CollectionConverters._
 class SpendReportingModelSpec extends AnyFlatSpecLike {
   object TestData {
     val defaultCurrency = "USD"
-    val defaultCredits = "0" // always 0 for Azure
+    val defaultAzureCredits = "0" // always 0 for Azure
 
     def buildBPMEmptyReport: SpendReport = {
       // some period
@@ -41,7 +41,37 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
         )
     }
 
-    def someBPMNonEmptyReport(from: DateTime, to: DateTime, costs: Map[CategoryEnum, BigDecimal]): SpendReport = {
+    def someBPMNonEmptyReport(from: DateTime, to: DateTime, costs: Map[CategoryEnum, BigDecimal]): SpendReport =
+      new SpendReport()
+        .spendSummary(
+          buildSpendReportingForDateRange(costs.values.sum.toString(),
+                                          defaultCurrency,
+                                          null,
+                                          from.toString(ISODateTimeFormat.date()),
+                                          to.toString(ISODateTimeFormat.date())
+          )
+        )
+        .spendDetails(
+          java.util.List.of(
+            buildSpendReportingAggregation(costs)
+          )
+        )
+
+    def buildSpendReportingForDateRange(cost: String,
+                                        currency: String,
+                                        category: SpendReportingForDateRangeBPM.CategoryEnum,
+                                        from: String,
+                                        to: String
+    ): SpendReportingForDateRangeBPM =
+      new SpendReportingForDateRangeBPM()
+        .cost(cost)
+        .credits(defaultAzureCredits)
+        .currency(currency)
+        .category(category)
+        .startTime(from)
+        .endTime(to)
+
+    def buildSpendReportingAggregation(costs: Map[CategoryEnum, BigDecimal]): SpendReportingAggregationBPM = {
       val categoriesCosts = costs
         .map(costPerCategoryKvp =>
           buildSpendReportingForDateRange(costPerCategoryKvp._2.toString,
@@ -55,40 +85,13 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
         .stream()
         .toList
 
-      new SpendReport()
-        .spendSummary(
-          buildSpendReportingForDateRange(costs.values.sum.toString(),
-                                          defaultCurrency,
-                                          null,
-                                          from.toString(ISODateTimeFormat.date()),
-                                          to.toString(ISODateTimeFormat.date())
-          )
-        )
-        .spendDetails(
-          java.util.List.of(
-            new SpendReportingAggregationBPM()
-              .aggregationKey(SpendReportingAggregationBPM.AggregationKeyEnum.CATEGORY)
-              .spendData(categoriesCosts)
-          )
-        )
+      new SpendReportingAggregationBPM()
+        .aggregationKey(SpendReportingAggregationBPM.AggregationKeyEnum.CATEGORY)
+        .spendData(categoriesCosts)
     }
-
-    private def buildSpendReportingForDateRange(cost: String,
-                                                currency: String,
-                                                category: SpendReportingForDateRangeBPM.CategoryEnum,
-                                                from: String,
-                                                to: String
-    ): SpendReportingForDateRangeBPM =
-      new SpendReportingForDateRangeBPM()
-        .cost(cost)
-        .credits(defaultCredits)
-        .currency(currency)
-        .category(category)
-        .startTime(from)
-        .endTime(to)
   }
 
-  behavior of "SpendReportingResultsConvertor"
+  behavior of "SpendReportingResults conversion"
 
   it should "successfully convert empty SpendReport" in {
     val emptySpendReport = TestData.buildBPMEmptyReport
@@ -119,18 +122,78 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
       .spendDetails(0)
       .spendData
       .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.Compute))
-    computeDetails.get shouldNot equal(null)
+    computeDetails.nonEmpty shouldBe true
     computeDetails.get.cost shouldBe computeCost.toString()
-    computeDetails.get.credits shouldBe TestData.defaultCredits
+    computeDetails.get.credits shouldBe TestData.defaultAzureCredits
     computeDetails.get.currency shouldBe TestData.defaultCurrency
 
     val storageDetails = result
       .spendDetails(0)
       .spendData
       .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.Storage))
-    storageDetails.get shouldNot equal(null)
+    storageDetails.nonEmpty shouldBe true
     storageDetails.get.cost shouldBe storageCost.toString()
-    storageDetails.get.credits shouldBe TestData.defaultCredits
+    storageDetails.get.credits shouldBe TestData.defaultAzureCredits
     storageDetails.get.currency shouldBe TestData.defaultCurrency
   }
+
+  behavior of "SpendReportingForDateRange conversion"
+
+  it should "successfully convert BPM model for SpendReportingForDateRange" in {
+    val cost = "20.51"
+    val category = CategoryEnum.STORAGE
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val spendReportingForDateRangeBPM =
+      TestData.buildSpendReportingForDateRange(cost,
+                                               TestData.defaultCurrency,
+                                               category,
+                                               from.toString(ISODateTimeFormat.date()),
+                                               to.toString(ISODateTimeFormat.date())
+      )
+
+    val result = SpendReportingForDateRange(spendReportingForDateRangeBPM)
+
+    result shouldNot equal(null)
+    result.cost shouldBe cost
+    result.category.nonEmpty shouldBe true
+    result.category.get shouldBe TerraSpendCategories.Storage
+    result.currency shouldBe TestData.defaultCurrency
+    result.credits shouldBe TestData.defaultAzureCredits
+    result.startTime.nonEmpty shouldBe true
+    result.startTime.get.toString(ISODateTimeFormat.date()) shouldBe from.toString(ISODateTimeFormat.date())
+    result.endTime.nonEmpty shouldBe true
+    result.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
+  }
+
+  behavior of "SpendReportingAggregation conversion"
+
+  it should "successfully convert BPM model for SpendReportingAggregation" in {
+    val computeCost: BigDecimal = 1000.20
+    val storageCost: BigDecimal = 900.32
+    val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost, CategoryEnum.STORAGE -> storageCost)
+
+    val spendReportingAggregationBPM = TestData.buildSpendReportingAggregation(categoriesCosts)
+    val result = SpendReportingAggregation(spendReportingAggregationBPM)
+
+    result shouldNot equal(null)
+    result.aggregationKey shouldBe SpendReportingAggregationKeys.Category
+    result.spendData should have size categoriesCosts.size
+
+    val computeCategory =
+      result.spendData.find(sd => sd.category.nonEmpty && sd.category.get.equals(TerraSpendCategories.Compute))
+    computeCategory.nonEmpty shouldBe true
+    computeCategory.get.cost shouldBe computeCost.toString()
+    computeCategory.get.credits shouldBe TestData.defaultAzureCredits
+    computeCategory.get.currency shouldBe TestData.defaultCurrency
+
+    val storageCategory =
+      result.spendData.find(sd => sd.category.nonEmpty && sd.category.get.equals(TerraSpendCategories.Storage))
+    storageCategory.nonEmpty shouldBe true
+    storageCategory.get.cost shouldBe storageCost.toString()
+    storageCategory.get.credits shouldBe TestData.defaultAzureCredits
+    storageCategory.get.currency shouldBe TestData.defaultCurrency
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -1,0 +1,110 @@
+package org.broadinstitute.dsde.rawls.model
+
+import bio.terra.profile.model.SpendReport
+import bio.terra.profile.model.{SpendReportingForDateRange => SpendReportingForDateRangeBPM}
+import bio.terra.profile.model.{SpendReportingAggregation => SpendReportingAggregationBPM}
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.must.Matchers.have
+import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
+
+import scala.jdk.CollectionConverters._
+
+class SpendReportingModelSpec extends AnyFlatSpecLike {
+  object TestData {
+    def buildBPMEmptyReport: SpendReport = {
+      // requested period
+      val from = DateTime.now().minusMonths(2)
+      val to = from.plusMonths(1)
+
+      // BVM return following spendReport in case specific data doesn't exist
+      new SpendReport()
+        .spendSummary(
+          buildSpendReportingForDateRange("0.00",
+                                          "n/a",
+                                          null,
+                                          from.toString(ISODateTimeFormat.date()),
+                                          to.toString(ISODateTimeFormat.date())
+          )
+        )
+        .spendDetails(
+          java.util.List.of(
+            new SpendReportingAggregationBPM()
+              .aggregationKey(SpendReportingAggregationBPM.AggregationKeyEnum.CATEGORY)
+              .spendData(java.util.List.of())
+          )
+        )
+    }
+
+    def someBPMNonEmptyReport(from: DateTime, to: DateTime, costs: Seq[BigDecimal]): SpendReport = {
+      val currency = "USD"
+      val categoriesCosts = costs
+        .map(cost =>
+          buildSpendReportingForDateRange(cost.toString(),
+                                          currency,
+                                          null,
+                                          from.toString(ISODateTimeFormat.date()),
+                                          to.toString(ISODateTimeFormat.date())
+          )
+        )
+        .asJava
+      new SpendReport()
+        .spendSummary(
+          buildSpendReportingForDateRange(costs.sum.toString(),
+                                          "n/a",
+                                          null,
+                                          from.toString(ISODateTimeFormat.date()),
+                                          to.toString(ISODateTimeFormat.date())
+          )
+        )
+        .spendDetails(
+          java.util.List.of(
+            new SpendReportingAggregationBPM()
+              .aggregationKey(SpendReportingAggregationBPM.AggregationKeyEnum.CATEGORY)
+              .spendData(categoriesCosts)
+          )
+        )
+    }
+
+    private def buildSpendReportingForDateRange(cost: String,
+                                                currency: String,
+                                                category: SpendReportingForDateRangeBPM.CategoryEnum,
+                                                from: String,
+                                                to: String
+    ): SpendReportingForDateRangeBPM =
+      new SpendReportingForDateRangeBPM()
+        .cost(cost)
+        .credits("0")
+        .currency(currency)
+        .category(category)
+        .startTime(from)
+        .endTime(to)
+  }
+
+  behavior of "SpendReportingResultsConvertor"
+
+  it should "successfully convert empty SpendReport" in {
+    val emptySpendReport = TestData.buildBPMEmptyReport
+
+    val result = SpendReportingResultsConvertor.apply(emptySpendReport)
+
+    result shouldNot equal(null)
+  }
+
+  it should "successfully convert some non empty SpendReport" in {
+    val from = DateTime.now().minusMonths(2)
+    val to = DateTime.now().plusMonths(1)
+    val computeCost: BigDecimal = 100.20
+    val storageCost: BigDecimal = 54.32
+    val categoriesCosts = Seq(computeCost, storageCost)
+
+    val result = TestData.someBPMNonEmptyReport(from, to, categoriesCosts)
+
+    result shouldNot equal(null)
+    result.getSpendSummary shouldNot equal(null)
+    result.getSpendDetails shouldNot equal(null)
+    result.getSpendDetails.get(0) shouldNot equal(null)
+    result.getSpendDetails.get(0).getSpendData should have size categoriesCosts.size
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -712,21 +712,21 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(bpmDAO.getAzureSpendReport(any(), any(), any(), any())(mockitoEq(executionContext)))
       .thenReturn(Future.apply(spendReport))
 
-    val billingProfileId = UUID.randomUUID().toString
+    val billingProfileId = UUID.randomUUID()
     val projectName = RawlsBillingProjectName(wsName.namespace)
     val azureBillingProject = RawlsBillingProject(
       projectName,
       CreationStatuses.Ready,
       Option(billingAccountName),
       None,
-      billingProfileId = Option.apply(billingProfileId)
+      billingProfileId = Option.apply(billingProfileId.toString)
     )
     when(billingRepository.getBillingProject(mockitoEq(projectName)))
       .thenReturn(Future.successful(Option.apply(azureBillingProject)))
 
-    val billingProfileIdCapture = ArgumentCaptor.forClass(classOf[UUID])
-    val startDateCapture = ArgumentCaptor.forClass(classOf[Date])
-    val endDateCapture = ArgumentCaptor.forClass(classOf[Date])
+    val billingProfileIdCapture: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
+    val startDateCapture: ArgumentCaptor[Date] = ArgumentCaptor.forClass(classOf[Date])
+    val endDateCapture: ArgumentCaptor[Date] = ArgumentCaptor.forClass(classOf[Date])
     val service = new SpendReportingService(
       testContext,
       mock[SlickDataSource],
@@ -757,10 +757,12 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                            any()
       )(mockitoEq(executionContext))
 
-    billingProfileIdCapture.getValue.toString shouldBe billingProfileId
-    startDateCapture.getValue.toString shouldBe from.toDate.toString
-    endDateCapture.getValue.toString shouldBe to.toDate.toString
+    billingProfileIdCapture.getValue shouldBe billingProfileId
+    startDateCapture.getValue shouldBe from.toDate
+    endDateCapture.getValue shouldBe to.toDate
   }
+
+  // "it" should "throw exception or be resilient and empty result" {}
 
   "validateReportParameters" should "not throw an exception when validating max start and end date range" in {
     val service = new SpendReportingService(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -13,6 +13,7 @@ import com.google.cloud.bigquery.{Option => _, _}
 import org.broadinstitute.dsde.rawls.billing.{
   BillingProfileManagerDAO,
   BillingRepository,
+  BpmAzureSpendReportApiException,
   BpmAzureSpendReportBadRequest
 }
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
@@ -818,6 +819,52 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     }
 
     e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
+    e.errorReport.message shouldBe errorMessage
+  }
+
+  it should "rethrow any exception from BPM client" in {
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
+    val errorMessage = "something went wrong"
+    doThrow(new BpmAzureSpendReportApiException(errorMessage))
+      .when(bpmDAO)
+      .getAzureSpendReport(any(), any(), any(), any())
+
+    val billingProfileId = UUID.randomUUID()
+    val projectName = RawlsBillingProjectName(wsName.namespace)
+    val azureBillingProject = RawlsBillingProject(
+      projectName,
+      CreationStatuses.Ready,
+      Option(billingAccountName),
+      None,
+      billingProfileId = Option.apply(billingProfileId.toString)
+    )
+    when(billingRepository.getBillingProject(mockitoEq(projectName)))
+      .thenReturn(Future.successful(Option.apply(azureBillingProject)))
+
+    val service = new SpendReportingService(
+      testContext,
+      mock[SlickDataSource],
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      billingRepository,
+      bpmDAO,
+      samDAO,
+      spendReportingServiceConfig
+    )
+
+    val e = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        service.getSpendForBillingProject(azureBillingProject.projectName, from, to, Set.empty),
+        Duration.Inf
+      )
+    }
+
+    e.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
     e.errorReport.message shouldBe errorMessage
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -255,6 +255,8 @@ trait ApiServiceSpec
     override val spendReportingConstructor = SpendReportingService.constructor(
       slickDataSource,
       spendReportingBigQueryService,
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
       samDAO,
       spendReportingServiceConfig
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,7 +126,7 @@ object Dependencies {
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.515-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
-  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.109-SNAPSHOT")
+  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.112-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.63-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-f554115")
 


### PR DESCRIPTION
Spend report endpoint now can return Azure spend data.

Ticket: https://broadworkbench.atlassian.net/browse/WOR-779

<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
