### PR TITLE
AJ-1348: disable alpha-only integration tests; replace with unit tests

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/SnapshotAPISpec.scala
@@ -54,7 +54,8 @@ class SnapshotAPISpec
   "TDR Snapshot integration" - {
     // as of this writing, hermione.owner is the user with access to snapshots
 
-    "should be able to contact Data Repo" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) in {
+    // ignore - this test is only valid as an integration test, and we are moving assertions away from integration tests
+    "should be able to contact Data Repo" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) ignore {
       // status API is unauthenticated, but all our utility methods expect a token.
       // so, we'll send a token to the unauthenticated API to make this code path easier.
       val owner = UserPool.userConfig.Owners.getUserCredential("hermione")
@@ -66,7 +67,14 @@ class SnapshotAPISpec
       }
     }
 
-    "should allow snapshot references to be added to workspaces" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) in {
+    // ignore - covered by:
+    // SnapshotServiceSpec:
+    //  - "create a new snapshot reference to a TDR snapshot"
+    //  - "create a WSM workspace if one doesn't exist when creating a snapshot reference"
+    //  - "not create a WSM workspace if one already exists when creating a snapshot reference"
+    // SnapshotApiServiceSpec:
+    //  - "return 200 when a user lists all snapshots in a workspace"
+    "should allow snapshot references to be added to workspaces" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) ignore {
       val owner = UserPool.userConfig.Owners.getUserCredential("hermione")
 
       implicit val ownerAuthToken: AuthToken = owner.makeAuthToken()
@@ -112,7 +120,11 @@ class SnapshotAPISpec
       }(owner.makeAuthToken(billingScopes))
     }
 
-    "should report the same tables/columns via metadata API as TDR reports" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) in {
+    // ignore - covered by
+    // DataRepoEntityProviderSpec:
+    //  - "return entity type metadata in the golden path"
+    //  - "return an empty Map if data repo snapshot has no tables"
+    "should report the same tables/columns via metadata API as TDR reports" taggedAs (Tags.AlphaTest, Tags.ExcludeInFiab) ignore {
       val numSnapshotsToVerify = 2
 
       val owner = UserPool.userConfig.Owners.getUserCredential("hermione")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -104,23 +104,24 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         mockDataRepoDAO
       )(testContext)
 
+      val snapshotUuid = UUID.randomUUID()
+      val snapRefName = DataReferenceName("refname")
+      val snapRefDescription = Option(DataReferenceDescriptionField("my reference description"))
+
       // call createSnapshot on the service
       Await.result(
         snapshotService.createSnapshot(workspace.toWorkspaceName,
-                                       NamedDataRepoSnapshot(DataReferenceName("foo"),
-                                                             Option(DataReferenceDescriptionField("foo")),
-                                                             UUID.randomUUID()
-                                       )
+                                       NamedDataRepoSnapshot(snapRefName, snapRefDescription, snapshotUuid)
         ),
         Duration.Inf
       )
 
       // assert that the service called WSM's createDataRepoSnapshotReference
       verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(
-        any[UUID],
-        any[UUID],
-        any[DataReferenceName],
-        any[Option[DataReferenceDescriptionField]],
+        ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
+        ArgumentMatchers.eq(snapshotUuid),
+        ArgumentMatchers.eq(snapRefName),
+        ArgumentMatchers.eq(snapRefDescription),
         any[String],
         any[CloningInstructionsEnum],
         any[RawlsRequestContext]
@@ -160,13 +161,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       // assert that the service checked to see if the workspace exists
       verify(mockWorkspaceManagerDAO, times(1)).getWorkspace(
-        any[UUID],
+        ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         any[RawlsRequestContext]
       )
 
       // assert that the service called WSM's createWorkspace
       verify(mockWorkspaceManagerDAO, times(1)).createWorkspace(
-        any[UUID],
+        ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         any[RawlsRequestContext]
       )
     }
@@ -202,7 +203,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
         // assert that the service checked to see if the workspace exists
         verify(mockWorkspaceManagerDAO, times(1)).getWorkspace(
-          any[UUID],
+          ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
           any[RawlsRequestContext]
         )
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1348

We have a few integration tests (aka Jenkins swatomation) that run exclusively in the alpha environment.

This PR ignores/disables all of those tests. Most of them already had equivalent unit tests, and this PR adds a couple unit tests to make up the remainder of the coverage.

Note that I am NOT yet fully deleting the alpha tests, simply ignoring them. I want to make sure that reducing to 0 tests does not cause problems for the Jenkins job and this makes it super easy to turn a test back on if necessary. I will delete the alpha tests fully once I see Jenkins succeed. I will leave the AJ-1348 ticket open until the tests are deleted.



---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
