### PR TITLE
[WOR-1064] Wireup creation of protected data workspaces in Azure

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5264,6 +5264,10 @@ components:
           type: boolean
           description: Create this workspace with a bucket that collects extra logging about data access.
           default: false
+        protectedData:
+          type: boolean
+          description: Optional, false if not specified. Attach a protected data policy to this workspace (only applicable for Azure workspaces). If true, this workspace must be created in a protected data billing project.
+          default: false
       description: ""
     WorkspaceRequestClone:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -70,7 +70,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                         displayName: String,
                                                         spendProfileId: String,
                                                         ctx: RawlsRequestContext
-                                                       ): CreatedWorkspace = {
+  ): CreatedWorkspace = {
     val policyInputs = new WsmPolicyInputs()
     val protectedPolicyInput = new WsmPolicyInput()
     protectedPolicyInput.name("protected-data")
@@ -87,7 +87,6 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
         .policies(policyInputs)
     )
   }
-
 
   override def cloneWorkspace(sourceWorkspaceId: UUID,
                               workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -66,6 +66,29 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
         .stage(WorkspaceStageModel.MC_WORKSPACE)
     )
 
+  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
+                                                        displayName: String,
+                                                        spendProfileId: String,
+                                                        ctx: RawlsRequestContext
+                                                       ): CreatedWorkspace = {
+    val policyInputs = new WsmPolicyInputs()
+    val protectedPolicyInput = new WsmPolicyInput()
+    protectedPolicyInput.name("protected-data")
+    protectedPolicyInput.namespace("terra")
+    protectedPolicyInput.additionalData(List().asJava)
+
+    policyInputs.addInputsItem(protectedPolicyInput)
+    getWorkspaceApi(ctx).createWorkspace(
+      new CreateWorkspaceRequestBody()
+        .id(workspaceId)
+        .displayName(displayName)
+        .spendProfile(spendProfileId)
+        .stage(WorkspaceStageModel.MC_WORKSPACE)
+        .policies(policyInputs)
+    )
+  }
+
+
   override def cloneWorkspace(sourceWorkspaceId: UUID,
                               workspaceId: UUID,
                               displayName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -19,6 +19,13 @@ trait WorkspaceManagerDAO {
                                       ctx: RawlsRequestContext
   ): CreatedWorkspace
 
+  def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
+                                      displayName: String,
+                                      spendProfileId: String,
+                                      ctx: RawlsRequestContext
+                                     ): CreatedWorkspace
+
+
   def cloneWorkspace(sourceWorkspaceId: UUID,
                      workspaceId: UUID,
                      displayName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -20,11 +20,10 @@ trait WorkspaceManagerDAO {
   ): CreatedWorkspace
 
   def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
-                                      displayName: String,
-                                      spendProfileId: String,
-                                      ctx: RawlsRequestContext
-                                     ): CreatedWorkspace
-
+                                               displayName: String,
+                                               spendProfileId: String,
+                                               ctx: RawlsRequestContext
+  ): CreatedWorkspace
 
   def cloneWorkspace(sourceWorkspaceId: UUID,
                      workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -415,11 +415,26 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       )
 
       _ = logger.info(s"Creating workspace in WSM [workspaceId = ${workspaceId}]")
-      _ <- traceWithParent("createMultiCloudWorkspaceInWSM", parentContext)(_ =>
-        Future(
-          workspaceManagerDAO.createWorkspaceWithSpendProfile(workspaceId, workspaceRequest.name, spendProfileId, ctx)
-        )
-      )
+      _ <- traceWithParent("createMultiCloudWorkspaceInWSM", parentContext) { _ =>
+        workspaceRequest.protectedData match {
+          case Some(true) =>
+            Future(
+              workspaceManagerDAO.createProtectedWorkspaceWithSpendProfile(workspaceId,
+                                                                           workspaceRequest.name,
+                                                                           spendProfileId,
+                                                                           ctx
+              )
+            )
+          case _ =>
+            Future(
+              workspaceManagerDAO.createWorkspaceWithSpendProfile(workspaceId,
+                                                                  workspaceRequest.name,
+                                                                  spendProfileId,
+                                                                  ctx
+              )
+            )
+        }
+      }
       _ = logger.info(s"Creating cloud context in WSM [workspaceId = ${workspaceId}]")
       cloudContextCreateResult <- traceWithParent("createAzureCloudContextInWSM", parentContext)(_ =>
         Future(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -16,7 +16,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
-import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.jdk.CollectionConverters._
 
 class HttpWorkspaceManagerDAOSpec
     extends AnyFlatSpec
@@ -270,4 +270,36 @@ class HttpWorkspaceManagerDAOSpec
 
     verify(workspaceApi).cloneWorkspace(expectedRequest, testData.azureWorkspace.workspaceIdAsUUID)
   }
+
+
+  behavior of "createProtectedWorkspaceWithSpendProfile"
+
+  it should "call the WSM workspace API" in {
+    val workspaceApi = mock[WorkspaceApi]
+    val wsmDao = new HttpWorkspaceManagerDAO(getApiClientProvider(workspaceApi = workspaceApi))
+    val policyInputs = new WsmPolicyInputs()
+    val protectedPolicyInput = new WsmPolicyInput()
+    protectedPolicyInput.name("protected-data")
+    protectedPolicyInput.namespace("terra")
+    protectedPolicyInput.additionalData(List().asJava)
+
+    policyInputs.addInputsItem(protectedPolicyInput)
+
+    val expectedRequest = new CreateWorkspaceRequestBody()
+      .id(testData.azureWorkspace.workspaceIdAsUUID)
+      .displayName(testData.azureWorkspace.name)
+      .spendProfile(testData.azureBillingProfile.getId.toString)
+      .stage(WorkspaceStageModel.MC_WORKSPACE)
+      .policies(policyInputs)
+
+    wsmDao.createProtectedWorkspaceWithSpendProfile(
+      testData.azureWorkspace.workspaceIdAsUUID,
+testData.azureWorkspace.name,
+      testData.azureBillingProfile.getId.toString,
+      testContext
+    )
+
+    verify(workspaceApi).createWorkspace(expectedRequest)
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -271,7 +271,6 @@ class HttpWorkspaceManagerDAOSpec
     verify(workspaceApi).cloneWorkspace(expectedRequest, testData.azureWorkspace.workspaceIdAsUUID)
   }
 
-
   behavior of "createProtectedWorkspaceWithSpendProfile"
 
   it should "call the WSM workspace API" in {
@@ -294,7 +293,7 @@ class HttpWorkspaceManagerDAOSpec
 
     wsmDao.createProtectedWorkspaceWithSpendProfile(
       testData.azureWorkspace.workspaceIdAsUUID,
-testData.azureWorkspace.name,
+      testData.azureWorkspace.name,
       testData.azureBillingProfile.getId.toString,
       testContext
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -204,6 +204,10 @@ class MockWorkspaceManagerDAO(
   ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
+  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID, displayName: String, spendProfileId: String, ctx: RawlsRequestContext): CreatedWorkspace =
+    mockCreateWorkspaceResponse(workspaceId)
+
+
   override def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult =
     mockInitialCreateAzureCloudContextResult()
 
@@ -256,6 +260,7 @@ class MockWorkspaceManagerDAO(
   def removeRole(workspaceId: UUID, email: WorkbenchEmail, role: IamRole, ctx: RawlsRequestContext): Unit = ???
 
   override def throwWhenUnavailable(): Unit = ()
+
 }
 
 object MockWorkspaceManagerDAO {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -204,6 +204,13 @@ class MockWorkspaceManagerDAO(
   ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
+  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
+                                                        displayName: String,
+                                                        spendProfileId: String,
+                                                        ctx: RawlsRequestContext
+  ): CreatedWorkspace =
+    mockCreateWorkspaceResponse(workspaceId)
+
   override def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult =
     mockInitialCreateAzureCloudContextResult()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -204,9 +204,12 @@ class MockWorkspaceManagerDAO(
   ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
-  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID, displayName: String, spendProfileId: String, ctx: RawlsRequestContext): CreatedWorkspace =
+  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
+                                                        displayName: String,
+                                                        spendProfileId: String,
+                                                        ctx: RawlsRequestContext
+  ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
-
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult =
     mockInitialCreateAzureCloudContextResult()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -673,7 +673,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     )
     val result: Workspace =
       Await.result(mcWorkspaceService.createMultiCloudWorkspace(request, new ProfileModel().id(UUID.randomUUID())),
-        Duration.Inf
+                   Duration.Inf
       )
 
     result.name shouldBe "fake_name"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -650,6 +650,55 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     verifyWorkspaceCreationRollback(workspaceManagerDAO, request.toWorkspaceName)
   }
 
+  it should "create a protected data workspace" in {
+    val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
+
+    val samDAO = new MockSamDAO(slickDataSource)
+
+    val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
+      slickDataSource,
+      workspaceManagerDAO,
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      activeMcWorkspaceConfig,
+      mock[MockLeonardoDAO],
+      workbenchMetricBaseName
+    )(testContext)
+    val namespace = "fake_ns" + UUID.randomUUID().toString
+    val request = WorkspaceRequest(
+      namespace,
+      "fake_name",
+      Map.empty,
+      protectedData = Some(true)
+    )
+    val result: Workspace =
+      Await.result(mcWorkspaceService.createMultiCloudWorkspace(request, new ProfileModel().id(UUID.randomUUID())),
+                   Duration.Inf
+      )
+
+    result.name shouldBe "fake_name"
+    result.workspaceType shouldBe WorkspaceType.McWorkspace
+    result.namespace shouldEqual namespace
+
+    Mockito
+      .verify(workspaceManagerDAO)
+      .createProtectedWorkspaceWithSpendProfile(
+        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
+        ArgumentMatchers.eq("fake_name"),
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.eq(testContext)
+      )
+
+    Mockito
+      .verify(workspaceManagerDAO, Mockito.times(0))
+      .createWorkspaceWithSpendProfile(
+        ArgumentMatchers.any[UUID](),
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.anyString(),
+        ArgumentMatchers.any()
+      )
+  }
+
   private def verifyWorkspaceCreationRollback(workspaceManagerDAO: MockWorkspaceManagerDAO,
                                               workspaceName: WorkspaceName
   ): Unit = {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -153,7 +153,8 @@ case class WorkspaceRequest(
   copyFilesWithPrefix: Option[String] = None,
   noWorkspaceOwner: Option[Boolean] = None,
   bucketLocation: Option[String] = None,
-  enhancedBucketLogging: Option[Boolean] = Option(false)
+  enhancedBucketLogging: Option[Boolean] = Option(false),
+  protectedData: Option[Boolean] = Option(false)
 ) extends Attributable {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
   def briefName: String = toWorkspaceName.toString
@@ -1028,7 +1029,7 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val AzureManagedAppCoordinatesFormat: RootJsonFormat[AzureManagedAppCoordinates] =
     jsonFormat4(AzureManagedAppCoordinates)
 
-  implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat8(WorkspaceRequest)
+  implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat9(WorkspaceRequest)
 
   implicit val workspaceFieldSpecsFormat: RootJsonFormat[WorkspaceFieldSpecs] = jsonFormat1(WorkspaceFieldSpecs.apply)
 


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1064)
## Why
We need to be able to create "protected" Azure workspaces. The policy wireup and protected data landing zone segments are wired up in workspace manager and TPS, Rawls now needs to know whether to attach such a policy during the creation of a workspace.

## This PR
* Adds a `protectedData` boolean to the create workspace request. If this is set and the workspace being created is Azure, Rawls will attach the `terra:protected-data` poilcy input to the creation request to WSM. WSM, in turn, will verify that the target landing zone is likewise protected and fail out if this is not the case. 
* Cloning just works, as the cloned workspace inherits the policy and the same check takes place (i.e., an attempt to clone a protected workspace into a non-protected landing zone will fail out)
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
