### PR TITLE
[SCP-5174] Revert "[WOR-522] Remove owner role from project-owner policy because it is now included in Sam role"

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3278,7 +3278,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     val projectOwnerPolicy =
       SamWorkspacePolicyNames.projectOwner -> SamPolicy(Set(billingProjectOwnerPolicyEmail),
                                                         Set.empty,
-                                                        Set(SamWorkspaceRoles.projectOwner)
+                                                        Set(SamWorkspaceRoles.owner, SamWorkspaceRoles.projectOwner)
       )
     val ownerPolicyMembership: Set[WorkbenchEmail] = if (workspaceRequest.noWorkspaceOwner.getOrElse(false)) {
       Set.empty


### PR DESCRIPTION
Reverts broadinstitute/rawls#2382