### PR TITLE
ID-522 Make FastPass Externally Configurable

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -455,8 +455,10 @@ object Boot extends IOApp with LazyLogging {
           metricsPrefix
         )
 
+      val fastPassConfig = FastPassConfig.apply(conf)
       val fastPassServiceConstructor: (RawlsRequestContext, DataAccess) => FastPassService =
         FastPassService.constructor(
+          fastPassConfig,
           appDependencies.httpGoogleIamDAO,
           appDependencies.httpGoogleStorageDAO,
           samDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/FastPassConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/FastPassConfig.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.dsde.rawls.config
+
+import com.typesafe.config.Config
+import org.broadinstitute.dsde.rawls.model.ProjectPoolId
+
+import java.time.Duration
+
+case class FastPassConfig(
+  enabled: Boolean,
+  grantPeriod: Duration
+)
+
+object FastPassConfig {
+  def apply(conf: Config): FastPassConfig = {
+    val fastPassConfig = conf.getConfig("fastPass")
+    FastPassConfig(
+      fastPassConfig.getBoolean("enabled"),
+      fastPassConfig.getDuration("grantPeriod")
+    )
+  }
+}

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -130,3 +130,8 @@ multiCloudWorkspaces {
         leonardoWsmApplicationId = "leo"
     }
 }
+
+fastPass {
+  enabled = true
+  grantPeriod = 2h
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -45,6 +45,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import spray.json._
 
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -502,7 +503,9 @@ class SubmissionSpec(_system: ActorSystem)
       val resourceBufferService = new ResourceBufferService(resourceBufferDAO, resourceBufferConfig)
       val resourceBufferSaEmail = resourceBufferConfig.saEmail
 
+      val fastPassConfig = FastPassConfig.apply(testConf)
       val fastPassServiceConstructor = FastPassService.constructor(
+        fastPassConfig,
         new MockGoogleIamDAO,
         new MockGoogleStorageDAO,
         samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -65,6 +65,7 @@ import org.mockito.ArgumentMatcher
 import org.scalatest.concurrent.Eventually
 import spray.json._
 
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -318,7 +319,9 @@ trait ApiServiceSpec
     val multiCloudWorkspaceAclManager =
       new MultiCloudWorkspaceAclManager(workspaceManagerDAO, samDAO, billingProfileManagerDAO, dataSource)
 
+    val fastPassConfig = FastPassConfig.apply(testConf)
     val fastPassServiceConstructor = FastPassService.constructor(
+      fastPassConfig,
       new MockGoogleIamDAO,
       new MockGoogleStorageDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -66,6 +66,7 @@ import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 import spray.json.DefaultJsonProtocol.immSeqFormat
 
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
@@ -256,7 +257,10 @@ class WorkspaceServiceSpec
     val terraBucketReaderRole = "fakeTerraBucketReaderRole"
     val terraBucketWriterRole = "fakeTerraBucketWriterRole"
 
+    val fastPassConfig = FastPassConfig.apply(testConf)
+
     val fastPassServiceConstructor = FastPassService.constructor(
+      fastPassConfig,
       googleIamDAO,
       googleStorageDAO,
       samDAO,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-522
Probably best to make it externally configurable so that it can be enabled/disabled per env

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
