### PR TITLE
Handle billing profile not found

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -21,6 +21,7 @@ import java.util.{Date, UUID}
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
 
 case class BpmAzureReportErrorMessage(message: String, statusCode: Int)
 
@@ -77,6 +78,11 @@ class ManagedAppNotFoundException(errorReport: ErrorReport) extends RawlsExcepti
 
 class BpmAzureSpendReportApiException(val statusCode: Int, message: String, cause: Throwable = null)
     extends Exception(message, cause)
+
+class BillingProfileNotFoundException(billingProfileId: UUID, cause: Throwable)
+    extends RawlsExceptionWithErrorReport(
+      ErrorReport(StatusCodes.NotFound, s"Billing profile not found $billingProfileId", cause)
+    )
 
 object BillingProfileManagerDAO {
   val BillingProfileRequestBatchSize = 1000
@@ -141,7 +147,12 @@ class BillingProfileManagerDAOImpl(
   }
 
   def getBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Option[ProfileModel] =
-    Option(apiClientProvider.getProfileApi(ctx).getProfile(billingProfileId))
+    Try(Option(apiClientProvider.getProfileApi(ctx).getProfile(billingProfileId))) match {
+      case Success(value) => value
+      case Failure(e: ApiException) if e.getCode == StatusCodes.NotFound.intValue =>
+        None
+      case Failure(e) => throw new BillingProfileNotFoundException(billingProfileId, e);
+    }
 
   override def deleteBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =
     apiClientProvider.getProfileApi(ctx).deleteProfile(billingProfileId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -79,9 +79,9 @@ class ManagedAppNotFoundException(errorReport: ErrorReport) extends RawlsExcepti
 class BpmAzureSpendReportApiException(val statusCode: Int, message: String, cause: Throwable = null)
     extends Exception(message, cause)
 
-class BillingProfileNotFoundException(billingProfileId: UUID, cause: Throwable)
+class BpmException(billingProfileId: UUID, cause: Throwable)
     extends RawlsExceptionWithErrorReport(
-      ErrorReport(StatusCodes.NotFound, s"Billing profile not found $billingProfileId", cause)
+      ErrorReport(StatusCodes.InternalServerError, s"Error fetching billing profile ID $billingProfileId", cause)
     )
 
 object BillingProfileManagerDAO {
@@ -151,7 +151,7 @@ class BillingProfileManagerDAOImpl(
       case Success(value) => value
       case Failure(e: ApiException) if e.getCode == StatusCodes.NotFound.intValue =>
         None
-      case Failure(e) => throw new BillingProfileNotFoundException(billingProfileId, e);
+      case Failure(e) => throw new BpmException(billingProfileId, e);
     }
 
   override def deleteBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -91,7 +91,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     val billingProfileManagerDAO =
       new BillingProfileManagerDAOImpl(apiProvider, MultiCloudWorkspaceConfig(true, None, Some(azConfig)))
 
-    intercept[BillingProfileNotFoundException] {
+    intercept[BpmException] {
       billingProfileManagerDAO.getBillingProfile(UUID.randomUUID(), testContext)
     }
   }


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1222)
This came up during testing of azure billing project creation and deletion via an automated github workflow. There is a race where the billing profile may be deleted but the rawls record may still be in place. We should handle the 404 from billing profile manager and move on if the billing profile is not present. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
