### PR TITLE
WOR-1101 Add policies from WSM to workspace details response

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It will also set up a process that will watch the local files for changes, and r
 
 See docker-rsync-local-rawls.sh for more configuration options.
 
-If Rawls successfully starts up, you can now access the Rawls Swagger page: https://local.broadinstitute.org:20443/
+If Rawls successfully starts up, you can now access the Rawls Swagger page: http://local.broadinstitute.org:20443/
 
 ### Useful Tricks:
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It will also set up a process that will watch the local files for changes, and r
 
 See docker-rsync-local-rawls.sh for more configuration options.
 
-If Rawls successfully starts up, you can now access the Rawls Swagger page: http://local.broadinstitute.org:20443/
+If Rawls successfully starts up, you can now access the Rawls Swagger page: https://local.broadinstitute.org:20443/
 
 ### Useful Tricks:
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-53fb1d87e"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-71ed998b"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("bio.terra", "workspace-manager-client"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-71ed998b"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-3be1dba4"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("bio.terra", "workspace-manager-client"),

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5384,6 +5384,10 @@ components:
       properties:
         accessLevel:
           $ref: '#/components/schemas/WorkspaceAccessLevel'
+        azureContext:
+          $ref: '#/components/schemas/AzureManagedAppCoordinates'
+          description: |
+            The AzureManagedAppCoordinates of the billing project, if this is an Azure workspace.
         bucketOptions:
           $ref: '#/components/schemas/WorkspaceBucketOptions'
         canCompute:
@@ -5398,11 +5402,24 @@ components:
             Owners of this workspace. This API only lists owners; use the get-workspace-ACL API to get the full list of all users at all permission levels.
           items:
             type: string
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkspacePolicy'
         workspace:
           $ref: '#/components/schemas/WorkspaceDetails'
         workspaceSubmissionStats:
           $ref: '#/components/schemas/WorkspaceSubmissionStats'
       description: ""
+    WorkspacePolicy:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        additionalData:
+          type: object
     WorkspaceListResponse:
       type: object
       properties:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.workspace
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.Materializer
 import bio.terra.workspace.client.ApiException
-import bio.terra.workspace.model.WorkspaceDescription
+import bio.terra.workspace.model.{WorkspaceDescription, WsmPolicyInput}
 import cats.implicits._
 import cats.{Applicative, ApplicativeThrow, MonadThrow}
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
@@ -326,7 +326,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Option(attrSpecs)) flatMap {
         workspaceContext =>
           dataSource.inTransaction { dataAccess =>
-            val azureInfo: Option[AzureManagedAppCoordinates] =
+            val azureInfo: Option[(AzureManagedAppCoordinates, List[WorkspacePolicy])] =
               getAzureCloudContextFromWorkspaceManager(workspaceContext, s1)
             val cloudPlatform = getCloudPlatform(workspaceContext)
 
@@ -439,7 +439,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                   stats,
                   bucketDetails,
                   owners,
-                  azureInfo
+                  azureInfo.map(_._1),
+                  azureInfo.map(_._2)
                 )
                 val filteredJson = deepFilterJsObject(workspaceResponse.toJson.asJsObject, options)
                 filteredJson
@@ -452,21 +453,23 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
   private def getAzureCloudContextFromWorkspaceManager(workspaceContext: Workspace,
                                                        parentContext: RawlsRequestContext
-  ) =
+  ): Option[(AzureManagedAppCoordinates, List[WorkspacePolicy])] =
     workspaceContext.workspaceType match {
       case WorkspaceType.McWorkspace =>
         val span = startSpanWithParent("getWorkspaceFromWorkspaceManager", parentContext.tracingSpan.orNull)
 
         try {
           val wsmInfo = workspaceManagerDAO.getWorkspace(workspaceContext.workspaceIdAsUUID, ctx)
-
           Option(wsmInfo.getAzureContext) match {
             case Some(azureContext) =>
               Some(
                 AzureManagedAppCoordinates(UUID.fromString(azureContext.getTenantId),
                                            UUID.fromString(azureContext.getSubscriptionId),
                                            azureContext.getResourceGroupId
-                )
+                ),
+                Option(wsmInfo.getPolicies)
+                  .map(policies => policies.asScala.toList.map(WorkspacePolicy.apply))
+                  .getOrElse(List.empty)
               )
             case None =>
               throw new RawlsExceptionWithErrorReport(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -1,0 +1,59 @@
+package org.broadinstitute.dsde.rawls.model
+
+import bio.terra.workspace.model.{WsmPolicyInput, WsmPolicyPair}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.util
+
+class WorkspaceModelSpec extends AnyFlatSpecLike with MockitoSugar with Matchers {
+
+  behavior of "Converting WsmPolicyInput to rawls' WorkspacePolicy"
+
+  it should "use the WsmPolicyInput name and namespace" in {
+    val wsmPolicyInput = new WsmPolicyInput()
+    wsmPolicyInput.name("test_name")
+    wsmPolicyInput.namespace("test_namespace")
+    wsmPolicyInput.additionalData(new util.ArrayList[WsmPolicyPair]())
+
+    val policy = WorkspacePolicy(wsmPolicyInput)
+    policy.name shouldEqual wsmPolicyInput.getName
+    policy.namespace shouldEqual wsmPolicyInput.getNamespace
+  }
+
+  it should "use an empty map when additionalData is null" in {
+    val wsmPolicyInput = new WsmPolicyInput()
+    wsmPolicyInput.name("test_name")
+    wsmPolicyInput.namespace("test_namespace")
+
+    val policy = WorkspacePolicy(wsmPolicyInput)
+
+    policy.additionalData should not be null
+    policy.additionalData shouldBe empty
+  }
+
+
+  it should "convert the additionalData to a map" in {
+    val wsmPolicyInput = new WsmPolicyInput()
+    wsmPolicyInput.name("test_name")
+    wsmPolicyInput.namespace("test_namespace")
+    val wsmPolicyPairs = new util.ArrayList[WsmPolicyPair]()
+    val pair1 = new WsmPolicyPair()
+    pair1.value("pair1Val")
+    pair1.key("pair1Key")
+    wsmPolicyPairs.add(pair1)
+    val pair2 = new WsmPolicyPair()
+    pair2.value("pair2Val")
+    pair2.key("pair2Key")
+    wsmPolicyPairs.add(pair2)
+    wsmPolicyInput.additionalData(wsmPolicyPairs)
+
+    val policy = WorkspacePolicy(wsmPolicyInput)
+
+    policy.additionalData.getOrElse(pair1.getKey, "fail") shouldEqual pair1.getValue
+    policy.additionalData.getOrElse(pair2.getKey, "fail") shouldEqual pair2.getValue
+
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -108,6 +108,7 @@ class PetSASpec extends ApiServiceSpec {
             Option(WorkspaceSubmissionStats(None, None, 0)),
             Option(WorkspaceBucketOptions(false)),
             Option(Set.empty),
+            None,
             None
           )
         ) {
@@ -121,6 +122,7 @@ class PetSASpec extends ApiServiceSpec {
             response.workspaceSubmissionStats,
             response.bucketOptions,
             response.owners,
+            None,
             None
           )
         }
@@ -155,6 +157,7 @@ class PetSASpec extends ApiServiceSpec {
             Option(WorkspaceSubmissionStats(None, None, 0)),
             Option(WorkspaceBucketOptions(false)),
             Option(Set.empty),
+            None,
             None
           )
         ) {
@@ -168,6 +171,7 @@ class PetSASpec extends ApiServiceSpec {
             response.workspaceSubmissionStats,
             response.bucketOptions,
             response.owners,
+            None,
             None
           )
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -257,6 +257,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
     Option(WorkspaceBucketOptions(false)),
     Option(Set.empty),
+    None,
     None
   )
 
@@ -286,6 +287,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
     None,
     None,
     WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = testTime), None, false),
+    None,
     None,
     None,
     None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -696,6 +696,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
             Option(WorkspaceBucketOptions(false)),
             Option(Set.empty),
+            None,
             None
           )
         ) {
@@ -709,6 +710,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             response.workspaceSubmissionStats,
             response.bucketOptions,
             response.owners,
+            None,
             None
           )
         }
@@ -737,6 +739,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
             Option(WorkspaceBucketOptions(false)),
             Option(Set.empty),
+            None,
             None
           )
         ) {
@@ -750,6 +753,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             response.workspaceSubmissionStats,
             response.bucketOptions,
             response.owners,
+            None,
             None
           )
         }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -722,7 +722,7 @@ case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
                              bucketOptions: Option[WorkspaceBucketOptions],
                              owners: Option[Set[String]],
                              azureContext: Option[AzureManagedAppCoordinates],
-                             policies: Option[List[WorkspacePolicy]]
+                             policies: Option[List[WorkspacePolicy]] = None
 )
 
 case class WorkspaceDetails(

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.model
 
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes.BadRequest
+import bio.terra.workspace.model.WsmPolicyInput
 import cats.implicits._
 import io.lemonlabs.uri.{Uri, Url}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
@@ -20,6 +21,7 @@ import spray.json._
 import java.net.{URLDecoder, URLEncoder}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object Attributable {
@@ -698,6 +700,19 @@ case class AzureManagedAppCoordinates(tenantId: UUID,
                                       landingZoneId: Option[UUID] = None
 )
 
+case class WorkspacePolicy(name: String, namespace: String, additionalData: Map[String, String])
+
+object WorkspacePolicy {
+  def apply(input: WsmPolicyInput): WorkspacePolicy =
+    WorkspacePolicy(
+      input.getName,
+      input.getNamespace,
+      Option(input.getAdditionalData)
+        .map(data => data.asScala.map(p => p.getKey -> p.getValue).toMap)
+        .getOrElse(Map.empty)
+    )
+}
+
 case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
                              canShare: Option[Boolean],
                              canCompute: Option[Boolean],
@@ -706,7 +721,8 @@ case class WorkspaceResponse(accessLevel: Option[WorkspaceAccessLevel],
                              workspaceSubmissionStats: Option[WorkspaceSubmissionStats],
                              bucketOptions: Option[WorkspaceBucketOptions],
                              owners: Option[Set[String]],
-                             azureContext: Option[AzureManagedAppCoordinates]
+                             azureContext: Option[AzureManagedAppCoordinates],
+                             policies: Option[List[WorkspacePolicy]]
 )
 
 case class WorkspaceDetails(
@@ -1029,6 +1045,8 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val AzureManagedAppCoordinatesFormat: RootJsonFormat[AzureManagedAppCoordinates] =
     jsonFormat4(AzureManagedAppCoordinates)
 
+  implicit val WorkspacePolicyFormat: RootJsonFormat[WorkspacePolicy] = jsonFormat3(WorkspacePolicy.apply)
+
   implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat9(WorkspaceRequest)
 
   implicit val workspaceFieldSpecsFormat: RootJsonFormat[WorkspaceFieldSpecs] = jsonFormat1(WorkspaceFieldSpecs.apply)
@@ -1158,7 +1176,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceListResponseFormat: RootJsonFormat[WorkspaceListResponse] = jsonFormat4(WorkspaceListResponse)
 
-  implicit val WorkspaceResponseFormat: RootJsonFormat[WorkspaceResponse] = jsonFormat9(WorkspaceResponse)
+  implicit val WorkspaceResponseFormat: RootJsonFormat[WorkspaceResponse] = jsonFormat10(WorkspaceResponse)
 
   implicit val PendingCloneWorkspaceFileTransferFormat: RootJsonFormat[PendingCloneWorkspaceFileTransfer] = jsonFormat5(
     PendingCloneWorkspaceFileTransfer

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -653,4 +653,5 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
     }
 
   }
+
 }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -413,7 +413,8 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
                           "workspaceSubmissionStats",
                           "bucketOptions",
                           "owners",
-                          "azureContext"
+                          "azureContext",
+                          "policies"
       )
       WorkspaceFieldNames.workspaceResponseClassNames should contain theSameElementsAs expected
     }
@@ -445,6 +446,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
     "should collate WorkspaceResponse and WorkspaceDetails correctly" in {
       val expected = List(
         "azureContext",
+        "policies",
         "accessLevel",
         "canShare",
         "canCompute",


### PR DESCRIPTION
Ticket: [WOR-1101](https://broadworkbench.atlassian.net/browse/WOR-1101)

When we get the azure coordinates of a workspace from WSM, also return the workspace's policies.

We're only changing the workspace response model, not the workspace model itself; so there's no database changes.

Once I made these changes, I was able to see the policies from WSM being retuned on a workspace when running locally.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1101]: https://broadworkbench.atlassian.net/browse/WOR-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ