### PR TITLE
AJ-1112 Numbers shouldn't stringify into scientific notation

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -960,7 +960,7 @@ object AttributeStringifier {
     attribute match {
       case AttributeNull                     => ""
       case AttributeString(value)            => value
-      case AttributeNumber(value)            => value.toString()
+      case AttributeNumber(value)            => value.bigDecimal.toPlainString
       case AttributeBoolean(value)           => value.toString
       case AttributeValueRawJson(value)      => value.toString()
       case AttributeEntityReference(_, name) => name

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
@@ -4,13 +4,11 @@ import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.scalatest.Assertions
-import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-class AttributeSpec extends AnyFreeSpec with Assertions with Matchers {
+class AttributeSpec extends AnyFreeSpec with Assertions {
 
   "AttributeName model" - {
 
@@ -690,23 +688,22 @@ class AttributeSpec extends AnyFreeSpec with Assertions with Matchers {
   }
 
   "AttributeStringifier" - {
-    "should not stringify large numbers in scientific notation" in {
-      val numbers = List(
-        (AttributeNumber(BigDecimal(1234567890)), "1234567890"),
-        (AttributeNumber(BigDecimal(2234567890000d)), "2234567890000"),
-        (AttributeNumber(BigDecimal(4123456789000011d)), "4123456789000011"),
-        (AttributeNumber(BigDecimal(2234567891098765432L)), "2234567891098765432"),
-        (AttributeNumber(BigDecimal(22345678910987000L)), "22345678910987000"),
-        (AttributeNumber(22345678900d), "22345678900"),
-        (AttributeNumber(41234567890000d), "41234567890000"),
-        (AttributeNumber(223456789100L), "223456789100")
-      )
 
-      numbers.foreach { case (attribute, string) =>
+    val numbers = List(
+      (AttributeNumber(BigDecimal(1234567890)), "1234567890"),
+      (AttributeNumber(BigDecimal(2234567890000d)), "2234567890000"),
+      (AttributeNumber(BigDecimal(4123456789000011d)), "4123456789000011"),
+      (AttributeNumber(BigDecimal(2234567891098765432L)), "2234567891098765432"),
+      (AttributeNumber(BigDecimal(22345678910987000L)), "22345678910987000"),
+      (AttributeNumber(22345678900d), "22345678900"),
+      (AttributeNumber(41234567890000d), "41234567890000"),
+      (AttributeNumber(223456789100L), "223456789100")
+    )
+
+    numbers.foreach { case (attribute, string) =>
+      s"should not stringify large number [$string] in scientific notation" in {
         assertResult(string)(AttributeStringifier(attribute))
-
       }
-
     }
   }
 

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/AttributeSpec.scala
@@ -4,11 +4,13 @@ import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.scalatest.Assertions
+import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-class AttributeSpec extends AnyFreeSpec with Assertions {
+class AttributeSpec extends AnyFreeSpec with Assertions with Matchers {
 
   "AttributeName model" - {
 
@@ -686,4 +688,26 @@ class AttributeSpec extends AnyFreeSpec with Assertions {
       }
     }
   }
+
+  "AttributeStringifier" - {
+    "should not stringify large numbers in scientific notation" in {
+      val numbers = List(
+        (AttributeNumber(BigDecimal(1234567890)), "1234567890"),
+        (AttributeNumber(BigDecimal(2234567890000d)), "2234567890000"),
+        (AttributeNumber(BigDecimal(4123456789000011d)), "4123456789000011"),
+        (AttributeNumber(BigDecimal(2234567891098765432L)), "2234567891098765432"),
+        (AttributeNumber(BigDecimal(22345678910987000L)), "22345678910987000"),
+        (AttributeNumber(22345678900d), "22345678900"),
+        (AttributeNumber(41234567890000d), "41234567890000"),
+        (AttributeNumber(223456789100L), "223456789100")
+      )
+
+      numbers.foreach { case (attribute, string) =>
+        assertResult(string)(AttributeStringifier(attribute))
+
+      }
+
+    }
+  }
+
 }


### PR DESCRIPTION
Ticket: [AJ-1112](https://broadworkbench.atlassian.net/browse/AJ-1112)
If an entity attribute was a number that was larger than about 9 digits, it would be converted to scientific notation when downloaded to a TSV.  (e.g. 2305150090 -> 2.30515009E+9).  This was due to the nature of the `BigDecimal` object that such numbers were unmarshalled as when pulled from the database, which by default limits the string version of the number to 9 digits.  This PR changes stringification of `AttributeNumber`s to plainString and adds a test to check for it.
Since this changes the rawls Model, there will be two follow-on PRs to complete this ticket:
1. After this PR merges, a new model will need to be released and rawls will be updated to reflect that.
2. Since the issue appears upon TSV download which happens through Firecloud-Orchestration, once the model is released orch will need to be updated to use the new model.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-1112]: https://broadworkbench.atlassian.net/browse/AJ-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ