### PR TITLE
[WOR-1061] Add bucket migration APIs for scheduling and fetching past attempts

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -939,7 +939,7 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
-  /api/admin/migrations:
+  /api/admin/workspaces/migrations:
     post:
       tags:
         - admin
@@ -967,6 +967,135 @@ paths:
                  $ref: '#/components/schemas/ErrorReport'
         500:
            $ref: '#/components/responses/RawlsInternalError'
+  /api/admin/bucketMigration/workspaces/{workspaceNamespace}/{workspaceName}:
+    get:
+      tags:
+        - admin
+      summary: list bucket migration attempts for workspace
+      description: list bucket migration attempts for workspace
+      operationId: listBucketMigrationsForWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to list migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+    post:
+      tags:
+        - admin
+      summary: start bucket migration attempt for workspace
+      description: start bucket migration attempt for workspace
+      operationId: startBucketMigrationForWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+      responses:
+        201:
+          description: Workspace scheduled for migration
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to start migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/admin/bucketMigration/workspaces:
+    post:
+      tags:
+        - admin
+      summary: batch start workspace migrations
+      description: batch start bucket migration attempts for workspaces
+      operationId: batchStartBucketMigrationForWorkspaces
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/BatchMigrateRequestBody'
+      responses:
+        201:
+          description: Workspaces scheduled for migration
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to start migration attempts
+          content:
+             'application/json':
+               schema:
+                 $ref: '#/components/schemas/ErrorReport'
+        500:
+           $ref: '#/components/responses/RawlsInternalError'
+  /api/admin/bucketMigration/billing/{projectId}:
+    get:
+      tags:
+        - admin
+      summary: list bucket migration attempts for workspaces in billing project
+      description: list bucket migration attempts for workspaces in billing project
+      operationId: listBucketMigrationsForBillingProject
+      parameters:
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to list migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+    post:
+      tags:
+        - admin
+      summary: start bucket migration attempt for workspaces in billing project
+      description: start bucket migration attempt for workspaces in billing project
+      operationId: startBucketMigrationForBillingProject
+      parameters:
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
+      responses:
+        201:
+          description: Workspaces in billing project scheduled for migration
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to start migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /api/admin/submissions/queueStatusByUser:
     get:
       tags:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -997,8 +997,8 @@ paths:
     post:
       tags:
         - admin
-      summary: start bucket migration attempt for workspace
-      description: start bucket migration attempt for workspace
+      summary: start bucket migration attempt for Google workspace
+      description: start bucket migration attempt for Google workspace
       operationId: startBucketMigrationForWorkspace
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
@@ -1022,8 +1022,8 @@ paths:
     post:
       tags:
         - admin
-      summary: batch start workspace migrations
-      description: batch start bucket migration attempts for workspaces
+      summary: batch start Google workspace bucket migrations
+      description: batch start bucket migration attempts for Google workspaces
       operationId: batchStartBucketMigrationForWorkspaces
       requestBody:
         content:
@@ -1076,8 +1076,8 @@ paths:
     post:
       tags:
         - admin
-      summary: start bucket migration attempt for workspaces in billing project
-      description: start bucket migration attempt for workspaces in billing project
+      summary: start bucket migration attempt for Google workspaces in billing project
+      description: start bucket migration attempt for Google workspaces in billing project
       operationId: startBucketMigrationForBillingProject
       parameters:
         - $ref: '#/components/parameters/billingProjectIdPathParam'

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1036,7 +1036,9 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
         403:
           description: You must be an admin to start migration attempts
           content:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -15,6 +15,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.sentry.{Hint, Sentry, SentryEvent, SentryOptions}
 import net.ceedubs.ficus.Ficus._
 import org.broadinstitute.dsde.rawls.billing._
+import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.HttpDataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.{HttpResourceBufferDAO, ResourceBufferDAO}
@@ -551,6 +552,9 @@ object Boot extends IOApp with LazyLogging {
           spendReportingServiceConfig
         )
 
+      val bucketMigrationServiceConstructor: RawlsRequestContext => BucketMigrationService =
+        BucketMigrationService.constructor(slickDataSource, samDAO, gcsDAO)
+
       val service = new RawlsApiServiceImpl(
         multiCloudWorkspaceServiceConstructor,
         workspaceServiceConstructor,
@@ -560,6 +564,7 @@ object Boot extends IOApp with LazyLogging {
         snapshotServiceConstructor,
         spendReportingServiceConstructor,
         billingProjectOrchestratorConstructor,
+        bucketMigrationServiceConstructor,
         statusServiceConstructor,
         shardedExecutionServiceCluster,
         ApplicationVersion(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -1,0 +1,122 @@
+package org.broadinstitute.dsde.rawls.bucketMigration
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.MonadThrow
+import cats.implicits.toTraverseOps
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, RawlsRequestContext, WorkspaceName}
+import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.monadThrowDBIOAction
+import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationMetadata
+import org.broadinstitute.dsde.rawls.util.{RoleSupport, WorkspaceSupport}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO, val gcsDAO: GoogleServicesDAO)(
+  val ctx: RawlsRequestContext
+)(implicit val executionContext: ExecutionContext)
+    extends RoleSupport
+    with WorkspaceSupport
+    with LazyLogging {
+
+  def getBucketMigrationAttemptsForWorkspace(
+    workspaceName: WorkspaceName
+  ): Future[List[MultiregionalBucketMigrationMetadata]] =
+    asFCAdmin {
+      for {
+        workspace <- getV2WorkspaceContext(workspaceName)
+        attempts <- dataSource.inTransaction { dataAccess =>
+          dataAccess.multiregionalBucketMigrationQuery.getMigrationAttempts(workspace)
+        }
+      } yield attempts.mapWithIndex(MultiregionalBucketMigrationMetadata.fromMultiregionalBucketMigration)
+    }
+
+  def getBucketMigrationAttemptsForBillingProject(
+    billingProjectName: RawlsBillingProjectName
+  ): Future[Map[String, List[MultiregionalBucketMigrationMetadata]]] =
+    asFCAdmin {
+      for {
+        workspaces <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
+        }
+        attempts <- workspaces.traverse { workspace =>
+          dataSource
+            .inTransaction { dataAccess =>
+              dataAccess.multiregionalBucketMigrationQuery.getMigrationAttempts(workspace)
+            }
+            .map { attempts =>
+              workspace.name -> attempts.mapWithIndex(
+                MultiregionalBucketMigrationMetadata.fromMultiregionalBucketMigration
+              )
+            }
+        }
+      } yield attempts.toMap
+    }
+
+  def migrateWorkspaceBucket(workspaceName: WorkspaceName): Future[MultiregionalBucketMigrationMetadata] =
+    asFCAdmin {
+      logger.info(s"Scheduling Workspace '$workspaceName' for bucket migration")
+      dataSource.inTransaction { dataAccess =>
+        dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspaceName)
+      }
+    }
+
+  def migrateAllWorkspaceBuckets(
+    workspaceNames: Iterable[WorkspaceName]
+  ): Future[Iterable[MultiregionalBucketMigrationMetadata]] =
+    asFCAdmin {
+      dataSource
+        .inTransaction { dataAccess =>
+          for {
+            errorsOrMigrationAttempts <- workspaceNames.toList.traverse { workspaceName =>
+              MonadThrow[ReadWriteAction].attempt {
+                dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspaceName)
+              }
+            }
+          } yield errorsOrMigrationAttempts
+        }
+        .map(raiseFailedMigrationAttempts)
+    }
+
+  def migrateWorkspaceBucketsInBillingProject(
+    billingProjectName: RawlsBillingProjectName
+  ): Future[Iterable[MultiregionalBucketMigrationMetadata]] =
+    asFCAdmin {
+      dataSource
+        .inTransaction { dataAccess =>
+          for {
+            workspaces <- dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
+            errorsOrMigrationAttempts <- workspaces.traverse { workspace =>
+              MonadThrow[ReadWriteAction].attempt {
+                dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspace.toWorkspaceName)
+              }
+            }
+          } yield errorsOrMigrationAttempts
+        }
+        .map(raiseFailedMigrationAttempts)
+    }
+
+  private def raiseFailedMigrationAttempts(
+    errorsOrMigrationAttempts: Seq[Either[Throwable, MultiregionalBucketMigrationMetadata]]
+  ): Seq[MultiregionalBucketMigrationMetadata] = {
+    val (errors, migrationAttempts) = errorsOrMigrationAttempts.partitionMap(identity)
+    if (errors.nonEmpty) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest,
+                    "One or more workspace buckets could not be scheduled for migration",
+                    errors.map(ErrorReport.apply)
+        )
+      )
+    } else {
+      migrationAttempts
+    }
+  }
+}
+
+object BucketMigrationService {
+  def constructor(dataSource: SlickDataSource, samDAO: SamDAO, gcsDAO: GoogleServicesDAO)(ctx: RawlsRequestContext)(
+    implicit executionContext: ExecutionContext
+  ) = new BucketMigrationService(dataSource, samDAO, gcsDAO)(ctx)
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -11,7 +11,8 @@ import org.broadinstitute.dsde.rawls.model.{
   GoogleProjectNumber,
   SubmissionStatuses,
   Workspace,
-  WorkspaceName
+  WorkspaceName,
+  WorkspaceType
 }
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.{unsafeFromEither, Outcome}
@@ -225,6 +226,14 @@ trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQue
         _ <- MonadThrow[ReadWriteAction].raiseWhen(workspace.isLocked) {
           new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest, s"'$workspaceName' bucket cannot be migrated as it is locked.")
+          )
+        }
+
+        _ <- MonadThrow[ReadWriteAction].raiseWhen(workspace.workspaceType == WorkspaceType.McWorkspace) {
+          new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.BadRequest,
+                        s"'$workspaceName' bucket cannot be migrated as it is not a Google workspace."
+            )
           )
         }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -17,6 +17,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.sentry.Sentry
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.billing.BillingProjectOrchestrator
+import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.dataaccess.{ExecutionServiceCluster, SamDAO}
 import org.broadinstitute.dsde.rawls.entities.EntityService
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
@@ -197,6 +198,7 @@ class RawlsApiServiceImpl(val multiCloudWorkspaceServiceConstructor: RawlsReques
                           val snapshotServiceConstructor: RawlsRequestContext => SnapshotService,
                           val spendReportingConstructor: RawlsRequestContext => SpendReportingService,
                           val billingProjectOrchestratorConstructor: RawlsRequestContext => BillingProjectOrchestrator,
+                          val bucketMigrationServiceConstructor: RawlsRequestContext => BucketMigrationService,
                           val statusServiceConstructor: () => StatusService,
                           val executionServiceCluster: ExecutionServiceCluster,
                           val appVersion: ApplicationVersion,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1693,20 +1693,15 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
         dataSource.inTransaction { dataAccess =>
           import dataAccess.WorkspaceExtensions
-          dataAccess.workspaceMigrationQuery
-            .isMigrating(workspaceContext)
-            .zipWith(
-              dataAccess.multiregionalBucketMigrationQuery.isMigrating(workspaceContext)
-            )(_ || _)
-            .flatMap {
-              case true =>
-                DBIO.failed(
-                  new RawlsExceptionWithErrorReport(
-                    ErrorReport(StatusCodes.BadRequest, "cannot unlock migrating workspace")
-                  )
+          dataAccess.multiregionalBucketMigrationQuery.isMigrating(workspaceContext).flatMap {
+            case true =>
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  ErrorReport(StatusCodes.BadRequest, "cannot unlock migrating workspace")
                 )
-              case false => dataAccess.workspaceQuery.withWorkspaceId(workspaceContext.workspaceIdAsUUID).unlock
-            }
+              )
+            case false => dataAccess.workspaceQuery.withWorkspaceId(workspaceContext.workspaceIdAsUUID).unlock
+          }
         }
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -1,0 +1,249 @@
+package org.broadinstitute.dsde.rawls.bucketMigration
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.model.{
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamUserStatusResponse,
+  UserInfo
+}
+import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.not
+import org.scalatest.matchers.should.Matchers._
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+import java.util.UUID
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
+  private def getBucketMigrationService(dataSource: SlickDataSource = slickDataSource,
+                                        samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
+                                        gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+                                        ctx: RawlsRequestContext = testContext
+  ): BucketMigrationService = BucketMigrationService.constructor(dataSource, samDAO, gcsDAO)(ctx)
+
+  private def getRequestContext(userEmail: String): RawlsRequestContext =
+    RawlsRequestContext(
+      UserInfo(RawlsUserEmail(userEmail), OAuth2BearerToken("fake_token"), 0L, RawlsUserSubjectId("user_id"))
+    )
+
+  // mock out authz checks needed to ensure a method is limited to fc-admins
+  def setupAdminEnforcementTest(): (BucketMigrationService, BucketMigrationService) = {
+    val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+    val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    val adminUser = "admin@example.com"
+    val nonAdminUser = "user@example.com"
+    val adminCtx = getRequestContext(adminUser)
+    val nonAdminCtx = getRequestContext(nonAdminUser)
+    when(mockGcsDAO.isAdmin(adminUser)).thenReturn(Future.successful(true))
+    when(mockGcsDAO.isAdmin(nonAdminUser)).thenReturn(Future.successful(false))
+    when(mockSamDAO.getUserStatus(adminCtx))
+      .thenReturn(Future.successful(Some(SamUserStatusResponse("userId", adminUser, true))))
+    (getBucketMigrationService(gcsDAO = mockGcsDAO, samDAO = mockSamDAO, ctx = adminCtx),
+     getBucketMigrationService(gcsDAO = mockGcsDAO, samDAO = mockSamDAO, ctx = nonAdminCtx)
+    )
+  }
+
+  it should "schedule a single workspace and return past migration attempts" in withMinimalTestDatabase { _ =>
+    val (adminService, _) = setupAdminEnforcementTest()
+
+    Await.result(
+      for {
+        preMigrationAttempts <- adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName)
+        _ <- adminService.migrateWorkspaceBucket(minimalTestData.wsName)
+        postMigrationAttempts <- adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName)
+      } yield {
+        preMigrationAttempts shouldBe List.empty
+        postMigrationAttempts should not be empty
+      },
+      Duration.Inf
+    )
+  }
+
+  it should "schedule all workspaces in a billing project and return the migration attempts" in withMinimalTestDatabase { _ =>
+    val (adminService, _) = setupAdminEnforcementTest()
+
+    Await.result(
+      for {
+        preMigrationAttempts <- adminService.getBucketMigrationAttemptsForBillingProject(
+          minimalTestData.billingProject.projectName
+        )
+        _ <- adminService.migrateWorkspaceBucketsInBillingProject(minimalTestData.billingProject.projectName)
+        postMigrationAttempts <- adminService.getBucketMigrationAttemptsForBillingProject(
+          minimalTestData.billingProject.projectName
+        )
+      } yield {
+        preMigrationAttempts.foreach { case (_, attempts) =>
+          attempts shouldBe List.empty
+        }
+        postMigrationAttempts.foreach { case (_, attempts) =>
+          attempts should not be empty
+        }
+      },
+      Duration.Inf
+    )
+  }
+
+  it should "schedule any eligible workspaces in a billing project for migration and return any failures" in withMinimalTestDatabase {
+    _ =>
+      val (adminService, _) = setupAdminEnforcementTest()
+
+      val lockedWorkspace =
+        minimalTestData.workspace.copy(name = "lockedWorkspace",
+          isLocked = true,
+          workspaceId = UUID.randomUUID.toString
+        )
+      runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(lockedWorkspace), Duration.Inf)
+
+      val exception = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(adminService.migrateWorkspaceBucketsInBillingProject(minimalTestData.billingProject.projectName),
+          Duration.Inf
+        )
+      }
+      exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+      Await
+        .result(adminService.getBucketMigrationAttemptsForBillingProject(minimalTestData.billingProject.projectName),
+          Duration.Inf
+        )
+        .foreach {
+          case (lockedWorkspace.name, attempts) => attempts shouldBe List.empty
+          case (_, attempts) => attempts should not be empty
+        }
+  }
+
+  it should "schedule all workspaces and return any errors that occur" in withMinimalTestDatabase { _ =>
+    val (adminService, _) = setupAdminEnforcementTest()
+
+    val lockedWorkspace =
+      minimalTestData.workspace.copy(name = "lockedWorkspace", isLocked = true, workspaceId = UUID.randomUUID.toString)
+    runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(lockedWorkspace), Duration.Inf)
+
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName),
+      Duration.Inf
+    ) shouldBe List.empty
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName2),
+      Duration.Inf
+    ) shouldBe List.empty
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(lockedWorkspace.toWorkspaceName),
+      Duration.Inf
+    ) shouldBe List.empty
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(adminService.migrateAllWorkspaceBuckets(
+        List(minimalTestData.wsName, minimalTestData.wsName2, lockedWorkspace.toWorkspaceName)
+      ),
+        Duration.Inf
+      )
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName),
+      Duration.Inf
+    ) should not be empty
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName2),
+      Duration.Inf
+    ) should not be empty
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(lockedWorkspace.toWorkspaceName),
+      Duration.Inf
+    ) shouldBe List.empty
+  }
+
+  behavior of "getBucketMigrationAttemptsForWorkspace"
+
+  it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
+    val (adminService, nonAdminService) = setupAdminEnforcementTest()
+
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName), Duration.Inf)
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(nonAdminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  behavior of "getBucketMigrationAttemptsForBillingProject"
+
+  it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
+    val (adminService, nonAdminService) = setupAdminEnforcementTest()
+
+    Await.result(adminService.getBucketMigrationAttemptsForBillingProject(minimalTestData.billingProject.projectName),
+                 Duration.Inf
+    )
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        nonAdminService.getBucketMigrationAttemptsForBillingProject(minimalTestData.billingProject.projectName),
+        Duration.Inf
+      )
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  behavior of "migrateWorkspaceBucket"
+
+  it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
+    val (adminService, nonAdminService) = setupAdminEnforcementTest()
+
+    Await.result(adminService.migrateWorkspaceBucket(minimalTestData.wsName), Duration.Inf)
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        nonAdminService.migrateWorkspaceBucket(minimalTestData.wsName),
+        Duration.Inf
+      )
+    }
+
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  it should "fail when a workspace is locked" in withMinimalTestDatabase { _ =>
+    val (adminService, _) = setupAdminEnforcementTest()
+
+    val lockedWorkspace =
+      minimalTestData.workspace.copy(name = "lockedWorkspace", isLocked = true, workspaceId = UUID.randomUUID.toString)
+    runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(lockedWorkspace), Duration.Inf)
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(adminService.migrateWorkspaceBucket(lockedWorkspace.toWorkspaceName), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+  }
+
+  behavior of "migrateAllWorkspaceBuckets"
+
+  it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
+    val (adminService, nonAdminService) = setupAdminEnforcementTest()
+
+    Await.result(adminService.migrateAllWorkspaceBuckets(List(minimalTestData.wsName, minimalTestData.wsName2)),
+                 Duration.Inf
+    )
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        nonAdminService.migrateAllWorkspaceBuckets(List(minimalTestData.wsName, minimalTestData.wsName2)),
+        Duration.Inf
+      )
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  behavior of "migrateWorkspaceBucketsInBillingProject"
+
+  it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
+    val (adminService, nonAdminService) = setupAdminEnforcementTest()
+
+    Await.result(adminService.migrateWorkspaceBucketsInBillingProject(minimalTestData.billingProject.projectName),
+                 Duration.Inf
+    )
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        nonAdminService.migrateWorkspaceBucketsInBillingProject(minimalTestData.billingProject.projectName),
+        Duration.Inf
+      )
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -29,8 +29,9 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
       UserInfo(RawlsUserEmail(userEmail), OAuth2BearerToken("fake_token"), 0L, RawlsUserSubjectId("user_id"))
     )
 
-  def mockAdminService(mockSamDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
-                       mockGcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+  def mockBucketMigrationServiceForAdminUser(mockSamDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
+                                             mockGcsDAO: GoogleServicesDAO =
+                                               mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
   ): BucketMigrationService = {
     val adminUser = "admin@example.com"
     val adminCtx = getRequestContext(adminUser)
@@ -41,8 +42,9 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
     BucketMigrationService.constructor(slickDataSource, mockSamDAO, mockGcsDAO)(adminCtx)
   }
 
-  def mockNonAdminService(mockSamDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
-                          mockGcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+  def mockBucketMigrationServiceForNonAdminUser(mockSamDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
+                                                mockGcsDAO: GoogleServicesDAO =
+                                                  mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
   ): BucketMigrationService = {
     val nonAdminUser = "user@example.com"
     val nonAdminCtx = getRequestContext(nonAdminUser)
@@ -54,13 +56,13 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
     val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
     val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
 
-    (mockAdminService(mockSamDAO = mockSamDAO, mockGcsDAO = mockGcsDAO),
-     mockNonAdminService(mockSamDAO = mockSamDAO, mockGcsDAO = mockGcsDAO)
+    (mockBucketMigrationServiceForAdminUser(mockSamDAO = mockSamDAO, mockGcsDAO = mockGcsDAO),
+     mockBucketMigrationServiceForNonAdminUser(mockSamDAO = mockSamDAO, mockGcsDAO = mockGcsDAO)
     )
   }
 
   it should "schedule a single workspace and return past migration attempts" in withMinimalTestDatabase { _ =>
-    val adminService = mockAdminService()
+    val adminService = mockBucketMigrationServiceForAdminUser()
 
     Await.result(
       for {
@@ -77,7 +79,7 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
 
   it should "schedule all workspaces in a billing project and return the migration attempts" in withMinimalTestDatabase {
     _ =>
-      val adminService = mockAdminService()
+      val adminService = mockBucketMigrationServiceForAdminUser()
 
       Await.result(
         for {
@@ -102,7 +104,7 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
 
   it should "schedule any eligible workspaces in a billing project for migration and return any failures" in withMinimalTestDatabase {
     _ =>
-      val adminService = mockAdminService()
+      val adminService = mockBucketMigrationServiceForAdminUser()
 
       val lockedWorkspace =
         minimalTestData.workspace.copy(name = "lockedWorkspace",
@@ -128,7 +130,7 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
   }
 
   it should "schedule all workspaces and return any errors that occur" in withMinimalTestDatabase { _ =>
-    val adminService = mockAdminService()
+    val adminService = mockBucketMigrationServiceForAdminUser()
 
     val lockedWorkspace =
       minimalTestData.workspace.copy(name = "lockedWorkspace", isLocked = true, workspaceId = UUID.randomUUID.toString)
@@ -210,7 +212,7 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
   }
 
   it should "fail when a workspace is locked" in withMinimalTestDatabase { _ =>
-    val adminService = mockAdminService()
+    val adminService = mockBucketMigrationServiceForAdminUser()
 
     val lockedWorkspace =
       minimalTestData.workspace.copy(name = "lockedWorkspace", isLocked = true, workspaceId = UUID.randomUUID.toString)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -19,6 +19,7 @@ import org.broadinstitute.dsde.rawls.billing.{
   BpmBillingProjectLifecycle,
   GoogleBillingProjectLifecycle
 }
+import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -266,6 +267,9 @@ trait ApiServiceSpec
       samDAO,
       spendReportingServiceConfig
     )
+
+    override val bucketMigrationServiceConstructor: RawlsRequestContext => BucketMigrationService =
+      BucketMigrationService.constructor(slickDataSource, samDAO, gcsDAO)
 
     val methodRepoDAO = new HttpMethodRepoDAO(
       MethodRepoConfig[Agora.type](mockServer.mockServerBaseUrl, ""),


### PR DESCRIPTION
Ticket: [WOR-1061](https://broadworkbench.atlassian.net/browse/WOR-1061)
* Add new admin APIs to schedule workspaces for bucket migrations one at a time, in a list, or by billing project. Also add admin APIs to list migration attempts for a single workspace or workspaces in a billing proejct.
* Add new `BucketMigrationService` to handle actual scheduling
* Prevent workspaces from being unlocked in the middle of a bucket migration

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1061]: https://broadworkbench.atlassian.net/browse/WOR-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ