### PR TITLE
ID-540 Users are sometimes Service Accounts

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -609,5 +609,25 @@ class FastPassServiceSpec
       ArgumentMatchers.eq(Some(GoogleProject(workspace.googleProjectId.value)))
     )
 
+    Await.ready(services.workspaceService.deleteWorkspace(workspaceRequest.toWorkspaceName), Duration.Inf)
+
+    // The user is removed from the project IAM policies
+    verify(services.googleIamDAO).removeRoles(
+      ArgumentMatchers.eq(GoogleProject(workspace.googleProjectId.value)),
+      ArgumentMatchers.eq(userEmail),
+      ArgumentMatchers.eq(IamMemberTypes.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraWorkspaceCanComputeRole, services.terraWorkspaceNextflowRole)),
+      ArgumentMatchers.eq(false)
+    )
+
+    // The user is removed from the bucket IAM policies
+    verify(services.googleStorageDAO).removeIamRoles(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(userEmail),
+      ArgumentMatchers.eq(IamMemberTypes.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraBucketWriterRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.eq(Some(GoogleProject(workspace.googleProjectId.value)))
+    )
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -82,6 +82,9 @@ class FastPassServiceSpec
     Map.empty
   )
 
+  val serviceAccountUser =
+    testData.userOwner.copy(userEmail = RawlsUserEmail("service-account@project-name.iam.gserviceaccount.com"))
+
   val mockServer = RemoteServicesMockServer()
 
   override def beforeAll(): Unit = {
@@ -302,6 +305,11 @@ class FastPassServiceSpec
   def withTestDataServices[T](testCode: TestApiService => T): T =
     withDefaultTestDatabase { dataSource: SlickDataSource =>
       withServices(dataSource, testData.userOwner)(testCode)
+    }
+
+  def withTestDataServicesCustomUser[T](user: RawlsUser)(testCode: TestApiService => T) =
+    withDefaultTestDatabase { dataSource: SlickDataSource =>
+      withServices(dataSource, user)(testCode)
     }
 
   def withServices[T](dataSource: SlickDataSource, user: RawlsUser, fastPassEnabled: Boolean = true)(
@@ -562,5 +570,44 @@ class FastPassServiceSpec
         runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(workspace.workspaceIdAsUUID))
 
       workspaceFastPassGrants should have size 0
+  }
+
+  it should "support service account users" in withTestDataServicesCustomUser(serviceAccountUser) { services =>
+    val newWorkspaceName = "space_for_workin"
+    val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
+
+    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+    val workspaceFastPassGrants =
+      runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(workspace.workspaceIdAsUUID))
+
+    val userEmail = WorkbenchEmail(services.user.userEmail.value)
+    val petEmail =
+      Await.result(services.samDAO.getUserPetServiceAccount(services.ctx1, workspace.googleProjectId), Duration.Inf)
+
+    workspaceFastPassGrants should not be empty
+    workspaceFastPassGrants.map(_.accountType) should contain only (IamMemberTypes.ServiceAccount)
+    workspaceFastPassGrants.map(_.accountEmail) should contain only (userEmail, petEmail)
+
+    // The user is added to the project IAM policies with a condition
+    verify(services.googleIamDAO).addRoles(
+      ArgumentMatchers.eq(GoogleProject(workspace.googleProjectId.value)),
+      ArgumentMatchers.eq(userEmail),
+      ArgumentMatchers.eq(IamMemberTypes.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraWorkspaceCanComputeRole, services.terraWorkspaceNextflowRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.argThat((c: Option[Expr]) => c.exists(_.title.contains(userEmail.value)))
+    )
+
+    // The user is added to the bucket IAM policies with a condition
+    verify(services.googleStorageDAO).addIamRoles(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(userEmail),
+      ArgumentMatchers.eq(IamMemberTypes.ServiceAccount),
+      ArgumentMatchers.eq(Set(services.terraBucketWriterRole)),
+      ArgumentMatchers.eq(false),
+      ArgumentMatchers.argThat((c: Option[Expr]) => c.exists(_.title.contains(userEmail.value))),
+      ArgumentMatchers.eq(Some(GoogleProject(workspace.googleProjectId.value)))
+    )
+
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-540
The user making the request is not always a real person. Service accounts are used in Terra.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
