### PR TITLE
[DDO-2787] Allow Rawls to be passed environment variables with periods in them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,17 @@ RUN mkdir /rawls
 COPY ./rawls*.jar /rawls
 
 # Add Rawls as a service (it will start when the container starts)
-CMD java $JAVA_OPTS -jar $(find /rawls -name 'rawls*.jar')
+# 1. “Exec” form of CMD necessary to avoid “shell” form’s `sh` stripping 
+#    environment variables with periods in them, often used in DSP for Lightbend 
+#    config.
+# 2. Handling $JAVA_OPTS is necessary as long as firecloud-develop or the app’s 
+#    chart tries to set it. Apps that use devops’s foundation subchart don’t need 
+#    to handle this.
+# 3. The jar’s location and naming scheme in the filesystem is required by preflight 
+#    liquibase migrations in some app charts. Apps that expose liveness endpoints 
+#    may not need preflight liquibase migrations.
+# We use the “exec” form with `bash` to accomplish all of the above.
+CMD ["/bin/bash", "-c", "java $JAVA_OPTS -jar $(find /rawls -name 'rawls*.jar')"]
 
 # These next 4 commands are for enabling SSH to the container.
 # id_rsa.pub is referenced below, but this should be any public key


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-2787

What:

Allows Rawls to be passed environment variables with periods in them.

Why:

Lightbend config expects folks to configure array fields by passing environment variables with periods in them. I'm standardizing this as much as I can, regardless of whether the app actually needs to use this. I just don't think we should have arbitrary differences between Dockerfiles, it'll just trip someone up at some point.

How:

Use bash instead of the implicit sh for the Dockerfile's CMD.

Like https://github.com/DataBiosphere/leonardo/pull/3291, https://github.com/broadinstitute/sam/pull/1060

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**

> No API changes!

- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).

> Nope!

- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email

> No substantial changes!
