### PR TITLE
[WOR-801] Run Azure E2E tests twice daily with Janitor

### DIFF
--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -1,6 +1,9 @@
 name: rawls-run-azure-e2e-tests
 
 on:
+  schedule:
+    # run twice a day at 10:00 and 22:00 UTC every day of the week
+    - cron: "0 10/12 * * *"
   workflow_dispatch:
     inputs:
       branch:
@@ -73,7 +76,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "version-template": "dev", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "bee-template-name": "rawls-e2e-azure-tests", "version-template": "dev", "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}" }'
 
   rawls-swat-e2e-test-job:
     runs-on: ubuntu-latest
@@ -113,7 +116,7 @@ jobs:
   notify-slack-on-failure:
     runs-on: ubuntu-latest
     needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
-    if: false # silence during development ${{ failure() }} # Can use !cancelled() if always want to notify.
+    if: ${{ failure() }}
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0


### PR DESCRIPTION
Ticket: [WOR-801](https://broadworkbench.atlassian.net/browse/WOR-801)
* Use `rawls-e2e-azure-tests` [BEE template](https://beehive.dsp-devops.broadinstitute.org/environments/rawls-e2e-azure-tests/chart-releases) which has the Janitor enabled in WSM so that leaked cloud resources created by WSM will be cleaned up
* Run twice daily at 10:00 and 22:00 UTC (6 am and 6 pm during DST)
* Notify Slack on failure

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-801]: https://broadworkbench.atlassian.net/browse/WOR-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ