### PR TITLE
AJ-1045: tracing tweaks: listWorkspaces, listSubmissions, and getSubmissionStatus

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -83,7 +83,8 @@ trait SubmissionApiService extends UserInfoDirectives {
             get {
               complete {
                 workspaceServiceConstructor(ctx).getSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                     submissionId, ctx
+                                                                     submissionId,
+                                                                     ctx
                 )
               }
             }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala
@@ -32,7 +32,7 @@ trait SubmissionApiService extends UserInfoDirectives {
       path("workspaces" / Segment / Segment / "submissions") { (workspaceNamespace, workspaceName) =>
         get {
           complete {
-            workspaceServiceConstructor(ctx).listSubmissions(WorkspaceName(workspaceNamespace, workspaceName))
+            workspaceServiceConstructor(ctx).listSubmissions(WorkspaceName(workspaceNamespace, workspaceName), ctx)
           }
         }
       } ~
@@ -83,7 +83,7 @@ trait SubmissionApiService extends UserInfoDirectives {
             get {
               complete {
                 workspaceServiceConstructor(ctx).getSubmissionStatus(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                     submissionId
+                                                                     submissionId, ctx
                 )
               }
             }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -988,6 +988,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
     s.foreach { span =>
       span.setStatus(Status.OK)
+      span.putAttribute("submissionStatsEnabled",
+                        OpenCensusAttributeValue.booleanAttributeValue(submissionStatsEnabled)
+      )
       span.end()
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2091,7 +2091,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
     }
 
-  def listSubmissions(workspaceName: WorkspaceName): Future[Seq[SubmissionListResponse]] = {
+  def listSubmissions(workspaceName: WorkspaceName,
+                      parentContext: RawlsRequestContext
+  ): Future[Seq[SubmissionListResponse]] = {
     val costlessSubmissionsFuture =
       getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
         dataSource.inTransaction { dataAccess =>
@@ -2113,15 +2115,17 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         case Success(costs) => costs
       }
 
-      costlessSubmissionsFuture map { costlessSubmissions =>
-        val costedSubmissions = costlessSubmissions map { costlessSubmission =>
-          // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
-          // val summedCost = costlessSubmission.workflowIds.map { workflowIds => workflowIds.flatMap(costMap.get).sum }
-          val summedCost = None
-          // Clearing workflowIds is a quick fix to prevent SubmissionListResponse from having too much data. Will address in the near future.
-          costlessSubmission.copy(cost = summedCost, workflowIds = None)
+      traceWithParent("costlessSubmissionsFuture", parentContext) { span =>
+        costlessSubmissionsFuture map { costlessSubmissions =>
+          val costedSubmissions = costlessSubmissions map { costlessSubmission =>
+            // TODO David An 2018-05-30: temporarily disabling cost calculations for submission list due to potential performance hit
+            // val summedCost = costlessSubmission.workflowIds.map { workflowIds => workflowIds.flatMap(costMap.get).sum }
+            val summedCost = None
+            // Clearing workflowIds is a quick fix to prevent SubmissionListResponse from having too much data. Will address in the near future.
+            costlessSubmission.copy(cost = summedCost, workflowIds = None)
+          }
+          costedSubmissions
         }
-        costedSubmissions
       }
     }
   }
@@ -2446,7 +2450,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
     }
 
-  def getSubmissionStatus(workspaceName: WorkspaceName, submissionId: String): Future[Submission] = {
+  def getSubmissionStatus(workspaceName: WorkspaceName,
+                          submissionId: String,
+                          parentContext: RawlsRequestContext
+  ): Future[Submission] = {
     val submissionWithoutCostsAndWorkspace =
       getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read) flatMap { workspaceContext =>
         dataSource.inTransaction { dataAccess =>
@@ -2456,32 +2463,34 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       }
 
-    submissionWithoutCostsAndWorkspace flatMap { case (submission, workspace) =>
-      val allWorkflowIds: Seq[String] = submission.workflows.flatMap(_.workflowId)
-      val submissionDoneDate: Option[DateTime] = WorkspaceService.getTerminalStatusDate(submission, None)
+    traceWithParent("submissionWithoutCostsAndWorkspace", parentContext) { span =>
+      submissionWithoutCostsAndWorkspace flatMap { case (submission, workspace) =>
+        val allWorkflowIds: Seq[String] = submission.workflows.flatMap(_.workflowId)
+        val submissionDoneDate: Option[DateTime] = WorkspaceService.getTerminalStatusDate(submission, None)
 
-      getSpendReportTableName(RawlsBillingProjectName(workspaceName.namespace)) flatMap { tableName =>
-        toFutureTry(
-          submissionCostService.getSubmissionCosts(submissionId,
-                                                   allWorkflowIds,
-                                                   workspace.googleProjectId,
-                                                   submission.submissionDate,
-                                                   submissionDoneDate,
-                                                   tableName
-          )
-        ) map {
-          case Failure(ex) =>
-            logger.error(s"Unable to get workflow costs for submission $submissionId", ex)
-            submission
-          case Success(costMap) =>
-            val costedWorkflows = submission.workflows.map { workflow =>
-              workflow.workflowId match {
-                case Some(wfId) => workflow.copy(cost = costMap.get(wfId))
-                case None       => workflow
+        getSpendReportTableName(RawlsBillingProjectName(workspaceName.namespace)) flatMap { tableName =>
+          toFutureTry(
+            submissionCostService.getSubmissionCosts(submissionId,
+                                                     allWorkflowIds,
+                                                     workspace.googleProjectId,
+                                                     submission.submissionDate,
+                                                     submissionDoneDate,
+                                                     tableName
+            )
+          ) map {
+            case Failure(ex) =>
+              logger.error(s"Unable to get workflow costs for submission $submissionId", ex)
+              submission
+            case Success(costMap) =>
+              val costedWorkflows = submission.workflows.map { workflow =>
+                workflow.workflowId match {
+                  case Some(wfId) => workflow.copy(cost = costMap.get(wfId))
+                  case None       => workflow
+                }
               }
-            }
-            val costedSubmission = submission.copy(cost = Some(costMap.values.sum), workflows = costedWorkflows)
-            costedSubmission
+              val costedSubmission = submission.copy(cost = Some(costMap.values.sum), workflows = costedWorkflows)
+              costedSubmission
+          }
         }
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -585,7 +585,7 @@ class SubmissionSpec(_system: ActorSystem)
                                     submissionId: String,
                                     workspaceName: WorkspaceName = testData.wsName
   ): Submission = {
-    val submissionStatusRqComplete = workspaceService.getSubmissionStatus(workspaceName, submissionId)
+    val submissionStatusRqComplete = workspaceService.getSubmissionStatus(workspaceName, submissionId, testContext)
 
     Await.result(submissionStatusRqComplete, Duration.Inf) match {
       case submissionData: Any =>
@@ -1011,8 +1011,9 @@ class SubmissionSpec(_system: ActorSystem)
         Await.result(workspaceService.createSubmission(testData.wsName, submissionRq), Duration.Inf)
 
       val submissionStatusResponse =
-        Await.result(workspaceService.getSubmissionStatus(testData.wsName, newSubmissionReport.submissionId),
-                     Duration.Inf
+        Await.result(
+          workspaceService.getSubmissionStatus(testData.wsName, newSubmissionReport.submissionId, testContext),
+          Duration.Inf
         )
 
       // Only the workflow with the dodgy expression (sample.tumortype on a normal) should fail
@@ -1041,7 +1042,7 @@ class SubmissionSpec(_system: ActorSystem)
     val submissionData = checkSubmissionStatus(workspaceService, newSubmissionReport.submissionId)
     assert(submissionData.workflows.size == 1)
 
-    val subList = Await.result(workspaceService.listSubmissions(testData.wsName), Duration.Inf)
+    val subList = Await.result(workspaceService.listSubmissions(testData.wsName, testContext), Duration.Inf)
 
     val oneSub = subList.filter(s => s.submissionId == newSubmissionReport.submissionId)
     assert(oneSub.nonEmpty)
@@ -1594,7 +1595,9 @@ class SubmissionSpec(_system: ActorSystem)
     report.workflows should have size 2
     assert(report.submitter == "owner-access")
     val submission =
-      Await.result(workspaceService.getSubmissionStatus(subTestData.wsName, report.submissionId), Duration.Inf)
+      Await.result(workspaceService.getSubmissionStatus(subTestData.wsName, report.submissionId, testContext),
+                   Duration.Inf
+      )
     assert(submission.userComment.get.contains("retry of submission"))
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3267,7 +3267,8 @@ class WorkspaceServiceSpec
         Duration.Inf
       )
 
-      val firstSubmission = Await.result(services.workspaceService.listSubmissions(workspaceName), Duration.Inf).head
+      val firstSubmission =
+        Await.result(services.workspaceService.listSubmissions(workspaceName, testContext), Duration.Inf).head
 
       val result = Await.result(
         services.workspaceService.getSubmissionMethodConfiguration(workspaceName, firstSubmission.submissionId),


### PR DESCRIPTION
Ticket: AJ-1045

_Reviewer: I suggest ignoring whitespace in the diff_

The high level goal of AJ-1045 is to identify some traces we can use to monitor Rawls performance before/after upgrading MySQL 5.6 to 5.7 - make sure we haven't caused a performance regression.

In this PR:
1. add a `submissionStatsEnabled=0|1` label to the listWorkspaces trace
2. add consistently-named subspans to the `listSubmissions` and `getSubmissionStatus` traces

## listWorkspaces

Terra UI makes two separate calls to listWorkspaces from the "homepage" of /#workspaces. The first call gets the name and description of each workspace and is designed to be fast. The second call gets the Cromwell submission information for each workspace and is known to be slow; you can see this in the loading spinners on the homepage that eventually fill in with submission status. This PR adds a label to the listWorkspaces trace that indicates which "mode" the API is currently using; we can use the `submissionStatsEnabled=0|1` label to analyze performance of the API in either mode.

## listSubmissions and getSubmissionStatus

Previously, these were instrumented by the `traceRequest` directive surrounding all the submission API definitions, [here](https://github.com/broadinstitute/rawls/blob/82c271e3eaad89d5a367a99072676029642e16ca/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiService.scala#L29). However, that results in spans that include the workspace namespace/name; you'd end up with a trace named like "/api/workspaces/davidan-project1/da-case-01/submissions" … this makes it hard to analyze traces across multiple workspaces.

This PR adds consistently-named subspans to these APIs. The end result is it should be easy, after this PR, to query for all traces across all workspaces for the `listSubmissions` and `getSubmissionStatus` APIs.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
