### PR TITLE
Do not return PROJECT_OWNER from getAcl for Azure workspaces (WOR-1181).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManager.scala
@@ -61,6 +61,9 @@ class MultiCloudWorkspaceAclManager(workspaceManagerDAO: WorkspaceManagerDAO,
   def getAcl(workspaceId: UUID, ctx: RawlsRequestContext): Future[WorkspaceACL] = {
     def roleBindingToAccessEntryList(roleBinding: RoleBinding): Future[List[(String, AccessEntry)]] =
       WorkspaceAccessLevels.withPolicyName(roleBinding.getRole.getValue) match {
+        // Similar to Rawls Acl implementation, do not return PROJECT_OWNER.
+        case Some(WorkspaceAccessLevels.ProjectOwner) =>
+          Future.successful(List.empty)
         case Some(workspaceAccessLevel) =>
           Future.traverse(roleBinding.getMembers.asScala.toList) { email =>
             isUserPending(email, ctx).map { pending =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1181

Before:

<img width="599" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/4c83c7c6-4992-40fb-aece-2c389a51aff3">

After:

<img width="586" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/90efc1a0-33d9-4e12-846b-55c6ec248aec">

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
