### PR TITLE
[DDO-2885] Remove claim verification from local development site.conf template

### DIFF
--- a/local-dev/templates/site.conf
+++ b/local-dev/templates/site.conf
@@ -1,6 +1,3 @@
-{{- $b2cAppId := ( secret "secret/dsde/terra/azure/dev/b2c/application_id" ).Data.value -}}
-{{- $legacyGoogleClientId := ( secret "secret/dsde/firecloud/dev/common/refresh-token-oauth-credential.json" ).Data.web.client_id -}}
-{{- $legacyGoogleClientIdPrefix := index (printf "%s" $legacyGoogleClientId | split "-") 0 -}}
 ServerTokens ProductOnly
 TraceEnable off
 

--- a/local-dev/templates/site.conf.ctmpl
+++ b/local-dev/templates/site.conf.ctmpl
@@ -134,13 +134,6 @@ ProxyTimeout ${PROXY_TIMEOUT}
           <RequireAll>
             ${AUTH_REQUIRE2}
           </RequireAll>
-          <RequireAny>
-            # Note: we need to reference %{REMOTE_USER} to ensure that this expression is evaluated _after_ the authentication has happened
-            # %{REMOTE_USER} != %{REMOTE_USER} will never evaluate to true but will ensure that the expression is evaluated at the correct time
-            # Allow service accounts for tests, and B2C app id ({{ $b2cAppId }}) and dev oauth client id ({{ $legacyGoogleClientIdPrefix }}) so that swagger oauth works
-            # (It's also reasonable to remove this check entirely for local development)
-            Require expr "%{REMOTE_USER} != %{REMOTE_USER} || ((%{HTTP:OAUTH2_CLAIM_email} =~ /\.gserviceaccount.com$/) || (%{HTTP:OAUTH2_CLAIM_xms_mirid} =~ m#^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/Microsoft\.ManagedIdentity/userAssignedIdentities/[^/]+$#) || (%{HTTP:OAUTH2_CLAIM_aud} =~ /^{{ $legacyGoogleClientIdPrefix }}/) || (%{HTTP:OAUTH2_CLAIM_aud} == '{{ $b2cAppId }}'))"
-          </RequireAny>
         </RequireAll>
 
         <Limit OPTIONS>


### PR DESCRIPTION
Ticket: [DDO-2885](https://broadworkbench.atlassian.net/browse/DDO-2885)

The local dev site.conf template I merged [last week](https://github.com/broadinstitute/rawls/pull/2383) is missing some claim allowlist clauses that are present in Terra's dev environment, so that eg. `@broadinstitute.org` identities get a 401. These claim checks as a security feature aren't necessary for local development so let's remove them.

### Testing

I spun up a local Rawls off of this PR and verified that I could:
* authenticate via Swagger with my BI account and execute `GET /api/workspaces`
* execute 
```
curl -H "content-type: application/json" --header "Authorization: Bearer `gcloud auth print-access-token`" https://local.broadinstitute.org:20443/api/workspaces
``` 
(which did not work prior to this PR)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[DDO-2885]: https://broadworkbench.atlassian.net/browse/DDO-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ