### PR TITLE
QA-2145: Update entities to use implicitly defined encoders / decoders

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -55,7 +55,6 @@ object Dependencies {
     "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
     "org.specs2"          %%  "specs2-core"   % "4.15.0"  % Test,
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
-    // "io.circe"            %%  "circe-generic" % "0.14.2"  % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-3891e8393"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
     "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
     "org.specs2"          %%  "specs2-core"   % "4.15.0"  % Test,
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
-    "io.circe"            %%  "circe-generic" % "0.14.2"  % Test,
+    // "io.circe"            %%  "circe-generic" % "0.14.2"  % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-3891e8393"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -35,8 +35,8 @@ import org.broadinstitute.dsde.test.pipeline._
 class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with CleanUp {
   // The values of the following vars are injected from the pipeline.
   var billingProject: String = _
-  var ownerAuthToken: AuthToken = _
-  var nonOwnerAuthToken: AuthToken = _
+  var ownerAuthToken: ProxyAuthToken = _
+  var nonOwnerAuthToken: ProxyAuthToken = _
 
   private val wsmUrl = RawlsConfig.wsmUrl
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -35,8 +35,8 @@ import org.broadinstitute.dsde.test.pipeline._
 class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with CleanUp {
   // The values of the following vars are injected from the pipeline.
   var billingProject: String = _
-  var ownerAuthToken: ProxyAuthToken = _
-  var nonOwnerAuthToken: ProxyAuthToken = _
+  var ownerAuthToken: AuthToken = _
+  var nonOwnerAuthToken: AuthToken = _
 
   private val wsmUrl = RawlsConfig.wsmUrl
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/PipelineInjector.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/PipelineInjector.scala
@@ -1,9 +1,7 @@
 package org.broadinstitute.dsde.test.pipeline
 
-// import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.parser
-// import org.broadinstitute.dsde.workbench.auth.AuthToken
 
 import java.util.Base64
 import scala.util.Random
@@ -32,7 +30,6 @@ trait PipelineInjector {
           json <- parser.parse(decodedB64)
           seq <- json.as[Seq[UserMetadata]]
         } yield seq
-        // val decoded = decode[Seq[UserMetadata]](new String(Base64.getDecoder.decode(b64), "UTF-8"))
         userMetadataSeq match {
           case Right(u)    => u
           case Left(_)     => Seq()

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserMetadata.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserMetadata.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.test.pipeline
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor, Json}
-import org.broadinstitute.dsde.workbench.auth.AuthToken
+// import org.broadinstitute.dsde.workbench.auth.AuthToken
 // import io.circe.generic.semiauto._
 
 /**
@@ -36,7 +36,7 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
   * }}}
   */
 case class UserMetadata(email: String, `type`: UserType, bearer: String) {
-  def makeAuthToken: AuthToken =
+  def makeAuthToken: ProxyAuthToken =
     ProxyAuthToken(this, (new MockGoogleCredential.Builder()).build())
 }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserMetadata.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserMetadata.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.test.pipeline
 
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
-import io.circe._
-import io.circe.generic.semiauto._
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, Encoder, HCursor, Json}
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+// import io.circe.generic.semiauto._
 
 /**
   * Represents metadata associated with a user.
@@ -10,10 +12,10 @@ import io.circe.generic.semiauto._
   * @param email  The email address associated with the user.
   * @param type   An instance of UserType (e.g., Owner or Student).
   * @param bearer The Bearer token to assert authorization.
-  *               
+  *
   * @example
   * {{{
-  * // Sample JSON representation of an array of user metadata injected from the pipeline 
+  * // Sample JSON representation of an array of user metadata injected from the pipeline
   * [
   *   {
   *     "email": "hermione.owner@quality.firecloud.org",
@@ -34,7 +36,7 @@ import io.circe.generic.semiauto._
   * }}}
   */
 case class UserMetadata(email: String, `type`: UserType, bearer: String) {
-  def makeAuthToken: ProxyAuthToken =
+  def makeAuthToken: AuthToken =
     ProxyAuthToken(this, (new MockGoogleCredential.Builder()).build())
 }
 
@@ -42,5 +44,20 @@ case class UserMetadata(email: String, `type`: UserType, bearer: String) {
   * Companion object containing some useful methods for UserMetadata.
   */
 object UserMetadata {
-  implicit val userMetadataDecoder: Decoder[UserMetadata] = deriveDecoder[UserMetadata]
+  //implicit val userMetadataDecoder: Decoder[UserMetadata] = deriveDecoder[UserMetadata]
+  implicit val userMetadataDecoder: Decoder[UserMetadata] = (c: HCursor) =>
+    for {
+      email <- c.downField("email").as[String]
+      userType <- c.downField("type").as[UserType]
+      bearer <- c.downField("bearer").as[String]
+    } yield UserMetadata(email, userType, bearer)
+
+  implicit val userMetadataEncoder: Encoder[UserMetadata] = (a: UserMetadata) =>
+    Json.obj(
+      ("email", Json.fromString(a.email)),
+      ("type", a.`type`.asJson),
+      ("bearer", Json.fromString(a.bearer))
+    )
+
+  implicit val seqUserMetadataDecoder: Decoder[Seq[UserMetadata]] = Decoder.decodeSeq[UserMetadata]
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserMetadata.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserMetadata.scala
@@ -3,8 +3,6 @@ package org.broadinstitute.dsde.test.pipeline
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, Encoder, HCursor, Json}
-// import org.broadinstitute.dsde.workbench.auth.AuthToken
-// import io.circe.generic.semiauto._
 
 /**
   * Represents metadata associated with a user.

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserType.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/pipeline/UserType.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.test.pipeline
 
-import io.circe.Decoder
+import io.circe.{Decoder, Encoder}
 
 /**
   * Enum-like sealed trait representing the user type.
@@ -9,11 +9,11 @@ sealed trait UserType { def title: String }
 
 /**
   * Enum-like user type for title 'Owner', 'Student'
-  * 
+  *
   * The user types assignment came directly from the original test horde users below.
-  * 
+  *
   * @example
-  * 
+  *
   * {
   *   "admins": {
   *     "dumbledore": "dumbledore.admin@quality.firecloud.org",
@@ -77,4 +77,6 @@ object UserType {
     case "student" => Right(Student)
     case other     => Left(s"Unknown user type: $other")
   }
+
+  implicit val userTypeEncoder: Encoder[UserType] = Encoder.encodeString.contramap(_.title)
 }


### PR DESCRIPTION
Ticket: [QA-2145](https://broadworkbench.atlassian.net/browse/QA-2145)

<Put notes here to help reviewer understand this PR>

This ticket is to replace the current semi-automatically derived decoders and encoders with their explicitly defined counterparts.

This change aims to reduce the likelihood of dependency conflicts when upgrading `circe` libraries to future versions.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[QA-2145]: https://broadworkbench.atlassian.net/browse/QA-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ