### PR TITLE
[AJ-1315] Remove akka's server header

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -123,6 +123,7 @@ akka.http.host-connection-pool.max-open-requests = 16384
 akka.http.host-connection-pool.max-connections = 20
 akka.http.server.idle-timeout = 210 s
 akka.http.server.request-timeout=180 s
+akka.http.server.server-header = ""
 
 dataRepoEntityProvider {
   # 10 expressions * 100000 base table rows


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1315

Currently, responses from Rawls include a "Server" header that identifies the version of the server. This has been identified as a security issue.

This removes the Server header set by the Akka server in the local dev config, which results in getting the more generic Server header from the Apache proxy, which does not include a version.


## Before
```
$ curl -I https://local.broadinstitute.org:20443/
...
Server: akka-http/10.2.10
...
```

## After
```
$ curl -I https://local.broadinstitute.org:20443/
...
Server: Apache
...
```

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
