### PR TITLE
WOR-1193 async updates

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceManagerResourceMonitorRecordDao.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/WorkspaceManagerResourceMonitorRecordDao.scala
@@ -13,6 +13,10 @@ case class WorkspaceManagerResourceMonitorRecordDao(dataSource: SlickDataSource)
   def selectAll(): Future[Seq[WorkspaceManagerResourceMonitorRecord]] =
     dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.getRecords)
 
+  def update(job: WorkspaceManagerResourceMonitorRecord): Future[Int] =
+    dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.updateJob(job))
+
   def delete(job: WorkspaceManagerResourceMonitorRecord): Future[Boolean] =
     dataSource.inTransaction(_.WorkspaceManagerResourceMonitorRecordQuery.delete(job))
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -23,7 +23,7 @@ object WorkspaceManagerResourceMonitorRecord {
 
 
     // FIXME: clean up deletion steps when switching to case class
-    val WorkspaceDelete: Value = Value("WorkspaceDelete")
+    val WorkspaceDeleteInit: Value = Value("WorkspaceDeleteInit")
     val LeoAppDeletionPoll: Value = Value("LeoAppDeletionPoll")
     val LeoRuntimeDeletionPoll: Value = Value("LeoRuntimeDeletionPoll")
     val WSMWorkspaceDeletionPoll: Value = Value("LeoRuntimeDeletionPoll")
@@ -82,24 +82,10 @@ object WorkspaceManagerResourceMonitorRecord {
   ): WorkspaceManagerResourceMonitorRecord =
     WorkspaceManagerResourceMonitorRecord(
       jobRecordId,
-      JobType.WorkspaceDelete,
+      JobType.WorkspaceDeleteInit,
       workspaceId = Some(workspaceId),
       billingProjectId = None,
       userEmail = Some(userEmail.value),
-      createdTime = Timestamp.from(Instant.now())
-    )
-
-  def workspaceDeleteStep(
-                           record: WorkspaceManagerResourceMonitorRecord,
-                           jobType: JobType,
-                           jobRecordId: UUID
-                         ): WorkspaceManagerResourceMonitorRecord =
-    WorkspaceManagerResourceMonitorRecord(
-      jobRecordId,
-      jobType,
-      workspaceId = record.workspaceId,
-      billingProjectId = record.billingProjectId,
-      userEmail = record.userEmail,
       createdTime = Timestamp.from(Instant.now())
     )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -10,8 +10,6 @@ import java.time.Instant
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
-
-
 object WorkspaceManagerResourceMonitorRecord {
   object JobType extends SlickEnum {
     type JobType = Value
@@ -21,12 +19,17 @@ object WorkspaceManagerResourceMonitorRecord {
     val GoogleBillingProjectDelete: Value = Value("GoogleBillingProjectDelete")
     val BpmBillingProjectDelete: Value = Value("AzureBillingProjectDelete")
 
-
-    // FIXME: clean up deletion steps when switching to case class
     val WorkspaceDeleteInit: Value = Value("WorkspaceDeleteInit")
     val LeoAppDeletionPoll: Value = Value("LeoAppDeletionPoll")
     val LeoRuntimeDeletionPoll: Value = Value("LeoRuntimeDeletionPoll")
     val WSMWorkspaceDeletionPoll: Value = Value("LeoRuntimeDeletionPoll")
+
+    val deleteJobTypes: List[WorkspaceManagerResourceMonitorRecord.JobType.Value] = List(
+      JobType.WorkspaceDeleteInit,
+      JobType.LeoRuntimeDeletionPoll,
+      JobType.LeoAppDeletionPoll,
+      JobType.WSMWorkspaceDeletionPoll
+    )
 
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -22,7 +22,7 @@ object WorkspaceManagerResourceMonitorRecord {
     val WorkspaceDeleteInit: Value = Value("WorkspaceDeleteInit")
     val LeoAppDeletionPoll: Value = Value("LeoAppDeletionPoll")
     val LeoRuntimeDeletionPoll: Value = Value("LeoRuntimeDeletionPoll")
-    val WSMWorkspaceDeletionPoll: Value = Value("LeoRuntimeDeletionPoll")
+    val WSMWorkspaceDeletionPoll: Value = Value("WSMWorkspaceDeletionPoll")
 
     val deleteJobTypes: List[WorkspaceManagerResourceMonitorRecord.JobType.Value] = List(
       JobType.WorkspaceDeleteInit,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -29,7 +29,7 @@ import org.broadinstitute.dsde.rawls.jobexec.{
 }
 import org.broadinstitute.dsde.rawls.model.{CromwellBackend, RawlsRequestContext, WorkflowStatuses}
 import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.AvroUpsertMonitorConfig
-import org.broadinstitute.dsde.rawls.monitor.migration.{MultiregionalBucketMigrationActor}
+import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationActor
 import org.broadinstitute.dsde.rawls.monitor.workspace.WorkspaceResourceMonitor
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.WorkspaceDeletionRunner
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.{
@@ -443,26 +443,17 @@ object BootMonitors extends LazyLogging {
     val billingRepo = new BillingRepository(dataSource)
 
     val deletionConfig = config.getConfig("workspaceManagerResourceMonitor.deletion")
-    val leoDeletionAction = new LeonardoResourceDeletionAction(
-      leonardoDAO,
-      util.toScalaDuration(deletionConfig.getDuration("leonardoPollInterval")),
-      util.toScalaDuration(deletionConfig.getDuration("leonardoJobTimeout"))
-    )(system)
-    val wsmDeletionAction = new WsmDeletionAction(
-      workspaceManagerDAO,
-      util.toScalaDuration(deletionConfig.getDuration("workspaceManagerPollInterval")),
-      util.toScalaDuration(deletionConfig.getDuration("workspaceManagerJobTimeout"))
-    )(system)
+    val leoDeletionAction = new LeonardoResourceDeletionAction(leonardoDAO)(system)
+    val wsmDeletionAction = new WsmDeletionAction(workspaceManagerDAO)(system)
     val monitorRecordDao = WorkspaceManagerResourceMonitorRecordDao(dataSource)
     val workspaceDeletionRunner = new WorkspaceDeletionRunner(samDAO,
-      workspaceManagerDAO,
-      workspaceRepository,
-      leoDeletionAction,
-      wsmDeletionAction,
-      gcsDAO,
-      monitorRecordDao
+                                                              workspaceManagerDAO,
+                                                              workspaceRepository,
+                                                              leoDeletionAction,
+                                                              wsmDeletionAction,
+                                                              gcsDAO,
+                                                              monitorRecordDao
     )
-
 
     system.actorOf(
       WorkspaceResourceMonitor.props(
@@ -482,7 +473,12 @@ object BootMonitors extends LazyLogging {
             gcsDAO,
             workspaceManagerDAO,
             billingRepo,
-            new BpmBillingProjectLifecycle(samDAO, billingRepo, billingProfileManagerDAO, workspaceManagerDAO, monitorRecordDao)
+            new BpmBillingProjectLifecycle(samDAO,
+                                           billingRepo,
+                                           billingProfileManagerDAO,
+                                           workspaceManagerDAO,
+                                           monitorRecordDao
+            )
           )
         )
       )
@@ -516,7 +512,6 @@ object BootMonitors extends LazyLogging {
         )
 
     }
-
 
   private def resetLaunchingWorkflows(dataSource: SlickDataSource) =
     Await.result(dataSource.inTransaction { dataAccess =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
@@ -11,21 +11,19 @@ import org.broadinstitute.dsde.workbench.client.leonardo.ApiException
 import org.broadinstitute.dsde.workbench.client.leonardo.model.{ListAppResponse, ListRuntimeResponse}
 
 import java.util.UUID
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO, pollInterval: FiniteDuration, timeout: FiniteDuration)(
-  implicit val system: ActorSystem
+class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
+  val system: ActorSystem
 ) extends Retry
     with LazyLogging {
 
-
-  def pollOnceForCompletion[T](
-      workspace: Workspace,
-      ctx: RawlsRequestContext,
-      checker: (Workspace, RawlsRequestContext) => Future[Seq[T]])(
-    implicit ec: ExecutionContext
+  def pollOperation[T](workspace: Workspace,
+                       ctx: RawlsRequestContext,
+                       checker: (Workspace, RawlsRequestContext) => Future[Seq[T]]
+  )(implicit
+    ec: ExecutionContext
   ): Future[Boolean] = checker(workspace, ctx).transformWith {
     case Failure(t: ApiException) =>
       if (t.getCode == StatusCodes.Forbidden.intValue) {
@@ -38,73 +36,18 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO, pollInterval: Fin
       } else {
         Future.failed(t)
       }
-    case Failure(t) => Future.failed(t)
+    case Failure(t)                               => Future.failed(t)
     case Success(resources) if resources.nonEmpty => Future.successful(false)
-    case Success(_) => Future.successful(true)
+    case Success(_)                               => Future.successful(true)
   }
 
-
-  def pollOperation[T](workspace: Workspace,
-                       ctx: RawlsRequestContext,
-                       checker: (Workspace, RawlsRequestContext) => Future[Seq[T]]
-  )(implicit
+  def pollRuntimeDeletion(workspace: Workspace, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext
-  ): Future[Unit] =
-    for {
-      result <- retryUntilSuccessOrTimeout(pred = jobStatusPredicate)(pollInterval, timeout) { () =>
-        isComplete(workspace, ctx, checker)
-      }
-    } yield result match {
-      case Left(_) =>
-        throw new LeonardoOperationFailureException(
-          s"Leonardo resource deletion failed [workspaceId=${workspace.workspaceId}]",
-          workspace.workspaceIdAsUUID
-        )
-      case Right(_) => ()
-    }
-
-  def isComplete[T](workspace: Workspace,
-                    ctx: RawlsRequestContext,
-                    checker: (Workspace, RawlsRequestContext) => Future[Seq[T]]
-  )(implicit ec: ExecutionContext): Future[Unit] = {
-    val result: Future[Seq[T]] =
-      checker(workspace, ctx).recoverWith {
-        case t: ApiException =>
-          if (t.getCode == StatusCodes.Forbidden.intValue) {
-            // leo gives back a 403 when the workspace is gone
-            logger.warn(s"403 when fetching leo resources, continuing [workspaceId=${workspace.workspaceId}]")
-            Future.successful(Seq.empty)
-          } else if (t.getCode == StatusCodes.NotFound.intValue) {
-            logger.warn(s"404 when fetching leo resources, continuing [workspaceId=${workspace.workspaceId}]")
-            Future.successful(Seq.empty)
-          } else {
-            Future.failed(t)
-          }
-        case t: Throwable => Future.failed(t)
-      }
-
-    result.flatMap { resources =>
-      if (resources.nonEmpty) {
-        Future.failed(
-          new LeonardoPollingException(s"Leo resources still present [workspaceId=${workspace.workspaceId}]")
-        )
-      } else {
-        Future.successful()
-      }
-    }
-  }
-
-  def jobStatusPredicate(t: Throwable): Boolean =
-    t match {
-      case _: LeonardoPollingException => true
-      case _                           => false
-    }
-
-  def pollRuntimeDeletion(workspace: Workspace, ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Boolean] =
-    pollOnceForCompletion[ListRuntimeResponse](workspace, ctx, listAzureRuntimes)
+  ): Future[Boolean] =
+    pollOperation[ListRuntimeResponse](workspace, ctx, listAzureRuntimes)
 
   def pollAppDeletion(workspace: Workspace, ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Boolean] =
-    pollOnceForCompletion[ListAppResponse](workspace, ctx, listApps)
+    pollOperation[ListAppResponse](workspace, ctx, listApps)
 
   def listApps(workspace: Workspace, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/WsmDeletionAction.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/WsmDeletionAction.scala
@@ -4,104 +4,53 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport.StatusEnum
-import bio.terra.workspace.model.JobResult
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500
 import org.broadinstitute.dsde.rawls.util.Retry
-import org.broadinstitute.dsde.rawls.workspace.WorkspaceManagerOperationFailureException
 
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class WsmDeletionAction(workspaceManagerDao: WorkspaceManagerDAO,
-                        pollInterval: FiniteDuration,
-                        timeout: FiniteDuration
-)(implicit
-  val system: ActorSystem
-) extends Retry
+class WsmDeletionAction(workspaceManagerDao: WorkspaceManagerDAO)(implicit val system: ActorSystem)
+    extends Retry
     with LazyLogging {
 
-  private def jobStatusPredicate(t: Throwable): Boolean =
-    t match {
-      case t: WorkspaceManagerPollingOperationException => t.status == StatusEnum.RUNNING
-      case _                                            => false
-    }
+  def pollForCompletion(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit
+    ec: ExecutionContext
+  ): Future[Boolean] =
+    retry(when500)(() => Future(isComplete(workspace, jobId, ctx)))
 
-  def isComplete(workspace: Workspace, jobId: String, ctx: RawlsRequestContext): Future[Boolean] = {
-    logger.info(
-      s"Checking for WSM deletion for workspace ${workspace.workspaceIdAsUUID} [pollInterval = ${pollInterval}, timeout = ${timeout}]"
-    )
-    val result: JobResult = Try(
-      workspaceManagerDao.getDeleteWorkspaceV2Result(workspace.workspaceIdAsUUID, jobId, ctx)
-    ) match {
-      case Success(w) => w
-      case Failure(e: ApiException) =>
-        if (e.getCode == StatusCodes.Forbidden.intValue) {
-          // WSM will give back a 403 during polling if the workspace is not present or already deleted.
-          logger.info(
-            s"Workspace deletion result status = ${e.getCode} for workspace ID ${workspace.workspaceId}, WSM record is gone. Proceeding with rawls workspace deletion"
-          )
-          return Future.successful(false)
-        } else {
-          return Future.failed(e)
-        }
-      case Failure(e) => throw e
-    }
-
-    result.getJobReport.getStatus match {
-      case StatusEnum.SUCCEEDED => Future.successful(true)
-      case _ =>
-        Future.failed(
-          new WorkspaceManagerPollingOperationException(
-            s"Polling workspace deletion for status to be ${StatusEnum.SUCCEEDED}. Current status: ${result.getJobReport.getStatus} [workspaceId=${workspace.workspaceId}, jobControlId = ${jobId}] ",
-            result.getJobReport.getStatus
-          )
-        )
-    }
-  }
-
-  def pollDeletionComplete(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit ec: ExecutionContext
+  private def isComplete(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit
+    ec: ExecutionContext
   ): Boolean = Try(workspaceManagerDao.getDeleteWorkspaceV2Result(workspace.workspaceIdAsUUID, jobId, ctx)) match {
-    case Success(result) => Option(result.getJobReport).map{ report => report.getStatus} match {
-      case Some(StatusEnum.SUCCEEDED) => true
-      case Some(StatusEnum.RUNNING) => false
-      case Some(StatusEnum.FAILED) => throw WorkspaceDeletionActionFailureException(
-        s"Workspace deletion returned status ${StatusEnum.FAILED} [workspaceId=${workspace.workspaceId}, jobControlId = ${jobId}]"
-      )
-      case None =>
-        val message = Option(result.getErrorReport).map { errorReport =>
-          errorReport.getMessage
-        }.getOrElse("No errors reported")
-         throw WorkspaceDeletionActionFailureException(
-          s"Workspace Deletion failed for [workspaceId=${workspace.workspaceId}, jobControlId = $jobId]: $message"
-      )
-    }
+    case Success(result) =>
+      Option(result.getJobReport).map(report => report.getStatus) match {
+        case Some(StatusEnum.SUCCEEDED) => true
+        case Some(StatusEnum.RUNNING)   => false
+        case Some(StatusEnum.FAILED) =>
+          throw WorkspaceDeletionActionFailureException(
+            s"Workspace deletion returned status ${StatusEnum.FAILED} [workspaceId=${workspace.workspaceId}, jobControlId = ${jobId}]"
+          )
+        case None =>
+          val message = Option(result.getErrorReport)
+            .map { errorReport =>
+              errorReport.getMessage
+            }
+            .getOrElse("No errors reported")
+          throw WorkspaceDeletionActionFailureException(
+            s"Workspace Deletion failed for [workspaceId=${workspace.workspaceId}, jobControlId = $jobId]: $message"
+          )
+      }
     // WSM will give back a 403 during polling if the workspace is not present or already deleted.
     case Failure(e: ApiException) if e.getCode == StatusCodes.Forbidden.intValue =>
-        logger.info(
-          s"Workspace deletion result status = ${e.getCode} for workspace ID ${workspace.workspaceId}, WSM record is gone. Proceeding with rawls workspace deletion"
-        )
-        true
+      logger.info(
+        s"Workspace deletion result status = ${e.getCode} for workspace ID ${workspace.workspaceId}, WSM record is gone. Proceeding with rawls workspace deletion"
+      )
+      true
     case Failure(e) => throw e
   }
-
-  def pollOperation(workspace: Workspace, jobControlId: String, ctx: RawlsRequestContext)(implicit
-    ec: ExecutionContext
-  ): Future[Unit] =
-    for {
-      result <- retryUntilSuccessOrTimeout(pred = jobStatusPredicate)(pollInterval, timeout) { () =>
-        isComplete(workspace, jobControlId, ctx)
-      }
-    } yield result match {
-      case Left(_) =>
-        throw WorkspaceDeletionActionFailureException(
-          s"Failed deleting workspace in WSM [workspaceId = ${workspace.workspaceId}, jobControlid=${jobControlId}]"
-        )
-      case Right(_) => ()
-    }
 
   def startStep(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -2,20 +2,13 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion
 
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, JobType}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, Incomplete, JobType}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, Workspace, WorkspaceState}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.WorkspaceDeletionRunnerSpec.{
-  azureWorkspace,
-  monitorRecord
-}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.{
-  LeonardoOperationFailureException,
-  LeonardoResourceDeletionAction,
-  WsmDeletionAction
-}
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.WorkspaceDeletionRunnerSpec.{azureWorkspace, monitorRecord}
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.{LeonardoOperationFailureException, LeonardoResourceDeletionAction, WsmDeletionAction}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
@@ -63,7 +56,8 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       mock[WorkspaceRepository](RETURNS_SMART_NULLS),
       mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
       mock[WsmDeletionAction](RETURNS_SMART_NULLS),
-      mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
 
     whenReady(runner(monitorRecord.copy(workspaceId = None)))(
@@ -82,7 +76,8 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       wsRepo,
       mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
       mock[WsmDeletionAction](RETURNS_SMART_NULLS),
-      mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
 
     whenReady(runner(monitorRecord.copy(userEmail = None)))(
@@ -97,72 +92,154 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       mock[WorkspaceRepository](RETURNS_SMART_NULLS),
       mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
       mock[WsmDeletionAction](RETURNS_SMART_NULLS),
-      mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
     intercept[IllegalArgumentException](runner(monitorRecord.copy(jobType = JobType.BpmBillingProjectDelete)))
   }
 
   behavior of "deletion orchestration"
 
-  it should "orchestrate the deletion of downstream resources" in {
-    val workspaceRepo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-    when(workspaceRepo.getWorkspace(ArgumentMatchers.eq(monitorRecord.workspaceId.get)))
-      .thenAnswer(_ => Future.successful(Some(azureWorkspace)))
-    when(workspaceRepo.deleteWorkspaceRecord(ArgumentMatchers.eq(azureWorkspace)))
-      .thenAnswer(_ => Future.successful(true))
-
+  it should "start deletion of leo apps and update job to LeoAppDeletionPoll on init" in {
     val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
-    when(leoDeletion.deleteApps(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(any[ExecutionContext]))
-      .thenAnswer(_ => Future.successful())
-    when(
-      leoDeletion.deleteRuntimes(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(any[ExecutionContext])
-    ).thenAnswer(_ => Future.successful())
-    when(
-      leoDeletion.pollAppDeletion(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(
-        any[ExecutionContext]
-      )
-    ).thenAnswer(_ => Future.successful())
-    when(
-      leoDeletion.pollRuntimeDeletion(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(
-        any[ExecutionContext]
-      )
-    ).thenAnswer(_ => Future.successful())
+    when (leoDeletion.deleteApps(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful())
+    val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
 
-    val wsmDeletion = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
-    when(
-      wsmDeletion.startStep(ArgumentMatchers.eq(azureWorkspace), anyString(), any[RawlsRequestContext])(
-        any[ExecutionContext]
-      )
-    ).thenAnswer(_ => Future.successful())
-    when(
-      wsmDeletion.pollOperation(ArgumentMatchers.eq(azureWorkspace), anyString(), any[RawlsRequestContext])(
-        any[ExecutionContext]
-      )
-    ).thenAnswer(_ => Future.successful())
-
-    val runner = spy(
-      new WorkspaceDeletionRunner(
+    val jobUpdate = monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll)
+    when (recordDao.update(jobUpdate)).thenReturn(Future.successful(1))
+    val runner = new WorkspaceDeletionRunner(
         mock[SamDAO](RETURNS_SMART_NULLS),
         mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
-        workspaceRepo,
+        mock[WorkspaceRepository](RETURNS_SMART_NULLS),
         leoDeletion,
-        wsmDeletion,
-        mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+        mock[WsmDeletionAction](RETURNS_SMART_NULLS),
+        mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      recordDao
       )
-    )
-    doReturn(Future.successful(new RawlsRequestContext(null, null)))
-      .when(runner)
-      .getUserCtx(anyString())(ArgumentMatchers.any())
-
-    whenReady(runner(monitorRecord))(_ shouldBe Complete)
-    verify(leoDeletion).deleteApps(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(any[ExecutionContext])
-    verify(leoDeletion).deleteRuntimes(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(
-      any[ExecutionContext]
-    )
-    verify(wsmDeletion).startStep(ArgumentMatchers.eq(azureWorkspace), anyString(), any[RawlsRequestContext])(
-      any[ExecutionContext]
-    )
+    whenReady(runner.runStep(monitorRecord, azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    verify(recordDao).update(jobUpdate)
+    verify(leoDeletion).deleteApps(any(), any())(any[ExecutionContext]())
   }
+
+  it should "return incomplete when leo apps are not deleted" in {
+    val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
+    when(leoDeletion.pollAppDeletion(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(false))
+
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      leoDeletion,
+      mock[WsmDeletionAction](RETURNS_SMART_NULLS),
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+    )
+    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    verify(leoDeletion).pollAppDeletion(any(), any())(any[ExecutionContext]())
+  }
+
+  it should "delete leo runtimes and update the job after leo apps are deleted" in {
+    val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
+    when(leoDeletion.pollAppDeletion(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(true))
+    when(leoDeletion.deleteRuntimes(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful())
+    val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+    val jobUpdate = monitorRecord.copy(jobType = JobType.LeoRuntimeDeletionPoll)
+    when(recordDao.update(jobUpdate)).thenReturn(Future.successful(1))
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      leoDeletion,
+      mock[WsmDeletionAction](RETURNS_SMART_NULLS),
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      recordDao
+    )
+    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    verify(leoDeletion).pollAppDeletion(any(), any())(any[ExecutionContext]())
+    verify(recordDao).update(jobUpdate)
+    verify(leoDeletion).deleteRuntimes(any(), any())(any[ExecutionContext]())
+  }
+
+  it should "return incomplete when leo runtimes are not deleted" in {
+    val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
+    when(leoDeletion.pollRuntimeDeletion(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(false))
+
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      leoDeletion,
+      mock[WsmDeletionAction](RETURNS_SMART_NULLS),
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+    )
+    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.LeoRuntimeDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    verify(leoDeletion).pollRuntimeDeletion(any(), any())(any[ExecutionContext]())
+  }
+
+  it should "delete the wsm workspace and update the job after leo runtimes are deleted" in {
+    val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
+    when(leoDeletion.pollRuntimeDeletion(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(true))
+    val wsmAction = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
+    when(wsmAction.startStep(any(), any(), any())(any[ExecutionContext]())).thenReturn(Future.successful())
+
+    val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+    val job = monitorRecord.copy(jobType = JobType.LeoRuntimeDeletionPoll)
+    val jobUpdate = monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll)
+    when(recordDao.update(jobUpdate)).thenReturn(Future.successful(1))
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      leoDeletion,
+      wsmAction,
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      recordDao
+    )
+    whenReady(runner.runStep(job, azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    verify(leoDeletion).pollRuntimeDeletion(any(), any())(any[ExecutionContext]())
+    verify(recordDao).update(jobUpdate)
+    verify(wsmAction).startStep(any(), any(), any())(any[ExecutionContext]())
+  }
+
+
+  it should "return incomplete when wsm workspace is not not deleted" in {
+    val wsmAction = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
+    when(wsmAction.pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())).thenReturn(false)
+
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
+      wsmAction,
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+    )
+    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    verify(wsmAction).pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())
+  }
+
+  it should "delete the rawls record and return Complete after the wsm workspace is deleted" in {
+    val wsmAction = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
+    when(wsmAction.pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())).thenReturn(true)
+    val repo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+    when(repo.deleteWorkspaceRecord(azureWorkspace)).thenReturn(Future.successful(true))
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
+      wsmAction,
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+    )
+    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Complete)
+    verify(wsmAction).pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())
+    verify(repo).deleteWorkspaceRecord(azureWorkspace)
+
+  }
+
 
   it should "fail if the workspace is not found" in {
     val workspaceRepo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
@@ -175,7 +252,8 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       workspaceRepo,
       mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
       mock[WsmDeletionAction](RETURNS_SMART_NULLS),
-      mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
 
     intercept[WorkspaceDeletionException] {
@@ -206,7 +284,8 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
         workspaceRepo,
         leoDeletion,
         mock[WsmDeletionAction](RETURNS_SMART_NULLS),
-        mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+        mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+        mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
       )
     )
     doReturn(Future.successful(new RawlsRequestContext(null, null)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -2,13 +2,24 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion
 
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, Incomplete, JobType}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
+  Complete,
+  Incomplete,
+  JobType
+}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, Workspace, WorkspaceState}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.WorkspaceDeletionRunnerSpec.{azureWorkspace, monitorRecord}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.{LeonardoOperationFailureException, LeonardoResourceDeletionAction, WsmDeletionAction}
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.WorkspaceDeletionRunnerSpec.{
+  azureWorkspace,
+  monitorRecord
+}
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.{
+  LeonardoOperationFailureException,
+  LeonardoResourceDeletionAction,
+  WsmDeletionAction
+}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
@@ -19,6 +30,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
+import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -102,20 +115,20 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
 
   it should "start deletion of leo apps and update job to LeoAppDeletionPoll on init" in {
     val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
-    when (leoDeletion.deleteApps(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful())
+    when(leoDeletion.deleteApps(any(), any())(any[ExecutionContext]())).thenReturn(Future.successful())
     val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
 
     val jobUpdate = monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll)
-    when (recordDao.update(jobUpdate)).thenReturn(Future.successful(1))
+    when(recordDao.update(jobUpdate)).thenReturn(Future.successful(1))
     val runner = new WorkspaceDeletionRunner(
-        mock[SamDAO](RETURNS_SMART_NULLS),
-        mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
-        mock[WorkspaceRepository](RETURNS_SMART_NULLS),
-        leoDeletion,
-        mock[WsmDeletionAction](RETURNS_SMART_NULLS),
-        mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+      mock[SamDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      leoDeletion,
+      mock[WsmDeletionAction](RETURNS_SMART_NULLS),
+      mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
       recordDao
-      )
+    )
     whenReady(runner.runStep(monitorRecord, azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
     verify(recordDao).update(jobUpdate)
     verify(leoDeletion).deleteApps(any(), any())(any[ExecutionContext]())
@@ -134,7 +147,12 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
       mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
-    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll),
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Incomplete)
     verify(leoDeletion).pollAppDeletion(any(), any())(any[ExecutionContext]())
   }
 
@@ -154,7 +172,12 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
       recordDao
     )
-    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll),
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Incomplete)
     verify(leoDeletion).pollAppDeletion(any(), any())(any[ExecutionContext]())
     verify(recordDao).update(jobUpdate)
     verify(leoDeletion).deleteRuntimes(any(), any())(any[ExecutionContext]())
@@ -173,7 +196,12 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
       mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
-    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.LeoRuntimeDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.LeoRuntimeDeletionPoll),
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Incomplete)
     verify(leoDeletion).pollRuntimeDeletion(any(), any())(any[ExecutionContext]())
   }
 
@@ -202,10 +230,9 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     verify(wsmAction).startStep(any(), any(), any())(any[ExecutionContext]())
   }
 
-
   it should "return incomplete when wsm workspace is not not deleted" in {
     val wsmAction = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
-    when(wsmAction.pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())).thenReturn(false)
+    when(wsmAction.pollForCompletion(any(), any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(false))
 
     val runner = new WorkspaceDeletionRunner(
       mock[SamDAO](RETURNS_SMART_NULLS),
@@ -216,30 +243,39 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
       mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
-    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Incomplete)
-    verify(wsmAction).pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll),
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Incomplete)
+    verify(wsmAction).pollForCompletion(any(), any(), any())(any[ExecutionContext]())
   }
 
   it should "delete the rawls record and return Complete after the wsm workspace is deleted" in {
     val wsmAction = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
-    when(wsmAction.pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())).thenReturn(true)
+    when(wsmAction.pollForCompletion(any(), any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(true))
     val repo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
     when(repo.deleteWorkspaceRecord(azureWorkspace)).thenReturn(Future.successful(true))
     val runner = new WorkspaceDeletionRunner(
       mock[SamDAO](RETURNS_SMART_NULLS),
       mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
-      mock[WorkspaceRepository](RETURNS_SMART_NULLS),
+      repo,
       mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS),
       wsmAction,
       mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
       mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
     )
-    whenReady(runner.runStep(monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll), azureWorkspace, RawlsRequestContext(null, null)))(_ shouldBe Complete)
-    verify(wsmAction).pollDeletionComplete(any(), any(), any())(any[ExecutionContext]())
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.WSMWorkspaceDeletionPoll),
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Complete)
+    verify(wsmAction).pollForCompletion(any(), any(), any())(any[ExecutionContext]())
     verify(repo).deleteWorkspaceRecord(azureWorkspace)
 
   }
-
 
   it should "fail if the workspace is not found" in {
     val workspaceRepo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
@@ -288,11 +324,48 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
         mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
       )
     )
-    doReturn(Future.successful(new RawlsRequestContext(null, null)))
+    doReturn(Future.successful(RawlsRequestContext(null, null)))
       .when(runner)
       .getUserCtx(anyString())(ArgumentMatchers.any())
 
     whenReady(runner(monitorRecord))(_ shouldBe Complete)
+    verify(workspaceRepo).updateState(ArgumentMatchers.eq(azureWorkspace.workspaceIdAsUUID),
+                                      ArgumentMatchers.eq(WorkspaceState.DeleteFailed)
+    )
+  }
+
+  it should "mark the workspace as DeleteFailed when a step times out" in {
+    val workspaceRepo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+    when(workspaceRepo.getWorkspace(ArgumentMatchers.eq(monitorRecord.workspaceId.get)))
+      .thenAnswer(_ => Future.successful(Some(azureWorkspace)))
+    when(workspaceRepo.updateState(ArgumentMatchers.eq(monitorRecord.workspaceId.get), any[WorkspaceState]))
+      .thenAnswer(_ => Future.successful(1))
+
+    val leoDeletion = mock[LeonardoResourceDeletionAction](RETURNS_SMART_NULLS)
+    when(
+      leoDeletion.pollAppDeletion(ArgumentMatchers.eq(azureWorkspace), any[RawlsRequestContext])(
+        any[ExecutionContext]
+      )
+    ).thenAnswer(_ => Future.successful(false))
+    val expiredtime =
+      Instant.ofEpochMilli(Instant.now().toEpochMilli - 600001) // -10 minutes will make operation time out
+    val job = monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll, createdTime = Timestamp.from(expiredtime))
+    val runner = spy(
+      new WorkspaceDeletionRunner(
+        mock[SamDAO](RETURNS_SMART_NULLS),
+        mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
+        workspaceRepo,
+        leoDeletion,
+        mock[WsmDeletionAction](RETURNS_SMART_NULLS),
+        mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+        mock[WorkspaceManagerResourceMonitorRecordDao](RETURNS_SMART_NULLS)
+      )
+    )
+    doReturn(Future.successful(RawlsRequestContext(null, null)))
+      .when(runner)
+      .getUserCtx(anyString())(ArgumentMatchers.any())
+
+    whenReady(runner(job))(_ shouldBe Complete)
     verify(workspaceRepo).updateState(ArgumentMatchers.eq(azureWorkspace.workspaceIdAsUUID),
                                       ArgumentMatchers.eq(WorkspaceState.DeleteFailed)
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -1304,7 +1304,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
           } yield {
             deletionResult.jobId shouldBe defined
             jobs.size shouldBe 1
-            jobs.head.jobType shouldBe JobType.WorkspaceDelete
+            jobs.head.jobType shouldBe JobType.WorkspaceDeleteInit
             jobs.head.workspaceId.value.toString shouldBe testData.azureWorkspace.workspaceId
             assertWorkspaceExists(testData.azureWorkspace)
             assertWorkspaceState(testData.azureWorkspace, WorkspaceState.Deleting)


### PR DESCRIPTION
creates several additional status enums to handle different steps of workspace deletion
each step starts the next step and updates the job when complete:

init => calls delete of leo apps
leo app poll => waits for leo  apps to complete, then starts deleting of runtimes
leo runtime delete poll => waits for runtime to delete then starts deleting WSM workspace
wsm delete poll => waits for WSM to delete, then deletes rawls record (and completes job)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
