### PR TITLE
Revert "[WOR-1099] Update liquibase-core from 4.17.2 to 4.23.0 (#2428)"

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -88,6 +88,10 @@
     <include file="changesets/20201106_workspace_google_project_columns.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20201113_add_billing_account_workspace.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210430_add_workspace_billing_account_error_message.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210524_add_memory_retry_multiplier.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210609_add_workspace_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210609_change_workspace_attr_temp_owner_id.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20210510_add_billing_project_export_columns.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210915_create_entity_cache_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210916_clone_workspace_file_transfer.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210924_sharded_entity_tables.xml" relativeToChangelogFile="true"/>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   val apacheCommonsIO: ModuleID = "commons-io"                    % "commons-io"            % "2.13.0"
   val antlrParser: ModuleID =     "org.antlr"                     % "antlr4-runtime"        % "4.13.0"
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.1.0"
-  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.23.0"
+  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
   val workbenchLibsHash = "85a080a"
 


### PR DESCRIPTION
This reverts commit ca8c215cf0e8fe2bb94624a3c1ab26b4b4590e4a.

Ticket: [WOR-1196](https://broadworkbench.atlassian.net/browse/WOR-1196)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1196]: https://broadworkbench.atlassian.net/browse/WOR-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ