### PR TITLE
AJ-1309: Disable cross-platform snapshots-by-reference

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -158,7 +158,11 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   ): DataRepoSnapshotResource = {
     val snapshot = new DataRepoSnapshotAttributes().instanceName(instanceName).snapshot(snapshotId.toString)
     val commonFields =
-      new ReferenceResourceCommonFields().name(name.value).cloningInstructions(CloningInstructionsEnum.NOTHING)
+      new ReferenceResourceCommonFields()
+        .name(name.value)
+        // Note: that we're ignoring the passed in `cloningInstructions` is a known issue, addressed as part of
+        // https://github.com/broadinstitute/rawls/pull/2081
+        .cloningInstructions(CloningInstructionsEnum.NOTHING)
     description.map(d => commonFields.description(d.value))
     val request = new CreateDataRepoSnapshotReferenceRequestBody().snapshot(snapshot).metadata(commonFields)
     getReferencedGcpResourceApi(ctx).createDataRepoSnapshotReference(request, workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
@@ -1,0 +1,54 @@
+package org.broadinstitute.dsde.rawls.snapshot
+
+import bio.terra.datarepo.model.{CloudPlatform => SnapshotCloudPlatform}
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.model.WorkspaceCloudPlatform.WorkspaceCloudPlatform
+import org.broadinstitute.dsde.rawls.model.{Workspace, WorkspaceCloudPlatform}
+
+object SnapshotReferenceCreationValidator {
+  def constructor(workspaceContext: Workspace, snapshot: WrappedSnapshot): SnapshotReferenceCreationValidator =
+    new SnapshotReferenceCreationValidator(workspaceContext, snapshot)
+}
+
+// thrown to disallow creation of a snapshot reference on an unsupported platform
+class UnsupportedPlatformException(message: String) extends RawlsException(message)
+// thrown to disallow creation of a snapshot reference across cloud boundaries
+class PlatformBoundaryException(message: String) extends RawlsException(message)
+// thrown to disallow creation of a snapshot reference across a protected data boundary
+class ProtectedDataException(message: String) extends RawlsException(message)
+
+class SnapshotReferenceCreationValidator(val workspaceContext: Workspace, val snapshot: WrappedSnapshot) {
+
+  // Ideally this would rely on Terra Policy Service, but until TPS is enabled for GCP
+  // We'll have to use this workaround for identifying protected status.
+  @throws(classOf[ProtectedDataException])
+  def validateProtectedStatus(): Unit =
+    if (!isWorkspaceProtected && snapshot.isProtected) {
+      throw new ProtectedDataException("Unable to add protected snapshot to unprotected workspace.")
+    }
+
+  // Throws an exception when the given snapshot cannot be referenced by the given workspace due to crossing an
+  // unsupported platform boundary.
+  @throws(classOf[PlatformBoundaryException])
+  def validateWorkspacePlatformCompatibility(workspacePlatform: WorkspaceCloudPlatform): Unit =
+    // Defining all acceptable combinations is overkill when all we really need to do is prevent anything Azure, but
+    // this is here as a safeguard against us introducing support for Azure without deliberately addressing the issue of
+    // snapshots by ref across cloud platforms.
+    (snapshot.platform, workspacePlatform) match {
+      case (SnapshotCloudPlatform.GCP, WorkspaceCloudPlatform.Gcp) => // ok
+      case _ =>
+        throw new PlatformBoundaryException(
+          "Snapshots by reference are not supported across the given cloud boundaries (" +
+            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform})."
+        )
+    }
+
+  @throws(classOf[UnsupportedPlatformException])
+  def validateSnapshotPlatform(): Unit =
+    if (snapshot.platform == SnapshotCloudPlatform.AZURE) {
+      throw new UnsupportedPlatformException("Snapshots by reference are not supported for Azure datasets.")
+    }
+
+  // TODO: get this information from a more authoritative source rather than relying on the hardcoded bucket prefix
+  private def isWorkspaceProtected: Boolean = workspaceContext.bucketName.startsWith("fc-secure")
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   SnapshotListResponse,
   WorkspaceAttributeSpecs,
+  WorkspaceCloudPlatform,
   WorkspaceName
 }
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
@@ -73,7 +74,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         snapshotValidator.validateWorkspacePlatformCompatibility(wsmWorkspace.getCloudPlatform)
       } catch {
         case _: AggregateWorkspaceNotFoundException =>
-          // create the stub workspace in WSM if it does not already exist
+          // if a WSM workspace does not already exist, assume the platform is GCP, confirm platform compatibility,
+          // and then create a stub workspace
+          snapshotValidator.validateWorkspacePlatformCompatibility(WorkspaceCloudPlatform.Gcp)
           workspaceManagerDAO.createWorkspace(wsid, rawlsWorkspace.workspaceType, ctx)
       }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -34,7 +34,14 @@ object SnapshotService {
                   terraDataRepoUrl: String,
                   dataRepoDAO: DataRepoDAO
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SnapshotService =
-    new SnapshotService(ctx, dataSource, samDAO, workspaceManagerDAO, terraDataRepoUrl, dataRepoDAO)
+    new SnapshotService(ctx,
+                        dataSource,
+                        samDAO,
+                        workspaceManagerDAO,
+                        terraDataRepoUrl,
+                        dataRepoDAO,
+                        new AggregatedWorkspaceService(workspaceManagerDAO)
+    )
 }
 
 class SnapshotService(protected val ctx: RawlsRequestContext,
@@ -42,7 +49,8 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
                       val samDAO: SamDAO,
                       workspaceManagerDAO: WorkspaceManagerDAO,
                       terraDataRepoInstanceName: String,
-                      dataRepoDAO: DataRepoDAO
+                      dataRepoDAO: DataRepoDAO,
+                      aggregatedWorkspaceService: AggregatedWorkspaceService
 )(implicit protected val executionContext: ExecutionContext)
     extends FutureSupport
     with WorkspaceSupport
@@ -59,7 +67,6 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
       val snapshot =
         new WrappedSnapshot(dataRepoDAO.getSnapshot(snapshotIdentifiers.snapshotId, ctx.userInfo.accessToken))
       val snapshotValidator = new SnapshotReferenceCreationValidator(rawlsWorkspace, snapshot)
-      val aggregatedWorkspaceService = new AggregatedWorkspaceService(workspaceManagerDAO)
 
       // prevent snapshots from disallowed platforms
       snapshotValidator.validateSnapshotPlatform()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/WrappedSnapshot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/WrappedSnapshot.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.rawls.snapshot
+
+import bio.terra.datarepo.model.{CloudPlatform, DatasetSummaryModel, SnapshotModel}
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+// A basic wrapper class to simplify interaction with the SnapshotModel from TDR
+class WrappedSnapshot(snapshot: SnapshotModel) {
+
+  // While getSource returns a list of SnapshotSourceModels, this is an artifact and we can make an assumption that
+  // a given snapshot will have exactly one source that will always have a dataset.  Violations of this assumption
+  // indicate a bug, in which case, crash and burn.
+  private def snapshotDataset(): DatasetSummaryModel = getOnlyElement(snapshot.getSource.asScala.toList).getDataset
+
+  private def getOnlyElement[A](list: List[A]): A = list match {
+    case head :: Nil => head
+    case _           => throw new NoSuchElementException(s"Expected exactly one element, but found ${list.size}")
+  }
+
+  def isProtected: Boolean = snapshotDataset().isSecureMonitoringEnabled()
+
+  def platform: CloudPlatform = snapshotDataset().getCloudPlatform
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockDataRepoDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.mock
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.datarepo.model.{DatasetSummaryModel, SnapshotModel, SnapshotSourceModel}
+import bio.terra.datarepo.model.{CloudPlatform, DatasetSummaryModel, SnapshotModel, SnapshotSourceModel}
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 
 import java.util.UUID
@@ -9,14 +9,13 @@ import java.util.UUID
 class MockDataRepoDAO(instanceName: String) extends DataRepoDAO {
   override def getInstanceName: String = instanceName
 
-  override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel = {
-    val snap = new SnapshotModel()
-    snap.id(snapshotId)
-    snap.name("snapshotName")
-    snap.description("snapshotDescription")
-    snap.source(java.util.List.of(new SnapshotSourceModel().dataset(new DatasetSummaryModel())))
+  override def getSnapshot(snapshotId: UUID, accessToken: OAuth2BearerToken): SnapshotModel =
+    new SnapshotModel()
+      .id(snapshotId)
+      .name("snapshotName")
+      .description("snapshotDescription")
+      .source(
+        java.util.List.of(new SnapshotSourceModel().dataset(new DatasetSummaryModel().cloudPlatform(CloudPlatform.GCP)))
+      )
 
-    snap
-
-  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -9,7 +9,12 @@ import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
-import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, ErrorReport, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceDescriptionField,
+  DataReferenceName,
+  ErrorReport,
+  RawlsRequestContext
+}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import java.util.UUID
@@ -23,7 +28,8 @@ class MockWorkspaceManagerDAO(
 
   val references: TrieMap[(UUID, UUID), DataRepoSnapshotResource] = TrieMap()
 
-  def mockGetWorkspaceResponse(workspaceId: UUID) = new WorkspaceDescription().id(workspaceId)
+  def mockGetWorkspaceResponse(workspaceId: UUID) =
+    new WorkspaceDescription().id(workspaceId).gcpContext(new GcpContext().projectId("some-project-id"))
   def mockCreateWorkspaceResponse(workspaceId: UUID) = new CreatedWorkspace().id(workspaceId)
   def mockReferenceResponse(workspaceId: UUID, referenceId: UUID) = references.getOrElse(
     (workspaceId, referenceId),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -1,7 +1,12 @@
 package org.broadinstitute.dsde.rawls.snapshot
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.datarepo.model.{DatasetSummaryModel, SnapshotModel, SnapshotSourceModel}
+import bio.terra.datarepo.model.{
+  CloudPlatform => SnapshotCloudPlatform,
+  DatasetSummaryModel,
+  SnapshotModel,
+  SnapshotSourceModel
+}
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.RawlsException
@@ -57,10 +62,12 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     mockSamDAO
   }
 
-  // create a mockito-powered WorkspaceManagerDAO that always returns success for creating
-  // a snapshot reference. Tests can add more responses/expectations to the mock returned by this method.
+  // create a mockito-powered WorkspaceManagerDAO that always returns a stubbed WSM workspace, and succeeds when
+  // creating a snapshot reference. Tests should add to or override these default behaviors to verify other scenarios.
   private def defaultMockWorkspaceManagerDao() = {
     val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
+    when(mockWorkspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext]))
+      .thenReturn(new WorkspaceDescription().gcpContext(new GcpContext().projectId("project-id")))
     when(
       mockWorkspaceManagerDAO.createDataRepoSnapshotReference(
         any[UUID],
@@ -87,14 +94,33 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
     mockWorkspaceManagerDAO
   }
 
+  // create a mockito-powered DataRepoDAO that always returns a stubbed snapshot
+  private def defaultDataRepoDao(): DataRepoDAO = {
+    val mockDataRepoDAO = mock[DataRepoDAO](RETURNS_SMART_NULLS)
+    when(
+      mockDataRepoDAO.getSnapshot(
+        any[UUID],
+        any[OAuth2BearerToken]
+      )
+    )
+      .thenReturn(
+        new SnapshotModel()
+          .id(java.util.UUID.randomUUID())
+          .name("snapshot")
+          .description("snapshot description")
+          .source(
+            java.util.List
+              .of(new SnapshotSourceModel().dataset(new DatasetSummaryModel().cloudPlatform(SnapshotCloudPlatform.GCP)))
+          )
+      )
+    mockDataRepoDAO
+  }
+
   "SnapshotService" should {
     "create a new snapshot reference to a TDR snapshot" in withMinimalTestDatabase { _ =>
       val mockSamDAO = defaultMockSamDao()
-
       val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()
-
-      val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
-
+      val mockDataRepoDAO = defaultDataRepoDao()
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
@@ -118,7 +144,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )
 
       // assert that the service called WSM's createDataRepoSnapshotReference
-      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(
+      verify(mockWorkspaceManagerDAO).createDataRepoSnapshotReference(
         ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         ArgumentMatchers.eq(snapshotUuid),
         ArgumentMatchers.eq(snapRefName),
@@ -135,7 +161,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()
       when(
         mockWorkspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])
-      ).thenAnswer(_ => new ApiException(404, "Workspace does not exist"))
+      ).thenAnswer(_ => throw new ApiException(404, "Workspace does not exist"))
 
       val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
 
@@ -161,13 +187,13 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )
 
       // assert that the service checked to see if the workspace exists
-      verify(mockWorkspaceManagerDAO, times(1)).getWorkspace(
+      verify(mockWorkspaceManagerDAO).getWorkspace(
         ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         any[RawlsRequestContext]
       )
 
       // assert that the service called WSM's createWorkspace
-      verify(mockWorkspaceManagerDAO, times(1)).createWorkspace(
+      verify(mockWorkspaceManagerDAO).createWorkspace(
         ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         ArgumentMatchers.eq(WorkspaceType.RawlsWorkspace),
         any[RawlsRequestContext]
@@ -204,7 +230,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         )
 
         // assert that the service checked to see if the workspace exists
-        verify(mockWorkspaceManagerDAO, times(1)).getWorkspace(
+        verify(mockWorkspaceManagerDAO).getWorkspace(
           ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
           any[RawlsRequestContext]
         )
@@ -327,7 +353,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         )
       )
 
-      val mockWorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS)
+      val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()
       when(
         mockWorkspaceManagerDAO.createDataRepoSnapshotReference(
           any[UUID],
@@ -352,7 +378,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
             .attributes(new DataRepoSnapshotAttributes())
         )
 
-      val mockDataRepoDAO = mock[DataRepoDAO](RETURNS_SMART_NULLS)
+      val mockDataRepoDAO = defaultDataRepoDao()
       when(
         mockDataRepoDAO.getSnapshot(
           any[UUID],
@@ -366,7 +392,11 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
             .description("snapshot description")
             .source(
               java.util.List
-                .of(new SnapshotSourceModel().dataset(new DatasetSummaryModel().secureMonitoringEnabled(true)))
+                .of(
+                  new SnapshotSourceModel().dataset(
+                    new DatasetSummaryModel().cloudPlatform(SnapshotCloudPlatform.GCP).secureMonitoringEnabled(true)
+                  )
+                )
             )
         )
 
@@ -390,7 +420,187 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         Duration.Inf
       )
 
-      verify(mockWorkspaceManagerDAO, times(1)).createDataRepoSnapshotReference(
+      verify(mockWorkspaceManagerDAO).createDataRepoSnapshotReference(
+        any[UUID],
+        any[UUID],
+        any[DataReferenceName],
+        any[Option[DataReferenceDescriptionField]],
+        any[String],
+        any[CloningInstructionsEnum],
+        any[RawlsRequestContext]
+      )
+    }
+
+    "not create a snapshot reference of an Azure snapshot in a GCP workspace" in withDefaultTestDatabase {
+      // stub an Azure snapshot
+      val mockDataRepoDAO = defaultDataRepoDao()
+      val azureSnapshot = new SnapshotModel()
+        .id(UUID.randomUUID())
+        .name("snapshotName")
+        .description("snapshotDescription")
+        .source(
+          java.util.List.of(
+            new SnapshotSourceModel()
+              .dataset(new DatasetSummaryModel().cloudPlatform(SnapshotCloudPlatform.AZURE))
+          )
+        )
+
+      when(mockDataRepoDAO.getSnapshot(any[UUID], any[OAuth2BearerToken]))
+        .thenReturn(azureSnapshot)
+
+      val snapshotService = SnapshotService.constructor(
+        slickDataSource,
+        defaultMockSamDao(),
+        defaultMockWorkspaceManagerDao(),
+        "fake-terra-data-repo-dev",
+        mockDataRepoDAO
+      )(testContext)
+
+      val thrown = intercept[RawlsException] {
+        Await.result(
+          snapshotService.createSnapshot(
+            testData.workspace.toWorkspaceName, // unless otherwise specified testData workspaces are GCP
+            NamedDataRepoSnapshot(DataReferenceName("refname"),
+                                  Option(DataReferenceDescriptionField("my reference description")),
+                                  UUID.randomUUID()
+            )
+          ),
+          Duration.Inf
+        )
+      }
+      assert(
+        thrown.getMessage === "Snapshots by reference are not supported for Azure datasets."
+      )
+
+      verify(defaultMockWorkspaceManagerDao(), never()).createDataRepoSnapshotReference(
+        any[UUID],
+        any[UUID],
+        any[DataReferenceName],
+        any[Option[DataReferenceDescriptionField]],
+        any[String],
+        any[CloningInstructionsEnum],
+        any[RawlsRequestContext]
+      )
+    }
+
+    "not create a snapshot reference of a GCP snapshot in an Azure workspace" in withDefaultTestDatabase {
+      // stub an Azure workspace
+      val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()
+      val azureWorkspaceDescription = new WorkspaceDescription()
+        .azureContext(
+          new AzureContext()
+            .tenantId(UUID.randomUUID().toString)
+            .subscriptionId(UUID.randomUUID().toString)
+            .resourceGroupId(UUID.randomUUID().toString)
+        )
+        .policies(
+          Seq(
+            new WsmPolicyInput()
+              .name("fakepolicy")
+              .namespace("fakens")
+              .addAdditionalDataItem(new WsmPolicyPair().key("dataKey").value("dataValue"))
+          ).asJava
+        )
+
+      when(mockWorkspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext]))
+        .thenReturn(azureWorkspaceDescription)
+
+      val snapshotService = SnapshotService.constructor(
+        slickDataSource,
+        defaultMockSamDao(),
+        mockWorkspaceManagerDAO,
+        "fake-terra-data-repo-dev",
+        // snapshots are assumed to be GCP unless they belong to a Dataset with the Azure cloudPlatform
+        new MockDataRepoDAO("mockDataRepo")
+      )(testContext)
+
+      val snapshotUuid = UUID.randomUUID()
+      val snapRefName = DataReferenceName("refname")
+      val snapRefDescription = Option(DataReferenceDescriptionField("my reference description"))
+
+      val thrown = intercept[RawlsException] {
+        Await.result(
+          snapshotService.createSnapshot(testData.azureWorkspace.toWorkspaceName,
+                                         NamedDataRepoSnapshot(snapRefName, snapRefDescription, snapshotUuid)
+          ),
+          Duration.Inf
+        )
+      }
+
+      assert(
+        thrown.getMessage === "Snapshots by reference are not supported across the given cloud boundaries (snapshot: gcp, workspace: Azure)."
+      )
+      verify(mockWorkspaceManagerDAO, never()).createDataRepoSnapshotReference(
+        any[UUID],
+        any[UUID],
+        any[DataReferenceName],
+        any[Option[DataReferenceDescriptionField]],
+        any[String],
+        any[CloningInstructionsEnum],
+        any[RawlsRequestContext]
+      )
+    }
+
+    "not create a snapshot reference even if both the snapshot and workspace are Azure" in withDefaultTestDatabase {
+      // stub an Azure workspace
+      val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()
+      val azureWorkspaceDescription = new WorkspaceDescription()
+        .azureContext(
+          new AzureContext()
+            .tenantId(UUID.randomUUID().toString)
+            .subscriptionId(UUID.randomUUID().toString)
+            .resourceGroupId(UUID.randomUUID().toString)
+        )
+        .policies(
+          Seq(
+            new WsmPolicyInput()
+              .name("fakepolicy")
+              .namespace("fakens")
+              .addAdditionalDataItem(new WsmPolicyPair().key("dataKey").value("dataValue"))
+          ).asJava
+        )
+      when(mockWorkspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext]))
+        .thenReturn(azureWorkspaceDescription)
+
+      // stub an Azure snapshot
+      val mockDataRepoDAO = defaultDataRepoDao()
+      val azureSnapshot = new SnapshotModel()
+        .id(UUID.randomUUID())
+        .name("snapshotName")
+        .description("snapshotDescription")
+        .source(
+          Seq(
+            new SnapshotSourceModel()
+              .dataset(new DatasetSummaryModel().cloudPlatform(SnapshotCloudPlatform.AZURE))
+          ).asJava
+        )
+      when(mockDataRepoDAO.getSnapshot(any[UUID], any[OAuth2BearerToken]))
+        .thenReturn(azureSnapshot)
+
+      val snapshotService = SnapshotService.constructor(
+        slickDataSource,
+        defaultMockSamDao(),
+        mockWorkspaceManagerDAO,
+        "fake-terra-data-repo-dev",
+        mockDataRepoDAO
+      )(testContext)
+      val thrown = intercept[RawlsException] {
+        Await.result(
+          snapshotService.createSnapshot(
+            testData.azureWorkspace.toWorkspaceName,
+            NamedDataRepoSnapshot(DataReferenceName("refname"),
+                                  Option(DataReferenceDescriptionField("my reference description")),
+                                  UUID.randomUUID()
+            )
+          ),
+          Duration.Inf
+        )
+      }
+
+      assert(
+        thrown.getMessage === "Snapshots by reference are not supported for Azure datasets."
+      )
+      verify(mockWorkspaceManagerDAO, never()).createDataRepoSnapshotReference(
         any[UUID],
         any[UUID],
         any[DataReferenceName],
@@ -435,7 +645,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
             .attributes(new DataRepoSnapshotAttributes())
         )
 
-      val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
+      val mockDataRepoDAO = defaultDataRepoDao()
       val workspace = minimalTestData.workspace
 
       val snapshotService = SnapshotService.constructor(
@@ -450,12 +660,12 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
 
       Await.result(snapshotService.deleteSnapshot(workspace.toWorkspaceName, snapshotUUID.toString), Duration.Inf)
 
-      verify(mockWorkspaceManagerDAO, times(1)).getDataRepoSnapshotReference(
+      verify(mockWorkspaceManagerDAO).getDataRepoSnapshotReference(
         ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         ArgumentMatchers.eq(snapshotUUID),
         any[RawlsRequestContext]
       )
-      verify(mockWorkspaceManagerDAO, times(1)).deleteDataRepoSnapshotReference(
+      verify(mockWorkspaceManagerDAO).deleteDataRepoSnapshotReference(
         ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
         ArgumentMatchers.eq(snapshotUUID),
         any[RawlsRequestContext]
@@ -791,7 +1001,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         resList
       }
 
-    val mockDataRepoDAO: DataRepoDAO = new MockDataRepoDAO("mockDataRepo")
+    val mockDataRepoDAO = defaultDataRepoDao()
 
     SnapshotService.constructor(
       slickDataSource,


### PR DESCRIPTION
Ticket: [AJ-1309](https://broadworkbench.atlassian.net/browse/AJ-1309)

Update `SnapshotService` to enforce stricter validation around the `cloudPlatform` of the snapshot & workspace.  Basically: disallow Azure-based snapshots by reference entirely, and futureproof the code to ensure that if we _do_ start supporting Azure snapshots by reference that we'll have to bake in support at the appropriate touchpoints in this area of the code.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes (N/A)
  - [x] **...and Orchestration's Swagger too!**(N/A)
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala). (N/A)
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email


[AJ-1309]: https://broadworkbench.atlassian.net/browse/AJ-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ