### PR TITLE
ID-653 Enhanced Bucket Logging without Auth Domains

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5292,7 +5292,7 @@ components:
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
         enhancedBucketLogging:
           type: boolean
-          description: Create this workspace with a bucket that collects extra logging about data access.
+          description: Clone this workspace with a bucket that collects extra logging about data access.
           default: false
       description: ""
     BucketUsageResponse:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5253,6 +5253,10 @@ components:
         bucketLocation:
           type: string
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
+        enhancedBucketLogging:
+          type: boolean
+          description: Create this workspace with a bucket that collects extra logging about data access.
+          default: false
       description: ""
     WorkspaceRequestClone:
       required:
@@ -5286,6 +5290,10 @@ components:
         bucketLocation:
           type: string
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
+        enhancedBucketLogging:
+          type: boolean
+          description: Create this workspace with a bucket that collects extra logging about data access.
+          default: false
       description: ""
     BucketUsageResponse:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1152,13 +1152,13 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
             newAttrs = sourceWorkspaceContext.attributes ++ destWorkspaceRequest.attributes
             destWorkspaceContext <- traceDBIOWithParent("createNewWorkspaceContext (cloneWorkspace)", ctx) { s =>
               val forceEnhancedBucketMonitoring =
-                destWorkspaceRequest.enhancedBucketLogging || sourceBucketNameOption.exists(
+                destWorkspaceRequest.enhancedBucketLogging.exists(identity) || sourceBucketNameOption.exists(
                   _.startsWith(s"${config.workspaceBucketNamePrefix}-secure")
                 )
               createNewWorkspaceContext(
                 destWorkspaceRequest.copy(authorizationDomain = Option(newAuthDomain),
                                           attributes = newAttrs,
-                                          enhancedBucketLogging = forceEnhancedBucketMonitoring
+                                          enhancedBucketLogging = Option(forceEnhancedBucketMonitoring)
                 ),
                 billingProject,
                 sourceBucketNameOption,
@@ -3431,7 +3431,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       _ = logger.info(s"createWorkspace - workspace:'${workspaceRequest.name}' - UUID:${workspaceId}")
       bucketName = getBucketName(
         workspaceId,
-        workspaceRequest.authorizationDomain.exists(_.nonEmpty) || workspaceRequest.enhancedBucketLogging
+        workspaceRequest.authorizationDomain.exists(_.nonEmpty) || workspaceRequest.enhancedBucketLogging.exists(
+          identity
+        )
       )
       // We should never get here with a missing or invalid Billing Account, but we still need to get the value out of the
       // Option, so we are being thorough

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2322,6 +2322,37 @@ class WorkspaceServiceSpec
       actualLabels should contain allElementsOf expectedNewLabels
   }
 
+  it should "create a workspace bucket with secure logging if told to, even without an auth domain" in withTestDataServices {
+    services =>
+      val newWorkspaceName = "secure_space_for_workin"
+      val workspaceRequest = WorkspaceRequest(
+        testData.testProject1Name.value,
+        newWorkspaceName,
+        Map.empty,
+        authorizationDomain = None,
+        enhancedBucketLogging = true
+      )
+
+      val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+
+      workspace.bucketName should startWith(s"${services.workspaceServiceConfig.workspaceBucketNamePrefix}-secure")
+  }
+
+  it should "create a workspace bucket with secure logging if an auth domain is specified" in withTestDataServices {
+    services =>
+      val newWorkspaceName = "secure_space_for_workin"
+      val workspaceRequest = WorkspaceRequest(
+        testData.testProject1Name.value,
+        newWorkspaceName,
+        Map.empty,
+        authorizationDomain = Option(Set(testData.dbGapAuthorizedUsersGroup))
+      )
+
+      val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+
+      workspace.bucketName should startWith(s"${services.workspaceServiceConfig.workspaceBucketNamePrefix}-secure")
+  }
+
   // There is another test in WorkspaceComponentSpec that gets into more scenarios for selecting the right Workspaces
   // that should be within a Service Perimeter
   "creating a Workspace in a Service Perimeter" should "attempt to overwrite the correct Service Perimeter" in withTestDataServices {
@@ -2645,6 +2676,83 @@ class WorkspaceServiceSpec
       )
 
     verify(services.resourceBufferService).getGoogleProjectFromBuffer(any[ProjectPoolType], any[String])
+  }
+
+  it should "clone a workspace bucket with enhanced logging, resulting in the child bucket having enhanced logging" in withTestDataServices {
+    services =>
+      val baseWorkspaceName = "secure_space_for_workin"
+      val baseWorkspaceRequest = WorkspaceRequest(
+        testData.testProject1Name.value,
+        baseWorkspaceName,
+        Map.empty,
+        authorizationDomain = None,
+        enhancedBucketLogging = true
+      )
+      val baseWorkspace = Await.result(services.workspaceService.createWorkspace(baseWorkspaceRequest), Duration.Inf)
+
+      val newWorkspaceName = "cloned_space"
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
+
+      val workspace =
+        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+                                                                          baseWorkspace.toWorkspaceName,
+                                                                          workspaceRequest
+                     ),
+                     Duration.Inf
+        )
+
+      workspace.bucketName should startWith(s"${services.workspaceServiceConfig.workspaceBucketNamePrefix}-secure")
+  }
+
+  it should "clone a workspace bucket with an Auth Domain, resulting in the child bucket having enhanced logging" in withTestDataServices {
+    services =>
+      val baseWorkspaceName = "secure_space_for_workin"
+      val baseWorkspaceRequest = WorkspaceRequest(
+        testData.testProject1Name.value,
+        baseWorkspaceName,
+        Map.empty,
+        authorizationDomain = Option(Set(testData.dbGapAuthorizedUsersGroup))
+      )
+      val baseWorkspace = Await.result(services.workspaceService.createWorkspace(baseWorkspaceRequest), Duration.Inf)
+
+      val newWorkspaceName = "cloned_space"
+      val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
+
+      val workspace =
+        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+                                                                          baseWorkspace.toWorkspaceName,
+                                                                          workspaceRequest
+                     ),
+                     Duration.Inf
+        )
+
+      workspace.bucketName should startWith(s"${services.workspaceServiceConfig.workspaceBucketNamePrefix}-secure")
+  }
+
+  it should "create a bucket with enhanced logging when told to, even if the parent workspace doesn't have it" in withTestDataServices {
+    services =>
+      val baseWorkspaceName = "secure_space_for_workin"
+      val baseWorkspaceRequest = WorkspaceRequest(
+        testData.testProject1Name.value,
+        baseWorkspaceName,
+        Map.empty,
+        authorizationDomain = None
+      )
+      val baseWorkspace = Await.result(services.workspaceService.createWorkspace(baseWorkspaceRequest), Duration.Inf)
+
+      val newWorkspaceName = "cloned_space"
+      val workspaceRequest =
+        WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty, enhancedBucketLogging = true)
+
+      val workspace =
+        Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,
+                                                                          baseWorkspace.toWorkspaceName,
+                                                                          workspaceRequest
+                     ),
+                     Duration.Inf
+        )
+
+      workspace.bucketName should startWith(s"${services.workspaceServiceConfig.workspaceBucketNamePrefix}-secure")
   }
 
   // There is another test in WorkspaceComponentSpec that gets into more scenarios for selecting the right Workspaces

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2330,7 +2330,7 @@ class WorkspaceServiceSpec
         newWorkspaceName,
         Map.empty,
         authorizationDomain = None,
-        enhancedBucketLogging = true
+        enhancedBucketLogging = Some(true)
       )
 
       val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
@@ -2686,7 +2686,7 @@ class WorkspaceServiceSpec
         baseWorkspaceName,
         Map.empty,
         authorizationDomain = None,
-        enhancedBucketLogging = true
+        enhancedBucketLogging = Some(true)
       )
       val baseWorkspace = Await.result(services.workspaceService.createWorkspace(baseWorkspaceRequest), Duration.Inf)
 
@@ -2742,7 +2742,11 @@ class WorkspaceServiceSpec
 
       val newWorkspaceName = "cloned_space"
       val workspaceRequest =
-        WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty, enhancedBucketLogging = true)
+        WorkspaceRequest(testData.testProject1Name.value,
+                         newWorkspaceName,
+                         Map.empty,
+                         enhancedBucketLogging = Some(true)
+        )
 
       val workspace =
         Await.result(services.mcWorkspaceService.cloneMultiCloudWorkspace(services.workspaceService,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -152,7 +152,8 @@ case class WorkspaceRequest(
   authorizationDomain: Option[Set[ManagedGroupRef]] = Option(Set.empty),
   copyFilesWithPrefix: Option[String] = None,
   noWorkspaceOwner: Option[Boolean] = None,
-  bucketLocation: Option[String] = None
+  bucketLocation: Option[String] = None,
+  enhancedBucketLogging: Boolean = false
 ) extends Attributable {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
   def briefName: String = toWorkspaceName.toString
@@ -1024,7 +1025,7 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val AzureManagedAppCoordinatesFormat: RootJsonFormat[AzureManagedAppCoordinates] =
     jsonFormat4(AzureManagedAppCoordinates)
 
-  implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat7(WorkspaceRequest)
+  implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat8(WorkspaceRequest)
 
   implicit val workspaceFieldSpecsFormat: RootJsonFormat[WorkspaceFieldSpecs] = jsonFormat1(WorkspaceFieldSpecs.apply)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -153,7 +153,7 @@ case class WorkspaceRequest(
   copyFilesWithPrefix: Option[String] = None,
   noWorkspaceOwner: Option[Boolean] = None,
   bucketLocation: Option[String] = None,
-  enhancedBucketLogging: Boolean = false
+  enhancedBucketLogging: Option[Boolean] = Option(false)
 ) extends Attributable {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
   def briefName: String = toWorkspaceName.toString


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-653

"Enhanced Bucket Logging" is currently enabled on Workspaces with an Auth Domain. However, this is a poor user experience if a user needs enhanced logging, but doesn't need the allowlist management of Auth Domains. Forcing our users to have to deal with allowlist management just to be in compliance is a poor user experience, and causes a lot of confusion and extra work for users of Terra.

"Enhanced Bucket Logging" is actually only actuated on the bucket name beginning with `fc-secure`. This PR makes a small modification to workspace creation (and cloning) functions to take an extra `enhancedBucketMonitoring` parameter to make the bucket name start with `fc-secure`, independent of the workspace having an Auth Domain.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
