### PR TITLE
[WOR-732] Remove leo app enabling workaround during clone

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -58,40 +58,20 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                spendProfileId: String,
                                                billingProjectNamespace: String,
                                                applicationIds: Seq[String],
+                                               policyInputs: Option[WsmPolicyInputs],
                                                ctx: RawlsRequestContext
-  ): CreatedWorkspace =
-    getWorkspaceApi(ctx).createWorkspace(
-      new CreateWorkspaceRequestBody()
-        .id(workspaceId)
-        .displayName(displayName)
-        .spendProfile(spendProfileId)
-        .stage(WorkspaceStageModel.MC_WORKSPACE)
-        .projectOwnerGroupId(billingProjectNamespace)
-        .applicationIds(applicationIds.asJava)
-    )
-
-  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
-                                                        displayName: String,
-                                                        spendProfileId: String,
-                                                        billingProjectNamespace: String,
-                                                        ctx: RawlsRequestContext
   ): CreatedWorkspace = {
-    val policyInputs = new WsmPolicyInputs()
-    val protectedPolicyInput = new WsmPolicyInput()
-    protectedPolicyInput.name("protected-data")
-    protectedPolicyInput.namespace("terra")
-    protectedPolicyInput.additionalData(List().asJava)
+    val request = new CreateWorkspaceRequestBody()
+      .id(workspaceId)
+      .displayName(displayName)
+      .spendProfile(spendProfileId)
+      .stage(WorkspaceStageModel.MC_WORKSPACE)
+      .projectOwnerGroupId(billingProjectNamespace)
+      .applicationIds(applicationIds.asJava)
 
-    policyInputs.addInputsItem(protectedPolicyInput)
-    getWorkspaceApi(ctx).createWorkspace(
-      new CreateWorkspaceRequestBody()
-        .id(workspaceId)
-        .displayName(displayName)
-        .spendProfile(spendProfileId)
-        .stage(WorkspaceStageModel.MC_WORKSPACE)
-        .policies(policyInputs)
-        .projectOwnerGroupId(billingProjectNamespace)
-    )
+    policyInputs.map(request.policies)
+
+    getWorkspaceApi(ctx).createWorkspace(request)
   }
 
   override def cloneWorkspace(sourceWorkspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -57,6 +57,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                displayName: String,
                                                spendProfileId: String,
                                                billingProjectNamespace: String,
+                                               applicationIds: Seq[String],
                                                ctx: RawlsRequestContext
   ): CreatedWorkspace =
     getWorkspaceApi(ctx).createWorkspace(
@@ -66,6 +67,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
         .spendProfile(spendProfileId)
         .stage(WorkspaceStageModel.MC_WORKSPACE)
         .projectOwnerGroupId(billingProjectNamespace)
+        .applicationIds(applicationIds.asJava)
     )
 
   override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
@@ -201,21 +203,6 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                            ResourceType.DATA_REPO_SNAPSHOT,
                                            StewardshipType.REFERENCED
     )
-
-  override def enableApplication(workspaceId: UUID,
-                                 applicationId: String,
-                                 ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription =
-    getWorkspaceApplicationApi(ctx).enableWorkspaceApplication(
-      workspaceId,
-      applicationId
-    )
-
-  override def disableApplication(workspaceId: UUID,
-                                  applicationId: String,
-                                  ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription =
-    getWorkspaceApplicationApi(ctx).disableWorkspaceApplication(workspaceId, applicationId)
 
   override def createAzureStorageContainer(workspaceId: UUID,
                                            storageContainerName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -17,6 +17,7 @@ trait WorkspaceManagerDAO {
                                       displayName: String,
                                       spendProfileId: String,
                                       billingProjectNamespace: String,
+                                      applicationIds: Seq[String],
                                       ctx: RawlsRequestContext
   ): CreatedWorkspace
 
@@ -79,14 +80,6 @@ trait WorkspaceManagerDAO {
                                           limit: Int,
                                           ctx: RawlsRequestContext
   ): ResourceList
-  def enableApplication(workspaceId: UUID,
-                        applicationId: String,
-                        ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription
-  def disableApplication(workspaceId: UUID,
-                         applicationId: String,
-                         ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription
 
   /**
     * Creates an Azure storage container in the workspace. This container will be created in the workspace's

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -18,15 +18,11 @@ trait WorkspaceManagerDAO {
                                       spendProfileId: String,
                                       billingProjectNamespace: String,
                                       applicationIds: Seq[String],
+                                      policyInputs: Option[WsmPolicyInputs],
                                       ctx: RawlsRequestContext
   ): CreatedWorkspace
 
-  def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
-                                               displayName: String,
-                                               spendProfileId: String,
-                                               billingProjectNamespace: String,
-                                               ctx: RawlsRequestContext
-  ): CreatedWorkspace
+
 
   def cloneWorkspace(sourceWorkspaceId: UUID,
                      workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -387,16 +387,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                           getWorkspaceCloneStatus
           )
         }
-        _ <- traceWithParent("workspaceManagerDAO.disableLeo", parentContext) { context =>
-          Future(blocking {
-            workspaceManagerDAO.disableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, context)
-          })
-        }
-        _ <- traceWithParent("workspaceManagerDAO.reenableLeo", parentContext) { context =>
-          Future(blocking {
-            workspaceManagerDAO.enableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, context)
-          })
-        }
 
         _ = logger.info(
           s"Starting workspace storage container clone in WSM [workspaceId = ${workspaceId}]"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -625,6 +625,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                                                   workspaceRequest.name,
                                                                   spendProfileId,
                                                                   workspaceRequest.namespace,
+                                                                  Seq(wsmConfig.leonardoWsmApplicationId),
                                                                   ctx
               )
             )
@@ -649,10 +650,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
         )
       )
 
-      _ = logger.info(s"Enabling leonardo app in WSM [workspaceId = ${workspaceId}]")
-      _ <- traceWithParent("enableLeoInWSM", parentContext)(_ =>
-        Future(workspaceManagerDAO.enableApplication(workspaceId, wsmConfig.leonardoWsmApplicationId, ctx))
-      )
       containerResult <- traceWithParent("createStorageContainer", parentContext)(_ =>
         Future(
           workspaceManagerDAO.createAzureStorageContainer(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -55,22 +55,6 @@ class HttpWorkspaceManagerDAOSpec
     override def getUnauthenticatedApi(): UnauthenticatedApi = ???
   }
 
-  behavior of "enableApplication"
-
-  it should "call the WSM app API" in {
-    val workspaceApplicationApi = mock[WorkspaceApplicationApi]
-    val controlledAzureResourceApi = mock[ControlledAzureResourceApi]
-
-    val wsmDao = new HttpWorkspaceManagerDAO(
-      getApiClientProvider(workspaceApplicationApi = workspaceApplicationApi,
-                           controlledAzureResourceApi = controlledAzureResourceApi
-      )
-    )
-
-    wsmDao.enableApplication(workspaceId, "leo", testContext)
-    verify(workspaceApplicationApi).enableWorkspaceApplication(workspaceId, "leo")
-  }
-
   def assertControlledResourceCommonFields(commonFields: ControlledResourceCommonFields,
                                            expectedCloningInstructions: CloningInstructionsEnum =
                                              CloningInstructionsEnum.NOTHING,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -259,7 +259,7 @@ class HttpWorkspaceManagerDAOSpec
     verify(workspaceApi).cloneWorkspace(expectedRequest, testData.azureWorkspace.workspaceIdAsUUID)
   }
 
-  behavior of "createProtectedWorkspaceWithSpendProfile"
+  behavior of "createWorkspaceWithSpendProfile"
 
   it should "call the WSM workspace API" in {
     val workspaceApi = mock[WorkspaceApi]
@@ -279,14 +279,17 @@ class HttpWorkspaceManagerDAOSpec
       .displayName(testData.azureWorkspace.name)
       .spendProfile(testData.azureBillingProfile.getId.toString)
       .stage(WorkspaceStageModel.MC_WORKSPACE)
+      .applicationIds(Seq("exampleApp").asJava)
       .policies(policyInputs)
       .projectOwnerGroupId(billingProjectId)
 
-    wsmDao.createProtectedWorkspaceWithSpendProfile(
+    wsmDao.createWorkspaceWithSpendProfile(
       testData.azureWorkspace.workspaceIdAsUUID,
       testData.azureWorkspace.name,
       testData.azureBillingProfile.getId.toString,
       billingProjectId,
+      Seq("exampleApp"),
+      Some(policyInputs),
       testContext
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -202,6 +202,7 @@ class MockWorkspaceManagerDAO(
                                                displayName: String,
                                                spendProfileId: String,
                                                billingProjectNamespace: String,
+                                               applicationIds: Seq[String],
                                                ctx: RawlsRequestContext
   ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
@@ -221,18 +222,6 @@ class MockWorkspaceManagerDAO(
                                                     jobControlId: String,
                                                     ctx: RawlsRequestContext
   ): CreateCloudContextResult = mockCreateAzureCloudContextResult()
-
-  override def enableApplication(workspaceId: UUID,
-                                 applicationId: String,
-                                 ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription =
-    new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
-
-  override def disableApplication(workspaceId: UUID,
-                                  applicationId: String,
-                                  ctx: RawlsRequestContext
-  ): WorkspaceApplicationDescription =
-    new WorkspaceApplicationDescription().workspaceId(workspaceId).applicationId(applicationId)
 
   override def createAzureStorageContainer(workspaceId: UUID,
                                            storageContainerName: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -203,15 +203,8 @@ class MockWorkspaceManagerDAO(
                                                spendProfileId: String,
                                                billingProjectNamespace: String,
                                                applicationIds: Seq[String],
+                                               policyInputs: Option[WsmPolicyInputs],
                                                ctx: RawlsRequestContext
-  ): CreatedWorkspace =
-    mockCreateWorkspaceResponse(workspaceId)
-
-  override def createProtectedWorkspaceWithSpendProfile(workspaceId: UUID,
-                                                        displayName: String,
-                                                        spendProfileId: String,
-                                                        billingProjectNamespace: String,
-                                                        ctx: RawlsRequestContext
   ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -1324,10 +1324,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
             }
           } yield {
             verify(mcWorkspaceService.workspaceManagerDAO, times(1))
-              .disableApplication(any(), any(), any())
-            verify(mcWorkspaceService.workspaceManagerDAO, times(1))
-              .enableApplication(any(), any(), any())
-            verify(mcWorkspaceService.workspaceManagerDAO, times(1))
               .cloneAzureStorageContainer(
                 equalTo(testData.azureWorkspace.workspaceIdAsUUID),
                 equalTo(clone.workspaceIdAsUUID),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -649,6 +649,12 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
 
   it should "still delete from the database when cleaning up the workspace in WSM fails" in {
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO() {
+      override def createAzureStorageContainer(workspaceId: UUID,
+                                               storageContainerName: String,
+                                               ctx: RawlsRequestContext
+      ): CreatedControlledAzureStorageContainer =
+        throw new ApiException(500, "error")
+
       override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit =
         throw new ApiException(500, "no take backsies")
     })

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -51,6 +51,7 @@ import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
+import scala.jdk.CollectionConverters._
 
 class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with OptionValues with TestDriverComponent {
 
@@ -420,7 +421,8 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         ArgumentMatchers.eq(name),
         any(), // spend profile id
         ArgumentMatchers.eq(namespace),
-        any(),
+        any[Seq[String]],
+        any[Option[WsmPolicyInputs]],
         ArgumentMatchers.eq(testContext)
       )
     Mockito
@@ -559,6 +561,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
                                                    spendProfileId: String,
                                                    billingProjectNamespace: String,
                                                    applicationIds: Seq[String],
+                                                   policyInputs: Option[WsmPolicyInputs],
                                                    ctx: RawlsRequestContext
       ): CreatedWorkspace = throw new ApiException(500, "whoops")
 
@@ -712,11 +715,25 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
 
     Mockito
       .verify(workspaceManagerDAO)
-      .createProtectedWorkspaceWithSpendProfile(
+      .createWorkspaceWithSpendProfile(
         ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
         ArgumentMatchers.eq("fake_name"),
         ArgumentMatchers.anyString(),
         ArgumentMatchers.eq(namespace),
+        any[Seq[String]],
+        ArgumentMatchers.eq(
+          Some(
+            new WsmPolicyInputs()
+              .inputs(
+                Seq(
+                  new WsmPolicyInput()
+                    .name("protected-data")
+                    .namespace("terra")
+                    .additionalData(List().asJava)
+                ).asJava
+              )
+          )
+        ),
         ArgumentMatchers.eq(testContext)
       )
 
@@ -728,6 +745,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         ArgumentMatchers.anyString(),
         ArgumentMatchers.eq(namespace),
         any(),
+        ArgumentMatchers.eq(None),
         ArgumentMatchers.any()
       )
   }


### PR DESCRIPTION
[Ticket WOR-732](https://broadworkbench.atlassian.net/browse/WOR-732)

## Context
WSM was not enabling applications properly during workspace clone due to a bug. Now that the bug has been [remediated](https://github.com/DataBiosphere/terra-workspace-manager/commit/0c7b05dc00fab0aa07ae47326ce3f7f717a5cda1) we no longer need the workaround of disabling/enabling to trigger the correct behavior. 

## This PR
* Removes the hack and updates associated tests.
