### PR TITLE
AJ-1116: remove full table scan for entity batchHide

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -272,9 +272,12 @@ trait EntityComponent {
         } else {
           // and ( (entity_type='mytype1' and name='foo') or (entity_type='mytype2' and name='bar') or (entity_type='mytype3' and name='baz') )
           val matchers = sql"""and ("""
-          val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref =>
-            sql"(entity_type = ${ref.entityType} and name = ${ref.entityName}) OR "
-          })
+          val entityTypeNameTuples = reduceSqlActionsWithDelim(
+            entities.map { ref =>
+              sql"(entity_type = ${ref.entityType} and name = ${ref.entityName})"
+            },
+            sql" OR "
+          )
           concatSqlActions(matchers, entityTypeNameTuples, sql")")
         }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -257,9 +257,9 @@ trait EntityComponent {
         val deletedDate = new Timestamp(new Date().getTime)
         // issue bulk rename/hide for all entities
         val baseUpdate =
-          sql"""update ENTITY set deleted=1, deleted_date=$deletedDate, name=CONCAT(name, $renameSuffix) where deleted=0 AND workspace_id=$workspaceId and (entity_type, name) in ("""
+          sql"""update ENTITY set deleted=1, deleted_date=$deletedDate, name=CONCAT(name, $renameSuffix) where deleted=0 AND workspace_id=$workspaceId and ("""
         val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref =>
-          sql"(${ref.entityType}, ${ref.entityName})"
+          sql"(entity_type = ${ref.entityType} and name = ${ref.entityName}) OR "
         })
         concatSqlActions(baseUpdate, entityTypeNameTuples, sql")").as[Int]
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -655,10 +655,13 @@ trait EntityComponent {
         val baseUpdate =
           sql"""update ENTITY_ATTRIBUTE_#$shardId ea join ENTITY e on ea.owner_id = e.id
                 set ea.deleted=1, ea.deleted_date=$deletedDate, ea.name=CONCAT(ea.name, $renameSuffix)
-                where e.workspace_id=${workspaceContext.workspaceIdAsUUID} and ea.deleted=0 and (e.entity_type, e.name) in ("""
-        val entityTypeNameTuples = reduceSqlActionsWithDelim(entities.map { ref =>
-          sql"(${ref.entityType}, ${ref.entityName})"
-        })
+                where e.workspace_id=${workspaceContext.workspaceIdAsUUID} and ea.deleted=0 and ("""
+        val entityTypeNameTuples = reduceSqlActionsWithDelim(
+          entities.map { ref =>
+            sql"(e.entity_type = ${ref.entityType} and e.name = ${ref.entityName})"
+          },
+          sql" OR "
+        )
         concatSqlActions(baseUpdate, entityTypeNameTuples, sql")").as[Int]
       }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1116

We've been running into lock waits where:
1. a large entity batch-delete was holding locks
2. the entity cache monitor was trying to update cache but waiting for the lock

I've identified slowness in the entity batch-delete query. When there are enough entities in the query, we had a full table scan. This PR tweaks syntax for those queries. Running `EXPLAIN` locally shows these change from full table scan to an index range scan, which will perform better.

SQL before this PR:
```sql
update ENTITY set deleted=1, deleted_date=?, name=CONCAT(name, ?)
where deleted=0 AND workspace_id=?
and (entity_type, name) in ((?, ?),(?, ?))
```

SQL after this PR, when all entities being deleted have the same type:
```sql
update ENTITY set deleted=1, deleted_date=?, name=CONCAT(name, ?)
where deleted=0 AND workspace_id=?
and entity_type=? and name in (?,?)
```

SQL after this PR, when entities being deleted have different types:
```sql
update ENTITY set deleted=1, deleted_date=?, name=CONCAT(name, ?)
where deleted=0 AND workspace_id=?
and ((entity_type = ? and name = ?) OR (entity_type = ? and name = ?))
```
I've also made a similar change to the related batch-delete-attributes query, though that wasn't obviously causing problems.



---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
