### PR TITLE
[WOR-801] Fix scheduled Azure E2E tests

### DIFF
--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -22,15 +22,21 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
 
 jobs:
-  workflow-inputs:
+  init-github-context:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ inputs.branch || 'develop' }}
-      delete-bee: ${{ inputs.delete-bee || true }}
+      branch: ${{ steps.extract-inputs.outputs.branch }}
+      delete-bee: ${{ steps.extract-inputs.outputs.delete-bee }}
+    steps:
+      - name: Get inputs or use defaults
+        id: extract-inputs
+        run: |
+          echo "branch=${{ inputs.branch || 'develop' }}" >> "$GITHUB_OUTPUT"
+          echo "delete-bee=${{ inputs.delete-bee || true }}" >> "$GITHUB_OUTPUT"
 
   rawls-build-tag-publish-job:
     runs-on: ubuntu-latest
-    needs: [workflow-inputs]
+    needs: [init-github-context]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -55,7 +61,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ needs.workflow-inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ needs.init-github-context.outputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -87,7 +93,7 @@ jobs:
 
   rawls-swat-e2e-test-job:
     runs-on: ubuntu-latest
-    needs: [create-bee-workflow, workflow-inputs]
+    needs: [create-bee-workflow, init-github-context]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -101,12 +107,12 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ needs.workflow-inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ needs.init-github-context.outputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest
-    needs: [rawls-swat-e2e-test-job, workflow-inputs]
-    if: ${{ needs.workflow-inputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+    needs: [rawls-swat-e2e-test-job, init-github-context]
+    if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -122,7 +128,7 @@ jobs:
 
   notify-slack-on-failure:
     runs-on: ubuntu-latest
-    needs: [workflow-inputs, rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
+    needs: [init-github-context, rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
     if: ${{ failure() }}
     steps:
       - name: Notify slack

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -3,7 +3,7 @@ name: rawls-run-azure-e2e-tests
 on:
   schedule:
     # run twice a day at 10:00 and 22:00 UTC every day of the week
-    - cron: "0 6/12 * * *"
+    - cron: "0 10/12 * * *"
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -136,6 +136,6 @@ jobs:
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests FAILED, branch: ${{ needs.input-github-context.outputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Azure E2E Tests FAILED, branch: ${{ needs.init-github-context.outputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -3,7 +3,7 @@ name: rawls-run-azure-e2e-tests
 on:
   schedule:
     # run twice a day at 10:00 and 22:00 UTC every day of the week
-    - cron: "0 10/12 * * *"
+    - cron: "0 6/12 * * *"
   workflow_dispatch:
     inputs:
       branch:
@@ -20,6 +20,8 @@ on:
 env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
+  BRANCH: ${{ inputs.branch || 'develop' }}
+  DELETE_BEE: ${{ inputs.delete-bee || true }}
 
 jobs:
   rawls-build-tag-publish-job:
@@ -48,7 +50,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ env.BRANCH }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -94,12 +96,12 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ env.BRANCH }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest
     needs: [rawls-swat-e2e-test-job]
-    if: ${{ inputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+    if: ${{ env.DELETE_BEE && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -123,6 +125,6 @@ jobs:
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Azure E2E Tests FAILED, branch: ${{ env.BRANCH }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -20,12 +20,17 @@ on:
 env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt}}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
-  BRANCH: ${{ inputs.branch || 'develop' }}
-  DELETE_BEE: ${{ inputs.delete-bee || true }}
 
 jobs:
+  workflow-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ inputs.branch || 'develop' }}
+      delete-bee: ${{ inputs.delete-bee || true }}
+
   rawls-build-tag-publish-job:
     runs-on: ubuntu-latest
+    needs: [workflow-inputs]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -50,7 +55,7 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ env.BRANCH }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
+          inputs: '{ "repository": "${{ github.event.repository.full_name }}", "ref": "refs/heads/${{ needs.workflow-inputs.branch }}", "rawls-release-tag": "${{ steps.tag.outputs.tag }}" }'
 
       - name: Render Rawls version
         id: render-rawls-version
@@ -82,7 +87,7 @@ jobs:
 
   rawls-swat-e2e-test-job:
     runs-on: ubuntu-latest
-    needs: [create-bee-workflow]
+    needs: [create-bee-workflow, workflow-inputs]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -96,12 +101,12 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ env.BRANCH }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
+          inputs: '{ "bee-name": "${{ env.BEE_NAME }}", "ENV": "qa", "ref": "refs/heads/${{ needs.workflow-inputs.branch }}", "test-group-name": "workspaces_azure", "test-command": "${{ env.rawls_test_command }}", "java-version": "17" }'
 
   destroy-bee-workflow:
     runs-on: ubuntu-latest
-    needs: [rawls-swat-e2e-test-job]
-    if: ${{ env.DELETE_BEE && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+    needs: [rawls-swat-e2e-test-job, workflow-inputs]
+    if: ${{ needs.workflow-inputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -117,7 +122,7 @@ jobs:
 
   notify-slack-on-failure:
     runs-on: ubuntu-latest
-    needs: [rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
+    needs: [workflow-inputs, rawls-build-tag-publish-job, create-bee-workflow, rawls-swat-e2e-test-job, destroy-bee-workflow] # Want to notify regardless of which step fails
     if: ${{ failure() }}
     steps:
       - name: Notify slack

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -136,6 +136,6 @@ jobs:
         with:
           # Channel is for #dsp-workspaces-test-alerts
           channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests FAILED, branch: ${{ env.BRANCH }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Azure E2E Tests FAILED, branch: ${{ needs.input-github-context.outputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}


### PR DESCRIPTION
Ticket: [WOR-801](https://broadworkbench.atlassian.net/browse/WOR-801)
* Test runs kicked off by the schedule don't have the inputs that are present in manually dispatched runs. Replace direct usage of `inputs` context with outputs from a GHA job that gets either the values from `inputs` or uses a reasonable default.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-801]: https://broadworkbench.atlassian.net/browse/WOR-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ