### PR TITLE
ID-501 ID-502 ID-503 ID-504 ID-505 ID-506 fastpass workspace creation and cloning

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -28,6 +28,7 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.{DrsHubResolver, MarthaResolver}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.DataAccess
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
@@ -449,17 +450,17 @@ object Boot extends IOApp with LazyLogging {
           metricsPrefix
         )
 
-      val fastPassServiceConstructor: RawlsRequestContext => FastPassService = FastPassService.constructor(
-        slickDataSource,
-        appDependencies.httpGoogleIamDAO,
-        samDAO,
-        terraBillingProjectOwnerRole = gcsConfig.getString("terraBillingProjectOwnerRole"),
-        terraWorkspaceCanComputeRole = gcsConfig.getString("terraWorkspaceCanComputeRole"),
-        terraWorkspaceNextflowRole = gcsConfig.getString("terraWorkspaceNextflowRole"),
-        terraBucketReaderRole = gcsConfig.getString("terraBucketReaderRole"),
-        terraBucketWriterRole = gcsConfig.getString("terraBucketWriterRole"),
-        metricsPrefix
-      )
+      val fastPassServiceConstructor: (RawlsRequestContext, DataAccess) => FastPassService =
+        FastPassService.constructor(
+          appDependencies.httpGoogleIamDAO,
+          samDAO,
+          terraBillingProjectOwnerRole = gcsConfig.getString("terraBillingProjectOwnerRole"),
+          terraWorkspaceCanComputeRole = gcsConfig.getString("terraWorkspaceCanComputeRole"),
+          terraWorkspaceNextflowRole = gcsConfig.getString("terraWorkspaceNextflowRole"),
+          terraBucketReaderRole = gcsConfig.getString("terraBucketReaderRole"),
+          terraBucketWriterRole = gcsConfig.getString("terraBucketWriterRole"),
+          metricsPrefix
+        )
 
       val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService = WorkspaceService.constructor(
         slickDataSource,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -552,6 +552,17 @@ class HttpSamDAO(baseSamServiceURL: String, serviceAccountCreds: Credential, tim
       callback.future
     }
 
+  override def getUserPetServiceAccount(ctx: RawlsRequestContext,
+                                        googleProjectId: GoogleProjectId
+  ): Future[WorkbenchEmail] =
+    retry(when401or5xx) { () =>
+      val callback = new SamApiCallback[String]("getPetServiceAccount")
+
+      googleApi(ctx).getPetServiceAccountAsync(googleProjectId.value, callback)
+
+      callback.future.map(WorkbenchEmail)
+    }
+
   private def getServiceAccountAccessToken = {
     val expiresInSeconds = Option(serviceAccountCreds.getExpiresInSeconds).map(_.longValue()).getOrElse(0L)
     if (expiresInSeconds < 60 * 5) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -138,6 +138,8 @@ trait SamDAO {
 
   def getUserArbitraryPetServiceAccountKey(userEmail: String): Future[String]
 
+  def getUserPetServiceAccount(ctx: RawlsRequestContext, googleProjectId: GoogleProjectId): Future[WorkbenchEmail]
+
   def deleteUserPetServiceAccount(googleProject: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit]
 
   def getStatus(): Future[SubsystemStatus]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -27,7 +27,8 @@ trait DataAccess
     with CloneWorkspaceFileTransferComponent
     with WorkspaceFeatureFlagComponent
     with WorkspaceMigrationHistory
-    with WorkspaceManagerResourceMonitorRecordComponent {
+    with WorkspaceManagerResourceMonitorRecordComponent
+    with FastPassGrantComponent {
 
   this: DriverComponent =>
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/FastPassGrantComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/FastPassGrantComponent.scala
@@ -29,7 +29,7 @@ object FastPassGrantRecord {
       fastPassGrant.userSubjectId.value,
       GcpResourceTypes.toName(fastPassGrant.resourceType),
       fastPassGrant.resourceName,
-      IamRoles.toName(fastPassGrant.roleName),
+      fastPassGrant.organizationRole,
       new Timestamp(fastPassGrant.expiration.getMillis),
       new Timestamp(fastPassGrant.created.getMillis)
     )
@@ -41,7 +41,7 @@ object FastPassGrantRecord {
       RawlsUserSubjectId(fastPassGrantRecord.userSubjectId),
       GcpResourceTypes.withName(fastPassGrantRecord.resourceType),
       fastPassGrantRecord.resourceName,
-      IamRoles.withName(fastPassGrantRecord.roleName),
+      fastPassGrantRecord.roleName,
       new DateTime(fastPassGrantRecord.expiration),
       new DateTime(fastPassGrantRecord.created)
     )
@@ -97,11 +97,13 @@ trait FastPassGrantComponent {
     def findFastPassGrantsForWorkspace(workspaceId: UUID): ReadAction[Seq[FastPassGrant]] =
       loadFastPassGrants(findByWorkspaceIdQuery(workspaceId))
 
-    def findFastPassGrantsForUser(userSubjectId: String): ReadAction[Seq[FastPassGrant]] =
-      loadFastPassGrants(findByUserIdQuery(userSubjectId))
+    def findFastPassGrantsForUser(userSubjectId: RawlsUserSubjectId): ReadAction[Seq[FastPassGrant]] =
+      loadFastPassGrants(findByUserIdQuery(userSubjectId.value))
 
-    def findFastPassGrantsForUserInWorkspace(workspaceId: UUID, userSubjectId: String): ReadAction[Seq[FastPassGrant]] =
-      loadFastPassGrants(findByWorkspaceAndUserQuery(workspaceId, userSubjectId))
+    def findFastPassGrantsForUserInWorkspace(workspaceId: UUID,
+                                             userSubjectId: RawlsUserSubjectId
+    ): ReadAction[Seq[FastPassGrant]] =
+      loadFastPassGrants(findByWorkspaceAndUserQuery(workspaceId, userSubjectId.value))
 
     def findExpiredFastPassGrants(): ReadAction[Seq[FastPassGrant]] =
       loadFastPassGrants(findExpiredQuery)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
@@ -149,7 +149,7 @@ class FastPassService(protected val ctx: RawlsRequestContext,
         bucketIamRoles.toList.map(bucketIamRole =>
           writeGrantToDb(
             workspace.workspaceId,
-            gcpResourceType = GcpResourceTypes.Project,
+            gcpResourceType = GcpResourceTypes.Bucket,
             workspace.googleProjectId.value,
             bucketIamRole,
             expirationDate
@@ -237,7 +237,7 @@ class FastPassService(protected val ctx: RawlsRequestContext,
         MemberType.User,
         organizationRoles
       )
-      _ <- googleIamDao.addIamRoles(
+      _ <- googleIamDao.removeIamRoles(
         GoogleProject(googleProjectId.value),
         userAndPet.petEmail,
         MemberType.ServiceAccount,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
@@ -13,18 +13,22 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceRoles,
   Workspace
 }
-import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.model.GcpResourceTypes.GcpResourceType
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
-import org.joda.time.DateTime
+import org.broadinstitute.dsde.workbench.google.IamModel.Expr
+import org.joda.time.{DateTime, DateTimeZone}
 import slick.dbio.DBIO
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object FastPassService {
   def constructor(googleIamDao: GoogleIamDAO,
+                  googleStorageDAO: GoogleStorageDAO,
                   samDAO: SamDAO,
                   terraBillingProjectOwnerRole: String,
                   terraWorkspaceCanComputeRole: String,
@@ -37,6 +41,7 @@ object FastPassService {
       ctx,
       dataAccess,
       googleIamDao,
+      googleStorageDAO,
       samDAO,
       terraBillingProjectOwnerRole,
       terraWorkspaceCanComputeRole,
@@ -51,6 +56,7 @@ object FastPassService {
 class FastPassService(protected val ctx: RawlsRequestContext,
                       protected val dataAccess: DataAccess,
                       protected val googleIamDao: GoogleIamDAO,
+                      protected val googleStorageDAO: GoogleStorageDAO,
                       protected val samDAO: SamDAO,
                       protected val terraBillingProjectOwnerRole: String,
                       protected val terraWorkspaceCanComputeRole: String,
@@ -61,6 +67,7 @@ class FastPassService(protected val ctx: RawlsRequestContext,
 )(implicit protected val executionContext: ExecutionContext)
     extends LazyLogging
     with RawlsInstrumented {
+  import cats.effect.unsafe.implicits.global
 
   private def samWorkspaceRoleToGoogleProjectIamRoles(samResourceRole: SamResourceRole) =
     samResourceRole match {
@@ -80,12 +87,14 @@ class FastPassService(protected val ctx: RawlsRequestContext,
       case _                              => Set.empty[String]
     }
 
-  def setupFastPassForUserInWorkspace(workspace: Workspace): ReadWriteAction[Unit] =
+  def setupFastPassForUserInWorkspace(workspace: Workspace): ReadWriteAction[Unit] = {
+    val expirationDate = DateTime.now(DateTimeZone.UTC)
     for {
       roles <- DBIO.from(samDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, ctx))
-      _ <- setupProjectRoles(workspace, roles)
-      _ <- setupBucketRoles(workspace, roles)
+      _ <- setupProjectRoles(workspace, roles, expirationDate)
+      _ <- setupBucketRoles(workspace, roles, expirationDate)
     } yield ()
+  }
 
   def deleteFastPassGrantsForWorkspace(workspace: Workspace): ReadWriteAction[Unit] =
     for {
@@ -96,41 +105,56 @@ class FastPassService(protected val ctx: RawlsRequestContext,
       _ <- removeBucketRoles(workspace, bucketGrants)
     } yield ()
 
-  private def setupProjectRoles(workspace: Workspace, samResourceRoles: Set[SamResourceRole]): ReadWriteAction[Unit] = {
+  private def setupProjectRoles(workspace: Workspace,
+                                samResourceRoles: Set[SamResourceRole],
+                                expirationDate: DateTime
+  ): ReadWriteAction[Unit] = {
     val projectIamRoles = samResourceRoles.flatMap(samWorkspaceRoleToGoogleProjectIamRoles)
+    val condition = conditionFromExpirationDate(expirationDate)
 
-    DBIO.seq(
-      projectIamRoles.toList.map(projectIamRole =>
-        DBIO
-          .from(addUserAndPetToProjectIamRole(workspace.googleProjectId, projectIamRole))
-          .flatMap(expirationDate =>
-            writeGrantToDb(workspace.workspaceId,
-                           gcpResourceType = GcpResourceTypes.Project,
-                           workspace.googleProjectId.value,
-                           projectIamRole,
-                           expirationDate
-            )
+    for {
+      _ <- DBIO.from(addUserAndPetToProjectIamRoles(workspace.googleProjectId, projectIamRoles, condition))
+      _ <- DBIO.seq(
+        projectIamRoles.toList.map(projectIamRole =>
+          writeGrantToDb(
+            workspace.workspaceId,
+            gcpResourceType = GcpResourceTypes.Project,
+            workspace.googleProjectId.value,
+            projectIamRole,
+            expirationDate
           )
-      ): _*
-    )
+        ): _*
+      )
+    } yield ()
   }
 
-  private def setupBucketRoles(workspace: Workspace, samResourceRoles: Set[SamResourceRole]): ReadWriteAction[Unit] = {
+  private def setupBucketRoles(workspace: Workspace,
+                               samResourceRoles: Set[SamResourceRole],
+                               expirationDate: DateTime
+  ): ReadWriteAction[Unit] = {
     val bucketIamRoles = samResourceRoles.flatMap(samWorkspaceRolesToGoogleBucketIamRoles)
-    DBIO.seq(
-      bucketIamRoles.toList.map(bucketIamRole =>
-        DBIO
-          .from(addUserAndPetToBucketIamRole(GcsBucketName(workspace.bucketName), bucketIamRole))
-          .flatMap(expirationDate =>
-            writeGrantToDb(workspace.workspaceId,
-                           gcpResourceType = GcpResourceTypes.Bucket,
-                           workspace.bucketName,
-                           bucketIamRole,
-                           expirationDate
-            )
+    val condition = conditionFromExpirationDate(expirationDate)
+
+    for {
+      _ <- DBIO.from(
+        addUserAndPetToBucketIamRole(workspace.googleProjectId,
+                                     GcsBucketName(workspace.bucketName),
+                                     bucketIamRoles,
+                                     condition
+        )
+      )
+      _ <- DBIO.seq(
+        bucketIamRoles.toList.map(bucketIamRole =>
+          writeGrantToDb(
+            workspace.workspaceId,
+            gcpResourceType = GcpResourceTypes.Project,
+            workspace.googleProjectId.value,
+            bucketIamRole,
+            expirationDate
           )
-      ): _*
-    )
+        ): _*
+      )
+    } yield ()
   }
 
   private def removeProjectRoles(workspace: Workspace, fastPassGrants: Seq[FastPassGrant]): ReadWriteAction[Unit] =
@@ -172,19 +196,61 @@ class FastPassService(protected val ctx: RawlsRequestContext,
   private def removeGrantFromDb(id: Long): ReadWriteAction[Boolean] =
     traceDBIOWithParent("deleteFastPassGrantFromDb", ctx)(_ => dataAccess.fastPassGrantQuery.delete(id))
 
+  def addUserAndPetToProjectIamRoles(googleProjectId: GoogleProjectId,
+                                     organizationRoles: Set[String],
+                                     condition: Expr
+  ): Future[Unit] =
+    for {
+      petEmail <- samDAO.getUserPetServiceAccount(ctx, googleProjectId)
+      _ <- googleIamDao.addIamRoles(
+        GoogleProject(googleProjectId.value),
+        WorkbenchEmail(ctx.userInfo.userEmail.value),
+        MemberType.User,
+        organizationRoles,
+        condition = Some(condition)
+      )
+      _ <- googleIamDao.addIamRoles(
+        GoogleProject(googleProjectId.value),
+        petEmail,
+        MemberType.ServiceAccount,
+        organizationRoles,
+        condition = Some(condition)
+      )
+    } yield ()
+
+  def addUserAndPetToBucketIamRole(googleProjectId: GoogleProjectId,
+                                   gcsBucketName: GcsBucketName,
+                                   organizationRoles: Set[String],
+                                   condition: Expr
+  ): Future[Unit] =
+    for {
+      petEmail <- samDAO.getUserPetServiceAccount(ctx, googleProjectId)
+      _ <- googleStorageDAO.addIamRoles(gcsBucketName,
+                                        WorkbenchEmail(ctx.userInfo.userEmail.value),
+                                        MemberType.User,
+                                        organizationRoles,
+                                        condition = Some(condition)
+      )
+      _ <- googleStorageDAO.addIamRoles(gcsBucketName,
+                                        petEmail,
+                                        MemberType.ServiceAccount,
+                                        organizationRoles,
+                                        condition = Some(condition)
+      )
+    } yield ()
+
   def removeUserAndPetFromProjectIamRole(googleProjectId: GoogleProjectId, organizationRole: String): Future[Unit] =
     Future.successful()
 
   def removeUserAndPetFromBucketIamRole(gcsBucketName: GcsBucketName, organizationRole: String): Future[Unit] =
     Future.successful()
 
-  def addUserAndPetToProjectIamRole(googleProjectId: GoogleProjectId, organizationRole: String): Future[DateTime] =
-    // Call Sam to get user's Pet
-    // Add user and pet
-    Future.successful(DateTime.now().plusHours(2))
-  def addUserAndPetToBucketIamRole(gcsBucketName: GcsBucketName, organizationRole: String): Future[DateTime] =
-    // Call Sam to get user's Pet
-    // Add user and pet to
-    Future.successful(DateTime.now().plusHours(2))
+  private def conditionFromExpirationDate(expirationDate: DateTime): Expr =
+    Expr(
+      s"FastPass access to ${ctx.userInfo.userEmail} for while IAM propagates through Google Groups",
+      s"""request.time < timestamp("${expirationDate.toString}")""",
+      null,
+      s"FastPass access for ${ctx.userInfo.userEmail}"
+    )
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -1,0 +1,467 @@
+package org.broadinstitute.dsde.rawls.fastpass
+
+import akka.actor.PoisonPill
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+
+import com.typesafe.config.ConfigFactory
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAOImpl
+import org.broadinstitute.dsde.rawls.config._
+import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
+import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
+import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, TestDriverComponent}
+import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.entities.EntityManager
+import org.broadinstitute.dsde.rawls.genomics.GenomicsService
+import org.broadinstitute.dsde.rawls.google.MockGoogleAccessContextManagerDAO
+import org.broadinstitute.dsde.rawls.jobexec.{SubmissionMonitorConfig, SubmissionSupervisor}
+import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
+import org.broadinstitute.dsde.rawls.mock._
+import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
+import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
+import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
+import org.broadinstitute.dsde.rawls.user.UserService
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.rawls.webservice._
+import org.broadinstitute.dsde.rawls.workspace.{
+  MultiCloudWorkspaceAclManager,
+  MultiCloudWorkspaceService,
+  RawlsWorkspaceAclManager,
+  WorkspaceService
+}
+import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
+import org.broadinstitute.dsde.workbench.google.IamModel.Expr
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.mockito.{ArgumentMatchers, Mockito}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Duration, _}
+import scala.concurrent.{Await, ExecutionContext}
+import scala.language.postfixOps
+
+//noinspection NameBooleanParameters,TypeAnnotation,EmptyParenMethodAccessedAsParameterless,ScalaUnnecessaryParentheses,RedundantNewCaseClass,ScalaUnusedSymbol
+class FastPassServiceSpec
+    extends AnyFlatSpec
+    with ScalatestRouteTest
+    with Matchers
+    with TestDriverComponent
+    with RawlsTestUtils
+    with Eventually
+    with MockitoTestUtils
+    with RawlsStatsDTestUtils
+    with BeforeAndAfterAll
+    with TableDrivenPropertyChecks
+    with OptionValues {
+  import driver.api._
+
+  val workspace = Workspace(
+    testData.wsName.namespace,
+    testData.wsName.name,
+    "aWorkspaceId",
+    "aBucket",
+    Some("workflow-collection"),
+    currentTime(),
+    currentTime(),
+    "test",
+    Map.empty
+  )
+
+  val mockServer = RemoteServicesMockServer()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    mockServer.startServer()
+  }
+
+  override def afterAll(): Unit = {
+    mockServer.stopServer
+    super.afterAll()
+  }
+
+  // noinspection TypeAnnotation,NameBooleanParameters,ConvertibleToMethodValue,UnitMethodIsParameterless
+  class TestApiService(dataSource: SlickDataSource, val user: RawlsUser)(implicit
+    val executionContext: ExecutionContext
+  ) extends WorkspaceApiService
+      with MethodConfigApiService
+      with SubmissionApiService
+      with MockUserInfoDirectivesWithUser {
+    val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
+    lazy val workspaceService: WorkspaceService = workspaceServiceConstructor(ctx1)
+    lazy val userService: UserService = userServiceConstructor(ctx1)
+    val slickDataSource: SlickDataSource = dataSource
+
+    def actorRefFactory = system
+    val submissionTimeout = FiniteDuration(1, TimeUnit.MINUTES)
+
+    val googleAccessContextManagerDAO = Mockito.spy(new MockGoogleAccessContextManagerDAO())
+    val gcsDAO = Mockito.spy(new MockGoogleServicesDAO("test", googleAccessContextManagerDAO))
+    val googleIamDAO: MockGoogleIamDAO = Mockito.spy(new MockGoogleIamDAO)
+    val googleStorageDAO: MockGoogleStorageDAO = Mockito.spy(new MockGoogleStorageDAO)
+    val samDAO = Mockito.spy(new MockSamDAO(dataSource))
+    val gpsDAO = new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
+    val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
+    val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
+    val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
+
+    val notificationTopic = "test-notification-topic"
+    val notificationDAO = Mockito.spy(new PubSubNotificationDAO(gpsDAO, notificationTopic))
+
+    val testConf = ConfigFactory.load()
+
+    val executionServiceCluster = MockShardedExecutionServiceCluster.fromDAO(
+      new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
+      slickDataSource
+    )
+    val submissionSupervisor = system.actorOf(
+      SubmissionSupervisor
+        .props(
+          executionServiceCluster,
+          new UncoordinatedDataSourceAccess(slickDataSource),
+          samDAO,
+          gcsDAO,
+          mockNotificationDAO,
+          gcsDAO.getBucketServiceAccountCredential,
+          SubmissionMonitorConfig(1 second, true, 20000, true),
+          workbenchMetricBaseName = "test"
+        )
+        .withDispatcher("submission-monitor-dispatcher")
+    )
+
+    val servicePerimeterServiceConfig = ServicePerimeterServiceConfig(
+      Map(
+        ServicePerimeterName("theGreatBarrier") -> Seq(GoogleProjectNumber("555555"), GoogleProjectNumber("121212")),
+        ServicePerimeterName("anotherGoodName") -> Seq(GoogleProjectNumber("777777"), GoogleProjectNumber("343434"))
+      ),
+      1 second,
+      5 seconds
+    )
+    val servicePerimeterService = mock[ServicePerimeterService](RETURNS_SMART_NULLS)
+    when(servicePerimeterService.overwriteGoogleProjectsInPerimeter(any[ServicePerimeterName], any[DataAccess]))
+      .thenReturn(DBIO.successful(()))
+
+    val billingProfileManagerDAO = mock[BillingProfileManagerDAOImpl](RETURNS_SMART_NULLS)
+
+    val userServiceConstructor = UserService.constructor(
+      slickDataSource,
+      gcsDAO,
+      samDAO,
+      MockBigQueryServiceFactory.ioFactory(),
+      testConf.getString("gcs.pathToCredentialJson"),
+      "requesterPaysRole",
+      DeploymentManagerConfig(testConf.getConfig("gcs.deploymentManager")),
+      ProjectTemplate.from(testConf.getConfig("gcs.projectTemplate")),
+      servicePerimeterService,
+      RawlsBillingAccountName("billingAccounts/ABCDE-FGHIJ-KLMNO"),
+      billingProfileManagerDAO,
+      mock[WorkspaceManagerDAO],
+      mock[NotificationDAO]
+    ) _
+
+    val genomicsServiceConstructor = GenomicsService.constructor(
+      slickDataSource,
+      gcsDAO
+    ) _
+
+    val bigQueryDAO = new MockGoogleBigQueryDAO
+    val submissionCostService = new MockSubmissionCostService(
+      "fakeTableName",
+      "fakeDatePartitionColumn",
+      "fakeServiceProject",
+      31,
+      bigQueryDAO
+    )
+    val execServiceBatchSize = 3
+    val maxActiveWorkflowsTotal = 10
+    val maxActiveWorkflowsPerUser = 2
+    val workspaceServiceConfig = WorkspaceServiceConfig(
+      true,
+      "fc-",
+      "us-central1"
+    )
+    val multiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(testConf)
+    override val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService =
+      MultiCloudWorkspaceService.constructor(
+        dataSource,
+        workspaceManagerDAO,
+        mock[BillingProfileManagerDAOImpl],
+        samDAO,
+        multiCloudWorkspaceConfig,
+        workbenchMetricBaseName
+      )
+    lazy val mcWorkspaceService: MultiCloudWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx1)
+
+    val bondApiDAO: BondApiDAO = new MockBondApiDAO(bondBaseUrl = "bondUrl")
+    val requesterPaysSetupService =
+      new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
+
+    val bigQueryServiceFactory: GoogleBigQueryServiceFactory = MockBigQueryServiceFactory.ioFactory()
+    val entityManager = EntityManager.defaultEntityManager(
+      dataSource,
+      workspaceManagerDAO,
+      dataRepoDAO,
+      samDAO,
+      bigQueryServiceFactory,
+      DataRepoEntityProviderConfig(100, 10, 0),
+      testConf.getBoolean("entityStatisticsCache.enabled"),
+      workbenchMetricBaseName
+    )
+
+    val resourceBufferDAO: ResourceBufferDAO = new MockResourceBufferDAO
+    val resourceBufferConfig = ResourceBufferConfig(testConf.getConfig("resourceBuffer"))
+    val resourceBufferService = Mockito.spy(new ResourceBufferService(resourceBufferDAO, resourceBufferConfig))
+    val resourceBufferSaEmail = resourceBufferConfig.saEmail
+
+    val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
+    val multiCloudWorkspaceAclManager =
+      new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
+
+    val terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole"
+    val terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole"
+    val terraWorkspaceNextflowRole = "fakeTerraWorkspaceNextflowRole"
+    val terraBucketReaderRole = "fakeTerraBucketReaderRole"
+    val terraBucketWriterRole = "fakeTerraBucketWriterRole"
+
+    val fastPassServiceConstructor = FastPassService.constructor(
+      googleIamDAO,
+      googleStorageDAO,
+      samDAO,
+      terraBillingProjectOwnerRole,
+      terraWorkspaceCanComputeRole,
+      terraWorkspaceNextflowRole,
+      terraBucketReaderRole,
+      terraBucketWriterRole,
+      workbenchMetricBaseName
+    ) _
+
+    val workspaceServiceConstructor = WorkspaceService.constructor(
+      slickDataSource,
+      new HttpMethodRepoDAO(
+        MethodRepoConfig[Agora.type](mockServer.mockServerBaseUrl, ""),
+        MethodRepoConfig[Dockstore.type](mockServer.mockServerBaseUrl, ""),
+        workbenchMetricBaseName = workbenchMetricBaseName
+      ),
+      new HttpExecutionServiceDAO(mockServer.mockServerBaseUrl, workbenchMetricBaseName = workbenchMetricBaseName),
+      executionServiceCluster,
+      execServiceBatchSize,
+      workspaceManagerDAO,
+      methodConfigResolver,
+      gcsDAO,
+      samDAO,
+      notificationDAO,
+      userServiceConstructor,
+      genomicsServiceConstructor,
+      maxActiveWorkflowsTotal,
+      maxActiveWorkflowsPerUser,
+      workbenchMetricBaseName,
+      submissionCostService,
+      workspaceServiceConfig,
+      requesterPaysSetupService,
+      entityManager,
+      resourceBufferService,
+      resourceBufferSaEmail,
+      servicePerimeterService,
+      googleIamDAO,
+      terraBillingProjectOwnerRole,
+      terraWorkspaceCanComputeRole,
+      terraWorkspaceNextflowRole,
+      terraBucketReaderRole,
+      terraBucketWriterRole,
+      rawlsWorkspaceAclManager,
+      multiCloudWorkspaceAclManager,
+      fastPassServiceConstructor
+    ) _
+
+    def cleanupSupervisor =
+      submissionSupervisor ! PoisonPill
+  }
+
+  class TestApiServiceWithCustomSamDAO(dataSource: SlickDataSource, override val user: RawlsUser)(implicit
+    override val executionContext: ExecutionContext
+  ) extends TestApiService(dataSource, user) {
+    override val samDAO: CustomizableMockSamDAO = Mockito.spy(new CustomizableMockSamDAO(dataSource))
+
+    // these need to be overridden to use the new samDAO
+    override val rawlsWorkspaceAclManager = new RawlsWorkspaceAclManager(samDAO)
+    override val multiCloudWorkspaceAclManager =
+      new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
+  }
+
+  def withTestDataServices[T](testCode: TestApiService => T): T =
+    withDefaultTestDatabase { dataSource: SlickDataSource =>
+      withServices(dataSource, testData.userOwner)(testCode)
+    }
+
+  def withServices[T](dataSource: SlickDataSource, user: RawlsUser)(testCode: (TestApiService) => T) = {
+    val apiService = new TestApiService(dataSource, user)
+    try
+      testCode(apiService)
+    finally
+      apiService.cleanupSupervisor
+  }
+
+  "FastPassService" should "add FastPassGrants for the user on workspace create" in withTestDataServices { services =>
+    val newWorkspaceName = "space_for_workin"
+    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
+
+    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+    val workspaceFastPassGrants =
+      runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(workspace.workspaceIdAsUUID))
+
+    val ownerRoles = Vector(
+      services.terraWorkspaceCanComputeRole,
+      services.terraWorkspaceNextflowRole,
+      services.terraBucketWriterRole
+    )
+    workspaceFastPassGrants should not be empty
+    workspaceFastPassGrants.map(_.organizationRole) should contain only (ownerRoles: _*)
+    workspaceFastPassGrants.map(_.userSubjectId) should contain only (services.user.userSubjectId)
+
+    val userFastPassGrants = runAndWait(fastPassGrantQuery.findFastPassGrantsForUser(services.user.userSubjectId))
+    userFastPassGrants should not be empty
+    workspaceFastPassGrants.map(_.organizationRole) should contain only (ownerRoles: _*)
+
+    val petEmail =
+      Await.result(services.samDAO.getUserPetServiceAccount(services.ctx1, workspace.googleProjectId), Duration.Inf)
+
+    // The user is added to the project IAM policies with a condition
+    verify(services.googleIamDAO).addIamRoles(
+      ArgumentMatchers.eq(GoogleProject(workspace.googleProjectId.value)),
+      ArgumentMatchers.eq(WorkbenchEmail(services.user.userEmail.value)),
+      ArgumentMatchers.eq(MemberType.User),
+      ArgumentMatchers.eq(Set(services.terraWorkspaceCanComputeRole, services.terraWorkspaceNextflowRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.argThat((c: Option[Expr]) => c.exists(_.title.contains(services.user.userEmail.value)))
+    )
+
+    // The user's pet is added to the project IAM policies with a condition
+    verify(services.googleIamDAO).addIamRoles(
+      ArgumentMatchers.eq(GoogleProject(workspace.googleProjectId.value)),
+      ArgumentMatchers.eq(petEmail),
+      ArgumentMatchers.eq(MemberType.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraWorkspaceCanComputeRole, services.terraWorkspaceNextflowRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.argThat((c: Option[Expr]) => c.exists(_.title.contains(services.user.userEmail.value)))
+    )
+
+    // The user is added to the bucket IAM policies with a condition
+    verify(services.googleStorageDAO).addIamRoles(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(WorkbenchEmail(services.user.userEmail.value)),
+      ArgumentMatchers.eq(MemberType.User),
+      ArgumentMatchers.eq(Set(services.terraBucketWriterRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.argThat((c: Option[Expr]) => c.exists(_.title.contains(services.user.userEmail.value)))
+    )
+
+    // The user's pet is added to the bucket IAM policies with a condition
+    verify(services.googleStorageDAO).addIamRoles(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(petEmail),
+      ArgumentMatchers.eq(MemberType.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraBucketWriterRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.argThat((c: Option[Expr]) => c.exists(_.title.contains(services.user.userEmail.value)))
+    )
+  }
+
+  it should "remove FastPassGrants for the user on workspace delete" in withTestDataServices { services =>
+    val newWorkspaceName = "space_for_workin"
+    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
+
+    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+
+    val workspaceFastPassGrants =
+      runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(workspace.workspaceIdAsUUID))
+    workspaceFastPassGrants should not be empty
+
+    Await.ready(services.workspaceService.deleteWorkspace(workspaceRequest.toWorkspaceName), Duration.Inf)
+
+    val noMoreWorkspaceFastPassGrants =
+      runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(workspace.workspaceIdAsUUID))
+    noMoreWorkspaceFastPassGrants should be(empty)
+
+    val petEmail =
+      Await.result(services.samDAO.getUserPetServiceAccount(services.ctx1, workspace.googleProjectId), Duration.Inf)
+
+    // The user is added to the project IAM policies with a condition
+    verify(services.googleIamDAO).removeIamRoles(
+      ArgumentMatchers.eq(GoogleProject(workspace.googleProjectId.value)),
+      ArgumentMatchers.eq(WorkbenchEmail(services.user.userEmail.value)),
+      ArgumentMatchers.eq(MemberType.User),
+      ArgumentMatchers.eq(Set(services.terraWorkspaceCanComputeRole, services.terraWorkspaceNextflowRole)),
+      ArgumentMatchers.eq(false)
+    )
+
+    // The user's pet is added to the project IAM policies with a condition
+    verify(services.googleIamDAO).removeIamRoles(
+      ArgumentMatchers.eq(GoogleProject(workspace.googleProjectId.value)),
+      ArgumentMatchers.eq(petEmail),
+      ArgumentMatchers.eq(MemberType.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraWorkspaceCanComputeRole, services.terraWorkspaceNextflowRole)),
+      ArgumentMatchers.eq(false)
+    )
+
+    // The user is added to the bucket IAM policies with a condition
+    verify(services.googleStorageDAO).removeIamRoles(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(WorkbenchEmail(services.user.userEmail.value)),
+      ArgumentMatchers.eq(MemberType.User),
+      ArgumentMatchers.eq(Set(services.terraBucketWriterRole)),
+      ArgumentMatchers.eq(false)
+    )
+
+    // The user's pet is added to the bucket IAM policies with a condition
+    verify(services.googleStorageDAO).removeIamRoles(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(petEmail),
+      ArgumentMatchers.eq(MemberType.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraBucketWriterRole)),
+      ArgumentMatchers.eq(false)
+    )
+  }
+
+  it should "add FastPassGrants for the user in the parent workspace when a workspace is cloned" in withTestDataServices {
+    services =>
+      val baseWorkspace = testData.workspace
+      val newWorkspaceName = "cloned_space"
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
+
+      val baseWorkspaceFastPassGrantsBefore = runAndWait(
+        fastPassGrantQuery.findFastPassGrantsForUserInWorkspace(baseWorkspace.workspaceIdAsUUID,
+                                                                services.user.userSubjectId
+        )
+      )
+
+      baseWorkspaceFastPassGrantsBefore should be(empty)
+
+      val workspace =
+        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+                                                                          baseWorkspace.toWorkspaceName,
+                                                                          workspaceRequest
+                     ),
+                     Duration.Inf
+        )
+
+      val baseWorkspaceFastPassGrantsAfter = runAndWait(
+        fastPassGrantQuery.findFastPassGrantsForUserInWorkspace(baseWorkspace.workspaceIdAsUUID,
+                                                                services.user.userSubjectId
+        )
+      )
+
+      baseWorkspaceFastPassGrantsAfter should not be empty
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -36,7 +36,7 @@ import org.broadinstitute.dsde.rawls.workspace.{
 }
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO}
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
@@ -504,6 +504,7 @@ class SubmissionSpec(_system: ActorSystem)
 
       val fastPassServiceConstructor = FastPassService.constructor(
         new MockGoogleIamDAO,
+        new MockGoogleStorageDAO,
         samDAO,
         terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
         terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -503,7 +503,6 @@ class SubmissionSpec(_system: ActorSystem)
       val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
       val fastPassServiceConstructor = FastPassService.constructor(
-        dataSource,
         new MockGoogleIamDAO,
         samDAO,
         terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -171,6 +171,10 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
 
   override def getUserArbitraryPetServiceAccountKey(userEmail: String): Future[String] = ???
 
+  override def getUserPetServiceAccount(ctx: RawlsRequestContext,
+                                        googleProjectId: GoogleProjectId
+  ): Future[WorkbenchEmail] =
+    Future.successful(WorkbenchEmail("pet-110347448408766049948@broad-dsde-dev.iam.gserviceaccount.com"))
   override def deleteUserPetServiceAccount(googleProject: GoogleProjectId, ctx: RawlsRequestContext): Future[Unit] =
     Future.unit
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -57,7 +57,7 @@ import org.broadinstitute.dsde.rawls.workspace.{
   WorkspaceService
 }
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO}
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.mockito.Mockito.RETURNS_SMART_NULLS
@@ -320,6 +320,7 @@ trait ApiServiceSpec
 
     val fastPassServiceConstructor = FastPassService.constructor(
       new MockGoogleIamDAO,
+      new MockGoogleStorageDAO,
       samDAO,
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",
       terraWorkspaceCanComputeRole = "fakeTerraWorkspaceCanComputeRole",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -319,7 +319,6 @@ trait ApiServiceSpec
       new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
 
     val fastPassServiceConstructor = FastPassService.constructor(
-      slickDataSource,
       new MockGoogleIamDAO,
       samDAO,
       terraBillingProjectOwnerRole = "fakeTerraBillingProjectOwnerRole",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -948,6 +948,13 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       )
       when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail))
         .thenReturn(Future.successful(petSAJson))
+      when(
+        services.samDAO.getUserPetServiceAccount(
+          any[RawlsRequestContext],
+          ArgumentMatchers.eq(testData.workspace.googleProjectId)
+        )
+      ).thenReturn(Future.successful(WorkbenchEmail("pet-email@domain.org")))
+
       when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[RawlsRequestContext]))
         .thenReturn(
           Future.successful()
@@ -1043,6 +1050,12 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       )
       when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail))
         .thenReturn(Future.successful(petSAJson))
+      when(
+        services.samDAO.getUserPetServiceAccount(
+          any[RawlsRequestContext],
+          ArgumentMatchers.eq(testData.workspace.googleProjectId)
+        )
+      ).thenReturn(Future.successful(WorkbenchEmail("pet-email@domain.org")))
       when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[RawlsRequestContext]))
         .thenReturn(
           Future.successful()
@@ -1133,6 +1146,12 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       )
       when(services.samDAO.getPetServiceAccountKeyForUser(googleProjectId, userInfo.userEmail))
         .thenReturn(Future.successful(petSAJson))
+      when(
+        services.samDAO.getUserPetServiceAccount(
+          any[RawlsRequestContext],
+          ArgumentMatchers.eq(testData.workspace.googleProjectId)
+        )
+      ).thenReturn(Future.successful(WorkbenchEmail("pet-email@domain.org")))
       when(services.samDAO.deleteUserPetServiceAccount(ArgumentMatchers.eq(googleProjectId), any[RawlsRequestContext]))
         .thenReturn(
           Future.successful()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2308,7 +2308,7 @@ class WorkspaceServiceSpec
       actualLabels should contain allElementsOf expectedNewLabels
   }
 
-  it should "Add FastPassGrants for the user on workspace create" in withTestDataServices { services =>
+  it should "add FastPassGrants for the user on workspace create" in withTestDataServices { services =>
     val newWorkspaceName = "space_for_workin"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
 
@@ -2330,7 +2330,7 @@ class WorkspaceServiceSpec
     workspaceFastPassGrants.map(_.organizationRole) should contain only (ownerRoles: _*)
   }
 
-  it should "Remove FastPassGrants for the user on workspace delete" in withTestDataServices { services =>
+  it should "remove FastPassGrants for the user on workspace delete" in withTestDataServices { services =>
     val newWorkspaceName = "space_for_workin"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
 
@@ -2672,7 +2672,7 @@ class WorkspaceServiceSpec
     verify(services.resourceBufferService).getGoogleProjectFromBuffer(any[ProjectPoolType], any[String])
   }
 
-  it should "Add FastPassGrants for the user in the parent workspace" in withTestDataServices { services =>
+  it should "add FastPassGrants for the user in the parent workspace" in withTestDataServices { services =>
     val baseWorkspace = testData.workspace
     val newWorkspaceName = "cloned_space"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -45,7 +45,7 @@ import org.broadinstitute.dsde.rawls.{
   RawlsTestUtils
 }
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
-import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO}
+import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.model.google.{
   BigQueryDatasetName,
@@ -257,6 +257,7 @@ class WorkspaceServiceSpec
 
     val fastPassServiceConstructor = FastPassService.constructor(
       new MockGoogleIamDAO,
+      new MockGoogleStorageDAO,
       samDAO,
       terraBillingProjectOwnerRole,
       terraWorkspaceCanComputeRole,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -7,6 +7,7 @@ import bio.terra.workspace.model.{IamRole, RoleBinding, RoleBindingList}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.dataaccess.slick.DataAccess
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
@@ -98,7 +99,8 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     terraBucketWriterRole: String = "",
     billingProfileManagerDAO: BillingProfileManagerDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS),
     aclManagerDatasource: SlickDataSource = mock[SlickDataSource](RETURNS_SMART_NULLS),
-    fastPassServiceConstructor: RawlsRequestContext => FastPassService = _ => mock[FastPassService](RETURNS_SMART_NULLS)
+    fastPassServiceConstructor: (RawlsRequestContext, DataAccess) => FastPassService = (_, _) =>
+      mock[FastPassService](RETURNS_SMART_NULLS)
   ): RawlsRequestContext => WorkspaceService = info =>
     WorkspaceService.constructor(
       datasource,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/FastPassModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/FastPassModel.scala
@@ -2,65 +2,39 @@ package org.broadinstitute.dsde.rawls.model
 
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.GcpResourceTypes.GcpResourceType
-import org.broadinstitute.dsde.rawls.model.IamRoles.IamRole
 import org.joda.time.DateTime
-
-import java.sql.Timestamp
 
 /**
   * Created by tlangs on 3/16/2023.
   */
 
+object FastPassGrant {
+  def newFastPassGrant(workspaceId: String,
+                       userSubjectId: RawlsUserSubjectId,
+                       resourceType: GcpResourceType,
+                       resourceName: String,
+                       organizationRole: String,
+                       expiration: DateTime
+  ) = FastPassGrant(-1L,
+                    workspaceId,
+                    userSubjectId,
+                    resourceType,
+                    resourceName,
+                    organizationRole,
+                    expiration,
+                    DateTime.now()
+  )
+}
 case class FastPassGrant(
   id: Long,
   workspaceId: String,
   userSubjectId: RawlsUserSubjectId,
   resourceType: GcpResourceType,
   resourceName: String,
-  roleName: IamRole,
+  organizationRole: String,
   expiration: DateTime,
   created: DateTime
 )
-
-object IamRoles {
-
-  sealed trait IamRole extends RawlsEnumeration[IamRole] {
-    override def withName(name: String) = IamRoles.withName(name)
-    override def toString = getClass.getSimpleName.stripSuffix("$")
-    def toName(iamRole: IamRole) = IamRoles.toName(iamRole)
-  }
-
-  // Roles on Projects
-  case object RequesterPays extends IamRole
-  case object TerraBillingProjectOwner extends IamRole
-  case object TerraWorkspaceCanCompute extends IamRole
-  case object TerraWorkspaceNextflow extends IamRole
-
-  // Roles on buckets
-  case object TerraBucketReader extends IamRole
-  case object TerraBucketWriter extends IamRole
-
-  def withName(name: String): IamRole =
-    name match {
-      case "RequesterPays"                 => RequesterPays
-      case "terra_billing_project_owner"   => TerraBillingProjectOwner
-      case "terra_workspace_can_compute"   => TerraWorkspaceCanCompute
-      case "terra_workspace_nextflow_role" => TerraWorkspaceNextflow
-      case "terraBucketReader"             => TerraBucketReader
-      case "terraBucketWriter"             => TerraBucketWriter
-      case _                               => throw new RawlsException(s"invalid IamRole [$name]")
-    }
-
-  def toName(iamRole: IamRole): String =
-    iamRole match {
-      case RequesterPays            => "RequesterPays"
-      case TerraBillingProjectOwner => "terra_billing_project_owner"
-      case TerraWorkspaceCanCompute => "terra_workspace_can_compute"
-      case TerraWorkspaceNextflow   => "terra_workspace_nextflow_role"
-      case TerraBucketReader        => "terraBucketReader"
-      case TerraBucketWriter        => "terraBucketWriter"
-    }
-}
 
 object GcpResourceTypes {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,10 +82,10 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "db348ae"
+  val workbenchLibsHash = "867ff8b"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.24-3338c2fe-SNAP"
+  val workbenchGoogleV = s"0.24-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,7 @@ object Dependencies {
   val workbenchLibsHash = "db348ae"
 
   val workbenchModelV  = s"0.15-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.23-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.24-3338c2fe-SNAP"
   val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-504 https://broadworkbench.atlassian.net/browse/ID-505

Workspace creation and cloning now add FastPassGrants for the user. This PR implements the hooks in WorkspaceService, but not the actual calling out to the GCP APIs.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
