### PR TITLE
AJ-864: add tracing attributes for filter-by-name and filter-by-column

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
-import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span}
+import io.opencensus.trace.{AttributeValue, AttributeValue => OpenCensusAttributeValue, Span}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
@@ -473,8 +473,15 @@ trait EntityComponent {
 
         val filterByColumn =
           entityQuery.columnFilter match {
-            case None => sql""
+            case None =>
+              parentContext.tracingSpan.map { span =>
+                span.putAttribute("isFilterByColumn", AttributeValue.booleanAttributeValue(false))
+              }
+              sql""
             case Some(columnFilter) =>
+              parentContext.tracingSpan.map { span =>
+                span.putAttribute("isFilterByColumn", AttributeValue.booleanAttributeValue(true))
+              }
               val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
 
               sql""" and e.id in (
@@ -950,8 +957,14 @@ trait EntityComponent {
       // if filtering by name, retrieve that entity directly, else do the full query:
       nameFilter match {
         case Some(entityName) =>
+          parentContext.tracingSpan.map { span =>
+            span.putAttribute("isFilterByName", AttributeValue.booleanAttributeValue(true))
+          }
           loadSingleEntityForPage(workspaceContext, entityType, entityName, entityQuery)
         case _ =>
+          parentContext.tracingSpan.map { span =>
+            span.putAttribute("isFilterByName", AttributeValue.booleanAttributeValue(false))
+          }
           EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
                                                                    entityType,
                                                                    entityQuery,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import akka.http.scaladsl.model.StatusCodes
-import io.opencensus.trace.{AttributeValue, AttributeValue => OpenCensusAttributeValue, Span}
+import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeName.toDelimitedName
 import org.broadinstitute.dsde.rawls.model.{Workspace, _}
@@ -475,12 +475,12 @@ trait EntityComponent {
           entityQuery.columnFilter match {
             case None =>
               parentContext.tracingSpan.map { span =>
-                span.putAttribute("isFilterByColumn", AttributeValue.booleanAttributeValue(false))
+                span.putAttribute("isFilterByColumn", OpenCensusAttributeValue.booleanAttributeValue(false))
               }
               sql""
             case Some(columnFilter) =>
               parentContext.tracingSpan.map { span =>
-                span.putAttribute("isFilterByColumn", AttributeValue.booleanAttributeValue(true))
+                span.putAttribute("isFilterByColumn", OpenCensusAttributeValue.booleanAttributeValue(true))
               }
               val shardId = determineShard(workspaceContext.workspaceIdAsUUID)
 
@@ -958,12 +958,12 @@ trait EntityComponent {
       nameFilter match {
         case Some(entityName) =>
           parentContext.tracingSpan.map { span =>
-            span.putAttribute("isFilterByName", AttributeValue.booleanAttributeValue(true))
+            span.putAttribute("isFilterByName", OpenCensusAttributeValue.booleanAttributeValue(true))
           }
           loadSingleEntityForPage(workspaceContext, entityType, entityName, entityQuery)
         case _ =>
           parentContext.tracingSpan.map { span =>
-            span.putAttribute("isFilterByName", AttributeValue.booleanAttributeValue(false))
+            span.putAttribute("isFilterByName", OpenCensusAttributeValue.booleanAttributeValue(false))
           }
           EntityAndAttributesRawSqlQuery.activeActionForPagination(workspaceContext,
                                                                    entityType,


### PR DESCRIPTION
Adds `isFilterByName` and `isFilterByColumn` attributes to tracing instrumentation, so we can inspect timings for these operations after the fact.

![Screenshot 3-20-2023 at 02 48 PM](https://user-images.githubusercontent.com/6041577/226437660-7dbf2afb-cbab-4f7a-9564-30720b88bc5d.png)
