### PR TITLE
[WOR-1271] Handle 401 from WSM during clone by failing out

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -81,7 +81,7 @@ class CloneWorkspaceContainerRunner(
                 val msg = s"Unable to find jobId ${job.jobControlId} in WSM for clone container operation"
                 cloneFail(workspaceId, msg).map(_ => Complete)
               case 401 =>
-                val msg = s"Unable to get job result, user is unauthed ${e.getMessage}"
+                val msg = s"Unable to get job result, user is unauthed with jobId ${job.jobControlId}: ${e.getMessage}"
                 cloneFail(workspaceId, msg).map(_ => Complete)
               case code =>
                 logFailure(s"API call to get clone result failed with status code $code: ${e.getMessage}")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -80,6 +80,9 @@ class CloneWorkspaceContainerRunner(
               case 404 =>
                 val msg = s"Unable to find jobId ${job.jobControlId} in WSM for clone container operation"
                 cloneFail(workspaceId, msg).map(_ => Complete)
+              case 401 =>
+                val msg = s"Unable to get job result, user is unauthed ${e.getMessage}"
+                cloneFail(workspaceId, msg).map(_ => Complete)
               case code =>
                 logFailure(s"API call to get clone result failed with status code $code: ${e.getMessage}")
                 Future.successful(Incomplete)


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1271)
The clone container runner should fail out if we get a 401 from WSM for any reason when polling the clone operation. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
