### PR TITLE
WOR-837 - remove landing zone id from billing project when landing zone creation fails

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -90,7 +90,7 @@ class BillingRepository(dataSource: SlickDataSource) {
         .landingZoneId
     }
 
-  def updateLandingZoneId(projectName: RawlsBillingProjectName, landingZoneId: UUID): Future[Int] =
+  def updateLandingZoneId(projectName: RawlsBillingProjectName, landingZoneId: Option[UUID]): Future[Int] =
     dataSource.inTransaction { dataAccess =>
       dataAccess.rawlsBillingProjectQuery.updateLandingZone(projectName, landingZoneId)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -160,7 +160,9 @@ class BpmBillingProjectLifecycle(
               _ = logger.info(
                 s"Initiated creation of landing zone ${landingZone.getLandingZoneId} with jobId ${jobReport.getId}"
               )
-              _ <- billingRepository.updateLandingZoneId(createProjectRequest.projectName, landingZone.getLandingZoneId)
+              _ <- billingRepository.updateLandingZoneId(createProjectRequest.projectName,
+                                                         Option(landingZone.getLandingZoneId)
+              )
               _ <- resourceMonitorRecordDao.create(
                 WorkspaceManagerResourceMonitorRecord.forAzureLandingZoneCreate(
                   UUID.fromString(jobReport.getId),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -285,11 +285,11 @@ trait RawlsBillingProjectComponent {
         .withProjectName(projectName)
         .setCreationStatus(status, message)
 
-    def updateLandingZone(projectName: RawlsBillingProjectName, landingZoneId: UUID): WriteAction[Int] =
+    def updateLandingZone(projectName: RawlsBillingProjectName, landingZoneId: Option[UUID]): WriteAction[Int] =
       rawlsBillingProjectQuery
         .withProjectName(projectName)
         .map(_.landingZoneId)
-        .update(Some(landingZoneId))
+        .update(landingZoneId)
 
     def listProjectsWithCreationStatus(status: CreationStatuses.CreationStatus): ReadAction[Seq[RawlsBillingProject]] =
       rawlsBillingProjectQuery

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
@@ -86,6 +86,7 @@ class LandingZoneCreationStatusRunner(
                     CreationStatuses.Error,
                     Some(s"Landing Zone creation failed: $msg")
                   )
+                  .flatMap(_ => billingRepository.updateLandingZoneId(billingProjectName, None))
                   .map(_ => Complete)
               case None =>
                 val msg = Option(result.getErrorReport)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -238,7 +238,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         .landingZoneId(landingZoneId)
         .jobReport(new JobReport().id(landingZoneJobId.toString))
     )
-    when(repo.updateLandingZoneId(createRequestWithExistingLz.projectName, landingZoneId))
+    when(repo.updateLandingZoneId(createRequestWithExistingLz.projectName, Option(landingZoneId)))
       .thenReturn(Future.successful(1))
     when(repo.setBillingProfileId(createRequestWithExistingLz.projectName, profileModel.getId))
       .thenReturn(Future.successful(1))
@@ -292,7 +292,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         .landingZoneId(landingZoneId)
         .jobReport(new JobReport().id(landingZoneJobId.toString))
     )
-    when(repo.updateLandingZoneId(createRequest.projectName, landingZoneId)).thenReturn(Future.successful(1))
+    when(repo.updateLandingZoneId(createRequest.projectName, Option(landingZoneId))).thenReturn(Future.successful(1))
     when(repo.setBillingProfileId(createRequest.projectName, profileModel.getId)).thenReturn(Future.successful(1))
 
     val wsmResouceRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
@@ -319,7 +319,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                                                     testContext,
                                                                     None
     )
-    verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, landingZoneId)
+    verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, Option(landingZoneId))
     verify(repo, Mockito.times(1)).setBillingProfileId(createRequest.projectName, profileModel.getId)
     verify(wsmResouceRecordDao, Mockito.times(1))
       .create(argThat { (job: WorkspaceManagerResourceMonitorRecord) =>
@@ -371,7 +371,8 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         .landingZoneId(landingZoneId)
         .jobReport(new JobReport().id(landingZoneJobId.toString))
     )
-    when(repo.updateLandingZoneId(createRequestWithMembers.projectName, landingZoneId)).thenReturn(Future.successful(1))
+    when(repo.updateLandingZoneId(createRequestWithMembers.projectName, Option(landingZoneId)))
+      .thenReturn(Future.successful(1))
     when(repo.setBillingProfileId(createRequestWithMembers.projectName, profileModel.getId))
       .thenReturn(Future.successful(1))
 
@@ -620,7 +621,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
       .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
-    when(repo.updateLandingZoneId(createRequest.projectName, landingZoneId))
+    when(repo.updateLandingZoneId(createRequest.projectName, Option(landingZoneId)))
       .thenReturn(Future.failed(new RuntimeException(billingRepoError)))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
@@ -685,7 +686,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
     // Exception thrown after creation of billing profile and landing zone.
     // This exception should be visible to the user.
-    when(repo.updateLandingZoneId(createRequest.projectName, landingZoneId))
+    when(repo.updateLandingZoneId(createRequest.projectName, Option(landingZoneId)))
       .thenReturn(Future.failed(new SQLException(billingRepoError)))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
@@ -213,7 +213,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
   }
 
-  it should "update the project as Errored and return a completed status when the job is marked as failed" in {
+  it should "update the project as Errored, unset the landing zone id, and return a completed status when the job is marked as failed" in {
     val ctx = mock[RawlsRequestContext]
     val failureMessage = "this is a very specific failure message"
     val wsmDao = mock[WorkspaceManagerDAO]
@@ -238,6 +238,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       assert(message.get.contains(failureMessage))
       Future.successful(1)
     }
+    when(billingRepository.updateLandingZoneId(billingProjectName, None)).thenReturn(Future.successful(1))
 
     val runner =
       spy(new LandingZoneCreationStatusRunner(mock[SamDAO], wsmDao, billingRepository, mock[GoogleServicesDAO]))


### PR DESCRIPTION
Ticket: [WOR-837](https://broadworkbench.atlassian.net/browse/WOR-837)

The change made earlier was to continue the deletion process if no landing zone id is present.

The landing zone id is set on billing project from the initial response to the lz creation request to WSM. 

When attempting to delete a nonexistent landing zone, WSM returns a 403, not a 404 - so we can’t use the api call status to determine correct behavior.

The additional change here should be to update the LandingZoneCreationStatusRunner to unset the landing zone id if creation fails, since we should be trusting the landing zone service to clean up after itself, and the landing zone id should be useless at that point anyway.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-837]: https://broadworkbench.atlassian.net/browse/WOR-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ