### PR TITLE
AJ-912: Update mysql-connector-java from 8.0.30 to 8.0.32

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val ficus: ModuleID =           "com.iheart"                    %% "ficus"                % "1.5.2"
   val apacheCommonsIO: ModuleID = "commons-io"                    % "commons-io"            % "2.11.0"
   val antlrParser: ModuleID =     "org.antlr"                     % "antlr4-runtime"        % "4.8-1"
-  val mysqlConnector: ModuleID =  "mysql"                         % "mysql-connector-java"  % "8.0.30"
+  val mysqlConnector: ModuleID =  "com.mysql"                     % "mysql-connector-j"     % "8.0.32"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
   val workbenchLibsHash = "db348ae"


### PR DESCRIPTION
This is a manual redo of Scala Steward's PR #2210.

The objective is to update mysql-connector-java from 8.0.30 to 8.0.32.

However, the release notes for [mysql-connector-java 8.0.31](https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-31.html) say:

> Important Change: To comply with proper naming guidelines, the Maven groupId and artifactId for Connector/J have been changed to the following starting with this release:
> 
> * groupId: com.mysql
> * artifactId: mysql-connector-j
> 
> The old groupId and artifactId can still be used for linking the Connector/J library, but they will point to a Maven relocation POM, redirecting users to the new coordinates.

So, I am also updating the groupId and artifactId, which Scala Steward did not do.
