### PR TITLE
Disallow workspace creation and cloning in old Azure billing profiles (WOR-1258).

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -496,12 +496,12 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotImplemented, "MC workspaces are not enabled"))
     }
 
-    val previewDate = new DateTime(2023, 9, 13, 0, 0, DateTimeZone.UTC)
+    val previewDate = new DateTime(2023, 9, 12, 0, 0, DateTimeZone.UTC)
     val isTestProfile = profile.getCreatedDate() == null || profile.getCreatedDate() == ""
     if (!isTestProfile && DateTime.parse(profile.getCreatedDate()).isBefore(previewDate)) {
       throw new RawlsExceptionWithErrorReport(
         ErrorReport(StatusCodes.Forbidden,
-                    "This billing project was created before 9/13/2023 and cannot be used for creating new workspaces."
+                    "This billing project was created before 9/12/2023 and cannot be used for creating new workspaces."
         )
       )
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -500,8 +500,9 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     val isTestProfile = profile.getCreatedDate() == null || profile.getCreatedDate() == ""
     if (!isTestProfile && DateTime.parse(profile.getCreatedDate()).isBefore(previewDate)) {
       throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.Forbidden,
-                    "This billing project was created before 9/12/2023 and cannot be used for creating new workspaces."
+        ErrorReport(
+          StatusCodes.Forbidden,
+          "Azure Terra billing projects created before 9/12/2023, and their associated workspaces, are unable to take advantage of new functionality. This billing project cannot be used for creating new workspaces. Please create a new billing project."
         )
       )
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -478,6 +478,15 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       .subscriptionId(UUID.randomUUID())
       .cloudPlatform(bio.terra.profile.model.CloudPlatform.AZURE)
       .managedResourceGroupId("fake-mrg")
+      .createdDate("2023-09-12T22:20:48.949Z")
+
+    val oldAzureBillingProfile = new ProfileModel()
+      .id(UUID.randomUUID())
+      .tenantId(UUID.randomUUID())
+      .subscriptionId(UUID.randomUUID())
+      .cloudPlatform(bio.terra.profile.model.CloudPlatform.AZURE)
+      .managedResourceGroupId("fake-mrg")
+      .createdDate("2023-09-11T22:20:48.949Z")
 
     val azureBillingProjectName = RawlsBillingProjectName("azure-billing-project")
     val azureBillingProject = RawlsBillingProject(
@@ -486,6 +495,14 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       Option(billingAccountName),
       None,
       billingProfileId = Some(azureBillingProfile.getId.toString)
+    )
+
+    val oldAzureBillingProject = RawlsBillingProject(
+      RawlsBillingProjectName("old-azure-billing-project"),
+      CreationStatuses.Ready,
+      Option(billingAccountName),
+      None,
+      billingProfileId = Some(oldAzureBillingProfile.getId.toString)
     )
 
     val wsAttrs = Map(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -480,14 +480,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       .managedResourceGroupId("fake-mrg")
       .createdDate("2023-09-12T22:20:48.949Z")
 
-    val oldAzureBillingProfile = new ProfileModel()
-      .id(UUID.randomUUID())
-      .tenantId(UUID.randomUUID())
-      .subscriptionId(UUID.randomUUID())
-      .cloudPlatform(bio.terra.profile.model.CloudPlatform.AZURE)
-      .managedResourceGroupId("fake-mrg")
-      .createdDate("2023-09-11T22:20:48.949Z")
-
     val azureBillingProjectName = RawlsBillingProjectName("azure-billing-project")
     val azureBillingProject = RawlsBillingProject(
       azureBillingProjectName,
@@ -497,6 +489,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       billingProfileId = Some(azureBillingProfile.getId.toString)
     )
 
+    // For testing of old Azure billing projects, can be removed if that code is removed.
     val oldAzureBillingProject = RawlsBillingProject(
       RawlsBillingProjectName("old-azure-billing-project"),
       CreationStatuses.Ready,
@@ -504,6 +497,13 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       None,
       billingProfileId = Some(oldAzureBillingProfile.getId.toString)
     )
+    val oldAzureBillingProfile = new ProfileModel()
+      .id(UUID.randomUUID())
+      .tenantId(UUID.randomUUID())
+      .subscriptionId(UUID.randomUUID())
+      .cloudPlatform(bio.terra.profile.model.CloudPlatform.AZURE)
+      .managedResourceGroupId("fake-mrg")
+      .createdDate("2023-09-11T22:20:48.949Z")
 
     val wsAttrs = Map(
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -490,13 +490,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     )
 
     // For testing of old Azure billing projects, can be removed if that code is removed.
-    val oldAzureBillingProject = RawlsBillingProject(
-      RawlsBillingProjectName("old-azure-billing-project"),
-      CreationStatuses.Ready,
-      Option(billingAccountName),
-      None,
-      billingProfileId = Some(oldAzureBillingProfile.getId.toString)
-    )
     val oldAzureBillingProfile = new ProfileModel()
       .id(UUID.randomUUID())
       .tenantId(UUID.randomUUID())
@@ -504,6 +497,13 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       .cloudPlatform(bio.terra.profile.model.CloudPlatform.AZURE)
       .managedResourceGroupId("fake-mrg")
       .createdDate("2023-09-11T22:20:48.949Z")
+    val oldAzureBillingProject = RawlsBillingProject(
+      RawlsBillingProjectName("old-azure-billing-project"),
+      CreationStatuses.Ready,
+      Option(billingAccountName),
+      None,
+      billingProfileId = Some(oldAzureBillingProfile.getId.toString)
+    )
 
     val wsAttrs = Map(
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -323,7 +323,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     thrown.errorReport.statusCode shouldBe Some(StatusCodes.Conflict)
   }
 
-  it should "throw an exception if the billing profile is too old" in {
+  it should "throw an exception if the billing profile was created before 9/12/2023" in {
     val workspaceManagerDAO = new MockWorkspaceManagerDAO()
     val samDAO = new MockSamDAO(slickDataSource)
     val leonardoDAO: LeonardoDAO = new MockLeonardoDAO()
@@ -346,7 +346,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     val thrown = intercept[RawlsExceptionWithErrorReport] {
       Await.result(mcWorkspaceService.createMultiCloudWorkspace(
                      request,
-                     new ProfileModel().id(billingProfileId).createdDate("2023-09-12T22:20:48.949Z")
+                     new ProfileModel().id(billingProfileId).createdDate("2023-09-11T22:20:48.949Z")
                    ),
                    Duration.Inf
       )
@@ -355,7 +355,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     thrown.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
   }
 
-  it should "not throw an exception for billing profiles created after 9/12/2023" in {
+  it should "not throw an exception for billing profiles created 9/12/2023 or later" in {
     val workspaceManagerDAO = new MockWorkspaceManagerDAO()
     val samDAO = new MockSamDAO(slickDataSource)
     val leonardoDAO: LeonardoDAO = new MockLeonardoDAO()
@@ -376,7 +376,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     val billingProfileId = UUID.randomUUID()
     Await.result(mcWorkspaceService.createMultiCloudWorkspace(
                    request,
-                   new ProfileModel().id(billingProfileId).createdDate("2023-09-13T22:20:48.949Z")
+                   new ProfileModel().id(billingProfileId).createdDate("2023-09-12T22:20:48.949Z")
                  ),
                  Duration.Inf
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -819,6 +819,14 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
       .when(bpmDAO)
       .getBillingProfile(equalTo(testData.azureBillingProfile.getId), any())
 
+    // For testing of old Azure billing projects, can be removed if that code is removed.
+    doReturn(Future.successful(testData.oldAzureBillingProject))
+      .when(mcWorkspaceService)
+      .getBillingProjectContext(equalTo(testData.oldAzureBillingProject.projectName), any())
+    doReturn(Some(testData.oldAzureBillingProfile))
+      .when(bpmDAO)
+      .getBillingProfile(equalTo(testData.oldAzureBillingProfile.getId), any())
+
     doReturn(Future.successful(testData.azureWorkspace))
       .when(mcWorkspaceService)
       .getV2WorkspaceContext(equalTo(testData.azureWorkspace.toWorkspaceName), any())
@@ -910,6 +918,34 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         )
 
         clone shouldBe empty
+      }
+    }
+
+  it should "throw an exception if the billing profile was created before 9/12/2023" in
+    withEmptyTestDatabase {
+      withMockedMultiCloudWorkspaceService { mcWorkspaceService =>
+        val cloneName = WorkspaceName(testData.oldAzureBillingProject.projectName.value, "unsupported")
+        val result = intercept[RawlsExceptionWithErrorReport] {
+          Await.result(
+            for {
+              _ <- insertWorkspaceWithBillingProject(testData.billingProject, testData.azureWorkspace)
+              _ <- mcWorkspaceService.cloneMultiCloudWorkspace(
+                mock[WorkspaceService](RETURNS_SMART_NULLS),
+                testData.azureWorkspace.toWorkspaceName,
+                WorkspaceRequest(
+                  cloneName.namespace,
+                  cloneName.name,
+                  Map.empty
+                )
+              )
+            } yield fail(
+              "cloneMultiCloudWorkspace does not fail when a workspace " +
+                "with the same name already exists."
+            ),
+            Duration.Inf
+          )
+        }
+        result.errorReport.statusCode.value shouldBe StatusCodes.Forbidden
       }
     }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1258

e2e tests passed on this branch (covers creating/clonging with a new billing project)

<img width="467" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/f815ba8e-8649-4931-8d60-1ea17d9bea43">


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
