### PR TITLE
[WOR-1245] Don't issue FastPass grants when a workspace's bucket is migrating

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
@@ -8,7 +8,14 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.FastPassConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.fastpass.FastPassService._
+import org.broadinstitute.dsde.rawls.fastpass.FastPassService.{
+  openTelemetryTags,
+  policyBindingsQuotaLimit,
+  removeFastPassGrants,
+  RemovalFailure,
+  SAdomain,
+  UserAndPetEmails
+}
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   FastPassGrant,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -39,9 +39,9 @@ import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO.toProjectPolicy
 import org.broadinstitute.dsde.workbench.google.HttpGoogleStorageDAO.toBucketPolicy
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.iam.IamMemberTypes.IamMemberType
+import org.broadinstitute.dsde.workbench.model.google.iam._
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, IamPermission}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.model.google.iam.{Binding, Expr, IamMemberTypes, IamResourceTypes, Policy}
 import org.broadinstitute.dsde.workbench.openTelemetry.FakeOpenTelemetryMetricsInterpreter
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -52,12 +52,14 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, OneInstancePerTest, OptionValues}
 
-import java.util.concurrent.TimeUnit
+import java.sql.Timestamp
 import java.time.{Duration => JavaDuration, LocalDateTime, OffsetDateTime, ZoneOffset}
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
-import scala.collection.JavaConverters._
 
 //noinspection NameBooleanParameters,TypeAnnotation,EmptyParenMethodAccessedAsParameterless,ScalaUnnecessaryParentheses,RedundantNewCaseClass,ScalaUnusedSymbol
 class FastPassServiceSpec
@@ -1391,5 +1393,43 @@ class FastPassServiceSpec
       verify(services.mockFastPassService, never()).syncFastPassesForUserInWorkspace(
         ArgumentMatchers.argThat((w: Workspace) => w.workspaceId.equals(testData.workspace.workspaceId))
       )
+  }
+
+  it should "not issue FastPass grants when a workspace's bucket is migrating" in withMinimalTestDatabase { _ =>
+    val ctx = RawlsRequestContext(
+      UserInfo(RawlsUserEmail("user@example.com"),
+               OAuth2BearerToken("fake_token"),
+               0L,
+               RawlsUserSubjectId(UUID.randomUUID().toString)
+      )
+    )
+    val config = FastPassConfig(true, JavaDuration.ZERO, JavaDuration.ZERO)
+    implicit val openTelemetry = FakeOpenTelemetryMetricsInterpreter
+    val iamDAO = spy(new MockGoogleIamDAO)
+    val storageDAO = spy(new MockGoogleStorageDAO)
+    val gcsDAO = spy(new MockGoogleServicesDAO("groupsPrefix"))
+    val fastPassService =
+      new FastPassService(ctx, slickDataSource, config, iamDAO, storageDAO, gcsDAO, null, "", "", "", "", "")
+
+    Await.result(
+      for {
+        _ <- slickDataSource.inTransaction { dataAccess =>
+          for {
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(minimalTestData.workspace, Option("US"))
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(minimalTestData.workspace.workspaceIdAsUUID)
+              .value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update(attempt.getOrElse(fail()).id,
+                                                                     multiregionalBucketMigrationQuery.startedCol,
+                                                                     Some(Timestamp.valueOf(LocalDateTime.now()))
+            )
+          } yield ()
+        }
+        _ <- fastPassService.syncFastPassesForUserInWorkspace(minimalTestData.workspace)
+      } yield (),
+      Duration.Inf
+    )
+
+    verifyNoInteractions(iamDAO, storageDAO, gcsDAO)
   }
 }


### PR DESCRIPTION
Ticket: [WOR-1245](https://broadworkbench.atlassian.net/browse/WOR-1245)
* Before issuing a FastPass grant, check if the workspace has an in-progress multiregion bucket migration and don't issue the FastPass grant if it does.
* The ticket also mentions adding resilience to this when restoring bucket IAM, but this would require more wide-reaching changes in Rawls. Since I was able to manually verify that this will prevent FastPass grants on a migrating workspace, this feels like overkill and I've decided not to include it in this PR.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1245]: https://broadworkbench.atlassian.net/browse/WOR-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ