### PR TITLE
Add workspace state (WOR-1180).

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -133,4 +133,5 @@
     <include file="changesets/20230628_multiregional_bucket_migration.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230719_autoupdate_updated_multiregional_bucket.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230802_more_precise_updated_multiregional_bucket.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230810_add_workspace_state_column.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230810_add_workspace_state_column.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230810_add_workspace_state_column.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="add_workspace_state_column" author="cahrens" logicalFilePath="dummy">
+        <addColumn tableName="WORKSPACE">
+            <column name="state" type="VARCHAR(254)" defaultValue="Ready">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="update_workspace_state_if_error" author="cahrens">
+        <sql>update WORKSPACE set state = "CreateFailed" where ERROR_MESSAGE is not null;</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230810_add_workspace_state_column.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230810_add_workspace_state_column.xml
@@ -9,7 +9,7 @@
     </changeSet>
 
     <changeSet id="update_workspace_state_if_error" author="cahrens">
-        <sql>update WORKSPACE set state = "CreateFailed" where ERROR_MESSAGE is not null;</sql>
+        <sql>update WORKSPACE set state = "UpdateFailed" where ERROR_MESSAGE is not null;</sql>
     </changeSet>
 
 </databaseChangeLog>

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5180,7 +5180,7 @@ components:
             - Updating
             - UpdateFailed
             - Deleting
-            - DeletedFailed
+            - DeleteFailed
       description: ""
     WorkspaceSubmissionStats:
       required:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5096,6 +5096,7 @@ components:
         - workspaceId
         - googleProject
         - workspaceVersion
+        - state
       type: object
       properties:
         attributes:
@@ -5169,6 +5170,17 @@ components:
           enum:
             - GCP
             - AZURE
+        state:
+          type: string
+          description: The lifecycle state of the workspace
+          enum:
+            - Creating
+            - CreateFailed
+            - Ready
+            - Updating
+            - UpdateFailed
+            - Deleting
+            - DeletedFailed
       description: ""
     WorkspaceSubmissionStats:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -36,7 +36,8 @@ case class WorkspaceRecord(
   currentBillingAccountOnGoogleProject: Option[String],
   errorMessage: Option[String],
   completedCloneWorkspaceFileTransfer: Option[Timestamp],
-  workspaceType: String
+  workspaceType: String,
+  state: String
 ) {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
 }
@@ -60,7 +61,8 @@ object WorkspaceRecord {
       workspace.currentBillingAccountOnGoogleProject.map(_.value),
       workspace.errorMessage,
       workspace.completedCloneWorkspaceFileTransfer.map(dateTime => new Timestamp(dateTime.getMillis)),
-      workspaceType = workspace.workspaceType.toString
+      workspaceType = workspace.workspaceType.toString,
+      state = workspace.state.toString
     )
 
   def toWorkspace(workspaceRec: WorkspaceRecord): Workspace =
@@ -81,7 +83,8 @@ object WorkspaceRecord {
       workspaceRec.currentBillingAccountOnGoogleProject.map(RawlsBillingAccountName),
       workspaceRec.errorMessage,
       workspaceRec.completedCloneWorkspaceFileTransfer.map(timestamp => new DateTime(timestamp)),
-      WorkspaceType.withName(workspaceRec.workspaceType)
+      WorkspaceType.withName(workspaceRec.workspaceType),
+      WorkspaceState.withName(workspaceRec.state)
     )
 
   def toWorkspace(workspaceRec: WorkspaceRecord, attributes: AttributeMap): Workspace =
@@ -102,7 +105,8 @@ object WorkspaceRecord {
       workspaceRec.currentBillingAccountOnGoogleProject.map(RawlsBillingAccountName),
       workspaceRec.errorMessage,
       workspaceRec.completedCloneWorkspaceFileTransfer.map(timestamp => new DateTime(timestamp)),
-      WorkspaceType.withName(workspaceRec.workspaceType)
+      WorkspaceType.withName(workspaceRec.workspaceType),
+      WorkspaceState.withName(workspaceRec.state)
     )
 }
 
@@ -137,6 +141,7 @@ trait WorkspaceComponent {
     def errorMessage = column[Option[String]]("error_message")
     def completedCloneWorkspaceFileTransfer = column[Option[Timestamp]]("completed_clone_workspace_file_transfer")
     def workspaceType = column[String]("workspace_type")
+    def state = column[String]("state")
 
     def uniqueNamespaceName = index("IDX_WS_UNIQUE_NAMESPACE_NAME", (namespace, name), unique = true)
 
@@ -156,7 +161,8 @@ trait WorkspaceComponent {
              currentBillingAccountOnGoogleProject,
              errorMessage,
              completedCloneWorkspaceFileTransfer,
-             workspaceType
+             workspaceType,
+             state
     ) <> ((WorkspaceRecord.apply _).tupled, WorkspaceRecord.unapply)
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -37,7 +37,8 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   Workspace,
   WorkspaceName,
-  WorkspaceRequest
+  WorkspaceRequest,
+  WorkspaceState
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceWithParent}
 import org.broadinstitute.dsde.rawls.util.{Retry, WorkspaceSupport}
@@ -714,7 +715,8 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       createdDate = currentDate,
       lastModified = currentDate,
       createdBy = ctx.userInfo.userEmail.value,
-      attributes = attributes
+      attributes = attributes,
+      WorkspaceState.Ready
     )
     traceDBIOWithParent("saveMultiCloudWorkspace", parentContext)(_ =>
       dataAccess.workspaceQuery.createOrUpdate(workspace)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -11,7 +11,7 @@ import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import com.google.cloud.storage.StorageException
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.startSpanWithParent
-import io.opencensus.trace.{Span, Status, AttributeValue => OpenCensusAttributeValue}
+import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue, Span, Status}
 import org.broadinstitute.dsde.rawls._
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import slick.jdbc.TransactionIsolation
@@ -3389,7 +3389,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                                         dataAccess: DataAccess,
                                         parentContext: RawlsRequestContext,
                                         workspaceType: WorkspaceType = WorkspaceType.RawlsWorkspace
-                                       ): ReadWriteAction[Workspace] = {
+  ): ReadWriteAction[Workspace] = {
     val currentDate = DateTime.now
     val completedCloneWorkspaceFileTransfer = workspaceRequest.copyFilesWithPrefix match {
       case Some(_) => None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import org.broadinstitute.dsde.rawls.dataaccess.AttributeTempTableType
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
-import org.broadinstitute.dsde.rawls.model.{Workspace, _}
+import org.broadinstitute.dsde.rawls.model.{Workspace, WorkspaceState, _}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsTestUtils}
 import org.joda.time.DateTime
 import org.mockito.ArgumentCaptor
@@ -472,7 +472,8 @@ class AttributeComponentSpec
         None,
         None,
         Option(defaultTimeStamp),
-        WorkspaceType.RawlsWorkspace.toString
+        WorkspaceType.RawlsWorkspace.toString,
+        WorkspaceState.Ready.toString
       )
     )
     val entityId = runAndWait(
@@ -525,7 +526,8 @@ class AttributeComponentSpec
         None,
         None,
         Option(defaultTimeStamp),
-        WorkspaceType.RawlsWorkspace.toString
+        WorkspaceType.RawlsWorkspace.toString,
+        WorkspaceState.Ready.toString
       )
     )
     val entityId1 = runAndWait(
@@ -659,7 +661,8 @@ class AttributeComponentSpec
         None,
         None,
         Option(defaultTimeStamp),
-        WorkspaceType.RawlsWorkspace.toString
+        WorkspaceType.RawlsWorkspace.toString,
+        WorkspaceState.Ready.toString
       )
     )
     val testAttribute = AttributeEntityReference("type", "name")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityAttributeStatisticsComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityAttributeStatisticsComponentSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeString,
   GoogleProjectId,
   Workspace,
+  WorkspaceState,
   WorkspaceType,
   WorkspaceVersions
 }
@@ -44,7 +45,8 @@ class EntityAttributeStatisticsSpec
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     runAndWait(workspaceQuery.createOrUpdate(workspace))
@@ -88,7 +90,8 @@ class EntityAttributeStatisticsSpec
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     runAndWait(workspaceQuery.createOrUpdate(workspace))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityTypeStatisticsComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityTypeStatisticsComponentSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeString,
   GoogleProjectId,
   Workspace,
+  WorkspaceState,
   WorkspaceType,
   WorkspaceVersions
 }
@@ -44,7 +45,8 @@ class EntityTypeStatisticsComponentSpec
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     runAndWait(workspaceQuery.createOrUpdate(workspace))
@@ -87,7 +89,8 @@ class EntityTypeStatisticsComponentSpec
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     runAndWait(workspaceQuery.createOrUpdate(workspace))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/FastPassGrantComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/FastPassGrantComponentSpec.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsBillingAccountName,
   Workspace,
   WorkspaceName,
+  WorkspaceState,
   WorkspaceType,
   WorkspaceVersions
 }
@@ -96,7 +97,8 @@ class FastPassGrantComponentSpec
     Option(workspaceBillingAccount),
     None,
     Option(currentTime()),
-    WorkspaceType.RawlsWorkspace
+    WorkspaceType.RawlsWorkspace,
+    WorkspaceState.Ready
   )
 
   "FastPassGrantRecord" - {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -231,7 +231,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       project.billingAccount,
       None,
       Option(createdDate),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
   def makeWorkspaceWithUsers(project: RawlsBillingProject,
                              name: String,
@@ -267,7 +268,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       currentBillingAccountOnWorkspace,
       errorMessage,
       completedCloneWorkspaceFileTransfer,
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
   class EmptyWorkspace() extends TestData {
@@ -352,7 +354,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       billingAccount,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     override def save() =
@@ -1657,7 +1660,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       currentBillingAccountOnGoogleProject = None,
       errorMessage = None,
       completedCloneWorkspaceFileTransfer = None,
-      workspaceType = WorkspaceType.McWorkspace
+      workspaceType = WorkspaceType.McWorkspace,
+      WorkspaceState.Ready
     )
 
     val allWorkspaces = Seq(
@@ -2059,7 +2063,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
     val v1Workspace2 = Workspace(
       v1WsName2.namespace,
@@ -2078,7 +2083,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     override def save() =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -42,7 +42,8 @@ class WorkspaceComponentSpec
     Option(workspaceBillingAccount),
     None,
     Option(currentTime()),
-    WorkspaceType.RawlsWorkspace
+    WorkspaceType.RawlsWorkspace,
+    WorkspaceState.Ready
   )
 
   "WorkspaceComponent" should "crud workspaces" in withEmptyTestDatabase {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceRequesterPaysComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceRequesterPaysComponentSpec.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.rawls.model.{
   GoogleProjectId,
   RawlsUserEmail,
   Workspace,
+  WorkspaceState,
   WorkspaceType,
   WorkspaceVersions
 }
@@ -32,7 +33,8 @@ class WorkspaceRequesterPaysComponentSpec extends TestDriverComponentWithFlatSpe
       None,
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     runAndWait(workspaceQuery.createOrUpdate(workspace))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
@@ -75,7 +75,8 @@ class BillingAccountChangeSynchronizerSpec
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val v2Workspace = Workspace(
         billingProject.projectName.value,
@@ -94,7 +95,8 @@ class BillingAccountChangeSynchronizerSpec
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val workspaceWithoutBillingAccount = v2Workspace.copy(
         name = "noBillingAccount",
@@ -167,7 +169,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait {
@@ -232,7 +235,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait {
@@ -299,7 +303,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait {
@@ -365,7 +370,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val workspace2 = Workspace(
         billingProject.projectName.value,
@@ -384,7 +390,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val badWorkspaceGoogleProjectId = GoogleProjectId("very bad")
       val badWorkspace = Workspace(
@@ -404,7 +411,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       val newBillingAccount = RawlsBillingAccountName("new-ba")
@@ -485,7 +493,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val secondV1Workspace = Workspace(
         billingProject.projectName.value,
@@ -504,7 +513,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val v2Workspace = Workspace(
         billingProject.projectName.value,
@@ -523,7 +533,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       val newBillingAccount = RawlsBillingAccountName("new-ba")
@@ -854,7 +865,8 @@ class BillingAccountChangeSynchronizerSpec
         originalBillingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       val newBillingAccount = RawlsBillingAccountName("new-ba")
@@ -927,7 +939,8 @@ class BillingAccountChangeSynchronizerSpec
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val v2Workspace = Workspace(
         billingProject.projectName.value,
@@ -946,7 +959,8 @@ class BillingAccountChangeSynchronizerSpec
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val workspaceWithoutBillingAccount = v2Workspace.copy(
         name = "noBillingAccount",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
@@ -80,7 +80,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val destWorkspace = Workspace(
         billingProject.projectName.value,
@@ -99,7 +100,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         None,
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
@@ -175,7 +177,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val destWorkspace = Workspace(
         billingProject.projectName.value,
@@ -194,7 +197,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         None,
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
@@ -262,7 +266,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val destWorkspace = Workspace(
         billingProject.projectName.value,
@@ -281,7 +286,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         None,
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
@@ -361,7 +367,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val destWorkspace = Workspace(
         billingProject.projectName.value,
@@ -380,7 +387,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         None,
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))
@@ -475,7 +483,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         Option(DateTime.now),
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val badDestWorkspace = Workspace(
         billingProject.projectName.value,
@@ -494,7 +503,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         None,
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
       val goodDestWorkspace = Workspace(
         billingProject.projectName.value,
@@ -513,7 +523,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
         billingProject.billingAccount,
         None,
         None,
-        WorkspaceType.RawlsWorkspace
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
       )
 
       runAndWait(rawlsBillingProjectQuery.create(billingProject))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -30,8 +30,8 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
+import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Mockito}
-import org.mockito.Mockito.{doReturn, doThrow, never, spy, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
@@ -99,7 +99,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       currentBillingAccountOnGoogleProject,
       errorMessage,
       None,
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     object Daily {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1197,7 +1197,7 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
                                                  billingProfileId = Some(UUID.randomUUID().toString)
         )
         val wsId = UUID.randomUUID()
-        val azureWorkspace = Workspace.buildMcWorkspace(
+        val azureWorkspace = Workspace.buildReadyMcWorkspace(
           namespace = "test-azure-bp",
           name = s"test-azure-ws-${wsId}",
           workspaceId = wsId.toString,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1261,7 +1261,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
       Option(RawlsBillingAccountName("fakeBillingAcct")),
       None,
       Option(currentTime()),
-      WorkspaceType.RawlsWorkspace
+      WorkspaceType.RawlsWorkspace,
+      WorkspaceState.Ready
     )
 
     runAndWait(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3208,8 +3208,9 @@ class WorkspaceServiceSpec
         WorkspaceDetails.fromWorkspaceAndOptions(azureWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Azure))
       val googleWorkspaceDetails =
         WorkspaceDetails.fromWorkspaceAndOptions(googleWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Gcp))
-      val expected = List((azureWorkspaceDetails.workspaceId, azureWorkspaceDetails.cloudPlatform, azureWorkspaceDetails.state),
-                          (googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform, googleWorkspaceDetails.state)
+      val expected = List(
+        (azureWorkspaceDetails.workspaceId, azureWorkspaceDetails.cloudPlatform, azureWorkspaceDetails.state),
+        (googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform, googleWorkspaceDetails.state)
       )
 
       runAndWait {
@@ -3255,7 +3256,9 @@ class WorkspaceServiceSpec
           .convertTo[Seq[WorkspaceListResponse]]
 
       // verify that the result is what you expect it to be
-      result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform, ws.workspace.state)) should contain theSameElementsAs expected
+      result.map(ws =>
+        (ws.workspace.workspaceId, ws.workspace.cloudPlatform, ws.workspace.state)
+      ) should contain theSameElementsAs expected
   }
 
   "listWorkspaces" should "not return a MC workspace that does not have a cloud context" in withTestDataServices {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2973,6 +2973,7 @@ class WorkspaceServiceSpec
     response.bucketOptions shouldBe Some(WorkspaceBucketOptions(false))
     response.azureContext shouldEqual None
     response.workspace.cloudPlatform shouldBe Some(WorkspaceCloudPlatform.Gcp)
+    response.workspace.state shouldBe WorkspaceState.Ready
   }
 
   private def createAzureWorkspace(services: TestApiService,
@@ -3019,6 +3020,7 @@ class WorkspaceServiceSpec
     response.azureContext.get.subscriptionId.toString shouldEqual managedAppCoordinates.subscriptionId.toString
     response.azureContext.get.managedResourceGroupId shouldEqual managedAppCoordinates.managedResourceGroupId
     response.workspace.cloudPlatform shouldBe Some(WorkspaceCloudPlatform.Azure)
+    response.workspace.state shouldBe WorkspaceState.Ready
   }
 
   it should "return the policies of an Azure workspace" in withTestDataServices { services =>
@@ -3176,7 +3178,7 @@ class WorkspaceServiceSpec
     }
   }
 
-  "listWorkspaces" should "list the correct cloud platform for Azure and Google workspaces" in withTestDataServices {
+  "listWorkspaces" should "list the correct cloud platform and state for Azure and Google workspaces" in withTestDataServices {
     services =>
       val service = services.workspaceService
       val workspaceId1 = UUID.randomUUID().toString
@@ -3206,8 +3208,8 @@ class WorkspaceServiceSpec
         WorkspaceDetails.fromWorkspaceAndOptions(azureWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Azure))
       val googleWorkspaceDetails =
         WorkspaceDetails.fromWorkspaceAndOptions(googleWorkspace, Some(Set()), true, Some(WorkspaceCloudPlatform.Gcp))
-      val expected = List((azureWorkspaceDetails.workspaceId, azureWorkspaceDetails.cloudPlatform),
-                          (googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform)
+      val expected = List((azureWorkspaceDetails.workspaceId, azureWorkspaceDetails.cloudPlatform, azureWorkspaceDetails.state),
+                          (googleWorkspaceDetails.workspaceId, googleWorkspaceDetails.cloudPlatform, googleWorkspaceDetails.state)
       )
 
       runAndWait {
@@ -3253,7 +3255,7 @@ class WorkspaceServiceSpec
           .convertTo[Seq[WorkspaceListResponse]]
 
       // verify that the result is what you expect it to be
-      result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform)) should contain theSameElementsAs expected
+      result.map(ws => (ws.workspace.workspaceId, ws.workspace.cloudPlatform, ws.workspace.state)) should contain theSameElementsAs expected
   }
 
   "listWorkspaces" should "not return a MC workspace that does not have a cloud context" in withTestDataServices {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3186,13 +3186,13 @@ class WorkspaceServiceSpec
 
       // set up test data
       val azureWorkspace =
-        Workspace.buildMcWorkspace("test_namespace1",
-                                   "name",
-                                   workspaceId1,
-                                   new DateTime(),
-                                   new DateTime(),
-                                   "testUser1",
-                                   Map.empty
+        Workspace.buildReadyMcWorkspace("test_namespace1",
+                                        "name",
+                                        workspaceId1,
+                                        new DateTime(),
+                                        new DateTime(),
+                                        "testUser1",
+                                        Map.empty
         )
       val googleWorkspace = Workspace("test_namespace2",
                                       workspaceId2,
@@ -3269,13 +3269,13 @@ class WorkspaceServiceSpec
 
       // set up test data
       val azureWorkspace =
-        Workspace.buildMcWorkspace("test_namespace1",
-                                   "name",
-                                   workspaceId1,
-                                   new DateTime(),
-                                   new DateTime(),
-                                   "testUser1",
-                                   Map.empty
+        Workspace.buildReadyMcWorkspace("test_namespace1",
+                                        "name",
+                                        workspaceId1,
+                                        new DateTime(),
+                                        new DateTime(),
+                                        "testUser1",
+                                        Map.empty
         )
       val googleWorkspace = Workspace("test_namespace2",
                                       workspaceId2,
@@ -3339,13 +3339,13 @@ class WorkspaceServiceSpec
 
       // set up test data
       val azureWorkspace =
-        Workspace.buildMcWorkspace("test_namespace1",
-                                   "name",
-                                   workspaceId1,
-                                   new DateTime(),
-                                   new DateTime(),
-                                   "testUser1",
-                                   Map.empty
+        Workspace.buildReadyMcWorkspace("test_namespace1",
+                                        "name",
+                                        workspaceId1,
+                                        new DateTime(),
+                                        new DateTime(),
+                                        "testUser1",
+                                        Map.empty
         )
       val googleWorkspace = Workspace("test_namespace2",
                                       workspaceId2,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -359,7 +359,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     val samDAO = mock[SamDAO]
     val workspaceService = workspaceServiceConstructor(samDAO = samDAO)(defaultRequestContext)
     val wsId = UUID.randomUUID().toString
-    val azureWorkspace = Workspace.buildMcWorkspace(
+    val azureWorkspace = Workspace.buildReadyMcWorkspace(
       namespace = "test-azure-bp",
       name = s"test-azure-ws-${wsId}",
       workspaceId = wsId,
@@ -741,7 +741,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
 
   it should "return azure as the cloud platform when the azure context is returned from WSM" in {
     val workspaceId = UUID.randomUUID()
-    val workspace = Workspace.buildMcWorkspace(
+    val workspace = Workspace.buildReadyMcWorkspace(
       "test-namespace",
       "test-name",
       workspaceId.toString,
@@ -760,7 +760,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
 
   it should "return gcp as the cloud platform when the gcp context is returned from WSM" in {
     val workspaceId = UUID.randomUUID()
-    val workspace = Workspace.buildMcWorkspace(
+    val workspace = Workspace.buildReadyMcWorkspace(
       "test-namespace",
       "test-name",
       workspaceId.toString,
@@ -779,7 +779,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
 
   it should "throw an exception when no cloud context is returned from WSM" in {
     val workspaceId = UUID.randomUUID()
-    val workspace = Workspace.buildMcWorkspace(
+    val workspace = Workspace.buildReadyMcWorkspace(
       "test-namespace",
       "test-name",
       workspaceId.toString,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.rawls.model.SortDirections.SortDirection
 import org.broadinstitute.dsde.rawls.model.UserModelJsonSupport.ManagedGroupRefFormat
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model.WorkspaceCloudPlatform.WorkspaceCloudPlatform
+import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model.WorkspaceVersions.WorkspaceVersion
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
@@ -188,7 +189,8 @@ case class Workspace(
   currentBillingAccountOnGoogleProject: Option[RawlsBillingAccountName],
   errorMessage: Option[String],
   completedCloneWorkspaceFileTransfer: Option[DateTime],
-  workspaceType: WorkspaceType
+  workspaceType: WorkspaceType,
+  state: WorkspaceState
 ) extends Attributable {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
   def briefName: String = toWorkspaceName.toString
@@ -232,7 +234,8 @@ object Workspace {
       None,
       None,
       Option(createdDate),
-      workspaceType = WorkspaceType.RawlsWorkspace
+      workspaceType = WorkspaceType.RawlsWorkspace,
+      state = WorkspaceState.Ready
     )
   }
 
@@ -261,7 +264,8 @@ object Workspace {
       None,
       None,
       None,
-      WorkspaceType.McWorkspace
+      WorkspaceType.McWorkspace,
+      WorkspaceState.Ready
     )
 }
 
@@ -450,6 +454,31 @@ object WorkspaceCloudPlatform {
 
   case object Azure extends WorkspaceCloudPlatform
   case object Gcp extends WorkspaceCloudPlatform
+}
+
+object WorkspaceState {
+  sealed trait WorkspaceState extends RawlsEnumeration[WorkspaceState] {
+    override def toString: String = getClass.getSimpleName.stripSuffix("$")
+    override def withName(name: String): WorkspaceState = WorkspaceState.withName(name)
+  }
+
+  def withName(name: String): WorkspaceState = name.toLowerCase match {
+    case "creating"     => Creating
+    case "createfailed" => CreateFailed
+    case "ready"        => Ready
+    case "updating"     => Updating
+    case "updatefailed" => UpdateFailed
+    case "deleting"     => Deleting
+    case "deletefailed" => DeleteFailed
+    case _              => throw new RawlsException(s"invalid WorkspaceState [$name]")
+  }
+  case object Creating extends WorkspaceState
+  case object CreateFailed extends WorkspaceState
+  case object Ready extends WorkspaceState
+  case object Updating extends WorkspaceState
+  case object UpdateFailed extends WorkspaceState
+  case object Deleting extends WorkspaceState
+  case object DeleteFailed extends WorkspaceState
 }
 
 sealed trait MethodRepoMethod {
@@ -734,7 +763,8 @@ case class WorkspaceDetails(
   errorMessage: Option[String] = None,
   completedCloneWorkspaceFileTransfer: Option[DateTime],
   workspaceType: Option[WorkspaceType],
-  cloudPlatform: Option[WorkspaceCloudPlatform]
+  cloudPlatform: Option[WorkspaceCloudPlatform],
+  state: WorkspaceState
 ) {
   def toWorkspace: Workspace = Workspace(
     namespace,
@@ -753,7 +783,8 @@ case class WorkspaceDetails(
     billingAccount,
     errorMessage,
     completedCloneWorkspaceFileTransfer,
-    workspaceType.getOrElse(WorkspaceType.RawlsWorkspace)
+    workspaceType.getOrElse(WorkspaceType.RawlsWorkspace),
+    state
   )
 }
 
@@ -842,7 +873,8 @@ object WorkspaceDetails {
       workspace.errorMessage,
       workspace.completedCloneWorkspaceFileTransfer,
       Some(workspace.workspaceType),
-      cloudPlatform
+      cloudPlatform,
+      workspace.state
     )
 }
 
@@ -854,8 +886,6 @@ case class PendingCloneWorkspaceFileTransfer(destWorkspaceId: UUID,
 )
 
 case class ManagedGroupAccessInstructions(groupName: String, instructions: String)
-
-case class WorkspacePermissionsPair(workspaceId: String, accessLevel: WorkspaceAccessLevel)
 
 case class WorkspaceStatus(workspaceName: WorkspaceName, statuses: Map[String, String])
 
@@ -1159,9 +1189,11 @@ class WorkspaceJsonSupport extends JsonSupport {
     WorkspaceBucketOptions
   )
 
+  implicit val WorkspaceStateFormat: RootJsonFormat[WorkspaceState] = rawlsEnumerationFormat(WorkspaceState.withName)
+
   implicit val WorkspaceTypeFormat: RootJsonFormat[WorkspaceType] = rawlsEnumerationFormat(WorkspaceType.withName)
 
-  implicit val WorkspaceDetailsFormat: RootJsonFormat[WorkspaceDetails] = jsonFormat20(WorkspaceDetails.apply)
+  implicit val WorkspaceDetailsFormat: RootJsonFormat[WorkspaceDetails] = jsonFormat21(WorkspaceDetails.apply)
 
   implicit val WorkspaceListResponseFormat: RootJsonFormat[WorkspaceListResponse] = jsonFormat4(WorkspaceListResponse)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -238,14 +238,30 @@ object Workspace {
       state = WorkspaceState.Ready
     )
   }
-
+  def buildReadyMcWorkspace(namespace: String,
+                            name: String,
+                            workspaceId: String,
+                            createdDate: DateTime,
+                            lastModified: DateTime,
+                            createdBy: String,
+                            attributes: AttributeMap
+  ) = buildMcWorkspace(namespace,
+                       name,
+                       workspaceId,
+                       createdDate,
+                       lastModified,
+                       createdBy,
+                       attributes,
+                       WorkspaceState.Ready
+  )
   def buildMcWorkspace(namespace: String,
                        name: String,
                        workspaceId: String,
                        createdDate: DateTime,
                        lastModified: DateTime,
                        createdBy: String,
-                       attributes: AttributeMap
+                       attributes: AttributeMap,
+                       state: WorkspaceState
   ) =
     new Workspace(
       namespace,
@@ -265,7 +281,7 @@ object Workspace {
       None,
       None,
       WorkspaceType.McWorkspace,
-      WorkspaceState.Ready
+      state
     )
 }
 

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.model
 
 import org.broadinstitute.dsde.rawls.RawlsException
-import org.broadinstitute.dsde.rawls.model.Attributable.{workspaceIdAttribute, AttributeMap}
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.MethodRepoMethodFormat
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
@@ -439,7 +439,8 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         "errorMessage",
         "completedCloneWorkspaceFileTransfer",
         "workspaceType",
-        "cloudPlatform"
+        "cloudPlatform",
+        "state"
       )
       WorkspaceFieldNames.workspaceDetailClassNames should contain theSameElementsAs expected
     }
@@ -474,7 +475,8 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         "workspace.billingAccountErrorMessage",
         "workspace.completedCloneWorkspaceFileTransfer",
         "workspace.workspaceType",
-        "workspace.cloudPlatform"
+        "workspace.cloudPlatform",
+        "workspace.state"
       )
       WorkspaceFieldNames.workspaceResponseFieldNames should contain theSameElementsAs expected
     }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1180

Adds `state` to Workspace records in preparation for async deletion work ([spec](https://broadworkbench.atlassian.net/wiki/spaces/WOR/pages/2819653639/Workspace+Async+Deletion)).

For existing workspaces, they are marked "Ready" if there is no error message stored on the workspace record, else they are marked "UpdatedFailed", as historically the error field was used for billing update failure messages.

Will publish a new Rawls model when this is merged.

Example of a completed migration, where the second workspace has an error


mysql> select * from WORKSPACE;
| namespace  | name           | id               | bucket_name                             | created_date               | last_modified              | created_by            | is_locked | record_version | workflow_collection                  | WORKSPACE_VERSION | GOOGLE_PROJECT_ID  | GOOGLE_PROJECT_NUMBER | BILLING_ACCOUNT_ON_GOOGLE_PROJECT    | ERROR_MESSAGE  | COMPLETED_CLONE_WORKSPACE_FILE_TRANSFER | workspace_type | state        |
+------------+----------------+------------------+-----------------------------------------+----------------------------+----------------------------+-----------------------+-----------+----------------+--------------------------------------+-------------------+--------------------+-----------------------+--------------------------------------+----------------+-----------------------------------------+----------------+--------------+
?8P?Χ?? | fc-45951a5a-4a8b-4b0d-9f38-50f4cea7bb98 | 2023-08-10 19:24:31.133000 | 2023-08-10 19:24:31.183000 | b.adm.firec@gmail.com |           |              0 | 45951a5a-4a8b-4b0d-9f38-50f4cea7bb98 | v2                | terra-dev-a74b998e | 23751669757           | billingAccounts/000CCF-F7C8D8-53173C | **NULL**           | 2023-08-10 19:24:31.133000              | rawls          | **Ready**        |
| CARBilling | ErrorWorkspace | ?̬??C???
                                       Ӆn? | fc-d60eccac-e0c4-43ae-9d9d-0cd3851f6ecb | 2023-08-10 19:25:20.981000 | 2023-08-10 19:25:20.988000 | b.adm.firec@gmail.com |           |              0 | d60eccac-e0c4-43ae-9d9d-0cd3851f6ecb | v2                | terra-dev-8b2d136c | 646919202983          | billingAccounts/000CCF-F7C8D8-53173C | **Error message!** | 2023-08-10 19:25:20.981000              | rawls          | **UpdateFailed** |

2 rows in set (0.00 sec)

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
