### PR TITLE
[WOR-1098] Finish porting over multiregional bucket migration pipeline

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -538,19 +538,11 @@ object MultiregionalBucketMigrationActor {
               .find(_.policyName == owner)
               .getOrElse(
                 throw WorkspaceMigrationException(
-                  message = s"""Workspace migration failed: no "$owner" policy on billing project.""",
+                  message = s"""Bucket migration failed: no "$owner" policy on billing project.""",
                   data = Map("migrationId" -> migration.id, "billingProject" -> workspace.namespace)
                 )
               )
               .email
-
-            // The `can-compute` policy group is sync'ed for v2 workspaces. This
-            // was done at the billing project level only for v1 workspaces.
-            _ <- deps.samDao.syncPolicyToGoogle(
-              SamResourceTypeNames.workspace,
-              workspace.workspaceId,
-              SamWorkspacePolicyNames.canCompute
-            )
 
             workspacePolicies <- deps.samDao.admin.listPolicies(
               SamResourceTypeNames.workspace,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -689,28 +689,28 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
 
   it should "create a new workspace bucket after deleting the original workspace bucket" in
     runMigrationTest {
-    for {
-      now <- nowTimestamp
-      migrationId <- inTransaction { dataAccess =>
-        import dataAccess.setOptionValueObject
-        for {
-          migrationId <- createAndScheduleWorkspace(testData.workspace)
-          _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
-            migrationId,
-            dataAccess.multiregionalBucketMigrationQuery.tmpBucketCol,
-            GcsBucketName("tmp-bucket-name").some,
-            dataAccess.multiregionalBucketMigrationQuery.workspaceBucketDeletedCol,
-            now.some
-          )
-        } yield migrationId
-      }
+      for {
+        now <- nowTimestamp
+        migrationId <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          for {
+            migrationId <- createAndScheduleWorkspace(testData.workspace)
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+              migrationId,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketCol,
+              GcsBucketName("tmp-bucket-name").some,
+              dataAccess.multiregionalBucketMigrationQuery.workspaceBucketDeletedCol,
+              now.some
+            )
+          } yield migrationId
+        }
 
-      _ <- migrate
-      migration <- inTransactionT { dataAccess =>
-        dataAccess.multiregionalBucketMigrationQuery.getAttempt(migrationId)
-      }
-    } yield migration.finalBucketCreated shouldBe defined
-  }
+        _ <- migrate
+        migration <- inTransactionT { dataAccess =>
+          dataAccess.multiregionalBucketMigrationQuery.getAttempt(migrationId)
+        }
+      } yield migration.finalBucketCreated shouldBe defined
+    }
 
   it should "issue configure the tmp and final workspace bucket iam policies for storage transfer" in
     runMigrationTest {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -670,7 +670,9 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           import dataAccess.setOptionValueObject
           for {
             _ <- createAndScheduleWorkspace(testData.workspace)
-            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(testData.workspace.workspaceIdAsUUID)
+              .value
             _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
               attempt.get.id,
               dataAccess.multiregionalBucketMigrationQuery.finalBucketCreatedCol,
@@ -682,7 +684,9 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
         }
 
         _ <- migrate
-        migration <- inTransactionT(_.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID))
+        migration <- inTransactionT(
+          _.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+        )
       } yield migration.tmpBucketTransferIamConfigured shouldBe defined
     }
 
@@ -694,7 +698,9 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           import dataAccess.setOptionValueObject
           for {
             _ <- createAndScheduleWorkspace(testData.workspace)
-            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(testData.workspace.workspaceIdAsUUID)
+              .value
             _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
               attempt.get.id,
               dataAccess.multiregionalBucketMigrationQuery.tmpBucketTransferIamConfiguredCol,
@@ -954,7 +960,6 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
       } yield succeed
     }
 
-
   it should "delete the temporary bucket and record when it was deleted" in
     runMigrationTest {
       for {
@@ -963,7 +968,9 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           import dataAccess.setOptionValueObject
           for {
             _ <- createAndScheduleWorkspace(testData.workspace)
-            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(testData.workspace.workspaceIdAsUUID)
+              .value
             _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
               attempt.get.id,
               dataAccess.multiregionalBucketMigrationQuery.tmpBucketTransferredCol,
@@ -990,7 +997,9 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           import dataAccess.setOptionValueObject
           for {
             _ <- createAndScheduleWorkspace(testData.workspace)
-            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(testData.workspace.workspaceIdAsUUID)
+              .value
             _ <- dataAccess.multiregionalBucketMigrationQuery.update(
               attempt.get.id,
               dataAccess.multiregionalBucketMigrationQuery.tmpBucketDeletedCol,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -640,6 +640,92 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
       }
     }
 
+  it should "delete the workspace bucket" in
+    runMigrationTest {
+      for {
+        now <- nowTimestamp
+        migrationId <- inTransaction { dataAccess =>
+          for {
+            migrationId <- createAndScheduleWorkspace(testData.workspace)
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update(
+              migrationId,
+              dataAccess.multiregionalBucketMigrationQuery.workspaceBucketTransferredCol,
+              now.some
+            )
+          } yield migrationId
+        }
+
+        _ <- migrate
+        migration <- inTransactionT { dataAccess =>
+          dataAccess.multiregionalBucketMigrationQuery.getAttempt(migrationId)
+        }
+      } yield migration.workspaceBucketDeleted shouldBe defined
+    }
+
+  it should "issue configure the tmp and final workspace bucket iam policies for storage transfer" in
+    runMigrationTest {
+      for {
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          for {
+            _ <- createAndScheduleWorkspace(testData.workspace)
+            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+              attempt.get.id,
+              dataAccess.multiregionalBucketMigrationQuery.finalBucketCreatedCol,
+              now.some,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketCol,
+              GcsBucketName("tmp-bucket-name").some
+            )
+          } yield ()
+        }
+
+        _ <- migrate
+        migration <- inTransactionT(_.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID))
+      } yield migration.tmpBucketTransferIamConfigured shouldBe defined
+    }
+
+  it should "issue a storage transfer job from the tmp bucket to the final workspace bucket" in
+    runMigrationTest {
+      for {
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          for {
+            _ <- createAndScheduleWorkspace(testData.workspace)
+            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+              attempt.get.id,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketTransferIamConfiguredCol,
+              now.some,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketCol,
+              GcsBucketName("tmp-bucket-name").some
+            )
+          } yield ()
+        }
+
+        _ <- migrate
+
+        (migration, transferJob) <- inTransactionT { dataAccess =>
+          for {
+            migration <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+            transferJob <- OptionT[ReadWriteAction, MultiregionalStorageTransferJob] {
+              storageTransferJobs
+                .filter(_.migrationId === migration.id)
+                .take(1)
+                .result
+                .headOption
+            }
+          } yield (migration, transferJob)
+        }
+      } yield {
+        transferJob.sourceBucket.value shouldBe "tmp-bucket-name"
+        transferJob.destBucket.value shouldBe testData.workspace.bucketName
+        migration.tmpBucketTransferJobIssued shouldBe defined
+      }
+    }
+
   it should "re-issue a storage transfer job when it receives permissions precondition failures" in
     runMigrationTest {
       for {
@@ -866,6 +952,63 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           test
         }
       } yield succeed
+    }
+
+
+  it should "delete the temporary bucket and record when it was deleted" in
+    runMigrationTest {
+      for {
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          for {
+            _ <- createAndScheduleWorkspace(testData.workspace)
+            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+              attempt.get.id,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketTransferredCol,
+              now.some,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketCol,
+              GcsBucketName("tmp-bucket-name").some
+            )
+          } yield ()
+        }
+
+        _ <- migrate
+
+        migration <- inTransactionT {
+          _.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+        }
+      } yield migration.tmpBucketDeleted shouldBe defined
+    }
+
+  it should "mark the migration as successful after the temporary bucket has been deleted" in
+    runMigrationTest {
+      for {
+        now <- nowTimestamp
+        _ <- inTransaction { dataAccess =>
+          import dataAccess.setOptionValueObject
+          for {
+            _ <- createAndScheduleWorkspace(testData.workspace)
+            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID).value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update(
+              attempt.get.id,
+              dataAccess.multiregionalBucketMigrationQuery.tmpBucketDeletedCol,
+              now.some
+            )
+          } yield ()
+        }
+
+        _ <- migrate
+
+        workspace <- getWorkspace(testData.workspace.workspaceIdAsUUID)
+        migration <- inTransactionT {
+          _.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+        }
+      } yield {
+        migration.finished shouldBe defined
+        migration.outcome shouldBe Success.some
+      }
     }
 
   it should "not prevent a workspace from being deleted if the migration was retried" in
@@ -1136,6 +1279,41 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
       } yield {
         after.workspaceBucketTransferred shouldBe defined
         after.tmpBucketTransferred should not be defined
+      }
+    }
+
+  it should "update TMP_BUCKET_TRANSFERRED on job success" in
+    runMigrationTest {
+      for {
+        now <- nowTimestamp
+        before <- inTransactionT { dataAccess =>
+          for {
+            _ <- OptionT.liftF(createAndScheduleWorkspace(testData.workspace))
+            attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+            _ <- OptionT.liftF {
+              dataAccess.multiregionalBucketMigrationQuery.update(
+                attempt.id,
+                dataAccess.multiregionalBucketMigrationQuery.workspaceBucketTransferredCol,
+                now.some
+              )
+            }
+            updated <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+          } yield updated
+        }
+
+        _ <- updateMigrationTransferJobStatus(
+          storageTransferJobForTesting.copy(
+            migrationId = before.id,
+            sourceBucket = GcsBucketName("workspace-bucket"),
+            destBucket = GcsBucketName("tmp-bucket-name"),
+            outcome = Success.some
+          )
+        )
+
+        after <- inTransactionT(_.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID))
+      } yield {
+        after.workspaceBucketTransferred shouldBe defined
+        after.tmpBucketTransferred shouldBe defined
       }
     }
 


### PR DESCRIPTION
Ticket: [WOR-1098](https://broadworkbench.atlassian.net/browse/WOR-1098)
* Ports over rest of PPW pipeline. Pipeline will now delete the original workspace bucket after the transfer to the temp bucket, re-create a new workspace bucket with the same name, and transfer back from the temp bucket to the new workspace bucket

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1098]: https://broadworkbench.atlassian.net/browse/WOR-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ