### PR TITLE
[WOR-1067] Bucket migration restart API

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -351,39 +351,41 @@ trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQue
               pastAttempt.tmpBucketTransferred
         ) match {
           case (Some(_), None, _, _) =>
-            multiregionalBucketMigrationQuery.update5(pastAttempt.id,
-                                                      finishedCol,
-                                                      None,
-                                                      messageCol,
-                                                      None,
-                                                      outcomeCol,
-                                                      None,
-                                                      workspaceBucketTransferIamConfiguredCol,
-                                                      None,
-                                                      workspaceBucketTransferJobIssuedCol,
-                                                      None
+            multiregionalBucketMigrationQuery.update5(
+              pastAttempt.id,
+              finishedCol,
+              Option.empty[Timestamp],
+              messageCol,
+              Option.empty[String],
+              outcomeCol,
+              Option.empty[String],
+              workspaceBucketTransferIamConfiguredCol,
+              Option.empty[Timestamp],
+              workspaceBucketTransferJobIssuedCol,
+              Option.empty[Timestamp]
             )
           case (_, _, Some(_), None) =>
-            multiregionalBucketMigrationQuery.update5(pastAttempt.id,
-                                                      finishedCol,
-                                                      None,
-                                                      messageCol,
-                                                      None,
-                                                      outcomeCol,
-                                                      None,
-                                                      tmpBucketTransferIamConfiguredCol,
-                                                      None,
-                                                      tmpBucketTransferJobIssuedCol,
-                                                      None
+            multiregionalBucketMigrationQuery.update5(
+              pastAttempt.id,
+              finishedCol,
+              Option.empty[Timestamp],
+              messageCol,
+              Option.empty[String],
+              outcomeCol,
+              Option.empty[String],
+              tmpBucketTransferIamConfiguredCol,
+              Option.empty[Timestamp],
+              tmpBucketTransferJobIssuedCol,
+              Option.empty[Timestamp]
             )
           case _ =>
             multiregionalBucketMigrationQuery.update3(pastAttempt.id,
                                                       finishedCol,
-                                                      None,
+                                                      Option.empty[Timestamp],
                                                       messageCol,
-                                                      None,
+                                                      Option.empty[String],
                                                       outcomeCol,
-                                                      None
+                                                      Option.empty[String]
             )
         }
       } yield pastAttempt.id

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -284,11 +284,6 @@ trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQue
       update3(migrationId, finishedCol, Some(now), outcomeCol, Some(status), messageCol, message)
     }
 
-    final def isPendingMigration(workspace: Workspace): ReadAction[Boolean] =
-      sql"select count(*) from #$tableName where #$workspaceIdCol = ${workspace.workspaceIdAsUUID} and #$finishedCol is null"
-        .as[Int]
-        .map(_.head > 0)
-
     final def isMigrating(workspace: Workspace): ReadAction[Boolean] =
       sql"select count(*) from #$tableName where #$workspaceIdCol = ${workspace.workspaceIdAsUUID} and #$startedCol is not null and #$finishedCol is null"
         .as[Int]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -295,7 +295,7 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           restartedAttempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
         } yield (failedAttempt, restartedAttempt)
       }
-      
+
       assert(failedAttempt.value.outcome.value.isFailure)
       assert(failedAttempt.value.finished.isDefined)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -257,14 +257,50 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
         for {
           a <- scheduleAndGetMetadata(minimalTestData.v1Workspace.toWorkspaceName)
           b <- scheduleAndGetMetadata(minimalTestData.v1Workspace2.toWorkspaceName)
-          attempt <- getAttempt(minimalTestData.v1Workspace.workspaceIdAsUUID).value
-          _ <- setMigrationFinished(attempt.value.id, Timestamp.from(Instant.now()), Success)
         } yield {
           a.id shouldBe 0
           b.id shouldBe 0
         }
       }
-      spec.runAndWait(scheduleAndGetMetadata(minimalTestData.v1Workspace.toWorkspaceName)).id shouldBe 1
+    }
+
+  it should "error when a successfully migrated workspace is scheduled again" in
+    spec.withMinimalTestDatabase { _ =>
+      import spec.multiregionalBucketMigrationQuery.{getAttempt, setMigrationFinished}
+      spec.runAndWait(for {
+        _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace.toWorkspaceName)
+        attempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
+        _ <- setMigrationFinished(attempt.value.id, Timestamp.from(Instant.now()), Success)
+      } yield ())
+
+      assertThrows[RawlsExceptionWithErrorReport] {
+        spec.runAndWait(
+          spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace.toWorkspaceName)
+        )
+      }
+    }
+
+  it should "restart a failed bucket migration" in
+    spec.withMinimalTestDatabase { _ =>
+      import spec.multiregionalBucketMigrationQuery.{getAttempt, setMigrationFinished}
+      val (failedAttempt, restartedAttempt) = spec.runAndWait {
+        for {
+          _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace.toWorkspaceName)
+          attempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
+
+          _ <- setMigrationFinished(attempt.value.id, Timestamp.from(Instant.now()), Failure("bucket failed"))
+          failedAttempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
+
+          _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace.toWorkspaceName)
+          restartedAttempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
+        } yield (failedAttempt, restartedAttempt)
+      }
+      
+      assert(failedAttempt.value.outcome.value.isFailure)
+      assert(failedAttempt.value.finished.isDefined)
+
+      restartedAttempt.value.outcome shouldBe None
+      restartedAttempt.value.finished shouldBe None
     }
 
   "updated" should "automagically get bumped to the current timestamp when the record is updated" in


### PR DESCRIPTION
Ticket: [WOR-1067](https://broadworkbench.atlassian.net/browse/WOR-1067)
* When scheduling a migration for a failed bucket migration, restart it
---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1067]: https://broadworkbench.atlassian.net/browse/WOR-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ