### PR TITLE
[WOR-1207] Only start migrations if workspace bucket is US multiregion

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -2,10 +2,8 @@ package org.broadinstitute.dsde.rawls.bucketMigration
 
 import akka.http.scaladsl.model.StatusCodes
 import cats.MonadThrow
-import cats.data.OptionT
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.{
@@ -18,8 +16,8 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
 import org.broadinstitute.dsde.rawls.monitor.migration._
 import org.broadinstitute.dsde.rawls.util.{RoleSupport, WorkspaceSupport}
+import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport}
 
-import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO, val gcsDAO: GoogleServicesDAO)(
@@ -133,61 +131,86 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
   def migrateWorkspaceBucket(workspaceName: WorkspaceName): Future[MultiregionalBucketMigrationMetadata] =
     asFCAdmin {
       logger.info(s"Scheduling Workspace '$workspaceName' for bucket migration")
-      dataSource.inTransaction { dataAccess =>
-        dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspaceName)
-      }
+      for {
+        workspaceOpt <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceQuery.findByName(workspaceName)
+        }
+        workspace = workspaceOpt.getOrElse(throw new NoSuchWorkspaceException(workspaceName.toString))
+        _ <- checkBucketLocation(workspace)
+
+        metadata <- dataSource.inTransaction { dataAccess =>
+          dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspace)
+        }
+      } yield metadata
     }
 
   def migrateAllWorkspaceBuckets(
     workspaceNames: Iterable[WorkspaceName]
   ): Future[Iterable[MultiregionalBucketMigrationMetadata]] =
     asFCAdmin {
-      dataSource
-        .inTransaction { dataAccess =>
-          for {
-            errorsOrMigrationAttempts <- workspaceNames.toList.traverse { workspaceName =>
-              MonadThrow[ReadWriteAction].attempt {
-                dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspaceName)
-              }
-            }
-          } yield errorsOrMigrationAttempts
+      for {
+        workspaces <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceQuery.listByNames(workspaceNames.toList)
         }
-        .map(raiseFailedMigrationAttempts)
+
+        res <- migrateWorkspaces(workspaces.toList)
+      } yield res
     }
 
   def migrateWorkspaceBucketsInBillingProject(
     billingProjectName: RawlsBillingProjectName
   ): Future[Iterable[MultiregionalBucketMigrationMetadata]] =
     asFCAdmin {
-      dataSource
-        .inTransaction { dataAccess =>
-          for {
-            workspaces <- dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
-            errorsOrMigrationAttempts <- workspaces.traverse { workspace =>
-              MonadThrow[ReadWriteAction].attempt {
-                dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspace.toWorkspaceName)
-              }
-            }
-          } yield errorsOrMigrationAttempts
+      for {
+        workspaces <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceQuery.listWithBillingProject(billingProjectName)
         }
-        .map(raiseFailedMigrationAttempts)
+
+        res <- migrateWorkspaces(workspaces.toList)
+      } yield res
     }
 
-  private def raiseFailedMigrationAttempts(
-    errorsOrMigrationAttempts: Seq[Either[Throwable, MultiregionalBucketMigrationMetadata]]
-  ): Seq[MultiregionalBucketMigrationMetadata] = {
-    val (errors, migrationAttempts) = errorsOrMigrationAttempts.partitionMap(identity)
-    if (errors.nonEmpty) {
-      throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.BadRequest,
-                    "One or more workspace buckets could not be scheduled for migration",
-                    errors.map(ErrorReport.apply)
+  private def migrateWorkspaces(workspaces: List[Workspace]): Future[Iterable[MultiregionalBucketMigrationMetadata]] =
+    for {
+      _ <- workspaces.traverse(checkBucketLocation)
+      errorsOrMigrationAttempts <- dataSource.inTransaction { dataAccess =>
+        workspaces.traverse { workspace =>
+          MonadThrow[ReadWriteAction].attempt {
+            dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(workspace)
+          }
+        }
+      }
+    } yield {
+      val (errors, migrationAttempts) = errorsOrMigrationAttempts.partitionMap(identity)
+      if (errors.nonEmpty) {
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest,
+                      "One or more workspace buckets could not be scheduled for migration",
+                      errors.map(ErrorReport.apply)
+          )
         )
-      )
-    } else {
-      migrationAttempts
+      } else {
+        migrationAttempts
+      }
     }
-  }
+
+  private def checkBucketLocation(workspace: Workspace): Future[Unit] =
+    gcsDAO.getBucket(workspace.bucketName, workspace.googleProjectId.some).map {
+      case Left(_) =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.NotFound,
+                      s"workspace ${workspace.toWorkspaceName} bucket ${workspace.bucketName} not found"
+          )
+        )
+      case Right(bucket) =>
+        if (!bucket.getLocation.equals("US"))
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              s"workspace ${workspace.toWorkspaceName} bucket ${workspace.bucketName} is not in the US multi-region and is therefore ineligible for migration"
+            )
+          )
+    }
 }
 
 object BucketMigrationService {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -342,6 +342,9 @@ trait WorkspaceComponent {
     ): ReadAction[Option[Workspace]] =
       loadWorkspace(findByNameQuery(workspaceName), attributeSpecs)
 
+    def listByNames(workspaceNames: List[WorkspaceName]): ReadAction[Seq[Workspace]] =
+      loadWorkspaces(findByNamesQuery(workspaceNames))
+
     def findV2WorkspaceByName(workspaceName: WorkspaceName,
                               attributeSpecs: Option[WorkspaceAttributeSpecs] = None
     ): ReadAction[Option[Workspace]] =
@@ -538,6 +541,9 @@ trait WorkspaceComponent {
 
     private def findByNameQuery(workspaceName: WorkspaceName): WorkspaceQueryType =
       filter(rec => (rec.namespace === workspaceName.namespace) && (rec.name === workspaceName.name))
+
+    private def findByNamesQuery(workspaceNames: List[WorkspaceName]): WorkspaceQueryType =
+      filter(rec => rec.name.inSetBind(workspaceNames.map(_.name)) && rec.namespace.inSetBind(workspaceNames.map(_.namespace)))
 
     private def findV2WorkspaceByNameQuery(workspaceName: WorkspaceName): WorkspaceQueryType =
       filter(rec =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -289,14 +289,11 @@ trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQue
         .as[Int]
         .map(_.head > 0)
 
-    final def scheduleAndGetMetadata: WorkspaceName => ReadWriteAction[MultiregionalBucketMigrationMetadata] =
+    final def scheduleAndGetMetadata: Workspace => ReadWriteAction[MultiregionalBucketMigrationMetadata] =
       (schedule _) >=> getMetadata
 
-    final def schedule(workspaceName: WorkspaceName): ReadWriteAction[Long] =
+    final def schedule(workspace: Workspace): ReadWriteAction[Long] =
       for {
-        workspaceOpt <- workspaceQuery.findByName(workspaceName)
-        workspace <- MonadThrow[ReadWriteAction].fromOption(workspaceOpt, NoSuchWorkspaceException(workspaceName))
-
         maybePastBucketMigration <- getAttempt(workspace.workspaceIdAsUUID).value
         id <- maybePastBucketMigration match {
           case None          => scheduleFirstMigrationAttempt(workspace)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.rawls.monitor.migration
 import akka.http.scaladsl.model.StatusCodes
 import cats.MonadThrow
 import cats.data.OptionT
-import cats.implicits.catsSyntaxFunction1FlatMap
 import com.google.storagetransfer.v1.proto.TransferTypes.TransferOperation
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
@@ -19,7 +19,6 @@ import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome.Success
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.{unsafeFromEither, Outcome}
 import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationStep.MultiregionalBucketMigrationStep
-import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.ValueObject
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.InstantFormat
@@ -289,19 +288,20 @@ trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQue
         .as[Int]
         .map(_.head > 0)
 
-    final def scheduleAndGetMetadata: Workspace => ReadWriteAction[MultiregionalBucketMigrationMetadata] =
-      (schedule _) >=> getMetadata
+    final def scheduleAndGetMetadata
+      : (Workspace, Option[String]) => ReadWriteAction[MultiregionalBucketMigrationMetadata] =
+      schedule(_, _).flatMap(getMetadata)
 
-    final def schedule(workspace: Workspace): ReadWriteAction[Long] =
+    final def schedule(workspace: Workspace, location: Option[String]): ReadWriteAction[Long] =
       for {
         maybePastBucketMigration <- getAttempt(workspace.workspaceIdAsUUID).value
         id <- maybePastBucketMigration match {
-          case None          => scheduleFirstMigrationAttempt(workspace)
+          case None          => scheduleFirstMigrationAttempt(workspace, location)
           case Some(attempt) => restartMigrationAttempt(attempt, workspace.toWorkspaceName)
         }
       } yield id
 
-    private def scheduleFirstMigrationAttempt(workspace: Workspace): ReadWriteAction[Long] =
+    private def scheduleFirstMigrationAttempt(workspace: Workspace, location: Option[String]): ReadWriteAction[Long] =
       for {
         _ <- MonadThrow[ReadWriteAction].raiseWhen(workspace.isLocked) {
           new RawlsExceptionWithErrorReport(
@@ -315,6 +315,15 @@ trait MultiregionalBucketMigrationHistory extends DriverComponent with RawSqlQue
           new RawlsExceptionWithErrorReport(
             ErrorReport(StatusCodes.BadRequest,
                         s"'${workspace.toWorkspaceName}' bucket cannot be migrated as it is not a Google workspace."
+            )
+          )
+        }
+
+        _ <- MonadThrow[ReadWriteAction].raiseWhen(!location.getOrElse("").equals("US")) {
+          new RawlsExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.BadRequest,
+              s"workspace ${workspace.toWorkspaceName} bucket ${workspace.bucketName} is not in the US multi-region and is therefore ineligible for migration"
             )
           )
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -3,10 +3,12 @@ package org.broadinstitute.dsde.rawls.bucketMigration
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import cats.implicits.catsSyntaxOptionId
+import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.model.{
+  RawlsBillingProjectName,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -21,6 +23,8 @@ import org.broadinstitute.dsde.rawls.monitor.migration.{
   MultiregionalStorageTransferJobs,
   STSJobProgress
 }
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.not
@@ -248,6 +252,42 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
     exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
   }
 
+  it should "fail for non-US multiregion buckets" in withMinimalTestDatabase { _ =>
+    val adminService = mockBucketMigrationServiceForAdminUser()
+
+    val nonUsWorkspace = minimalTestData.workspace.copy(name = "nonUsWorkspace",
+                                                        workspaceId = UUID.randomUUID.toString,
+                                                        bucketName = "nonUsBucket"
+    )
+    runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(nonUsWorkspace), Duration.Inf)
+
+    val usBucket = mock[Bucket]
+    when(usBucket.getLocation).thenReturn("US")
+    when(
+      adminService.gcsDAO.getBucket(ArgumentMatchers.eq(minimalTestData.workspace.bucketName),
+                                    ArgumentMatchers.eq(minimalTestData.workspace.googleProjectId.some)
+      )(any())
+    ).thenReturn(Future.successful(Right(usBucket)))
+
+    val nonUsBucket = mock[Bucket]
+    when(nonUsBucket.getLocation).thenReturn("northamerica-northeast1")
+    when(
+      adminService.gcsDAO.getBucket(ArgumentMatchers.eq(nonUsWorkspace.bucketName),
+                                    ArgumentMatchers.eq(nonUsWorkspace.googleProjectId.some)
+      )(any())
+    ).thenReturn(Future.successful(Right(nonUsBucket)))
+
+    Await.result(adminService.migrateWorkspaceBucket(minimalTestData.wsName), Duration.Inf)
+    Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName),
+                 Duration.Inf
+    ) should have size 1
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(adminService.migrateWorkspaceBucket(nonUsWorkspace.toWorkspaceName), Duration.Inf)
+    }
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+  }
+
   behavior of "migrateAllWorkspaceBuckets"
 
   it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
@@ -265,6 +305,48 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
     exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
   }
 
+  it should "throw an exception if a non-US bucket is scheduled, but still schedule any eligible workspaces" in withMinimalTestDatabase {
+    _ =>
+      val adminService = mockBucketMigrationServiceForAdminUser()
+
+      val nonUsWorkspace = minimalTestData.workspace.copy(name = "nonUsWorkspace",
+                                                          workspaceId = UUID.randomUUID.toString,
+                                                          bucketName = "nonUsBucket"
+      )
+      runAndWait(slickDataSource.dataAccess.workspaceQuery.createOrUpdate(nonUsWorkspace), Duration.Inf)
+
+      val usBucket = mock[Bucket]
+      when(usBucket.getLocation).thenReturn("US")
+      when(
+        adminService.gcsDAO.getBucket(ArgumentMatchers.eq(minimalTestData.workspace.bucketName),
+                                      ArgumentMatchers.eq(minimalTestData.workspace.googleProjectId.some)
+        )(any())
+      ).thenReturn(Future.successful(Right(usBucket)))
+
+      val nonUsBucket = mock[Bucket]
+      when(nonUsBucket.getLocation).thenReturn("northamerica-northeast1")
+      when(
+        adminService.gcsDAO.getBucket(ArgumentMatchers.eq(nonUsWorkspace.bucketName),
+                                      ArgumentMatchers.eq(nonUsWorkspace.googleProjectId.some)
+        )(any())
+      ).thenReturn(Future.successful(Right(nonUsBucket)))
+
+      val exception = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(
+          adminService.migrateAllWorkspaceBuckets(List(minimalTestData.wsName, nonUsWorkspace.toWorkspaceName)),
+          Duration.Inf
+        )
+      }
+      exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+
+      Await.result(adminService.getBucketMigrationAttemptsForWorkspace(minimalTestData.wsName),
+                   Duration.Inf
+      ) should have size 1
+      Await.result(adminService.getBucketMigrationAttemptsForWorkspace(nonUsWorkspace.toWorkspaceName),
+                   Duration.Inf
+      ) should have size 0
+  }
+
   behavior of "migrateWorkspaceBucketsInBillingProject"
 
   it should "be limited to fc-admins" in withMinimalTestDatabase { _ =>
@@ -280,6 +362,60 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
       )
     }
     exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+  }
+
+  it should "throw an exception if a non-US bucket is scheduled, but still schedule any eligible workspaces" in withMinimalTestDatabase {
+    _ =>
+      val adminService = mockBucketMigrationServiceForAdminUser()
+      val newProjectName = "new-project"
+      val newProject = minimalTestData.billingProject.copy(projectName = RawlsBillingProjectName(newProjectName))
+      val nonUsWorkspace = minimalTestData.workspace.copy(name = "nonUsWorkspace",
+                                                          namespace = newProjectName,
+                                                          workspaceId = UUID.randomUUID.toString,
+                                                          bucketName = "nonUsBucket"
+      )
+      val usWorkspace = minimalTestData.workspace.copy(name = "usWorkspace",
+                                                       namespace = newProjectName,
+                                                       workspaceId = UUID.randomUUID.toString,
+                                                       bucketName = "usBucket"
+      )
+
+      runAndWait(
+        for {
+          _ <- slickDataSource.dataAccess.rawlsBillingProjectQuery.create(newProject)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(nonUsWorkspace)
+          _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(usWorkspace)
+        } yield (),
+        Duration.Inf
+      )
+
+      val usBucket = mock[Bucket]
+      when(usBucket.getLocation).thenReturn("US")
+      when(
+        adminService.gcsDAO.getBucket(ArgumentMatchers.eq(usWorkspace.bucketName),
+                                      ArgumentMatchers.eq(usWorkspace.googleProjectId.some)
+        )(any())
+      ).thenReturn(Future.successful(Right(usBucket)))
+
+      val nonUsBucket = mock[Bucket]
+      when(nonUsBucket.getLocation).thenReturn("northamerica-northeast1")
+      when(
+        adminService.gcsDAO.getBucket(ArgumentMatchers.eq(nonUsWorkspace.bucketName),
+                                      ArgumentMatchers.eq(nonUsWorkspace.googleProjectId.some)
+        )(any())
+      ).thenReturn(Future.successful(Right(nonUsBucket)))
+
+      val exception = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(adminService.migrateWorkspaceBucketsInBillingProject(newProject.projectName), Duration.Inf)
+      }
+      exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+
+      Await.result(adminService.getBucketMigrationAttemptsForWorkspace(usWorkspace.toWorkspaceName),
+                   Duration.Inf
+      ) should have size 1
+      Await.result(adminService.getBucketMigrationAttemptsForWorkspace(nonUsWorkspace.toWorkspaceName),
+                   Duration.Inf
+      ) should have size 0
   }
 
   behavior of "getBucketMigrationProgressForWorkspace"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -52,6 +52,10 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
     when(mockSamDAO.getUserStatus(adminCtx))
       .thenReturn(Future.successful(Some(SamUserStatusResponse("userId", adminUser, true))))
 
+    val bucket = mock[Bucket]
+    when(bucket.getLocation).thenReturn("US")
+    when(mockGcsDAO.getBucket(any(), any())(any())).thenReturn(Future.successful(Right(bucket)))
+
     BucketMigrationService.constructor(slickDataSource, mockSamDAO, mockGcsDAO)(adminCtx)
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -91,6 +91,8 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
       name = UUID.randomUUID().toString,
       workspaceId = UUID.randomUUID().toString
     )
+
+    val bucketLocation = "US".some
   }
 
   def runMigrationTest(test: MigrateAction[Assertion]): Assertion =
@@ -221,7 +223,7 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
 
   def createAndScheduleWorkspace(workspace: Workspace): ReadWriteAction[Long] =
     spec.workspaceQuery.createOrUpdate(workspace) *>
-      spec.multiregionalBucketMigrationQuery.schedule(workspace)
+      spec.multiregionalBucketMigrationQuery.schedule(workspace, testData.bucketLocation)
 
   def writeStarted(workspaceId: UUID): ReadWriteAction[Unit] =
     spec.multiregionalBucketMigrationQuery
@@ -241,10 +243,12 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
 
   "schedule" should "error when a workspace is scheduled concurrently" in
     spec.withMinimalTestDatabase { _ =>
-      spec.runAndWait(spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.v1Workspace))
+      spec.runAndWait(
+        spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.v1Workspace, testData.bucketLocation)
+      )
       assertThrows[RawlsExceptionWithErrorReport] {
         spec.runAndWait(
-          spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.v1Workspace)
+          spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.v1Workspace, testData.bucketLocation)
         )
       }
     }
@@ -255,8 +259,8 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
       import spec.multiregionalBucketMigrationQuery.{getAttempt, scheduleAndGetMetadata, setMigrationFinished}
       spec.runAndWait {
         for {
-          a <- scheduleAndGetMetadata(minimalTestData.v1Workspace)
-          b <- scheduleAndGetMetadata(minimalTestData.v1Workspace2)
+          a <- scheduleAndGetMetadata(minimalTestData.v1Workspace, testData.bucketLocation)
+          b <- scheduleAndGetMetadata(minimalTestData.v1Workspace2, testData.bucketLocation)
         } yield {
           a.id shouldBe 0
           b.id shouldBe 0
@@ -268,14 +272,14 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
     spec.withMinimalTestDatabase { _ =>
       import spec.multiregionalBucketMigrationQuery.{getAttempt, setMigrationFinished}
       spec.runAndWait(for {
-        _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace)
+        _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace, testData.bucketLocation)
         attempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
         _ <- setMigrationFinished(attempt.value.id, Timestamp.from(Instant.now()), Success)
       } yield ())
 
       assertThrows[RawlsExceptionWithErrorReport] {
         spec.runAndWait(
-          spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace)
+          spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace, testData.bucketLocation)
         )
       }
     }
@@ -285,13 +289,13 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
       import spec.multiregionalBucketMigrationQuery.{getAttempt, setMigrationFinished}
       val (failedAttempt, restartedAttempt) = spec.runAndWait {
         for {
-          _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace)
+          _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace, testData.bucketLocation)
           attempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
 
           _ <- setMigrationFinished(attempt.value.id, Timestamp.from(Instant.now()), Failure("bucket failed"))
           failedAttempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
 
-          _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace)
+          _ <- spec.multiregionalBucketMigrationQuery.schedule(spec.minimalTestData.workspace, testData.bucketLocation)
           restartedAttempt <- getAttempt(spec.minimalTestData.workspace.workspaceIdAsUUID).value
         } yield (failedAttempt, restartedAttempt)
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -935,7 +935,8 @@ class WorkspaceServiceSpec
     runAndWait(
       for {
         _ <- slickDataSource.dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(
-          testData.workspace
+          testData.workspace,
+          Option("US")
         )
         attempts <- slickDataSource.dataAccess.multiregionalBucketMigrationQuery.getMigrationAttempts(
           testData.workspace

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -935,7 +935,7 @@ class WorkspaceServiceSpec
     runAndWait(
       for {
         _ <- slickDataSource.dataAccess.multiregionalBucketMigrationQuery.scheduleAndGetMetadata(
-          testData.workspace.toWorkspaceName
+          testData.workspace
         )
         attempts <- slickDataSource.dataAccess.multiregionalBucketMigrationQuery.getMigrationAttempts(
           testData.workspace


### PR DESCRIPTION
Ticket: [WOR-1207](https://broadworkbench.atlassian.net/browse/WOR-1207)
* Grab bucket location for all workspaces and only start migration if workspace bucket is in US multiregion. Fail otherwise

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1207]: https://broadworkbench.atlassian.net/browse/WOR-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ