### PR TITLE
Allow restricting workspace cloning to a single directory (WOR-544).

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V exclude ("org.slf4j", "slf4j-api")
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions :+ rawlsModelExclusion:_*)
 
-  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.459-SNAPSHOT"
+  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client" % "0.254.659-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32" // scala-steward:off (must match TDR)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -205,7 +205,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     val jobControlId = UUID.randomUUID().toString
     val prefixesToClone = prefixToClone match {
       case Some(prefix) => List(prefix)
-      case _ => List()
+      case _            => List()
     }
     getControlledAzureResourceApi(ctx).cloneAzureStorageContainer(
       new CloneControlledAzureStorageContainerRequest()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -199,14 +199,20 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                           sourceContainerId: UUID,
                                           destinationContainerName: String,
                                           cloningInstructions: CloningInstructionsEnum,
+                                          prefixToClone: Option[String],
                                           ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult = {
     val jobControlId = UUID.randomUUID().toString
+    val prefixesToClone = prefixToClone match {
+      case Some(prefix) => List(prefix)
+      case _ => List()
+    }
     getControlledAzureResourceApi(ctx).cloneAzureStorageContainer(
       new CloneControlledAzureStorageContainerRequest()
         .destinationWorkspaceId(destinationWorkspaceId)
         .name(destinationContainerName)
         .cloningInstructions(cloningInstructions)
+        .prefixesToClone(prefixesToClone.asJava)
         .jobControl(new JobControl().id(jobControlId)),
       sourceWorkspaceId,
       sourceContainerId

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -107,6 +107,7 @@ trait WorkspaceManagerDAO {
                                  sourceContainerId: UUID,
                                  destinationContainerName: String,
                                  cloningInstructions: CloningInstructionsEnum,
+                                 prefixToClone: Option[String],
                                  ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/CloudPlatform.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/CloudPlatform.scala
@@ -18,7 +18,7 @@ object CloudPlatform extends Enumeration {
   def apply(platform: WSMCloudPlatform): CloudPlatform = platform match {
     case WSMCloudPlatform.GCP   => GCP
     case WSMCloudPlatform.AZURE => AZURE
-    case WSMCloudPlatform.AWS => UNKNOWN // AWS exists only in WorkspaceManager at the moment
+    case WSMCloudPlatform.AWS   => UNKNOWN // AWS exists only in WorkspaceManager at the moment
   }
 
   def apply(platform: DRCloudPlatform): CloudPlatform = platform match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/CloudPlatform.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/CloudPlatform.scala
@@ -18,6 +18,7 @@ object CloudPlatform extends Enumeration {
   def apply(platform: WSMCloudPlatform): CloudPlatform = platform match {
     case WSMCloudPlatform.GCP   => GCP
     case WSMCloudPlatform.AZURE => AZURE
+    case WSMCloudPlatform.AWS => UNKNOWN // AWS exists only in WorkspaceManager at the moment
   }
 
   def apply(platform: DRCloudPlatform): CloudPlatform = platform match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -274,7 +274,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         )
         containerCloneResult <- traceWithParent("workspaceManagerDAO.cloneAzureStorageContainer", parentContext) {
           context =>
-            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID, workspaceId, context)
+            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID, workspaceId, request.copyFilesWithPrefix, context)
         }
       } yield containerCloneResult).recoverWith { t: Throwable =>
         logger.warn(
@@ -309,6 +309,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
 
   def cloneWorkspaceStorageContainer(sourceWorkspaceId: UUID,
                                      destinationWorkspaceId: UUID,
+                                     prefixToClone: Option[String],
                                      ctx: RawlsRequestContext
   ): Future[CloneControlledAzureStorageContainerResult] = {
 
@@ -334,6 +335,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             container.get.getMetadata.getResourceId,
             MultiCloudWorkspaceService.getStorageContainerName(destinationWorkspaceId),
             CloningInstructionsEnum.RESOURCE,
+            prefixToClone,
             ctx
           )
         })

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -274,7 +274,11 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         )
         containerCloneResult <- traceWithParent("workspaceManagerDAO.cloneAzureStorageContainer", parentContext) {
           context =>
-            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID, workspaceId, request.copyFilesWithPrefix, context)
+            cloneWorkspaceStorageContainer(sourceWorkspace.workspaceIdAsUUID,
+                                           workspaceId,
+                                           request.copyFilesWithPrefix,
+                                           context
+            )
         }
       } yield containerCloneResult).recoverWith { t: Throwable =>
         logger.warn(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -128,12 +128,14 @@ class HttpWorkspaceManagerDAOSpec
     val sourceContainerID = UUID.randomUUID()
     val destinationContainerName = "containerName"
     val cloningInstructions = CloningInstructionsEnum.DEFINITION
+    val prefixToClone = "prefix/"
 
     wsmDao.cloneAzureStorageContainer(workspaceId,
                                       destinationWorkspaceUUID,
                                       sourceContainerID,
                                       destinationContainerName,
                                       cloningInstructions,
+                                      Some(prefixToClone),
                                       testContext
     )
     verify(controlledAzureResourceApi).cloneAzureStorageContainer(cloneArgumentCaptor.capture,
@@ -143,6 +145,7 @@ class HttpWorkspaceManagerDAOSpec
     cloneArgumentCaptor.getValue.getDestinationWorkspaceId shouldBe destinationWorkspaceUUID
     cloneArgumentCaptor.getValue.getName shouldBe destinationContainerName
     cloneArgumentCaptor.getValue.getCloningInstructions shouldBe cloningInstructions
+    cloneArgumentCaptor.getValue.getPrefixesToClone shouldEqual (java.util.List.of(prefixToClone))
   }
 
   behavior of "enumerateStorageContainers"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -1,14 +1,14 @@
 package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
 import akka.actor.ActorSystem
-import bio.terra.workspace.api.{ResourceApi, _}
+import bio.terra.workspace.api._
 import bio.terra.workspace.client.ApiClient
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.mockito.ArgumentMatchers
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.verify
 import org.scalatest.flatspec.AnyFlatSpec
@@ -130,6 +130,7 @@ class HttpWorkspaceManagerDAOSpec
     val cloningInstructions = CloningInstructionsEnum.DEFINITION
     val prefixToClone = "prefix/"
 
+    // Call first with a prefix to limit cloning
     wsmDao.cloneAzureStorageContainer(workspaceId,
                                       destinationWorkspaceUUID,
                                       sourceContainerID,
@@ -138,14 +139,27 @@ class HttpWorkspaceManagerDAOSpec
                                       Some(prefixToClone),
                                       testContext
     )
-    verify(controlledAzureResourceApi).cloneAzureStorageContainer(cloneArgumentCaptor.capture,
-                                                                  ArgumentMatchers.eq(workspaceId),
-                                                                  ArgumentMatchers.eq(sourceContainerID)
+
+    // Call second with no prefix
+    wsmDao.cloneAzureStorageContainer(workspaceId,
+                                      destinationWorkspaceUUID,
+                                      sourceContainerID,
+                                      destinationContainerName,
+                                      cloningInstructions,
+                                      None,
+                                      testContext
     )
+    verify(controlledAzureResourceApi, Mockito.times(2)).cloneAzureStorageContainer(
+      cloneArgumentCaptor.capture,
+      ArgumentMatchers.eq(workspaceId),
+      ArgumentMatchers.eq(sourceContainerID)
+    )
+
     cloneArgumentCaptor.getValue.getDestinationWorkspaceId shouldBe destinationWorkspaceUUID
     cloneArgumentCaptor.getValue.getName shouldBe destinationContainerName
     cloneArgumentCaptor.getValue.getCloningInstructions shouldBe cloningInstructions
-    cloneArgumentCaptor.getValue.getPrefixesToClone shouldEqual (java.util.List.of(prefixToClone))
+    cloneArgumentCaptor.getAllValues.get(0).getPrefixesToClone shouldEqual (java.util.List.of(prefixToClone))
+    cloneArgumentCaptor.getAllValues.get(1).getPrefixesToClone shouldEqual (java.util.List.of())
   }
 
   behavior of "enumerateStorageContainers"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -75,6 +75,7 @@ class MockWorkspaceManagerDAO(
                                           sourceContainerId: UUID,
                                           destinationContainerName: String,
                                           cloningInstructions: CloningInstructionsEnum,
+                                          prefixToClone: Option[String],
                                           ctx: RawlsRequestContext
   ): CloneControlledAzureStorageContainerResult = {
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -14,7 +14,18 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.McWorkspace
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamResourceTypeNames, Workspace, WorkspaceName, WorkspaceRequest, WorkspaceType}
+import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamBillingProjectActions,
+  SamResourceTypeNames,
+  Workspace,
+  WorkspaceName,
+  WorkspaceRequest,
+  WorkspaceType
+}
 import org.broadinstitute.dsde.rawls.workspace.MultiCloudWorkspaceService.getStorageContainerName
 import org.mockito.ArgumentMatchers.{any, eq => equalTo}
 import org.mockito.Mockito._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -14,24 +14,12 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.mock.{MockSamDAO, MockWorkspaceManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.McWorkspace
-import org.broadinstitute.dsde.rawls.model.{
-  ErrorReport,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
-  RawlsRequestContext,
-  SamBillingProjectActions,
-  SamResourceTypeNames,
-  Workspace,
-  WorkspaceName,
-  WorkspaceRequest,
-  WorkspaceType
-}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamResourceTypeNames, Workspace, WorkspaceName, WorkspaceRequest, WorkspaceType}
 import org.broadinstitute.dsde.rawls.workspace.MultiCloudWorkspaceService.getStorageContainerName
 import org.mockito.ArgumentMatchers.{any, eq => equalTo}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.{ArgumentMatchers, Mockito}
-import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Assertion, OptionValues}
@@ -666,7 +654,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         assert(actual.errorReport.message.contains("does not have the expected storage container"))
 
         verify(mcWorkspaceService.workspaceManagerDAO, never())
-          .cloneAzureStorageContainer(any(), any(), any(), any(), any(), any())
+          .cloneAzureStorageContainer(any(), any(), any(), any(), any(), any(), any())
 
         // fail if the workspace exists
         val clone = Await.result(
@@ -719,7 +707,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         assert(actual.errorReport.message.contains("does not have the expected storage container"))
 
         verify(mcWorkspaceService.workspaceManagerDAO, never())
-          .cloneAzureStorageContainer(any(), any(), any(), any, any(), any())
+          .cloneAzureStorageContainer(any(), any(), any(), any, any(), any(), any())
 
         // fail if the workspace exists
         val clone = Await.result(
@@ -805,7 +793,9 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
               WorkspaceRequest(
                 cloneName.namespace,
                 cloneName.name,
-                Map.empty
+                Map.empty,
+                None,
+                Some("analyses/")
               )
             )
             _ = clone.toWorkspaceName shouldBe cloneName
@@ -834,6 +824,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
                 equalTo(sourceContainerUUID),
                 equalTo(getStorageContainerName(clone.workspaceIdAsUUID)),
                 equalTo(CloningInstructionsEnum.RESOURCE),
+                equalTo(Some("analyses/")),
                 any()
               )
             clone.completedCloneWorkspaceFileTransfer shouldBe None

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,7 +127,7 @@ object Dependencies {
   // "Terra Common Lib" Exclusions:
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j)
 
-  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.643-SNAPSHOT")
+  val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.659-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.112-SNAPSHOT")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-544

Companion terra-ui PR: https://github.com/DataBiosphere/terra-ui/pull/3881

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
