### PR TITLE
AJ-1428: abbreviate error message to avoid tokens

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -44,6 +44,7 @@ import com.google.cloud.storage.Storage.BucketSourceOption
 import com.google.cloud.storage.StorageException
 import io.opencensus.scala.Tracing._
 import io.opencensus.trace.{AttributeValue, Span}
+import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.rawls.dataaccess.CloudResourceManagerV2Model.{Folder, FolderSearchResponse}
 import org.broadinstitute.dsde.rawls.dataaccess.HttpGoogleServicesDAO._
 import org.broadinstitute.dsde.rawls.google.{AccessContextManagerDAO, GoogleUtilities}
@@ -1267,8 +1268,11 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       val tokenInfo = executeGoogleRequest(oauth2.tokeninfo().setAccessToken(creds.getAccessToken), logRequest = false)
       RawlsUser(RawlsUserSubjectId(tokenInfo.getUserId), RawlsUserEmail(tokenInfo.getEmail))
     }.recover { case e: GoogleJsonResponseException =>
+      // abbreviate the error message to ensure we don't include a token in the exception
       throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.InternalServerError, s"Failed to get token info: ${e.getMessage}")
+        ErrorReport(StatusCodes.InternalServerError,
+                    s"Failed to get token info: ${StringUtils.abbreviate(e.getMessage, 50)}"
+        )
       )
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1428

Under the right (wrong?) circumstances, this exception can include a full token value. This will happen if Google returns a 502, for instance, in which case the error message will be `502 Bad Gateway
POST https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=ya29….`.

This PR changes the exception to abbreviate the error message, ensuring we won't log a full token.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
