### PR TITLE
[WOR-1329] Handle processing exception (i.e., connection resets) when polling WSM

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/DeletionAction.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/DeletionAction.scala
@@ -3,11 +3,14 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions
 import bio.terra.workspace.client.{ApiException => WsmApiException}
 import org.broadinstitute.dsde.workbench.client.leonardo.{ApiException => LeoApiException}
 
+import javax.ws.rs.ProcessingException
+
 object DeletionAction {
-  def when500(throwable: Throwable): Boolean =
+  def when500OrProcessingException(throwable: Throwable): Boolean =
     throwable match {
-      case t: WsmApiException => t.getCode / 100 == 5
-      case t: LeoApiException => t.getCode / 100 == 5
-      case _ => false
+      case t: WsmApiException     => t.getCode / 100 == 5
+      case t: LeoApiException     => t.getCode / 100 == 5
+      case _: ProcessingException => true
+      case _                      => false
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.LeonardoDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500OrProcessingException
 import org.broadinstitute.dsde.rawls.util.Retry
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiException
 import org.broadinstitute.dsde.workbench.client.leonardo.model.{ListAppResponse, ListRuntimeResponse}
@@ -58,7 +58,7 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
   def listApps(workspace: Workspace, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext
   ): Future[Seq[ListAppResponse]] =
-    retry(when500) { () =>
+    retry(when500OrProcessingException) { () =>
       Future {
         blocking {
           leonardoDAO.listApps(ctx.userInfo.accessToken.token, workspace.workspaceIdAsUUID)
@@ -69,7 +69,7 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
   def listAzureRuntimes(workspace: Workspace, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext
   ): Future[Seq[ListRuntimeResponse]] =
-    retry(when500) { () =>
+    retry(when500OrProcessingException) { () =>
       Future {
         blocking {
           leonardoDAO.listAzureRuntimes(ctx.userInfo.accessToken.token, workspace.workspaceIdAsUUID)
@@ -78,7 +78,7 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
     }
 
   def deleteApps(workspace: Workspace, ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Unit] =
-    retry(when500) { () =>
+    retry(when500OrProcessingException) { () =>
       Future {
         blocking {
           logger.info(s"Sending app deletion request [workspaceId=${workspace.workspaceIdAsUUID}]")
@@ -88,7 +88,7 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
     }
 
   def deleteRuntimes(workspace: Workspace, ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Unit] =
-    retry(when500) { () =>
+    retry(when500OrProcessingException) { () =>
       Future {
         blocking {
           logger.info(s"Sending runtime deletion request [workspaceId=${workspace.workspaceIdAsUUID}]")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/WsmDeletionAction.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/WsmDeletionAction.scala
@@ -7,9 +7,10 @@ import bio.terra.workspace.model.JobReport.StatusEnum
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500OrProcessingException
 import org.broadinstitute.dsde.rawls.util.Retry
 
+import javax.ws.rs.ProcessingException
 import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -20,7 +21,7 @@ class WsmDeletionAction(workspaceManagerDao: WorkspaceManagerDAO)(implicit val s
   def pollForCompletion(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext
   ): Future[Boolean] =
-    retry(when500)(() => Future(isComplete(workspace, jobId, ctx)))
+    retry(when500OrProcessingException)(() => Future(isComplete(workspace, jobId, ctx)))
 
   private def isComplete(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext
@@ -56,7 +57,7 @@ class WsmDeletionAction(workspaceManagerDao: WorkspaceManagerDAO)(implicit val s
   def startStep(workspace: Workspace, jobId: String, ctx: RawlsRequestContext)(implicit
     ec: ExecutionContext
   ): Future[Unit] =
-    retry(when500) { () =>
+    retry(when500OrProcessingException) { () =>
       startDeletion(workspace, jobId, ctx)
     }
 


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1329)
I observed several connection reset events in prod during a long poll against WSM for deletion. Assuming these are short lived events, they should be retried. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
