### PR TITLE
Allow WDS creation to be disabled for tests (WOR-919).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -589,7 +589,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       case _ =>
         // create a WDS application in Leo. Do not fail workspace creation if WDS creation fails.
         logger.info(s"Creating WDS instance [workspaceId = ${workspaceId}]")
-        Future.successful()
         traceWithParent("createWDSInstance", parentContext)(_ =>
           Future(
             leonardoDAO.createWDSInstance(parentContext.userInfo.accessToken.token, workspaceId, sourceWorkspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -581,12 +581,13 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                       sourceWorkspaceId: Option[UUID],
                                       workspaceAttributeMap: AttributeMap
   ): Future[Unit] =
-    // create a WDS application in Leo. Do not fail workspace creation if WDS creation fails.
     workspaceAttributeMap.get(AttributeName.withDefaultNS("disableAutomaticAppCreation")) match {
       case Some(AttributeBoolean(true)) =>
+        // Skip WDS deployment for testing purposes.
         logger.info("Skipping creation of WDS per request attributes")
         Future.successful()
       case _ =>
+        // create a WDS application in Leo. Do not fail workspace creation if WDS creation fails.
         logger.info(s"Creating WDS instance [workspaceId = ${workspaceId}]")
         Future.successful()
         traceWithParent("createWDSInstance", parentContext)(_ =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-919

If `disableAutomaticAppCreation` is present with a value of true in the workspace request attributes, do not create WDS. This will be used for our E2E integration tests of workspace creation and cloning to avoid WDS creation, which takes a long time for both creation and deletion.

I tested this with a locally running terra-ui by adding `attributes: { description, disableAutomaticAppCreation: true }` to [NewWorkspaceModal](https://github.com/DataBiosphere/terra-ui/blob/0a3b6da2f5757e790b68bc16fb0439c73dc4acc8/src/components/NewWorkspaceModal.js#L109).

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
