### PR TITLE
[WOR-816] Don't directly log HttpGoogleServicesDAO errors to Sentry

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -67,7 +67,6 @@
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
-        <appender-ref ref="Sentry" />
     </logger>
 
     <logger name="org.broadinstitute.dsde.rawls.google.HttpGooglePubSubDAO" level="debug" additivity="false">

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -67,6 +67,7 @@
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry" />
     </logger>
 
     <logger name="org.broadinstitute.dsde.rawls.google.HttpGooglePubSubDAO" level="debug" additivity="false">

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilter.scala
@@ -13,6 +13,19 @@ object SentryEventFilter {
           if msg.getMessage.contains("requirement failed: count cannot be decreased") ||
             msg.getMessage.contains("pet service account not found") =>
         null
-      case _ => event
+      case _ =>
+        Option(event.getLogger) match {
+          case Some(loggerName)
+              if loggerName.equals("org.broadinstitute.dsde.rawls.dataaccess.HttpGoogleServicesDAO") =>
+            Option(event.getThrowable) match {
+              case Some(throwable)
+                  if throwable.getMessage.contains("requester pays bucket but no user project provided") ||
+                    throwable.getMessage.contains("billing account for the owning project is disabled") =>
+                null
+              case _ =>
+                event
+            }
+          case _ => event
+        }
     }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilterSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilterSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.util
 
+import com.google.cloud.storage.StorageException
 import io.sentry.SentryEvent
 import io.sentry.protocol.Message
 import org.scalatest.flatspec.AnyFlatSpec
@@ -17,6 +18,11 @@ class SentryEventFilterSpec extends AnyFlatSpec with Matchers {
 
     event
   }
+
+  val requesterPaysMessage = "Bucket is a requester pays bucket but no user project provided"
+  val billingDisabledMessage = "The billing account for the owning project is disabled in state absent"
+  val httpGoogleServicesDao = "org.broadinstitute.dsde.rawls.dataaccess.HttpGoogleServicesDAO"
+  val rawlsApiService = "org.broadinstitute.dsde.rawls.webservice.RawlsApiService$"
 
   behavior of "SentryEventFilter"
 
@@ -37,6 +43,44 @@ class SentryEventFilterSpec extends AnyFlatSpec with Matchers {
     val result = SentryEventFilter.filterEvent(e)
 
     result shouldBe null
+  }
+
+  it should "filter out 'requester pays bucket' errors from direct HttpGoogleServicesDAO logging" in {
+    val throwable = new StorageException(400, requesterPaysMessage)
+    val e = new SentryEvent(throwable)
+    e.setLogger(httpGoogleServicesDao)
+
+    SentryEventFilter.filterEvent(e) shouldBe null
+  }
+
+  it should "not filter out 'requester pays bucket' errors from other loggers" in {
+    val throwable = new StorageException(400, requesterPaysMessage)
+    val e = evt(Some(requesterPaysMessage))
+    e.setLogger(rawlsApiService)
+    // In reality will have only the message and no throwable if from RawlsApiService,
+    // but check that no filtering happens based on either field.
+    e.setThrowable(throwable)
+
+    SentryEventFilter.filterEvent(e) shouldBe e
+  }
+
+  it should "filter out 'billing disabled' errors from direct HttpGoogleServicesDAO logging" in {
+    val throwable = new StorageException(403, billingDisabledMessage)
+    val e = new SentryEvent(throwable)
+    e.setLogger(httpGoogleServicesDao)
+
+    SentryEventFilter.filterEvent(e) shouldBe null
+  }
+
+  it should "not filter out 'billing disabled' errors from other loggers" in {
+    val throwable = new StorageException(403, billingDisabledMessage)
+    val e = evt(Some(requesterPaysMessage))
+    e.setLogger(rawlsApiService)
+    // In reality will have only the message and no throwable if from RawlsApiService,
+    // but check that no filtering happens based on either field.
+    e.setThrowable(throwable)
+
+    SentryEventFilter.filterEvent(e) shouldBe e
   }
 
   it should "not filter out other events" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilterSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilterSpec.scala
@@ -83,6 +83,17 @@ class SentryEventFilterSpec extends AnyFlatSpec with Matchers {
     SentryEventFilter.filterEvent(e) shouldBe e
   }
 
+  it should "not filter out other events in HttpGoogleServicesDAO logger" in {
+    val messageEvent = evt(Some("other event"))
+    messageEvent.setLogger(httpGoogleServicesDao)
+    SentryEventFilter.filterEvent(messageEvent) shouldBe messageEvent
+
+    val throwable = new StorageException(403, "some event")
+    val throwableEvent = new SentryEvent(throwable)
+    throwableEvent.setLogger(httpGoogleServicesDao)
+    SentryEventFilter.filterEvent(throwableEvent) shouldBe throwableEvent
+  }
+
   it should "not filter out other events" in {
     val e = evt(Some("other event"))
 


### PR DESCRIPTION
This change is to resolve the following scenario:

1) We want to check if Google permissions have synced. If they have not, we expect a 400 or 403 from the Google APIs.
2) At the place where we make the call for this permission check, we catch the Google exception and wrap it in a RawlsExceptionWithErrorReport, retaining its status code. (Implemented in https://github.com/broadinstitute/rawls/pull/2278-- before 2278 the uncaught exception would get wrapped as a 500 error, which got logged to Sentry)
3) We don't log 4xx RawlsExceptionWithErrorReports to Sentry, which is the behavior we want.
4) BUT this logback handling was causing all `HttpGoogleServicesDAO` errors to log to Sentry anyway.

Since uncaught errors from `HttpGoogleServicesDAO` will get wrapped with a 500 error and logged to Sentry, there is no need to also directly log them to Sentry via logback… it leads to duplicate logging (which is behavior we saw before #2278 was implemented).

~~The change in behavior though is that 4xx errors from `HttpGoogleServicesDAO` will not get logged at all if the errors are caught and wrapped with a RawlsExceptionWithErrorReport with the appropriate status code. That's exactly the behavior we want for this permission checking method, but is it generally OK?~~

Solution modified to only suppress `HttpGoogleServicesDAO` logging for 2 specific error messages.