### PR TITLE
ID-563 Make FastPassMonitor not run IAM updates in parallel

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,1 +1,2 @@
 core/src/test/scala/org/broadinstitute/dsde/rawls/model/ExecutionModelSpec.scala
+core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/MockFastPassService.scala

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/FastPassGrantComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/FastPassGrantComponent.scala
@@ -3,9 +3,9 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.model.google.iam.{IamMemberTypes, IamResourceTypes}
-import org.joda.time.DateTime
 
 import java.sql.Timestamp
+import java.time.{Instant, OffsetDateTime, ZoneId, ZoneOffset}
 import java.util.UUID
 import scala.language.postfixOps
 
@@ -26,6 +26,7 @@ case class FastPassGrantRecord(
 )
 
 object FastPassGrantRecord {
+
   def fromFastPassGrant(fastPassGrant: FastPassGrant): FastPassGrantRecord =
     FastPassGrantRecord(
       fastPassGrant.id,
@@ -36,8 +37,8 @@ object FastPassGrantRecord {
       fastPassGrant.resourceType.value,
       fastPassGrant.resourceName,
       fastPassGrant.organizationRole,
-      new Timestamp(fastPassGrant.expiration.getMillis),
-      new Timestamp(fastPassGrant.created.getMillis)
+      new Timestamp(fastPassGrant.expiration.toInstant.toEpochMilli),
+      new Timestamp(fastPassGrant.created.toInstant.toEpochMilli)
     )
 
   def toFastPassGrant(fastPassGrantRecord: FastPassGrantRecord): FastPassGrant =
@@ -50,8 +51,8 @@ object FastPassGrantRecord {
       IamResourceTypes.withName(fastPassGrantRecord.resourceType),
       fastPassGrantRecord.resourceName,
       fastPassGrantRecord.roleName,
-      new DateTime(fastPassGrantRecord.expiration),
-      new DateTime(fastPassGrantRecord.created)
+      Instant.ofEpochMilli(fastPassGrantRecord.expiration.getTime).atZone(ZoneId.systemDefault()).toOffsetDateTime,
+      Instant.ofEpochMilli(fastPassGrantRecord.created.getTime).atZone(ZoneId.systemDefault()).toOffsetDateTime
     )
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitor.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.fastpass.FastPassMonitor.DeleteExpiredGrants
-import org.broadinstitute.dsde.rawls.model.{errorReportSource, FastPassGrant, GoogleProjectId, Workspace}
+import org.broadinstitute.dsde.rawls.model.{FastPassGrant, GoogleProjectId}
 import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
 import slick.dbio.DBIO
@@ -14,8 +14,6 @@ import slick.dbio.DBIO
 import scala.concurrent.Future
 import scala.language.postfixOps
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-
-import scala.util.{Failure, Success}
 
 object FastPassMonitor {
   sealed trait FastPassMonitorMessage

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
@@ -6,8 +6,24 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.FastPassConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
-import org.broadinstitute.dsde.rawls.fastpass.FastPassService.{SAdomain, UserAndPetEmails, openTelemetryTags, policyBindingsQuotaLimit}
-import org.broadinstitute.dsde.rawls.model.{FastPassGrant, GoogleProjectId, RawlsRequestContext, RawlsUserEmail, SamResourceRole, SamResourceTypeNames, SamUserStatusResponse, SamWorkspaceRoles, UserIdInfo, Workspace}
+import org.broadinstitute.dsde.rawls.fastpass.FastPassService.{
+  openTelemetryTags,
+  policyBindingsQuotaLimit,
+  SAdomain,
+  UserAndPetEmails
+}
+import org.broadinstitute.dsde.rawls.model.{
+  FastPassGrant,
+  GoogleProjectId,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  SamResourceRole,
+  SamResourceTypeNames,
+  SamUserStatusResponse,
+  SamWorkspaceRoles,
+  UserIdInfo,
+  Workspace
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceDBIOWithParent
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO.fromProjectPolicy
 import org.broadinstitute.dsde.workbench.google.HttpGoogleStorageDAO.fromBucketPolicy
@@ -165,9 +181,8 @@ object FastPassService extends LazyLogging {
     * @param petSaKey
     * @return The Pet Account Email
     */
-  def getEmailFromPetSaKey(petSaKey: String): WorkbenchEmail = {
+  def getEmailFromPetSaKey(petSaKey: String): WorkbenchEmail =
     WorkbenchEmail(petSaKey.parseJson.asJsObject.fields("client_email").asInstanceOf[JsString].value)
-  }
 
   private case class UserAndPetEmails(userEmail: WorkbenchEmail, userType: IamMemberType, petEmail: WorkbenchEmail) {
     override def toString: String = s"${userType.value}:${userEmail.value} and Pet:${petEmail.value}"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.rawls.fastpass
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.config.FastPassConfig
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO.User

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -446,7 +446,9 @@ class FastPassServiceSpec
 
     val petKey =
       Await.result(
-        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
+        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId,
+                                                                   RawlsUserEmail(samUserStatus.userEmail)
+        ),
         Duration.Inf
       )
     val petEmail = FastPassService.getEmailFromPetSaKey(petKey)
@@ -516,7 +518,9 @@ class FastPassServiceSpec
 
     val petKey =
       Await.result(
-        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
+        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId,
+                                                                   RawlsUserEmail(samUserStatus.userEmail)
+        ),
         Duration.Inf
       )
     val petEmail = FastPassService.getEmailFromPetSaKey(petKey)
@@ -586,14 +590,18 @@ class FastPassServiceSpec
 
       val parentWorkspacePetKey =
         Await.result(
-          services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(parentWorkspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
+          services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(parentWorkspace.googleProjectId,
+                                                                     RawlsUserEmail(samUserStatus.userEmail)
+          ),
           Duration.Inf
         )
       val parentWorkspacePetEmail = FastPassService.getEmailFromPetSaKey(parentWorkspacePetKey)
 
       val childWorkspacePetKey =
         Await.result(
-          services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(childWorkspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
+          services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(childWorkspace.googleProjectId,
+                                                                     RawlsUserEmail(samUserStatus.userEmail)
+          ),
           Duration.Inf
         )
       val childWorkspacePetEmail = FastPassService.getEmailFromPetSaKey(childWorkspacePetKey)
@@ -857,7 +865,9 @@ class FastPassServiceSpec
     val userEmail = WorkbenchEmail(services.user.userEmail.value)
     val petKey =
       Await.result(
-        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, services.user.userEmail),
+        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId,
+                                                                   services.user.userEmail
+        ),
         Duration.Inf
       )
     val petEmail = FastPassService.getEmailFromPetSaKey(petKey)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -444,11 +444,12 @@ class FastPassServiceSpec
     val timeBetween = new JodaDuration(beforeCreate, bucketGrant.expiration)
     timeBetween.getStandardHours.toInt should be(services.fastPassConfig.grantPeriod.toHoursPart)
 
-    val petEmail =
+    val petKey =
       Await.result(
-        services.fastPassMockSamDAO.getUserPetServiceAccount(services.ctx1, testData.workspace.googleProjectId),
+        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
         Duration.Inf
       )
+    val petEmail = FastPassService.getEmailFromPetSaKey(petKey)
 
     // The user is added to the project IAM policies with a condition
     verify(services.googleIamDAO).addRoles(
@@ -513,11 +514,12 @@ class FastPassServiceSpec
       runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(testData.workspaceNoAttrs.workspaceIdAsUUID))
     yesMoreWorkspace2FastPassGrants should not be empty
 
-    val petEmail =
+    val petKey =
       Await.result(
-        services.fastPassMockSamDAO.getUserPetServiceAccount(services.ctx1, testData.workspace.googleProjectId),
+        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
         Duration.Inf
       )
+    val petEmail = FastPassService.getEmailFromPetSaKey(petKey)
 
     // The user is removed from the project IAM policies
     verify(services.googleIamDAO).removeRoles(
@@ -582,21 +584,24 @@ class FastPassServiceSpec
         )
       )
 
-      val parentWorkspacePet = Await
-        .result(services.fastPassMockSamDAO.getUserPetServiceAccount(services.ctx1, parentWorkspace.googleProjectId),
-                Duration.Inf
+      val parentWorkspacePetKey =
+        Await.result(
+          services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(parentWorkspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
+          Duration.Inf
         )
-        .value
-      val childWorkspacePet = Await
-        .result(services.fastPassMockSamDAO.getUserPetServiceAccount(services.ctx1, childWorkspace.googleProjectId),
-                Duration.Inf
-        )
-        .value
+      val parentWorkspacePetEmail = FastPassService.getEmailFromPetSaKey(parentWorkspacePetKey)
 
-      parentWorkspacePet should not be childWorkspacePet
+      val childWorkspacePetKey =
+        Await.result(
+          services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(childWorkspace.googleProjectId, RawlsUserEmail(samUserStatus.userEmail)),
+          Duration.Inf
+        )
+      val childWorkspacePetEmail = FastPassService.getEmailFromPetSaKey(childWorkspacePetKey)
+
+      parentWorkspacePetEmail should not be childWorkspacePetEmail
 
       parentWorkspaceFastPassGrantsAfter.map(_.accountEmail).toSet should be(
-        Set(WorkbenchEmail(childWorkspacePet), WorkbenchEmail(samUserStatus.userEmail))
+        Set(childWorkspacePetEmail, WorkbenchEmail(samUserStatus.userEmail))
       )
 
   }
@@ -850,11 +855,12 @@ class FastPassServiceSpec
       runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(testData.workspace.workspaceIdAsUUID))
 
     val userEmail = WorkbenchEmail(services.user.userEmail.value)
-    val petEmail =
+    val petKey =
       Await.result(
-        services.fastPassMockSamDAO.getUserPetServiceAccount(services.ctx1, testData.workspace.googleProjectId),
+        services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId, services.user.userEmail),
         Duration.Inf
       )
+    val petEmail = FastPassService.getEmailFromPetSaKey(petKey)
 
     workspaceFastPassGrants should not be empty
     workspaceFastPassGrants.map(_.accountType) should contain only (IamMemberTypes.ServiceAccount)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -51,7 +51,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, OneInstancePerTest, OptionValues}
 
 import java.util.concurrent.TimeUnit
-import java.time.{Duration => JavaDuration, OffsetDateTime, ZoneOffset}
+import java.time.{Duration => JavaDuration, LocalDateTime, OffsetDateTime, ZoneOffset}
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
@@ -1124,7 +1124,7 @@ class FastPassServiceSpec
 
     allGrants.foreach(grant => runAndWait(fastPassGrantQuery.insert(grant)))
 
-    val startTime = OffsetDateTime.now()
+    val startTime = LocalDateTime.now()
 
     val fastPassGrants1 =
       runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(testData.workspace.workspaceIdAsUUID))
@@ -1150,7 +1150,7 @@ class FastPassServiceSpec
 
     runAndWait(DBIO.seq(project1Removal, project2Removal))
 
-    val endTime = OffsetDateTime.now()
+    val endTime = LocalDateTime.now()
 
     val postCleanupWorkspace1FastPassGrants =
       runAndWait(fastPassGrantQuery.findFastPassGrantsForWorkspace(testData.workspace.workspaceIdAsUUID))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/MockFastPassService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/MockFastPassService.scala
@@ -109,14 +109,17 @@ object MockFastPassService {
 
       def projectPetInfo(googleProject: String): (WorkbenchEmail, String) = {
         val petEmail = WorkbenchEmail(s"${testUser.userEmail.value}-pet@$googleProject.iam.gserviceaccount.com")
-        val petKey = s"""{"private_key_id": "${testUser.userEmail.value}-$googleProject-pet-key", "client_id": "${petUserSubjectId.value}", "client_email": "${petEmail.value}" }"""
+        val petKey =
+          s"""{"private_key_id": "${testUser.userEmail.value}-$googleProject-pet-key", "client_id": "${petUserSubjectId.value}", "client_email": "${petEmail.value}" }"""
         (petEmail, petKey)
       }
 
       doReturn(Future.successful(userStatusResponse))
         .when(samDAO)
         .getUserStatus(
-          ArgumentMatchers.argThat((ctx: RawlsRequestContext) => ctx.userInfo.userEmail.value.startsWith(s"${testUser.userEmail.value}-pet"))
+          ArgumentMatchers.argThat((ctx: RawlsRequestContext) =>
+            ctx.userInfo.userEmail.value.startsWith(s"${testUser.userEmail.value}-pet")
+          )
         )
 
       doAnswer { invocation =>
@@ -142,7 +145,11 @@ object MockFastPassService {
       doReturn(
         Future.successful(
           UserInfo(RawlsUserEmail(""), OAuth2BearerToken("test_token"), 0, petUserSubjectId)
-        )).when(gcsDAO).getUserInfoUsingJson(ArgumentMatchers.argThat((key: String) => key.contains(s"${testUser.userEmail.value}-pet")))
+        )
+      ).when(gcsDAO)
+        .getUserInfoUsingJson(
+          ArgumentMatchers.argThat((key: String) => key.contains(s"${testUser.userEmail.value}-pet"))
+        )
 
       doReturn(Future.successful(testUser match {
         case testUser if testUser.userEmail.value.equals("writer-access") =>
@@ -156,9 +163,7 @@ object MockFastPassService {
         .listUserRolesForResource(
           ArgumentMatchers.eq(SamResourceTypeNames.workspace),
           ArgumentMatchers.any[String],
-          ArgumentMatchers.argThat((arg: RawlsRequestContext) => {
-            arg.userInfo.userSubjectId.equals(petUserSubjectId)
-          })
+          ArgumentMatchers.argThat((arg: RawlsRequestContext) => arg.userInfo.userSubjectId.equals(petUserSubjectId))
         )
     }
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/FastPassModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/FastPassModel.scala
@@ -3,7 +3,8 @@ package org.broadinstitute.dsde.rawls.model
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.model.google.iam.IamMemberTypes.IamMemberType
 import org.broadinstitute.dsde.workbench.model.google.iam.IamResourceTypes.IamResourceType
-import org.joda.time.DateTime
+
+import java.time.OffsetDateTime
 
 /**
   * Created by tlangs on 3/16/2023.
@@ -17,7 +18,7 @@ object FastPassGrant {
                        resourceType: IamResourceType,
                        resourceName: String,
                        organizationRole: String,
-                       expiration: DateTime
+                       expiration: OffsetDateTime
   ) = FastPassGrant(-1L,
                     workspaceId,
                     userSubjectId,
@@ -27,7 +28,7 @@ object FastPassGrant {
                     resourceName,
                     organizationRole,
                     expiration,
-                    DateTime.now()
+                    OffsetDateTime.now()
   )
 }
 case class FastPassGrant(
@@ -39,6 +40,6 @@ case class FastPassGrant(
   resourceType: IamResourceType,
   resourceName: String,
   organizationRole: String,
-  expiration: DateTime,
-  created: DateTime
+  expiration: OffsetDateTime,
+  created: OffsetDateTime
 )

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/FastPassModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/FastPassModel.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.model.google.iam.IamMemberTypes.IamMemberType
 import org.broadinstitute.dsde.workbench.model.google.iam.IamResourceTypes.IamResourceType
 
-import java.time.OffsetDateTime
+import java.time.{OffsetDateTime, ZoneOffset}
 
 /**
   * Created by tlangs on 3/16/2023.
@@ -28,7 +28,7 @@ object FastPassGrant {
                     resourceName,
                     organizationRole,
                     expiration,
-                    OffsetDateTime.now()
+                    OffsetDateTime.now(ZoneOffset.UTC)
   )
 }
 case class FastPassGrant(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-563

`FastPassService.removeFastPassGrantsInWorkspaceProject` already groups the grants its removing by email and makes sure that they don’t conflict by executing policy updates in series. `FastPassMonitor` no longer pre-groups the expired grants and instead let `FastPassService` do it.

I've modified `FastPassService.removeFastPassGrantsInWorkspaceProject` to return a list of errors and the failed FastPass grants to the caller, so that `FastPassMonitor` can output useful log messages. I've also added a test in `FastPassServiceSpec` to make sure `FastPassService.removeFastPassGrantsInWorkspaceProject` is applying all the policy removals it can, and collecting the errors once finished.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
