### PR TITLE
[WOR-1247] Fix workspace multiregional bucket migration routes

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceV2.scala
@@ -27,16 +27,18 @@ trait WorkspaceApiServiceV2 extends UserInfoDirectives {
     requireUserInfo(Option(span)) { userInfo =>
       val ctx = RawlsRequestContext(userInfo, Option(span))
       pathPrefix("workspaces" / "v2") {
-        path(Segment / Segment) { (namespace, name) =>
+        pathPrefix(Segment / Segment) { (namespace, name) =>
           val workspaceName = WorkspaceName(namespace, name)
-          delete {
-            complete {
-              val workspaceService = workspaceServiceConstructor(ctx)
-              val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
-              mcWorkspaceService
-                .deleteMultiCloudOrRawlsWorkspaceV2(workspaceName, workspaceService)
-                .map(result => StatusCodes.Accepted -> JsObject(Map("result" -> result.toJson)))
+          pathEndOrSingleSlash {
+            delete {
+              complete {
+                val workspaceService = workspaceServiceConstructor(ctx)
+                val mcWorkspaceService = multiCloudWorkspaceServiceConstructor(ctx)
+                mcWorkspaceService
+                  .deleteMultiCloudOrRawlsWorkspaceV2(workspaceName, workspaceService)
+                  .map(result => StatusCodes.Accepted -> JsObject(Map("result" -> result.toJson)))
 
+              }
             }
           } ~
             pathPrefix("bucketMigration") {


### PR DESCRIPTION
Ticket: [WOR-1247](https://broadworkbench.atlassian.net/browse/WOR-1247)
* I messed up the v2 workspaces routes and apparently never tested them manually. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1247]: https://broadworkbench.atlassian.net/browse/WOR-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ