### PR TITLE
ID-784 Rawls Exercises User Bucket Permissions for Access Checks

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -335,6 +335,19 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
     executionContext: ExecutionContext
   ): Future[Set[IamPermission]]
 
+  /**
+    *
+    * @param googleProject Google Project
+    * @param bucketName Google Bucket
+    * @param saKey Pet Service Account Key of the user
+    * @param executionContext Execution Context
+    * @return A Future Option. If the Option is Some(String), then the SA was able to get the bucket location,
+    *         and the location is returned. If the Option is None, then the SA was unable to get the bucket location.
+    */
+  def testSAGoogleBucketGetLocation(googleProject: GoogleProject, bucketName: GcsBucketName, saKey: String)(implicit
+    executionContext: ExecutionContext
+  ): Future[Option[String]]
+
   def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
     executionContext: ExecutionContext
   ): Future[Set[IamPermission]]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -341,12 +341,15 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
     * @param bucketName Google Bucket
     * @param saKey Pet Service Account Key of the user
     * @param executionContext Execution Context
-    * @return A Future Option. If the Option is Some(String), then the SA was able to get the bucket location,
-    *         and the location is returned. If the Option is None, then the SA was unable to get the bucket location.
+    * @return A Future Boolean. If true, the SA was able to get the bucket location, or the bucket is requester-pays.
+    *         If false, the bucket location could not be retrieved and the bucket is not requester-pays.
     */
-  def testSAGoogleBucketGetLocation(googleProject: GoogleProject, bucketName: GcsBucketName, saKey: String)(implicit
+  def testSAGoogleBucketGetLocationOrRequesterPays(googleProject: GoogleProject,
+                                                   bucketName: GcsBucketName,
+                                                   saKey: String
+  )(implicit
     executionContext: ExecutionContext
-  ): Future[Option[String]]
+  ): Future[Boolean]
 
   def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
     executionContext: ExecutionContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -44,6 +44,7 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util._
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceService.BUCKET_GET_PERMISSION
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
 import org.broadinstitute.dsde.workbench.model.Notifications.{WorkspaceName => NotificationWorkspaceName}
@@ -139,6 +140,8 @@ object WorkspaceService {
   val SECURITY_LABEL_KEY = "security"
   val HIGH_SECURITY_LABEL = "high"
   val LOW_SECURITY_LABEL = "low"
+
+  val BUCKET_GET_PERMISSION = "storage.buckets.get"
 
   private[workspace] def extractOperationIdsFromCromwellMetadata(metadataJson: JsObject): Iterable[String] = {
     case class Call(jobId: Option[String])
@@ -2805,7 +2808,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         }
       _ <-
         if (
-          expectedGoogleBucketPermissions.contains(IamPermission("storage.buckets.get")) && bucketLocationResult.isEmpty
+          expectedGoogleBucketPermissions.contains(IamPermission(BUCKET_GET_PERMISSION)) && bucketLocationResult.isEmpty
         ) {
           val message = s"user email ${ctx.userInfo.userEmail}, pet email ${petEmail
               .toString()} was unable to get bucket location for ${workspace.googleProjectId.value}/${workspace.bucketName} for workspace ${workspace.toWorkspaceName.toString}"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2756,9 +2756,10 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
             val code = getStatusCodeHandlingUnknown(t.getStatusCode)
             Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(code, t.getDetails.toString)))
         }
-      bucketLocationResult <- gcsDAO.testSAGoogleBucketGetLocation(GoogleProject(workspace.googleProjectId.value),
-                                                                   GcsBucketName(workspace.bucketName),
-                                                                   petKey
+      bucketLocationResult <- gcsDAO.testSAGoogleBucketGetLocationOrRequesterPays(
+        GoogleProject(workspace.googleProjectId.value),
+        GcsBucketName(workspace.bucketName),
+        petKey
       )
       _ <- ApplicativeThrow[Future].raiseWhen(useDefaultPet && expectedGoogleProjectPermissions.nonEmpty) {
         new RawlsException("user has workspace read-only access yet has expected google project permissions")
@@ -2807,9 +2808,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           Future.successful(())
         }
       _ <-
-        if (
-          expectedGoogleBucketPermissions.contains(IamPermission(BUCKET_GET_PERMISSION)) && bucketLocationResult.isEmpty
-        ) {
+        if (expectedGoogleBucketPermissions.contains(IamPermission(BUCKET_GET_PERMISSION)) && !bucketLocationResult) {
           val message = s"user email ${ctx.userInfo.userEmail}, pet email ${petEmail
               .toString()} was unable to get bucket location for ${workspace.googleProjectId.value}/${workspace.bucketName} for workspace ${workspace.toWorkspaceName.toString}"
           logger.warn("checkWorkspaceCloudPermissions: " + message)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2804,7 +2804,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           Future.successful(())
         }
       _ <-
-        if (bucketLocationResult.isEmpty) {
+        if (
+          expectedGoogleBucketPermissions.contains(IamPermission("storage.buckets.get")) && bucketLocationResult.isEmpty
+        ) {
           val message = s"user email ${ctx.userInfo.userEmail}, pet email ${petEmail
               .toString()} was unable to get bucket location for ${workspace.googleProjectId.value}/${workspace.bucketName} for workspace ${workspace.toWorkspaceName.toString}"
           logger.warn("checkWorkspaceCloudPermissions: " + message)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -303,9 +303,12 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     executionContext: ExecutionContext
   ): Future[Set[IamPermission]] = Future.successful(permissions)
 
-  def testSAGoogleBucketGetLocation(googleProject: GoogleProject, bucketName: GcsBucketName, saKey: String)(implicit
+  def testSAGoogleBucketGetLocationOrRequesterPays(googleProject: GoogleProject,
+                                                   bucketName: GcsBucketName,
+                                                   saKey: String
+  )(implicit
     executionContext: ExecutionContext
-  ): Future[Option[String]] = Future.successful(Some("central"))
+  ): Future[Boolean] = Future.successful(true)
 
   override def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
     executionContext: ExecutionContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -303,6 +303,10 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     executionContext: ExecutionContext
   ): Future[Set[IamPermission]] = Future.successful(permissions)
 
+  def testSAGoogleBucketGetLocation(googleProject: GoogleProject, bucketName: GcsBucketName, saKey: String)(implicit
+    executionContext: ExecutionContext
+  ): Future[Option[String]] = Future.successful(Some("central"))
+
   override def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
     executionContext: ExecutionContext
   ): Future[Set[IamPermission]] = Future.successful(permissions)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -1347,10 +1347,13 @@ class FastPassServiceSpec
         )
       ).thenReturn(Future.successful(Set(IamPermission(storageRole))))
       when(
-        services.gcsDAO.testSAGoogleBucketGetLocation(any[GoogleProject], any[GcsBucketName], any[String])(
+        services.gcsDAO.testSAGoogleBucketGetLocationOrRequesterPays(any[GoogleProject],
+                                                                     any[GcsBucketName],
+                                                                     any[String]
+        )(
           any[ExecutionContext]
         )
-      ).thenReturn(Future.successful(None))
+      ).thenReturn(Future.successful(false))
       val err = intercept[RawlsExceptionWithErrorReport] {
         Await.result(services.workspaceService.checkWorkspaceCloudPermissions(testData.workspace.toWorkspaceName),
                      Duration.Inf
@@ -1374,10 +1377,13 @@ class FastPassServiceSpec
         )
       ).thenReturn(Future.successful(Set(IamPermission(storageRole))))
       when(
-        services.gcsDAO.testSAGoogleBucketGetLocation(any[GoogleProject], any[GcsBucketName], any[String])(
+        services.gcsDAO.testSAGoogleBucketGetLocationOrRequesterPays(any[GoogleProject],
+                                                                     any[GcsBucketName],
+                                                                     any[String]
+        )(
           any[ExecutionContext]
         )
-      ).thenReturn(Future.successful(None))
+      ).thenReturn(Future.successful(false))
       Await.result(services.workspaceService.checkWorkspaceCloudPermissions(testData.workspace.toWorkspaceName),
                    Duration.Inf
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -26,6 +26,7 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceService.BUCKET_GET_PERMISSION
 import org.broadinstitute.dsde.rawls.workspace.{
   MultiCloudWorkspaceAclManager,
   MultiCloudWorkspaceService,
@@ -1337,7 +1338,7 @@ class FastPassServiceSpec
 
   it should "add a FastPass grant when the users bucket permissions are unable to be exercised" in withTestDataServices {
     services =>
-      val storageRole = "storage.buckets.get"
+      val storageRole = BUCKET_GET_PERMISSION
       when(services.googleIamDAO.getOrganizationCustomRole(services.workspaceService.terraBucketWriterRole))
         .thenReturn(Future.successful(Option(new Role().setIncludedPermissions(List(storageRole).asJava))))
       when(
@@ -1364,7 +1365,7 @@ class FastPassServiceSpec
 
   it should "not add a FastPass grant when the user doesn't have bucket get permissions" in withTestDataServices {
     services =>
-      val storageRole = "storage.buckets.notget"
+      val storageRole = BUCKET_GET_PERMISSION + "not"
       when(services.googleIamDAO.getOrganizationCustomRole(services.workspaceService.terraBucketWriterRole))
         .thenReturn(Future.successful(Option(new Role().setIncludedPermissions(List(storageRole).asJava))))
       when(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-784

`checkWorkspaceCloudPermissions`, which is called by Terra UI when loading a workspace, is supposed to tell the UI if the user has all the appropriate permissions. However, due to permissions propagation issues, the permissions google _says_ the user has and the permissions the user _actually_ has can be different! So, I've inserted a block that gets the workspace bucket location into the method to actually exercise the `storage.buckets.get` permission, and if that call fails, vend a FastPass Grant to the user. This is what the UI does currently, and just does so repeatedly while waiting for permissions to propagate. If we vend a FastPass Grant in Rawls on the first instance of this check, we can severely cut down how long user are waiting for permissions.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
