### PR TITLE
Upgrade workbenchLibs, fix rawls model publish script (WOR-1041).

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,12 +7,12 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.14.1"
 
-  val workbenchLibsHash = "42c499b"
-  val serviceTestV = s"2.1-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.26-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.27-${workbenchLibsHash}"
-  val workbenchModelV  = s"0.17-${workbenchLibsHash}"
-  val workbenchMetricsV  = s"0.6-${workbenchLibsHash}"
+  val workbenchLibsHash = "7dbb965"
+  val serviceTestV = s"3.1-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.27-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.30-${workbenchLibsHash}"
+  val workbenchModelV  = s"0.18-${workbenchLibsHash}"
+  val workbenchMetricsV  = s"0.7-${workbenchLibsHash}"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val workbenchMetrics: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-metrics" % workbenchMetricsV

--- a/core/src/bin/publishRelease.sh
+++ b/core/src/bin/publishRelease.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-SBT_OPTS=-Dproject.isSnapshot=false sbt +publish
+sbt -J-Dproject.isSnapshot=false +publish

--- a/core/src/bin/publishSnapshot.sh
+++ b/core/src/bin/publishSnapshot.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-SBT_OPTS=-Dproject.isSnapshot=true sbt +publish
+sbt -J-Dproject.isSnapshot=true +publish

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.0.33"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "d764a9b"
+  val workbenchLibsHash = "7dbb965"
 
   val workbenchModelV  = s"0.18-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.27-${workbenchLibsHash}"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1041

Upgrade workbench-libs version in Rawls to pick up the new Rawls model version (leveraging new WSM client) that was made… yep, in Rawls. 

I *think* this resolves all the Jackson.databind vulnerability issues.

Now:

```
roberts@wm365-d20 rawls % sbt "whatDependsOn com.fasterxml.jackson.core jackson-databind 2.11.3"
[info] welcome to sbt 1.6.2 (Oracle Corporation Java 17.0.2)
[info] loading global plugins from /Users/roberts/.sbt/1.0/plugins
[info] loading settings for project rawls-build from plugins.sbt ...
[info] loading project definition from /Users/roberts/Documents/Source/rawls/project
[info] loading settings for project rawls from build.sbt ...
[info] resolving key references (10884 settings) ...
[info] set current project to rawls (in build file:/Users/roberts/Documents/Source/rawls/)
[error] Expected 'com.typesafe'
[error] Expected 'com.readytalk'
[error] Expected 'com.typesafe.akka'
[error] Expected 'com.typesafe.scala-logging'
[error] Expected '2.14.2'
[error] Expected '2.10.1'
[error] Expected '2.13.4'
[error] Expected '2.12.2'
[error] Expected '2.14.0-rc2'
[error] whatDependsOn com.fasterxml.jackson.core jackson-databind 2.11.3
[error]                                                              ^
```

Before:
```
roberts@wm365-d20 rawls % sbt "whatDependsOn com.fasterxml.jackson.core jackson-databind 2.11.3"
[info] welcome to sbt 1.6.2 (Oracle Corporation Java 17.0.2)
[info] loading global plugins from /Users/roberts/.sbt/1.0/plugins
[info] loading settings for project rawls-build from plugins.sbt ...
[info] loading project definition from /Users/roberts/Documents/Source/rawls/project
[info] loading settings for project rawls from build.sbt ...
[info] resolving key references (10884 settings) ...
[info] set current project to rawls (in build file:/Users/roberts/Documents/Source/rawls/)
[info] com.fasterxml.jackson.core:jackson-databind:2.11.3
[info]   +-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
[info]   | +-bio.terra:workspace-manager-client:0.254.767-SNAPSHOT
[info]   |   +-org.broadinstitute.dsde:rawls-model_2.13:0.1-10ed3487f-SNAP [S]
[info]   |     +-org.broadinstitute.dsde:workbench-google_2.13:0.1-10ed3487f-SNAP [S]
[info]   |     
[info]   +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.10.1
[info]   | +-org.glassfish.jersey.media:jersey-media-json-jackson:2.32
[info]   |   +-bio.terra:workspace-manager-client:0.254.767-SNAPSHOT
[info]   |     +-org.broadinstitute.dsde:rawls-model_2.13:0.1-10ed3487f-SNAP [S]
[info]   |       +-org.broadinstitute.dsde:workbench-google_2.13:0.1-10ed3487f-SNAP [S]
[info]   |       
[info]   +-org.glassfish.jersey.media:jersey-media-json-jackson:2.32
[info]     +-bio.terra:workspace-manager-client:0.254.767-SNAPSHOT
[info]       +-org.broadinstitute.dsde:rawls-model_2.13:0.1-10ed3487f-SNAP [S]
[info]         +-org.broadinstitute.dsde:workbench-google_2.13:0.1-10ed3487f-SNAP [S]
[info]         
[info] com.fasterxml.jackson.core:jackson-databind:2.11.3
[info]   +-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3
[info]   | +-bio.terra:workspace-manager-client:0.254.767-SNAPSHOT
[info]   |   +-org.broadinstitute.dsde:rawls-model_2.13:0.1-10ed3487f-SNAP [S]
[info]   |   
[info]   +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.10.1
[info]   | +-org.glassfish.jersey.media:jersey-media-json-jackson:2.32
[info]   |   +-bio.terra:workspace-manager-client:0.254.767-SNAPSHOT
[info]   |     +-org.broadinstitute.dsde:rawls-model_2.13:0.1-10ed3487f-SNAP [S]
[info]   |     
[info]   +-org.glassfish.jersey.media:jersey-media-json-jackson:2.32
[info]     +-bio.terra:workspace-manager-client:0.254.767-SNAPSHOT
[info]       +-org.broadinstitute.dsde:rawls-model_2.13:0.1-10ed3487f-SNAP [S]
[info]       
[success] Total time: 9 s, completed Jun 14, 2023, 11:19:14 AM
```

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
