### PR TITLE
WX-1259 Liquibase for Cromwell resource monitoring workflow options

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -124,4 +124,5 @@
     <include file="changesets/20230810_add_workspace_state_column.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230810_track_mrb_sts_progress.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230829_mrb_add_sts_project.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20231013_submission_monitor_script.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20231013_submission_monitor_script.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20231013_submission_monitor_script.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="add_monitoring_script" author="anichols" logicalFilePath="dummy">
+        <addColumn tableName="SUBMISSION">
+            <column name="MONITORING_SCRIPT" type="VARCHAR(1024)" remarks="Script that runs in the task container">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add_monitoring_image" author="anichols" logicalFilePath="dummy">
+        <addColumn tableName="SUBMISSION">
+            <column name="MONITORING_IMAGE" type="VARCHAR(1024)" remarks="Separate container that runs alongside task container">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add_monitoring_image_script" author="anichols" logicalFilePath="dummy">
+        <addColumn tableName="SUBMISSION">
+            <column name="MONITORING_IMAGE_SCRIPT" type="VARCHAR(1024)" remarks="Script that runs in the separate `MONITORING_IMAGE` container">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: [WX-1259](https://broadworkbench.atlassian.net/browse/WX-1259)
<Put notes here to help reviewer understand this PR>

This PR adds three columns to the `SUBMISSION` table needed to support Cromwell's `monitoring_*` options [documented here](https://cromwell.readthedocs.io/en/stable/wf_options/Google/). For a better idea what the rest of the Rawls changes will do, check out this [draft PR](https://github.com/broadinstitute/rawls/pull/2587) that relies on these changes. Basically, we need to accept the new options when Rawls creates a new submission, write them to the DB, and then read them back & send to Cromwell when the submission launches.

Sample Liquibase output running on my clone of Dev, `anichols-rawls-clone-2023-10-17`:

```
rawls[ERROR] Oct 18, 2023 7:54:01 PM liquibase.lockservice
rawls[ERROR] INFO: Successfully acquired change log lock
rawls[ERROR] Oct 18, 2023 7:54:04 PM liquibase.changelog
rawls[ERROR] INFO: Reading from rawls.DATABASECHANGELOG
rawls[ERROR] Oct 18, 2023 7:54:05 PM liquibase.servicelocator
rawls[ERROR] INFO: Cannot load service: liquibase.hub.HubService: Provider liquibase.hub.core.StandardHubService could not be instantiated
rawls Running Changeset: dummy::add_monitoring_script::anichols
rawls[ERROR] Oct 18, 2023 7:54:06 PM liquibase.changelog
rawls[ERROR] INFO: Columns MONITORING_SCRIPT(VARCHAR(1024)) added to SUBMISSION
rawls[ERROR] Oct 18, 2023 7:54:06 PM liquibase.changelog
rawls[ERROR] INFO: ChangeSet dummy::add_monitoring_script::anichols ran successfully in 752ms
rawls Running Changeset: dummy::add_monitoring_image::anichols
rawls[ERROR] Oct 18, 2023 7:54:07 PM liquibase.changelog
rawls[ERROR] INFO: Columns MONITORING_IMAGE(VARCHAR(1024)) added to SUBMISSION
rawls[ERROR] Oct 18, 2023 7:54:07 PM liquibase.changelog
rawls[ERROR] INFO: ChangeSet dummy::add_monitoring_image::anichols ran successfully in 718ms
rawls Running Changeset: dummy::add_monitoring_image_script::anichols
rawls[ERROR] Oct 18, 2023 7:54:08 PM liquibase.changelog
rawls[ERROR] INFO: Columns MONITORING_IMAGE_SCRIPT(VARCHAR(1024)) added to SUBMISSION
rawls[ERROR] Oct 18, 2023 7:54:08 PM liquibase.changelog
rawls[ERROR] INFO: ChangeSet dummy::add_monitoring_image_script::anichols ran successfully in 742ms
rawls[ERROR] Oct 18, 2023 7:54:08 PM liquibase.lockservice
rawls[ERROR] INFO: Successfully released change log lock
```

<img width="1029" alt="Screenshot 2023-10-18 at 16 15 46" src="https://github.com/broadinstitute/rawls/assets/1087943/10715c86-d2a5-4633-9a3c-aa5277b6214f">


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WX-1259]: https://broadworkbench.atlassian.net/browse/WX-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ