### PR TITLE
remove method config copy test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodConfigApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodConfigApiSpec.scala
@@ -24,79 +24,7 @@ class MethodConfigApiSpec
 
   val billingAccountId: String = ServiceTestConfig.Projects.billingAccountId
 
-  /*
-   * This test does
-   *
-   * Given) a registered user
-   * When) the user is authenticated with access token
-   * Then) the user can get a clean billing project
-   * and)  the user can create two new workspaces
-   * and)  the user can create new method config in one workspace
-   * and)  the user can copy the method config from one workspace to another workspace
-   *
-   */
   "import method config" - {
-    "copy from a workspace" in {
-
-      val user = UserPool.chooseProjectOwner
-      implicit val authToken: AuthToken = user.makeAuthToken()
-
-      withTemporaryBillingProject(billingAccountId) { billingProject =>
-        withCleanUp {
-          val copyFromWorkspaceSource = uuidWithPrefix("MethodConfigApiSpec_copyMethodConfigFromWorkspaceSource")
-          Rawls.workspaces.create(billingProject, copyFromWorkspaceSource);
-          register cleanUp Orchestration.workspaces.delete(billingProject, copyFromWorkspaceSource)
-
-          val copyToWorkspaceDestination = uuidWithPrefix("MethodConfigApiSpec_copyMethodConfigToWorkspaceDestination")
-          Rawls.workspaces.create(billingProject, copyToWorkspaceDestination);
-          register cleanUp Orchestration.workspaces.delete(billingProject, copyToWorkspaceDestination)
-
-          withMethod("MethodConfigApiSpec_from_workspace", MethodData.SimpleMethod, 1) { methodName =>
-            val method = MethodData.SimpleMethod.copy(methodName = methodName)
-
-            Rawls.methodConfigs.createMethodConfigInWorkspace(billingProject,
-                                                              copyFromWorkspaceSource,
-                                                              method,
-                                                              method.methodNamespace,
-                                                              method.methodName,
-                                                              1,
-                                                              Map.empty,
-                                                              Map.empty,
-                                                              method.rootEntityType
-            )
-
-            Orchestration.workspaces.waitForBucketReadAccess(billingProject, copyToWorkspaceDestination)
-
-            val sourceMethodConfig =
-              Map("name" -> method.methodName,
-                  "namespace" -> method.methodNamespace,
-                  "workspaceName" -> Map("namespace" -> billingProject, "name" -> copyFromWorkspaceSource)
-              )
-
-            val destMethodName: String = uuidWithPrefix(method.methodName)
-            val destMethodNamespace: String = uuidWithPrefix(method.methodNamespace)
-
-            val destMethodConfig = Map(
-              "name" -> destMethodName,
-              "namespace" -> destMethodNamespace,
-              "workspaceName" -> Map("namespace" -> billingProject, "name" -> copyToWorkspaceDestination)
-            )
-
-            // copy method config from source workspace to destination workspace
-            Rawls.methodConfigs.copyMethodConfigFromWorkspace(sourceMethodConfig, destMethodConfig)
-
-            // verify method config in destination workspace
-            assertMethodConfigInWorkspace(billingProject,
-                                          copyToWorkspaceDestination,
-                                          destMethodNamespace,
-                                          destMethodName
-            )
-
-          }
-        }
-      }(user.makeAuthToken(billingScopes))
-    }
-
     /*
      * This test does
      *


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1328

Removes an e2e test that is mostly covered by unit tests.
More details in Ticket.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
