### PR TITLE
[WOR-1320] Prevent FastPass interference with bucket migrations

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -34,7 +34,8 @@ abstract class GoogleServicesDAO(groupsPrefix: String) extends ErrorReportable {
 
   def updateBucketIam(bucketName: GcsBucketName,
                       policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail],
-                      userProject: Option[GoogleProjectId] = None
+                      userProject: Option[GoogleProjectId] = None,
+                      iamPolicyVersion: Int = 1
   ): Future[Unit]
 
   // returns bucket and group information

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -127,7 +127,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
 
   override def updateBucketIam(bucketName: GcsBucketName,
                                policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail],
-                               userProject: Option[GoogleProjectId]
+                               userProject: Option[GoogleProjectId],
+                               iamPolicyVersion: Int = 1
   ): Future[Unit] = {
     // default object ACLs are no longer used. bucket only policy is enabled on buckets to ensure that objects
     // do not have separate permissions that deviate from the bucket-level permissions.
@@ -175,7 +176,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
                                                                 RetryPredicates.whenStatusCode(400),
                                                                 RetryPredicates.whenStatusCode(404)
         ),
-        bucketSourceOptions = userProject.map(p => BucketSourceOption.userProject(p.value)).toList
+        bucketSourceOptions = userProject.map(p => BucketSourceOption.userProject(p.value)).toList,
+        version = iamPolicyVersion
       )
       .compile
       .drain

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -598,7 +598,8 @@ object MultiregionalBucketMigrationActor {
             .updateBucketIam(
               bucket,
               bucketPolicies,
-              Option.when(migration.requesterPaysEnabled)(GoogleProjectId(deps.googleProjectToBill.value))
+              Option.when(migration.requesterPaysEnabled)(GoogleProjectId(deps.googleProjectToBill.value)),
+              iamPolicyVersion = 3
             )
             .io *>
             Applicative[IO].whenA(migration.requesterPaysEnabled) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -90,7 +90,8 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
   override def updateBucketIam(bucketName: GcsBucketName,
                                policyGroupsByAccessLevel: Map[WorkspaceAccessLevel, WorkbenchEmail],
-                               userProject: Option[GoogleProjectId]
+                               userProject: Option[GoogleProjectId],
+                               iamPolicyVersion: Int = 1
   ): Future[Unit] =
     Future.unit
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -463,7 +463,7 @@ class FastPassServiceSpec
 
     val samUserStatus = Await
       .result(services.fastPassMockSamDAO.getUserIdInfoForEmail(WorkbenchEmail(services.user.userEmail.value)),
-        Duration.Inf
+              Duration.Inf
       )
     val userSubjectId = WorkbenchUserId(samUserStatus.userSubjectId)
     val userEmail = WorkbenchEmail(samUserStatus.userEmail)
@@ -498,7 +498,7 @@ class FastPassServiceSpec
     val petKey =
       Await.result(
         services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId,
-          RawlsUserEmail(samUserStatus.userEmail)
+                                                                   RawlsUserEmail(samUserStatus.userEmail)
         ),
         Duration.Inf
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -451,6 +451,10 @@ class FastPassServiceSpec
   }
 
   it should "sync FastPass grants for a workspace with the current user context" in withTestDataServices { services =>
+    verifyFastPassGrantsSynced(services)
+  }
+
+  def verifyFastPassGrantsSynced(services: TestApiService) = {
     val beforeCreate = OffsetDateTime.now(ZoneOffset.UTC)
     Await.ready(services.mockFastPassService.syncFastPassesForUserInWorkspace(testData.workspace), Duration.Inf)
 
@@ -459,7 +463,7 @@ class FastPassServiceSpec
 
     val samUserStatus = Await
       .result(services.fastPassMockSamDAO.getUserIdInfoForEmail(WorkbenchEmail(services.user.userEmail.value)),
-              Duration.Inf
+        Duration.Inf
       )
     val userSubjectId = WorkbenchUserId(samUserStatus.userSubjectId)
     val userEmail = WorkbenchEmail(samUserStatus.userEmail)
@@ -494,7 +498,7 @@ class FastPassServiceSpec
     val petKey =
       Await.result(
         services.fastPassMockSamDAO.getPetServiceAccountKeyForUser(testData.workspace.googleProjectId,
-                                                                   RawlsUserEmail(samUserStatus.userEmail)
+          RawlsUserEmail(samUserStatus.userEmail)
         ),
         Duration.Inf
       )
@@ -1431,5 +1435,74 @@ class FastPassServiceSpec
     )
 
     verifyNoInteractions(iamDAO, storageDAO, gcsDAO)
+  }
+
+  it should "not issue FastPass grants when a workspace's bucket migration failed" in withMinimalTestDatabase { _ =>
+    val ctx = RawlsRequestContext(
+      UserInfo(RawlsUserEmail("user@example.com"),
+               OAuth2BearerToken("fake_token"),
+               0L,
+               RawlsUserSubjectId(UUID.randomUUID().toString)
+      )
+    )
+    val config = FastPassConfig(true, JavaDuration.ZERO, JavaDuration.ZERO)
+    implicit val openTelemetry = FakeOpenTelemetryMetricsInterpreter
+    val iamDAO = spy(new MockGoogleIamDAO)
+    val storageDAO = spy(new MockGoogleStorageDAO)
+    val gcsDAO = spy(new MockGoogleServicesDAO("groupsPrefix"))
+    val fastPassService =
+      new FastPassService(ctx, slickDataSource, config, iamDAO, storageDAO, gcsDAO, null, "", "", "", "", "")
+
+    Await.result(
+      for {
+        _ <- slickDataSource.inTransaction { dataAccess =>
+          for {
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(minimalTestData.workspace, Option("US"))
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(minimalTestData.workspace.workspaceIdAsUUID)
+              .value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update3(
+              attempt.getOrElse(fail()).id,
+              multiregionalBucketMigrationQuery.startedCol,
+              Some(Timestamp.valueOf(LocalDateTime.now())),
+              multiregionalBucketMigrationQuery.finishedCol,
+              Some(Timestamp.valueOf(LocalDateTime.now())),
+              multiregionalBucketMigrationQuery.outcomeCol,
+              Some("Failure")
+            )
+          } yield ()
+        }
+        _ <- fastPassService.syncFastPassesForUserInWorkspace(minimalTestData.workspace)
+      } yield (),
+      Duration.Inf
+    )
+
+    verifyNoInteractions(iamDAO, storageDAO, gcsDAO)
+  }
+
+  it should "issue FastPass grants when a workspace's bucket has been migrated successfully" in withTestDataServices {
+    services =>
+      Await.result(
+        services.slickDataSource.inTransaction { dataAccess =>
+          for {
+            _ <- dataAccess.multiregionalBucketMigrationQuery.schedule(testData.workspace, Option("US"))
+            attempt <- dataAccess.multiregionalBucketMigrationQuery
+              .getAttempt(testData.workspace.workspaceIdAsUUID)
+              .value
+            _ <- dataAccess.multiregionalBucketMigrationQuery.update3(
+              attempt.getOrElse(fail()).id,
+              multiregionalBucketMigrationQuery.startedCol,
+              Some(Timestamp.valueOf(LocalDateTime.now())),
+              multiregionalBucketMigrationQuery.finishedCol,
+              Some(Timestamp.valueOf(LocalDateTime.now())),
+              multiregionalBucketMigrationQuery.outcomeCol,
+              Some("Success")
+            )
+          } yield ()
+        },
+        Duration.Inf
+      )
+
+      verifyFastPassGrantsSynced(services)
   }
 }


### PR DESCRIPTION
Ticket: [WOR-1320](https://broadworkbench.atlassian.net/browse/WOR-1320)
* Explicitly set the IAM policy version to 3 when restoring IAM at the end of the migration
    * When FastPass grants are present on a migrating workspace bucket, the call to restore IAM on the bucket fails due to an invalid policy number (see https://cloud.google.com/iam/help/allow-policies/versions for more details).
* Prevent FastPass grants on workspaces that have failed to be migrated
    * We were already preventing FastPass from working on migrating workspaces. Adding this change will prevent FastPass from granting users access to their workspace buckets after a migration has failed. Users still should not have access to their workspace buckets at this time as the workspace should be considered in progress
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1320]: https://broadworkbench.atlassian.net/browse/WOR-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ