### PR TITLE
[WOR-916] Azure e2e Github action workflow

### DIFF
--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -29,7 +29,7 @@ jobs:
         id: tag
         env:
           DEFAULT_BUMP: patch
-          GITHUB_TOKEN: $TOKEN
+          GITHUB_TOKEN: '$TOKEN'
           RELEASE_BRANCHES: main
           WITH_V: true
 
@@ -39,7 +39,7 @@ jobs:
           workflow: rawls-build
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: $TOKEN
+          token: '$TOKEN'
           inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
@@ -67,7 +67,7 @@ jobs:
           workflow: bee-create
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: $TOKEN
+          token: '$TOKEN'
           inputs: '{ "bee-name": "$BEE_NAME", "version-template": "dev", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   rawls-swat-e2e-test-job:
@@ -85,7 +85,7 @@ jobs:
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: $TOKEN
+          token: '$TOKEN'
           inputs: '{ "bee-name": "$BEE_NAME", "ENV": "qa", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
 
   destroy-bee-workflow:
@@ -102,7 +102,7 @@ jobs:
           workflow: bee-destroy
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: $TOKEN
+          token: '$TOKEN'
           inputs: '{ "bee-name": "$BEE_NAME" }'
 
   notify-slack-on-failure:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -117,7 +117,7 @@ jobs:
         with:
           # Channel is for #workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests ${{ job.status }} ${{ needs.create-bee-workflow.outputs.custom-version-json }}"
+          slack-message: "Azure E2E Tests ${{ job.status }} ${{ needs.create-bee-workflow.outputs.custom-version-json }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -108,6 +108,18 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
+      - name: "Notify Workspaces Slack"
+        if: always() # && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
+        uses: broadinstitute/action-slack@v3.8.0
+        # see https://github.com/broadinstitute/action-slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          channel: "#workspaces-test-alerts"
+          username: "Azure E2E Tests ${{ steps.set-env-step.outputs.test-env }} tests"
+          author_name: "Azure E2E Tests ${{ steps.set-env-step.outputs.test-env }} tests"
+          fields: repo,job,workflow,commit,eventName,author,took
 
   destroy-bee-workflow:
     strategy:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -91,10 +91,10 @@ jobs:
         with:
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/iv-rawls-add-branch-config
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
 
   destroy-bee-workflow:
     strategy:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -103,7 +103,8 @@ jobs:
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests ${{ inputs.branch || github.head_ref }} ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "Azure E2E Tests ${{ inputs.branch || github.head_ref }} ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -1,0 +1,131 @@
+name: rawls-build-tag-publish-and-run-tests
+
+on:
+  pull_request:
+    paths-ignore: ['**.md']
+
+jobs:
+  rawls-build-tag-publish-job:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    outputs:
+      custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
+    steps:
+      - uses: 'actions/checkout@v3'
+
+      - name: Bump the tag to a new version
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
+        id: tag
+        env:
+          DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          RELEASE_BRANCHES: main
+          WITH_V: true
+
+      - name: Extract branch
+        id: extract-branch
+        run: |
+          GITHUB_EVENT_NAME=${{ github.event_name }}
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            GITHUB_REF=${{ github.ref }}
+            GITHUB_SHA=${{ github.sha }}
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            GITHUB_REF=refs/heads/${{ github.head_ref }}
+            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            echo "Failed to extract branch information"
+            exit 1
+          fi
+
+          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
+          echo "name=$GITHUB_SHA" >> $GITHUB_OUTPUT
+
+      - name: dispatch build to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v3
+        with:
+          workflow: rawls-build
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "${{ steps.extract-branch.outputs.ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+
+      - name: Render Rawls version
+        id: render-rawls-version
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
+
+  create-bee-workflow:
+    strategy:
+      matrix:
+        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
+    runs-on: ubuntu-latest
+    needs: [rawls-build-tag-publish-job]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Echo Rawls version
+        run: |
+          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
+
+      - name: dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v3
+        with:
+          workflow: bee-create
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
+
+  rawls-swat-test-job:
+    strategy:
+      matrix:
+        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
+        testing-env: [ qa ] # what env resources to use, e.g. SA keys
+        test-group: [ # TODO: share with rawls-build-tag-publish-and-run-tests but allow passing the test-group?
+          { group_name: workspaces_azure, tag: "-n org.broadinstitute.dsde.test.api.AuthDomainsTest -n org.broadinstitute.dsde.test.api.BillingsTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest" }
+        ] # Rawls test groups
+    runs-on: ubuntu-latest
+    needs: [create-bee-workflow]
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: dispatch to terra-github-workflows
+        env:
+          rawls_base_test_entrypoint: "testOnly -- -l ProdTest -l NotebooksCanaryTest"
+        uses: broadinstitute/workflow-dispatch@v3
+        with:
+          workflow: .github/workflows/rawls-swat-tests.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
+
+  destroy-bee-workflow:
+    strategy:
+      matrix:
+        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
+    runs-on: ubuntu-latest
+    needs: [rawls-swat-test-job]
+    if: always() # always run to confirm bee is destroyed
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v3
+        with:
+          workflow: bee-destroy
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
+          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}" }'

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ foobar }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "foobar", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -118,16 +118,16 @@ jobs:
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}" }'
 
-  notify-slack:
+  notify-slack-on-failure:
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: ${{ failure() }} # Can use !cancelled() if always want to notify.
+    if: ${{ failed() }} # Can use !cancelled() if always want to notify.
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests, branch: ${{ inputs.branch || github.head_ref }} status: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.branch || github.head_ref }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/iv-rawls-add-branch-config
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -89,7 +89,7 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
         test-group: [ # TODO: share with rawls-build-tag-publish-and-run-tests but allow passing the test-group?
-          { group_name: workspaces_azure, tag: "-n org.broadinstitute.dsde.test.api.AuthDomainsTest -n org.broadinstitute.dsde.test.api.BillingsTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest" }
+          { group_name: workspaces_azure, tag: "-n org.broadinstitute.dsde.test.api.WorkspacesAzureTest" }
         ] # Rawls test groups
     runs-on: ubuntu-latest
     needs: [create-bee-workflow]

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -8,7 +8,6 @@ on:
         required: true
         default: 'develop'
         type: string
-  pull_request:
 
 jobs:
   rawls-build-tag-publish-job:
@@ -37,7 +36,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -128,6 +127,6 @@ jobs:
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.branch || github.head_ref }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -121,7 +121,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: ${{ failed() }} # Can use !cancelled() if always want to notify.
+    if: ${{ failure() }} # Can use !cancelled() if always want to notify.
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -121,7 +121,7 @@ jobs:
   notify-slack-on-failure:
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: ${{ failed() }} # Can use !cancelled() if always want to notify.
+    if: ${{ failure() }} # Can use !cancelled() if always want to notify.
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -9,6 +9,10 @@ on:
         default: 'develop'
         type: string
 
+env:
+  BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-dev'
+  TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
+
 jobs:
   rawls-build-tag-publish-job:
     runs-on: ubuntu-latest
@@ -25,7 +29,7 @@ jobs:
         id: tag
         env:
           DEFAULT_BUMP: patch
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+          GITHUB_TOKEN: $TOKEN
           RELEASE_BRANCHES: main
           WITH_V: true
 
@@ -35,7 +39,7 @@ jobs:
           workflow: rawls-build
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
+          token: $TOKEN
           inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
@@ -47,9 +51,6 @@ jobs:
           echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
 
   create-bee-workflow:
-    strategy:
-      matrix:
-        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job]
     permissions:
@@ -66,18 +67,10 @@ jobs:
           workflow: bee-create
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
+          token: $TOKEN
+          inputs: '{ "bee-name": "$BEE_NAME", "version-template": "dev", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   rawls-swat-e2e-test-job:
-    strategy:
-      matrix:
-        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
-        testing-env: [ qa ] # what env resources to use, e.g. SA keys
-        test-group: [
-          { group_name: workspaces_azure, tag: "-n org.broadinstitute.dsde.test.api.WorkspacesAzureTest" }
-        ] # Rawls test groups
     runs-on: ubuntu-latest
     needs: [create-bee-workflow]
     permissions:
@@ -86,20 +79,16 @@ jobs:
     steps:
       - name: dispatch to terra-github-workflows
         env:
-          rawls_base_test_entrypoint: "testOnly -- -l ProdTest -l NotebooksCanaryTest"
+          rawls_test_command: "testOnly -- -l ProdTest -l NotebooksCanaryTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest"
         uses: broadinstitute/workflow-dispatch@v3
         with:
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
+          token: $TOKEN
+          inputs: '{ "bee-name": "$BEE_NAME", "ENV": "qa", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
 
   destroy-bee-workflow:
-    strategy:
-      matrix:
-        terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs: [rawls-swat-e2e-test-job]
     if: always() # always run to confirm bee is destroyed
@@ -113,9 +102,8 @@ jobs:
           workflow: bee-destroy
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}" }'
+          token: $TOKEN
+          inputs: '{ "bee-name": "$BEE_NAME" }'
 
   notify-slack-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -8,6 +8,7 @@ on:
         required: true
         default: 'develop'
         type: string
+  pull_request:
 
 jobs:
   rawls-build-tag-publish-job:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -115,12 +115,12 @@ jobs:
         uses: broadinstitute/action-slack@v3.8.0
         # see https://github.com/broadinstitute/action-slack
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.QA_SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
           channel: "#workspaces-test-alerts"
-          username: "Azure E2E Tests ${{ needs.create-bee-workflow.outputs.custom-version-json }} tests"
-          author_name: "Azure E2E Tests ${{ needs.create-bee-workflow.outputs.custom-version-json }} tests"
+          username: "Azure E2E Tests ${{ needs.create-bee-workflow.outputs.custom-version-json }}"
+          author_name: "Azure E2E Tests"
           fields: repo,job,workflow,commit,eventName,author,took
 
   destroy-bee-workflow:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -29,7 +29,7 @@ jobs:
         id: tag
         env:
           DEFAULT_BUMP: patch
-          GITHUB_TOKEN: '$TOKEN'
+          GITHUB_TOKEN: ${{ env.TOKEN }}
           RELEASE_BRANCHES: main
           WITH_V: true
 
@@ -39,7 +39,7 @@ jobs:
           workflow: rawls-build
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: '$TOKEN'
+          token: ${{ env.TOKEN }}
           inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
@@ -67,8 +67,8 @@ jobs:
           workflow: bee-create
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: '$TOKEN'
-          inputs: '{ "bee-name": "$BEE_NAME", "version-template": "dev", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
+          token: ${{ env.TOKEN }}
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "version-template": "dev", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   rawls-swat-e2e-test-job:
     runs-on: ubuntu-latest
@@ -85,8 +85,8 @@ jobs:
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: '$TOKEN'
-          inputs: '{ "bee-name": "$BEE_NAME", "ENV": "qa", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
+          token: ${{ env.TOKEN }}
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest
@@ -102,8 +102,8 @@ jobs:
           workflow: bee-destroy
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: '$TOKEN'
-          inputs: '{ "bee-name": "$BEE_NAME" }'
+          token: ${{ env.TOKEN }}
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}" }'
 
   notify-slack-on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -68,6 +68,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+    outputs:
+      custom-version-json: ${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}
     steps:
       - name: Echo Rawls version
         run: |
@@ -117,8 +119,8 @@ jobs:
         with:
           status: ${{ job.status }}
           channel: "#workspaces-test-alerts"
-          username: "Azure E2E Tests ${{ steps.set-env-step.outputs.test-env }} tests"
-          author_name: "Azure E2E Tests ${{ steps.set-env-step.outputs.test-env }} tests"
+          username: "Azure E2E Tests ${{ needs.create-bee-workflow.outputs.custom-version-json }} tests"
+          author_name: "Azure E2E Tests ${{ needs.create-bee-workflow.outputs.custom-version-json }} tests"
           fields: repo,job,workflow,commit,eventName,author,took
 
   destroy-bee-workflow:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -123,7 +123,7 @@ jobs:
 
   notify-slack:
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: !cancelled() # TODO: change to failed()
+    if: ${{ !cancelled() }} # TODO: change to failed()
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -98,13 +98,12 @@ jobs:
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
       - name: Notify slack on failure
         id: slack
-        if: always()
+        if: always() # TODO: change to just notify on failure, probably will want to always notify to qa channel
         uses: slackapi/slack-github-action@v1.23.0
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests ${{ inputs.branch || github.head_ref }} ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "Azure E2E Tests, branch: ${{ inputs.branch || github.head_ref }} status: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "foobar", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -30,24 +30,6 @@ jobs:
           RELEASE_BRANCHES: main
           WITH_V: true
 
-      - name: Extract branch
-        id: extract-branch
-        run: |
-          GITHUB_EVENT_NAME=${{ github.event_name }}
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            GITHUB_REF=${{ github.ref }}
-            GITHUB_SHA=${{ github.sha }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            GITHUB_REF=refs/heads/${{ github.head_ref }}
-            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
-          else
-            echo "Failed to extract branch information"
-            exit 1
-          fi
-
-          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-          echo "name=$GITHUB_SHA" >> $GITHUB_OUTPUT    
-
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
@@ -55,7 +37,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "${{ steps.extract-branch.outputs.ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -70,6 +52,7 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
+    if: false
     needs: [rawls-build-tag-publish-job]
     permissions:
       contents: 'read'
@@ -99,6 +82,7 @@ jobs:
         ] # Rawls test groups
     runs-on: ubuntu-latest
     needs: [create-bee-workflow]
+    if: false
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -114,16 +98,6 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
-      - name: Notify slack on failure
-        id: slack
-        if: always() # TODO: change to just notify on failure, probably will want to always notify to qa channel
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          # Channel is for #dsp-workspaces-test-alerts
-          channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests, branch: ${{ inputs.branch || github.head_ref }} status: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
 
   destroy-bee-workflow:
     strategy:
@@ -131,7 +105,8 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs: [rawls-swat-e2e-test-job]
-    if: always() # always run to confirm bee is destroyed
+    if: false
+    # if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -145,3 +120,16 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}" }'
+
+  notify-slack:
+    needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
+    if: !cancelled() # TODO: change to failed()
+    steps:
+      - name: Notify slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # Channel is for #dsp-workspaces-test-alerts
+          channel-id: 'C03F21QEWV7'
+          slack-message: "Azure E2E Tests, branch: ${{ inputs.branch || github.head_ref }} status: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -30,6 +30,24 @@ jobs:
           RELEASE_BRANCHES: main
           WITH_V: true
 
+      - name: Extract branch
+        id: extract-branch
+        run: |
+          GITHUB_EVENT_NAME=${{ github.event_name }}
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            GITHUB_REF=${{ github.ref }}
+            GITHUB_SHA=${{ github.sha }}
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            GITHUB_REF=refs/heads/${{ github.head_ref }}
+            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            echo "Failed to extract branch information"
+            exit 1
+          fi
+
+          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
+          echo "name=$GITHUB_SHA" >> $GITHUB_OUTPUT    
+
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
@@ -37,7 +55,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "${{ steps.extract-branch.outputs.ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ foobar }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -52,7 +52,6 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
-    if: false
     needs: [rawls-build-tag-publish-job]
     permissions:
       contents: 'read'
@@ -82,7 +81,6 @@ jobs:
         ] # Rawls test groups
     runs-on: ubuntu-latest
     needs: [create-bee-workflow]
-    if: false
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -105,8 +103,7 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs: [rawls-swat-e2e-test-job]
-    if: false
-    # if: always() # always run to confirm bee is destroyed
+    if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -124,7 +121,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: ${{ !cancelled() }} # TODO: change to failed()
+    if: ${{ failed() }} # Can use !cancelled() if always want to notify.
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -110,18 +110,17 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}", "test-group-name": "${{ matrix.test-group.group_name }}", "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}", "java-version": "17" }'
-      - name: "Notify Workspaces Slack"
-        if: always() # && (steps.set-env-step.outputs.test-env == 'alpha' || steps.set-env-step.outputs.test-env == 'staging')
-        uses: broadinstitute/action-slack@v3.8.0
-        # see https://github.com/broadinstitute/action-slack
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.QA_SLACK_WEBHOOK_URL }}
+      - name: Notify slack on failure
+        id: slack
+        if: always()
+        uses: slackapi/slack-github-action@v1.23.0
         with:
-          status: ${{ job.status }}
-          channel: "#workspaces-test-alerts"
-          username: "Azure E2E Tests ${{ needs.create-bee-workflow.outputs.custom-version-json }}"
-          author_name: "Azure E2E Tests"
-          fields: repo,job,workflow,commit,eventName,author,took
+          # Channel is for #workspaces-test-alerts
+          channel-id: 'C03F21QEWV7'
+          slack-message: "Azure E2E Tests ${{ job.status }} ${{ needs.create-bee-workflow.outputs.custom-version-json }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+
 
   destroy-bee-workflow:
     strategy:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -108,7 +108,7 @@ jobs:
   notify-slack-on-failure:
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: ${{ failure() }} # Can use !cancelled() if always want to notify.
+    if: false # silence during development ${{ failure() }} # Can use !cancelled() if always want to notify.
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -122,6 +122,7 @@ jobs:
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}" }'
 
   notify-slack:
+    runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
     if: ${{ !cancelled() }} # TODO: change to failed()
     steps:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -1,8 +1,13 @@
 name: rawls-run-azure-e2e-tests
 
 on:
-  pull_request:
-    paths-ignore: ['**.md']
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch of rawls to run tests on'
+        required: true
+        default: 'develop'
+        type: string
 
 jobs:
   rawls-build-tag-publish-job:
@@ -24,24 +29,6 @@ jobs:
           RELEASE_BRANCHES: main
           WITH_V: true
 
-      - name: Extract branch
-        id: extract-branch
-        run: |
-          GITHUB_EVENT_NAME=${{ github.event_name }}
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            GITHUB_REF=${{ github.ref }}
-            GITHUB_SHA=${{ github.sha }}
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            GITHUB_REF=refs/heads/${{ github.head_ref }}
-            GITHUB_SHA=${{ github.event.pull_request.head.sha }}
-          else
-            echo "Failed to extract branch information"
-            exit 1
-          fi
-
-          echo "ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-          echo "name=$GITHUB_SHA" >> $GITHUB_OUTPUT
-
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v3
         with:
@@ -49,7 +36,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "${{ steps.extract-branch.outputs.ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -117,7 +104,7 @@ jobs:
         with:
           # Channel is for #workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests ${{ job.status }} ${{ needs.create-bee-workflow.outputs.custom-version-json }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "Azure E2E Tests ${{ inputs.branch }} ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -37,7 +37,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch || github.head_ref }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -56,8 +56,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    outputs:
-      custom-version-json: ${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}
     steps:
       - name: Echo Rawls version
         run: |
@@ -78,7 +76,7 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
-        test-group: [ # TODO: share with rawls-build-tag-publish-and-run-tests but allow passing the test-group?
+        test-group: [
           { group_name: workspaces_azure, tag: "-n org.broadinstitute.dsde.test.api.WorkspacesAzureTest" }
         ] # Rawls test groups
     runs-on: ubuntu-latest
@@ -103,12 +101,11 @@ jobs:
         if: always()
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          # Channel is for #workspaces-test-alerts
+          # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests ${{ inputs.branch }} ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          slack-message: "Azure E2E Tests ${{ inputs.branch || github.head_ref }} ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-
 
   destroy-bee-workflow:
     strategy:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -1,4 +1,4 @@
-name: rawls-build-tag-publish-and-run-tests
+name: rawls-run-azure-e2e-tests
 
 on:
   pull_request:
@@ -83,7 +83,7 @@ jobs:
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{ "bee-name": "${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-${{ matrix.terra-env }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
 
-  rawls-swat-test-job:
+  rawls-swat-e2e-test-job:
     strategy:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
@@ -114,7 +114,7 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
-    needs: [rawls-swat-test-job]
+    needs: [rawls-swat-e2e-test-job]
     if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -35,24 +35,24 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
   implicit val token: AuthToken = ownerAuthToken
 
   "Rawls" should "allow creation and deletion of azure workspaces" in {
-    // assert(true)
-    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
-      val workspaceName = generateWorkspaceName()
-      Rawls.workspaces.create(
-        projectName,
-        workspaceName,
-        Set.empty,
-        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
-      )
-
-      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
-      response.workspace.name should be(workspaceName)
-      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
-      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
-
-      Rawls.workspaces.delete(projectName, workspaceName)
-      assertNoAccessToWorkspace(projectName, workspaceName)
-    }
+    assert(true)
+//    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
+//      val workspaceName = generateWorkspaceName()
+//      Rawls.workspaces.create(
+//        projectName,
+//        workspaceName,
+//        Set.empty,
+//        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
+//      )
+//
+//      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
+//      response.workspace.name should be(workspaceName)
+//      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
+//      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
+//
+//      Rawls.workspaces.delete(projectName, workspaceName)
+//      assertNoAccessToWorkspace(projectName, workspaceName)
+//    }
   }
 
   private def generateWorkspaceName(): String = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -35,24 +35,24 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
   implicit val token: AuthToken = ownerAuthToken
 
   "Rawls" should "allow creation and deletion of azure workspaces" in {
-    assert(true)
-//    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
-//      val workspaceName = generateWorkspaceName()
-//      Rawls.workspaces.create(
-//        projectName,
-//        workspaceName,
-//        Set.empty,
-//        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
-//      )
-//
-//      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
-//      response.workspace.name should be(workspaceName)
-//      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
-//      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
-//
-//      Rawls.workspaces.delete(projectName, workspaceName)
-//      assertNoAccessToWorkspace(projectName, workspaceName)
-//    }
+    // assert(true)
+    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
+      val workspaceName = generateWorkspaceName()
+      Rawls.workspaces.create(
+        projectName,
+        workspaceName,
+        Set.empty,
+        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
+      )
+
+      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
+      response.workspace.name should be(workspaceName)
+      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
+      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
+
+      Rawls.workspaces.delete(projectName, workspaceName)
+      assertNoAccessToWorkspace(projectName, workspaceName)
+    }
   }
 
   private def generateWorkspaceName(): String = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.test.api
 
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, WorkspaceCloudPlatform, WorkspaceResponse, WorkspaceType}
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AzureManagedAppCoordinates, WorkspaceCloudPlatform, WorkspaceResponse, WorkspaceType}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryAzureBillingProject

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -25,36 +25,34 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
     owner.makeAuthToken()
   }
 
-//  private val azureManagedAppCoordinates = AzureManagedAppCoordinates(
-//    UUID.fromString("fad90753-2022-4456-9b0a-c7e5b934e408"),
-//    UUID.fromString("f557c728-871d-408c-a28b-eb6b2141a087"),
-//    "staticTestingMrg",
-//    Some(UUID.fromString("f41c1a97-179b-4a18-9615-5214d79ba600"))
-//  )
+  private val azureManagedAppCoordinates = AzureManagedAppCoordinates(
+    UUID.fromString("fad90753-2022-4456-9b0a-c7e5b934e408"),
+    UUID.fromString("f557c728-871d-408c-a28b-eb6b2141a087"),
+    "staticTestingMrg",
+    Some(UUID.fromString("f41c1a97-179b-4a18-9615-5214d79ba600"))
+  )
 
   implicit val token: AuthToken = ownerAuthToken
 
   "Rawls" should "allow creation and deletion of azure workspaces" in {
-    assert(true)
-//    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
-//      val workspaceName = generateWorkspaceName()
-//      Rawls.workspaces.create(
-//        projectName,
-//        workspaceName,
-//        Set.empty,
-//        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
-//      )
-//
-//      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
-//      response.workspace.name should be(workspaceName)
-//      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
-//      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
-//
-//      Rawls.workspaces.delete(projectName, workspaceName)
-//      assertNoAccessToWorkspace(projectName, workspaceName)
-//    }
-  }
+    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
+      val workspaceName = generateWorkspaceName()
+      Rawls.workspaces.create(
+        projectName,
+        workspaceName,
+        Set.empty,
+        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
+      )
 
+      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
+      response.workspace.name should be(workspaceName)
+      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
+      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
+
+      Rawls.workspaces.delete(projectName, workspaceName)
+      assertNoAccessToWorkspace(projectName, workspaceName)
+    }
+  }
 
   private def generateWorkspaceName(): String = {
     s"${UUID.randomUUID().toString()}-azure-test-workspace"
@@ -64,7 +62,6 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
     exception.message.parseJson.asJsObject.fields("statusCode").convertTo[Int] should be(statusCode)
   }
 
-
   private def assertNoAccessToWorkspace(projectName: String, workspaceName: String)(implicit token: AuthToken): Unit = {
     eventually {
       val exception = intercept[RestException](Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName)(token))
@@ -73,5 +70,4 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
   }
 
   private def workspaceResponse(response: String): WorkspaceResponse = response.parseJson.convertTo[WorkspaceResponse]
-
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -35,6 +35,7 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
   implicit val token: AuthToken = ownerAuthToken
 
   "Rawls" should "allow creation and deletion of azure workspaces" in {
+    logger.info("Executing test case")
     withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
       val workspaceName = generateWorkspaceName()
       Rawls.workspaces.create(
@@ -43,6 +44,7 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
         Set.empty,
         Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
       )
+      logger.info(s"Created workspace $workspaceName")
 
       val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
       response.workspace.name should be(workspaceName)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -35,25 +35,24 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
   implicit val token: AuthToken = ownerAuthToken
 
   "Rawls" should "allow creation and deletion of azure workspaces" in {
-    logger.info("Executing test case")
-    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
-      val workspaceName = generateWorkspaceName()
-      Rawls.workspaces.create(
-        projectName,
-        workspaceName,
-        Set.empty,
-        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
-      )
-      logger.info(s"Created workspace $workspaceName")
-
-      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
-      response.workspace.name should be(workspaceName)
-      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
-      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
-
-      Rawls.workspaces.delete(projectName, workspaceName)
-      assertNoAccessToWorkspace(projectName, workspaceName)
-    }
+    assert(true)
+//    withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
+//      val workspaceName = generateWorkspaceName()
+//      Rawls.workspaces.create(
+//        projectName,
+//        workspaceName,
+//        Set.empty,
+//        Map(AttributeName.withDefaultNS("disableAutomaticAppCreation") -> AttributeBoolean(true))
+//      )
+//
+//      val response = workspaceResponse(Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName))
+//      response.workspace.name should be(workspaceName)
+//      response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
+//      response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
+//
+//      Rawls.workspaces.delete(projectName, workspaceName)
+//      assertNoAccessToWorkspace(projectName, workspaceName)
+//    }
   }
 
   private def generateWorkspaceName(): String = {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-916

Notes:

1. Much of this workflow is taken from https://github.com/broadinstitute/rawls/blob/develop/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml. There are some modifications around the branch that is used for running the tests, and how the workflow is triggered; I also simplified the jobs somewhat based on the more limited assumptions for this workflow. I did attempt pulling out github actions that could be used by both workflows, but I found that it was not helpful-- the shared bits are mostly just calling other actions (so with documentation and inputs for the individual steps the total amount of code was actually quite a bit larger), and more importantly, I was seeing strange behavior with invocations of steps being mixed (as if they are stepping on each other). Ivan said he had seen this type of behavior in the past; given that the usefulness of the refactoring was already minimal, I decided to punt on it in favor of getting a reliable version of the workflow checked in that we can use to move forward with the e2e tests.

2. As I'm sure everyone saw, I have tested the [Slack channel notification](https://broadinstitute.slack.com/archives/C03F21QEWV7/p1683579559404869) quite a bit. :) In this version of the workflow, the notifications are disabled since we don't really wish to post to Slack as we are actively developing the tests.

3. Once the workflow is merged to `develop`, it will be possible to manually trigger it via https://github.com/broadinstitute/rawls/actions/workflows/rawls-run-azure-e2e-tests.yaml. Until then, it has to be triggered via the command line: `gh workflow run rawls-run-azure-e2e-tests.yaml --ref WOR-916 -f branch=WOR-916`

4. Example passing workflow: https://github.com/broadinstitute/rawls/actions/runs/4920072758

5. Example failing workflow (test not yet working properly): https://github.com/broadinstitute/rawls/actions/runs/4919859625

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
