### PR TITLE
QA-2092: Specify an environment in can-i-deploy workflow dispatch

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -142,4 +142,4 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
-          inputs: '{ "pacticipant": "rawls-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}" }'
+          inputs: '{ "pacticipant": "rawls-consumer", "version": "${{ needs.init-github-context.outputs.repo-version }}", "environment": "alpha" }'


### PR DESCRIPTION
Ticket: [QA-2092](https://broadworkbench.atlassian.net/browse/QA-2092)

Provide an additional `environment` parameter to bypass matrix strategy in `can-i-deploy` workflow.

Please refer to the `can-i-deploy` [workflow](https://github.com/broadinstitute/terra-github-workflows/actions/runs/5533143227/jobs/10096243245) associated with this PR.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[QA-2092]: https://broadworkbench.atlassian.net/browse/QA-2092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ