### PR TITLE
ID-707 Fix workflow submission notifications for b2c users.

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -463,8 +463,9 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
                 notification => notificationDAO.fireAndForgetNotification(notification)
               )
             case None =>
-              logger.info(
-                s"Submitter does not have a googleSubjectId. Will not send an email notification for submission ${submissionId}."              )
+              toThurloeNotification(submission, workspaceName, finalStatus, WorkbenchUserId(userIdInfo.userSubjectId)).fold()(
+                notification => notificationDAO.fireAndForgetNotification(notification)
+              )
           }
         }
       case None =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserModel.scala
@@ -3,14 +3,18 @@ package org.broadinstitute.dsde.rawls.model
 /**
  * Created by dvoet on 10/27/15.
  */
-case class UserIdInfo(userSubjectId: String, userEmail: String, googleSubjectId: Option[String])
+case class UserIdInfo(userSubjectId: String,
+                      userEmail: String,
+                      googleSubjectId: Option[String],
+                      azureB2CId: Option[String]
+)
 
 case class UserList(userList: Seq[String])
 
 class UserJsonSupport extends JsonSupport {
   import spray.json.DefaultJsonProtocol._
 
-  implicit val UserIdInfoFormat = jsonFormat3(UserIdInfo)
+  implicit val UserIdInfoFormat = jsonFormat4(UserIdInfo)
   implicit val UserListFormat = jsonFormat1(UserList)
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1617,8 +1617,8 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         // Thurloe needs the google subject id (in the case of gcp user) or the b2c id.
         userIdInfo <- samDAO.getUserIdInfo(accessUpdate.email, ctx)
         userId = userIdInfo match {
-          case SamDAO.User(UserIdInfo(_, _, Some(googleSubjectId))) => googleSubjectId
-          case SamDAO.User(UserIdInfo(samSubjectId, _, None))       => samSubjectId
+          case SamDAO.User(UserIdInfo(_, _, Some(googleSubjectId), _)) => googleSubjectId
+          case SamDAO.User(UserIdInfo(_, _, _, Some(azureB2CId)))      => azureB2CId
           case _ => throw new RawlsException(s"Unable to find user id for ${accessUpdate.email}")
         }
         _ =
@@ -1651,14 +1651,14 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
       // Thurloe needs the google subject id (in the case of gcp user) or the b2c id.
       notificationMessages = userIdInfos.collect {
-        case UserIdInfo(_, _, Some(googleSubjectId)) =>
+        case UserIdInfo(_, _, Some(googleSubjectId), _) =>
           Notifications.WorkspaceChangedNotification(
             WorkbenchUserId(googleSubjectId),
             NotificationWorkspaceName(workspaceName.namespace, workspaceName.name)
           )
-        case UserIdInfo(userSubjectId, _, _) =>
+        case UserIdInfo(_, _, _, Some(azureB2CId)) =>
           Notifications.WorkspaceChangedNotification(
-            WorkbenchUserId(userSubjectId),
+            WorkbenchUserId(azureB2CId),
             NotificationWorkspaceName(workspaceName.namespace, workspaceName.name)
           )
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -211,7 +211,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         verify(mockNotificationDAO, Mockito.times(1))
           .fireAndForgetNotification(notificationCapture.capture())(any[ExecutionContext])
         val notification: Notifications.AbortedSubmissionNotification = notificationCapture.getValue
-        notification.recipientUserId.value shouldBe mockSamDAO.userSubjectId
+        notification.recipientUserId.value shouldBe mockSamDAO.azureB2cId
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -11,6 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: ExecutionContext) extends SamDAO {
   import dataSource.dataAccess.{rawlsBillingProjectQuery, workspaceQuery, RawlsBillingProjectExtensions}
   val userSubjectId = "111111111111111"
+  val azureB2cId = "0000-0000-0000-0000"
 
   override def registerUser(ctx: RawlsRequestContext): Future[Option[RawlsUser]] = ???
 
@@ -21,7 +22,7 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
 
   override def getUserIdInfo(userEmail: String, ctx: RawlsRequestContext): Future[SamDAO.GetUserIdInfoResult] =
     Future.successful(
-      SamDAO.User(UserIdInfo(userSubjectId, userEmail, Option(ctx.userInfo.userSubjectId.value)))
+      SamDAO.User(UserIdInfo(userSubjectId, userEmail, Option(ctx.userInfo.userSubjectId.value), Option(azureB2cId)))
     )
 
   override def createResource(resourceTypeName: SamResourceTypeName,
@@ -96,7 +97,7 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
   override def inviteUser(userEmail: String, ctx: RawlsRequestContext): Future[Unit] = ???
 
   override def getUserIdInfoForEmail(userEmail: WorkbenchEmail): Future[UserIdInfo] =
-    Future.successful(UserIdInfo(userSubjectId, "user@email.example", None))
+    Future.successful(UserIdInfo(userSubjectId, "user@email.example", None, Option(azureB2cId)))
 
   override def syncPolicyToGoogle(resourceTypeName: SamResourceTypeName,
                                   resourceId: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -10,6 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: ExecutionContext) extends SamDAO {
   import dataSource.dataAccess.{rawlsBillingProjectQuery, workspaceQuery, RawlsBillingProjectExtensions}
+  val userSubjectId = "111111111111111"
 
   override def registerUser(ctx: RawlsRequestContext): Future[Option[RawlsUser]] = ???
 
@@ -20,7 +21,7 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
 
   override def getUserIdInfo(userEmail: String, ctx: RawlsRequestContext): Future[SamDAO.GetUserIdInfoResult] =
     Future.successful(
-      SamDAO.User(UserIdInfo(ctx.userInfo.userSubjectId.value, userEmail, Option(ctx.userInfo.userSubjectId.value)))
+      SamDAO.User(UserIdInfo(userSubjectId, userEmail, Option(ctx.userInfo.userSubjectId.value)))
     )
 
   override def createResource(resourceTypeName: SamResourceTypeName,
@@ -95,7 +96,7 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
   override def inviteUser(userEmail: String, ctx: RawlsRequestContext): Future[Unit] = ???
 
   override def getUserIdInfoForEmail(userEmail: WorkbenchEmail): Future[UserIdInfo] =
-    Future.successful(UserIdInfo("111111111111111", "user@email.example", None))
+    Future.successful(UserIdInfo(userSubjectId, "user@email.example", None))
 
   override def syncPolicyToGoogle(resourceTypeName: SamResourceTypeName,
                                   resourceId: String,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-707

Users with legacy google subject ids are able to receive notifications but not users with only new b2c ids. This pr adds the path to use the user id sam returns. In the original registration with thurloe, orchestration uses the [sam user id from the request header as a fallback if the goog subject id isnt present](https://github.com/broadinstitute/firecloud-orchestration/blob/HEAD/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala#L21C1-L21C138) to save the thurloe record. So we should follow that same logic here.

Long term we may want to consider migrating all thurloe records to b2c to clean up tech debt, but I see that as out of scope of this support ticket.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
