### PR TITLE
[WOR-1239] Retry 404s when updating removing IAM after STS jobs complete

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -210,7 +210,9 @@ object MultiregionalBucketMigrationActor {
   val storageTransferJobs = MultiregionalStorageTransferJobs.storageTransferJobs
 
   final def restartMigration: MigrateAction[Unit] =
-    restartFailuresLike(FailureModes.noBucketPermissionsFailure, FailureModes.gcsUnavailableFailure) |
+    restartFailuresLike(MultiregionalBucketMigrationFailureModes.noBucketPermissionsFailure,
+                        MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure
+    ) |
       reissueFailedStsJobs
 
   final def startMigration: MigrateAction[Unit] =
@@ -663,7 +665,7 @@ object MultiregionalBucketMigrationActor {
           }
         } yield ()).value
       },
-      FailureModes.noObjectPermissionsFailure
+      MultiregionalBucketMigrationFailureModes.noObjectPermissionsFailure
     )
 
   def retryFailuresLike(update: (DataAccess, Long) => ReadWriteAction[Any],
@@ -1293,7 +1295,9 @@ object MultiregionalBucketMigrationActor {
 
               case RetryKnownFailures =>
                 List(
-                  restartFailuresLike(FailureModes.stsRateLimitedFailure, FailureModes.gcsUnavailableFailure),
+                  restartFailuresLike(MultiregionalBucketMigrationFailureModes.stsRateLimitedFailure,
+                                      MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure
+                  ),
                   reissueFailedStsJobs
                 )
                   .traverse_(r => runStep(r.foreverM)) // Greedily retry

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -210,10 +210,7 @@ object MultiregionalBucketMigrationActor {
   val storageTransferJobs = MultiregionalStorageTransferJobs.storageTransferJobs
 
   final def restartMigration: MigrateAction[Unit] =
-    restartFailuresLike(FailureModes.noBucketPermissionsFailure,
-                        FailureModes.gcsUnavailableFailure,
-                        FailureModes.bucketNotFoundFailure
-    ) |
+    restartFailuresLike(FailureModes.noBucketPermissionsFailure, FailureModes.gcsUnavailableFailure) |
       reissueFailedStsJobs
 
   final def startMigration: MigrateAction[Unit] =
@@ -1296,10 +1293,7 @@ object MultiregionalBucketMigrationActor {
 
               case RetryKnownFailures =>
                 List(
-                  restartFailuresLike(FailureModes.stsRateLimitedFailure,
-                                      FailureModes.gcsUnavailableFailure,
-                                      FailureModes.bucketNotFoundFailure
-                  ),
+                  restartFailuresLike(FailureModes.stsRateLimitedFailure, FailureModes.gcsUnavailableFailure),
                   reissueFailedStsJobs
                 )
                   .traverse_(r => runStep(r.foreverM)) // Greedily retry

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -732,7 +732,6 @@ object MultiregionalBucketMigrationActor {
               )
             }
 
-            _ <- getLogger[IO].info(s"polling on $destBucketName to be created")
             // Don't need a requester pays project for the bucket in the new region
             // as requester pays if enabled at the end of the migration, if at all.
             bucket <- env.storageService.getBucket(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/PpwWorkspaceMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/PpwWorkspaceMigration.scala
@@ -89,8 +89,6 @@ object FailureModes {
     "%RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Create requests' " +
       "and limit 'Create requests per day' of service 'storagetransfer.googleapis.com'%"
 
-  val bucketNotFoundFailure: String = "The specified bucket does not exist."
-
   // transfer operations fail midway
   val noObjectPermissionsFailure: String =
     "%PERMISSION_DENIED%project-%@storage-transfer-service.iam.gserviceaccount.com " +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/PpwWorkspaceMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/PpwWorkspaceMigration.scala
@@ -89,6 +89,8 @@ object FailureModes {
     "%RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Create requests' " +
       "and limit 'Create requests per day' of service 'storagetransfer.googleapis.com'%"
 
+  val bucketNotFoundFailure: String = "The specified bucket does not exist."
+
   // transfer operations fail midway
   val noObjectPermissionsFailure: String =
     "%PERMISSION_DENIED%project-%@storage-transfer-service.iam.gserviceaccount.com " +


### PR DESCRIPTION
Ticket: [WOR-1239](https://broadworkbench.atlassian.net/browse/WOR-1239)
* Migrations were failing with the following error after the bucket had been successfully transferred when we try to remove the STS SA permissions on the bucket
``` Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 404 Not Found
 GET https://storage.googleapis.com/storage/v1/b/fc-61973dff-bb44-4371-aa96-bce8eecb2618/iam
 {
   "code" : 404,
   "errors" : [ {
     "domain" : "global",
     "message" : "The specified bucket does not exist.",
     "reason" : "notFound"
   } ],
   "message" : "The specified bucket does not exist."
 }
```
* Given that we poll on the bucket's creation and that we've just transferred files to this bucket, we can be reasonably sure that the bucket *does* exist and that we're just seeing inconsistency on Google's end, so this PR makes it so we will retry when we get 404s.
---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1239]: https://broadworkbench.atlassian.net/browse/WOR-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ