### PR TITLE
[WOR-1240] Don't log tokeninfo requests in GoogleServicesDao

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -195,8 +195,6 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
 
   def getResourceBufferServiceAccountCredential: Credential
 
-  def getServiceAccountRawlsUser(): Future[RawlsUser]
-
   def getServiceAccountUserInfo(): Future[UserInfo]
 
   def getBucketDetails(bucket: String, project: GoogleProjectId): Future[WorkspaceBucketOptions]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1228,6 +1228,10 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       creds.refreshToken()
       val tokenInfo = executeGoogleRequest(oauth2.tokeninfo().setAccessToken(creds.getAccessToken), logRequest = false)
       RawlsUser(RawlsUserSubjectId(tokenInfo.getUserId), RawlsUserEmail(tokenInfo.getEmail))
+    }.recover { case e: GoogleJsonResponseException =>
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.InternalServerError, s"Failed to get token info: ${e.getMessage}")
+      )
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1221,15 +1221,12 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
     }
   }
 
-  def getServiceAccountRawlsUser(): Future[RawlsUser] =
-    getRawlsUserForCreds(getBucketServiceAccountCredential)
-
   def getRawlsUserForCreds(creds: Credential): Future[RawlsUser] = {
     implicit val service = GoogleInstrumentedService.Groups
     val oauth2 = new Builder(httpTransport, jsonFactory, null).setApplicationName(appName).build()
     Future {
       creds.refreshToken()
-      val tokenInfo = executeGoogleRequest(oauth2.tokeninfo().setAccessToken(creds.getAccessToken))
+      val tokenInfo = executeGoogleRequest(oauth2.tokeninfo().setAccessToken(creds.getAccessToken), logRequest = false)
       RawlsUser(RawlsUserSubjectId(tokenInfo.getUserId), RawlsUserEmail(tokenInfo.getEmail))
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -199,9 +199,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
   def toGoogleGroupName(groupName: RawlsGroupName): String = s"GROUP_${groupName.value}@dev.firecloud.org"
 
-  override def getServiceAccountRawlsUser(): Future[RawlsUser] =
-    Future.successful(RawlsUser(RawlsUserSubjectId("12345678000"), RawlsUserEmail("foo@bar.com")))
-
   def getServiceAccountUserInfo(): Future[UserInfo] = Future.successful(
     UserInfo(RawlsUserEmail("foo@bar.com"), OAuth2BearerToken("test_token"), 0, RawlsUserSubjectId("12345678000"))
   )


### PR DESCRIPTION
Ticket: [WOR-1240](https://broadworkbench.atlassian.net/browse/WOR-1240)
* The goal of this PR is to prevent Sentry issues like [this one](https://broad-institute.sentry.io/issues/4455261052/?alert_rule_id=233979&alert_type=issue&project=153297&referrer=slack)
  * Don't log tokeninfo requests as this logs the access token
  * If the tokeninfo request fails, catch the exception and rethrow it with just the message. I haven't tested that the message is safe to include as I don't have a way to reproduce the original exception, but I expect it will be okay.
  * remove `getServiceAccountRawlsUser` as it was unused

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1240]: https://broadworkbench.atlassian.net/browse/WOR-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ