### PR TITLE
Persist clone completion date for Azure (WOR-1023).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -261,8 +261,9 @@ trait WorkspaceComponent {
 
     /**
       * Creates or updates the provided Workspace.  First queries the database to see if a Workspace record already
-      * exists with the same workspaceId.  If yes, then the existing Workspace record will be updated, otherwise a new
-      * Workspace record will be created.
+      * exists with the same workspaceId.  If yes, then the existing Workspace record will be updated (NOTE: ONLY
+      * the attributes map and last modified date will be updated!!), otherwise a new Workspace record will be created.
+      *
       * @param workspace
       * @return The updated or created Workspace
       */
@@ -409,8 +410,8 @@ trait WorkspaceComponent {
       loadWorkspaces(workspaces)
     }
 
-    def updateCompletedCloneWorkspaceFileTransfer(workspaceId: UUID): WriteAction[Int] = {
-      val currentTime = new Timestamp(new Date().getTime)
+    def updateCompletedCloneWorkspaceFileTransfer(workspaceId: UUID, completedTime: Date): WriteAction[Int] = {
+      val currentTime = new Timestamp(completedTime.getTime)
       findByIdQuery(workspaceId).map(_.completedCloneWorkspaceFileTransfer).update(Option(currentTime))
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -410,9 +410,9 @@ trait WorkspaceComponent {
       loadWorkspaces(workspaces)
     }
 
-    def updateCompletedCloneWorkspaceFileTransfer(workspaceId: UUID, completedTime: Date): WriteAction[Int] = {
-      val currentTime = new Timestamp(completedTime.getTime)
-      findByIdQuery(workspaceId).map(_.completedCloneWorkspaceFileTransfer).update(Option(currentTime))
+    def updateCompletedCloneWorkspaceFileTransfer(workspaceId: UUID, completedDate: Date): WriteAction[Int] = {
+      val timestamp = new Timestamp(completedDate.getTime)
+      findByIdQuery(workspaceId).map(_.completedCloneWorkspaceFileTransfer).update(Option(timestamp))
     }
 
     def deleteAllWorkspaceErrorMessagesInBillingProject(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitor.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.CloneWorkspaceFileTransferMonitor.CheckAll
 
+import java.util.Date
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -112,7 +113,7 @@ class CloneWorkspaceFileTransferMonitorActor(val dataSource: SlickDataSource,
       for {
         _ <- dataAccess.cloneWorkspaceFileTransferQuery.delete(pendingCloneWorkspaceFileTransfer.destWorkspaceId)
         _ <- dataAccess.workspaceQuery.updateCompletedCloneWorkspaceFileTransfer(
-          pendingCloneWorkspaceFileTransfer.destWorkspaceId
+          pendingCloneWorkspaceFileTransfer.destWorkspaceId, new Date()
         )
       } yield ()
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -3,19 +3,19 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{
-  WorkspaceManagerResourceJobRunner,
-  WorkspaceManagerResourceMonitorRecord
-}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
   Complete,
   Incomplete,
   JobStatus,
   JobType
 }
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  WorkspaceManagerResourceJobRunner,
+  WorkspaceManagerResourceMonitorRecord
+}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.model.Workspace
 import org.joda.time.DateTime
 
 import java.util.UUID
@@ -107,12 +107,11 @@ class CloneWorkspaceContainerRunner(
 
   def cloneSuccess(wsId: UUID, finishTime: DateTime)(implicit
     executionContext: ExecutionContext
-  ): Future[Option[Workspace]] =
+  ): Future[Int] =
     getWorkspace(wsId).flatMap {
-      case Some(workspace) =>
-        val updatedWS = workspace.copy(completedCloneWorkspaceFileTransfer = Some(finishTime))
-        dataSource.inTransaction(_.workspaceQuery.createOrUpdate(updatedWS)).map(Option(_))
-      case None => Future.successful(None)
+      case Some(_) =>
+        dataSource.inTransaction(_.workspaceQuery.updateCompletedCloneWorkspaceFileTransfer(wsId, finishTime.toDate))
+      case None => Future.successful(0)
     }
 
   def cloneFail(wsId: UUID, message: String)(implicit executionContext: ExecutionContext): Future[Option[Workspace]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -105,6 +105,13 @@ class CloneWorkspaceContainerRunner(
       cloneFail(workspaceId, "Cloning workspace resource container failed").map(_ => Complete)
   }
 
+  /**
+    * If the workspace still exists, updates the clone completed time on the workspace. Otherwise does nothing.
+    *
+    * @param wsId the ID of the workspace
+    * @param finishTime the time cloning completed
+    * @return the number of records updated, wrapped in a Future
+    */
   def cloneSuccess(wsId: UUID, finishTime: DateTime)(implicit
     executionContext: ExecutionContext
   ): Future[Int] =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -92,7 +92,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     doAnswer { answer =>
       val specifiedTime = answer.getArgument(1).asInstanceOf[DateTime]
       specifiedTime shouldBe expectedTime
-      Future.successful(None)
+      Future.successful(0)
     }.when(runner)
       .cloneSuccess(ArgumentMatchers.eq(workspaceId), ArgumentMatchers.eq(expectedTime))(
         ArgumentMatchers.any[ExecutionContext]()
@@ -221,7 +221,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
 
   behavior of "handling the clone container report"
 
-  it should "set completedCloneWorkspaceFileTransfer on the workspace to the complete time in the report" in {
+  it should "calls cloneSuccess with the time from the job and updates the record to Complete" in {
     val runner = spy(
       new CloneWorkspaceContainerRunner(
         mock[SamDAO],
@@ -236,7 +236,7 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
     doAnswer { answer =>
       val specifiedTime = answer.getArgument(1).asInstanceOf[DateTime]
       specifiedTime shouldBe expectedTime
-      Future.successful(Some(workspace.copy(completedCloneWorkspaceFileTransfer = Some(expectedTime))))
+      Future.successful(1)
     }.when(runner)
       .cloneSuccess(ArgumentMatchers.eq(workspaceId), ArgumentMatchers.eq(expectedTime))(
         ArgumentMatchers.any[ExecutionContext]()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1023

We were calling a method that only updated the attributes (a map) on the workspace. 

After:
![image](https://github.com/broadinstitute/rawls/assets/484484/1989813c-30fe-48db-9e19-da90f8585869)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
