### PR TITLE
[WOR-1309] Don't error for non-Ready MC Workspaces that have no cloud context.

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4134,7 +4134,7 @@ paths:
       tags:
         - workspaces_v2
       summary: Delete workspace
-      description: Starts a job to delete a workspace and all of its contents. Note that this is an in-progress API and currently unsupported.
+      description: Starts a job to delete a workspace and all of its contents.
       operationId: deleteWorkspaceV2
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5703,7 +5703,7 @@ components:
           format: date-time
         cloudPlatform:
           type: string
-          description: The cloud platform of the workspace
+          description: The cloud platform of the workspace. If the workspace is not in the Ready state, the cloud platform may be missing.
           enum:
             - GCP
             - AZURE

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
@@ -30,12 +30,17 @@ class SnapshotReferenceCreationValidator(val workspaceContext: Workspace, val sn
   // Throws an exception when the given snapshot cannot be referenced by the given workspace due to crossing an
   // unsupported platform boundary.
   @throws(classOf[PlatformBoundaryException])
-  def validateWorkspacePlatformCompatibility(workspacePlatform: WorkspaceCloudPlatform): Unit =
+  def validateWorkspacePlatformCompatibility(workspacePlatform: Option[WorkspaceCloudPlatform]): Unit =
     // Defining all acceptable combinations is overkill when all we really need to do is prevent anything Azure, but
     // this is here as a safeguard against us introducing support for Azure without deliberately addressing the issue of
     // snapshots by ref across cloud platforms.
     (snapshot.platform, workspacePlatform) match {
-      case (SnapshotCloudPlatform.GCP, WorkspaceCloudPlatform.Gcp) => // ok
+      case (SnapshotCloudPlatform.GCP, Some(WorkspaceCloudPlatform.Gcp)) => // ok
+      case (_, None) =>
+        throw new PlatformBoundaryException(
+          "Snapshots by reference are not supported into a workspace with no cloud context (" +
+            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform})."
+        )
       case _ =>
         throw new PlatformBoundaryException(
           "Snapshots by reference are not supported across the given cloud boundaries (" +

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
@@ -44,7 +44,7 @@ class SnapshotReferenceCreationValidator(val workspaceContext: Workspace, val sn
       case _ =>
         throw new PlatformBoundaryException(
           "Snapshots by reference are not supported across the given cloud boundaries (" +
-            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform})."
+            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform.get})."
         )
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -83,7 +83,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         case _: AggregateWorkspaceNotFoundException =>
           // if a WSM workspace does not already exist, assume the platform is GCP, confirm platform compatibility,
           // and then create a stub workspace
-          snapshotValidator.validateWorkspacePlatformCompatibility(WorkspaceCloudPlatform.Gcp)
+          snapshotValidator.validateWorkspacePlatformCompatibility(Some(WorkspaceCloudPlatform.Gcp))
           workspaceManagerDAO.createWorkspace(wsid, rawlsWorkspace.workspaceType, ctx)
       }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspace.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspace.scala
@@ -28,24 +28,7 @@ case class AggregatedWorkspace(
   policies: List[WorkspacePolicy]
 ) {
 
-  def getCloudPlatform: WorkspaceCloudPlatform = {
-    if (baseWorkspace.workspaceType == WorkspaceType.RawlsWorkspace) {
-      return WorkspaceCloudPlatform.Gcp
-    }
-    (googleProjectId, azureCloudContext) match {
-      case (Some(_), None) => WorkspaceCloudPlatform.Gcp
-      case (None, Some(_)) => WorkspaceCloudPlatform.Azure
-      case (_, _) =>
-        throw new InvalidCloudContextException(
-          ErrorReport(
-            StatusCodes.NotImplemented,
-            s"Unexpected state, expected exactly one set of cloud metadata for workspace ${baseWorkspace.workspaceId}"
-          )
-        )
-    }
-  }
-
-  def getCloudPlatformHandlingNonReady: Option[WorkspaceCloudPlatform] = {
+  def getCloudPlatform: Option[WorkspaceCloudPlatform] = {
     if (baseWorkspace.workspaceType == WorkspaceType.RawlsWorkspace) {
       return Some(WorkspaceCloudPlatform.Gcp)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
@@ -70,19 +70,27 @@ class AggregatedWorkspaceService(workspaceManagerDAO: WorkspaceManagerDAO) exten
             azureCloudContext = None,
             convertPolicies(wsmInfo)
           )
-        case (WorkspaceStageModel.MC_WORKSPACE, None, None, WorkspaceState.Deleting) =>
-          AggregatedWorkspace(
-            workspace,
-            googleProjectId = None,
-            azureCloudContext = None,
-            convertPolicies(wsmInfo)
-          )
-        case (_, _, _, _) =>
+        case (WorkspaceStageModel.MC_WORKSPACE, Some(_), Some(_), _) =>
           throw new InvalidCloudContextException(
             ErrorReport(
               StatusCodes.NotImplemented,
               s"Unexpected state, expected exactly one set of cloud metadata for workspace ${workspace.workspaceId}"
             )
+          )
+        case (WorkspaceStageModel.MC_WORKSPACE, None, None, WorkspaceState.Ready) =>
+          throw new InvalidCloudContextException(
+            ErrorReport(
+              StatusCodes.NotImplemented,
+              s"Unexpected state, no cloud metadata for ready workspace ${workspace.workspaceId}"
+            )
+          )
+        case (WorkspaceStageModel.MC_WORKSPACE, None, None, _) =>
+          // Tolerate no cloud context for a workspace that is not ready.
+          AggregatedWorkspace(
+            workspace,
+            googleProjectId = None,
+            azureCloudContext = None,
+            convertPolicies(wsmInfo)
           )
       }
     } catch {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
@@ -7,7 +7,16 @@ import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.scala.Tracing.startSpanWithParent
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, ErrorReport, GoogleProjectId, RawlsRequestContext, Workspace, WorkspacePolicy, WorkspaceState, WorkspaceType}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  ErrorReport,
+  GoogleProjectId,
+  RawlsRequestContext,
+  Workspace,
+  WorkspacePolicy,
+  WorkspaceState,
+  WorkspaceType
+}
 
 import java.util.UUID
 import scala.jdk.CollectionConverters._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -355,7 +355,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                 traceWithParent("getUserComputePermissions", s1)(_ =>
                   getUserComputePermissions(workspaceContext.workspaceIdAsUUID.toString,
                                             accessLevel,
-                                            wsmContext.getCloudPlatformHandlingDeleting
+                                            wsmContext.getCloudPlatformHandlingNonReady
                   )
                     .map(Option(_))
                 )
@@ -429,7 +429,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                   WorkspaceDetails.fromWorkspaceAndOptions(workspaceContext,
                                                            authDomain,
                                                            useAttributes,
-                                                           wsmContext.getCloudPlatformHandlingDeleting
+                                                           wsmContext.getCloudPlatformHandlingNonReady
                   ),
                   stats,
                   bucketDetails,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -355,7 +355,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                 traceWithParent("getUserComputePermissions", s1)(_ =>
                   getUserComputePermissions(workspaceContext.workspaceIdAsUUID.toString,
                                             accessLevel,
-                                            wsmContext.getCloudPlatformHandlingNonReady
+                                            wsmContext.getCloudPlatform
                   )
                     .map(Option(_))
                 )
@@ -429,7 +429,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                   WorkspaceDetails.fromWorkspaceAndOptions(workspaceContext,
                                                            authDomain,
                                                            useAttributes,
-                                                           wsmContext.getCloudPlatformHandlingNonReady
+                                                           wsmContext.getCloudPlatform
                   ),
                   stats,
                   bucketDetails,
@@ -1008,9 +1008,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                         )
                       ),
                       attributesEnabled,
-                      Some(
-                        wsmContext.getCloudPlatform
-                      ) // catch below will filter out workspaces with missing cloud context
+                      wsmContext.getCloudPlatform
                     )
                   // remove submission stats if they were not requested
                   val submissionStats: Option[WorkspaceSubmissionStats] = if (submissionStatsEnabled) {
@@ -1035,6 +1033,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                       s"MC Workspace ${workspace.name} (${workspace.workspaceIdAsUUID}) does not exist in the current WSM instance. "
                     )
                     None
+                  // This catches the case of a MC workspace with no cloud context, filtering out such workspaces
                   case ex: WorkspaceAggregationException =>
                     logger.error(ex.getMessage)
                     None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -314,8 +314,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Option(attrSpecs)) flatMap {
         workspaceContext =>
           dataSource.inTransaction { dataAccess =>
-            val wsmContext =
-              wsmService.optimizedFetchAggregatedWorkspace(workspaceContext, ctx) // Do we need to protect here?
+            val wsmContext = wsmService.optimizedFetchAggregatedWorkspace(workspaceContext, ctx)
 
             // maximum access level is required to calculate canCompute and canShare. Therefore, if any of
             // accessLevel, canCompute, canShare is specified, we have to get it.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1663,6 +1663,27 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       WorkspaceState.Ready
     )
 
+    val deletingAzureWorkspace = new Workspace(
+      namespace = azureBillingProjectName.value,
+      name = "test-deleting-azure-workspace",
+      workspaceId = UUID.randomUUID().toString,
+      bucketName = "",
+      workflowCollectionName = None,
+      createdDate = currentTime(),
+      lastModified = currentTime(),
+      createdBy = "testUser",
+      attributes = Map.empty,
+      isLocked = false,
+      workspaceVersion = WorkspaceVersions.V2,
+      googleProjectId = GoogleProjectId(""),
+      googleProjectNumber = None,
+      currentBillingAccountOnGoogleProject = None,
+      errorMessage = None,
+      completedCloneWorkspaceFileTransfer = None,
+      workspaceType = WorkspaceType.McWorkspace,
+      WorkspaceState.Deleting
+    )
+
     val allWorkspaces = Seq(
       workspace,
       workspaceLocked,
@@ -1685,7 +1706,8 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       workspaceToTestGrant,
       workspaceConfigCopyDestination,
       regionalWorkspace,
-      azureWorkspace
+      azureWorkspace,
+      deletingAzureWorkspace
     )
     val saveAllWorkspacesAction = DBIO.sequence(allWorkspaces.map(workspaceQuery.createOrUpdate))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceSpec.scala
@@ -110,7 +110,11 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
 
   it should "return None for a non-ready MC workspace that has no cloud info" in {
     val ws =
-      AggregatedWorkspace(deleteFailedMcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
+      AggregatedWorkspace(deleteFailedMcWorkspace,
+                          googleProjectId = None,
+                          azureCloudContext = None,
+                          policies = List.empty
+      )
 
     val cp = ws.getCloudPlatform
     cp shouldBe None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceSpec.scala
@@ -29,7 +29,7 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
     attributes = Map.empty
   )
 
-  private val mcWorkspace = Workspace.buildReadyMcWorkspace(
+  private val readyMcWorkspace = Workspace.buildReadyMcWorkspace(
     namespace = "fake",
     name = "fakews",
     workspaceId = UUID.randomUUID.toString,
@@ -39,64 +39,7 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
     attributes = Map.empty
   )
 
-  behavior of "getCloudPlatform"
-
-  it should "return GCP for a rawls workspace" in {
-    val ws =
-      AggregatedWorkspace(rawlsWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
-
-    val cp = ws.getCloudPlatform
-
-    cp shouldBe WorkspaceCloudPlatform.Gcp
-  }
-
-  it should "return Azure for an Azure MC workspace" in {
-    val ws = AggregatedWorkspace(mcWorkspace,
-                                 googleProjectId = None,
-                                 Some(AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake")),
-                                 policies = List.empty
-    )
-
-    val cp = ws.getCloudPlatform
-
-    cp shouldBe WorkspaceCloudPlatform.Azure
-  }
-
-  it should "return Gcp for a Gcp MC workspace" in {
-    val ws = AggregatedWorkspace(mcWorkspace,
-                                 Some(GoogleProjectId("project-id")),
-                                 azureCloudContext = None,
-                                 policies = List.empty
-    )
-
-    val cp = ws.getCloudPlatform
-    cp shouldBe WorkspaceCloudPlatform.Gcp
-  }
-
-  it should "raise for an MC workspace that has cloud info for multiple clouds" in {
-    val ws = AggregatedWorkspace(
-      mcWorkspace,
-      Some(GoogleProjectId("project-id")),
-      Some(AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake")),
-      policies = List.empty
-    )
-
-    val thrown = intercept[InvalidCloudContextException] {
-      ws.getCloudPlatform
-    }
-    thrown.getMessage should include("expected exactly one set of cloud metadata for workspace")
-  }
-
-  it should "raise for an MC workspace that has no cloud info" in {
-    val ws = AggregatedWorkspace(mcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
-
-    val thrown = intercept[InvalidCloudContextException] {
-      ws.getCloudPlatform
-    }
-    thrown.getMessage should include("expected exactly one set of cloud metadata for workspace")
-  }
-
-  private val deletingWs = buildMcWorkspace(
+  private val deletingMcWorkspace = buildMcWorkspace(
     "namespace",
     "name",
     workspaceId = UUID.randomUUID.toString,
@@ -107,67 +50,69 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
     WorkspaceState.Deleting
   )
 
-  behavior of "getCloudPlatformHandlingNonReady"
+  behavior of "getCloudPlatform"
 
   it should "return GCP for a rawls workspace" in {
     val ws =
       AggregatedWorkspace(rawlsWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
 
-    val cp = ws.getCloudPlatformHandlingNonReady
+    val cp = ws.getCloudPlatform
 
     cp shouldBe Some(WorkspaceCloudPlatform.Gcp)
   }
 
   it should "return Azure for an Azure MC workspace" in {
-    val ws = AggregatedWorkspace(mcWorkspace,
+    val ws = AggregatedWorkspace(readyMcWorkspace,
                                  googleProjectId = None,
                                  Some(AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake")),
                                  policies = List.empty
     )
 
-    val cp = ws.getCloudPlatformHandlingNonReady
+    val cp = ws.getCloudPlatform
 
     cp shouldBe Some(WorkspaceCloudPlatform.Azure)
   }
 
   it should "return Gcp for a Gcp MC workspace" in {
-    val ws = AggregatedWorkspace(mcWorkspace,
+    val ws = AggregatedWorkspace(readyMcWorkspace,
                                  Some(GoogleProjectId("project-id")),
                                  azureCloudContext = None,
                                  policies = List.empty
     )
 
-    val cp = ws.getCloudPlatformHandlingNonReady
+    val cp = ws.getCloudPlatform
     cp shouldBe Some(WorkspaceCloudPlatform.Gcp)
   }
 
   it should "raise for an MC workspace that has cloud info for multiple clouds" in {
     val ws = AggregatedWorkspace(
-      deletingWs,
+      deletingMcWorkspace,
       Some(GoogleProjectId("project-id")),
       Some(AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake")),
       policies = List.empty
     )
 
     val thrown = intercept[InvalidCloudContextException] {
-      ws.getCloudPlatformHandlingNonReady
+      ws.getCloudPlatform
     }
     thrown.getMessage should include("expected exactly one set of cloud metadata for workspace")
   }
 
   it should "raise for a ready MC workspace that has no cloud info" in {
-    val ws = AggregatedWorkspace(mcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
+    val ws =
+      AggregatedWorkspace(readyMcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
 
     val thrown = intercept[InvalidCloudContextException] {
-      ws.getCloudPlatformHandlingNonReady
+      ws.getCloudPlatform
     }
     thrown.getMessage should include("no cloud metadata for ready workspace")
   }
 
   it should "return None for a non-ready MC workspace that has no cloud info" in {
-    val ws = AggregatedWorkspace(deletingWs, googleProjectId = None, azureCloudContext = None, policies = List.empty)
+    val ws =
+      AggregatedWorkspace(deletingMcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
 
-    val cp = ws.getCloudPlatformHandlingNonReady
+    val cp = ws.getCloudPlatform
     cp shouldBe None
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceSpec.scala
@@ -39,7 +39,7 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
     attributes = Map.empty
   )
 
-  private val deletingMcWorkspace = buildMcWorkspace(
+  private val deleteFailedMcWorkspace = buildMcWorkspace(
     "namespace",
     "name",
     workspaceId = UUID.randomUUID.toString,
@@ -47,7 +47,7 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
     lastModified = DateTime.now(),
     createdBy = "fake",
     attributes = Map.empty,
-    WorkspaceState.Deleting
+    WorkspaceState.DeleteFailed
   )
 
   behavior of "getCloudPlatform"
@@ -86,7 +86,7 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
 
   it should "raise for an MC workspace that has cloud info for multiple clouds" in {
     val ws = AggregatedWorkspace(
-      deletingMcWorkspace,
+      deleteFailedMcWorkspace,
       Some(GoogleProjectId("project-id")),
       Some(AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake")),
       policies = List.empty
@@ -110,7 +110,7 @@ class AggregatedWorkspaceSpec extends AnyFlatSpec {
 
   it should "return None for a non-ready MC workspace that has no cloud info" in {
     val ws =
-      AggregatedWorkspace(deletingMcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
+      AggregatedWorkspace(deleteFailedMcWorkspace, googleProjectId = None, azureCloudContext = None, policies = List.empty)
 
     val cp = ws.getCloudPlatform
     cp shouldBe None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3052,9 +3052,6 @@ class WorkspaceServiceSpec
 
     val response = readWorkspace.convertTo[WorkspaceResponse]
 
-    // response.azureContext.get.tenantId.toString shouldEqual managedAppCoordinates.tenantId.toString
-    // response.azureContext.get.subscriptionId.toString shouldEqual managedAppCoordinates.subscriptionId.toString
-    // response.azureContext.get.managedResourceGroupId shouldEqual managedAppCoordinates.managedResourceGroupId
     response.workspace.state shouldBe WorkspaceState.Deleting
     response.workspace.cloudPlatform shouldBe None
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1309

The particular use case is that we need to be able to query workspace details for a workspace that is deleting-- there is a period of time when WSM has already deleted the cloud context, but has not yet finished deleting the workspace itself.

We decided to generalize the change though to any workspace that is not in the Ready state.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
