### PR TITLE
AJ-429: attribute temp table should have same character set and collation as real tables

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -129,4 +129,5 @@
     <include file="changesets/20221116_add_user_email_workspace_manager_resource_monitor_record.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230109_rename_workspace_error_field.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230316_fastpass_grants.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230504_update_entity_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230504_update_entity_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230504_update_entity_attr_temp_table_procedure.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="update_entity_attr_temp_table">
+        <createProcedure replaceIfExists="true" procedureName="createEntityAttributeTempTable">
+            CREATE PROCEDURE createEntityAttributeTempTable ()
+            BEGIN
+            create temporary table ENTITY_ATTRIBUTE_TEMP (
+                id bigint(20) unsigned NOT NULL AUTO_INCREMENT primary key,
+                namespace text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+                name text CHARACTER SET utf8 COLLATE utf8_bin NOT NULL,
+                value_string text,
+                value_json longtext,
+                value_number double DEFAULT NULL,
+                value_boolean bit(1) DEFAULT NULL,
+                value_entity_ref bigint(20) unsigned DEFAULT NULL,
+                list_index int(11) DEFAULT NULL,
+                list_length int(11) DEFAULT NULL,
+                owner_id bigint(20) unsigned NOT NULL,
+                deleted bit(1) DEFAULT false,
+                deleted_date timestamp NULL DEFAULT NULL,
+                transaction_id CHAR(36) NOT NULL,
+                INDEX entity_tmp_owner_id_idx (owner_id)
+            );
+            END
+        </createProcedure>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-429

Found while investigating Rawls compatibility with MySQL 8.

The `ENTITY_ATTRIBUTE_TEMP` temp table, created by the `createEntityAttributeTempTable()` stored procedure, did not have the same `utf8_bin` collation for its namespace and name columns as the real tables.

This hasn't seemed to cause problems on MySQL 5.6, but it does cause one unit test to fail on MySQL 8: CaseSensitivitySpec's "should update all attributes correctly when batch updating entities".

Let's address the temp table now.





---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
