### PR TITLE
Fix bug with wrong version of branch (WOR-1132).

### DIFF
--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -44,6 +44,8 @@ jobs:
       custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
     steps:
       - uses: 'actions/checkout@v3'
+        with:
+          ref: ${{ needs.init-github-context.outputs.branch }}
 
       - name: Bump the tag to a new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1132

Ran the e2e tests specifying this branch for the one to run the workflow from, and WOR-522 for the branch to test code against.

<img width="738" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/3cd87350-6759-44c1-9648-58acbeb6ed9e">

<img width="861" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/8edecdf4-c4eb-4552-84f3-313be13259d2">

Before:
<img width="506" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/1a2ffd05-a8ea-4803-ae24-16afcb046592">

<img width="783" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/d1f44adb-8cdc-4fc9-b7a9-1e892493f3a3">

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
