### PR TITLE
AJ-1308 don't import protected snapshots into unprotected workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -510,7 +510,8 @@ object Boot extends IOApp with LazyLogging {
         slickDataSource,
         samDAO,
         workspaceManagerDAO,
-        conf.getString("dataRepo.terraInstanceName")
+        conf.getString("dataRepo.terraInstanceName"),
+        dataRepoDAO
       )
 
       val spendReportingBigQueryService =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -22,7 +22,6 @@ import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
 
 import java.util.UUID
 import scala.annotation.tailrec
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
@@ -80,7 +79,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     if (!workspaceContext.bucketName.startsWith("fc-secure")) {
       // if not, check if snapshot is protected
       val sources = dataRepoDAO.getSnapshot(snapshot.snapshotId, ctx.userInfo.accessToken).getSource
-      if (sources.exists(_.getDataset.isSecureMonitoringEnabled)) {
+      if (sources.asScala.exists(_.getDataset.isSecureMonitoringEnabled)) {
         throw new RawlsException("Unable to add protected snapshot to unprotected workspace.")
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -78,9 +78,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     if (!workspaceContext.bucketName.startsWith("fc-secure")) {
       // if not, check if snapshot is protected
       val sources = dataRepoDAO.getSnapshot(snapshot.snapshotId, ctx.userInfo.accessToken).getSource
-      sources.filter(source => source.getDataset.isSecureMonitoringEnabled) match {
-        case Nil => // this is fine
-        case _   => throw new RawlsException("Unable to add protected snapshot to unprotected workspace.")
+      if(sources.exists(_.getDataset.isSecureMonitoringEnabled)) {
+        throw new RawlsException("Unable to add protected snapshot to unprotected workspace.")
+      }
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -71,6 +71,8 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       Future.successful(snapshotRef)
     }
 
+  // Ideally this would rely on Terra Policy Service, but until TPS is enabled for GCP
+  // We'll have to use this workaround for identifying protected status
   def validateProtectedStatus(workspaceContext: Workspace, snapshot: NamedDataRepoSnapshot): Unit =
     // logically it might make more sense to check if the snapshot is protected before the workspace
     // but that is a more expensive check
@@ -78,9 +80,8 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     if (!workspaceContext.bucketName.startsWith("fc-secure")) {
       // if not, check if snapshot is protected
       val sources = dataRepoDAO.getSnapshot(snapshot.snapshotId, ctx.userInfo.accessToken).getSource
-      if(sources.exists(_.getDataset.isSecureMonitoringEnabled)) {
+      if (sources.exists(_.getDataset.isSecureMonitoringEnabled)) {
         throw new RawlsException("Unable to add protected snapshot to unprotected workspace.")
-      }
       }
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -2012,6 +2012,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val wsName2 = WorkspaceName(billingProject.projectName.value, "myWorkspace2")
     val v1WsName = WorkspaceName(billingProject.projectName.value, "myV1Workspace")
     val v1WsName2 = WorkspaceName(billingProject.projectName.value, "myV1Workspace2")
+    val adWsName = WorkspaceName(billingProject.projectName.value, "myADWorkspace")
     val ownerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-OWNER", Set.empty)
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set.empty)
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set.empty)
@@ -2086,7 +2087,17 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       WorkspaceType.RawlsWorkspace,
       WorkspaceState.Ready
     )
-
+    val adWorkspace = Workspace(
+      adWsName.namespace,
+      adWsName.name,
+      UUID.randomUUID().toString,
+      "fc-secure-bucket",
+      Some("workflow-collection"),
+      currentTime(),
+      currentTime(),
+      "testUser",
+      Map.empty
+    )
     override def save() =
       DBIO.seq(
         workspaceQuery.createOrUpdate(workspace),
@@ -2094,6 +2105,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
         // TODO (CA-1235): Remove these after PPW Migration is complete
         workspaceQuery.createOrUpdate(v1Workspace),
         workspaceQuery.createOrUpdate(v1Workspace2),
+        workspaceQuery.createOrUpdate(adWorkspace),
         rawlsBillingProjectQuery.create(billingProject)
       )
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.mock
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.datarepo.model.SnapshotModel
+import bio.terra.datarepo.model.{DatasetSummaryModel, SnapshotModel, SnapshotSourceModel}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 
 import java.util.UUID
@@ -14,6 +14,7 @@ class MockDataRepoDAO(instanceName: String) extends DataRepoDAO {
     snap.id(snapshotId)
     snap.name("snapshotName")
     snap.description("snapshotDescription")
+    snap.source(java.util.List.of(new SnapshotSourceModel().dataset(new DatasetSummaryModel())))
 
     snap
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -201,7 +201,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )
     }
 
-    "create a protected snapshot reference in a protected workspace" in withMinimalTestDatabase { _ =>
+    "create a protected snapshot reference in a protected workspace" in withProtectedWorkspaceTestDatabase { _ =>
       val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
       when(
         mockSamDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
@@ -261,7 +261,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
             )
         )
 
-      val workspace = minimalTestData.adWorkspace
+      val workspace = protectedWorkspaceTestData.protectedWorkspace
 
       val snapshotService = SnapshotService.constructor(
         slickDataSource,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -1,9 +1,13 @@
 package org.broadinstitute.dsde.rawls.snapshot
 
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import bio.terra.datarepo.model.{DatasetSummaryModel, SnapshotModel, SnapshotSourceModel}
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
+import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.mock.MockDataRepoDAO
 import org.broadinstitute.dsde.rawls.model.{
   DataReferenceDescriptionField,
   DataReferenceName,
@@ -72,13 +76,16 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
             .attributes(new DataRepoSnapshotAttributes())
         )
 
+      val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
+
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
         slickDataSource,
         mockSamDAO,
         mockWorkspaceManagerDAO,
-        "fake-terra-data-repo-dev"
+        "fake-terra-data-repo-dev",
+        mockDataRepoDAO
       )(testContext)
 
       Await.result(
@@ -136,13 +143,15 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
             .attributes(new DataRepoSnapshotAttributes())
         )
 
+      val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
         slickDataSource,
         mockSamDAO,
         mockWorkspaceManagerDAO,
-        "fake-terra-data-repo-dev"
+        "fake-terra-data-repo-dev",
+        mockDataRepoDAO
       )(testContext)
 
       val snapshotUUID = UUID.randomUUID()
@@ -490,11 +499,14 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         resList
       }
 
+    val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
+
     SnapshotService.constructor(
       slickDataSource,
       mockSamDAO,
       mockWorkspaceManagerDAO,
-      "fake-terra-data-repo-dev"
+      "fake-terra-data-repo-dev",
+      mockDataRepoDAO
     )(testContext)
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -248,7 +248,8 @@ trait ApiServiceSpec
       slickDataSource,
       samDAO,
       workspaceManagerDAO,
-      mockServer.mockServerBaseUrl
+      mockServer.mockServerBaseUrl,
+      dataRepoDAO
     )
 
     override val genomicsServiceConstructor = GenomicsService.constructor(


### PR DESCRIPTION
[AJ-1308](https://broadworkbench.atlassian.net/browse/AJ-1308)
Protected snapshots-by-reference should not be allowed in unprotected workspaces.  Future work should rely on terra policy service to identify protected snapshots and workspaces, but to fill in the compliance gap in the short term, this PR checks the protected status of a snapshot by `isSecureMonitoringEnabled` on its root dataset and of the workspace by the `fc-secure` prefix of its bucket.  
In order to check the root dataset of a snapshot, I needed to fetch the snapshot from TDR; this means adding a `DataRepoDAO` to the `SnapshotService`, with associated changes wherever `SnapshotService` is used.

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] ~~Make sure Swagger is updated if API changes~~
  - [ ] ~~**...and Orchestration's Swagger too!**~~
- [ ] ~~If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).~~
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-1308]: https://broadworkbench.atlassian.net/browse/AJ-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ