### PR TITLE
Revert "[WOR-1309] Don't error for non-Ready MC Workspaces that have no cloud context."

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = s"4.1-365557ae-SNAP"
+  val serviceTestV = s"4.1-279ef3bc-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val jacksonV      = "2.15.2"
 
   val workbenchLibsHash = "e42c23c"
-  val serviceTestV = s"4.0-${workbenchLibsHash}"
+  val serviceTestV = s"4.1-365557ae-SNAP"
   val workbenchGoogleV = s"0.29-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.32-${workbenchLibsHash}"
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4134,7 +4134,7 @@ paths:
       tags:
         - workspaces_v2
       summary: Delete workspace
-      description: Starts a job to delete a workspace and all of its contents.
+      description: Starts a job to delete a workspace and all of its contents. Note that this is an in-progress API and currently unsupported.
       operationId: deleteWorkspaceV2
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
@@ -5703,7 +5703,7 @@ components:
           format: date-time
         cloudPlatform:
           type: string
-          description: The cloud platform of the workspace. If the workspace is not in the Ready state, the cloud platform may be missing.
+          description: The cloud platform of the workspace
           enum:
             - GCP
             - AZURE

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotReferenceCreationValidator.scala
@@ -30,21 +30,16 @@ class SnapshotReferenceCreationValidator(val workspaceContext: Workspace, val sn
   // Throws an exception when the given snapshot cannot be referenced by the given workspace due to crossing an
   // unsupported platform boundary.
   @throws(classOf[PlatformBoundaryException])
-  def validateWorkspacePlatformCompatibility(workspacePlatform: Option[WorkspaceCloudPlatform]): Unit =
+  def validateWorkspacePlatformCompatibility(workspacePlatform: WorkspaceCloudPlatform): Unit =
     // Defining all acceptable combinations is overkill when all we really need to do is prevent anything Azure, but
     // this is here as a safeguard against us introducing support for Azure without deliberately addressing the issue of
     // snapshots by ref across cloud platforms.
     (snapshot.platform, workspacePlatform) match {
-      case (SnapshotCloudPlatform.GCP, Some(WorkspaceCloudPlatform.Gcp)) => // ok
-      case (_, None) =>
-        throw new PlatformBoundaryException(
-          "Snapshots by reference are not supported into a workspace with no cloud context (" +
-            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform})."
-        )
+      case (SnapshotCloudPlatform.GCP, WorkspaceCloudPlatform.Gcp) => // ok
       case _ =>
         throw new PlatformBoundaryException(
           "Snapshots by reference are not supported across the given cloud boundaries (" +
-            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform.get})."
+            s"snapshot: ${snapshot.platform}, workspace: ${workspacePlatform})."
         )
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -83,7 +83,7 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         case _: AggregateWorkspaceNotFoundException =>
           // if a WSM workspace does not already exist, assume the platform is GCP, confirm platform compatibility,
           // and then create a stub workspace
-          snapshotValidator.validateWorkspacePlatformCompatibility(Some(WorkspaceCloudPlatform.Gcp))
+          snapshotValidator.validateWorkspacePlatformCompatibility(WorkspaceCloudPlatform.Gcp)
           workspaceManagerDAO.createWorkspace(wsid, rawlsWorkspace.workspaceType, ctx)
       }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -1663,27 +1663,6 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       WorkspaceState.Ready
     )
 
-    val deletingAzureWorkspace = new Workspace(
-      namespace = azureBillingProjectName.value,
-      name = "test-deleting-azure-workspace",
-      workspaceId = UUID.randomUUID().toString,
-      bucketName = "",
-      workflowCollectionName = None,
-      createdDate = currentTime(),
-      lastModified = currentTime(),
-      createdBy = "testUser",
-      attributes = Map.empty,
-      isLocked = false,
-      workspaceVersion = WorkspaceVersions.V2,
-      googleProjectId = GoogleProjectId(""),
-      googleProjectNumber = None,
-      currentBillingAccountOnGoogleProject = None,
-      errorMessage = None,
-      completedCloneWorkspaceFileTransfer = None,
-      workspaceType = WorkspaceType.McWorkspace,
-      WorkspaceState.Deleting
-    )
-
     val allWorkspaces = Seq(
       workspace,
       workspaceLocked,
@@ -1706,8 +1685,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       workspaceToTestGrant,
       workspaceConfigCopyDestination,
       regionalWorkspace,
-      azureWorkspace,
-      deletingAzureWorkspace
+      azureWorkspace
     )
     val saveAllWorkspacesAction = DBIO.sequence(allWorkspaces.map(workspaceQuery.createOrUpdate))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotServiceSpec.scala
@@ -542,59 +542,6 @@ class SnapshotServiceSpec extends AnyWordSpecLike with Matchers with MockitoSuga
       )
     }
 
-    "not create a snapshot reference of a GCP snapshot in an Azure workspace with no cloud context" in withDefaultTestDatabase {
-      // stub an Azure workspace
-      val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()
-      val azureWorkspaceDescription = new WorkspaceDescription()
-        .stage(WorkspaceStageModel.MC_WORKSPACE)
-        .policies(
-          Seq(
-            new WsmPolicyInput()
-              .name("fakepolicy")
-              .namespace("fakens")
-              .addAdditionalDataItem(new WsmPolicyPair().key("dataKey").value("dataValue"))
-          ).asJava
-        )
-
-      when(mockWorkspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext]))
-        .thenReturn(azureWorkspaceDescription)
-
-      val snapshotService = SnapshotService.constructor(
-        slickDataSource,
-        defaultMockSamDao(),
-        mockWorkspaceManagerDAO,
-        "fake-terra-data-repo-dev",
-        // snapshots are assumed to be GCP unless they belong to a Dataset with the Azure cloudPlatform
-        new MockDataRepoDAO("mockDataRepo")
-      )(testContext)
-
-      val snapshotUuid = UUID.randomUUID()
-      val snapRefName = DataReferenceName("refname")
-      val snapRefDescription = Option(DataReferenceDescriptionField("my reference description"))
-
-      val thrown = intercept[RawlsException] {
-        Await.result(
-          snapshotService.createSnapshot(testData.deletingAzureWorkspace.toWorkspaceName,
-                                         NamedDataRepoSnapshot(snapRefName, snapRefDescription, snapshotUuid)
-          ),
-          Duration.Inf
-        )
-      }
-
-      assert(
-        thrown.getMessage === "Snapshots by reference are not supported into a workspace with no cloud context (snapshot: gcp, workspace: None)."
-      )
-      verify(mockWorkspaceManagerDAO, never()).createDataRepoSnapshotReference(
-        any[UUID],
-        any[UUID],
-        any[DataReferenceName],
-        any[Option[DataReferenceDescriptionField]],
-        any[String],
-        any[CloningInstructionsEnum],
-        any[RawlsRequestContext]
-      )
-    }
-
     "not create a snapshot reference even if both the snapshot and workspace are Azure" in withDefaultTestDatabase {
       // stub an Azure workspace
       val mockWorkspaceManagerDAO = defaultMockWorkspaceManagerDao()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -39,7 +39,6 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock._
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ProjectPoolType.ProjectPoolType
-import org.broadinstitute.dsde.rawls.model.Workspace.buildMcWorkspace
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
@@ -3002,61 +3001,6 @@ class WorkspaceServiceSpec
     response.workspace.state shouldBe WorkspaceState.Ready
   }
 
-  it should "get the details of an Azure workspace that is deleting" in withTestDataServices { services =>
-    val service = services.workspaceService
-    val workspaceId1 = UUID.randomUUID().toString
-
-    val deletingAzureWorkspace =
-      Workspace.buildMcWorkspace("test_namespace1",
-                                 "name",
-                                 workspaceId1,
-                                 new DateTime(),
-                                 new DateTime(),
-                                 "testUser1",
-                                 Map.empty,
-                                 WorkspaceState.Deleting
-      )
-
-    runAndWait {
-      for {
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(deletingAzureWorkspace)
-      } yield ()
-    }
-
-    when(service.workspaceManagerDAO.getWorkspace(deletingAzureWorkspace.workspaceIdAsUUID, services.ctx1))
-      .thenReturn(
-        new WorkspaceDescription().stage(WorkspaceStageModel.MC_WORKSPACE)
-      ) // no azureContext, should not be returned
-
-    when(service.samDAO.listUserResources(SamResourceTypeNames.workspace, services.ctx1)).thenReturn(
-      Future(
-        Seq(
-          SamUserResource(
-            workspaceId1,
-            SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
-            SamRolesAndActions(Set.empty, Set.empty),
-            SamRolesAndActions(Set.empty, Set.empty),
-            Set.empty,
-            Set.empty
-          )
-        )
-      )
-    )
-
-    val readWorkspace = Await.result(
-      services.workspaceService.getWorkspace(
-        WorkspaceName(deletingAzureWorkspace.namespace, deletingAzureWorkspace.name),
-        WorkspaceFieldSpecs()
-      ),
-      Duration.Inf
-    )
-
-    val response = readWorkspace.convertTo[WorkspaceResponse]
-
-    response.workspace.state shouldBe WorkspaceState.Deleting
-    response.workspace.cloudPlatform shouldBe None
-  }
-
   it should "return the policies of an Azure workspace" in withTestDataServices { services =>
     val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
     val wsmPolicyInput = new WsmPolicyInput()
@@ -3307,24 +3251,21 @@ class WorkspaceServiceSpec
       ) should contain theSameElementsAs expected
   }
 
-  it should "not return MC workspaces that do not have a cloud context" in withTestDataServices { services =>
+  it should "not return a MC workspace that does not have a cloud context" in withTestDataServices { services =>
     val service = services.workspaceService
     val workspaceId1 = UUID.randomUUID().toString
     val workspaceId2 = UUID.randomUUID().toString
-    val workspaceId3 = UUID.randomUUID().toString
 
     // set up test data
-    val deletingAzureWorkspace =
-      Workspace.buildMcWorkspace("test_namespace1",
-                                 "name1",
-                                 workspaceId1,
-                                 new DateTime(),
-                                 new DateTime(),
-                                 "testUser1",
-                                 Map.empty,
-                                 WorkspaceState.Deleting
+    val azureWorkspace =
+      Workspace.buildReadyMcWorkspace("test_namespace1",
+                                      "name",
+                                      workspaceId1,
+                                      new DateTime(),
+                                      new DateTime(),
+                                      "testUser1",
+                                      Map.empty
       )
-
     val googleWorkspace = Workspace("test_namespace2",
                                     workspaceId2,
                                     workspaceId2,
@@ -3336,29 +3277,14 @@ class WorkspaceServiceSpec
                                     Map.empty
     )
 
-    val readyAzureWorkspace =
-      Workspace.buildReadyMcWorkspace("test_namespace3",
-                                      "name3",
-                                      workspaceId3,
-                                      new DateTime(),
-                                      new DateTime(),
-                                      "testUser3",
-                                      Map.empty
-      )
-
     runAndWait {
       for {
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(readyAzureWorkspace)
+        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(azureWorkspace)
         _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(googleWorkspace)
-        _ <- slickDataSource.dataAccess.workspaceQuery.createOrUpdate(deletingAzureWorkspace)
       } yield ()
     }
 
-    when(service.workspaceManagerDAO.getWorkspace(deletingAzureWorkspace.workspaceIdAsUUID, services.ctx1))
-      .thenReturn(
-        new WorkspaceDescription().stage(WorkspaceStageModel.MC_WORKSPACE)
-      ) // no azureContext, should not be returned
-    when(service.workspaceManagerDAO.getWorkspace(readyAzureWorkspace.workspaceIdAsUUID, services.ctx1))
+    when(service.workspaceManagerDAO.getWorkspace(azureWorkspace.workspaceIdAsUUID, services.ctx1))
       .thenReturn(
         new WorkspaceDescription().stage(WorkspaceStageModel.MC_WORKSPACE)
       ) // no azureContext, should not be returned
@@ -3378,14 +3304,6 @@ class WorkspaceServiceSpec
           ),
           SamUserResource(
             workspaceId2,
-            SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
-            SamRolesAndActions(Set.empty, Set.empty),
-            SamRolesAndActions(Set.empty, Set.empty),
-            Set.empty,
-            Set.empty
-          ),
-          SamUserResource(
-            workspaceId3,
             SamRolesAndActions(Set(SamWorkspaceRoles.owner), Set.empty),
             SamRolesAndActions(Set.empty, Set.empty),
             SamRolesAndActions(Set.empty, Set.empty),


### PR DESCRIPTION
Reverts broadinstitute/rawls#2591

This is only to test out if the e2e Azure tests fail when they run against this branch.