### PR TITLE
AJ-1035: deploy standalone WDS as multi-user

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAO.scala
@@ -2,8 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.rawls.config.LeonardoConfig
 import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsV2Api
-import org.broadinstitute.dsde.workbench.client.leonardo.model.CreateAppRequest
-import org.broadinstitute.dsde.workbench.client.leonardo.model.AppType
+import org.broadinstitute.dsde.workbench.client.leonardo.model.{AppAccessScope, AppType, CreateAppRequest}
 
 import java.util.UUID
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient
@@ -37,6 +36,7 @@ class HttpLeonardoDAO(leonardoConfig: LeonardoConfig) extends LeonardoDAO {
     }
     val appTypeEnum = AppType.fromValue(appType)
     createAppRequest.setAppType(appTypeEnum)
+    createAppRequest.setAccessScope(AppAccessScope.WORKSPACE_SHARED)
 
     createAppRequest
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAOSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 import org.broadinstitute.dsde.rawls.config.LeonardoConfig
-import org.broadinstitute.dsde.workbench.client.leonardo.model.{AppType, CreateAppRequest}
+import org.broadinstitute.dsde.workbench.client.leonardo.model.{AppAccessScope, AppType, CreateAppRequest}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpecLike
 
@@ -57,6 +57,7 @@ class HttpLeonardoDAOSpec extends TestKit(ActorSystem("HttpLeonardoDAOSpec")) wi
     val expectedAppRequest: CreateAppRequest = new CreateAppRequest()
     expectedAppRequest.setAppType(AppType.CROMWELL)
     expectedAppRequest.setSourceWorkspaceId(sourceWorkspaceId.toString)
+    expectedAppRequest.setAccessScope(AppAccessScope.WORKSPACE_SHARED)
 
     assertResult(expectedAppRequest)(createAppRequest)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1035

Changes the WDS app to be multi-user. See Slack thread: https://broadinstitute.slack.com/archives/CA3NP1733/p1683301114575749?thread_ts=1683298960.921219&cid=CA3NP1733



---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
