### PR TITLE
[DDO-2885] Migrate local development config out of firecloud-develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,10 @@ And when you're done, spin down mysql (it is also fine to leave it running for y
 
 * [Docker Desktop](https://www.docker.com/products/docker-desktop) (4GB+, 8GB recommended)
 * Broad internal internet connection (or VPN, non-split recommended)
-* Render the local configuration files. From the root of the [firecloud-develop](https://github.com/broadinstitute/firecloud-develop) repo, run:
+* Render the local configuration files. From the root of the Rawls repo, run:
 ```sh
-sh run-context/local/scripts/firecloud-setup.sh
+./local-dev/bin/render
 ```
-Note: this script will offer to set up configuration for several other services as well. You can skip those if you only want to set up configuration for Rawls. If this is your first time running Rawls or rendering configuration files, you will want to run through the "Setup vault" step. You must also have a Ruby interpreter installed at `/usr/bin/ruby` for this script to work as expected.
-
 *  The `/etc/hosts` file on your machine must contain this entry (for calling Rawls endpoints):
 ```sh
 127.0.0.1	local.broadinstitute.org
@@ -111,7 +109,6 @@ If you are writing Liquibase migrations or doing database work, it is mandatory 
 ## Developer quick links:
 * Swagger UI: https://rawls.dsde-dev.broadinstitute.org
 * Jenkins: https://dsde-jenkins.broadinstitute.org/job/rawls-dev-build
-* Running locally in docker https://github.com/broadinstitute/firecloud-develop
 
 ## Build Rawls docker image
 
@@ -166,8 +163,7 @@ For integration test issues, see [automation/README.md](automation/README.md).
 
 ## Debugging in Intellij IDEA
 You can attach Intellij's interactive debugger to Rawls running locally in a 
-docker container configured via `run-context/local/scripts/firecloud-setup.sh` in 
-[firecloud-develop](https://github.com/broadinstitute/firecloud-develop/blob/dev/run-context/local/README.md).
+docker container run via the `./config/docker-rsync-local-rawls.sh` script.
 
 Add a "Remote JVM Debug" configuration that attaches to `localhost` on port `25050`.
 See the link below for more detailed steps.

--- a/local-dev/bin/render
+++ b/local-dev/bin/render
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+
+IMAGE_NAME="${IMAGE_NAME:-us-central1-docker.pkg.dev/dsp-artifact-registry/firecloud-develop-shim/firecloud-develop-shim}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
+
+VAULT_TOKEN=$( cat ~/.vault-token )
+
+docker run --pull always \
+  -e VAULT_TOKEN="${VAULT_TOKEN}" \
+  -v "${REPO_ROOT}:/code" \
+  --rm -it "${IMAGE}" \
+  --secrets /code/local-dev/secrets.yaml \
+  --templates /code/local-dev/templates \
+  --output-dir /code/config
+
+cat <<EOF
+
+Don't forget to add the local.broadinstitute.org alias to your hosts file!
+
+$ sudo sh -c "echo '127.0.0.1       local.broadinstitute.org' >> /etc/hosts"
+
+EOF

--- a/local-dev/secrets.yaml
+++ b/local-dev/secrets.yaml
@@ -1,0 +1,46 @@
+# an list of Vault secrets to be downloaded, in the form:
+#
+#
+# - path: "some/path"       # [required] Path in Vault to pull from
+#
+#   key: "some-key"         # [optional] Key in Vault to pull from; by
+#                           # default all KV pairs in the secret will be 
+#                           # copied as a JSON-formatted object
+#
+#   filename: "secret.txt"  # [optional] Name of the local file the
+#                           # secret is downloaded to; by default, the
+#                           # last component of the secret's path is used
+#
+#   encoding: "text"        # [optional] Encoding of the secret, either
+#                           # "text" or "base64". If base64, the content
+#                           # of the secret will be decoded. Requires 
+#                           # use of the `key` attribute.
+vault:
+  # Service account keys
+  # Rawls SA in 3 files/formats
+  - path: secret/dsde/firecloud/dev/rawls/rawls-account.json
+    file: rawls-account.json
+  - path: secret/dsde/firecloud/dev/rawls/rawls-account.json
+    file: sqlproxy-service-account.json
+  - path: secret/dsde/firecloud/dev/rawls/rawls-account.pem
+    key: key.pem
+    file: rawls-account.pem
+  # Billing SA
+  - path: secret/dsde/firecloud/dev/common/billing-account-yale.pem
+    key: key.pem
+    file: billing-account.pem
+  # BigQuery SA
+  - path: secret/dsde/firecloud/dev/common/bigquery-account.json
+    file: bigquery-account.json
+  # Buffer client SA
+  - path: secret/dsde/terra/kernel/dev/dev/buffer/client-sa
+    encoding: base64
+    key: key
+    file: buffer-account.json
+  # local.broadinstitute.org cert & key - used by Apache proxy
+  - path: secret/dsde/firecloud/local/common/server.key
+    key: value
+    file: server.key
+  - path: secret/dsde/firecloud/local/common/server.crt
+    key: value
+    file: server.crt

--- a/local-dev/templates/docker-rsync-local-rawls.sh
+++ b/local-dev/templates/docker-rsync-local-rawls.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+# v1.1.0 rmeffan@broad
+# v1.0 zarsky@broad
+
+# Run rawls locally. By default this will launch rawls as a front end instance accessing
+# the dev rawls database and dev sam. To run with a local database set the env var LOCAL_MYSQL
+# to 'true'. The local database is stored in a docker volume named local-rawls-mysqlstore.
+# Run `docker volume rm local-rawls-mysqlstore` to remove it and start fresh.
+# Set the env var BACK_RAWLS to 'true' to start a backend instance.
+# Set the env var LOCAL_SAM to 'true' if running a local instance of sam.
+
+#
+# Functions
+#
+
+clean_up () {
+    echo
+    echo "Cleaning up after myself..."
+    docker rm -f rawls-rsync-container rawls-proxy rawls-sbt sqlproxy rawls_mysql
+    docker network rm fc-rawls
+    pkill -P $$
+    [[ -f ./.docker-rsync-local.pid ]] && rm ./.docker-rsync-local.pid
+    [[ -f config/built-config.conf ]] && rm config/built-config.conf
+}
+
+make_config () {
+    echo "include \"rawls.conf\"" > config/built-config.conf
+
+    if [[ "$LOCAL_SAM" == 'true' ]]; then
+        echo "Using local sam ..."
+        echo "include \"local-sam.conf\"" >> config/built-config.conf
+    fi
+    if [[ "$LOCAL_MYSQL" == 'true' ]]; then
+        echo "Using local mysql ..."
+        echo "include \"local-mysql.conf\"" >> config/built-config.conf
+    fi
+}
+
+run_rsync ()  {
+    rsync --blocking-io -azl --delete -e "docker exec -i" . rawls-rsync-container:working \
+        --filter='+ /build.sbt' \
+        --filter='+ /config/***' \
+        --filter='- /core/target/***' \
+        --filter='+ /core/***' \
+        --filter='- /model/target/***' \
+        --filter='+ /model/***' \
+        --filter='- /metrics/target/***' \
+        --filter='+ /metrics/***' \
+        --filter='- /util/target/***' \
+        --filter='+ /util/***' \
+        --filter='- /google/target/***' \
+        --filter='+ /google/***' \
+        --filter='- /project/project/target/***' \
+        --filter='- /project/target/***' \
+        --filter='+ /project/***' \
+        --filter='+ /.git/***' \
+        --filter='- *'
+}
+
+start_server () {
+    docker network create fc-rawls
+
+    echo "Creating Google sqlproxy container..."
+    source ./config/sqlproxy.env
+    docker create --name sqlproxy \
+        --restart "always" \
+        --network="fc-rawls" \
+        gcr.io/cloudsql-docker/gce-proxy:1.30.0 /cloud_sql_proxy -credential_file=/etc/sqlproxy-service-account.json -instances=${GOOGLE_PROJECT}:${CLOUDSQL_ZONE}:${CLOUDSQL_INSTANCE}=tcp:0.0.0.0:3306
+
+    docker cp config/sqlproxy-service-account.json sqlproxy:/etc/sqlproxy-service-account.json
+
+    JAVA_OPTS='-Dconfig.file=/app/config/built-config.conf'
+
+    if [[ "$BACK_RAWLS" == 'true' ]]; then
+        echo "Booting rawls as BACK ..."
+        JAVA_OPTS+=' -DbackRawls=true'
+    else
+        echo "Booting rawls as FRONT ..."
+        JAVA_OPTS+=' -DbackRawls=false'
+    fi
+
+    # Get the last commit hash and set it as an environment variable
+    GIT_HASH=$(git log -n 1 --pretty=format:%h)
+
+    echo "Creating SBT docker container..."
+    docker create -it --name rawls-sbt \
+    -v ~/.m2:/root/.m2 \
+    -v rawls-shared-source:/app -w /app \
+    -v sbt-cache:/root/.sbt \
+    -v jar-cache:/root/.ivy2 \
+    -v coursier-cache:/root/.cache/coursier \
+    -p 25050:5050 \
+    --network=fc-rawls \
+    -e HOSTNAME=$HOSTNAME \
+    -e JAVA_OPTS="$JAVA_OPTS" \
+    -e GOOGLE_APPLICATION_CREDENTIALS='/etc/rawls-account.json' \
+    -e GIT_HASH=$GIT_HASH \
+    hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 \
+    sbt clean \~reStart
+
+    docker cp config/rawls-account.pem rawls-sbt:/etc/rawls-account.pem
+    docker cp config/rawls-account.json rawls-sbt:/etc/rawls-account.json
+    docker cp config/billing-account.pem rawls-sbt:/etc/billing-account.pem
+    docker cp config/buffer-account.json rawls-sbt:/etc/buffer-account.json
+    docker cp config/bigquery-account.json rawls-sbt:/etc/bigquery-account.json
+
+    if [[ "$LOCAL_MYSQL" == 'true' ]]; then
+        echo "Creating mysql..."
+	    docker run --network=fc-rawls --name rawls_mysql -e MYSQL_ROOT_HOST='%' -e MYSQL_ROOT_PASSWORD=rawls-test -e MYSQL_USER=rawls-test -e MYSQL_PASSWORD=rawls-test -e MYSQL_DATABASE=rawls -v local-rawls-mysqlstore:/var/lib/mysql -d mysql/mysql-server:5.7 --character-set-server=utf8
+
+        sleep 5
+    fi
+
+    echo "Creating proxy..."
+    docker create --name rawls-proxy \
+    --restart "always" \
+    --network=fc-rawls \
+    -p 20080:80 -p 20443:443 \
+    -e APACHE_HTTPD_TIMEOUT='650' \
+    -e APACHE_HTTPD_KEEPALIVE='On' \
+    -e APACHE_HTTPD_KEEPALIVETIMEOUT='650' \
+    -e APACHE_HTTPD_MAXKEEPALIVEREQUESTS='500' \
+    -e APACHE_HTTPD_PROXYTIMEOUT='650' \
+    -e PROXY_TIMEOUT='650' \
+    -e PROXY_URL='http://rawls-sbt:8080/' \
+    -e PROXY_URL2='http://rawls-sbt:8080/api' \
+    -e PROXY_URL3='http://rawls-sbt:8080/register' \
+    -e CALLBACK_URI='https://local.broadinstitute.org/oauth2callback' \
+    -e LOG_LEVEL='debug' \
+    -e SERVER_NAME='local.broadinstitute.org' \
+    -e APACHE_HTTPD_TIMEOUT='650' \
+    -e APACHE_HTTPD_KEEPALIVE='On' \
+    -e APACHE_HTTPD_KEEPALIVETIMEOUT='650' \
+    -e APACHE_HTTPD_MAXKEEPALIVEREQUESTS='500' \
+    -e APACHE_HTTPD_PROXYTIMEOUT='650' \
+    -e PROXY_TIMEOUT='650' \
+    -e REMOTE_USER_CLAIM='sub' \
+    -e ENABLE_STACKDRIVER='yes' \
+    -e FILTER2='AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript' \
+    us.gcr.io/broad-dsp-gcr-public/httpd-terra-proxy:v0.1.16
+
+    docker cp config/server.crt rawls-proxy:/etc/ssl/certs/server.crt
+    docker cp config/server.key rawls-proxy:/etc/ssl/private/server.key
+    docker cp config/ca-bundle.crt rawls-proxy:/etc/ssl/certs/server-ca-bundle.crt
+    docker cp config/oauth2.conf rawls-proxy:/etc/httpd/conf.d/oauth2.conf
+    docker cp config/site.conf rawls-proxy:/etc/httpd/conf.d/site.conf
+
+    echo "Starting sqlproxy..."
+    docker start sqlproxy
+    echo "Starting proxy..."
+    docker start rawls-proxy
+    echo "Starting SBT..."
+    docker start -ai rawls-sbt
+}
+
+#
+# Main
+#
+
+# Step 0 - Prereq Check
+hash fswatch 2>/dev/null || {
+    echo >&2 "This script requires fswatch (https://github.com/emcrisostomo/fswatch), but it's not installed. On Darwin, just \"brew install fswatch\".  Aborting."; exit 1;
+}
+
+# Step 1 - Clean up remains of previous incomplete runs
+if [ -a ./.docker-rsync-local.pid ]; then
+    echo "Looks like clean-up wasn't completed, doing it now..."
+    docker rm -f rawls-rsync-container rawls-proxy rawls-sbt
+    docker network rm fc-rawls
+    pkill -P $(< "./.docker-rsync-local.pid")
+    rm ./.docker-rsync-local.pid
+    rm config/built-config.conf
+fi
+
+# Step 2 - Initialization
+
+#Configure a trap to enable proper cleanup if script exits prematurely.
+trap clean_up EXIT HUP INT QUIT PIPE TERM 0 20
+
+#ensure git secrets hooks in place
+cp -r ./hooks/ ./.git/hooks/
+chmod 755 ./.git/hooks/apply-git-secrets.sh
+
+echo "Creating shared volumes if they don't exist..."
+docker volume create --name rawls-shared-source
+docker volume create --name sbt-cache
+docker volume create --name jar-cache
+docker volume create --name coursier-cache
+
+# Step 3 - Generate configuration and start rsync container
+echo "Building config..."
+make_config
+
+echo "Launching rsync container..."
+docker run -d \
+    --name rawls-rsync-container \
+    -v rawls-shared-source:/working \
+    -e DAEMON=docker \
+    tjamet/rsync
+
+# Step 4 - Perform the rsync
+echo "Performing initial file sync..."
+run_rsync
+fswatch -o . | while read f; do run_rsync; done &
+echo $$ > ./.docker-rsync-local.pid
+
+# Step 5 - Start
+start_server

--- a/local-dev/templates/liquibase.properties
+++ b/local-dev/templates/liquibase.properties
@@ -1,0 +1,8 @@
+# From rawls.conf#liquibase.changelog
+changeLogFile: org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+# From rawls.conf#slick.db.driver
+driver: com.mysql.jdbc.Driver
+# From rawls.conf#slick.db.url
+url: jdbc:mysql://127.0.0.1:3306/rawls?requireSSL=false&useSSL=false&rewriteBatchedStatements=true
+# From rawls.conf#gcs.appsDomain, per Boot.scala
+parameter.gcs\:appsDomain: dev.test.firecloud.org

--- a/local-dev/templates/local-mysql.conf
+++ b/local-dev/templates/local-mysql.conf
@@ -1,0 +1,14 @@
+slick {
+  db {
+    # Changes to slick.db.url value must also be reflected in liquibase.properties
+    url = "jdbc:mysql://rawls_mysql:3306/rawls?requireSSL=false&useSSL=false&rewriteBatchedStatements=true"
+    # Changes to slick.db.driver value must also be reflected in liquibase.properties
+    user = rawls-test
+    password = rawls-test
+    numThreads = 5
+  }
+}
+
+liquibase {
+  initWithLiquibase = true
+}

--- a/local-dev/templates/local-sam.conf
+++ b/local-dev/templates/local-sam.conf
@@ -1,0 +1,3 @@
+sam {
+  server = "https://local.broadinstitute.org:50443"
+}

--- a/local-dev/templates/mod_security_ignore.conf
+++ b/local-dev/templates/mod_security_ignore.conf
@@ -1,0 +1,3 @@
+SecRule REQUEST_URI "@contains importEntities" phase:1,id:'1000000001',nolog,allow,ctl:ruleEngine=Off,ctl:auditEngine=Off
+SecRule REQUEST_URI "@contains batchUpsert" phase:1,id:'1000000002',nolog,allow,ctl:ruleEngine=Off,ctl:auditEngine=Off
+SecRule REQUEST_URI "@contains loading..." phase:1,id:'1000000003',nolog,allow,ctl:ruleEngine=Off,ctl:auditEngine=Off

--- a/local-dev/templates/oauth2.conf
+++ b/local-dev/templates/oauth2.conf
@@ -1,0 +1,7 @@
+OAuth2Cache shm max_val_size=16384
+OAuth2TokenVerify metadata https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin_dev metadata.ssl_verify=true&verify.exp=required&verify.iat=skip
+OAuth2TokenVerify metadata https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin_billing_dev metadata.ssl_verify=true&verify.exp=required&verify.iat=skip
+OAuth2TokenVerify metadata https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin_tdr_dev metadata.ssl_verify=true&verify.exp=required&verify.iat=skip
+OAuth2TokenVerify metadata https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration metadata.ssl_verify=true&verify.exp=required&verify.iat=skip
+OAuth2TokenVerify metadata https://accounts.google.com/.well-known/openid-configuration metadata.ssl_verify=true&verify.exp=required&verify.iat=skip
+OAuth2TokenVerify introspect https://127.0.0.1/introspect/ introspect.ssl_verify=false&verify.exp=required&verify.iat=skip

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -1,0 +1,460 @@
+{{- $appsDomain := "test.firecloud.org" -}}
+{{- $appsSubDomain := printf "dev.%s" $appsDomain -}}
+{{- $orgId := "400176686919" -}}
+{{- $b2cEnv := "dev" -}}
+{{- $b2cTenant := "dev" -}}
+
+{{- $rawlsOauthCredential := (secret "secret/dsde/firecloud/dev/rawls/rawls-oauth-credential.json").Data }}
+{{- $rawlsConf := (secret "secret/dsde/firecloud/dev/rawls/rawls.conf").Data -}}
+{{- $refreshTokenCredential := (secret "secret/dsde/firecloud/dev/common/refresh-token-oauth-credential.json").Data -}}
+{{- $rawlsSaKey := (secret "secret/dsde/firecloud/dev/rawls/rawls-account.json").Data -}}
+{{- $cromwellSaKey := (secret "secret/dsde/firecloud/dev/cromwell/cromwell-account.json").Data -}}
+{{- $staticPerimeterProjects := (secret "secret/dsde/firecloud/dev/rawls/service-perimeters/static-projects").Data -}}
+{{- $b2cAppId := (secret "secret/dsde/terra/azure/dev/b2c/application_id" ).Data.value -}}
+{{- $landingZonePostgres := (secret "secret/dsde/terra/azure/dev/workspacemanager/azure-postgres-credential" ).Data -}}
+
+backRawls = true
+
+gcs {
+  deletedBucketCheckSeconds = "21600"
+  adminRegisterBillingAccountId = "billingAccounts/{{ (secret "secret/dsde/firecloud/local/rawls/gcs/admin-billing-account-id").Data.id }}"
+  appName = "firecloud:rawls"
+  # Changes to gcs.appsDomain value must also be reflected in liquibase.properties
+  appsDomain = "{{ $appsSubDomain }}"
+  groupsPrefix = "fc"
+  pathToPem = "/etc/rawls-account.pem"
+  pathToCredentialJson = "/etc/rawls-account.json"
+  secrets = """{{ $rawlsOauthCredential | toJSON }}"""
+  serviceClientEmail = "{{ $rawlsSaKey.client_email }}"
+  serviceProject = "broad-dsde-dev"
+  subEmail = "google@{{ $appsSubDomain }}"
+  tokenEncryptionKey = "{{ $rawlsConf.gcs_tokenEncryptionKey }}"
+  tokenSecretsJson = """{{ $refreshTokenCredential | toJSON }}"""
+  pathToBillingPem = "/etc/billing-account.pem"
+  billingPemEmail = "billing@broad-dsde-dev.iam.gserviceaccount.com"
+  billingEmail = "billing@{{ $appsDomain }}"
+  billingGroupEmail = "terra-billing@{{ $appsDomain }}"
+  billingGroupEmailAliases = ["terra-billing@{{ $appsDomain }}"]
+  pathToBigQueryJson = "/etc/bigquery-account.json"
+  billingExportTableName = "broad-gcp-billing.gcp_billing_export_views.gcp_billing_export_v1_001AC2_2B914D_822931"
+  billingExportTimePartitionColumn = "partition_time"
+  billingExportDatePartitionColumn = "partition_date"
+  billingSearchWindowDays = 31
+  pathToResourceBufferJson = "/etc/buffer-account.json"
+
+  deploymentManager {
+    # NOTE: You may set this to either a GCP project/deployment_name, or a URL reference to a template.
+    # We typically use GitHub here. In this case, make sure of two things:
+	#    1. The URL you put here is the raw text version of the template, not GitHub's HTML preview of the page. You'll know it's right if the URL starts "https://raw.githubusercontent.com". Rawls sanity checks this and will fail to start up if you get it wrong.
+	#    2. Don't refer to the file via a GitHub branch. This URL will point to the most recent version of the file on that branch, which means the template could change underneath you. This is really bad because it means we can't track which template we used to create any given project. Instead, refer to it through a specific commit, which is immutable. The only exception to this is if you're running on a FiaB and developing the DM template, in which case doing this deliberately will spare you repeatedly changing the Rawls config and redeploying for new versions. To combat getting this wrong, Rawls checks for "master" and "develop" branches in the URL and will fail to start up if they're present.
+
+    templatePath = "https://raw.githubusercontent.com/broadinstitute/gcp-dm-templates/6a5d404906ccb2a0f97a8b7631f4935ef8f224bf/firecloud_project.py"
+
+    projectID = "terra-deployments-dev"
+    billingProbeEmail = "billingprobe@terra-deployments-dev.iam.gserviceaccount.com"
+
+    orgID = {{ $orgId }}
+
+    #If you're working on DM and want to keep the deployments around for inspection after they're done, set this to false.
+    #Don't set it to false in prod, ever, as there is a 1000 deployment limit and we'll hit it real quick without cleanup.
+    cleanupDeploymentAfterCreating = true
+  }
+
+  projectTemplate {
+    # note that all members of owners must be in the same domain as billingEmail, this includes any group members
+    owners = ["group:firecloud-project-owners@{{ $appsDomain }}"]
+    editors = ["serviceAccount:{{ $rawlsSaKey.client_email }}", "serviceAccount:{{ $cromwellSaKey.client_email }}"]
+    ownerGrantableRoles = ["bigquery.jobUser"]
+  }
+
+  groupMonitor {
+   pollInterval = 45s
+   pollIntervalJitter = 15s
+   topicName = rawls-groups-to-sync-local
+   subscriptionName = rawls-groups-to-sync-local-sub
+   workerCount = 10
+   samTopicName = sam-group-sync-local
+  }
+
+  notifications.topicName=workbench-notifications-local
+
+  # custom iam roles
+  requesterPaysRole=organizations/{{ $orgId }}/roles/RequesterPays
+  terraBucketReaderRole=organizations/{{ $orgId }}/roles/terraBucketReader
+  terraBucketWriterRole=organizations/{{ $orgId }}/roles/terraBucketWriter
+  terraBillingProjectOwnerRole=organizations/{{ $orgId }}/roles/terra_billing_project_owner
+  terraWorkspaceCanComputeRole=organizations/{{ $orgId }}/roles/terra_workspace_can_compute
+  terraWorkspaceNextflowRole=organizations/{{ $orgId }}/roles/terra_workspace_nextflow_role
+
+  servicePerimeters {
+    staticProjects = {{$staticPerimeterProjects | toJSON}}
+    pollInterval = 1s
+    pollTimeout = 50s
+  }
+
+  spendReporting {
+    maxDateRange = 90
+  }
+}
+
+agora {
+  server = "https://agora.dsde-dev.broadinstitute.org:443"
+  path = "/api/v1"
+}
+
+dockstore {
+  server = "https://staging.dockstore.org/api"
+  path = "/api"
+}
+
+sam {
+  server = "https://sam.dsde-dev.broadinstitute.org:443"
+}
+
+bond {
+  baseUrl = "https://broad-bond-dev.appspot.com"
+}
+
+martha {
+  baseUrl = "https://us-central1-broad-dsde-dev.cloudfunctions.net"
+}
+
+drs {
+    martha {
+      baseUrl = "https://us-central1-broad-dsde-dev.cloudfunctions.net"
+    }
+    drshub {
+      baseUrl = "https://drshub.dsde-dev.broadinstitute.org"
+    }
+    resolver = "drshub"
+}
+
+billingProfileManager {
+  baseUrl = "https://bpm.dsde-dev.broadinstitute.org"
+}
+
+workspaceManager {
+  baseUrl = "https://workspace.dsde-dev.broadinstitute.org"
+}
+
+dataRepo {
+  terraInstance = "https://jade.datarepo-dev.broadinstitute.org"
+  terraInstanceName = "terra"
+}
+
+resourceBuffer {
+  projectPool {
+    regular = "cwb_ws_dev_v6"
+    exfiltrationControlled = "vpc_sc_v10"
+  }
+  url = "https://buffer.dsde-dev.broadinstitute.org"
+  saEmail = "buffer-dev@broad-dsde-dev.iam.gserviceaccount.com"
+}
+
+executionservice {
+  readServers = { "cromwell1": "https://cromiam-priv.dsde-dev.broadinstitute.org:443" }
+      submitServers = { "cromwell1": "https://cromiam-priv.dsde-dev.broadinstitute.org:443" }
+      abortServers = { "cromwell1": "https://cromiam-priv.dsde-dev.broadinstitute.org:443" }
+  defaultRuntimeOptions = { "zones": "us-central1-a us-central1-b us-central1-c us-central1-f" }
+  workflowSubmissionTimeout = "5m"
+  # each batch contains workflow(s) from exactly one submission and has a fixed number of HTTP calls to Agora, Sam
+  # BW-683/1169: tweak batch size to increase submission rate while hopefully staying below max-HTTP-packet size.
+  batchSize = 20
+  processInterval = 10ms   # idle time between checking for workflows
+  pollInterval = 10s       # BW-683: decreased poll interval to increase submission rate
+  parallelSubmitters = 10
+
+  # The value of Cromwell's `max-concurrent-workflows` (currently 12500) times the number of runners (currently 6)
+  # "server" in this context means a logical Cromwell, e.g. `cromwell1`, not a specific runner
+  maxActiveWorkflowsPerServer = 75000
+
+  # Number of users that could together occupy all the workflow slots
+  # Rawls submits fast enough (~100 workflows per second) that users max out slots in <3 minutes, not a factor. [WM-683]
+  # Cromwell starts new workflows from whichever group has the fewest workflows already running, so the algorithm
+  # trends towards an equilibrium where all groups are running the same number of workflows. [WM-568]
+  # However, last time we tried increasing this we saw a maybe-associated call caching storm during a large submission (10/19/22-10/20/22)
+  # 75,000 ÷ 25 = 3,000
+  activeWorkflowHogFactor = 25
+
+  # True if the workflow collection should be passed to Cromwell as a field.
+  useWorkflowCollectionField = false
+  # True if the workflow collection should be passed to Cromwell as a label.
+  useWorkflowCollectionLabel = true
+
+  defaultNetworkBackend = "PAPIv2-beta"
+  highSecurityNetworkBackend = "PAPIv2-CloudNAT"
+
+  cromiamUrl = "https://cromiam-priv.dsde-dev.broadinstitute.org"
+}
+avroUpsertMonitor {
+  pubSubProject = "broad-dsde-dev"
+
+  server = "https://terra-importservice-dev.appspot.com"
+  bucketName = "import-service-batchupsert-dev"
+
+  importRequestPubSubTopic = "rawls-async-import-topic-local"
+  importRequestPubSubSubscription = "rawls-async-import-topic-sub-local"
+  updateImportStatusPubSubProject = "terra-importservice-dev"
+  updateImportStatusPubSubTopic = "import-service-notify-local"
+
+  batchSize = 1000
+  ackDeadlineSeconds = 600
+  pollInterval = 1m
+  pollJitter = 10s
+  # This worker count is 1 because any more would create a race condition in the avroUpsertMonitor
+  workerCount = 1
+}
+
+
+userLdap {
+  providerUrl = "ldaps://opendj.dsde-dev.broadinstitute.org"
+  user = "cn=Directory Manager"
+  password = "changeme"
+  groupDn = "cn=enabled-users,ou=groups,dc=dsde-dev,dc=broadinstitute,dc=org"
+  memberAttribute = "member"
+  userObjectClasses = ["inetOrgPerson", "organizationalPerson", "person", "top"]
+  userAttributes = ["uid", "sn", "cn"]
+  userDnFormat =  "uid=%s,ou=people,dc=dsde-dev,dc=broadinstitute,dc=org"
+}
+
+slick {
+  driver = "slick.driver.MySQLDriver$"
+  # batchSize is used for writes, to group inserts/updates
+  # this must be explicitly utilized via custom business logic
+  batchSize = 2000
+  # fetchSize is used during Slick streaming to set the size of pages
+  # this must be explicitly set via withStatementParameters
+  fetchSize = 5000
+  db {
+    # Changes to slick.db.url value must also be reflected in liquibase.properties
+    url = "jdbc:mysql://sqlproxy:3306/rawls?requireSSL=false&useSSL=false&rewriteBatchedStatements=true&useCursorFetch=true"
+    # Changes to slick.db.driver value must also be reflected in liquibase.properties
+    driver = com.mysql.jdbc.Driver
+    user = "{{ $rawlsConf.slick_db_user }}"
+    password = "{{ $rawlsConf.slick_db_password }}"
+    connectionTimeout = 5000
+    numThreads = 200
+    leakDetectionThreshold = 120000
+  }
+}
+
+liquibase {
+  # Changes to liquibase.changelog value must also be reflected in liquibase.properties
+  changelog = "org/broadinstitute/dsde/rawls/liquibase/changelog.xml"
+  initWithLiquibase = false
+}
+
+akka {
+  loglevel = INFO
+  logger-startup-timeout = 20s
+
+  http {
+    server {
+      idle-timeout = 210 s
+      request-timeout=180 s
+      parsing {
+        # allow parsing of larger responses from cromwell (and others). Description from Akka doc:
+        # "Note that it is not necessarily a problem to set this to a high value as all stream operations
+        # are always properly backpressured.
+        # Nevertheless you might want to apply some limit in order to prevent a single client from consuming
+        # an excessive amount of server resources."
+        max-content-length = 200m
+      }
+    }
+    host-connection-pool {
+      max-open-requests = 16384
+      max-connections = 2000
+      response-entity-subscription-timeout = 30 s
+    }
+  }
+}
+
+entityUpsert {
+  # 212MB. This is slightly higher than the akka.http.server.parsing.max-content-length
+  # value, to make it easy to read error messages and know which value is taking effect.
+  maxContentSizeBytes = 222298112
+}
+
+entityStatisticsCache {
+  enabled = true
+  timeoutPerWorkspace = 15 minutes
+  standardPollInterval = 1 minute
+  workspaceCooldown = 90 seconds
+}
+
+integration.runFullLoadTest = false
+
+
+submissionmonitor {
+  # https://broadworkbench.atlassian.net/browse/WA-205
+  trackDetailedSubmissionMetrics = false
+}
+
+workspace-billing-account-monitor {
+  pollInterval = 5s
+  initialDelay = 60s
+}
+
+clone-workspace-file-transfer-monitor {
+  pollInterval = 1m
+  initialDelay = 1m
+}
+
+submission-monitor-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 2
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 2.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 20
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 1
+}
+
+metrics {
+  enabled = false
+  # setting the prefix to bee because rawls metrics only work in bees not fiabs
+  # we want the prefix to be the same across all bees so that the metric name is consistent
+  # then filter on other labels added to the metric
+  prefix = "dev.firecloud.rawls"
+  includeHostname = false
+  reporters {
+    # Direct metrics to statsd-exporter sidecar to send to Prometheus
+    statsd-sidecar {
+      host = "localhost"
+      port = 9125
+      period = 30s
+    }
+  }
+}
+
+directory {
+  url = "ldaps://opendj.dsde-dev.broadinstitute.org"
+  user = "cn=Directory Manager"
+  password = "changeme"
+  baseDn = "dc=dsde-dev,dc=broadinstitute,dc=org"
+}
+
+oidc {
+  authorityEndpoint = "https://terra{{ $b2cTenant }}b2c.b2clogin.com/terra{{ $b2cTenant }}b2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin_{{ $b2cEnv }}"
+  oidcClientId = "{{ $b2cAppId }}"
+  legacyGoogleClientId = "{{ $refreshTokenCredential.web.client_id }}"
+}
+
+# TODO: remove once https://github.com/broadinstitute/rawls/pull/1794 is merged
+swagger {
+  googleClientId = "{{ $refreshTokenCredential.web.client_id }}"
+  realm = "broad-dsde-dev"
+}
+
+wdl-parsing {
+  # number of parsed WDLs to cache
+  cache-max-size = 7500
+  # TTL for WDLs where the parser returned normally
+  # Cromwell itself caches WDLs for 5 seconds, so Rawls doesn't need to be too conservative in calling Cromwell.
+  # Note that both Rawls and Cromwell cache Dockstore WDLs by their URL, so it could
+  # take up to 10 seconds (5s + 5s) for a change in URL content to propagate.
+  cache-ttl-success-seconds = 5
+  # TTL for WDLs where the parser encountered a transient/retryable error, such as a timeout.
+  # Set this to zero to not cache these failures. Set this to a low number to return the cached failure
+  # to any queued threads waiting on WDL parsing, and thus allow the queue to drain quickly instead
+  # of backing up on a slow error
+  cache-ttl-failure-seconds = 2
+  server = "https://cromiam-priv.dsde-dev.broadinstitute.org:443"
+  # Whether or not to cache validation responses from Cromwell
+  useCache = true
+}
+
+opencensus-scala {
+  trace {
+    sampling-probability = 0
+    exporters {
+      stackdriver {
+        enabled = false
+        project-id = "broad-dsde-dev"
+      }
+    }
+  }
+}
+
+# See PROD-400 regarding a transaction that took 2 minutes to complete.
+data-source {
+  coordinated-access {
+    # When true avoids certain database deadlock conditions by sending some data access transactions through an actor
+    # Default is `true`; could be set to `false` as an emergency relief valve. Lets submissions contend with each other in the DB instead of waiting for the actor.
+    enabled = true
+    # How long to wait for each transaction to start
+    start-timeout = 4 minutes
+    # How long to wait for each transaction to run
+    wait-timeout = 4 minutes
+    # How long to wait for each transaction to reply (incl. wait to start, and then run)
+    ask-timeout = 10 minutes
+  }
+}
+
+multiCloudWorkspaces {
+  enabled = true
+  azureConfig {
+    alphaFeatureGroup = "alpha-azure-feature-group"
+    landingZoneDefinition = "CromwellBaseResourcesFactory"
+    landingZoneVersion = "v1"
+    
+    landingZoneParameters = {
+      # Total Network IP Space Size - 16,384 unique ips
+      "VNET_ADDRESS_SPACE": "10.1.0.0/18"
+      # Each subnet will have 1024 unique ips
+      # This intenionally leaves a large number of the vnet address space unallocated
+      # This is hedging against future need for additional subnets or expanding the current ones
+      "AKS_SUBNET": "10.1.0.0/22"
+      "BATCH_SUBNET": "10.1.4.0/22"
+      "POSTGRESQL_SUBNET": "10.1.8.0/22"
+      "COMPUTE_SUBNET": "10.1.12.0/22"
+      "POSTGRES_DB_ADMIN": "{{ $landingZonePostgres.username }}"
+      "POSTGRES_DB_PASSWORD": "{{ $landingZonePostgres.password }}"
+      "AKS_AUTOSCALING_ENABLED": "true"
+      "AKS_AUTOSCALING_MIN": "1"
+      "AKS_AUTOSCALING_MAX": "100"
+      "AKS_MACHINE_TYPE": "Standard_D4as_v5"
+    }
+  },
+  workspaceManager {
+    pollTimeoutSeconds = 80 seconds,
+    leonardoWsmApplicationId = "leo"
+  }
+}
+
+workspace-migration {
+  polling-interval = 4s
+  transfer-job-refresh-interval = 2s
+
+  # unused, for backwards compatibility
+  rate-limit-restart-interval = 1h
+
+  google-project-id-to-bill = "broad-dsde-dev"
+  google-project-parent-folder-id = "803412578462"
+  max-concurrent-migrations = 100
+  retry-interval = 1h
+  max-retries = 24
+}
+
+leonardo {
+  server = "https://leonardo.dsde-dev.broadinstitute.org"
+  wdsType = "WDS" # "CROMWELL" for joint WDS+CBAS; "WDS" for standalone/decoupled WDS
+}
+
+fastPass {
+  enabled = true
+  grantPeriod = 2h
+  monitorCleanupPeriod = 10m
+}
+
+

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -13,7 +13,7 @@
 {{- $b2cAppId := (secret "secret/dsde/terra/azure/dev/b2c/application_id" ).Data.value -}}
 {{- $landingZonePostgres := (secret "secret/dsde/terra/azure/dev/workspacemanager/azure-postgres-credential" ).Data -}}
 
-backRawls = true
+backRawls = false
 
 gcs {
   deletedBucketCheckSeconds = "21600"

--- a/local-dev/templates/site.conf.ctmpl
+++ b/local-dev/templates/site.conf.ctmpl
@@ -1,0 +1,204 @@
+{{- $b2cAppId := ( secret "secret/dsde/terra/azure/dev/b2c/application_id" ).Data.value -}}
+{{- $legacyGoogleClientId := ( secret "secret/dsde/firecloud/dev/common/refresh-token-oauth-credential.json" ).Data.web.client_id -}}
+{{- $legacyGoogleClientIdPrefix := index (printf "%s" $legacyGoogleClientId | split "-") 0 -}}
+ServerTokens ProductOnly
+TraceEnable off
+
+LogFormat "%h %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{Origin}i\" \"%{User-Agent}i\"" combined
+LogFormat "%{X-Forwarded-For}i %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{Origin}i\" \"%{User-Agent}i\"" proxy
+SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+CustomLog "/dev/stdout" combined env=!forwarded
+CustomLog "/dev/stdout" proxy env=forwarded
+LogLevel ${LOG_LEVEL}
+
+AddType application/x-httpd-php .php
+
+Header unset X-Frame-Options
+Header always set X-Frame-Options SAMEORIGIN
+Header unset X-XSS-Protection
+Header always set X-XSS-Protection "1; mode=block"
+Header unset X-Content-Type-Options
+Header always set X-Content-Type-Options: nosniff
+Header unset Strict-Transport-Security
+Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+Header unset Referrer-Policy
+Header always set Referrer-Policy "strict-origin-when-cross-origin"
+
+
+ProxyTimeout ${PROXY_TIMEOUT}
+
+
+<VirtualHost _default_:${HTTPD_PORT}>
+    ServerAdmin ${SERVER_ADMIN}
+    ServerName ${SERVER_NAME}
+
+
+
+    ErrorLog /dev/stdout
+    CustomLog "/dev/stdout" combined
+    Redirect 307 / https://${SERVER_NAME}/
+</VirtualHost>
+
+<VirtualHost _default_:${SSL_HTTPD_PORT}>
+    ServerAdmin ${SERVER_ADMIN}
+    ServerName ${SERVER_NAME}
+
+
+
+    TimeOut ${APACHE_HTTPD_TIMEOUT}
+    KeepAlive ${APACHE_HTTPD_KEEPALIVE}
+    KeepAliveTimeout ${APACHE_HTTPD_KEEPALIVETIMEOUT}
+    MaxKeepAliveRequests ${APACHE_HTTPD_MAXKEEPALIVEREQUESTS}
+
+    DocumentRoot /app
+
+    <Directory "/app">
+        # disable mod_rewrite
+        RewriteEngine off
+
+        AllowOverride All
+        Options -Indexes
+
+        Order allow,deny
+        Allow from all
+    </Directory>
+
+    ErrorLog /dev/stdout
+    CustomLog "/dev/stdout" combined
+
+    SSLEngine on
+    SSLProxyEngine on
+    SSLProtocol ${SSL_PROTOCOL}
+    SSLCipherSuite ${SSL_CIPHER_SUITE}
+    SSLCertificateFile "/etc/ssl/certs/server.crt"
+    SSLCertificateKeyFile "/etc/ssl/private/server.key"
+
+    <Location ${INTROSPECT_PATH}>
+        RewriteEngine off
+        Require all granted
+        AuthType None
+    </Location>
+
+    <LocationMatch "^(?!${INTROSPECT_PATH})(${PROXY_PATH})(.*)">
+        Header unset Access-Control-Allow-Origin
+        Header always set Access-Control-Allow-Origin "*"
+        Header unset Access-Control-Allow-Headers
+        Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin,x-app-id"
+        Header unset Access-Control-Allow-Methods
+        Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
+
+        RewriteEngine On
+        RewriteCond %{REQUEST_METHOD} OPTIONS
+        RewriteRule ^(.*)$ $1 [R=204,L]
+
+        <Limit OPTIONS>
+            Require all granted
+        </Limit>
+
+        ${AUTH_TYPE}
+        ${AUTH_REQUIRE}
+
+        <Limit OPTIONS>
+            Require all granted
+        </Limit>
+
+        ProxyPassMatch ${PROXY_URL}$2
+        ProxyPassReverse ${PROXY_URL}
+
+        ${FILTER}
+    </LocationMatch>
+
+    <Location ${PROXY_PATH2}>
+        Header unset Access-Control-Allow-Origin
+        Header always set Access-Control-Allow-Origin "*"
+        Header unset Access-Control-Allow-Headers
+        Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin,x-app-id"
+        Header unset Access-Control-Allow-Methods
+        Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
+
+        RewriteEngine On
+        RewriteCond %{REQUEST_METHOD} OPTIONS
+        RewriteRule ^(.*)$ $1 [R=204,L]
+
+        <Limit OPTIONS>
+            Require all granted
+        </Limit>
+
+        ${AUTH_TYPE2}
+
+        <RequireAll>
+          <RequireAll>
+            ${AUTH_REQUIRE2}
+          </RequireAll>
+          <RequireAny>
+            # Note: we need to reference %{REMOTE_USER} to ensure that this expression is evaluated _after_ the authentication has happened
+            # %{REMOTE_USER} != %{REMOTE_USER} will never evaluate to true but will ensure that the expression is evaluated at the correct time
+            # Allow service accounts for tests, and B2C app id ({{ $b2cAppId }}) and dev oauth client id ({{ $legacyGoogleClientIdPrefix }}) so that swagger oauth works
+            # (It's also reasonable to remove this check entirely for local development)
+            Require expr "%{REMOTE_USER} != %{REMOTE_USER} || ((%{HTTP:OAUTH2_CLAIM_email} =~ /\.gserviceaccount.com$/) || (%{HTTP:OAUTH2_CLAIM_xms_mirid} =~ m#^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[^/]+$#) || (%{HTTP:OAUTH2_CLAIM_aud} =~ /^{{ $legacyGoogleClientIdPrefix }}/) || (%{HTTP:OAUTH2_CLAIM_aud} == '{{ $b2cAppId }}'))"
+          </RequireAny>
+        </RequireAll>
+
+        <Limit OPTIONS>
+            Require all granted
+        </Limit>
+
+        RequestHeader set oidc_claim_email "expr=%{HTTP:OAUTH2_CLAIM_email}"
+        RequestHeader set oidc_claim_user_id "expr=%{HTTP:OAUTH2_CLAIM_sub}"
+        RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
+        RequestHeader set oidc_claim_expires_in "expr=%{HTTP:OAUTH2_CLAIM_exp}"
+
+        ProxyPass ${PROXY_URL2}
+        ProxyPassReverse ${PROXY_URL2}
+
+        ${FILTER2}
+    </Location>
+
+    <Location ${PROXY_PATH3}>
+        Header unset Access-Control-Allow-Origin
+        Header always set Access-Control-Allow-Origin "*"
+        Header unset Access-Control-Allow-Headers
+        Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin,x-app-id"
+        Header unset Access-Control-Allow-Methods
+        Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        Header unset Access-Control-Max-Age
+        Header always set Access-Control-Max-Age 1728000
+
+        RewriteEngine On
+        RewriteCond %{REQUEST_METHOD} OPTIONS
+        RewriteRule ^(.*)$ $1 [R=204,L]
+
+        <Limit OPTIONS>
+            Require all granted
+        </Limit>
+
+        ${AUTH_TYPE3}
+        ${AUTH_REQUIRE3}
+
+        <Limit OPTIONS>
+            Require all granted
+        </Limit>
+
+        RequestHeader set oidc_claim_email "expr=%{HTTP:OAUTH2_CLAIM_email}"
+        RequestHeader set oidc_claim_user_id "expr=%{HTTP:OAUTH2_CLAIM_sub}"
+        RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
+        RequestHeader set oidc_claim_expires_in "expr=%{HTTP:OAUTH2_CLAIM_exp}"
+
+        ProxyPass ${PROXY_URL3}
+        ProxyPassReverse ${PROXY_URL3}
+
+        ${FILTER3}
+    </Location>
+
+    <Location ${CALLBACK_PATH}>
+        AuthType openid-connect
+        Require valid-user
+    </Location>
+
+</VirtualHost>
+
+# The end

--- a/local-dev/templates/sqlproxy.env.ctmpl
+++ b/local-dev/templates/sqlproxy.env.ctmpl
@@ -1,0 +1,5 @@
+{{- $secret := (secret "secret/dsde/firecloud/dev/rawls/mysql/instance").Data -}}
+GOOGLE_PROJECT={{ $secret.project }}
+CLOUDSQL_ZONE={{ $secret.zone }}
+CLOUDSQL_MAXCONNS=300
+CLOUDSQL_INSTANCE={{ $secret.name }}


### PR DESCRIPTION
**Ticket**: [DDO-2885](https://broadworkbench.atlassian.net/browse/DDO-2885)

The goal of this PR is to do **the minimal amount of work** to migrate the existing Rawls local development configuration out of firecloud-develop.

Under the existing process, developers clone firecloud-develop and run `sh run-context/local/scripts/firecloud-setup.sh`, which populates the Rawls repo's `configs` subdirectory with a bunch of configuration files and secrets, as well as a script called `docker-rsync-local-rawls.sh`, which can be run to spin up a local Rawls server inside a container.

This PR replaces the firecloud-develop step with a new helper script, `local-dev/bin/render`, that **generates the same set of files**. The [`render` tool](https://github.com/broadinstitute/firecloud-develop-shim) generates 3 types of configuration files, giving it approximate parity with firecloud-develop's `configure.rb`:
* secrets pulled from Vault (declared in `local-dev/secrets.yaml`)
* flat configuration files (checked in under `local-dev/templates` without a `.ctmpl`  extension)
* consul templates (checked in under `local-dev/templates` with a `.ctmpl` extension)

### Testing

I verified that I could run the `docker-rsync-local-rawls.sh` script, connect to Rawls swagger at https://local.broadinstitute.org:20443/, authorize to Swagger via the implicit OAuth flow, and successfully execute the `GET /api/workspaces` API call. 

### Modified files

A diff on the files generated by the old process and the new process showed the following delta:

#### changed: `billing-account.pem`

The firecloud-develop configs pull an old static billing service account key located at `secret/dsde/firecloud/dev/common/billing-account.json`; this PR pulls a key that is automatically rotated by Yale and stored in Vault at `secret/dsde/firecloud/dev/common/billing-account-yale.pem`.

####  changed:`rawls.conf`

Single-line removal of a comment that no longer made sense with the new rawls.conf.ctmpl template in this PR.
```
diff -B -w -r config/rawls.conf config-from-fc-dev/rawls.conf
4a5
>   # This billing account ID corresponds to the billing account 'Broad Institute - 8201528'
```

#### added: `server.crt`, `server.key`

These files are the `local.broadinstitute.org` cert & key pair located at `secret/dsde/firecloud/local/common`. They were removed from Rawls' firecloud-develop configs by https://github.com/broadinstitute/firecloud-develop/pull/3326, which broke TLS for local Rawls. This PR adds them back.

#### changed: `site.conf`

Simplify the Apache proxy's OAuth claim allowlist so that it includes just the legacy dev Google OAuth credential and the Terra dev B2C app id, which are used by the Rawls swagger page for auth.

#### deleted: `tcell_agent.config`

There's no need to run TCell locally.

### Related

* https://github.com/broadinstitute/firecloud-develop/pull/3379 will be merged after this PR to prevent confusion (i.e. people updating old files that are no longer used)
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[DDO-2885]: https://broadworkbench.atlassian.net/browse/DDO-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ