### PR TITLE
AJ-908: validate internal ordering of db rows in entityQuery

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1615,11 +1615,6 @@ trait EntityComponent {
             s"entityAttributeRecords is properly ordered? FALSE; length: ${entityAttributeRecords.length}; " +
               s"workspaceId: ${rec.workspaceId}; entityType: ${rec.entityType}; first offender: ${rec.name}"
           )
-          entityAttributeRecords foreach { eaar =>
-            logger.info(s"$eaar")
-          }
-          // TODO: don't actually throw an error; for this commit, we're throwing to see if any unit tests fail
-          throw new RawlsException("EntityAndAttributesResult ordering problem")
         }
       }
       // TEMP: end validation

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1572,6 +1572,9 @@ trait EntityComponent {
     // tail-recursive method that validates if all entity ids are contiguous within the Seq[EntityAndAttributesResult]
     // an order of 3,3,3,2,2,2,1,1 is ok
     // an order of 1,2,3,1 is bad, because the 1 is repeated non-contiguously
+    // Returns an Option[EntityRecord]. If the Option is None, the rows are ordered as expected.
+    // if the Option is Some(entityRecord), the entityRecord is the first row that was found to
+    // be non-contiguous.
     @tailrec
     def validateEntityIdOrdering(prevId: Long,
                                  current: EntityAndAttributesResult,
@@ -1602,15 +1605,15 @@ trait EntityComponent {
       }
 
       if (validateOrdering) {
-        val isProperlyOrdered: Option[EntityRecord] =
+        val orderingProblem: Option[EntityRecord] =
           validateEntityIdOrdering(-1, entityAttributeRecords.head, Set.empty[Long], entityAttributeRecords.tail)
 
-        if (isProperlyOrdered.isEmpty) {
+        if (orderingProblem.isEmpty) {
           logger.info(
             s"entityAttributeRecords is properly ordered? TRUE; length: ${entityAttributeRecords.length}"
           )
         } else {
-          val rec = isProperlyOrdered.get
+          val rec = orderingProblem.get
           logger.info(
             s"entityAttributeRecords is properly ordered? FALSE; length: ${entityAttributeRecords.length}; " +
               s"workspaceId: ${rec.workspaceId}; entityType: ${rec.entityType}; first offender: ${rec.name}"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -1707,4 +1707,46 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
+  behavior of "validateEntityIdOrdering"
+
+  it should "return ok when everything is ordered correctly" in {
+    val dummyUuid = UUID.randomUUID()
+    val entityAttributeRecords: Seq[EntityAndAttributesResult] = Seq(
+      EntityAndAttributesResult(EntityRecord(2, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(2, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(3, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(3, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(1, "name", "type", dummyUuid, 1, deleted = false, None), None, None)
+    )
+
+    val isProperlyOrdered: Option[EntityRecord] =
+      entityQuery.validateEntityIdOrdering(-1,
+                                           entityAttributeRecords.head,
+                                           Set.empty[Long],
+                                           entityAttributeRecords.tail
+      )
+
+    isProperlyOrdered shouldBe None
+  }
+
+  it should "return the offending EntityRecord when not ordered correctly" in {
+    val dummyUuid = UUID.randomUUID()
+    val entityAttributeRecords: Seq[EntityAndAttributesResult] = Seq(
+      EntityAndAttributesResult(EntityRecord(2, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(1, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(3, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(1, "offender", "type", dummyUuid, 1, deleted = false, None), None, None),
+      EntityAndAttributesResult(EntityRecord(1, "name", "type", dummyUuid, 1, deleted = false, None), None, None)
+    )
+
+    val isProperlyOrdered: Option[EntityRecord] =
+      entityQuery.validateEntityIdOrdering(-1,
+                                           entityAttributeRecords.head,
+                                           Set.empty[Long],
+                                           entityAttributeRecords.tail
+      )
+
+    isProperlyOrdered shouldBe Some(EntityRecord(1, "offender", "type", dummyUuid, 1, deleted = false, None))
+  }
+
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-908

Context:
* We are hoping to reduce instances of heavy/expensive garbage collection pauses in Rawls.
* We see that these garbage collections predominantly happen a few minutes after the hour - 3:04, 6:03, 7:03, 11:05, etc.
* We see that there exists more than one user who is regularly making multiple calls to the [`entityQuery`](https://rawls.dsde-dev.broadinstitute.org/#/entities/entityQuery) API on the hour (this must be a cron job).
* We hope that reducing memory consumption of the `entityQuery` API will alleviate these garbage collection pauses.
* We hope that moving the `entityQuery` API to a steaming model instead of fully materializing entire result sets will reduce its memory consumption.

We previously moved the [`list_entities`](https://rawls.dsde-dev.broadinstitute.org/#/entities/list_entities) API to a streaming model in #2247. The key to moving the API to a stream is ensuring that rows are returned from the DB to Rawls in the correct order; else, the stream results will be invalid.

The `entityQuery` API is much more involved than the `list_entities` API. Its SQL queries are complex and difficult to reason about as a human. While I _think_ that the rows are currently returned in an order that is valid for streaming, I am not 100% confident.

This PR adds validation of those results. It inspects the ordering of db rows for the `entityQuery` API, then logs either "entityAttributeRecords is properly ordered? TRUE" or "entityAttributeRecords is properly ordered? FALSE".

My proposal is to merge this PR and let it run in prod for 1-2 weeks and use log analysis to check for any database result sets that are not properly ordered. If we find that 100% of the result sets are in the correct order, I'll have a lot more confidence in moving the API to streaming.










---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
