### PR TITLE
ID-525 FastPass OpenTelemetry

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -128,3 +128,7 @@ dataRepoEntityProvider {
 }
 
 sam.timeout = 3 minutes
+
+prometheus {
+  endpointPort = 9098
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -464,6 +464,7 @@ object Boot extends IOApp with LazyLogging {
         FastPassService.constructor(
           fastPassConfig,
           appDependencies.httpGoogleIamDAO,
+          appDependencies.httpGoogleIamDAO,
           appDependencies.httpGoogleStorageDAO,
           samDAO,
           terraBillingProjectOwnerRole = gcsConfig.getString("terraBillingProjectOwnerRole"),
@@ -700,8 +701,8 @@ object Boot extends IOApp with LazyLogging {
     val metadataNotificationConfig = NotificationCreaterConfig(pathToCredentialJson, googleApiUri)
 
     implicit val logger: StructuredLogger[F] = Slf4jLogger.getLogger[F]
-    // This is for sending custom metrics to stackdriver. all custom metrics starts with `OpenCensus/sam/`.
-    // Typing in `sam` in metrics explorer will show all sam custom metrics.
+    // This is for sending custom metrics to stackdriver. all custom metrics starts with `OpenCensus/rawls/`.
+    // Typing in `rawls` in metrics explorer will show all rawls custom metrics.
     // As best practice, we should have all related metrics under same prefix separated by `/`
     val prometheusConfig = PrometheusConfig.apply(config)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/PrometheusConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/PrometheusConfig.scala
@@ -1,0 +1,14 @@
+package org.broadinstitute.dsde.rawls.config
+
+import com.typesafe.config.Config
+
+final case class PrometheusConfig(endpointPort: Int)
+
+object PrometheusConfig {
+  def apply(conf: Config): PrometheusConfig = {
+    val prometheusConfig = conf.getConfig("prometheus")
+    PrometheusConfig(
+      prometheusConfig.getInt("endpointPort")
+    )
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -38,6 +38,7 @@ import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorRep
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
@@ -418,6 +419,7 @@ class SubmissionSpec(_system: ActorSystem)
     withDataOp { dataSource =>
       val execServiceCluster: ExecutionServiceCluster =
         MockShardedExecutionServiceCluster.fromDAO(executionServiceDAO, dataSource)
+      implicit val openTelemetry = FakeOpenTelemetryMetricsInterpreter
 
       val config = SubmissionMonitorConfig(250.milliseconds, trackDetailedSubmissionMetrics = true, 20000, false)
       val gcsDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -60,6 +60,7 @@ import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNoti
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
+import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.mockito.Mockito.RETURNS_SMART_NULLS
 import org.mockito.ArgumentMatcher
 import org.scalatest.concurrent.Eventually
@@ -164,6 +165,9 @@ trait ApiServiceSpec
     def actorRefFactory = system
 
     implicit override val materializer = ActorMaterializer()
+
+    implicit val openTelemetry = FakeOpenTelemetryMetricsInterpreter
+
     override val workbenchMetricBaseName: String = "test"
     override val submissionTimeout = FiniteDuration(1, TimeUnit.MINUTES)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -55,6 +55,7 @@ import org.broadinstitute.dsde.workbench.model.google.{
   GoogleProject,
   IamPermission
 }
+import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -123,6 +124,8 @@ class WorkspaceServiceSpec
       with SubmissionApiService
       with MockUserInfoDirectivesWithUser {
     val ctx1 = RawlsRequestContext(UserInfo(user.userEmail, OAuth2BearerToken("foo"), 0, user.userSubjectId))
+    implicit val openTelemetry = FakeOpenTelemetryMetricsInterpreter
+
     lazy val workspaceService: WorkspaceService = workspaceServiceConstructor(ctx1)
     lazy val userService: UserService = userServiceConstructor(ctx1)
     val slickDataSource: SlickDataSource = dataSource

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,6 +89,7 @@ object Dependencies {
   val workbenchNotificationsV = s"0.3-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.25-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.2-${workbenchLibsHash}"
+  val workbenchOpenTelemetryV = s"0.3-$workbenchLibsHash"
 
   def excludeWorkbenchGoogle = ExclusionRule("org.broadinstitute.dsde.workbench", "workbench-google_2.13")
 
@@ -101,6 +102,9 @@ object Dependencies {
   val workbenchNotifications: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV excludeAll(excludeWorkbenchGoogle)
   val workbenchOauth2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V
   val workbenchOauth2Tests: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % workbenchOauth2V % "test" classifier "tests"
+  val workbenchOpenTelemetry: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV
+  val workbenchOpenTelemetryTests: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % workbenchOpenTelemetryV classifier "tests"
+
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test"
 
   val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.6-${workbenchLibsHash}"
@@ -257,6 +261,8 @@ object Dependencies {
     betterMonadicFor,
     workbenchOauth2,
     workbenchOauth2Tests,
+    workbenchOpenTelemetry,
+    workbenchOpenTelemetryTests,
     terraCommonLib,
     sam
   )


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-525

Instead of using the hacked-in StatsD metrics in Rawls, FastPass will use the new standard: OpenTelemetry.

This PR adds metrics for per-user FastPass grants and removals, as well as per-principal IAM grants and removals.

I've also re-written how FastPass grants are removed when a workspace is deleted. Before, we were only removing the grants for the requester. Now, we're removing all grants for all users in the workspace.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
