### PR TITLE
AJ-1113: length limit for workspace description and other string attributes

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3057,6 +3057,13 @@ paths:
             type: array
             items:
               type: string
+        - name: stringAttributeMaxLength
+          in: query
+          description: |
+            When specified, return only the first N characters of attributes. This setting only works for string attributes, and only for fields
+            inside workspace.attributes. Specify -1 or omit this parameter for no limit on attribute length.
+          schema:
+            type: integer
       responses:
         200:
           description: Successful Request

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -196,72 +196,41 @@ trait WorkspaceComponent {
         // we have workspaceIds, and we will be retrieving attributes.
         val workspaceIdList = reduceSqlActionsWithDelim(workspaceIds.map(id => sql"$id"))
 
-        /*
-          if:
-            !attributeSpecs.all
-            attributeSpecs.attrsToSelect.size == 1
-          then:
-            get the attribute name
+        // does this need "AND WORKSPACE_ATTRIBUTE.deleted = FALSE"?
+        // the method this replaced did not specify that, so we also don't specify it here.
+        val startSql = sql"""select
+        a.id, a.owner_id, a.namespace, a.name, """
 
-          if:
-            regex match "default:description\[\d+\]"
-          then:
-            get the number and use special-case SQL
-         */
-
-        val descriptionLength: Int = if (!attributeSpecs.all && attributeSpecs.attrsToSelect.size == 1) {
-          val singleAttr: String = AttributeName.toDelimitedName(attributeSpecs.attrsToSelect.head)
-          val descriptionSubstringPattern = "description\\[(\\d+)\\]".r
-
-          singleAttr match {
-            case descriptionSubstringPattern(len) => len.toInt
-            case _                                => -1
-          }
+        val stringAttributeSelector = if (attributeSpecs.stringAttributeMaxLength < 0) {
+          sql"a.value_string"
         } else {
-          -1
+          sql"LEFT(a.value_string, ${attributeSpecs.stringAttributeMaxLength})"
         }
 
-        // optimized case for when retrieving only the workspace description
-        val sqlResult =
-          if (descriptionLength > -1) {
-            val startSql = sql"""select
-              a.id, a.owner_id, a.namespace, a.name, LEFT(a.value_string, ${descriptionLength.toString}),
-              null, null, null, null, null, null, 0, null,
-              null
-              from WORKSPACE_ATTRIBUTE a
-              where a.namespace = 'default' and a.name = 'description'
-              and a.owner_id in ("""
+        val midSql =
+          sql""", a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
+        e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
+        from WORKSPACE_ATTRIBUTE a
+        left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id
+        where a.owner_id in ("""
 
-            val endSql = sql")"
+        val endSql = attributeSpecs match {
+          case specs if specs.all =>
+            // user supplied a filter but explicitly told us to get all attributes; so, don't add to the where clause
+            sql""")"""
+          case specs if specs.attrsToSelect.nonEmpty =>
+            // user requested specific attributes. include them in the where clause.
+            val attrNamespaceNameTuples = reduceSqlActionsWithDelim(specs.attrsToSelect.map { attrName =>
+              sql"(${attrName.namespace}, ${attrName.name})"
+            })
+            concatSqlActions(sql") and (a.namespace, a.name) in (", attrNamespaceNameTuples, sql")")
+          case _ =>
+            // this case should never happen, because of the short-circuits at the beginning of the method.
+            throw new RawlsException(s"encountered unexpected attributeSpecs: $attributeSpecs")
+        }
 
-            concatSqlActions(startSql, workspaceIdList, endSql).as[WorkspaceAttributeWithReference]
-          } else {
-            // does this need "AND WORKSPACE_ATTRIBUTE.deleted = FALSE"?
-            // the method this replaced did not specify that, so we also don't specify it here.
-            val startSql = sql"""select
-            a.id, a.owner_id, a.namespace, a.name, a.value_string, a.value_number, a.value_boolean, a.value_json, a.value_entity_ref, a.list_index, a.list_length, a.deleted, a.deleted_date,
-            e_ref.id, e_ref.name, e_ref.entity_type, e_ref.workspace_id, e_ref.record_version, e_ref.deleted, e_ref.deleted_date
-            from WORKSPACE_ATTRIBUTE a
-            left outer join ENTITY e_ref on a.value_entity_ref = e_ref.id
-            where a.owner_id in ("""
-
-            val endSql = attributeSpecs match {
-              case specs if specs.all =>
-                // user supplied a filter but explicitly told us to get all attributes; so, don't add to the where clause
-                sql""")"""
-              case specs if specs.attrsToSelect.nonEmpty =>
-                // user requested specific attributes. include them in the where clause.
-                val attrNamespaceNameTuples = reduceSqlActionsWithDelim(specs.attrsToSelect.map { attrName =>
-                  sql"(${attrName.namespace}, ${attrName.name})"
-                })
-                concatSqlActions(sql") and (a.namespace, a.name) in (", attrNamespaceNameTuples, sql")")
-              case _ =>
-                // this case should never happen, because of the short-circuits at the beginning of the method.
-                throw new RawlsException(s"encountered unexpected attributeSpecs: $attributeSpecs")
-            }
-
-            concatSqlActions(startSql, workspaceIdList, endSql).as[WorkspaceAttributeWithReference]
-          }
+        val sqlResult = concatSqlActions(startSql, stringAttributeSelector, midSql, workspaceIdList, endSql)
+          .as[WorkspaceAttributeWithReference]
 
         // this implementation is a refactor of a previous impl that returns a Seq[ ( (UUID, WorkspaceAttributeRecord), Option[EntityRecord] ) ]
         // it's an awkward signature, but we'll return exactly that here:
@@ -597,6 +566,8 @@ trait WorkspaceComponent {
     ): ReadAction[Seq[Workspace]] = {
       // if the caller did not supply a WorkspaceAttributeSpecs, default to retrieving all attributes
       val attributeSpecs = attributeSpecsOption.getOrElse(WorkspaceAttributeSpecs(all = true))
+      // if the caller did not supply a WorkspaceAttributeSpecs, default to -1 for stringAttributeMaxLength
+      val stringAttributeMaxLength: Int = attributeSpecsOption.map(_.stringAttributeMaxLength).getOrElse(-1)
 
       for {
         workspaceRecs <- lookup.result

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/JsonFilterUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/JsonFilterUtils.scala
@@ -14,17 +14,12 @@ trait JsonFilterUtils extends LazyLogging {
     * @param filters the JSON keys to include in the return object
     * @return a new JSON object filtered to the specified keys, or a copy of the original JSON object if no filters specified.
     */
-  def shallowFilterJsObject(in: JsObject, filters: Set[String]): JsObject = {
-    val newFilters = filters map { filter =>
-      filter.split("\\[").head
-    }
-
-    if (newFilters.isEmpty) {
+  def shallowFilterJsObject(in: JsObject, filters: Set[String]): JsObject =
+    if (filters.isEmpty) {
       in.copy()
     } else {
-      JsObject(in.fields.view.filterKeys(newFilters.contains).toMap)
+      JsObject(in.fields.view.filterKeys(filters.contains).toMap)
     }
-  }
 
   /** Filters a JSON object to only those keys specified in the `filters`
     * argument. Recurse into nested objects. To specify nested keys, use dot-notation.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/JsonFilterUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/JsonFilterUtils.scala
@@ -14,12 +14,17 @@ trait JsonFilterUtils extends LazyLogging {
     * @param filters the JSON keys to include in the return object
     * @return a new JSON object filtered to the specified keys, or a copy of the original JSON object if no filters specified.
     */
-  def shallowFilterJsObject(in: JsObject, filters: Set[String]): JsObject =
-    if (filters.isEmpty) {
+  def shallowFilterJsObject(in: JsObject, filters: Set[String]): JsObject = {
+    val newFilters = filters map { filter =>
+      filter.split("\\[").head
+    }
+
+    if (newFilters.isEmpty) {
       in.copy()
     } else {
-      JsObject(in.fields.view.filterKeys(filters.contains).toMap)
+      JsObject(in.fields.view.filterKeys(newFilters.contains).toMap)
     }
+  }
 
   /** Filters a JSON object to only those keys specified in the `filters`
     * argument. Recurse into nested objects. To specify nested keys, use dot-notation.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -49,10 +49,13 @@ trait WorkspaceApiService extends UserInfoDirectives {
         } ~
           get {
             parameterSeq { allParams =>
-              complete {
-                workspaceServiceConstructor(ctx).listWorkspaces(
-                  WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
-                )
+              parameter("stringAttributeMaxLength".as[Int].withDefault(-1)) { stringAttributeMaxLength =>
+                complete {
+                  workspaceServiceConstructor(ctx).listWorkspaces(
+                    WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                    stringAttributeMaxLength
+                  )
+                }
               }
             }
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -961,7 +961,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       }
     } yield result
 
-  def listWorkspaces(params: WorkspaceFieldSpecs): Future[JsValue] = {
+  def listWorkspaces(params: WorkspaceFieldSpecs, stringAttributeMaxLength: Int): Future[JsValue] = {
 
     val s = ctx.tracingSpan.map(startSpanWithParent("optionHandling", _))
 
@@ -978,7 +978,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       options
         .filter(_.startsWith("workspace.attributes."))
         .map(str => AttributeName.fromDelimitedName(str.replaceFirst("workspace.attributes.", "")))
-        .toList
+        .toList,
+      stringAttributeMaxLength
     )
 
     // Can this be shared with get-workspace somehow?

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3106,7 +3106,9 @@ class WorkspaceServiceSpec
 
       // actually call listWorkspaces to get result it returns given the mocked calls you set up
       val result =
-        Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf).convertTo[Seq[WorkspaceListResponse]]
+        Await
+          .result(service.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
+          .convertTo[Seq[WorkspaceListResponse]]
 
       // verify that the result is what you expect it to be
       result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
@@ -3175,7 +3177,7 @@ class WorkspaceServiceSpec
       )
 
       val err = intercept[RawlsException] {
-        Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf)
+        Await.result(service.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
       }
   }
 
@@ -3246,9 +3248,247 @@ class WorkspaceServiceSpec
       )
 
       val result =
-        Await.result(service.listWorkspaces(WorkspaceFieldSpecs()), Duration.Inf).convertTo[Seq[WorkspaceListResponse]]
+        Await
+          .result(service.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
+          .convertTo[Seq[WorkspaceListResponse]]
 
       result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
+  }
+
+  "listWorkspaces" should "return only the leftmost N characters of string attributes" in withTestDataServices {
+    services =>
+      val service = services.workspaceService
+      val workspaceId1 = UUID.randomUUID().toString
+      val workspaceId2 = UUID.randomUUID().toString
+
+      val descriptionKey = AttributeName.withDefaultNS("description")
+
+      val shortDescription = AttributeString("the quick brown fox jumped over the lazy dog")
+      val longDescription = AttributeString("abcd" * 10000) // should be 40000 chars
+
+      // set up test data
+      val descriptive1 = Workspace(
+        "test_namespace2",
+        workspaceId1,
+        workspaceId1,
+        "aBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "testUser2",
+        Map(descriptionKey -> shortDescription)
+      )
+      val descriptive2 = Workspace(
+        "test_namespace2",
+        workspaceId2,
+        workspaceId2,
+        "aBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "testUser2",
+        Map(descriptionKey -> longDescription)
+      )
+
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(descriptive1)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(descriptive2)
+        } yield ()
+      }
+
+      when(service.samDAO.listUserResources(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any())).thenReturn(
+        Future(
+          Seq(
+            SamUserResource(
+              workspaceId1,
+              SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              Set.empty,
+              Set.empty
+            ),
+            SamUserResource(
+              workspaceId2,
+              SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              Set.empty,
+              Set.empty
+            )
+          )
+        )
+      )
+
+      List(0, 1, 10, 200, 4096) foreach { stringAttributeMaxLength =>
+        info(s"for stringAttributeMaxLength = $stringAttributeMaxLength")
+        val result =
+          Await
+            .result(service.listWorkspaces(WorkspaceFieldSpecs(), stringAttributeMaxLength), Duration.Inf)
+            .convertTo[Seq[WorkspaceListResponse]]
+
+        result.map { ws =>
+          val actualAttributes = ws.workspace.attributes.getOrElse(Map())
+          actualAttributes.keySet should contain(descriptionKey)
+          val actual = actualAttributes.getOrElse(descriptionKey, AttributeNull)
+          actual match {
+            case AttributeString(s) =>
+              s.length should be <= stringAttributeMaxLength
+            case x => fail(s"description attribute was returned as a ${x.getClass.getSimpleName}")
+          }
+        }
+      }
+  }
+
+  "listWorkspaces" should "return entire string attributes when stringAttributeMaxLength = -1" in withTestDataServices {
+    services =>
+      val service = services.workspaceService
+      val workspaceId1 = UUID.randomUUID().toString
+      val workspaceId2 = UUID.randomUUID().toString
+
+      val descriptionKey = AttributeName.withDefaultNS("description")
+
+      val shortDescription = AttributeString("the quick brown fox jumped over the lazy dog")
+      val longDescription = AttributeString("abcd" * 10000) // should be 40000 chars
+
+      // set up test data
+      val descriptive1 = Workspace(
+        "test_namespace2",
+        workspaceId1,
+        workspaceId1,
+        "aBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "testUser2",
+        Map(descriptionKey -> shortDescription)
+      )
+      val descriptive2 = Workspace(
+        "test_namespace2",
+        workspaceId2,
+        workspaceId2,
+        "aBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "testUser2",
+        Map(descriptionKey -> longDescription)
+      )
+
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(descriptive1)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(descriptive2)
+        } yield ()
+      }
+
+      when(service.samDAO.listUserResources(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any())).thenReturn(
+        Future(
+          Seq(
+            SamUserResource(
+              workspaceId1,
+              SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              Set.empty,
+              Set.empty
+            ),
+            SamUserResource(
+              workspaceId2,
+              SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              Set.empty,
+              Set.empty
+            )
+          )
+        )
+      )
+
+      val result =
+        Await
+          .result(service.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
+          .convertTo[Seq[WorkspaceListResponse]]
+
+      result.map { ws =>
+        val actualAttributes = ws.workspace.attributes.getOrElse(Map())
+        actualAttributes.keySet should contain(descriptionKey)
+        val actual = actualAttributes.getOrElse(descriptionKey, AttributeNull)
+        if (ws.workspace.workspaceId == workspaceId1) {
+          actual shouldBe shortDescription
+        } else {
+          actual shouldBe longDescription
+        }
+      }
+  }
+
+  "listWorkspaces" should "return numbers unchanged when specifying stringAttributeMaxLength" in withTestDataServices {
+    services =>
+      val service = services.workspaceService
+      val workspaceId1 = UUID.randomUUID().toString
+
+      val descriptionKey = AttributeName.withDefaultNS("description")
+      val numberKey = AttributeName.withDefaultNS("iamanumber")
+
+      val shortDescription = AttributeString("the quick brown fox jumped over the lazy dog")
+      val numberAttr = AttributeNumber(123456789)
+
+      // set up test data
+      val descriptive1 = Workspace(
+        "test_namespace2",
+        workspaceId1,
+        workspaceId1,
+        "aBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "testUser2",
+        Map(descriptionKey -> shortDescription, numberKey -> numberAttr)
+      )
+
+      runAndWait {
+        for {
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(descriptive1)
+        } yield ()
+      }
+
+      when(service.samDAO.listUserResources(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any())).thenReturn(
+        Future(
+          Seq(
+            SamUserResource(
+              workspaceId1,
+              SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              SamRolesAndActions(Set.empty, Set.empty),
+              Set.empty,
+              Set.empty
+            )
+          )
+        )
+      )
+
+      val stringAttributeMaxLength = 5
+
+      val result =
+        Await
+          .result(service.listWorkspaces(WorkspaceFieldSpecs(), stringAttributeMaxLength), Duration.Inf)
+          .convertTo[Seq[WorkspaceListResponse]]
+
+      result.map { ws =>
+        val actualAttributes = ws.workspace.attributes.getOrElse(Map())
+        actualAttributes.keySet should contain(descriptionKey)
+        actualAttributes.keySet should contain(numberKey)
+        val actualDescription = actualAttributes.getOrElse(descriptionKey, AttributeNull)
+        val actualNumber = actualAttributes.getOrElse(numberKey, AttributeNull)
+
+        actualDescription match {
+          case AttributeString(s) =>
+            s.length shouldBe stringAttributeMaxLength
+          case x => fail(s"description attribute was returned as a ${x.getClass.getSimpleName}")
+        }
+
+        actualNumber shouldBe numberAttr
+      }
   }
 
   "getSubmissionMethodConfiguration" should "return the method configuration that was used to launch the submission" in withTestDataServices {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -777,7 +777,10 @@ object WorkspaceFieldSpecs {
   * if `all` is true, always return all attributes for this workspace.
   * if `all` is false, but `attrsToSelect` is populated, return only the attrs in `attrsToSelect`.
   */
-case class WorkspaceAttributeSpecs(all: Boolean, attrsToSelect: List[AttributeName] = List.empty[AttributeName])
+case class WorkspaceAttributeSpecs(all: Boolean,
+                                   attrsToSelect: List[AttributeName] = List.empty[AttributeName],
+                                   stringAttributeMaxLength: Int = -1
+)
 
 /** Contains List[String]s with the names of the members of the WorkspaceResponse
   * and WorkspaceDetails case classes. Also contains the concatenation of those two lists,


### PR DESCRIPTION
Ticket: <Link to Jira ticket>

See also https://github.com/DataBiosphere/terra-ui/pull/3968, which will take advantage of this from the UI.

This PR adds a new `stringAttributeMaxLength` query parameter to the list-workspaces API. When omitted, or when negative, behavior is the same as before this PR. When specified, Rawls will only return the first N characters of any `workspace.attributes` string values. Numeric, boolean, etc. attributes are unchanged.

This change specifically targets the Terra UI "homepage" that lists workspaces. The UI returns workspace descriptions, but only renders roughly 100 characters of each description. The remainder of the data returned from Rawls is ignored.

My personal workspace list in production is large, as a result of gaining access to lots of workspaces as a project owner and via support. In conjunction with https://github.com/DataBiosphere/terra-ui/pull/3968, this change reduces *my* workspace list from 22.1 MB to 2.4 MB uncompressed and pretty-printed; when gzipped to approximate actual ajax sizes, the difference is 6.1 MB to 387 KB.



---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
