### PR TITLE
AJ-1428: Use helmchart name for pact identifier.

### DIFF
--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -96,7 +96,7 @@ jobs:
 
   rawls-consumer-contract-tests:
     runs-on: ubuntu-latest
-    needs: [init-github-context]
+    needs: [ init-github-context ]
     outputs:
       pact-b64: ${{ steps.encode-pact.outputs.pact-b64 }}
 
@@ -115,7 +115,7 @@ jobs:
         id: encode-pact
         run: |
           cd pact4s
-          NON_BREAKING_B64=$(cat target/pacts/rawls-consumer-bpm-provider.json | base64 -w 0)
+          NON_BREAKING_B64=$(cat target/pacts/rawls-bpm.json | base64 -w 0)
           echo "pact-b64=${NON_BREAKING_B64}" >> $GITHUB_OUTPUT
 
   # Prevent untrusted sources from using PRs to publish contracts
@@ -160,6 +160,6 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{
             "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
-            "pacticipant": "rawls-consumer",
+            "pacticipant": "rawls",
             "version": "${{ needs.init-github-context.outputs.repo-version }}"
           }'

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -182,11 +182,9 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     )
   }.build()
 
-  val consumerPactBuilder: ConsumerPactBuilder = ConsumerPactBuilder
-    .consumer("rawls-consumer")
+  val consumerPactBuilder: ConsumerPactBuilder = ConsumerPactBuilder.consumer("rawls")
 
-  val pactProvider: PactDslWithProvider = consumerPactBuilder
-    .hasPactWith("bpm-provider")
+  val pactProvider: PactDslWithProvider = consumerPactBuilder.hasPactWith("bpm")
 
   // stateParams provides the desired subsystem states
   // for BPM provider to generate the expected response


### PR DESCRIPTION
Prefer helmchart name as the pacticipant identifier:
* `rawls-consumer` -> `rawls`
* `bpm-provider` -> `bpm`
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698068076950019) discussing the `-consumer` and `-provider` suffix anti-pattern.
* See [thread](https://broadinstitute.slack.com/archives/C043YJ40719/p1698241095600099) discussing the recommendation to use the helm chart name.

Tickets:
[AJ-1428](https://broadworkbench.atlassian.net/browse/AJ-1428) - General maintenance ticket.
[AJ-1234](https://broadworkbench.atlassian.net/browse/AJ-1234) - Adjacent / similar, but not strictly dependent work.

[AJ-1428]: https://broadworkbench.atlassian.net/browse/AJ-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AJ-1234]: https://broadworkbench.atlassian.net/browse/AJ-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ