### PR TITLE
WX-820 Finite monitoring for submissions

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -50,6 +50,7 @@ gcs {
 
 submissionmonitor {
   submissionPollInterval = 1m
+  submissionPollExpiration = 30 days
   trackDetailedSubmissionMetrics = true
   attributeUpdatesPerWorkflow = 20000
   enableEmailNotifications = true

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -280,7 +280,8 @@ trait SubmissionComponent {
       )
 
     def listRecentActiveSubmissionIdsWithWorkspace(): ReadAction[Seq[(UUID, WorkspaceName)]] = {
-      // Exclude submissions from monitoring if they are ancient/stuck
+      // Exclude submissions from monitoring if they are ancient/stuck [WX-820]
+      // Empirically as of 3/23 there were no successful submissions that lasted longer than ~20 days
       val cutoffTime = new Timestamp(DateTime.now().minusDays(90).getMillis)
       val query = findActiveSubmissionsAfterTime(cutoffTime) join workspaceQuery on (_.workspaceId === _.id)
       val result = query.map { case (sub, ws) => (sub.id, ws.namespace, ws.name) }.result

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -769,6 +769,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
 }
 
 final case class SubmissionMonitorConfig(submissionPollInterval: FiniteDuration,
+                                         submissionPollExpiration: FiniteDuration,
                                          trackDetailedSubmissionMetrics: Boolean,
                                          attributeUpdatesPerWorkflow: Int,
                                          enableEmailNotifications: Boolean

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -221,7 +221,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     val monitoredSubmissions = context.children.map(_.path.name).toSet
 
     datasource.inTransaction { dataAccess =>
-      dataAccess.submissionQuery.listRecentActiveSubmissionIdsWithWorkspace() map { activeSubs =>
+      dataAccess.submissionQuery.listActiveSubmissionIdsWithWorkspace(limit = submissionMonitorConfig.submissionPollExpiration) map { activeSubs =>
         val unmonitoredSubmissions = activeSubs.filterNot { case (subId, _) =>
           monitoredSubmissions.contains(subId.toString)
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -221,7 +221,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     val monitoredSubmissions = context.children.map(_.path.name).toSet
 
     datasource.inTransaction { dataAccess =>
-      dataAccess.submissionQuery.listAllActiveSubmissionIdsWithWorkspace() map { activeSubs =>
+      dataAccess.submissionQuery.listRecentActiveSubmissionIdsWithWorkspace() map { activeSubs =>
         val unmonitoredSubmissions = activeSubs.filterNot { case (subId, _) =>
           monitoredSubmissions.contains(subId.toString)
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -221,7 +221,9 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     val monitoredSubmissions = context.children.map(_.path.name).toSet
 
     datasource.inTransaction { dataAccess =>
-      dataAccess.submissionQuery.listActiveSubmissionIdsWithWorkspace(limit = submissionMonitorConfig.submissionPollExpiration) map { activeSubs =>
+      dataAccess.submissionQuery.listActiveSubmissionIdsWithWorkspace(limit =
+        submissionMonitorConfig.submissionPollExpiration
+      ) map { activeSubs =>
         val unmonitoredSubmissions = activeSubs.filterNot { case (subId, _) =>
           monitoredSubmissions.contains(subId.toString)
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -100,6 +100,7 @@ object BootMonitors extends LazyLogging {
     val submissionmonitorConfigRoot = conf.getConfig("submissionmonitor")
     val submissionMonitorConfig = SubmissionMonitorConfig(
       util.toScalaDuration(submissionmonitorConfigRoot.getDuration("submissionPollInterval")),
+      util.toScalaDuration(submissionmonitorConfigRoot.getDuration("submissionPollExpiration")),
       submissionmonitorConfigRoot.getBoolean("trackDetailedSubmissionMetrics"),
       submissionmonitorConfigRoot.getInt("attributeUpdatesPerWorkflow"),
       submissionmonitorConfigRoot.getBoolean("enableEmailNotifications")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -1876,7 +1876,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                                    execSvcDAO: ExecutionServiceDAO,
                                    trackDetailedSubmissionMetrics: Boolean = true
   ): TestActorRef[SubmissionMonitorActor] = {
-    val config = SubmissionMonitorConfig(1 second, trackDetailedSubmissionMetrics, 10, true)
+    val config = SubmissionMonitorConfig(1 second, 30 days, trackDetailedSubmissionMetrics, 10, true)
     TestActorRef[SubmissionMonitorActor](
       SubmissionMonitorActor.props(
         wsName,
@@ -1900,7 +1900,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                               wsName: WorkspaceName,
                               execSvcDAO: ExecutionServiceDAO
   ): SubmissionMonitor = {
-    val config = SubmissionMonitorConfig(1 minutes, true, 10, true)
+    val config = SubmissionMonitorConfig(1 minutes, 30 days, true, 10, true)
     new TestSubmissionMonitor(
       wsName,
       UUID.fromString(submission.submissionId),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -417,7 +417,7 @@ class SubmissionSpec(_system: ActorSystem)
       val execServiceCluster: ExecutionServiceCluster =
         MockShardedExecutionServiceCluster.fromDAO(executionServiceDAO, dataSource)
 
-      val config = SubmissionMonitorConfig(250.milliseconds, trackDetailedSubmissionMetrics = true, 20000, false)
+      val config = SubmissionMonitorConfig(250.milliseconds, 30 days, trackDetailedSubmissionMetrics = true, 20000, false)
       val gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")
       val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
       val samDAO = new MockSamDAO(dataSource)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -417,7 +417,8 @@ class SubmissionSpec(_system: ActorSystem)
       val execServiceCluster: ExecutionServiceCluster =
         MockShardedExecutionServiceCluster.fromDAO(executionServiceDAO, dataSource)
 
-      val config = SubmissionMonitorConfig(250.milliseconds, 30 days, trackDetailedSubmissionMetrics = true, 20000, false)
+      val config =
+        SubmissionMonitorConfig(250.milliseconds, 30 days, trackDetailedSubmissionMetrics = true, 20000, false)
       val gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")
       val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
       val samDAO = new MockSamDAO(dataSource)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -67,7 +67,7 @@ class SubmissionSupervisorSpec
   def withSupervisor[T](trackDetailedMetrics: Boolean = true)(op: ActorRef => T): T = {
     val execSvcDAO = new MockExecutionServiceDAO()
     val execCluster = MockShardedExecutionServiceCluster.fromDAO(execSvcDAO, slickDataSource)
-    val config = SubmissionMonitorConfig(20 minutes, trackDetailedMetrics, 20000, true)
+    val config = SubmissionMonitorConfig(20 minutes, 30 days, trackDetailedMetrics, 20000, true)
     val submissionSupervisor = system.actorOf(
       SubmissionSupervisor
         .props(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -178,7 +178,7 @@ trait ApiServiceSpec
       slickDataSource
     )
 
-    val config = SubmissionMonitorConfig(5 seconds, true, 20000, true)
+    val config = SubmissionMonitorConfig(5 seconds, 30 days, true, 20000, true)
     val submissionSupervisor = system.actorOf(
       SubmissionSupervisor
         .props(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -156,7 +156,7 @@ class WorkspaceServiceSpec
           gcsDAO,
           mockNotificationDAO,
           gcsDAO.getBucketServiceAccountCredential,
-          SubmissionMonitorConfig(1 second, true, 20000, true),
+          SubmissionMonitorConfig(1 second, 30 days, true, 20000, true),
           workbenchMetricBaseName = "test"
         )
         .withDispatcher("submission-monitor-dispatcher")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WX-820

Exceptions in workflow/submission monitoring frequently cause infinite retry loops. It's not a perfect fix, but backing off from infinity to 90 days should take a lot of load off of the system.

Generated query looks like this:

```
select 
  x2.x3, 
  x4.`namespace`, 
  x4.`name` 
from 
  (
    select 
      `STATUS` as x5, 
      `DATE_SUBMITTED` as x6, 
      `ID` as x3, 
      `WORKSPACE_ID` as x7 
    from 
      `SUBMISSION` 
    where 
      (
        `STATUS` in (
          'Accepted', 'Evaluating', 'Submitting', 
          'Submitted', 'Aborting'
        )
      ) 
      and (
        `DATE_SUBMITTED` > '2023-02-26 21:36:54.762'
      )
  ) x2, 
  `WORKSPACE` x4 
where 
  x2.x7 = x4.`id`
```

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
