### PR TITLE
[WOR-848] Get cloud platform from BPM

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -4,24 +4,34 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.SpendReportingAggregation.AggregationKeyEnum
 import bio.terra.profile.model.SpendReportingForDateRange.CategoryEnum
-import bio.terra.profile.model.{ProfileModel, SpendReport => SpendReportBPM, SpendReportingAggregation => SpendReportingAggregationBPM, SpendReportingForDateRange => SpendReportingForDateRangeBPM, CloudPlatform => BpmCloudPlatform}
+import bio.terra.profile.model.{
+  CloudPlatform => BpmCloudPlatform,
+  ProfileModel,
+  SpendReport => SpendReportBPM,
+  SpendReportingAggregation => SpendReportingAggregationBPM,
+  SpendReportingForDateRange => SpendReportingForDateRangeBPM
+}
 import cats.effect.{IO, Resource}
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Option => _, _}
-import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmAzureSpendReportApiException}
+import org.broadinstitute.dsde.rawls.billing.{
+  BillingProfileManagerDAO,
+  BillingRepository,
+  BpmAzureSpendReportApiException
+}
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext, model}
+import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.{ArgumentCaptor, Mockito}
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, doReturn, doThrow, never, spy, verify, when}
+import org.mockito.Mockito.{doReturn, doThrow, never, spy, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -730,7 +740,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       TestData.BpmSpendReport.spendData(from, to, currency, Map("Compute" -> price1, "Storage" -> price2))
     when(bpmDAO.getAzureSpendReport(any(), any(), any(), any()))
       .thenReturn(spendReport)
-    when(bpmDAO.getBillingProfile(mockitoEq(billingProfileId), any())).thenReturn(Option(new ProfileModel().id(billingProfileId).cloudPlatform(BpmCloudPlatform.AZURE)))
+    when(bpmDAO.getBillingProfile(mockitoEq(billingProfileId), any()))
+      .thenReturn(Option(new ProfileModel().id(billingProfileId).cloudPlatform(BpmCloudPlatform.AZURE)))
 
     val billingProfileIdCapture: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
     val startDateCapture: ArgumentCaptor[Date] = ArgumentCaptor.forClass(classOf[Date])
@@ -778,7 +789,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
     val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
 
-    when(bpmDAO.getBillingProfile(any(), any())).thenReturn(Option(new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BpmCloudPlatform.AZURE)))
+    when(bpmDAO.getBillingProfile(any(), any()))
+      .thenReturn(Option(new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BpmCloudPlatform.AZURE)))
     val errorMessage = "something went wrong"
     doThrow(new BpmAzureSpendReportApiException(StatusCodes.BadRequest.intValue, errorMessage))
       .when(bpmDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -4,30 +4,24 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.SpendReportingAggregation.AggregationKeyEnum
 import bio.terra.profile.model.SpendReportingForDateRange.CategoryEnum
-import bio.terra.profile.model.{SpendReport => SpendReportBPM}
-import bio.terra.profile.model.{SpendReportingAggregation => SpendReportingAggregationBPM}
-import bio.terra.profile.model.{SpendReportingForDateRange => SpendReportingForDateRangeBPM}
+import bio.terra.profile.model.{ProfileModel, SpendReport => SpendReportBPM, SpendReportingAggregation => SpendReportingAggregationBPM, SpendReportingForDateRange => SpendReportingForDateRangeBPM, CloudPlatform => BpmCloudPlatform}
 import cats.effect.{IO, Resource}
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Option => _, _}
-import org.broadinstitute.dsde.rawls.billing.{
-  BillingProfileManagerDAO,
-  BillingRepository,
-  BpmAzureSpendReportApiException
-}
+import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmAzureSpendReportApiException}
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext}
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext, model}
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.{ArgumentCaptor, Mockito}
-import org.mockito.Mockito.{doReturn, doThrow, never, spy, verify, when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, doReturn, doThrow, never, spy, verify, when}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -724,6 +718,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       TestData.BpmSpendReport.spendData(from, to, currency, Map("Compute" -> price1, "Storage" -> price2))
     when(bpmDAO.getAzureSpendReport(any(), any(), any(), any()))
       .thenReturn(spendReport)
+    when(bpmDAO.getBillingProfile(any(), any())).thenReturn(Option(new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BpmCloudPlatform.AZURE)))
 
     val billingProfileId = UUID.randomUUID()
     val projectName = RawlsBillingProjectName(wsName.namespace)
@@ -783,6 +778,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
     val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
 
+    when(bpmDAO.getBillingProfile(any(), any())).thenReturn(Option(new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BpmCloudPlatform.AZURE)))
     val errorMessage = "something went wrong"
     doThrow(new BpmAzureSpendReportApiException(StatusCodes.BadRequest.intValue, errorMessage))
       .when(bpmDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -781,6 +781,104 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     endDateCapture.getValue shouldBe to.toDate
   }
 
+  it should "not get the spend report from BPM for Google billing projects with a billing profile" in {
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+    val billingProfileId = UUID.randomUUID()
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+    when(bpmDAO.getBillingProfile(mockitoEq(billingProfileId), any()))
+      .thenReturn(Option(new ProfileModel().id(billingProfileId).cloudPlatform(BpmCloudPlatform.GCP)))
+
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    when(billingRepository.getBillingProject(mockitoEq(billingProject.projectName)))
+      .thenReturn(Future.successful(Option(billingProject.copy(billingProfileId = Option(billingProfileId.toString)))))
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    val bigQueryService = mockBigQuery(TestData.Workspace.table)
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bigQueryService,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getWorkspaceGoogleProjects(any())
+
+    Await.result(
+      service.getSpendForBillingProject(
+        billingProject.projectName,
+        from,
+        to,
+        Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))
+      ),
+      Duration.Inf
+    )
+
+    verify(bpmDAO, Mockito.times(0)).getAzureSpendReport(any(), any(), any(), any())
+    verify(service, Mockito.times(1)).getSpendForGCPBillingProject(
+      mockitoEq(billingProject.projectName),
+      mockitoEq(from),
+      mockitoEq(to),
+      mockitoEq(Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace)))
+    )
+  }
+
+  it should "not get the spend report from BPM for Google billing projects without a billing profile" in {
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    when(billingRepository.getBillingProject(mockitoEq(billingProject.projectName)))
+      .thenReturn(Future.successful(Option(billingProject.copy(billingProfileId = None))))
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    val bigQueryService = mockBigQuery(TestData.Workspace.table)
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bigQueryService,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getWorkspaceGoogleProjects(any())
+
+    Await.result(
+      service.getSpendForBillingProject(
+        billingProject.projectName,
+        from,
+        to,
+        Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))
+      ),
+      Duration.Inf
+    )
+
+    verify(bpmDAO, Mockito.times(0)).getBillingProfile(any(), any())
+    verify(bpmDAO, Mockito.times(0)).getAzureSpendReport(any(), any(), any(), any())
+    verify(service, Mockito.times(1)).getSpendForGCPBillingProject(
+      mockitoEq(billingProject.projectName),
+      mockitoEq(from),
+      mockitoEq(to),
+      mockitoEq(Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace)))
+    )
+  }
+
   it should "handle/rethrow ApiException from BPM client" in {
     val from = DateTime.now().minusMonths(2)
     val to = from.plusMonths(1)


### PR DESCRIPTION
Ticket: [WOR-848](https://broadworkbench.atlassian.net/browse/WOR-848)
- Stop using presence of billing profile to determine a billing project's cloud platform for spend reporting. If billing project has billing profile, fetch profile from BPM and check cloud platform on returned profile
- I searched through Rawls and the only other places with code paths that branch based on the presence of a billing profile are sharing and deletion. Sharing is fine as is -- we want Rawls to share the billing profile if present when sharing a billing project so that access to the billing profile remains in sync with access to the billing project. Deletion is also fine -- if a billing project has a billing profile, we need to delete the billing profile when deleting the project regardless of cloud platform. 

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-848]: https://broadworkbench.atlassian.net/browse/WOR-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ