### PR TITLE
[WOR-1062] Add bucket migration progress API

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -134,4 +134,5 @@
     <include file="changesets/20230719_autoupdate_updated_multiregional_bucket.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230802_more_precise_updated_multiregional_bucket.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230810_add_workspace_state_column.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20230810_track_mrb_sts_progress.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230810_track_mrb_sts_progress.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20230810_track_mrb_sts_progress.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="mtalbott" id="add_STS_PROGRESS_MRB_MIGRATION_STORAGE_TRANSFER_JOB">
+        <addColumn tableName="MULTIREGIONAL_BUCKET_MIGRATION_STORAGE_TRANSFER_SERVICE_JOB">
+            <column name="TOTAL_BYTES_TO_TRANSFER" type="BIGINT">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="MULTIREGIONAL_BUCKET_MIGRATION_STORAGE_TRANSFER_SERVICE_JOB">
+            <column name="BYTES_TRANSFERRED" type="BIGINT">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="MULTIREGIONAL_BUCKET_MIGRATION_STORAGE_TRANSFER_SERVICE_JOB">
+            <column name="TOTAL_OBJECTS_TO_TRANSFER" type="BIGINT">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="MULTIREGIONAL_BUCKET_MIGRATION_STORAGE_TRANSFER_SERVICE_JOB">
+            <column name="OBJECTS_TRANSFERRED" type="BIGINT">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1045,7 +1045,6 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
-
   /api/admin/bucketMigration/workspaces:
     post:
       tags:
@@ -1120,6 +1119,32 @@ paths:
                   $ref: '#/components/schemas/WorkspaceMigrationMetadata'
         403:
           description: You must be an admin to start migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/admin/bucketMigration/billing/{projectId}/progress:
+    get:
+      tags:
+        - admin
+      summary: get bucket migration progress for workspaces in billing project
+      description: get bucket migration progress for workspaces in billing project
+      operationId: getBucketMigrationProgressForBillingProject
+      parameters:
+        - $ref: '#/components/parameters/billingProjectIdPathParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to list migration attempts
           content:
             'application/json':
               schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1036,7 +1036,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+                  $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
         403:
           description: You must be an admin to list migration attempts
           content:
@@ -1091,7 +1091,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+                  type: object
+                  description: workspaceNamespace/workspaceName -> bucket migration metadata
+                  additionalProperties:
+                    $ref: '#/components/schemas/WorkspaceMigrationMetadata'
         403:
           description: You must be an admin to list migration attempts
           content:
@@ -1142,7 +1145,10 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+                  type: object
+                  description: workspaceNamespace/workspaceName -> bucket migration progress
+                  additionalProperties:
+                    $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
         403:
           description: You must be an admin to list migration attempts
           content:
@@ -6253,6 +6259,50 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/WorkspaceName'
+    MultiregionalBucketMigrationProgress:
+      description: Represents the progress of a workspace bucket through the multiregional bucket migration pipeline
+      type: object
+      required:
+        - migrationStep
+      properties:
+        migrationStep:
+          description: User facing step of migration
+          type: string
+          enum:
+            - ScheduledForMigration
+            - PreparingTransferToTempBucket
+            - TransferringToTempBucket
+            - PreparingTransferToFinalBucket
+            - TransferringToFinalBucket
+            - FinishingUp
+            - Finished
+        outcome:
+          $ref: '#/components/schemas/WorkspaceMigrationOutcome'
+        tempBucketTransferProgress:
+          $ref: '#/components/schemas/StorageTransferJobProgress'
+        finalBucketTransferProgress:
+          $ref: '#/components/schemas/StorageTransferJobProgress'
+    StorageTransferJobProgress:
+      description: Represents the progress of a single Storage Transfer Service job to move a bucket
+      type: object
+      required:
+        - totalBytesToTransfer
+        - bytesTransferred
+        - totalObjectsToTransfer
+        - objectsTransferred
+      properties:
+        totalBytesToTransfer:
+          description: total bytes that this job will transfer
+          type: integer
+        bytesTransferred:
+          description: bytes that this job has transferred so far
+          type: integer
+        totalObjectsToTransfer:
+          description: total objects that this job will transfer
+          type: integer
+        objectsTransferred:
+          description: objects that this job has transferred so far
+          type: integer
   parameters:
     billingProjectIdPathParam:
       name: projectId

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1018,6 +1018,34 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
+  /api/admin/bucketMigration/workspaces/{workspaceNamespace}/{workspaceName}/progress:
+    get:
+      tags:
+        - admin
+      summary: get bucket migration progress for workspace
+      description: get bucket migration progress for workspace
+      operationId: getBucketMigrationProgressForWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespacePathParam'
+        - $ref: '#/components/parameters/workspaceNamePathParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an admin to list migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+
   /api/admin/bucketMigration/workspaces:
     post:
       tags:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -63,7 +63,7 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
     for {
       // most recent migration attempt, need the two STS jobs if they exist and need to turn them into STSJobProgress
       attemptOpt <- dataAccess.multiregionalBucketMigrationQuery
-        .getAttempt(UUID.fromString(workspace.workspaceId))
+        .getAttempt(workspace.workspaceIdAsUUID)
         .value
       attempt = attemptOpt.getOrElse(
         throw new RawlsExceptionWithErrorReport(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -61,7 +61,6 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
   )(dataAccess: DataAccess): ReadWriteAction[Option[MultiregionalBucketMigrationProgress]] = {
     import dataAccess.driver.api._
     for {
-      // most recent migration attempt, need the two STS jobs if they exist and need to turn them into STSJobProgress
       attemptOpt <- dataAccess.multiregionalBucketMigrationQuery
         .getAttempt(workspace.workspaceIdAsUUID)
         .value

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -86,13 +86,13 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
           .result
           .headOption
 
-    } yield
-      MultiregionalBucketMigrationProgress(
-          workspace.toWorkspaceName,
-          MultiregionalBucketMigrationStep.fromMultiregionalBucketMigration(attempt),
-          STSJobProgress.fromMultiregionalStorageTransferJob(tempTransferJob),
-          STSJobProgress.fromMultiregionalStorageTransferJob(finalTransferJob)
-        ).some
+    } yield MultiregionalBucketMigrationProgress(
+      workspace.toWorkspaceName,
+      MultiregionalBucketMigrationStep.fromMultiregionalBucketMigration(attempt),
+      attempt.outcome,
+      STSJobProgress.fromMultiregionalStorageTransferJob(tempTransferJob),
+      STSJobProgress.fromMultiregionalStorageTransferJob(finalTransferJob)
+    ).some
   }
 
   def getBucketMigrationAttemptsForWorkspace(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -48,7 +48,10 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
           dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
         }
         progress <- workspaces.traverse { workspace =>
-          dataSource.inTransaction(getBucketMigrationProgress(workspace)).map(workspace.toWorkspaceName.toString -> _)
+          dataSource
+            .inTransaction(getBucketMigrationProgress(workspace))
+            .recover(_ => None)
+            .map(workspace.toWorkspaceName.toString -> _)
         }
       } yield progress.toMap
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -2,17 +2,24 @@ package org.broadinstitute.dsde.rawls.bucketMigration
 
 import akka.http.scaladsl.model.StatusCodes
 import cats.MonadThrow
-import cats.implicits.toTraverseOps
+import cats.data.OptionT
+import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, RawlsRequestContext, WorkspaceName}
-import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.monadThrowDBIOAction
+import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  Workspace,
+  WorkspaceName
+}
+import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
 import org.broadinstitute.dsde.rawls.monitor.migration._
 import org.broadinstitute.dsde.rawls.util.{RoleSupport, WorkspaceSupport}
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO, val gcsDAO: GoogleServicesDAO)(
@@ -28,40 +35,54 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
     asFCAdmin {
       for {
         workspace <- getV2WorkspaceContext(workspaceName)
-        res <- dataSource.inTransaction { dataAccess =>
-          import dataAccess.driver.api._
-          for {
-            // most recent migration attempt, need the two STS jobs if they exist and need to turn them into STSJobProgress
-            attempts <- dataAccess.multiregionalBucketMigrationQuery.getMigrationAttempts(workspace)
-            stsJobs <- attempts
-              .sortBy(_.created)
-              .lastOption
-              .map { mostRecentMigration =>
-                MultiregionalStorageTransferJobs.storageTransferJobs
-                  .filter(_.migrationId === mostRecentMigration.id)
-                  .result
-              }
-              .getOrElse(DBIO.successful(Seq.empty))
-          } yield {
-            val (finalTransferJobs, tempTransferJobs) =
-              stsJobs.sortBy(_.created).partition(m => m.destBucket.equals(GcsBucketName(workspace.bucketName)))
-
-            val finalProgressOpt =
-              STSJobProgress.fromMultiregionalStorageTransferJobOption(finalTransferJobs.headOption)
-            val tempProgressOpt = STSJobProgress.fromMultiregionalStorageTransferJobOption(tempTransferJobs.headOption)
-            attempts.lastOption.map { attempt =>
-              MultiregionalBucketMigrationProgress(
-                workspace.toWorkspaceName,
-                MultiregionalBucketMigrationStep.fromMultiregionalBucketMigration(attempt),
-                tempProgressOpt,
-                finalProgressOpt
-              )
-            }
-          }
-        }
+        res <- dataSource.inTransaction(getBucketMigrationProgress(workspace))
       } yield res
     }
 
+  def getBucketMigrationProgressForBillingProject(billingProjectName: RawlsBillingProjectName): Future[List[MultiregionalBucketMigrationProgress]] = {
+    asFCAdmin {
+      for {
+        workspaces <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
+        }
+        progress <- workspaces.traverse { workspace =>
+          dataSource.inTransaction(getBucketMigrationProgress(workspace))
+        }
+      } yield progress.flatten.toList
+    }
+  }
+
+  private def getBucketMigrationProgress(
+    workspace: Workspace
+  )(dataAccess: DataAccess): ReadWriteAction[Option[MultiregionalBucketMigrationProgress]] = {
+    import dataAccess.driver.api._
+    (for {
+      // most recent migration attempt, need the two STS jobs if they exist and need to turn them into STSJobProgress
+      attempt <- dataAccess.multiregionalBucketMigrationQuery.getAttempt(UUID.fromString(workspace.workspaceId))
+      tempTransferJob <- OptionT[ReadWriteAction, MultiregionalStorageTransferJob] {
+        MultiregionalStorageTransferJobs.storageTransferJobs
+          .filter(_.migrationId === attempt.id)
+          .filter(_.sourceBucket === workspace.bucketName)
+          .sortBy(_.created.desc)
+          .result
+          .headOption
+      }
+      finalTransferJob <- OptionT[ReadWriteAction, MultiregionalStorageTransferJob] {
+        MultiregionalStorageTransferJobs.storageTransferJobs
+          .filter(_.migrationId === attempt.id)
+          .filter(_.destBucket === workspace.bucketName)
+          .sortBy(_.created.desc)
+          .result
+          .headOption
+      }
+    } yield MultiregionalBucketMigrationProgress(
+      workspace.toWorkspaceName,
+      MultiregionalBucketMigrationStep.fromMultiregionalBucketMigration(attempt),
+      STSJobProgress.fromMultiregionalStorageTransferJob(tempTransferJob),
+      STSJobProgress.fromMultiregionalStorageTransferJob(finalTransferJob)
+    )).value
+
+  }
   def getBucketMigrationAttemptsForWorkspace(
     workspaceName: WorkspaceName
   ): Future[List[MultiregionalBucketMigrationMetadata]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -123,17 +123,17 @@ final case class STSJobProgress(totalBytesToTransfer: Long,
 
 object STSJobProgress {
   def fromMultiregionalStorageTransferJob(
-    job: MultiregionalStorageTransferJob
-  ): Option[STSJobProgress] =
+    jobOpt: Option[MultiregionalStorageTransferJob]
+  ): Option[STSJobProgress] = jobOpt.collect { job =>
     (job.totalBytesToTransfer, job.bytesTransferred, job.totalObjectsToTransfer, job.objectsTransferred) match {
       case (Some(totalBytesToTransfer),
             Some(bytesTransferred),
             Some(totalObjectsToTransfer),
             Some(objectsTransferred)
           ) =>
-        Option(STSJobProgress(totalBytesToTransfer, bytesTransferred, totalObjectsToTransfer, objectsTransferred))
-      case _ => None
+        STSJobProgress(totalBytesToTransfer, bytesTransferred, totalObjectsToTransfer, objectsTransferred)
     }
+  }
 }
 
 final case class MultiregionalBucketMigrationProgress(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -140,11 +140,11 @@ object STSJobProgress {
     for {
       op <- Option(operation)
       counters <- Option(op.getCounters)
-    } yield STSJobProgress(counters.getBytesFoundFromSource,
-                           counters.getBytesCopiedToSink,
-                           counters.getObjectsFoundFromSource,
-                           counters.getObjectsCopiedToSink
-    )
+      totalBytesToTransfer <- Option(counters.getBytesFoundFromSource)
+      bytesTransferred <- Option(counters.getBytesCopiedToSink)
+      totalObjectsToTransfer <- Option(counters.getObjectsFoundFromSource)
+      objectsTransferred <- Option(counters.getObjectsCopiedToSink)
+    } yield STSJobProgress(totalBytesToTransfer, bytesTransferred, totalObjectsToTransfer, objectsTransferred)
 }
 
 final case class MultiregionalBucketMigrationProgress(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -137,7 +137,6 @@ object STSJobProgress {
 }
 
 final case class MultiregionalBucketMigrationProgress(
-  workspaceName: WorkspaceName,
   migrationStep: MultiregionalBucketMigrationStep,
   outcome: Option[Outcome],
   tempBucketTransferProgress: Option[STSJobProgress],
@@ -145,7 +144,6 @@ final case class MultiregionalBucketMigrationProgress(
 )
 
 object MultiregionalBucketMigrationJsonSupport {
-  import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.WorkspaceNameFormat
   import spray.json.DefaultJsonProtocol._
 
   implicit val MultiregionalBucketMigrationDetailsJsonFormat = jsonFormat6(MultiregionalBucketMigrationMetadata.apply)
@@ -162,7 +160,7 @@ object MultiregionalBucketMigrationJsonSupport {
   }
 
   implicit val MultiregionalBucketMigrationProgressJsonFormat: RootJsonFormat[MultiregionalBucketMigrationProgress] =
-    jsonFormat5(MultiregionalBucketMigrationProgress.apply)
+    jsonFormat4(MultiregionalBucketMigrationProgress.apply)
 }
 
 trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQuery {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.MonadThrow
 import cats.data.OptionT
 import cats.implicits.catsSyntaxFunction1FlatMap
+import com.google.storagetransfer.v1.proto.TransferTypes.TransferOperation
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
@@ -134,6 +135,16 @@ object STSJobProgress {
         STSJobProgress(totalBytesToTransfer, bytesTransferred, totalObjectsToTransfer, objectsTransferred)
     }
   }
+
+  def fromTransferOperation(operation: TransferOperation): Option[STSJobProgress] =
+    for {
+      op <- Option(operation)
+      counters <- Option(op.getCounters)
+    } yield STSJobProgress(counters.getBytesFoundFromSource,
+                           counters.getBytesCopiedToSink,
+                           counters.getObjectsFoundFromSource,
+                           counters.getObjectsCopiedToSink
+    )
 }
 
 final case class MultiregionalBucketMigrationProgress(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -135,24 +135,24 @@ final case class STSJobProgress(totalBytesToTransfer: Long,
 )
 
 object STSJobProgress {
-  def fromMultiregionalStorageTransferJobOption(
-    multiregionalStorageTransferJobOpt: Option[MultiregionalStorageTransferJob]
-  ): Option[STSJobProgress] = multiregionalStorageTransferJobOpt.collect { job =>
+  def fromMultiregionalStorageTransferJob(
+    job: MultiregionalStorageTransferJob
+  ): Option[STSJobProgress] =
     (job.totalBytesToTransfer, job.bytesTransferred, job.totalObjectsToTransfer, job.objectsTransferred) match {
       case (Some(totalBytesToTransfer),
             Some(bytesTransferred),
             Some(totalObjectsToTransfer),
             Some(objectsTransferred)
           ) =>
-        STSJobProgress(totalBytesToTransfer, bytesTransferred, totalObjectsToTransfer, objectsTransferred)
+        Option(STSJobProgress(totalBytesToTransfer, bytesTransferred, totalObjectsToTransfer, objectsTransferred))
+      case _ => None
     }
-  }
 
   implicit val STSJobProgressJsonFormat: RootJsonFormat[STSJobProgress] = jsonFormat4(STSJobProgress.apply)
 }
 
 final case class MultiregionalBucketMigrationProgress(
-  name: WorkspaceName,
+  workspaceName: WorkspaceName,
   migrationStep: MultiregionalBucketMigrationStep,
   tempBucketTransferProgress: Option[STSJobProgress],
   finalBucketTransferProgress: Option[STSJobProgress]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -98,11 +98,11 @@ object MultiregionalBucketMigrationFailureModes {
 object MultiregionalBucketMigrationStep extends Enumeration {
   type MultiregionalBucketMigrationStep = Value
   val ScheduledForMigration, PreparingTransferToTempBucket, TransferringToTempBucket, PreparingTransferToFinalBucket,
-    TransferringToFinalBucket, FinishingUp, Finished, Failed = Value
+    TransferringToFinalBucket, FinishingUp, Finished = Value
 
   def fromMultiregionalBucketMigration(migration: MultiregionalBucketMigration): MultiregionalBucketMigrationStep =
     migration match {
-      case m if m.finished.isDefined => if (m.outcome.contains(Outcome.Success)) Finished else Failed
+      case m if m.finished.isDefined                                             => Finished
       case m if m.tmpBucketTransferred.isDefined || m.tmpBucketDeleted.isDefined => FinishingUp
       case m if m.tmpBucketTransferJobIssued.isDefined                           => TransferringToFinalBucket
       case m
@@ -139,6 +139,7 @@ object STSJobProgress {
 final case class MultiregionalBucketMigrationProgress(
   workspaceName: WorkspaceName,
   migrationStep: MultiregionalBucketMigrationStep,
+  outcome: Option[Outcome],
   tempBucketTransferProgress: Option[STSJobProgress],
   finalBucketTransferProgress: Option[STSJobProgress]
 )
@@ -161,7 +162,7 @@ object MultiregionalBucketMigrationJsonSupport {
   }
 
   implicit val MultiregionalBucketMigrationProgressJsonFormat: RootJsonFormat[MultiregionalBucketMigrationProgress] =
-    jsonFormat4(MultiregionalBucketMigrationProgress.apply)
+    jsonFormat5(MultiregionalBucketMigrationProgress.apply)
 }
 
 trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQuery {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -170,71 +170,75 @@ trait AdminApiService extends UserInfoDirectives {
               }
             }
         } ~
-        path("admin" / "bucketMigration" / "workspaces") {
-          post {
-            entity(as[List[WorkspaceName]]) { workspaceNames =>
-              complete {
-                bucketMigrationServiceConstructor(ctx)
-                  .migrateAllWorkspaceBuckets(workspaceNames)
-                  .map(StatusCodes.Created -> _)
-              }
-            }
-          }
-        } ~
-        pathPrefix("admin" / "bucketMigration" / "workspaces" / Segment / Segment) { (namespace, name) =>
-          val workspaceName = WorkspaceName(namespace, name)
-          pathEndOrSingleSlash {
-            get {
-              complete {
-                bucketMigrationServiceConstructor(ctx)
-                  .getBucketMigrationAttemptsForWorkspace(workspaceName)
-                  .map(ms => StatusCodes.OK -> ms)
-              }
-            } ~
+        pathPrefix("admin" / "bucketMigration") {
+          pathPrefix("workspaces") {
+            pathEndOrSingleSlash {
               post {
-                complete {
-                  bucketMigrationServiceConstructor(ctx)
-                    .migrateWorkspaceBucket(workspaceName)
-                    .map(StatusCodes.Created -> _)
+                entity(as[List[WorkspaceName]]) { workspaceNames =>
+                  complete {
+                    bucketMigrationServiceConstructor(ctx)
+                      .migrateAllWorkspaceBuckets(workspaceNames)
+                      .map(StatusCodes.Created -> _)
+                  }
                 }
-              }
-          } ~
-            path("progress") {
-              get {
-                complete {
-                  bucketMigrationServiceConstructor(ctx)
-                    .getBucketMigrationProgressForWorkspace(workspaceName)
-                    .map(StatusCodes.OK -> _)
-                }
-              }
-            }
-        } ~
-        pathPrefix("admin" / "bucketMigration" / "billing" / Segment) { projectName =>
-          val billingProjectName = RawlsBillingProjectName(projectName)
-          pathEndOrSingleSlash {
-            post {
-              complete {
-                bucketMigrationServiceConstructor(ctx)
-                  .migrateWorkspaceBucketsInBillingProject(billingProjectName)
-                  .map(StatusCodes.Created -> _)
               }
             } ~
-              get {
-                complete {
-                  bucketMigrationServiceConstructor(ctx)
-                    .getBucketMigrationAttemptsForBillingProject(billingProjectName)
-                    .map(ms => StatusCodes.OK -> ms)
-                }
+              pathPrefix(Segment / Segment) { (namespace, name) =>
+                val workspaceName = WorkspaceName(namespace, name)
+                pathEndOrSingleSlash {
+                  get {
+                    complete {
+                      bucketMigrationServiceConstructor(ctx)
+                        .getBucketMigrationAttemptsForWorkspace(workspaceName)
+                        .map(ms => StatusCodes.OK -> ms)
+                    }
+                  } ~
+                    post {
+                      complete {
+                        bucketMigrationServiceConstructor(ctx)
+                          .migrateWorkspaceBucket(workspaceName)
+                          .map(StatusCodes.Created -> _)
+                      }
+                    }
+                } ~
+                  path("progress") {
+                    get {
+                      complete {
+                        bucketMigrationServiceConstructor(ctx)
+                          .getBucketMigrationProgressForWorkspace(workspaceName)
+                          .map(StatusCodes.OK -> _)
+                      }
+                    }
+                  }
               }
           } ~
-            path("progress") {
-              get {
-                complete {
-                  bucketMigrationServiceConstructor(ctx)
-                    .getBucketMigrationProgressForBillingProject(billingProjectName)
-                    .map(StatusCodes.OK -> _)
+            pathPrefix("billing" / Segment) { projectName =>
+              val billingProjectName = RawlsBillingProjectName(projectName)
+              pathEndOrSingleSlash {
+                post {
+                  complete {
+                    bucketMigrationServiceConstructor(ctx)
+                      .migrateWorkspaceBucketsInBillingProject(billingProjectName)
+                      .map(StatusCodes.Created -> _)
+                  }
+                } ~
+                  get {
+                    complete {
+                      bucketMigrationServiceConstructor(ctx)
+                        .getBucketMigrationAttemptsForBillingProject(billingProjectName)
+                        .map(ms => StatusCodes.OK -> ms)
+                    }
+                  }
+              } ~
+                path("progress") {
+                  get {
+                    complete {
+                      bucketMigrationServiceConstructor(ctx)
+                        .getBucketMigrationProgressForBillingProject(billingProjectName)
+                        .map(StatusCodes.OK -> _)
+                    }
+                  }
                 }
-              }
             }
         } ~
         path("admin" / "workspaces" / Segment / Segment / "flags") { (workspaceNamespace, workspaceName) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -180,20 +180,31 @@ trait AdminApiService extends UserInfoDirectives {
             }
           }
         } ~
-        path("admin" / "bucketMigration" / "workspaces" / Segment / Segment) { (namespace, name) =>
+        pathPrefix("admin" / "bucketMigration" / "workspaces" / Segment / Segment) { (namespace, name) =>
           val workspaceName = WorkspaceName(namespace, name)
-          get {
-            complete {
-              bucketMigrationServiceConstructor(ctx)
-                .getBucketMigrationAttemptsForWorkspace(workspaceName)
-                .map(ms => StatusCodes.OK -> ms)
-            }
-          } ~
-            post {
+          pathEndOrSingleSlash {
+            get {
               complete {
                 bucketMigrationServiceConstructor(ctx)
-                  .migrateWorkspaceBucket(workspaceName)
-                  .map(StatusCodes.Created -> _)
+                  .getBucketMigrationAttemptsForWorkspace(workspaceName)
+                  .map(ms => StatusCodes.OK -> ms)
+              }
+            } ~
+              post {
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .migrateWorkspaceBucket(workspaceName)
+                    .map(StatusCodes.Created -> _)
+                }
+              }
+          } ~
+            path("progress") {
+              get {
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .getBucketMigrationProgressForWorkspace(workspaceName)
+                    .map(StatusCodes.OK -> _)
+                }
               }
             }
         } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationJsonSupport._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiService.scala
@@ -208,20 +208,31 @@ trait AdminApiService extends UserInfoDirectives {
               }
             }
         } ~
-        path("admin" / "bucketMigration" / "billing" / Segment) { projectName =>
+        pathPrefix("admin" / "bucketMigration" / "billing" / Segment) { projectName =>
           val billingProjectName = RawlsBillingProjectName(projectName)
-          post {
-            complete {
-              bucketMigrationServiceConstructor(ctx)
-                .migrateWorkspaceBucketsInBillingProject(billingProjectName)
-                .map(StatusCodes.Created -> _)
-            }
-          } ~
-            get {
+          pathEndOrSingleSlash {
+            post {
               complete {
                 bucketMigrationServiceConstructor(ctx)
-                  .getBucketMigrationAttemptsForBillingProject(billingProjectName)
-                  .map(ms => StatusCodes.OK -> ms)
+                  .migrateWorkspaceBucketsInBillingProject(billingProjectName)
+                  .map(StatusCodes.Created -> _)
+              }
+            } ~
+              get {
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .getBucketMigrationAttemptsForBillingProject(billingProjectName)
+                    .map(ms => StatusCodes.OK -> ms)
+                }
+              }
+          } ~
+            path("progress") {
+              get {
+                complete {
+                  bucketMigrationServiceConstructor(ctx)
+                    .getBucketMigrationProgressForBillingProject(billingProjectName)
+                    .map(StatusCodes.OK -> _)
+                }
               }
             }
         } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -351,7 +351,6 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
       )
   }
 
-
   private def insertSTSJobs(workspace: Workspace): Future[Unit] =
     slickDataSource.inTransaction { dataAccess =>
       import dataAccess.driver.api._
@@ -362,33 +361,17 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
         attempt = attemptOpt.getOrElse(fail("migration not found"))
         _ <- MultiregionalStorageTransferJobs.storageTransferJobs.map(job =>
           (job.jobName,
-            job.migrationId,
-            job.destBucket,
-            job.sourceBucket,
-            job.totalBytesToTransfer,
-            job.bytesTransferred,
-            job.totalObjectsToTransfer,
-            job.objectsTransferred
+           job.migrationId,
+           job.destBucket,
+           job.sourceBucket,
+           job.totalBytesToTransfer,
+           job.bytesTransferred,
+           job.totalObjectsToTransfer,
+           job.objectsTransferred
           )
         ) forceInsertAll List(
-          ("jobName",
-            attempt.id,
-            workspace.bucketName,
-            "tempBucketName",
-            100L.some,
-            50L.some,
-            4L.some,
-            2L.some
-          ),
-          ("jobName",
-            attempt.id,
-            "tempBucketName",
-            workspace.bucketName,
-            100L.some,
-            100L.some,
-            4L.some,
-            4L.some
-          )
+          ("jobName", attempt.id, workspace.bucketName, "tempBucketName", 100L.some, 50L.some, 4L.some, 2L.some),
+          ("jobName", attempt.id, "tempBucketName", workspace.bucketName, 100L.some, 100L.some, 4L.some, 4L.some)
         )
       } yield ()
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -133,8 +133,8 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
                 Duration.Inf
         )
         .foreach {
-          case (lockedWorkspace.name, attempts) => attempts shouldBe List.empty
-          case (_, attempts)                    => attempts should not be empty
+          case (name, attempts) if name.equals(lockedWorkspace.toWorkspaceName.toString) => attempts shouldBe List.empty
+          case (_, attempts)                                                             => attempts should not be empty
         }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -1312,7 +1312,11 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
     destBucket = null,
     sourceBucket = null,
     finished = null,
-    outcome = null
+    outcome = null,
+    totalBytesToTransfer = null,
+    bytesTransferred = null,
+    totalObjectsToTransfer = null,
+    objectsTransferred = null
   )
 
   "updateMigrationTransferJobStatus" should "update WORKSPACE_BUCKET_TRANSFERRED on job success" in


### PR DESCRIPTION
Ticket: [WOR-1062](https://broadworkbench.atlassian.net/browse/WOR-1062)
* when checking STS job progress, also fetch transfer progress stats (objects and bytes transferred so far along with the total amount to be transferred)
    * write these stats to the db regardless of if the operation has finished
* add enum `MultiregionalBucketMigrationStep` of user-facing migration steps to be returned in progress API


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1062]: https://broadworkbench.atlassian.net/browse/WOR-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ