### PR TITLE
Remove coverage while we sort out the issue (WOR-908).

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -105,16 +105,7 @@ jobs:
                           -v jar-cache:/root/.ivy2 \
                           -w /working \
                           sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 \
-                          sbt "project pact4s" clean coverage test coverageReport
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          flags: pact
-          token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          working-directory: ./pact4s
+                          sbt "project pact4s" clean test
 
       - name: Output consumer contract as non-breaking base64 string
         id: encode-pact


### PR DESCRIPTION
After I merged my PR with the first Rawls pact test, coverage uploads started failing (though the coverage upload passed on the PR itself).

Removing the uploading of coverage until we sort this out so as to not impact other PRs… coverage won't tell us much at this point anyway!

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
