### PR TITLE
[WOR-802] Wire up optional LZ ID for testing purposes

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -56,7 +56,7 @@ submissionmonitor {
 }
 
 workspaceManagerResourceMonitor {
-  defaultRetrySeconds = 60
+  defaultRetrySeconds = 4
   retryUncompletedJobsSeconds = 5
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -8,16 +8,15 @@ import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZon
 import cats.implicits.{catsSyntaxFlatMapOps, toTraverseOps}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
   BpmBillingProjectDelete,
   JobType
 }
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.rawls.model.{
-  AzureManagedAppCoordinates,
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
   ErrorReport => RawlsErrorReport,
@@ -183,7 +182,7 @@ class BpmBillingProjectLifecycle(
             }
           }
           .recoverWith { case t: Throwable =>
-            logger.error("Billing project creation failed, cleaning up billing profile")
+            logger.error("Billing project creation failed, cleaning up billing profile", t)
             cleanupBillingProfile(profileModel.getId, projectName, ctx).recover { case cleanupError: Throwable =>
               // Log the exception that prevented cleanup from completing, but do not throw it so original
               // cause of billing project failure is shown to user.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -105,17 +105,22 @@ class BpmBillingProjectLifecycle(
 
     // This starts a landing zone creation job. There is a separate monitor that polls to see when it
     // completes and then updates the billing project status accordingly.
-    def createLandingZone(profileModel: ProfileModel): Future[CreateLandingZoneResult] =
+    def createLandingZone(profileModel: ProfileModel): Future[CreateLandingZoneResult] = {
+      val lzId =    createProjectRequest.managedAppCoordinates.get.landingZoneId
+      val maybeAttach = if(lzId.isDefined) Map("attach" -> "true") else Map.empty
+      val params = config.azureConfig.get.landingZoneParameters ++ maybeAttach
+
       Future(blocking {
         workspaceManagerDAO.createLandingZone(
           config.azureConfig.get.landingZoneDefinition,
           config.azureConfig.get.landingZoneVersion,
-          config.azureConfig.get.landingZoneParameters,
+          params,
           profileModel.getId,
           ctx,
-          config.azureConfig.get.landingZoneId
+          lzId
         )
       })
+    }
 
     def addMembersToBillingProfile(profileModel: ProfileModel): Future[Set[Unit]] = {
       val members = createProjectRequest.members.getOrElse(Set.empty)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import org.broadinstitute.dsde.rawls.util
 import org.broadinstitute.dsde.rawls.util.ScalaConfig._
 
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
@@ -17,7 +18,8 @@ final case class MultiCloudWorkspaceManagerConfig(leonardoWsmApplicationId: Stri
 
 final case class AzureConfig(landingZoneDefinition: String,
                              landingZoneVersion: String,
-                             landingZoneParameters: Map[String, String]
+                             landingZoneParameters: Map[String, String],
+                             landingZoneId: Option[UUID] = None
 )
 
 case object MultiCloudWorkspaceConfig {
@@ -35,7 +37,8 @@ case object MultiCloudWorkspaceConfig {
               .map { entry =>
                 entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
               }
-              .toMap
+              .toMap,
+            azc.getStringOption("landingZoneId").flatMap(s => Option(UUID.fromString(s)))
           )
         )
       case _ => None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -18,7 +18,8 @@ final case class MultiCloudWorkspaceManagerConfig(leonardoWsmApplicationId: Stri
 
 final case class AzureConfig(landingZoneDefinition: String,
                              landingZoneVersion: String,
-                             landingZoneParameters: Map[String, String]
+                             landingZoneParameters: Map[String, String],
+                             landingZoneAllowAttach: Boolean
 )
 
 case object MultiCloudWorkspaceConfig {
@@ -36,7 +37,8 @@ case object MultiCloudWorkspaceConfig {
               .map { entry =>
                 entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
               }
-              .toMap
+              .toMap,
+            azc.getBooleanOption("landingZoneAllowAttach").getOrElse(false)
           )
         )
       case _ => None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -18,8 +18,7 @@ final case class MultiCloudWorkspaceManagerConfig(leonardoWsmApplicationId: Stri
 
 final case class AzureConfig(landingZoneDefinition: String,
                              landingZoneVersion: String,
-                             landingZoneParameters: Map[String, String],
-                             landingZoneId: Option[UUID] = None
+                             landingZoneParameters: Map[String, String]
 )
 
 case object MultiCloudWorkspaceConfig {
@@ -37,8 +36,7 @@ case object MultiCloudWorkspaceConfig {
               .map { entry =>
                 entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
               }
-              .toMap,
-            azc.getStringOption("landingZoneId").flatMap(s => Option(UUID.fromString(s)))
+              .toMap
           )
         )
       case _ => None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -14,9 +14,9 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvider)(implicit
-                                                                                    val system: ActorSystem,
-                                                                                    val materializer: Materializer,
-                                                                                    val executionContext: ExecutionContext
+  val system: ActorSystem,
+  val materializer: Materializer,
+  val executionContext: ExecutionContext
 ) extends WorkspaceManagerDAO {
 
   private def getApiClient(ctx: RawlsRequestContext): ApiClient =
@@ -57,7 +57,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                displayName: String,
                                                spendProfileId: String,
                                                ctx: RawlsRequestContext
-                                              ): CreatedWorkspace =
+  ): CreatedWorkspace =
     getWorkspaceApi(ctx).createWorkspace(
       new CreateWorkspaceRequestBody()
         .id(workspaceId)
@@ -72,7 +72,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                               spendProfile: ProfileModel,
                               ctx: RawlsRequestContext,
                               location: Option[String]
-                             ): CloneWorkspaceResult =
+  ): CloneWorkspaceResult =
     getWorkspaceApi(ctx).cloneWorkspace(
       new CloneWorkspaceRequest()
         .destinationWorkspaceId(workspaceId)
@@ -88,24 +88,24 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getCloneWorkspaceResult(workspaceId: UUID,
                                        jobControlId: String,
                                        ctx: RawlsRequestContext
-                                      ): CloneWorkspaceResult =
+  ): CloneWorkspaceResult =
     getWorkspaceApi(ctx).getCloneWorkspaceResult(workspaceId, jobControlId)
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                                 ctx: RawlsRequestContext
-                                               ): CreateCloudContextResult = {
+  ): CreateCloudContextResult = {
     val jobControlId = UUID.randomUUID().toString
     getWorkspaceApi(ctx).createCloudContext(new CreateCloudContextRequest()
-      .cloudPlatform(CloudPlatform.AZURE)
-      .jobControl(new JobControl().id(jobControlId)),
-      workspaceId
+                                              .cloudPlatform(CloudPlatform.AZURE)
+                                              .jobControl(new JobControl().id(jobControlId)),
+                                            workspaceId
     )
   }
 
   override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                                     jobControlId: String,
                                                     ctx: RawlsRequestContext
-                                                   ): CreateCloudContextResult =
+  ): CreateCloudContextResult =
     getWorkspaceApi(ctx).getCreateCloudContextResult(workspaceId, jobControlId)
 
   override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit =
@@ -118,7 +118,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                instanceName: String,
                                                cloningInstructions: CloningInstructionsEnum,
                                                ctx: RawlsRequestContext
-                                              ): DataRepoSnapshotResource = {
+  ): DataRepoSnapshotResource = {
     val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId.toString)
     val commonFields =
       new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
@@ -131,7 +131,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                referenceId: UUID,
                                                updateInfo: UpdateDataRepoSnapshotReferenceRequestBody,
                                                ctx: RawlsRequestContext
-                                              ): Unit =
+  ): Unit =
     getReferencedGcpResourceApi(ctx).updateDataRepoSnapshotReferenceResource(updateInfo, workspaceId, referenceId)
 
   override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit =
@@ -140,31 +140,31 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getDataRepoSnapshotReference(workspaceId: UUID,
                                             referenceId: UUID,
                                             ctx: RawlsRequestContext
-                                           ): DataRepoSnapshotResource =
+  ): DataRepoSnapshotResource =
     getReferencedGcpResourceApi(ctx).getDataRepoSnapshotReference(workspaceId, referenceId)
 
   override def getDataRepoSnapshotReferenceByName(workspaceId: UUID,
                                                   refName: DataReferenceName,
                                                   ctx: RawlsRequestContext
-                                                 ): DataRepoSnapshotResource =
+  ): DataRepoSnapshotResource =
     getReferencedGcpResourceApi(ctx).getDataRepoSnapshotReferenceByName(workspaceId, refName.value)
 
   override def enumerateDataRepoSnapshotReferences(workspaceId: UUID,
                                                    offset: Int,
                                                    limit: Int,
                                                    ctx: RawlsRequestContext
-                                                  ): ResourceList =
+  ): ResourceList =
     getResourceApi(ctx).enumerateResources(workspaceId,
-      offset,
-      limit,
-      ResourceType.DATA_REPO_SNAPSHOT,
-      StewardshipType.REFERENCED
+                                           offset,
+                                           limit,
+                                           ResourceType.DATA_REPO_SNAPSHOT,
+                                           StewardshipType.REFERENCED
     )
 
   override def enableApplication(workspaceId: UUID,
                                  applicationId: String,
                                  ctx: RawlsRequestContext
-                                ): WorkspaceApplicationDescription =
+  ): WorkspaceApplicationDescription =
     getWorkspaceApplicationApi(ctx).enableWorkspaceApplication(
       workspaceId,
       applicationId
@@ -173,37 +173,16 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def disableApplication(workspaceId: UUID,
                                   applicationId: String,
                                   ctx: RawlsRequestContext
-                                 ): WorkspaceApplicationDescription =
+  ): WorkspaceApplicationDescription =
     getWorkspaceApplicationApi(ctx).disableWorkspaceApplication(workspaceId, applicationId)
-
-  override def createAzureStorageAccount(workspaceId: UUID,
-                                         region: String,
-                                         ctx: RawlsRequestContext
-                                        ): CreatedControlledAzureStorage = {
-    // Storage account names must be unique and 3-24 characters in length, numbers and lowercase letters only.
-    val prefix = workspaceId.toString.substring(0, workspaceId.toString.indexOf("-"))
-    val suffix = workspaceId.toString.substring(workspaceId.toString.lastIndexOf("-") + 1)
-    getControlledAzureResourceApi(ctx).createAzureStorage(
-      new CreateControlledAzureStorageRequestBody()
-        .common(
-          createCommonFields(s"sa-${workspaceId}")
-        )
-        .azureStorage(
-          new AzureStorageCreationParameters().storageAccountName(s"sa${prefix}${suffix}").region(region)
-        ),
-      workspaceId
-    )
-  }
 
   override def createAzureStorageContainer(workspaceId: UUID,
                                            storageContainerName: String,
-                                           storageAccountId: Option[UUID],
                                            ctx: RawlsRequestContext
-                                          ) = {
+  ) = {
     val creationParams =
       new AzureStorageContainerCreationParameters()
         .storageContainerName(storageContainerName)
-        .storageAccountId(storageAccountId.orNull)
 
     val requestBody = new CreateControlledAzureStorageContainerRequestBody()
       .common(
@@ -221,7 +200,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                           destinationContainerName: String,
                                           cloningInstructions: CloningInstructionsEnum,
                                           ctx: RawlsRequestContext
-                                         ): CloneControlledAzureStorageContainerResult = {
+  ): CloneControlledAzureStorageContainerResult = {
     val jobControlId = UUID.randomUUID().toString
     getControlledAzureResourceApi(ctx).cloneAzureStorageContainer(
       new CloneControlledAzureStorageContainerRequest()
@@ -237,19 +216,19 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getCloneAzureStorageContainerResult(workspaceId: UUID,
                                                    jobId: String,
                                                    ctx: RawlsRequestContext
-                                                  ): CloneControlledAzureStorageContainerResult =
+  ): CloneControlledAzureStorageContainerResult =
     getControlledAzureResourceApi(ctx).getCloneAzureStorageContainerResult(workspaceId, jobId)
 
   override def enumerateStorageContainers(workspaceId: UUID,
                                           offset: Int,
                                           limit: Int,
                                           ctx: RawlsRequestContext
-                                         ): ResourceList =
+  ): ResourceList =
     getResourceApi(ctx).enumerateResources(workspaceId,
-      offset,
-      limit,
-      ResourceType.AZURE_STORAGE_CONTAINER,
-      StewardshipType.CONTROLLED
+                                           offset,
+                                           limit,
+                                           ResourceType.AZURE_STORAGE_CONTAINER,
+                                           StewardshipType.CONTROLLED
     )
 
   override def getRoles(workspaceId: UUID, ctx: RawlsRequestContext) = getWorkspaceApi(ctx).getRoles(workspaceId)
@@ -270,7 +249,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                  billingProfileId: UUID,
                                  ctx: RawlsRequestContext,
                                  landingZoneId: Option[UUID] = None
-                                ): CreateLandingZoneResult = {
+  ): CreateLandingZoneResult = {
     val jobControlId = UUID.randomUUID().toString
     var lzRequestBody = new CreateAzureLandingZoneRequestBody()
       .definition(definition)
@@ -306,7 +285,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   def getDeleteLandingZoneResult(jobId: String,
                                  landingZoneId: UUID,
                                  ctx: RawlsRequestContext
-                                ): DeleteAzureLandingZoneJobResult =
+  ): DeleteAzureLandingZoneJobResult =
     getLandingZonesApi(ctx).getDeleteAzureLandingZoneResult(landingZoneId, jobId)
 
   override def throwWhenUnavailable(): Unit =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -14,9 +14,9 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
 class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvider)(implicit
-  val system: ActorSystem,
-  val materializer: Materializer,
-  val executionContext: ExecutionContext
+                                                                                    val system: ActorSystem,
+                                                                                    val materializer: Materializer,
+                                                                                    val executionContext: ExecutionContext
 ) extends WorkspaceManagerDAO {
 
   private def getApiClient(ctx: RawlsRequestContext): ApiClient =
@@ -57,7 +57,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                displayName: String,
                                                spendProfileId: String,
                                                ctx: RawlsRequestContext
-  ): CreatedWorkspace =
+                                              ): CreatedWorkspace =
     getWorkspaceApi(ctx).createWorkspace(
       new CreateWorkspaceRequestBody()
         .id(workspaceId)
@@ -72,7 +72,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                               spendProfile: ProfileModel,
                               ctx: RawlsRequestContext,
                               location: Option[String]
-  ): CloneWorkspaceResult =
+                             ): CloneWorkspaceResult =
     getWorkspaceApi(ctx).cloneWorkspace(
       new CloneWorkspaceRequest()
         .destinationWorkspaceId(workspaceId)
@@ -88,24 +88,24 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getCloneWorkspaceResult(workspaceId: UUID,
                                        jobControlId: String,
                                        ctx: RawlsRequestContext
-  ): CloneWorkspaceResult =
+                                      ): CloneWorkspaceResult =
     getWorkspaceApi(ctx).getCloneWorkspaceResult(workspaceId, jobControlId)
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID,
                                                 ctx: RawlsRequestContext
-  ): CreateCloudContextResult = {
+                                               ): CreateCloudContextResult = {
     val jobControlId = UUID.randomUUID().toString
     getWorkspaceApi(ctx).createCloudContext(new CreateCloudContextRequest()
-                                              .cloudPlatform(CloudPlatform.AZURE)
-                                              .jobControl(new JobControl().id(jobControlId)),
-                                            workspaceId
+      .cloudPlatform(CloudPlatform.AZURE)
+      .jobControl(new JobControl().id(jobControlId)),
+      workspaceId
     )
   }
 
   override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                                     jobControlId: String,
                                                     ctx: RawlsRequestContext
-  ): CreateCloudContextResult =
+                                                   ): CreateCloudContextResult =
     getWorkspaceApi(ctx).getCreateCloudContextResult(workspaceId, jobControlId)
 
   override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit =
@@ -118,7 +118,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                instanceName: String,
                                                cloningInstructions: CloningInstructionsEnum,
                                                ctx: RawlsRequestContext
-  ): DataRepoSnapshotResource = {
+                                              ): DataRepoSnapshotResource = {
     val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId.toString)
     val commonFields =
       new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
@@ -131,7 +131,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                referenceId: UUID,
                                                updateInfo: UpdateDataRepoSnapshotReferenceRequestBody,
                                                ctx: RawlsRequestContext
-  ): Unit =
+                                              ): Unit =
     getReferencedGcpResourceApi(ctx).updateDataRepoSnapshotReferenceResource(updateInfo, workspaceId, referenceId)
 
   override def deleteDataRepoSnapshotReference(workspaceId: UUID, referenceId: UUID, ctx: RawlsRequestContext): Unit =
@@ -140,31 +140,31 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getDataRepoSnapshotReference(workspaceId: UUID,
                                             referenceId: UUID,
                                             ctx: RawlsRequestContext
-  ): DataRepoSnapshotResource =
+                                           ): DataRepoSnapshotResource =
     getReferencedGcpResourceApi(ctx).getDataRepoSnapshotReference(workspaceId, referenceId)
 
   override def getDataRepoSnapshotReferenceByName(workspaceId: UUID,
                                                   refName: DataReferenceName,
                                                   ctx: RawlsRequestContext
-  ): DataRepoSnapshotResource =
+                                                 ): DataRepoSnapshotResource =
     getReferencedGcpResourceApi(ctx).getDataRepoSnapshotReferenceByName(workspaceId, refName.value)
 
   override def enumerateDataRepoSnapshotReferences(workspaceId: UUID,
                                                    offset: Int,
                                                    limit: Int,
                                                    ctx: RawlsRequestContext
-  ): ResourceList =
+                                                  ): ResourceList =
     getResourceApi(ctx).enumerateResources(workspaceId,
-                                           offset,
-                                           limit,
-                                           ResourceType.DATA_REPO_SNAPSHOT,
-                                           StewardshipType.REFERENCED
+      offset,
+      limit,
+      ResourceType.DATA_REPO_SNAPSHOT,
+      StewardshipType.REFERENCED
     )
 
   override def enableApplication(workspaceId: UUID,
                                  applicationId: String,
                                  ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription =
+                                ): WorkspaceApplicationDescription =
     getWorkspaceApplicationApi(ctx).enableWorkspaceApplication(
       workspaceId,
       applicationId
@@ -173,13 +173,13 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def disableApplication(workspaceId: UUID,
                                   applicationId: String,
                                   ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription =
+                                 ): WorkspaceApplicationDescription =
     getWorkspaceApplicationApi(ctx).disableWorkspaceApplication(workspaceId, applicationId)
 
   override def createAzureStorageAccount(workspaceId: UUID,
                                          region: String,
                                          ctx: RawlsRequestContext
-  ): CreatedControlledAzureStorage = {
+                                        ): CreatedControlledAzureStorage = {
     // Storage account names must be unique and 3-24 characters in length, numbers and lowercase letters only.
     val prefix = workspaceId.toString.substring(0, workspaceId.toString.indexOf("-"))
     val suffix = workspaceId.toString.substring(workspaceId.toString.lastIndexOf("-") + 1)
@@ -199,7 +199,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                            storageContainerName: String,
                                            storageAccountId: Option[UUID],
                                            ctx: RawlsRequestContext
-  ) = {
+                                          ) = {
     val creationParams =
       new AzureStorageContainerCreationParameters()
         .storageContainerName(storageContainerName)
@@ -221,7 +221,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                           destinationContainerName: String,
                                           cloningInstructions: CloningInstructionsEnum,
                                           ctx: RawlsRequestContext
-  ): CloneControlledAzureStorageContainerResult = {
+                                         ): CloneControlledAzureStorageContainerResult = {
     val jobControlId = UUID.randomUUID().toString
     getControlledAzureResourceApi(ctx).cloneAzureStorageContainer(
       new CloneControlledAzureStorageContainerRequest()
@@ -237,19 +237,19 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getCloneAzureStorageContainerResult(workspaceId: UUID,
                                                    jobId: String,
                                                    ctx: RawlsRequestContext
-  ): CloneControlledAzureStorageContainerResult =
+                                                  ): CloneControlledAzureStorageContainerResult =
     getControlledAzureResourceApi(ctx).getCloneAzureStorageContainerResult(workspaceId, jobId)
 
   override def enumerateStorageContainers(workspaceId: UUID,
                                           offset: Int,
                                           limit: Int,
                                           ctx: RawlsRequestContext
-  ): ResourceList =
+                                         ): ResourceList =
     getResourceApi(ctx).enumerateResources(workspaceId,
-                                           offset,
-                                           limit,
-                                           ResourceType.AZURE_STORAGE_CONTAINER,
-                                           StewardshipType.CONTROLLED
+      offset,
+      limit,
+      ResourceType.AZURE_STORAGE_CONTAINER,
+      StewardshipType.CONTROLLED
     )
 
   override def getRoles(workspaceId: UUID, ctx: RawlsRequestContext) = getWorkspaceApi(ctx).getRoles(workspaceId)
@@ -268,24 +268,27 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                  version: String,
                                  landingZoneParameters: Map[String, String],
                                  billingProfileId: UUID,
-                                 ctx: RawlsRequestContext
-  ): CreateLandingZoneResult = {
+                                 ctx: RawlsRequestContext,
+                                 landingZoneId: Option[UUID] = None
+                                ): CreateLandingZoneResult = {
     val jobControlId = UUID.randomUUID().toString
-    getLandingZonesApi(ctx).createAzureLandingZone(
-      new CreateAzureLandingZoneRequestBody()
-        .definition(definition)
-        .version(version)
-        .billingProfileId(billingProfileId)
-        .parameters(
-          landingZoneParameters
-            .map { case (k, v) =>
-              new AzureLandingZoneParameter().key(k).value(v)
-            }
-            .toList
-            .asJava
-        )
-        .jobControl(new JobControl().id(jobControlId))
-    )
+    var lzRequestBody = new CreateAzureLandingZoneRequestBody()
+      .definition(definition)
+      .version(version)
+      .billingProfileId(billingProfileId)
+      .parameters(
+        landingZoneParameters
+          .map { case (k, v) =>
+            new AzureLandingZoneParameter().key(k).value(v)
+          }
+          .toList
+          .asJava
+      )
+      .jobControl(new JobControl().id(jobControlId))
+    if (landingZoneId.isDefined) {
+      lzRequestBody = lzRequestBody.landingZoneId(landingZoneId.get)
+    }
+    getLandingZonesApi(ctx).createAzureLandingZone(lzRequestBody)
   }
 
   override def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult =
@@ -303,7 +306,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   def getDeleteLandingZoneResult(jobId: String,
                                  landingZoneId: UUID,
                                  ctx: RawlsRequestContext
-  ): DeleteAzureLandingZoneJobResult =
+                                ): DeleteAzureLandingZoneJobResult =
     getLandingZonesApi(ctx).getDeleteAzureLandingZoneResult(landingZoneId, jobId)
 
   override def throwWhenUnavailable(): Unit =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -150,7 +150,8 @@ trait WorkspaceManagerDAO {
                         version: String,
                         landingZoneParameters: Map[String, String],
                         billingProfileId: UUID,
-                        ctx: RawlsRequestContext
+                        ctx: RawlsRequestContext,
+                        landingZoneId: Option[UUID] = None
   ): CreateLandingZoneResult
 
   def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -73,24 +73,18 @@ trait WorkspaceManagerDAO {
                          applicationId: String,
                          ctx: RawlsRequestContext
   ): WorkspaceApplicationDescription
-  def createAzureStorageAccount(workspaceId: UUID,
-                                region: String,
-                                ctx: RawlsRequestContext
-  ): CreatedControlledAzureStorage
 
   /**
-    * Creates an Azure storage container in the workspace.
+    * Creates an Azure storage container in the workspace. This container will be created in the workspace's
+    * parent landing zone.
     *
     * @param workspaceId the UUID of the workspace
     * @param storageContainerName the name of the new container
-    * @param storageAccountId optional UUID of a storage account resource. If not specified, the storage
-    *                         account from the workspace's landing zone will be used
     * @param ctx Rawls context
     * @return the response from workspace manager
     */
   def createAzureStorageContainer(workspaceId: UUID,
                                   storageContainerName: String,
-                                  storageAccountId: Option[UUID],
                                   ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -422,7 +422,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
           workspaceManagerDAO.createAzureStorageContainer(
             workspaceId,
             MultiCloudWorkspaceService.getStorageContainerName(workspaceId),
-            None,
             ctx
           )
         )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -41,7 +41,8 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
   val azConfig: AzureConfig = AzureConfig(
     "fake-landing-zone-definition",
     "fake-landing-zone-version",
-    Map("fake_parameter" -> "fake_value")
+    Map("fake_parameter" -> "fake_value"),
+    landingZoneAllowAttach = false
   )
   val userInfo: UserInfo = UserInfo(
     RawlsUserEmail("fake@example.com"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -45,7 +45,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   val azConfig: AzureConfig = AzureConfig(
     "fake-landing-zone-definition",
     "fake-landing-zone-version",
-    Map("fake_parameter" -> "fake_value")
+    Map("fake_parameter" -> "fake_value"),
+    landingZoneAllowAttach = false
   )
 
   val userInfo: UserInfo =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -166,7 +166,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenReturn(
       new CreateLandingZoneResult()
@@ -197,7 +198,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                                                     landingZoneVersion,
                                                                     landingZoneParameters,
                                                                     profileModel.getId,
-                                                                    testContext
+                                                                    testContext,
+                                                                    None
     )
     verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, landingZoneId)
     verify(repo, Mockito.times(1)).setBillingProfileId(createRequest.projectName, profileModel.getId)
@@ -243,7 +245,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenReturn(
       new CreateLandingZoneResult()
@@ -325,7 +328,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenReturn(
       new CreateLandingZoneResult().errorReport(new ErrorReport().statusCode(500).message(landingZoneErrorMessage))
@@ -378,7 +382,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenReturn(
       new CreateLandingZoneResult()
@@ -434,7 +439,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenThrow(new RuntimeException(unexpectedError))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
@@ -486,7 +492,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenReturn(
       new CreateLandingZoneResult()
@@ -547,7 +554,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                             landingZoneVersion,
                                             landingZoneParameters,
                                             profileModel.getId,
-                                            testContext
+                                            testContext,
+                                            None
       )
     ).thenReturn(
       new CreateLandingZoneResult()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -3,7 +3,13 @@ package org.broadinstitute.dsde.rawls.billing
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.{AzureManagedAppModel, ProfileModel}
-import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZoneResult, ErrorReport, JobReport}
+import bio.terra.workspace.model.{
+  AzureLandingZoneDefinition,
+  CreateLandingZoneResult,
+  DeleteAzureLandingZoneResult,
+  ErrorReport,
+  JobReport
+}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
@@ -25,7 +31,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsUserSubjectId,
   UserInfo
 }
-import org.mockito.ArgumentMatchers.{any, argThat}
+import org.mockito.ArgumentMatchers.{any, anyMap, anyString, argThat}
 import org.mockito.Mockito.{doNothing, doReturn, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.concurrent.ScalaFutures
@@ -149,6 +155,117 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   }
 
   behavior of "postCreationSteps"
+
+  it should "fail if a landing zone ID is provided and Rawls is not configured to attach to existing landing zones" in {
+    val repo = mock[BillingRepository]
+    val bpm = mock[BillingProfileManagerDAO]
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
+      billingProjectName,
+      None,
+      None,
+      Some(AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake", Some(UUID.randomUUID()))),
+      None,
+      None
+    )
+    when(
+      bpm.createBillingProfile(
+        ArgumentMatchers.eq(createRequestWithExistingLz.projectName.value),
+        ArgumentMatchers.eq(createRequestWithExistingLz.billingInfo),
+        ArgumentMatchers.eq(testContext)
+      )
+    )
+      .thenReturn(profileModel)
+    val monitorRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
+
+    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, monitorRecordDao)
+
+    intercept[LandingZoneCreationException] {
+      Await.result(bp.postCreationSteps(
+                     createRequestWithExistingLz,
+                     new MultiCloudWorkspaceConfig(true, None, Some(azConfig)),
+                     testContext
+                   ),
+                   Duration.Inf
+      )
+    }
+
+    verify(workspaceManagerDAO, Mockito.times(0)).createLandingZone(anyString(),
+                                                                    anyString(),
+                                                                    any[Map[String, String]](),
+                                                                    any[UUID],
+                                                                    any[RawlsRequestContext],
+                                                                    any[Option[UUID]]
+    )
+  }
+
+  it should "attach the provided landing zone ID if configured" in {
+    val repo = mock[BillingRepository]
+    val bpm = mock[BillingProfileManagerDAO]
+    val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    val lzId = UUID.randomUUID()
+    val lzAttachAzConfig =
+      AzureConfig(landingZoneDefinition, landingZoneVersion, landingZoneParameters, landingZoneAllowAttach = true)
+    val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
+      billingProjectName,
+      None,
+      None,
+      Some(
+        AzureManagedAppCoordinates(coords.tenantId, coords.subscriptionId, coords.managedResourceGroupId, Some(lzId))
+      ),
+      None,
+      None
+    )
+    when(
+      bpm.createBillingProfile(
+        ArgumentMatchers.eq(createRequestWithExistingLz.projectName.value),
+        ArgumentMatchers.eq(createRequestWithExistingLz.billingInfo),
+        ArgumentMatchers.eq(testContext)
+      )
+    )
+      .thenReturn(profileModel)
+    val expectedLzParams = landingZoneParameters ++ Map("attach" -> "true")
+    when(
+      workspaceManagerDAO.createLandingZone(landingZoneDefinition,
+                                            landingZoneVersion,
+                                            expectedLzParams,
+                                            profileModel.getId,
+                                            testContext,
+                                            Some(lzId)
+      )
+    ).thenReturn(
+      new CreateLandingZoneResult()
+        .landingZoneId(landingZoneId)
+        .jobReport(new JobReport().id(landingZoneJobId.toString))
+    )
+    when(repo.updateLandingZoneId(createRequestWithExistingLz.projectName, landingZoneId))
+      .thenReturn(Future.successful(1))
+    when(repo.setBillingProfileId(createRequestWithExistingLz.projectName, profileModel.getId))
+      .thenReturn(Future.successful(1))
+    val monitorRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
+    doReturn(Future.successful())
+      .when(monitorRecordDao)
+      .create(any)
+    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, monitorRecordDao)
+
+    assertResult(CreationStatuses.CreatingLandingZone) {
+      Await.result(bp.postCreationSteps(
+                     createRequestWithExistingLz,
+                     new MultiCloudWorkspaceConfig(true, None, Some(lzAttachAzConfig)),
+                     testContext
+                   ),
+                   Duration.Inf
+      )
+    }
+
+    verify(workspaceManagerDAO, Mockito.times(1)).createLandingZone(landingZoneDefinition,
+                                                                    landingZoneVersion,
+                                                                    expectedLzParams,
+                                                                    profileModel.getId,
+                                                                    testContext,
+                                                                    Some(lzId)
+    )
+  }
 
   it should "store the landing zone ID and job creation ID and link the profile ID to the billing project record" in {
     val repo = mock[BillingRepository]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -61,7 +61,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   val azConfig: AzureConfig = AzureConfig(
     landingZoneDefinition,
     landingZoneVersion,
-    landingZoneParameters
+    landingZoneParameters,
+    false
   )
   val landingZoneId = UUID.randomUUID()
   val landingZoneJobId = UUID.randomUUID()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -90,7 +90,6 @@ class HttpWorkspaceManagerDAOSpec
       new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
 
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
-    val storageAccountId = UUID.randomUUID()
     val containerName = "containerName"
     wsmDao.createAzureStorageContainer(workspaceId, containerName, testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -82,21 +82,6 @@ class HttpWorkspaceManagerDAOSpec
     commonFields.getManagedBy shouldBe ManagedBy.USER
   }
 
-  behavior of "createAzureStorageAccount"
-
-  it should "call the WSM controlled azure resource API" in {
-    val controlledAzureResourceApi = mock[ControlledAzureResourceApi]
-    val wsmDao =
-      new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
-
-    val saArgumentCaptor = captor[CreateControlledAzureStorageRequestBody]
-    wsmDao.createAzureStorageAccount(workspaceId, "arlington", testContext)
-    verify(controlledAzureResourceApi).createAzureStorage(saArgumentCaptor.capture, any[UUID])
-    saArgumentCaptor.getValue.getAzureStorage.getRegion shouldBe "arlington"
-    saArgumentCaptor.getValue.getAzureStorage.getStorageAccountName should startWith("sa")
-    assertControlledResourceCommonFields(saArgumentCaptor.getValue.getCommon)
-  }
-
   behavior of "createAzureStorageContainer"
 
   it should "call the WSM controlled azure resource API with a SA id" in {
@@ -107,10 +92,9 @@ class HttpWorkspaceManagerDAOSpec
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
     val storageAccountId = UUID.randomUUID()
     val containerName = "containerName"
-    wsmDao.createAzureStorageContainer(workspaceId, containerName, Some(storageAccountId), testContext)
+    wsmDao.createAzureStorageContainer(workspaceId, containerName, testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe containerName
-    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe storageAccountId
     assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon,
                                          CloningInstructionsEnum.NOTHING,
                                          containerName
@@ -123,10 +107,9 @@ class HttpWorkspaceManagerDAOSpec
       new HttpWorkspaceManagerDAO(getApiClientProvider(controlledAzureResourceApi = controlledAzureResourceApi))
     val containerName = "containerName"
     val scArgumentCaptor = captor[CreateControlledAzureStorageContainerRequestBody]
-    wsmDao.createAzureStorageContainer(workspaceId, containerName, None, testContext)
+    wsmDao.createAzureStorageContainer(workspaceId, containerName, testContext)
     verify(controlledAzureResourceApi).createAzureStorageContainer(scArgumentCaptor.capture, any[UUID])
     scArgumentCaptor.getValue.getAzureStorageContainer.getStorageContainerName shouldBe containerName
-    scArgumentCaptor.getValue.getAzureStorageContainer.getStorageAccountId shouldBe null
     assertControlledResourceCommonFields(scArgumentCaptor.getValue.getCommon,
                                          CloningInstructionsEnum.NOTHING,
                                          containerName

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -39,8 +39,6 @@ class MockWorkspaceManagerDAO(
   def mockInitialCreateAzureCloudContextResult() =
     MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.RUNNING)
   def mockCreateAzureCloudContextResult() = createCloudContextResult
-  def mockCreateAzureStorageAccountResult() =
-    new CreatedControlledAzureStorage().resourceId(UUID.randomUUID()).azureStorage(new AzureStorageResource())
   def mockCreateAzureStorageContainerResult() = new CreatedControlledAzureStorageContainer()
 
   override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription =
@@ -225,15 +223,8 @@ class MockWorkspaceManagerDAO(
   ): WorkspaceApplicationDescription =
     new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
 
-  override def createAzureStorageAccount(workspaceId: UUID,
-                                         region: String,
-                                         ctx: RawlsRequestContext
-  ): CreatedControlledAzureStorage =
-    mockCreateAzureStorageAccountResult()
-
   override def createAzureStorageContainer(workspaceId: UUID,
                                            storageContainerName: String,
-                                           storageAccountId: Option[UUID],
                                            ctx: RawlsRequestContext
   ): CreatedControlledAzureStorageContainer =
     mockCreateAzureStorageContainerResult()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -242,7 +242,8 @@ class MockWorkspaceManagerDAO(
                         version: String,
                         landingZoneParameters: Map[String, String],
                         billingProfileId: UUID,
-                        ctx: RawlsRequestContext
+                        ctx: RawlsRequestContext,
+                        landingZoneId: Option[UUID] = None
   ): CreateLandingZoneResult = ???
 
   override def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport = ???

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -343,7 +343,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       .createAzureStorageContainer(
         ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
         ArgumentMatchers.eq(MultiCloudWorkspaceService.getStorageContainerName(UUID.fromString(result.workspaceId))),
-        ArgumentMatchers.eq(None),
         ArgumentMatchers.eq(testContext)
       )
   }
@@ -432,7 +431,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO() {
       override def createAzureStorageContainer(workspaceId: UUID,
                                                storageContainerName: String,
-                                               storageAccountId: Option[UUID],
                                                ctx: RawlsRequestContext
       ): CreatedControlledAzureStorageContainer = throw new ApiException(500, "what's a container?")
     })

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -54,7 +54,8 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       AzureConfig(
         "fake-landing-zone-definition",
         "fake-landing-zone-version",
-        Map("fake_parameter" -> "fake_value")
+        Map("fake_parameter" -> "fake_value"),
+        landingZoneAllowAttach = false
       )
     )
   )

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -690,7 +690,7 @@ case class WorkspaceListResponse(accessLevel: WorkspaceAccessLevel,
                                  public: Boolean
 )
 
-case class AzureManagedAppCoordinates(tenantId: UUID, subscriptionId: UUID, managedResourceGroupId: String)
+case class AzureManagedAppCoordinates(tenantId: UUID, subscriptionId: UUID, managedResourceGroupId: String, landingZoneId: Option[UUID] = None)
 
 case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
                              canShare: Option[Boolean],
@@ -1018,7 +1018,7 @@ class WorkspaceJsonSupport extends JsonSupport {
     rawlsEnumerationFormat(WorkspaceCloudPlatform.withName)
 
   implicit val AzureManagedAppCoordinatesFormat: RootJsonFormat[AzureManagedAppCoordinates] =
-    jsonFormat3(AzureManagedAppCoordinates)
+    jsonFormat4(AzureManagedAppCoordinates)
 
   implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat7(WorkspaceRequest)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -123,7 +123,7 @@ object Dependencies {
   // "Terra Common Lib" Exclusions:
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.623-SNAPSHOT")
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.643-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.112-SNAPSHOT")


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-802)
[Design doc](https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2674950157/Azure+Test+Automation)

## Context
We want to be able to reuse landing zones in testing scenarios. To this end, I've introduced the notion of attaching landing zones in the Landing Zone Service (and it's owning service WSM). This allows a consumer to provide a landing zone ID and an attach arg which when set will direct the LZS to reuse previously deployed Azure resources rather than creating them fresh and burning 10 minutes to do so.  Rawls will need to accommodate this and know that it should provide the LZ ID and attach arg.

## This PR
* Adds an optional landing zone ID to the azure managed app coords parameter passed in via the billing project creation request. This allows the reuse of the same LZ ID from test to test.
* Adds a "landingZoneAllowAttach" configuration variable, defaulting to false. If false and a landing zone parameter is passed in the billing project creation request, an exception is thrown and creation fails. If true, Rawls will pass the "attach -> true" parameter to WSM and LZS.
* Removes dead WSM methods that were removed as part of the region updates in WSM
* Various scalafmt'ing

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
