### PR TITLE
[WOR-1212] Update workbenchLibs version.

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val akkaV         = "2.6.8"
   val akkaHttpV     = "10.2.0"
-  val jacksonV      = "2.14.1"
+  val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
   val serviceTestV = s"4.0-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,12 +7,12 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.14.1"
 
-  val workbenchLibsHash = "85a080a"
-  val serviceTestV = s"3.1-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.27-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.30-${workbenchLibsHash}"
-  val workbenchModelV  = s"0.18-${workbenchLibsHash}"
-  val workbenchMetricsV  = s"0.7-${workbenchLibsHash}"
+  val workbenchLibsHash = "e42c23c"
+  val serviceTestV = s"4.0-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
+  val workbenchModelV  = s"0.19-${workbenchLibsHash}"
+  val workbenchMetricsV  = s"0.8-${workbenchLibsHash}"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val workbenchMetrics: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-metrics" % workbenchMetricsV

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupRoleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupRoleSpec.scala
@@ -61,7 +61,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkVisibleAndAccessible(projectName, workspaceName, List(groupName))(studentToken)
 
             // remove "student" from billing project
-            Rawls.billing.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
 
@@ -120,7 +120,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkVisibleAndAccessible(projectName, workspaceName, List(groupName))(studentToken)
 
             // remove "student" from billing project
-            Rawls.billing.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
@@ -146,7 +146,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
 
             // add "student" to billing project with owner role
-            Rawls.billing.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
             AuthDomainMatcher.checkVisibleAndAccessible(projectName, workspaceName, List(groupName))(studentToken)
@@ -175,13 +175,13 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
 
             // add "student" to billing project with owner role
-            Rawls.billing.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
             AuthDomainMatcher.checkVisibleAndAccessible(projectName, workspaceName, List(groupName))(studentToken)
 
             // remove "student" from billing project
-            Rawls.billing.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
@@ -206,7 +206,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
 
             // add "student" to billing project with owner role
-            Rawls.billing.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
 
@@ -238,7 +238,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
 
             // add "student" to billing project with owner role
-            Rawls.billing.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
 
@@ -248,7 +248,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             AuthDomainMatcher.checkVisibleAndAccessible(projectName, workspaceName, List(groupName))(studentToken)
 
             // remove "student" from billing project
-            Rawls.billing.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)
@@ -276,7 +276,7 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             Sam.user.addUserToPolicy(groupName, GroupRole.Member.toString, student.email)(projectOwnerToken)
 
             // add "student" to billing project with owner role
-            Rawls.billing.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
 
@@ -309,14 +309,14 @@ class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with Gr
             Sam.user.addUserToPolicy(groupName, GroupRole.Member.toString, student.email)(projectOwnerToken)
 
             // add "student" to billing project with owner role
-            Rawls.billing.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.addUserToBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
 
             AuthDomainMatcher.checkVisibleAndAccessible(projectName, workspaceName, List(groupName))(studentToken)
 
             // remove "student" from billing project
-            Rawls.billing.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
+            Rawls.billingV2.removeUserFromBillingProject(projectName, student.email, BillingProjectRole.Owner)(
               projectOwnerToken
             )
             AuthDomainMatcher.checkNotVisibleNotAccessible(projectName, workspaceName)(studentToken)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
@@ -7,7 +7,7 @@ import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, LiftIO}
 import cats.implicits.{
   catsSyntaxApplicativeError,
-  catsSyntaxApply,
+  catsSyntaxApplyOps,
   catsSyntaxOptionId,
   catsSyntaxSemigroup,
   toFlatMapOps,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.util
 
 import akka.http.scaladsl.model.StatusCodes
-import cats.implicits.{catsSyntaxApply, toFoldableOps}
+import cats.implicits.{catsSyntaxApplyOps, toFoldableOps}
 import cats.{Applicative, ApplicativeThrow}
 import org.broadinstitute.dsde.rawls._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.monitor
 
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.unsafe.implicits.global
-import cats.implicits.{catsSyntaxApply, catsSyntaxOptionId, toFoldableOps}
+import cats.implicits.{catsSyntaxApplyOps, catsSyntaxOptionId, toFoldableOps}
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import io.opencensus.trace.{Span => OpenCensusSpan}
 import org.broadinstitute.dsde.rawls.dataaccess._

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -8,4 +8,4 @@ Added:
 - Support 2.13
 - ExecutionModel classes moved from core to model
 
-SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "0.1-97814d79a"`
+SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "0.1-3891e8393"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,7 @@ object Dependencies {
   val sentryLogback: ModuleID =   "io.sentry"                     % "sentry-logback"        % "6.28.0"
   val webjarsLocator: ModuleID =  "org.webjars"                   % "webjars-locator"       % "0.46"
   val commonsJEXL: ModuleID =     "org.apache.commons"            % "commons-jexl"          % "2.1.1"
-  val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.9.0"
+  val cats: ModuleID =            "org.typelevel"                 %% "cats-core"                 % "2.10.0"
   val logbackClassic: ModuleID =  "ch.qos.logback"                % "logback-classic"       % "1.4.11"
   val scalaUri: ModuleID =        "io.lemonlabs"                  %% "scala-uri"            % "3.0.0"
   val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.2.15" % "test"
@@ -81,14 +81,14 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.1.0"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "85a080a"
+  val workbenchLibsHash = "e42c23c"
 
-  val workbenchModelV  = s"0.18-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.27-${workbenchLibsHash}"
-  val workbenchNotificationsV = s"0.5-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.30-${workbenchLibsHash}"
-  val workbenchOauth2V = s"0.4-${workbenchLibsHash}"
-  val workbenchOpenTelemetryV = s"0.5-$workbenchLibsHash"
+  val workbenchModelV  = s"0.19-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
+  val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
+  val workbenchOauth2V = s"0.5-${workbenchLibsHash}"
+  val workbenchOpenTelemetryV = s"0.6-$workbenchLibsHash"
 
   def excludeWorkbenchGoogle = ExclusionRule("org.broadinstitute.dsde.workbench", "workbench-google_2.13")
 
@@ -106,7 +106,7 @@ object Dependencies {
 
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.127.2" % "test"
 
-  val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.9-${workbenchLibsHash}"
+  val workbenchUtil: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.10-${workbenchLibsHash}"
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "0.14.2"
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,7 +15,7 @@ object Merging {
     case PathList("javax", "ws", "rs", _ @_*)                  => MergeStrategy.first
     case "version.conf"                                        => MergeStrategy.concat
     case "logback.xml"                                         => MergeStrategy.first
-    case x if x.endsWith("kotlin_module")                      => MergeStrategy.preferProject
+    case x if x.endsWith("kotlin_module")                      => MergeStrategy.first
     case x if x.endsWith("io.netty.versions.properties")       => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")               => MergeStrategy.concat
     case x                                                     => oldStrategy(x)

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,8 +15,8 @@ object Merging {
     case PathList("javax", "ws", "rs", _ @_*)                  => MergeStrategy.first
     case "version.conf"                                        => MergeStrategy.concat
     case "logback.xml"                                         => MergeStrategy.first
-    case x if x.endsWith("kotlin-stdlib.kotlin_module")        => MergeStrategy.discard
-    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.discard
+    case x if x.endsWith("kotlin-stdlib.kotlin_module")        => MergeStrategy.preferProject
+    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.preferProject
     case x if x.endsWith("io.netty.versions.properties")       => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")               => MergeStrategy.concat
     case x                                                     => oldStrategy(x)

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,8 +15,7 @@ object Merging {
     case PathList("javax", "ws", "rs", _ @_*)                  => MergeStrategy.first
     case "version.conf"                                        => MergeStrategy.concat
     case "logback.xml"                                         => MergeStrategy.first
-    case x if x.endsWith("kotlin-stdlib.kotlin_module")        => MergeStrategy.preferProject
-    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.preferProject
+    case x if x.endsWith("kotlin_module")                      => MergeStrategy.preferProject
     case x if x.endsWith("io.netty.versions.properties")       => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")               => MergeStrategy.concat
     case x                                                     => oldStrategy(x)

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,8 +15,6 @@ object Merging {
     case PathList("javax", "ws", "rs", _ @_*)                  => MergeStrategy.first
     case "version.conf"                                        => MergeStrategy.concat
     case "logback.xml"                                         => MergeStrategy.first
-    case x if x.endsWith("kotlin-stdlib.kotlin_module")        => MergeStrategy.first
-    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
     case x if x.endsWith("io.netty.versions.properties")       => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")               => MergeStrategy.concat
     case x                                                     => oldStrategy(x)

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -15,6 +15,8 @@ object Merging {
     case PathList("javax", "ws", "rs", _ @_*)                  => MergeStrategy.first
     case "version.conf"                                        => MergeStrategy.concat
     case "logback.xml"                                         => MergeStrategy.first
+    case x if x.endsWith("kotlin-stdlib.kotlin_module")        => MergeStrategy.discard
+    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.discard
     case x if x.endsWith("io.netty.versions.properties")       => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")               => MergeStrategy.concat
     case x                                                     => oldStrategy(x)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1212

My initial goal was just to update to the newest workbench libs version so it was using the Rawls model version specified in https://github.com/broadinstitute/rawls/pull/2500, but this change became more complicated because a lot of 3rd party libraries were updated recently in workbench libs.

Given that we would eventually need to tackle this update, I figured it was worth sorting through the various issues now.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
