### PR TITLE
[WOR-1284] Switch Azure e2e test to using the async deletion API

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = "4.1-cd966bed-SNAP"
+  val serviceTestV = "4.1-365557ae-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,10 +7,10 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.15.2"
 
-  val workbenchLibsHash = "e42c23c"
-  val serviceTestV = "4.1-279ef3bc-SNAP"
-  val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
+  val workbenchLibsHash = "a562dff"
+  val serviceTestV = s"4.2-${workbenchLibsHashP"
+  val workbenchGoogleV = s"0.30-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.34-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.8-${workbenchLibsHash}"
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = "4.1-5a69c44f-SNAP"
+  val serviceTestV = "4.1-735ac3e3-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = "4.1-735ac3e3-SNAP"
+  val serviceTestV = "4.1-cd966bed-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = "4.1-365557ae-SNAP"
+  val serviceTestV = "4.1-279ef3bc-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "a562dff"
-  val serviceTestV = s"4.2-${workbenchLibsHashP"
+  val serviceTestV = s"4.2-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.30-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.34-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = s"4.0-${workbenchLibsHash}"
+  val serviceTestV = "4.1-5a69c44f-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -74,7 +74,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
       response.accessLevel should be(Some(ProjectOwner))
     } finally {
-      Rawls.workspaces.delete(projectName, workspaceName, 20)
+      Rawls.workspaces.delete(projectName, workspaceName)
       assertNoAccessToWorkspace(projectName, workspaceName)
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -157,12 +157,16 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
           verifyBlobNotCloned(cloneSasUrl, nonAnalysesFilename)
         }
       } finally {
-        Rawls.workspaces.delete(projectName, workspaceCloneName)
-        assertNoAccessToWorkspace(projectName, workspaceCloneName)
+        withClue(s"deleting the cloned workspace ${workspaceCloneName} failed") {
+          Rawls.workspaces.delete(projectName, workspaceCloneName)
+          assertNoAccessToWorkspace(projectName, workspaceCloneName)
+        }
       }
     } finally {
-      Rawls.workspaces.delete(projectName, workspaceName)
-      assertNoAccessToWorkspace(projectName, workspaceName)
+      withClue(s"deleting the original workspace ${workspaceName} failed") {
+        Rawls.workspaces.delete(projectName, workspaceName)
+        assertNoAccessToWorkspace(projectName, workspaceName)
+      }
     }
   }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -74,7 +74,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       response.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
       response.accessLevel should be(Some(ProjectOwner))
     } finally {
-      Rawls.workspaces.delete(projectName, workspaceName)
+      Rawls.workspaces.delete(projectName, workspaceName, 20)
       assertNoAccessToWorkspace(projectName, workspaceName)
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1284

Successful Azure e2e test run on this branch: https://github.com/broadinstitute/rawls/actions/runs/6659234257

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
