### PR TITLE
[WOR-816] Avoid throwing 500 errors from checkWorkspaceCloudPermissions for requester pays and workspaces with bad billing

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2734,27 +2734,31 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         _.filterNot(_.value.startsWith("resourcemanager."))
       )
 
-      bucketIamResults <- gcsDAO.testSAGoogleBucketIam(
-        GcsBucketName(workspace.bucketName),
-        petKey,
-        expectedGoogleBucketPermissions
-      ).recoverWith { case t: StorageException =>
-         // Throw with the status code of the exception (for example 403 for invalid billing, 400 for requester pays)
-         // instead of a 500 to avoid Sentry notifications.
-         Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(t.getCode, t)))
-      }
+      bucketIamResults <- gcsDAO
+        .testSAGoogleBucketIam(
+          GcsBucketName(workspace.bucketName),
+          petKey,
+          expectedGoogleBucketPermissions
+        )
+        .recoverWith { case t: StorageException =>
+          // Throw with the status code of the exception (for example 403 for invalid billing, 400 for requester pays)
+          // instead of a 500 to avoid Sentry notifications.
+          Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(t.getCode, t)))
+        }
 
       _ <- ApplicativeThrow[Future].raiseWhen(useDefaultPet && expectedGoogleProjectPermissions.nonEmpty) {
         new RawlsException("user has workspace read-only access yet has expected google project permissions")
       }
 
-      projectIamResults <- gcsDAO.testSAGoogleProjectIam(GoogleProject(workspace.googleProjectId.value),
-                                                         petKey,
-                                                         expectedGoogleProjectPermissions
-      ).recoverWith { case t: IOException =>
-        // Throw a 400 to avoid Sentry notifications.
-        Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, t)))
-      }
+      projectIamResults <- gcsDAO
+        .testSAGoogleProjectIam(GoogleProject(workspace.googleProjectId.value),
+                                petKey,
+                                expectedGoogleProjectPermissions
+        )
+        .recoverWith { case t: IOException =>
+          // Throw a 400 to avoid Sentry notifications.
+          Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, t)))
+        }
 
       missingBucketPermissions = expectedGoogleBucketPermissions -- bucketIamResults
       missingProjectPermissions = expectedGoogleProjectPermissions -- projectIamResults

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3341,7 +3341,7 @@ class WorkspaceServiceSpec
     ).thenReturn(Future.failed(new StorageException(403, mockErrorMessage)))
     val err = intercept[RawlsExceptionWithErrorReport] {
       Await.result(services.workspaceService.checkWorkspaceCloudPermissions(testData.workspace.toWorkspaceName),
-        Duration.Inf
+                   Duration.Inf
       )
     }
 
@@ -3361,7 +3361,7 @@ class WorkspaceServiceSpec
     ).thenReturn(Future.failed(new IOException(mockErrorMessage)))
     val err = intercept[RawlsExceptionWithErrorReport] {
       Await.result(services.workspaceService.checkWorkspaceCloudPermissions(testData.workspace.toWorkspaceName),
-        Duration.Inf
+                   Duration.Inf
       )
     }
 


### PR DESCRIPTION
Both of the specific errors (requester pays and bad billing) mentioned in https://broadworkbench.atlassian.net/browse/WOR-816 are cases of `StorageExceptions` being thrown from `testSAGoogleBucketIam`. 

There was some discussion of possibly avoiding the error on a RequestPays workspaces by using a different account to make the query, but that will not work because the user does not have write access (which Nick thought of later in the Slack thread discussion). And given that we want to handle the bad billing case as well, I think it makes more sense just to ensure that we retain the original 4xx status code, which ensures that the errors won't propagate to Sentry-- `RawlsExceptionWithErrorReport` instances are only [sent to Sentry](https://github.com/broadinstitute/rawls/blob/93afe2d5401da2b026a8359f612814379f5cd5aa/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala#L41) if they have 5xx status codes. 

Before on a requester pays workspace:
![image](https://user-images.githubusercontent.com/484484/226993109-1e80bcf8-3439-4017-ba84-ff5b81bf2ba8.png)
![image](https://user-images.githubusercontent.com/484484/226993383-a5ce1aaf-59ed-4f8f-acce-786173f4275b.png)

After on same workspace:
![image](https://user-images.githubusercontent.com/484484/226993285-da617f49-aad6-4abd-a6ec-ecdbf581c7a0.png)
![image](https://user-images.githubusercontent.com/484484/226992634-85ca1577-9625-4607-a0f5-c1abbc6369f2.png)


**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
