### PR TITLE
AJ-1309: Allow GCP aggregated workspace

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -6,7 +6,13 @@ import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.api.{ReferencedGcpResourceApi, ResourceApi, WorkspaceApi}
 import bio.terra.workspace.client.ApiClient
 import bio.terra.workspace.model._
-import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceDescriptionField,
+  DataReferenceName,
+  RawlsRequestContext,
+  WorkspaceType
+}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import java.util.UUID
@@ -50,8 +56,16 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription =
     getWorkspaceApi(ctx).getWorkspace(workspaceId, null) // use default value for role
 
-  override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace =
-    getWorkspaceApi(ctx).createWorkspace(new CreateWorkspaceRequestBody().id(workspaceId))
+  override def createWorkspace(workspaceId: UUID,
+                               workspaceType: WorkspaceType,
+                               ctx: RawlsRequestContext
+  ): CreatedWorkspace = {
+    val stage = workspaceType match {
+      case WorkspaceType.RawlsWorkspace => WorkspaceStageModel.RAWLS_WORKSPACE
+      case WorkspaceType.McWorkspace    => WorkspaceStageModel.MC_WORKSPACE
+    }
+    getWorkspaceApi(ctx).createWorkspace(new CreateWorkspaceRequestBody().id(workspaceId).stage(stage))
+  }
 
   override def createWorkspaceWithSpendProfile(workspaceId: UUID,
                                                displayName: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model._
+import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, RawlsRequestContext}
 import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, WorkbenchEmail}
 
@@ -12,7 +13,7 @@ trait WorkspaceManagerDAO {
   val errorReportSource = ErrorReportSource("WorkspaceManager")
 
   def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription
-  def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace
+  def createWorkspace(workspaceId: UUID, workspaceType: WorkspaceType, ctx: RawlsRequestContext): CreatedWorkspace
   def createWorkspaceWithSpendProfile(workspaceId: UUID,
                                       displayName: String,
                                       spendProfileId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspace.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspace.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceCloudPlatform.WorkspaceCloud
 import org.broadinstitute.dsde.rawls.model.{
   AzureManagedAppCoordinates,
   ErrorReport,
+  GoogleProjectId,
   Workspace,
   WorkspaceCloudPlatform,
   WorkspacePolicy,
@@ -14,12 +15,14 @@ import org.broadinstitute.dsde.rawls.model.{
 /**
   * Represents the aggregation of a "rawls" workspace with any data from
   * external sources (i.e,. workspace manager cloud context, policies, etc.)
-  * @param baseWorkspace Source rawls worksapce
+  * @param baseWorkspace Source rawls workspace
+  * @param googleProjectId Google project ID (if present)
   * @param azureCloudContext Azure cloud context (if present)
   * @param policies Terra policies
   */
 case class AggregatedWorkspace(
   baseWorkspace: Workspace,
+  googleProjectId: Option[GoogleProjectId],
   azureCloudContext: Option[AzureManagedAppCoordinates],
   policies: List[WorkspacePolicy]
 ) {
@@ -28,12 +31,14 @@ case class AggregatedWorkspace(
     if (baseWorkspace.workspaceType == WorkspaceType.RawlsWorkspace) {
       return WorkspaceCloudPlatform.Gcp
     }
-    azureCloudContext match {
-      case Some(_) => WorkspaceCloudPlatform.Azure
-      case None =>
+    (googleProjectId, azureCloudContext) match {
+      case (Some(_), None) => WorkspaceCloudPlatform.Gcp
+      case (None, Some(_)) => WorkspaceCloudPlatform.Azure
+      case (_, _) =>
         throw new InvalidCloudContextException(
-          ErrorReport(StatusCodes.NotImplemented,
-                      s"Unexpected state, no cloud context found for workspace ${baseWorkspace.workspaceId}"
+          ErrorReport(
+            StatusCodes.NotImplemented,
+            s"Unexpected state, expected exactly one set of cloud metadata for workspace ${baseWorkspace.workspaceId}"
           )
         )
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -8,12 +8,8 @@ import bio.terra.workspace.model.JobReport.StatusEnum
 import bio.terra.workspace.model._
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{
-  DataReferenceDescriptionField,
-  DataReferenceName,
-  ErrorReport,
-  RawlsRequestContext
-}
+import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
+import org.broadinstitute.dsde.rawls.model.{DataReferenceDescriptionField, DataReferenceName, ErrorReport, RawlsRequestContext}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import java.util.UUID
@@ -44,7 +40,10 @@ class MockWorkspaceManagerDAO(
   override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription =
     mockGetWorkspaceResponse(workspaceId)
 
-  override def createWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): CreatedWorkspace =
+  override def createWorkspace(workspaceId: UUID,
+                               workspaceType: WorkspaceType, // currently ignored by the mock
+                               ctx: RawlsRequestContext
+  ): CreatedWorkspace =
     mockCreateWorkspaceResponse(workspaceId)
 
   override def cloneWorkspace(sourceWorkspaceId: UUID,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -17,7 +17,8 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   SamResourceAction,
   SamResourceTypeNames,
-  SamUserStatusResponse
+  SamUserStatusResponse,
+  WorkspaceType
 }
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -168,6 +169,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       // assert that the service called WSM's createWorkspace
       verify(mockWorkspaceManagerDAO, times(1)).createWorkspace(
         ArgumentMatchers.eq(workspace.workspaceIdAsUUID),
+        ArgumentMatchers.eq(WorkspaceType.RawlsWorkspace),
         any[RawlsRequestContext]
       )
     }
@@ -210,6 +212,7 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
         // assert that the service DID NOT call WSM's createWorkspace
         verify(mockWorkspaceManagerDAO, times(0)).createWorkspace(
           any[UUID],
+          ArgumentMatchers.eq(WorkspaceType.RawlsWorkspace),
           any[RawlsRequestContext]
         )
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceServiceSpec.scala
@@ -18,9 +18,11 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.joda.time.DateTime
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.include
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import java.util.UUID
@@ -30,25 +32,25 @@ import scala.language.postfixOps
 class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
 
   private val rawlsWorkspace = Workspace(
-    "test-namespace",
-    "test-name",
-    "aWorkspaceId",
-    "aBucket",
-    Some("workflow-collection"),
-    new DateTime(),
-    new DateTime(),
-    "test",
-    Map.empty
+    namespace = "test-namespace",
+    name = "test-name",
+    workspaceId = UUID.randomUUID.toString,
+    bucketName = "aBucket",
+    workflowCollectionName = Some("workflow-collection"),
+    createdDate = new DateTime(),
+    lastModified = new DateTime(),
+    createdBy = "test",
+    attributes = Map.empty
   )
 
   private val mcWorkspace = Workspace.buildReadyMcWorkspace(
-    "fake",
-    "fakews",
-    UUID.randomUUID.toString,
-    DateTime.now(),
-    DateTime.now(),
-    "fake",
-    Map.empty
+    namespace = "fake",
+    name = "fakews",
+    workspaceId = UUID.randomUUID.toString,
+    createdDate = DateTime.now(),
+    lastModified = DateTime.now(),
+    createdBy = "fake",
+    attributes = Map.empty
   )
 
   val defaultRequestContext: RawlsRequestContext =
@@ -56,7 +58,7 @@ class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
       UserInfo(RawlsUserEmail("test"), OAuth2BearerToken("Bearer 123"), 123, RawlsUserSubjectId("abc"))
     )
 
-  behavior of "getAggregatedWorkspace"
+  behavior of "fetchAggregatedWorkspace"
 
   it should "combine WSM data with Rawls data for Azure MC workspaces" in {
     val wsmDao = mock[WorkspaceManagerDAO]
@@ -79,7 +81,7 @@ class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
     )
     val svc = new AggregatedWorkspaceService(wsmDao)
 
-    val aggregatedWorkspace = svc.getAggregatedWorkspace(mcWorkspace, defaultRequestContext)
+    val aggregatedWorkspace = svc.fetchAggregatedWorkspace(mcWorkspace, defaultRequestContext)
 
     aggregatedWorkspace.baseWorkspace shouldBe mcWorkspace
     aggregatedWorkspace.azureCloudContext shouldBe Some(azContext)
@@ -99,50 +101,15 @@ class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
 
   it should "combine WSM data with Rawls data for GCP MC workspaces" in {
     val wsmDao = mock[WorkspaceManagerDAO]
-    val googleProjectId = GoogleProjectId("project-id")
-    val policies = Seq(
-      new WsmPolicyInput()
-        .name("fakepolicy")
-        .namespace("fakens")
-        .addAdditionalDataItem(new WsmPolicyPair().key("dataKey").value("dataValue"))
-    )
-    when(wsmDao.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
-      new WorkspaceDescription()
-        .gcpContext(
-          new GcpContext().projectId(googleProjectId.toString())
-        )
-        .policies(policies.asJava)
-    )
+    when(wsmDao.getWorkspace(any[UUID], any[RawlsRequestContext]))
+      .thenReturn(new WorkspaceDescription().gcpContext(new GcpContext().projectId("project-id")))
     val svc = new AggregatedWorkspaceService(wsmDao)
 
-    val aggregatedWorkspace = svc.getAggregatedWorkspace(mcWorkspace, defaultRequestContext)
+    val aggregatedWorkspace = svc.fetchAggregatedWorkspace(mcWorkspace, defaultRequestContext)
 
     aggregatedWorkspace.baseWorkspace shouldBe mcWorkspace
-    aggregatedWorkspace.googleProjectId shouldBe Some(googleProjectId)
+    aggregatedWorkspace.googleProjectId shouldBe Some(GoogleProjectId("project-id"))
     aggregatedWorkspace.getCloudPlatform shouldBe WorkspaceCloudPlatform.Gcp
-    aggregatedWorkspace.policies shouldBe policies.map(input =>
-      WorkspacePolicy(
-        input.getName,
-        input.getNamespace,
-        Option(
-          input.getAdditionalData.asScala.toList
-            .map(data => Map.apply(data.getKey -> data.getValue))
-        )
-          .getOrElse(List.empty)
-      )
-    )
-  }
-
-  it should "not reach out to WSM for legacy GCP Rawls workspaces" in {
-    val wsmDao = mock[WorkspaceManagerDAO]
-    val svc = new AggregatedWorkspaceService(wsmDao)
-
-    val aggregatedWorkspace = svc.getAggregatedWorkspace(rawlsWorkspace, defaultRequestContext)
-
-    aggregatedWorkspace.baseWorkspace shouldBe rawlsWorkspace
-    aggregatedWorkspace.azureCloudContext shouldBe None
-    aggregatedWorkspace.getCloudPlatform shouldBe WorkspaceCloudPlatform.Gcp
-    verify(wsmDao, times(0)).getWorkspace(any[UUID], any[RawlsRequestContext])
   }
 
   it should "raise if the workspace is not found by WSM" in {
@@ -152,7 +119,7 @@ class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
     val svc = new AggregatedWorkspaceService(wsmDao)
 
     intercept[AggregateWorkspaceNotFoundException] {
-      svc.getAggregatedWorkspace(mcWorkspace, defaultRequestContext)
+      svc.optimizedFetchAggregatedWorkspace(mcWorkspace, defaultRequestContext)
     }
 
     verify(wsmDao).getWorkspace(any[UUID], any[RawlsRequestContext])
@@ -165,21 +132,55 @@ class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
     val svc = new AggregatedWorkspaceService(wsmDao)
 
     intercept[WorkspaceAggregationException] {
-      svc.getAggregatedWorkspace(mcWorkspace, defaultRequestContext)
+      svc.optimizedFetchAggregatedWorkspace(mcWorkspace, defaultRequestContext)
     }
 
     verify(wsmDao).getWorkspace(any[UUID], any[RawlsRequestContext])
   }
 
-  it should "raise if the WSM workspace does not have an Azure cloud context" in {
+  it should "raise if the WSM workspace is missing any form of cloud context" in {
     val wsmDao = mock[WorkspaceManagerDAO]
     when(wsmDao.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
       new WorkspaceDescription()
     )
     val svc = new AggregatedWorkspaceService(wsmDao)
 
-    intercept[InvalidCloudContextException] {
-      svc.getAggregatedWorkspace(mcWorkspace, defaultRequestContext)
+    val thrown = intercept[InvalidCloudContextException] {
+      svc.optimizedFetchAggregatedWorkspace(mcWorkspace, defaultRequestContext)
     }
+
+    thrown.getMessage should include("expected exactly one set of cloud metadata")
+  }
+
+  it should "reach out to WSM for legacy GCP rawls workspaces" in {
+    val wsmDao = mock[WorkspaceManagerDAO]
+    when(wsmDao.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
+      new WorkspaceDescription().gcpContext(new GcpContext().projectId("project-id"))
+    )
+    val svc = new AggregatedWorkspaceService(wsmDao)
+
+    val aggregatedWorkspace = svc.fetchAggregatedWorkspace(rawlsWorkspace, defaultRequestContext)
+
+    aggregatedWorkspace.baseWorkspace shouldBe rawlsWorkspace
+    aggregatedWorkspace.azureCloudContext shouldBe None
+    aggregatedWorkspace.getCloudPlatform shouldBe WorkspaceCloudPlatform.Gcp
+    verify(wsmDao).getWorkspace(ArgumentMatchers.eq(rawlsWorkspace.workspaceIdAsUUID), any[RawlsRequestContext])
+  }
+
+  behavior of "optimizedFetchAggregatedWorkspace"
+
+  it should "not reach out to WSM for legacy GCP Rawls workspaces" in {
+    val wsmDao = mock[WorkspaceManagerDAO]
+    when(wsmDao.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
+      new WorkspaceDescription().gcpContext(new GcpContext().projectId("project-id"))
+    )
+    val svc = new AggregatedWorkspaceService(wsmDao)
+
+    val aggregatedWorkspace = svc.optimizedFetchAggregatedWorkspace(rawlsWorkspace, defaultRequestContext)
+
+    aggregatedWorkspace.baseWorkspace shouldBe rawlsWorkspace
+    aggregatedWorkspace.azureCloudContext shouldBe None
+    aggregatedWorkspace.getCloudPlatform shouldBe WorkspaceCloudPlatform.Gcp
+    verify(wsmDao, never()).getWorkspace(any[UUID], any[RawlsRequestContext])
   }
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.model
 
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes.BadRequest
-import bio.terra.workspace.model.WsmPolicyInput
 import cats.implicits._
 import io.lemonlabs.uri.{Uri, Url}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
@@ -22,7 +21,6 @@ import spray.json._
 import java.net.{URLDecoder, URLEncoder}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
-import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object Attributable {


### PR DESCRIPTION
Ticket: [AJ-1309](https://broadworkbench.atlassian.net/browse/AJ-1309)

This PR includes three refactoring commits which should lower the barrier to using `AggregatedWorkspaceService` in `SnapshotService`.

---

**PR checklist**

- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala). _not doing this as it's an internal only change_
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email _(n/a, this is a minor refactoring change that unlocks more functional changes)_


[AJ-1309]: https://broadworkbench.atlassian.net/browse/AJ-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ