### PR TITLE
AJ-1359: Remove MinnieKenny doc from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@
 
 ```sh
 git clone git@github.com:broadinstitute/rawls.git
-brew install git-secrets # if not already installed
 cd rawls
 sbt antlr4:antlr4Generate # Generates source code for IntellIJ IDEA
-./minnie-kenny.sh -f
 ```
 
 ## scalafmt


### PR DESCRIPTION
[AJ-1359](https://broadworkbench.atlassian.net/browse/AJ-1359)

This process is no longer recommended by #dsp-infosec-champions.  Drop it from the README.md so that it doesn't get incidentally turned on and create problems.

[AJ-1359]: https://broadworkbench.atlassian.net/browse/AJ-1359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ