### PR TITLE
[WOR-1280] Add optional policies field on workspace creation

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5789,8 +5789,16 @@ components:
           default: false
         protectedData:
           type: boolean
-          description: Optional, false if not specified. Attach a protected data policy to this workspace (only applicable for Azure workspaces). If true, this workspace must be created in a protected data billing project.
+          deprecated: True
+          description: |
+            Optional, false if not specified. Applicable only for Azure workspaces. Attach a protected data policy to this workspace (only applicable for Azure workspaces). If true, this workspace must be created in a protected data billing project.
+            Note this field is deprecated. A protected data policy should be attached by utilizing the policies field instead.
           default: false
+        policies:
+          type: array
+          description: Optional, array of policies to attach to the workspace.
+          items:
+            $ref: '#/components/schemas/WorkspacePolicy'
       description: ""
     WorkspaceRequestClone:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -20,7 +20,8 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   Workspace,
   WorkspaceAttributeSpecs,
-  WorkspaceName
+  WorkspaceName,
+  WorkspaceRequest
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceWithParent}
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -20,8 +20,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   Workspace,
   WorkspaceAttributeSpecs,
-  WorkspaceName,
-  WorkspaceRequest
+  WorkspaceName
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceWithParent}
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2064,6 +2064,20 @@ class WorkspaceServiceSpec
     )
   }
 
+  it should "fail with 400 if policies are provided for a GCP workspace" in withTestDataServices { services =>
+    val error = intercept[RawlsExceptionWithErrorReport] {
+      val workspaceName = WorkspaceName(testData.testProject1Name.value, s"${UUID.randomUUID()}")
+      val workspaceRequest = WorkspaceRequest(workspaceName.namespace,
+                                              workspaceName.name,
+                                              Map.empty,
+                                              policies = Some(List(WorkspacePolicy("fake", "fake", List.empty)))
+      )
+      Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+    }
+
+    error.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
+  }
+
   // TODO: This test will need to be deleted when implementing https://broadworkbench.atlassian.net/browse/CA-947
   it should "fail with 400 when the BillingProject is not Ready" in withTestDataServices { services =>
     (CreationStatuses.all - CreationStatuses.Ready).foreach { projectStatus =>


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1280)
We want to allow the addition of policies at the of azure workspace creation.

### This PR
* Adds an optional `policies` field to the createWorkspace API requests. 
   * If included on a GCP workspace creation request and the field contains anything but null or an empty list, a 400 will be returned
   * For azure workspaces, these are added to the set of policies included in the WSM createWorkspace call
   

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
