### PR TITLE
[WOR-1259] Bucket migration list workspaces API

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3936,7 +3936,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NotificationType'
-  /api/workspaces/v2:
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}:
     delete:
       tags:
         - workspaces_v2
@@ -3974,6 +3974,33 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         404:
           description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/v2/bucketMigration:
+    get:
+      tags:
+        - workspaces_v2
+      summary: get workspaces eligible for bucket migration and their migration progress if it exists
+      description: get workspaces eligible for bucket migration and their migration progress if it exists
+      operationId: getEligibleWorkspacesForBucketMigrationWithProgress
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: workspaceNamespace/workspaceName -> bucket migration progress
+                  additionalProperties:
+                    $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
+        403:
+          description: You must be an admin to list migration attempts
           content:
             'application/json':
               schema:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3999,12 +3999,6 @@ paths:
                   description: workspaceNamespace/workspaceName -> bucket migration progress
                   additionalProperties:
                     $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
-        403:
-          description: You must be an admin to list migration attempts
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
 components:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -10,6 +10,8 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   RawlsBillingProjectName,
   RawlsRequestContext,
+  SamResourceTypeNames,
+  SamWorkspaceRoles,
   Workspace,
   WorkspaceName
 }
@@ -18,7 +20,11 @@ import org.broadinstitute.dsde.rawls.monitor.migration._
 import org.broadinstitute.dsde.rawls.util.{RoleSupport, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport}
 
+import java.sql.Timestamp
+import java.time.Instant
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO, val gcsDAO: GoogleServicesDAO)(
   val ctx: RawlsRequestContext
@@ -26,6 +32,77 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
     extends RoleSupport
     with WorkspaceSupport
     with LazyLogging {
+
+  def getEligibleOrMigratingWorkspaces: Future[Map[String, Option[MultiregionalBucketMigrationProgress]]] = {
+    def getOwnedWorkspaces: Future[Seq[Workspace]] = for {
+      userWorkspaces <- samDAO.listUserResources(SamResourceTypeNames.workspace, ctx)
+      workspaceIds = userWorkspaces
+        .filter(_.hasRole(SamWorkspaceRoles.owner))
+        .map(workspaceResource => Try(UUID.fromString(workspaceResource.resourceId)))
+        .flatMap(_.toOption)
+      workspaces <- dataSource.inTransaction(_.workspaceQuery.listV2WorkspacesByIds(workspaceIds))
+    } yield workspaces
+
+    def getEligibleUnmigratedWorkspaces(
+      workspaces: Seq[Workspace]
+    ): Future[Seq[(Workspace, Option[MultiregionalBucketMigrationProgress])]] =
+      workspaces
+        .traverse { workspace =>
+          getBucketLocation(workspace).map(workspace -> _)
+        }
+        .map {
+          _.collect {
+            case (workspace, Some(location)) if location.equals("US") =>
+              (workspace, Option.empty[MultiregionalBucketMigrationProgress])
+          }
+        }
+
+    def getMigratingOrRecentlyFinishedWorkspaces(
+      workspaces: Seq[(Workspace, Option[MultiregionalBucketMigrationProgress])]
+    ): Future[Seq[(Workspace, Option[MultiregionalBucketMigrationProgress])]] =
+      workspaces
+        .traverse {
+          case (workspace, progress @ Some(MultiregionalBucketMigrationProgress(_, Some(_), _, _))) =>
+            dataSource
+              .inTransaction(_.multiregionalBucketMigrationQuery.getMigrationAttempts(workspace))
+              .map { migrations =>
+                if (
+                  migrations.exists(
+                    _.finished
+                      .getOrElse(Timestamp.from(Instant.MIN))
+                      .after(Timestamp.from(Instant.now().minusSeconds(86400 * 7)))
+                  )
+                ) Some(workspace -> progress)
+                else None
+              }
+          case unfinishedWorkspaceWithProgress @ (_, Some(MultiregionalBucketMigrationProgress(_, None, _, _))) =>
+            Future.successful(unfinishedWorkspaceWithProgress.some)
+          case _ =>
+            Future.successful(
+              None
+            )
+        }
+        .map(_.flatten)
+
+    for {
+      workspaces <- getOwnedWorkspaces
+
+      // get migration progress if it exists
+      workspacesWithProgressOpt <- workspaces.traverse { workspace =>
+        dataSource
+          .inTransaction(getBucketMigrationProgress(workspace))
+          .recover(_ => None)
+          .map(workspace -> _)
+      }
+
+      (scheduledWorkspaces, unscheduledWorkspaces) = workspacesWithProgressOpt.partition(_._2.isDefined)
+
+      eligibleWorkspaces <- getEligibleUnmigratedWorkspaces(unscheduledWorkspaces.map(_._1))
+      migratingOrRecentlyFinishedWorkspaces <- getMigratingOrRecentlyFinishedWorkspaces(scheduledWorkspaces)
+    } yield (migratingOrRecentlyFinishedWorkspaces ++ eligibleWorkspaces).map { case (workspace, progressOpt) =>
+      workspace.toWorkspaceName.toString -> progressOpt
+    }.toMap
+  }
 
   def getBucketMigrationProgressForWorkspace(
     workspaceName: WorkspaceName

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -101,10 +101,15 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
       // partition workspaces by whether they have any past migration attempts
       (scheduledWorkspaces, unscheduledWorkspaces) = workspacesWithProgressOpt.partition(_._2.isDefined)
 
-      eligibleWorkspacesWithEmptyProgress <- getEligibleUnmigratedWorkspacesWithEmptyProgress(unscheduledWorkspaces.map(_._1))
-      migratingOrRecentlyFinishedWorkspacesWithProgress <- getMigratingOrRecentlyFinishedWorkspacesWithProgress(scheduledWorkspaces)
-    } yield (migratingOrRecentlyFinishedWorkspacesWithProgress ++ eligibleWorkspacesWithEmptyProgress).map { case (workspace, progressOpt) =>
-      workspace.toWorkspaceName.toString -> progressOpt
+      eligibleWorkspacesWithEmptyProgress <- getEligibleUnmigratedWorkspacesWithEmptyProgress(
+        unscheduledWorkspaces.map(_._1)
+      )
+      migratingOrRecentlyFinishedWorkspacesWithProgress <- getMigratingOrRecentlyFinishedWorkspacesWithProgress(
+        scheduledWorkspaces
+      )
+    } yield (migratingOrRecentlyFinishedWorkspacesWithProgress ++ eligibleWorkspacesWithEmptyProgress).map {
+      case (workspace, progressOpt) =>
+        workspace.toWorkspaceName.toString -> progressOpt
     }.toMap
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationService.scala
@@ -22,6 +22,7 @@ import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWi
 
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -70,7 +71,7 @@ class BucketMigrationService(val dataSource: SlickDataSource, val samDAO: SamDAO
                   migrations.exists(
                     _.finished
                       .getOrElse(Timestamp.from(Instant.MIN))
-                      .after(Timestamp.from(Instant.now().minusSeconds(86400 * 7))) || outcome.isFailure
+                      .after(Timestamp.from(Instant.now().minus(7, ChronoUnit.DAYS))) || outcome.isFailure
                   )
                 ) Some(workspace -> progress)
                 else None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceV2.scala
@@ -5,10 +5,13 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import io.opencensus.scala.akka.http.TracingDirective._
+import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationJsonSupport._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceService, WorkspaceService}
+import spray.json.DefaultJsonProtocol._
 import spray.json.{JsObject, _}
 
 import scala.concurrent.ExecutionContext
@@ -18,6 +21,7 @@ trait WorkspaceApiServiceV2 extends UserInfoDirectives {
 
   val workspaceServiceConstructor: RawlsRequestContext => WorkspaceService
   val multiCloudWorkspaceServiceConstructor: RawlsRequestContext => MultiCloudWorkspaceService
+  val bucketMigrationServiceConstructor: RawlsRequestContext => BucketMigrationService
 
   val workspaceRoutesV2: server.Route = traceRequest { span =>
     requireUserInfo(Option(span)) { userInfo =>
@@ -34,7 +38,15 @@ trait WorkspaceApiServiceV2 extends UserInfoDirectives {
 
             }
           }
-        }
+        } ~
+          path("bucketMigration") {
+            get {
+              complete {
+                bucketMigrationServiceConstructor(ctx).getEligibleOrMigratingWorkspaces
+                  .map(StatusCodes.OK -> _)
+              }
+            }
+          }
       }
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -628,7 +628,9 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
       returnedWorkspaces(usWorkspace.toWorkspaceName.toString) shouldBe None
       returnedWorkspaces(migratingWorkspace.toWorkspaceName.toString).get.outcome shouldBe None
       returnedWorkspaces(recentlyMigratedWorkspace.toWorkspaceName.toString).get.outcome shouldBe Some(Outcome.Success)
-      returnedWorkspaces(oldUnsuccessfullyMigratedWorkspace.toWorkspaceName.toString).get.outcome shouldBe Some(Outcome.Failure("error"))
+      returnedWorkspaces(oldUnsuccessfullyMigratedWorkspace.toWorkspaceName.toString).get.outcome shouldBe Some(
+        Outcome.Failure("error")
+      )
   }
 
   private def insertSTSJobs(workspace: Workspace): Future[Unit] =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceSpec.scala
@@ -12,17 +12,24 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
+  SamResourceRole,
+  SamResourceTypeNames,
+  SamRolesAndActions,
+  SamUserResource,
   SamUserStatusResponse,
+  SamWorkspaceRoles,
   UserInfo,
   Workspace,
   WorkspaceType
 }
+import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome
 import org.broadinstitute.dsde.rawls.monitor.migration.{
   MultiregionalBucketMigrationProgress,
   MultiregionalBucketMigrationStep,
   MultiregionalStorageTransferJobs,
   STSJobProgress
 }
+import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
@@ -31,6 +38,8 @@ import org.scalatest.matchers.must.Matchers.not
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -489,6 +498,135 @@ class BucketMigrationServiceSpec extends AnyFlatSpec with TestDriverComponent {
         },
         Duration.Inf
       )
+  }
+
+  behavior of "getEligibleOrMigratingWorkspaces"
+
+  it should "return owned workspaces either with US multi-region buckets or that are currently or recently migrated" in withMinimalTestDatabase {
+    _ =>
+      def makeSamUserResponse(workspaceId: String, role: SamResourceRole): SamUserResource = SamUserResource(
+        workspaceId,
+        SamRolesAndActions(Set(role), Set.empty),
+        SamRolesAndActions(Set.empty, Set.empty),
+        SamRolesAndActions(Set.empty, Set.empty),
+        Set.empty,
+        Set.empty
+      )
+
+      def makeWorkspace(name: String, creator: String): Workspace = Workspace(
+        minimalTestData.billingProject.projectName.value,
+        name,
+        UUID.randomUUID().toString,
+        UUID.randomUUID().toString,
+        None,
+        DateTime.now(),
+        DateTime.now(),
+        creator,
+        Map.empty
+      )
+
+      val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      val gcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      val userCtx = getRequestContext("user@example.com")
+      val bucketMigrationService = BucketMigrationService.constructor(slickDataSource, samDAO, gcsDAO)(userCtx)
+
+      val nonOwnedWorkspace =
+        makeWorkspace("nonOwnedWorkspace", "notThisUser@example.com")
+      val usWorkspace = makeWorkspace("usWorkspace", userCtx.userInfo.userEmail.value)
+      val nonUSWorkspace = makeWorkspace("nonUSWorkspace", userCtx.userInfo.userEmail.value)
+      val migratingWorkspace = makeWorkspace("migratingWorkspace", userCtx.userInfo.userEmail.value)
+      val recentlyMigratedWorkspace = makeWorkspace("recentlyMigratedWorkspace", userCtx.userInfo.userEmail.value)
+      val oldSuccessfullyMigratedWorkspace =
+        makeWorkspace("oldSuccessfullyMigratedWorkspace", userCtx.userInfo.userEmail.value)
+      val oldUnsuccessfullyMigratedWorkspace =
+        makeWorkspace("oldUnsuccessfullyMigratedWorkspace", userCtx.userInfo.userEmail.value)
+
+      val samResources = Seq(
+        makeSamUserResponse(nonOwnedWorkspace.workspaceId, SamWorkspaceRoles.writer),
+        makeSamUserResponse(usWorkspace.workspaceId, SamWorkspaceRoles.owner),
+        makeSamUserResponse(nonUSWorkspace.workspaceId, SamWorkspaceRoles.owner),
+        makeSamUserResponse(migratingWorkspace.workspaceId, SamWorkspaceRoles.owner),
+        makeSamUserResponse(recentlyMigratedWorkspace.workspaceId, SamWorkspaceRoles.owner),
+        makeSamUserResponse(oldSuccessfullyMigratedWorkspace.workspaceId, SamWorkspaceRoles.owner),
+        makeSamUserResponse(oldUnsuccessfullyMigratedWorkspace.workspaceId, SamWorkspaceRoles.owner)
+      )
+      when(samDAO.listUserResources(SamResourceTypeNames.workspace, userCtx))
+        .thenReturn(Future.successful(samResources))
+
+      val usBucket = mock[Bucket]
+      when(usBucket.getLocation).thenReturn("US")
+      val nonUSBucket = mock[Bucket]
+      when(nonUSBucket.getLocation).thenReturn("us-central1")
+      when(gcsDAO.getBucket(any(), any())(any())).thenReturn(Future.successful(Right(usBucket)))
+      when(gcsDAO.getBucket(ArgumentMatchers.eq(nonUSWorkspace.bucketName), any())(any()))
+        .thenReturn(Future.successful(Right(nonUSBucket)))
+
+      Await.result(
+        slickDataSource.inTransaction { dataAccess =>
+          for {
+            _ <- dataAccess.workspaceQuery.createOrUpdate(nonOwnedWorkspace)
+            _ <- dataAccess.workspaceQuery.createOrUpdate(usWorkspace)
+            _ <- dataAccess.workspaceQuery.createOrUpdate(nonUSWorkspace)
+            _ <- dataAccess.workspaceQuery.createOrUpdate(migratingWorkspace)
+            _ <- dataAccess.workspaceQuery.createOrUpdate(recentlyMigratedWorkspace)
+            _ <- dataAccess.workspaceQuery.createOrUpdate(oldSuccessfullyMigratedWorkspace)
+            _ <- dataAccess.workspaceQuery.createOrUpdate(oldUnsuccessfullyMigratedWorkspace)
+
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(migratingWorkspace, "US".some)
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(recentlyMigratedWorkspace, "US".some)
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(oldSuccessfullyMigratedWorkspace, "US".some)
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(oldUnsuccessfullyMigratedWorkspace, "US".some)
+
+            recentlyMigratedAttempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(recentlyMigratedWorkspace.workspaceIdAsUUID)
+              .value
+            oldSuccessfullyMigratedAttempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(oldSuccessfullyMigratedWorkspace.workspaceIdAsUUID)
+              .value
+            oldUnsuccessfullyMigratedAttempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(oldUnsuccessfullyMigratedWorkspace.workspaceIdAsUUID)
+              .value
+
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+              recentlyMigratedAttempt.getOrElse(fail()).id,
+              multiregionalBucketMigrationQuery.finishedCol,
+              Timestamp.from(Instant.now().minusSeconds(86400)).some,
+              multiregionalBucketMigrationQuery.outcomeCol,
+              "Success".some
+            )
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+              oldSuccessfullyMigratedAttempt.getOrElse(fail()).id,
+              multiregionalBucketMigrationQuery.finishedCol,
+              Timestamp.from(Instant.now().minusSeconds(86400 * 10)).some,
+              multiregionalBucketMigrationQuery.outcomeCol,
+              "Success".some
+            )
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update3(
+              oldUnsuccessfullyMigratedAttempt.getOrElse(fail()).id,
+              multiregionalBucketMigrationQuery.finishedCol,
+              Timestamp.from(Instant.now().minusSeconds(86400 * 10)).some,
+              multiregionalBucketMigrationQuery.outcomeCol,
+              "Failure".some,
+              multiregionalBucketMigrationQuery.messageCol,
+              "reason the migration failed".some
+            )
+          } yield ()
+        },
+        Duration.Inf
+      )
+
+      val res = Await.result(bucketMigrationService.getEligibleOrMigratingWorkspaces, Duration.Inf)
+      res.map {
+        case (name, None) if name.equals(usWorkspace.toWorkspaceName.toString) =>
+        case (name, Some(migrationProgress)) if name.equals(migratingWorkspace.toWorkspaceName.toString) =>
+          migrationProgress.outcome shouldBe None
+        case (name, Some(migrationProgress)) if name.equals(recentlyMigratedWorkspace.toWorkspaceName.toString) =>
+          migrationProgress.outcome shouldBe Some(Outcome.Success)
+        case (name, Some(migrationProgress))
+            if name.equals(oldUnsuccessfullyMigratedWorkspace.toWorkspaceName.toString) =>
+          assert(migrationProgress.outcome.getOrElse(fail()).isFailure)
+        case regrets => fail(s"unexpected workspace with progress found: $regrets")
+      }
   }
 
   private def insertSTSJobs(workspace: Workspace): Future[Unit] =


### PR DESCRIPTION
Ticket: [WOR-1259](https://broadworkbench.atlassian.net/browse/WOR-1259)
* Add API to fetch workspaces for display in UI bucket migrations page
* Include unmigrated workspaces with US multiregion bucket, workspaces currently migrating, and workspaces that have successfully migrated in the past 7 days or that have failed migration.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1259]: https://broadworkbench.atlassian.net/browse/WOR-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ