### PR TITLE
Add workspace sharing test (WOR-1106).

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -155,7 +155,7 @@ class AzureWorkspacesSpec extends AnyFlatSpec with Matchers with CleanUp {
     }
   }
 
-  "Rawls" should "allow sharing a workspace" in {
+  it should "allow sharing a workspace" in {
     implicit val token = owner.makeAuthToken()
     withTemporaryAzureBillingProject(azureManagedAppCoordinates) { projectName =>
       val workspaceName = generateWorkspaceName()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1106

Adds smoke workspace sharing test so that we can remove this from the manual Azure e2e testing script.

Successful run of the test can be seen here: https://github.com/broadinstitute/terra-github-workflows/actions/runs/5508558345/jobs/10039999267

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
