### PR TITLE
[WOR-1295] Restart failures when STS SA is not found

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigration.scala
@@ -94,6 +94,9 @@ object MultiregionalBucketMigrationFailureModes {
 
   val gcsUnavailableFailure: String =
     "%UNAVAILABLE:%Additional details: GCS is temporarily unavailable."
+
+  val stsSANotFoundFailure: String =
+    "%NOT_FOUND%project-%@storage-transfer-service.iam.gserviceaccount.com does not exist."
 }
 
 object MultiregionalBucketMigrationStep extends Enumeration {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -210,8 +210,10 @@ object MultiregionalBucketMigrationActor {
   val storageTransferJobs = MultiregionalStorageTransferJobs.storageTransferJobs
 
   final def restartMigration: MigrateAction[Unit] =
-    restartFailuresLike(MultiregionalBucketMigrationFailureModes.noBucketPermissionsFailure,
-                        MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure
+    restartFailuresLike(
+      MultiregionalBucketMigrationFailureModes.noBucketPermissionsFailure,
+      MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure,
+      MultiregionalBucketMigrationFailureModes.stsSANotFoundFailure
     ) |
       reissueFailedStsJobs
 
@@ -1295,8 +1297,10 @@ object MultiregionalBucketMigrationActor {
 
               case RetryKnownFailures =>
                 List(
-                  restartFailuresLike(MultiregionalBucketMigrationFailureModes.stsRateLimitedFailure,
-                                      MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure
+                  restartFailuresLike(
+                    MultiregionalBucketMigrationFailureModes.stsRateLimitedFailure,
+                    MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure,
+                    MultiregionalBucketMigrationFailureModes.stsSANotFoundFailure
                   ),
                   reissueFailedStsJobs
                 )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -8,13 +8,7 @@ import cats.implicits._
 import com.google.cloud.Identity
 import com.google.cloud.storage.{Acl, BucketInfo, Storage}
 import com.google.rpc.Code
-import com.google.storagetransfer.v1.proto.TransferTypes.{
-  ErrorLogEntry,
-  ErrorSummary,
-  TransferCounters,
-  TransferJob,
-  TransferOperation
-}
+import com.google.storagetransfer.v1.proto.TransferTypes._
 import io.grpc.{Status, StatusRuntimeException}
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.ReadWriteAction
@@ -24,8 +18,8 @@ import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome._
 import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationActor._
 import org.broadinstitute.dsde.rawls.monitor.migration.{
-  FailureModes,
   MultiregionalBucketMigration,
+  MultiregionalBucketMigrationFailureModes,
   MultiregionalBucketMigrationStep,
   MultiregionalStorageTransferJob
 }
@@ -256,7 +250,7 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
   it should "return normalized ids rather than real ids" in
     spec.withMinimalTestDatabase { _ =>
       import spec.minimalTestData
-      import spec.multiregionalBucketMigrationQuery.{getAttempt, scheduleAndGetMetadata, setMigrationFinished}
+      import spec.multiregionalBucketMigrationQuery.scheduleAndGetMetadata
       spec.runAndWait {
         for {
           a <- scheduleAndGetMetadata(minimalTestData.workspace, testData.bucketLocation)
@@ -636,7 +630,7 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           migration.outcome shouldBe Some(Failure(error.getMessage))
         }
 
-        _ <- allowOne(restartFailuresLike(FailureModes.gcsUnavailableFailure))
+        _ <- allowOne(restartFailuresLike(MultiregionalBucketMigrationFailureModes.gcsUnavailableFailure))
         _ <- migrate
 
         _ <- inTransaction { dataAccess =>
@@ -895,7 +889,7 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           test
         }
 
-        _ <- allowOne(restartFailuresLike(FailureModes.noBucketPermissionsFailure))
+        _ <- allowOne(restartFailuresLike(MultiregionalBucketMigrationFailureModes.noBucketPermissionsFailure))
         _ <- migrate
 
         _ <- inTransaction { dataAccess =>
@@ -963,7 +957,7 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
           migration.outcome shouldBe Some(Failure(error.getMessage))
         }
 
-        _ <- allowOne(restartFailuresLike(FailureModes.stsRateLimitedFailure))
+        _ <- allowOne(restartFailuresLike(MultiregionalBucketMigrationFailureModes.stsRateLimitedFailure))
         _ <- migrate
 
         _ <- inTransaction { dataAccess =>
@@ -986,6 +980,65 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
         }
       } yield succeed
     }
+
+  it should "restart a migration that fails due to STS SA propagation delays" in runMigrationTest {
+    for {
+      now <- nowTimestamp
+      _ <- inTransaction { dataAccess =>
+        for {
+          _ <- createAndScheduleWorkspace(testData.workspace)
+          attempt <- dataAccess.multiregionalBucketMigrationQuery
+            .getAttempt(testData.workspace.workspaceIdAsUUID)
+            .value
+          _ <- dataAccess.multiregionalBucketMigrationQuery.update2(
+            attempt.get.id,
+            dataAccess.multiregionalBucketMigrationQuery.tmpBucketCreatedCol,
+            now.some,
+            dataAccess.multiregionalBucketMigrationQuery.tmpBucketCol,
+            GcsBucketName("tmp-bucket-name").some
+          )
+        } yield ()
+      }
+
+      error = new StatusRuntimeException(
+        Status.NOT_FOUND.withDescription(
+          s"Service account projects/-/serviceAccounts/project-630363624422@storage-transfer-service.iam.gserviceaccount.com does not exist."
+        )
+      )
+
+      mockSts = new MockStorageTransferService {
+        override def getStsServiceAccount(project: GoogleProject) =
+          IO.raiseError(error)
+      }
+
+      _ <- MigrateAction.local(_.copy(storageTransferService = mockSts))(migrate)
+      _ <- inTransactionT {
+        _.multiregionalBucketMigrationQuery.getAttempt(testData.workspace.workspaceIdAsUUID)
+      }.map { migration =>
+        migration.finished shouldBe defined
+        migration.outcome shouldBe Some(Failure(error.getMessage))
+      }
+
+      _ <- allowOne(restartFailuresLike(MultiregionalBucketMigrationFailureModes.stsSANotFoundFailure))
+      _ <- migrate
+
+      _ <- inTransaction { dataAccess =>
+        @nowarn("msg=not.*?exhaustive")
+        val test = for {
+          Some(migration) <- dataAccess.multiregionalBucketMigrationQuery
+            .getAttempt(testData.workspace.workspaceIdAsUUID)
+            .value
+          retries <- dataAccess.multiregionalBucketMigrationRetryQuery.getOrCreate(migration.id)
+        } yield {
+          migration.finished shouldBe empty
+          migration.outcome shouldBe empty
+          migration.workspaceBucketTransferIamConfigured shouldBe defined
+          retries.numRetries shouldBe 1
+        }
+        test
+      }
+    } yield succeed
+  }
 
   it should "not retry a failed migration when the maximum number of retries has been exceeded" in
     runMigrationTest {


### PR DESCRIPTION
Ticket: [WOR-1295](https://broadworkbench.atlassian.net/browse/WOR-1295)
* Occasionally, migrations will fail with an error indicating that the STS SA that performs the migration does not exist. Restarting these migrations works as the initial error appears to be the result of the SA's existence being slow to propagate throughout Google. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1295]: https://broadworkbench.atlassian.net/browse/WOR-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ