### PR TITLE
Temporarily remove spend report test case (WOR-908)

### DIFF
--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -11,8 +11,19 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAOImpl, HttpBillingProfileManagerClientProvider}
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.consumer.PactHelper.{buildInteraction, jsonRequestHeaders, jsonRequestHeadersWithBody, jsonResponseHeaders}
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.broadinstitute.dsde.rawls.consumer.PactHelper.{
+  buildInteraction,
+  jsonRequestHeaders,
+  jsonRequestHeadersWithBody,
+  jsonResponseHeaders
+}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  UserInfo
+}
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -5,26 +5,14 @@ import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
 import au.com.dius.pact.consumer.dsl._
 import au.com.dius.pact.consumer.{ConsumerPactBuilder, PactTestExecutionContext}
 import au.com.dius.pact.core.model.RequestResponsePact
-import bio.terra.profile.client.ApiClient
 import bio.terra.profile.model.{CloudPlatform, SystemStatus, SystemStatusSystems}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAOImpl, HttpBillingProfileManagerClientProvider}
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.consumer.PactHelper.{
-  buildInteraction,
-  jsonRequestHeaders,
-  jsonRequestHeadersWithBody,
-  jsonResponseHeaders
-}
-import org.broadinstitute.dsde.rawls.model.{
-  AzureManagedAppCoordinates,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  RawlsUserSubjectId,
-  UserInfo
-}
+import org.broadinstitute.dsde.rawls.consumer.PactHelper.{buildInteraction, jsonRequestHeaders, jsonRequestHeadersWithBody, jsonResponseHeaders}
+import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -151,36 +139,36 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     .array("members")
     .closeArray()
 
-  val spendReportResponse: DslPart = newJsonBody { o =>
-    o.`array`(
-      "spendDetails",
-      a =>
-        a.`object` { ao =>
-          ao.stringType("aggregationKey", "Category")
-          ao.`array`(
-            "spendData",
-            sp =>
-              sp.`object` { spo =>
-                spo.stringType("category")
-                spo.stringType("cost")
-                spo.stringType("credits")
-                spo.stringType("currency")
-              }
-          )
-        }
-    )
-    o.`object`(
-      "spendSummary",
-      { so =>
-        so.stringType("startTime")
-          .valueFromProviderState("startTime", "${startTime}", new ApiClient().formatDate(dummyDate))
-        so.stringType("endTime").valueFromProviderState("endTime", "${endTime}", new ApiClient().formatDate(dummyDate))
-        so.stringType("cost")
-        so.stringType("credits")
-        so.stringType("currency")
-      }
-    )
-  }.build()
+//  val spendReportResponse: DslPart = newJsonBody { o =>
+//    o.`array`(
+//      "spendDetails",
+//      a =>
+//        a.`object` { ao =>
+//          ao.stringType("aggregationKey", "Category")
+//          ao.`array`(
+//            "spendData",
+//            sp =>
+//              sp.`object` { spo =>
+//                spo.stringType("category")
+//                spo.stringType("cost")
+//                spo.stringType("credits")
+//                spo.stringType("currency")
+//              }
+//          )
+//        }
+//    )
+//    o.`object`(
+//      "spendSummary",
+//      { so =>
+//        so.stringType("startTime")
+//          .valueFromProviderState("startTime", "${startTime}", new ApiClient().formatDate(dummyDate))
+//        so.stringType("endTime").valueFromProviderState("endTime", "${endTime}", new ApiClient().formatDate(dummyDate))
+//        so.stringType("cost")
+//        so.stringType("credits")
+//        so.stringType("currency")
+//      }
+//    )
+//  }.build()
 
   val consumerPactBuilder: ConsumerPactBuilder = ConsumerPactBuilder
     .consumer("rawls-consumer")
@@ -290,21 +278,21 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     .headers(jsonResponseHeaders)
     .body(emptyPolicyMemberResponse)
 
-  pactDslResponse = pactDslResponse
-    .`given`("an Azure billing profile")
-    .`given`("an Azure spend report service exists")
-    .uponReceiving("Request for spend report")
-    .method("GET")
-    .pathFromProviderState("/api/profiles/v1/${azureProfileId}/spendReport",
-                           s"/api/profiles/v1/${dummyBillingProfileId}/spendReport"
-    )
-    .headers(jsonRequestHeaders)
-    .queryParameterFromProviderState("spendReportStartDate", "${startTime}", new ApiClient().formatDate(dummyDate))
-    .queryParameterFromProviderState("spendReportEndDate", "${endTime}", new ApiClient().formatDate(dummyDate))
-    .willRespondWith()
-    .status(200)
-    .headers(jsonResponseHeaders)
-    .body(spendReportResponse)
+//  pactDslResponse = pactDslResponse
+//    .`given`("an Azure billing profile")
+//    .`given`("an Azure spend report service exists")
+//    .uponReceiving("Request for spend report")
+//    .method("GET")
+//    .pathFromProviderState("/api/profiles/v1/${azureProfileId}/spendReport",
+//                           s"/api/profiles/v1/${dummyBillingProfileId}/spendReport"
+//    )
+//    .headers(jsonRequestHeaders)
+//    .queryParameterFromProviderState("spendReportStartDate", "${startTime}", new ApiClient().formatDate(dummyDate))
+//    .queryParameterFromProviderState("spendReportEndDate", "${endTime}", new ApiClient().formatDate(dummyDate))
+//    .willRespondWith()
+//    .status(200)
+//    .headers(jsonResponseHeaders)
+//    .body(spendReportResponse)
 
   override val pact: RequestResponsePact = pactDslResponse.toPact
 
@@ -395,13 +383,13 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     )
   }
 
-  it should "return a spend report" in {
-    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
-      new HttpBillingProfileManagerClientProvider(Some(mockServer.getUrl)),
-      multiCloudWorkspaceConfig
-    )
-    val spendReport =
-      billingProfileManagerDAO.getAzureSpendReport(dummyBillingProfileId, dummyDate, dummyDate, testContext)
-    spendReport.getSpendDetails.isEmpty shouldBe false
-  }
+//  it should "return a spend report" in {
+//    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
+//      new HttpBillingProfileManagerClientProvider(Some(mockServer.getUrl)),
+//      multiCloudWorkspaceConfig
+//    )
+//    val spendReport =
+//      billingProfileManagerDAO.getAzureSpendReport(dummyBillingProfileId, dummyDate, dummyDate, testContext)
+//    spendReport.getSpendDetails.isEmpty shouldBe false
+//  }
 }


### PR DESCRIPTION
There is a problem with how values are being replaced with provider state. I want to unblock PRs/get Rawls into a healthy state, so removing this while I try to sort it out.

Failure:
```
==== Pact Broker Response ====
{
  "notices": [
    {
      "type": "error",
      "text": "Cannot change the content of the pact for bpm-provider version 88f21377cc54169f83ff05a06ef09d1725b39d1c and provider bpm-provider, as race conditions will cause unreliable results for can-i-deploy. Each pact must be published with a unique consumer version number. Some Pact libraries generate random data when a concrete value for a type matcher is not specified, and this can cause the contract to mutate - ensure you have given example values for all type matchers. For more information see https://docs.pact.io/go/versioning"
    },
    {
      "type": "info",
      "text": "       \"request\": {\n         \"query\": {\n           \"spendReportEndDate\": [\n-            \"2023-06-30T13:16:57.602Z\",\n+            \"2023-06-30T15:00:07.989Z\"\n           ],\n           \"spendReportStartDate\": [\n-            \"2023-06-30T13:16:57.602Z\",\n+            \"2023-06-30T15:00:07.989Z\"\n           ]\n         }\n       },\n       \"response\": {\n         \"body\": {\n           \"spendSummary\": {\n-            \"endTime\": \"2023-06-30T13:16:57.602Z\",\n-            \"startTime\": \"2023-06-30T13:16:57.602Z\"\n+            \"endTime\": \"2023-06-30T15:00:07.989Z\",\n+            \"startTime\": \"2023-06-30T15:00:07.989Z\"\n           }\n         }\n       }"
    }
  ],
  "errors": {
    "contracts": [
      "Cannot change the content of the pact for bpm-provider version 88f2[137](https://github.com/broadinstitute/terra-github-workflows/actions/runs/5424512018/jobs/9863971506#step:3:143)7cc54169f83ff05a06ef09d1725b39d1c and provider bpm-provider, as race conditions will cause unreliable results for can-i-deploy. Each pact must be published with a unique consumer version number. Some Pact libraries generate random data when a concrete value for a type matcher is not specified, and this can cause the contract to mutate - ensure you have given example values for all type matchers. For more information see https://docs.pact.io/go/versioning"
    ]
  }
}
Error: Process completed with exit code 1.
---
