### PR TITLE
AJ-864: maybe optimize filter-by-column

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -484,6 +484,7 @@ trait EntityComponent {
                 and filter_e.deleted = 0
                 and filter_e.workspace_id = ${workspaceContext.workspaceIdAsUUID}
                 and filter_e.entity_type = $entityType
+                and filter_a.deleted = 0
                 and filter_a.namespace = ${columnFilter.attributeName.namespace}
                 and filter_a.name = ${columnFilter.attributeName.name}
                 and COALESCE(filter_a.value_string, filter_a.value_number) = ${columnFilter.term}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -486,8 +486,7 @@ trait EntityComponent {
                 and filter_e.entity_type = $entityType
                 and filter_a.namespace = ${columnFilter.attributeName.namespace}
                 and filter_a.name = ${columnFilter.attributeName.name}
-                and (filter_a.value_string = ${columnFilter.term} or
-                     filter_a.value_number = ${columnFilter.term})
+                and COALESCE(filter_a.value_string, filter_a.value_number) = ${columnFilter.term}
              )"""
           }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -481,9 +481,13 @@ trait EntityComponent {
                 select filter_e.id
                 from ENTITY filter_e, ENTITY_ATTRIBUTE_#${shardId} filter_a
                 where filter_a.owner_id = filter_e.id
+                and filter_e.deleted = 0
+                and filter_e.workspace_id = ${workspaceContext.workspaceIdAsUUID}
+                and filter_e.entity_type = $entityType
                 and filter_a.namespace = ${columnFilter.attributeName.namespace}
                 and filter_a.name = ${columnFilter.attributeName.name}
-                and COALESCE(filter_a.value_string, filter_a.value_number) = ${columnFilter.term}
+                and (filter_a.value_string = ${columnFilter.term} or
+                     filter_a.value_number = ${columnFilter.term})
              )"""
           }
 


### PR DESCRIPTION
optimization for filter-by-column.

The filter-by-column subquery previously used just (pseudocode) "where attributeName = ?". This created a large set of rows for MySQL to consider, especially in the pretty common case where the same attributeName exists in multiple workspaces and/or multiple entity types. This PR adds filtering criteria to the subquery - it matches on workspaceId, entityType, and deleted=false as well as attributeName.

Explain-plan diagrams and tables below (scroll to the right to see the full table). Note that the "before" plan uses a temp table and `distinct` clause, while the "after" plan does not.

I have not done comprehensive latency testing on this. We can see that the query is optimized so it feels worth merging, even without knowing a number-of-milliseconds change.



## Before
![before](https://user-images.githubusercontent.com/6041577/226375230-4346d1dc-1e7e-4a50-b916-0ec2ba90b682.png)

id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | PRIMARY | <derived2> | ALL | NULL | NULL | NULL | NULL | 10 | Using filesort
1 | PRIMARY | e | eq_ref | PRIMARY | PRIMARY | 8 | p.id | 1 | NULL
1 | PRIMARY | a | ref | UNQ_ENTITY_ATTRIBUTE | UNQ_ENTITY_ATTRIBUTE | 8 | p.id | 6 | Using where
1 | PRIMARY | e_ref | eq_ref | PRIMARY | PRIMARY | 8 | rawls.a.value_entity_ref | 1 | NULL
2 | DERIVED | e | ref | PRIMARY,idx_entity_type_name | idx_entity_type_name | 781 | const,const | 8328 | Using index condition; Using where
2 | DERIVED | filter_a | ref | UNQ_ENTITY_ATTRIBUTE | UNQ_ENTITY_ATTRIBUTE | 710 | rawls.e.id,const,const | 1 | **Using index condition; Using where; Start temporary**
2 | DERIVED | filter_e | eq_ref | PRIMARY | PRIMARY | 8 | rawls.e.id | 1 | **Using index; End temporary**

[before.csv](https://github.com/broadinstitute/rawls/files/11019648/before.csv)

---

## After
![after2](https://user-images.githubusercontent.com/6041577/226387491-39530888-8ada-40f8-b0ca-df386908ba37.png)

id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | PRIMARY | <derived2> | ALL | NULL | NULL | NULL | NULL | 10 | Using filesort
1 | PRIMARY | e | eq_ref | PRIMARY | PRIMARY | 8 | p.id | 1 | NULL
1 | PRIMARY | a | ref | UNQ_ENTITY_ATTRIBUTE | UNQ_ENTITY_ATTRIBUTE | 8 | p.id | 6 | Using where
1 | PRIMARY | e_ref | eq_ref | PRIMARY | PRIMARY | 8 | rawls.a.value_entity_ref | 1 | NULL
2 | DERIVED | e | ref | PRIMARY,idx_entity_type_name | idx_entity_type_name | 781 | const,const | 8328 | Using index condition; Using where
2 | DERIVED | filter_e | eq_ref | PRIMARY,idx_entity_type_name | PRIMARY | 8 | rawls.e.id | 1 | **Using where**
2 | DERIVED | filter_a | ref | UNQ_ENTITY_ATTRIBUTE | UNQ_ENTITY_ATTRIBUTE | 710 | rawls.e.id,const,const | 1 | **Using index condition; Using where; FirstMatch(filter_e)**

[after2.csv](https://github.com/broadinstitute/rawls/files/11019907/after2.csv)