### PR TITLE
WOR-973: add logging of job status to resource monitor

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
@@ -46,6 +46,7 @@ class WorkspaceMonitorRouter(val config: WorkspaceManagerResourceMonitorConfig, 
 ) extends Actor
     with LazyLogging {
 
+  logger.info("WorkspaceResourceMonitor initialized: scheduling initial run")
   self ! CheckDone(0)
 
   override def receive: Receive = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
@@ -49,7 +49,10 @@ class WorkspaceMonitorRouter(val config: WorkspaceManagerResourceMonitorConfig, 
   self ! CheckDone(0)
 
   override def receive: Receive = {
-    case CheckNow => monitor.checkJobs().andThen(res => self ! res.getOrElse(CheckDone(0)))
+    // run the jobs, then send a message to itself containing the number of remaining uncompleted jobs, to reschedule
+    case CheckNow =>
+      logger.info("WorkspaceResourceMonitor run started")
+      monitor.checkJobs().andThen(res => self ! res.getOrElse(CheckDone(0)))
 
     // This monitor is always on and polling, and we want that default poll rate to be low, maybe once per minute.
     // if more jobs are active, we want to poll more frequently, say ~once per 5 seconds

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/WorkspaceResourceMonitor.scala
@@ -84,6 +84,7 @@ case class WorkspaceResourceMonitor(
     */
   def checkJobs(): Future[CheckDone] = for {
     jobs: Seq[WorkspaceManagerResourceMonitorRecord] <- jobDao.selectAll()
+    _ = logger.info(s"WorkspaceResourceMonitor running for ${jobs.size} jobs")
     jobResults <- Future.sequence(jobs.map(runJob))
   } yield {
     val complete = jobResults.count(_.isDone)


### PR DESCRIPTION
Ticket: [WOR-973](https://broadworkbench.atlassian.net/browse/WOR-973)

Adds logging around WSM resource monitor runs:

- Router initialization
- On receipt of message to run jobs in router (before the run itself starts)
- After jobs are retrieved from the db, before evaluating them
- Results of job status, post evaluation

This should cover all of the observed cases where we've had issues determining the status of the monitor.

The logging in the monitor itself can be seen with existing unit tests. Logging for the router requires starting the service.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-973]: https://broadworkbench.atlassian.net/browse/WOR-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ