### PR TITLE
[WOR-1154] Check for 403 when polling on WSM deletion

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -110,8 +110,10 @@ trait WorkspaceApiService extends UserInfoDirectives {
             } ~
             delete {
               complete {
-                workspaceServiceConstructor(ctx)
-                  .deleteWorkspace(WorkspaceName(workspaceNamespace, workspaceName))
+                val workspaceService = workspaceServiceConstructor(ctx)
+                val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
+                mcWorkspaceService
+                  .deleteMultiCloudOrRawlsWorkspace(WorkspaceName(workspaceNamespace, workspaceName), workspaceService)
                   .map(maybeBucketName => StatusCodes.Accepted -> workspaceDeleteMessage(maybeBucketName))
               }
             }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -1458,6 +1458,68 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     )
   }
 
+  it should "fail for for non 403 errors" in {
+    val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
+    when(workspaceManagerDAO.getDeleteWorkspaceV2Result(any[UUID], anyString(), any[RawlsRequestContext])).thenAnswer(
+      _ => throw new ApiException(StatusCodes.BadRequest.intValue, "failure")
+    )
+    val samDAO = new MockSamDAO(slickDataSource)
+    val svc = MultiCloudWorkspaceService.constructor(
+      slickDataSource,
+      workspaceManagerDAO,
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      activeMcWorkspaceConfig,
+      mock[LeonardoDAO],
+      workbenchMetricBaseName
+    )(testContext)
+
+    val actual = intercept[ApiException] {
+      Await.result(svc.deleteWorkspaceInWSM(testData.azureWorkspace.workspaceIdAsUUID), Duration.Inf)
+    }
+
+    actual.getMessage shouldBe "failure"
+    verify(svc.workspaceManagerDAO).deleteWorkspaceV2(equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+                                                      any[RawlsRequestContext]
+    )
+    verify(svc.workspaceManagerDAO, times(1)).getDeleteWorkspaceV2Result(
+      equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+      anyString,
+      any[RawlsRequestContext]
+    )
+  }
+
+  it should "fail for for non-ApiException errors" in {
+    val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
+    when(workspaceManagerDAO.getDeleteWorkspaceV2Result(any[UUID], anyString(), any[RawlsRequestContext])).thenAnswer(
+      _ => throw new Exception("failure")
+    )
+    val samDAO = new MockSamDAO(slickDataSource)
+    val svc = MultiCloudWorkspaceService.constructor(
+      slickDataSource,
+      workspaceManagerDAO,
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      activeMcWorkspaceConfig,
+      mock[LeonardoDAO],
+      workbenchMetricBaseName
+    )(testContext)
+
+    val actual = intercept[Exception] {
+      Await.result(svc.deleteWorkspaceInWSM(testData.azureWorkspace.workspaceIdAsUUID), Duration.Inf)
+    }
+
+    actual.getMessage shouldBe "failure"
+    verify(svc.workspaceManagerDAO).deleteWorkspaceV2(equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+                                                      any[RawlsRequestContext]
+    )
+    verify(svc.workspaceManagerDAO, times(1)).getDeleteWorkspaceV2Result(
+      equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+      anyString,
+      any[RawlsRequestContext]
+    )
+  }
+
   it should "delete the rawls workspace when workspace manager returns 403 during polling" in {
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO() {
       var times = 0

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -1458,6 +1458,45 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     )
   }
 
+  it should "delete the rawls workspace when workspace manager returns 403 during polling" in {
+    val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO() {
+      var times = 0
+
+      override def getDeleteWorkspaceV2Result(workspaceId: UUID,
+                                              jobControlId: String,
+                                              ctx: RawlsRequestContext
+      ): JobResult = {
+        times = times + 1
+        if (times > 1) {
+          throw new ApiException(StatusCodes.Forbidden.intValue, "forbidden")
+        } else {
+          new JobResult().jobReport(new JobReport().id(jobControlId).status(StatusEnum.RUNNING))
+        }
+      }
+    })
+
+    val samDAO = new MockSamDAO(slickDataSource)
+
+    val svc = MultiCloudWorkspaceService.constructor(
+      slickDataSource,
+      workspaceManagerDAO,
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      activeMcWorkspaceConfig,
+      mock[LeonardoDAO],
+      workbenchMetricBaseName
+    )(testContext)
+    Await.result(svc.deleteWorkspaceInWSM(testData.azureWorkspace.workspaceIdAsUUID), Duration.Inf)
+    verify(svc.workspaceManagerDAO).deleteWorkspaceV2(equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+                                                      any[RawlsRequestContext]
+    )
+    verify(svc.workspaceManagerDAO, times(2)).getDeleteWorkspaceV2Result(
+      equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+      anyString,
+      any[RawlsRequestContext]
+    )
+  }
+
   it should "start deletion and poll for success when the workspace exists in workspace manager" in {
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO() {
       var times = 0


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1154)

## Context
The initial cutover of this caused flakiness with our Azure end to end tests, where the deletion result polling would occasionally get back a 403 from WSM. There is a race in WSM during workspace deletion where the Sam resource is deleted before the workspace record is deleted. This opens the possibility of getting a 403 while the deletion job is still in flight. We should guard against this possibility in Rawls.

## This PR
* Adds a check against 403s from the deletion job result endpoint during workspace deletion. Since a 403 here means that the Sam resource is gone and the workspace is effectively unreadable, I think this is a safe assumption to make in Rawls. 
* [This](https://github.com/broadinstitute/rawls/actions/runs/5728207068) is an E2E test run that bumped into the 403 and completed successfully.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
