### PR TITLE
[WOR-522] Remove owner role from project-owner policy because it is now included in Sam role

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3277,7 +3277,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     val projectOwnerPolicy =
       SamWorkspacePolicyNames.projectOwner -> SamPolicy(Set(billingProjectOwnerPolicyEmail),
                                                         Set.empty,
-                                                        Set(SamWorkspaceRoles.owner, SamWorkspaceRoles.projectOwner)
+                                                        Set(SamWorkspaceRoles.projectOwner)
       )
     val ownerPolicyMembership: Set[WorkbenchEmail] = if (workspaceRequest.noWorkspaceOwner.getOrElse(false)) {
       Set.empty


### PR DESCRIPTION
This is a small part of [WOR-522](https://broadworkbench.atlassian.net/browse/WOR-522), building on top of this recently merged Sam PR: https://github.com/broadinstitute/sam/pull/1093.

Tested with local Rawls against dev Sam with the following steps:
1) Created GCP billing project that 2 owners and 1 user.
2) Created workspace as the user.
3) Verified I could access it as both of the project owners (and it showed that role on the workspace dashboard).
4) Verified that when logged in as the user, the project owners weren't shown as owners on the workspace and thus I could not delete them.
5) Verified that I could delete the workspace when logged in as project owner (and I could remove the user as an owner of the project).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-522]: https://broadworkbench.atlassian.net/browse/WOR-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ