### PR TITLE
WOR-837 - Make Terra resilient if a landing zone fails to create

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectLifecycle.scala
@@ -29,6 +29,9 @@ trait BillingProjectLifecycle extends LazyLogging {
   val samDAO: SamDAO
   val billingRepository: BillingRepository
 
+  // The type of WorkspaceManagerResourceMonitorRecord job that should be created to finalize deletion when necessary
+  val deleteJobType: JobType
+
   // This code also lives in UserService as unregisterBillingProjectWithUserInfo
   // if this was scala 3.x, we could just use a parameterized trait and this would work basically everywhere
   def unregisterBillingProject(projectName: RawlsBillingProjectName, ctx: RawlsRequestContext)(implicit
@@ -61,6 +64,7 @@ trait BillingProjectLifecycle extends LazyLogging {
   /**
     * Initiates deletion of a billing project
     * @return an id of an async job the final stages of deleting are waiting on, if applicable.
+    *         If None is returned, the project can be deleted immediately via finalizeDelete
     */
   def initiateDelete(projectName: RawlsBillingProjectName, ctx: RawlsRequestContext)(implicit
     executionContext: ExecutionContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -9,10 +9,7 @@ import io.sentry.{Sentry, SentryEvent}
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
-  BpmBillingProjectDelete,
-  GoogleBillingProjectDelete
-}
+
 import org.broadinstitute.dsde.rawls.model.{
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
@@ -189,9 +186,9 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
             )
         }
       billingProfileId <- billingRepository.getBillingProfileId(projectName)
-      (deleteType, projectLifecycle) = billingProfileId match {
-        case None    => (GoogleBillingProjectDelete, googleBillingProjectLifecycle)
-        case Some(_) => (BpmBillingProjectDelete, bpmBillingProjectLifecycle)
+      projectLifecycle = billingProfileId match {
+        case None    => googleBillingProjectLifecycle
+        case Some(_) => bpmBillingProjectLifecycle
       }
       _ <- billingRepository.failUnlessHasNoWorkspaces(projectName)
       _ <- billingRepository.getCreationStatus(projectName).map { status =>
@@ -203,19 +200,19 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
           )
       }
       jobControlId <- projectLifecycle.initiateDelete(projectName, ctx)
-      _ <- deleteType match {
-        case GoogleBillingProjectDelete => projectLifecycle.finalizeDelete(projectName, ctx)
-        case BpmBillingProjectDelete =>
+      _ <- jobControlId match {
+        case Some(id) =>
           resourceMonitorRecordDao
             .create(
               WorkspaceManagerResourceMonitorRecord.forBillingProjectDelete(
-                jobControlId.getOrElse(UUID.randomUUID()),
+                id,
                 projectName,
                 ctx.userInfo.userEmail,
-                BpmBillingProjectDelete
+                projectLifecycle.deleteJobType
               )
             )
             .flatMap(_ => billingRepository.updateCreationStatus(projectName, CreationStatuses.Deleting, None))
+        case None => projectLifecycle.finalizeDelete(projectName, ctx)
       }
     } yield ()
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -32,7 +32,6 @@ import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValid
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchUserId}
 
-import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -10,6 +10,10 @@ import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePol
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
+  BpmBillingProjectDelete,
+  JobType
+}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.rawls.model.{
@@ -36,6 +40,8 @@ class BpmBillingProjectLifecycle(
   resourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao
 )(implicit val executionContext: ExecutionContext)
     extends BillingProjectLifecycle {
+
+  override val deleteJobType: JobType = BpmBillingProjectDelete
 
   /**
    * Validates that the desired azure managed application access.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
-import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
   GoogleBillingProjectDelete,
@@ -16,8 +15,6 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReportSource,
   RawlsBillingProjectName,
   RawlsRequestContext,
-  SamResourceTypeNames,
-  UserInfo
 }
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService.{
@@ -36,6 +33,8 @@ class GoogleBillingProjectLifecycle(
   executionContext: ExecutionContext
 ) extends BillingProjectLifecycle {
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
+
+  override val deleteJobType: JobType = GoogleBillingProjectDelete
 
   /**
    * Validates that the desired billing account has granted Terra proper access as well as any needed service

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   ErrorReportSource,
   RawlsBillingProjectName,
-  RawlsRequestContext,
+  RawlsRequestContext
 }
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService.{

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectLifecycleSpec.scala
@@ -3,7 +3,10 @@ package org.broadinstitute.dsde.rawls.billing
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
+  GoogleBillingProjectDelete,
+  JobType
+}
 import org.broadinstitute.dsde.rawls.model.{
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
@@ -49,6 +52,7 @@ class BillingProjectLifecycleSpec extends AnyFlatSpec {
     val billingLifecycle = new BillingProjectLifecycle {
       override val samDAO: SamDAO = samDAOMock
       override val billingRepository: BillingRepository = repo
+      override val deleteJobType: JobType = GoogleBillingProjectDelete
 
       override def validateBillingProjectCreationRequest(
         createProjectRequest: CreateRawlsV2BillingProjectFullRequest,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -322,6 +322,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   def initiateDeleteLifecycle(returnValue: Future[Option[UUID]]): BillingProjectLifecycle = {
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
+    when(billingProjectLifecycle.deleteJobType).thenReturn(BpmBillingProjectDelete)
     when(billingProjectLifecycle.initiateDelete(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(returnValue)
     billingProjectLifecycle
@@ -497,7 +498,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   it should "create a job to delete the Azure project after calling initiateDelete" in {
     val billingProjectName = RawlsBillingProjectName("fake_billing_account_name")
-    val jobId = UUID.fromString("c1024c05-40a6-4a12-b12e-028e445aec3b")
+    val jobId = UUID.randomUUID()
 
     def matchedExpectedEvent(e: WorkspaceManagerResourceMonitorRecord) =
       e.jobControlId.toString == jobId.toString &&
@@ -506,7 +507,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
         e.jobType == BpmBillingProjectDelete
     val monitorRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     when(monitorRecordDao.create(ArgumentMatchers.argThat(matchedExpectedEvent))).thenReturn(Future.successful())
-
     val bpo = new BillingProjectOrchestrator(
       testContext,
       alwaysGiveAccessSamDao,


### PR DESCRIPTION
Ticket: [WOR-837](https://broadworkbench.atlassian.net/browse/WOR-837)

The main change was to proceed with deletion immediately if there is no landing zone to delete. 

I was able to delete a billing project where retrieving the landing zone delete results had failed, after manually deleting the landing zone id on the billing project.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-837]: https://broadworkbench.atlassian.net/browse/WOR-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ