### PR TITLE
Wire up protected data landing zone creation

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5663,6 +5663,11 @@ components:
             this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME].
             Caller must have the add_project action for this service perimeter in
             Sam.
+        protectedData:
+          type: boolean
+          description: Optional, false if not specified. Applicable only for azure 
+            billing projects. When set, a billing project with suitable infrastructure
+            for protected data workspaces will be created.
       description: ""
     CreateRawlsV2BillingProjectFullRequest:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -115,9 +115,14 @@ class BpmBillingProjectLifecycle(
       val maybeAttach = if (lzId.isDefined) Map("attach" -> "true") else Map.empty
       val params = config.azureConfig.get.landingZoneParameters ++ maybeAttach
 
+      val lzDefinition = createProjectRequest.protectedData match {
+        case Some(true) => config.azureConfig.get.protectedDataLandingZoneDefinition
+        case _          => config.azureConfig.get.landingZoneDefinition
+      }
+
       Future(blocking {
         workspaceManagerDAO.createLandingZone(
-          config.azureConfig.get.landingZoneDefinition,
+          lzDefinition,
           config.azureConfig.get.landingZoneVersion,
           params,
           profileModel.getId,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -17,6 +17,7 @@ final case class MultiCloudWorkspaceConfig(multiCloudWorkspacesEnabled: Boolean,
 final case class MultiCloudWorkspaceManagerConfig(leonardoWsmApplicationId: String, pollTimeout: FiniteDuration)
 
 final case class AzureConfig(landingZoneDefinition: String,
+                             protectedDataLandingZoneDefinition: String,
                              landingZoneVersion: String,
                              landingZoneParameters: Map[String, String],
                              landingZoneAllowAttach: Boolean
@@ -29,6 +30,7 @@ case object MultiCloudWorkspaceConfig {
         Some(
           AzureConfig(
             azc.getString("landingZoneDefinition"),
+            azc.getString("protectedDataLandingZoneDefinition"),
             azc.getString("landingZoneVersion"),
             azc
               .getConfig("landingZoneParameters")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -198,7 +198,8 @@ case class CreateRawlsV2BillingProjectFullRequest(
   servicePerimeter: Option[ServicePerimeterName],
   managedAppCoordinates: Option[AzureManagedAppCoordinates],
   members: Option[Set[ProjectAccessUpdate]],
-  inviteUsersNotFound: Option[Boolean]
+  inviteUsersNotFound: Option[Boolean],
+  protectedData: Option[Boolean] = Option(false)
 ) {
 
   def billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates] = {
@@ -302,7 +303,7 @@ class UserAuthJsonSupport extends JsonSupport {
     jsonFormat6(CreateRawlsBillingProjectFullRequest)
 
   implicit val CreateRawlsV2BillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsV2BillingProjectFullRequest] =
-    jsonFormat6(CreateRawlsV2BillingProjectFullRequest)
+    jsonFormat7(CreateRawlsV2BillingProjectFullRequest)
 
   implicit val UpdateRawlsBillingAccountRequestFormat: RootJsonFormat[UpdateRawlsBillingAccountRequest] = jsonFormat1(
     UpdateRawlsBillingAccountRequest

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -119,6 +119,7 @@ multiCloudWorkspaces {
     azureConfig {
         alphaFeatureGroup = "fake_alpha_group"
         landingZoneDefinition = "fake_landing_zone_definition"
+        protectedDataLandingZoneDefinition = "fake_landing_zone_definition"
         landingZoneVersion = "fake_landing_zone_version"
         landingZoneParameters = {
             "FAKE_PARAMETER": "fake_value",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -40,6 +40,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
 
   val azConfig: AzureConfig = AzureConfig(
     "fake-landing-zone-definition",
+    "fake-protected-landing-zone-definition",
     "fake-landing-zone-version",
     Map("fake_parameter" -> "fake_value"),
     landingZoneAllowAttach = false

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -44,6 +44,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   val azConfig: AzureConfig = AzureConfig(
     "fake-landing-zone-definition",
+    "fake-protected-landing-zone-definition",
     "fake-landing-zone-version",
     Map("fake_parameter" -> "fake_value"),
     landingZoneAllowAttach = false

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -23,7 +23,8 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
         |    enabled = true
         |    azureConfig {
         |      alphaFeatureGroup = "fake_group",
-        |      landingZoneDefinition = "fake_landing_zone_definition"
+        |      landingZoneDefinition = "fake_landing_zone_definition",
+        |      protectedDataLandingZoneDefinition = "fake_protected_landing_zone_definition"
         |      landingZoneVersion = "fake_landing_zone_version"
         |      landingZoneParameters = {
         |        "FAKE_PARAMETER": "fake_value",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -57,6 +57,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     Some(
       AzureConfig(
         "fake-landing-zone-definition",
+        "fake-protected-landing-zone-definition",
         "fake-landing-zone-version",
         Map("fake_parameter" -> "fake_value"),
         landingZoneAllowAttach = false

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -406,6 +406,7 @@ multiCloudWorkspaces {
   azureConfig {
     alphaFeatureGroup = "alpha-azure-feature-group"
     landingZoneDefinition = "CromwellBaseResourcesFactory"
+    protectedDataLandingZoneDefinition = "ProtectedDataResourcesFactory"
     landingZoneVersion = "v1"
     
     landingZoneParameters = {


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1076)

## Why
We need to be able to create protected data billing projects and the related landing zone via the API. 

## This PR 
* Wires up a new parameter in the create billing project V2 API call. 

## TODO
- [ ] [Pre-requisite related FC develop PR](https://github.com/broadinstitute/firecloud-develop/pull/3391)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
