### PR TITLE
[WOR-1179] Change log level to WARN for workflow cost errors

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2503,7 +2503,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
             )
           ) map {
             case Failure(ex) =>
-              logger.error(s"Unable to get workflow costs for submission $submissionId", ex)
+              logger.warn(s"Unable to get workflow costs for submission $submissionId", ex)
               submission
             case Success(costMap) =>
               val costedWorkflows = submission.workflows.map { workflow =>


### PR DESCRIPTION
## Context  
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1179

Workflow cost submission access control problems log at error and ping sentry. There is nothing actionable with these errors so I'm setting them to WARN. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
