### PR TITLE
[WOR-1308] Retry 404s when configuring IAM for STS jobs

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -800,6 +800,13 @@ object MultiregionalBucketMigrationActor {
             serviceAccountList = NonEmptyList.one(Identity.serviceAccount(serviceAccount.email.value))
             // STS requires the following to read from the origin bucket and delete objects after
             // transfer
+
+            retryConfig = RetryPredicates.retryAllConfig.copy(retryable =
+              RetryPredicates.combine(
+                Seq(RetryPredicates.standardGoogleRetryPredicate, RetryPredicates.whenStatusCode(404))
+              )
+            )
+
             _ <- storageService
               .setIamPolicy(
                 srcBucket,
@@ -808,7 +815,8 @@ object MultiregionalBucketMigrationActor {
                 ),
                 bucketSourceOptions =
                   if (migration.requesterPaysEnabled) List(BucketSourceOption.userProject(googleProject.value))
-                  else List.empty
+                  else List.empty,
+                retryConfig = retryConfig
               )
               .compile
               .drain
@@ -820,7 +828,8 @@ object MultiregionalBucketMigrationActor {
                 dstBucket,
                 Map(StorageRole.LegacyBucketWriter -> serviceAccountList,
                     StorageRole.ObjectCreator -> serviceAccountList
-                )
+                ),
+                retryConfig = retryConfig
               )
               .compile
               .drain


### PR DESCRIPTION
Ticket: [WOR-1308](https://broadworkbench.atlassian.net/browse/WOR-1308)
* We only begin configuring IAM for STS jobs once Google has confirmed that the bucket exists, but Google will occasionally return a 404 while setting IAM policy indicating that the bucket does not exist. Retry these 404s as they are the result of inconsistency on Google's end.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1308]: https://broadworkbench.atlassian.net/browse/WOR-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ