### PR TITLE
[WOR-1283] store an error message when workspace deletion fails

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -388,6 +388,9 @@ trait WorkspaceComponent {
     def updateState(workspaceId: UUID, state: WorkspaceState): WriteAction[Int] =
       findByIdQuery(workspaceId).map(_.state).update(state.toString)
 
+    def updateStateWithErrorMessage(workspaceId: UUID, state: WorkspaceState, errorMessage: String): WriteAction[Int] =
+      findByIdQuery(workspaceId).map(ws => (ws.state, ws.errorMessage)).update(state.toString, errorMessage.some)
+
     def updateLastModified(workspaceId: UUID) = {
       val currentTime = new Timestamp(new Date().getTime)
       findByIdQuery(workspaceId).map(_.lastModified).update(currentTime)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -30,6 +30,11 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
       access.workspaceQuery.updateState(workspaceId, state)
     }
 
+  def setFailedState(workspaceId: UUID, state: WorkspaceState, message: String): Future[Int] =
+    dataSource.inTransaction { access =>
+      access.workspaceQuery.updateStateWithErrorMessage(workspaceId, state, message)
+    }
+
   def deleteWorkspaceRecord(workspace: Workspace): Future[Boolean] =
     dataSource.inTransaction { access =>
       access.workspaceQuery.delete(workspace.toWorkspaceName)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -96,7 +96,11 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     whenReady(runner(monitorRecord.copy(userEmail = None)))(
       _ shouldBe WorkspaceManagerResourceMonitorRecord.Complete
     )
-    verify(wsRepo).setFailedState(any(), any(), any())
+    verify(wsRepo).setFailedState(
+      monitorRecord.workspaceId.get,
+      WorkspaceState.DeleteFailed,
+      s"Job to monitor workspace deletion for workspace id = ${monitorRecord.workspaceId.get} created with id ${monitorRecord.jobControlId} but no user email set"
+    )
   }
 
   it should "throw an exception if called with a job type that is not WorkspaceDelete" in {


### PR DESCRIPTION
Ticket: [WOR-1283](https://broadworkbench.atlassian.net/browse/WOR-1283)
* Store an error message on the workspace record when workspace deletion fails

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1283]: https://broadworkbench.atlassian.net/browse/WOR-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ