### PR TITLE
DDO-3190 Update Rawls build tag publish job to send metrics to Grafana

### DIFF
--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -150,7 +150,7 @@ jobs:
           run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}"
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/DDO-3190
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -150,7 +150,7 @@ jobs:
           run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}"
           workflow: .github/workflows/rawls-swat-tests.yaml
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/DDO-3190
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -151,7 +151,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-            "additional-args": JSON.stringify({ "logging": "true", "java-version": "17" }),
+            "additional-args": JSON.stringify({ "logging": "true", "java-version": "17", "billing-project":"" }),
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -154,7 +154,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-            "additional-args": "{'logging':'true','java-version':'17','billing-project':''}",
+            "additional-args": "{\'logging\':\'true\',\'java-version\':\'17\',\'billing-project\':\'\'}",
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -76,6 +76,21 @@ jobs:
           echo "$GITHUB_CONTEXT"
           echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
 
+  prepare-configs:
+    runs-on: ubuntu-latest
+    outputs:
+      log-results: ${{ steps.prepare-outputs.outputs.log-results }}
+      test-context: ${{ steps.prepare-outputs.outputs.test-context }}
+    steps:
+      - id: prepare-outputs
+        run: |-
+          echo 'log-results=true' >> $GITHUB_OUTPUT
+          if ${{ github.ref_name == 'develop' }}; then
+            echo 'test-context=dev-merge' >> $GITHUB_OUTPUT
+          else
+            echo 'test-context=pr-test' >> $GITHUB_OUTPUT
+          fi
+          
   create-bee-workflow:
     strategy:
       matrix:

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -165,7 +165,7 @@ jobs:
 
   destroy-bee-workflow:
     strategy:
-      matrix:g
+      matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -154,7 +154,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-            "additional-args": "{\'logging\':\'true\',\'java-version\':\'17\',\'billing-project\':\'\'}",
+            "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"\"}",
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -151,12 +151,12 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
+            "additional-args": JSON.stringify({ "logging": "true", "java-version": "17" }),
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",
             "test-group-name": "${{ matrix.test-group.group_name }}",
-            "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}",
-            "java-version": "17"
+            "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}"
           }'
 
   destroy-bee-workflow:

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -154,7 +154,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-            "additional-args": JSON.stringify({ "logging": "true", "java-version": "17", "billing-project":"" }),
+            "additional-args": ${{ JSON.stringify({ "logging": "true", "java-version": "17", "billing-project":"" }) }},
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -76,13 +76,14 @@ jobs:
           echo "$GITHUB_CONTEXT"
           echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
 
-  prepare-configs:
+  init-github-context:
     runs-on: ubuntu-latest
     outputs:
-      log-results: ${{ steps.prepare-outputs.outputs.log-results }}
-      test-context: ${{ steps.prepare-outputs.outputs.test-context }}
+      log-results: ${{ steps.set-test-context.outputs.log-results }}
+      test-context: ${{ steps.set-test-context.outputs.test-context }}
     steps:
-      - id: prepare-outputs
+      - name: Get test context
+        id: set-test-context
         run: |-
           echo 'log-results=true' >> $GITHUB_OUTPUT
           if ${{ github.ref_name == 'develop' }}; then
@@ -135,6 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - create-bee-workflow
+      - init-github-context
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -142,6 +144,7 @@ jobs:
       - name: dispatch to terra-github-workflows
         env:
           rawls_base_test_entrypoint: "testOnly -- -l ProdTest -l NotebooksCanaryTest"
+          test-context: ${{ needs.init-github-context.outputs.test-context }}
         uses: broadinstitute/workflow-dispatch@v4.0.0
         with:
           run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}"
@@ -156,12 +159,13 @@ jobs:
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",
             "test-group-name": "${{ matrix.test-group.group_name }}",
-            "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}"
+            "test-command": "${{ env.rawls_base_test_entrypoint }} ${{ matrix.test-group.tag }}",
+            "test-context": "${{ env.test-context }}"
           }'
 
   destroy-bee-workflow:
     strategy:
-      matrix:
+      matrix:g
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -154,7 +154,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-            "additional-args": ${{ JSON.stringify({ "logging": "true", "java-version": "17", "billing-project":"" }) }},
+            "additional-args": "{'logging':'true','java-version':'17','billing-project':''}",
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}-${{ matrix.terra-env }}-${{ matrix.testing-env }}-${{ matrix.test-group.group_name }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "ENV": "${{ matrix.testing-env }}",


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-3190

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email

<h2> Summary </h2>

DDO-3190. Updates rawls swat job to add metrics reporting as seen in DDO-3190 in [terra-github-workflows](https://github.com/broadinstitute/terra-github-workflows/pull/122/files)

<h2> Testing </h2>

This build will be disabled, just like it was originally. Checks ran successfully when pointed to the updated branch. Lastly, results showed up in  [grafana dashboards](https://grafana.dsp-devops.broadinstitute.org/d/hzlH8jeVk/gha-swatomation-test-analytics?orgId=1&from=now-7d&to=now&var-service=sam&var-environment=pr-test)
