### PR TITLE
AJ-1122: re-enable test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -168,7 +168,7 @@ class SnapshotAPISpec
 
     }
 
-    "should be able to run analysis on a snapshot" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) ignore {
+    "should be able to run analysis on a snapshot" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) in {
       val owner = UserPool.userConfig.Owners.getUserCredential("hermione")
 
       implicit val ownerAuthToken: AuthToken = owner.makeAuthToken()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1122

This re-enables the automation test that was disabled in #2399.

I've run this test a few times locally and it is passing. Note that this test only runs nightly in alpha; it does not run in BEEs (aka FiaBs), so we won't see it pass/fail in this PR. We'll have to merge the PR and see what happens overnight.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
