### PR TITLE
AJ-915 switch wds apptype to WDS

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -138,7 +138,7 @@ dataRepoEntityProvider {
 }
 
 leonardo {
-    wdsType = "CROMWELL" # "CROMWELL" for joint WDS+CBAS; "WDS" for standalone/decoupled WDS
+    wdsType = "WDS" # "CROMWELL" for joint WDS+CBAS; "WDS" for standalone/decoupled WDS
     server = "add-leo-hostname-here"
 }
 

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -132,7 +132,7 @@ multiCloudWorkspaces {
 }
 
 leonardo {
-    wdsType = "CROMWELL" # "CROMWELL" for joint WDS+CBAS; "WDS" for standalone/decoupled WDS
+    wdsType = "WDS" # "CROMWELL" for joint WDS+CBAS; "WDS" for standalone/decoupled WDS
     server = "add-leo-hostname-here"
 }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAOSpec.scala
@@ -16,7 +16,7 @@ class HttpLeonardoDAOSpec extends TestKit(ActorSystem("HttpLeonardoDAOSpec")) wi
 
   val testConf: Config =
     ConfigFactory
-      .parseMap(Map("wdsType" -> "CROMWELL", "server" -> "http://localhost").asJava)
+      .parseMap(Map("wdsType" -> "WDS", "server" -> "http://localhost").asJava)
       .resolve()
   val leonardoConfig: LeonardoConfig = LeonardoConfig.apply(testConf)
 
@@ -42,7 +42,7 @@ class HttpLeonardoDAOSpec extends TestKit(ActorSystem("HttpLeonardoDAOSpec")) wi
         ArgumentMatchers.eq(token),
         ArgumentMatchers.eq(workspaceId),
         ArgumentMatchers.eq(s"wds-$workspaceId"),
-        ArgumentMatchers.eq("CROMWELL")
+        ArgumentMatchers.eq("WDS")
       )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -133,7 +133,7 @@ object Dependencies {
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.128-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.63-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-f554115")
-  val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.11" % "1.3.5-178c33e"
+  val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.11" % "1.3.6-801b78f"
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"
   val opencensusAkkaHttp: ModuleID = "com.github.sebruck" %% "opencensus-scala-akka-http" % "0.7.2"


### PR DESCRIPTION
Ticket: [AJ-915](https://broadworkbench.atlassian.net/browse/AJ-915)
When Rawls creates a WDS app, it will now create only WDS, not WDS+CROMWELL.
I have tested this in a bee and verified that WDS is successfully launched, but not CBAS.
Depends on https://github.com/broadinstitute/firecloud-develop/pull/3316

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-915]: https://broadworkbench.atlassian.net/browse/AJ-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ