### PR TITLE
WOR-1156 fix incorrect api docs

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5608,44 +5608,6 @@ components:
           items:
             $ref: '#/components/schemas/Entity'
       description: ""
-    CreateRawlsBillingProjectFullRequest:
-      required:
-        - billingAccount
-        - projectName
-      type: object
-      properties:
-        projectName:
-          type: string
-          description: the name of the project to create
-        billingAccount:
-          type: string
-          description: the id of the billing account to use, must start with 'billingAccounts/'
-        highSecurityNetwork:
-          type: boolean
-          description: Optional, false if not specified. If true, spin up all compute
-            in a VPC network.
-        enableFlowLogs:
-          type: boolean
-          description: Optional, false if not specified. If true, enable flow logs
-            within the high security network. Requires highSecurityNetwork = true.
-        privateIpGoogleAccess:
-          type: boolean
-          description: Optional, false if not specified. If true, it configures the
-            VPC network to only allow access to GCP APIs that are protected by the
-            project's service perimeter and routes all allowed API traffic through
-            a narrow IP range. Requires highSecurityNetwork = true.
-        servicePerimeter:
-          type: string
-          description: The fully qualified name of the GCP service perimeter to put
-            this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME].
-            Caller must have the add_project action for this service perimeter in
-            Sam.
-        protectedData:
-          type: boolean
-          description: Optional, false if not specified. Applicable only for azure 
-            billing projects. When set, a billing project with suitable infrastructure
-            for protected data workspaces will be created.
-      description: ""
     CreateRawlsV2BillingProjectFullRequest:
       required:
         - projectName
@@ -5673,6 +5635,11 @@ components:
         inviteUsersNotFound:
           description: If true, invite the users to Terra if they are not registered in the system. They will be given access to the project when they register.
           type: boolean
+        protectedData:
+          type: boolean
+          description: Optional, false if not specified. Applicable only for azure
+            billing projects. When set, a billing project with suitable infrastructure
+            for protected data workspaces will be created.
       description: ""
     ProjectRole:
       description: the role on the billing project


### PR DESCRIPTION
Ticket: [WOR-1156](https://broadworkbench.atlassian.net/browse/WOR-1156)

The swagger doc was incorrect. This brings it in line with what the service is actually expecting.
* add protectedData property to correct component definition 
* remove unused component
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1156]: https://broadworkbench.atlassian.net/browse/WOR-1156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ