### PR TITLE
Revert "Update workbenchLibs to match Rawls model version (WOR-1243)."

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,10 +7,10 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.15.2"
 
-  val workbenchLibsHash = "2b9e095"
-  val serviceTestV = s"4.1-${workbenchLibsHash}"
+  val workbenchLibsHash = "e42c23c"
+  val serviceTestV = s"4.0-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.33-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.8-${workbenchLibsHash}"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,14 +81,14 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.1.0"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "2b9e095"
+  val workbenchLibsHash = "e42c23c"
 
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.33-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.5-${workbenchLibsHash}"
-  val workbenchOpenTelemetryV = s"0.7-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.6-$workbenchLibsHash"
 
   def excludeWorkbenchGoogle = ExclusionRule("org.broadinstitute.dsde.workbench", "workbench-google_2.13")
 


### PR DESCRIPTION
Reverts broadinstitute/rawls#2523

Reverting because this is causing our Azure e2e tests to fail due to an incompatibility with io.circe. The upgrade wasn't strictly necessary, so let's get tests passing again while this issue is being investigated.

```
[info] org.broadinstitute.dsde.test.api.WorkspacesAzureApiSpec *** ABORTED *** (334 milliseconds)
[info]   java.lang.NoClassDefFoundError: io/circe/DecodingFailure$Reason
[info]   at io.circe.generic.decoding.ReprDecoder$.<clinit>(ReprDecoder.scala:23)
[info]   at org.broadinstitute.dsde.test.pipeline.UserMetadata$anon$lazy$macro$15$1$$anon$1.apply(UserMetadata.scala:45)
[info]   at io.circe.generic.decoding.DerivedDecoder$$anon$1.apply(DerivedDecoder.scala:13)
[info]   at io.circe.SeqDecoder.apply(SeqDecoder.scala:17)