### PR TITLE
[WOR-1037] Set protected-data policy on billing profile for protected data Azure billing projects

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6457,6 +6457,9 @@ components:
           type: string
           format: uuid
           description: the UUID of the landing zone associated with the project (cloudPlatform AZURE only)
+        protectedData:
+          type: boolean
+          description: whether this billing project supports protected data (cloudPlatform AZURE only)
     AzureManagedAppCoordinates:
       required:
         - tenantId

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -140,11 +140,9 @@ class BillingProfileManagerDAOImpl(
             .namespace("terra") // policy namespaces in Rawls are always 'terra'
             .name(policyName)
             .additionalData(
-              additionalData
-                .map { case (key, value) =>
-                  new BpmApiPolicyPair().key(key).value(value)
-                }
-                .asJava
+              additionalData.map { case (key, value) =>
+                new BpmApiPolicyPair().key(key).value(value)
+              }.asJava
             )
         }
         .toList

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -38,7 +38,7 @@ import BpmAzureReportErrorMessageJsonProtocol._
 trait BillingProfileManagerDAO {
   def createBillingProfile(displayName: String,
                            billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates],
-                           policies: Map[String, Map[String, String]],
+                           policies: Map[String, List[(String, String)]],
                            ctx: RawlsRequestContext
   ): ProfileModel
 
@@ -125,7 +125,7 @@ class BillingProfileManagerDAOImpl(
   override def createBillingProfile(
     displayName: String,
     billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates],
-    policies: Map[String, Map[String, String]] = Map.empty,
+    policies: Map[String, List[(String, String)]] = Map.empty,
     ctx: RawlsRequestContext
   ): ProfileModel = {
     val azureManagedAppCoordinates = billingInfo match {
@@ -144,7 +144,6 @@ class BillingProfileManagerDAOImpl(
                 .map { case (key, value) =>
                   new BpmApiPolicyPair().key(key).value(value)
                 }
-                .toList
                 .asJava
             )
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -92,7 +92,8 @@ class BpmBillingProjectLifecycle(
     def createBillingProfile: Future[ProfileModel] =
       Future(blocking {
         val policies: Map[String, List[(String, String)]] =
-          if (createProjectRequest.protectedData.getOrElse(false)) Map("protected-data" -> List[(String, String)]()) else Map.empty
+          if (createProjectRequest.protectedData.getOrElse(false)) Map("protected-data" -> List[(String, String)]())
+          else Map.empty
         val profileModel = billingProfileManagerDAO.createBillingProfile(
           projectName.value,
           createProjectRequest.billingInfo,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -91,9 +91,12 @@ class BpmBillingProjectLifecycle(
 
     def createBillingProfile: Future[ProfileModel] =
       Future(blocking {
+        val policies: Map[String, Map[String, String]] =
+          if (createProjectRequest.protectedData.getOrElse(false)) Map("protected-data" -> Map.empty) else Map.empty
         val profileModel = billingProfileManagerDAO.createBillingProfile(
           projectName.value,
           createProjectRequest.billingInfo,
+          policies,
           ctx
         )
         logger.info(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -91,8 +91,8 @@ class BpmBillingProjectLifecycle(
 
     def createBillingProfile: Future[ProfileModel] =
       Future(blocking {
-        val policies: Map[String, Map[String, String]] =
-          if (createProjectRequest.protectedData.getOrElse(false)) Map("protected-data" -> Map.empty) else Map.empty
+        val policies: Map[String, List[(String, String)]] =
+          if (createProjectRequest.protectedData.getOrElse(false)) Map("protected-data" -> List[(String, String)]()) else Map.empty
         val profileModel = billingProfileManagerDAO.createBillingProfile(
           projectName.value,
           createProjectRequest.billingInfo,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -100,14 +100,16 @@ case class RawlsBillingProjectResponse(
   message: Option[String],
   managedAppCoordinates: Option[AzureManagedAppCoordinates], // remove after ui is updated  to use cloud context
   cloudPlatform: String,
-  landingZoneId: Option[String]
+  landingZoneId: Option[String],
+  protectedData: Boolean
 )
 
 object RawlsBillingProjectResponse {
   def apply(
     roles: Set[ProjectRole],
     project: RawlsBillingProject,
-    platform: CloudPlatform = CloudPlatform.UNKNOWN
+    platform: CloudPlatform = CloudPlatform.UNKNOWN,
+    protectedData: Boolean = false
   ): RawlsBillingProjectResponse = this(
     project.projectName,
     project.billingAccount,
@@ -118,7 +120,8 @@ object RawlsBillingProjectResponse {
     project.message,
     project.azureManagedAppCoordinates,
     platform.toString,
-    project.landingZoneId
+    project.landingZoneId,
+    protectedData
   )
 }
 
@@ -316,7 +319,7 @@ class UserAuthJsonSupport extends JsonSupport {
   )
 
   implicit val RawlsBillingProjectResponseFormat: RootJsonFormat[RawlsBillingProjectResponse] =
-    jsonFormat10(RawlsBillingProjectResponse.apply)
+    jsonFormat11(RawlsBillingProjectResponse.apply)
 }
 
 object UserAuthJsonSupport extends UserAuthJsonSupport

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -101,7 +101,7 @@ case class RawlsBillingProjectResponse(
   managedAppCoordinates: Option[AzureManagedAppCoordinates], // remove after ui is updated  to use cloud context
   cloudPlatform: String,
   landingZoneId: Option[String],
-  protectedData: Boolean
+  protectedData: Option[Boolean]
 )
 
 object RawlsBillingProjectResponse {
@@ -109,7 +109,7 @@ object RawlsBillingProjectResponse {
     roles: Set[ProjectRole],
     project: RawlsBillingProject,
     platform: CloudPlatform = CloudPlatform.UNKNOWN,
-    protectedData: Boolean = false
+    protectedData: Option[Boolean] = None
   ): RawlsBillingProjectResponse = this(
     project.projectName,
     project.billingAccount,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -317,20 +317,24 @@ class UserService(
     billingProfile: Option[ProfileModel],
     roles: Set[ProjectRole]
   ): RawlsBillingProjectResponse = (project.billingProfileId, billingProfile) match {
-    case (None, _) => RawlsBillingProjectResponse(roles, project, CloudPlatform.GCP, protectedData = false)
+    case (None, _) => RawlsBillingProjectResponse(roles, project, CloudPlatform.GCP, protectedData = None)
     case (Some(_), Some(p)) =>
       val platform = CloudPlatform(p)
       val responseProject = if (platform == CloudPlatform.AZURE) {
         val c = AzureManagedAppCoordinates(p.getTenantId, p.getSubscriptionId, p.getManagedResourceGroupId)
         project.copy(azureManagedAppCoordinates = Some(c))
       } else project
-      val protectedData = Option(p.getPolicies).map(
-        _.getInputs.asScala.exists(policy =>
-          policy.getNamespace.equals("terra") && policy.getName.equals("protected-data")
-        )
-      )
+      val protectedData = Option(p.getPolicies) match {
+        case Some(policies) =>
+          Option(
+            policies.getInputs.asScala.exists(policy =>
+              policy.getNamespace.equals("terra") && policy.getName.equals("protected-data")
+            )
+          )
+        case None => Option(false)
+      }
 
-      RawlsBillingProjectResponse(roles, responseProject, platform, protectedData.getOrElse(false))
+      RawlsBillingProjectResponse(roles, responseProject, platform, protectedData)
     case (Some(id), None) =>
       val message = Some(s"Unable to find billing profile in Billing Profile Manager for billing profile id: $id")
       RawlsBillingProjectResponse(roles, project.copy(message = message, status = CreationStatuses.Error))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -28,6 +28,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success}
 
 /**
@@ -283,7 +284,9 @@ class UserService(
     billingProfile = billingProject.flatMap {
       _.billingProfileId.flatMap(id => billingProfileManagerDAO.getBillingProfile(UUID.fromString(id), ctx))
     }
-  } yield billingProject.flatMap(p => if (roles.nonEmpty) Some(mapCloudPlatform(p, billingProfile, roles)) else None)
+  } yield billingProject.flatMap(p =>
+    if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(p, billingProfile, roles)) else None
+  )
 
   def listBillingProjectsV2(): Future[List[RawlsBillingProjectResponse]] = for {
     samUserResources <- samDAO.listUserResources(SamResourceTypeNames.billingProject, ctx)
@@ -299,29 +302,35 @@ class UserService(
     .map { p =>
       val roles = rolesByResourceId.getOrElse(p.projectName.value, Set())
       val billingProfile = p.billingProfileId.flatMap(id => billingProfiles.find(_.getId == UUID.fromString(id)))
-      mapCloudPlatform(p, billingProfile, roles)
+      mapCloudPlatformAndPolicies(p, billingProfile, roles)
     }
     .filter(p => p.roles.nonEmpty)
 
   /**
     * Map the cloud platform to a billing project.
     * if no BPM id is set it's a GCP project
-    * if a BPM id is set and a billing profile was found, use cloud platform from bpm and add the the coordinates if it's Azure
+    * if a BPM id is set and a billing profile was found, use cloud platform from bpm, add the the coordinates if it's Azure, check for protected-data policy on the billing profile
     * if a BPM id is set and no billing profile was found, mark as UNKNOWN
     */
-  def mapCloudPlatform(
+  def mapCloudPlatformAndPolicies(
     project: RawlsBillingProject,
     billingProfile: Option[ProfileModel],
     roles: Set[ProjectRole]
   ): RawlsBillingProjectResponse = (project.billingProfileId, billingProfile) match {
-    case (None, _) => RawlsBillingProjectResponse(roles, project, CloudPlatform.GCP)
+    case (None, _) => RawlsBillingProjectResponse(roles, project, CloudPlatform.GCP, protectedData = false)
     case (Some(_), Some(p)) =>
       val platform = CloudPlatform(p)
       val responseProject = if (platform == CloudPlatform.AZURE) {
         val c = AzureManagedAppCoordinates(p.getTenantId, p.getSubscriptionId, p.getManagedResourceGroupId)
         project.copy(azureManagedAppCoordinates = Some(c))
       } else project
-      RawlsBillingProjectResponse(roles, responseProject, platform)
+      val protectedData = Option(p.getPolicies).map(
+        _.getInputs.asScala.exists(policy =>
+          policy.getNamespace.equals("terra") && policy.getName.equals("protected-data")
+        )
+      )
+
+      RawlsBillingProjectResponse(roles, responseProject, platform, protectedData.getOrElse(false))
     case (Some(id), None) =>
       val message = Some(s"Unable to find billing profile in Billing Profile Manager for billing profile id: $id")
       RawlsBillingProjectResponse(roles, project.copy(message = message, status = CreationStatuses.Error))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -133,7 +133,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     val bpmDAO = new BillingProfileManagerDAOImpl(provider, config)
 
     intercept[NotImplementedError] {
-      bpmDAO.createBillingProfile("fake", Left(RawlsBillingAccountName("fake")), testContext)
+      bpmDAO.createBillingProfile("fake", Left(RawlsBillingAccountName("fake")), Map.empty, testContext)
     }
   }
 
@@ -147,7 +147,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar {
     val config = new MultiCloudWorkspaceConfig(true, None, None)
     val bpmDAO = new BillingProfileManagerDAOImpl(provider, config)
 
-    val profile = bpmDAO.createBillingProfile("fake", Right(coords), testContext)
+    val profile = bpmDAO.createBillingProfile("fake", Right(coords), Map.empty, testContext)
 
     assertResult(expectedProfile)(profile)
     verify(profileApi, times(1)).createProfile(ArgumentMatchers.any[CreateProfileRequest])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -294,7 +294,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequest.projectName.value),
         ArgumentMatchers.eq(createRequest.billingInfo),
-        ArgumentMatchers.eq(Map[String, Map[String, String]]()),
+        ArgumentMatchers.eq(Map[String, List[(String, String)]]()),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -341,7 +341,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     verify(bpm, Mockito.times(1)).createBillingProfile(createRequest.projectName.value,
                                                        createRequest.billingInfo,
-                                                       Map[String, Map[String, String]](),
+                                                       Map[String, List[(String, String)]](),
                                                        testContext
     )
     verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, Option(landingZoneId))
@@ -461,7 +461,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val repo = mock[BillingRepository]
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
-    val expectedPolicy = Map("protected-data" -> Map[String, String]())
+    val expectedPolicy = Map("protected-data" -> List[(String, String)]())
 
     when(
       bpm.createBillingProfile(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -183,6 +183,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequestWithExistingLz.projectName.value),
         ArgumentMatchers.eq(createRequestWithExistingLz.billingInfo),
+        any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -236,6 +237,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequestWithExistingLz.projectName.value),
         ArgumentMatchers.eq(createRequestWithExistingLz.billingInfo),
+        any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -291,6 +293,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -370,6 +373,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequestWithMembers.projectName.value),
         ArgumentMatchers.eq(createRequestWithMembers.billingInfo),
+        any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -423,6 +427,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -455,6 +460,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createProtectedRequest.projectName.value),
         ArgumentMatchers.eq(createProtectedRequest.billingInfo),
+        any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -511,6 +517,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -565,6 +572,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -622,6 +630,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -675,6 +684,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -735,7 +745,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val billingRepoError = "SQLException from billing repository"
     when(
-      bpm.createBillingProfile(createRequest.projectName.value, createRequest.billingInfo, testContext)
+      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value), ArgumentMatchers.eq(createRequest.billingInfo), any(), ArgumentMatchers.eq(testContext))
     )
       .thenReturn(profileModel)
     // Throw exception when deleting profile during cleanup code.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -291,10 +291,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
 
     when(
-      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
-                               ArgumentMatchers.eq(createRequest.billingInfo),
-                               any(),
-                               ArgumentMatchers.eq(testContext)
+      bpm.createBillingProfile(
+        ArgumentMatchers.eq(createRequest.projectName.value),
+        ArgumentMatchers.eq(createRequest.billingInfo),
+        ArgumentMatchers.eq(Map[String, Map[String, String]]()),
+        ArgumentMatchers.eq(testContext)
       )
     )
       .thenReturn(profileModel)
@@ -337,6 +338,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                                                     profileModel.getId,
                                                                     testContext,
                                                                     None
+    )
+    verify(bpm, Mockito.times(1)).createBillingProfile(createRequest.projectName.value,
+                                                       createRequest.billingInfo,
+                                                       Map[String, Map[String, String]](),
+                                                       testContext
     )
     verify(repo, Mockito.times(1)).updateLandingZoneId(createRequest.projectName, Option(landingZoneId))
     verify(repo, Mockito.times(1)).setBillingProfileId(createRequest.projectName, profileModel.getId)
@@ -451,16 +457,17 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     }
   }
 
-  it should "create a protected data landing zone if requested" in {
+  it should "create a protected data landing zone and attach a protected-data policy to the billing profile if requested" in {
     val repo = mock[BillingRepository]
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    val expectedPolicy = Map("protected-data" -> Map[String, String]())
 
     when(
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createProtectedRequest.projectName.value),
         ArgumentMatchers.eq(createProtectedRequest.billingInfo),
-        any(),
+        ArgumentMatchers.eq(expectedPolicy),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -506,6 +513,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                                                                     profileModel.getId,
                                                                     testContext,
                                                                     None
+    )
+    verify(bpm, Mockito.times(1)).createBillingProfile(createProtectedRequest.projectName.value,
+                                                       createProtectedRequest.billingInfo,
+                                                       expectedPolicy,
+                                                       testContext
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -293,7 +293,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+                               any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -427,7 +427,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+                               any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -517,7 +517,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+                               any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -572,7 +572,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+                               any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -630,7 +630,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+                               any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -684,7 +684,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(
       bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
                                ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+                               any(),
                                ArgumentMatchers.eq(testContext)
       )
     )
@@ -745,7 +745,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val billingRepoError = "SQLException from billing repository"
     when(
-      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value), ArgumentMatchers.eq(createRequest.billingInfo), any(), ArgumentMatchers.eq(testContext))
+      bpm.createBillingProfile(ArgumentMatchers.eq(createRequest.projectName.value),
+                               ArgumentMatchers.eq(createRequest.billingInfo),
+                               any(),
+                               ArgumentMatchers.eq(testContext)
+      )
     )
       .thenReturn(profileModel)
     // Throw exception when deleting profile during cleanup code.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1241,7 +1241,8 @@ class UserServiceSpec
 
     val userService = getUserService(samDAO = samDAO, bpmDAO = bpmDAO, billingRepository = Some(repository))
 
-    val expected = Some(RawlsBillingProjectResponse(Set(ProjectRoles.Owner), project, CloudPlatform.AZURE))
+    val expected =
+      Some(RawlsBillingProjectResponse(Set(ProjectRoles.Owner), project, CloudPlatform.AZURE, Option(false)))
     Await.result(userService.getBillingProject(projectName), Duration.Inf) shouldEqual expected
   }
 
@@ -1306,7 +1307,8 @@ class UserServiceSpec
       RawlsBillingProjectResponse(
         Set(ProjectRoles.User),
         project.copy(azureManagedAppCoordinates = Some(AzureManagedAppCoordinates(null, null, null))),
-        CloudPlatform.AZURE
+        CloudPlatform.AZURE,
+        Option(false)
       )
     )
 
@@ -1407,11 +1409,15 @@ class UserServiceSpec
 
     val expected = Seq(
       RawlsBillingProjectResponse(Set(ProjectRoles.Owner), ownerProject, CloudPlatform.GCP),
-      RawlsBillingProjectResponse(Set(ProjectRoles.User), billingProfileBackedProject, CloudPlatform.AZURE),
+      RawlsBillingProjectResponse(Set(ProjectRoles.User),
+                                  billingProfileBackedProject,
+                                  CloudPlatform.AZURE,
+                                  protectedData = Option(false)
+      ),
       RawlsBillingProjectResponse(Set(ProjectRoles.Owner),
                                   protectedDataBillingProfileBackedProject,
                                   CloudPlatform.AZURE,
-                                  protectedData = true
+                                  protectedData = Option(true)
       )
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -2,8 +2,7 @@ package org.broadinstitute.dsde.rawls.user
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.profile.model.{CloudPlatform => BPMCloudPlatform, ProfileModel}
-import bio.terra.workspace.model.{AzureLandingZoneDetails, AzureLandingZoneResult, JobReport}
+import bio.terra.profile.model.{BpmApiPolicyInput, BpmApiPolicyInputs, CloudPlatform => BPMCloudPlatform, ProfileModel}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
 import com.typesafe.config.{Config, ConfigFactory}
@@ -11,7 +10,7 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestDriverComponent, WorkspaceManagerResourceMonitorRecord}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
@@ -28,11 +27,10 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
-import java.sql.Timestamp
-import java.time.Instant
 import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.jdk.CollectionConverters._
 
 class UserServiceSpec
     extends AnyFlatSpecLike
@@ -1362,11 +1360,26 @@ class UserServiceSpec
       billingProfileId = Some(bpmBillingProfile.getId.toString)
     )
 
-    val billingProjects = Set(ownerProject, billingProfileBackedProject)
+    // Azure, BPM-backed, protected project
+    val policies = new BpmApiPolicyInputs().inputs(
+      List(new BpmApiPolicyInput().namespace("terra").name("protected-data").additionalData(List.empty.asJava)).asJava
+    )
+    val bpmProtectedDataBillingProfile =
+      new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BPMCloudPlatform.AZURE).policies(policies)
+    val protectedDataBillingProfileBackedProject = RawlsBillingProject(
+      RawlsBillingProjectName(UUID.randomUUID().toString),
+      CreationStatuses.Ready,
+      None,
+      None,
+      azureManagedAppCoordinates = Some(AzureManagedAppCoordinates(null, null, null)),
+      billingProfileId = Some(bpmProtectedDataBillingProfile.getId.toString)
+    )
+
+    val billingProjects = Set(ownerProject, billingProfileBackedProject, protectedDataBillingProfileBackedProject)
 
     val repository = mock[BillingRepository]
     when(repository.getBillingProjects(ArgumentMatchers.eq(billingProjects.map(_.projectName))))
-      .thenReturn(Future.successful(Seq(ownerProject, billingProfileBackedProject)))
+      .thenReturn(Future.successful(billingProjects.toSeq))
 
     // Setup mock DAOs
     val ownerRole = SamRolesAndActions(Set(SamBillingProjectRoles.owner), Set(SamBillingProjectActions.createWorkspace))
@@ -1375,18 +1388,31 @@ class UserServiceSpec
       SamRolesAndActions(Set(SamBillingProjectRoles.workspaceCreator), Set(SamBillingProjectActions.createWorkspace))
     val userBillingResources = Seq(
       SamUserResource(ownerProject.projectName.value, ownerRole, noRole, noRole, Set.empty, Set.empty),
-      SamUserResource(billingProfileBackedProject.projectName.value, creatorRole, noRole, noRole, Set.empty, Set.empty)
+      SamUserResource(billingProfileBackedProject.projectName.value, creatorRole, noRole, noRole, Set.empty, Set.empty),
+      SamUserResource(protectedDataBillingProfileBackedProject.projectName.value,
+                      ownerRole,
+                      noRole,
+                      noRole,
+                      Set.empty,
+                      Set.empty
+      )
     )
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(samDAO.listUserResources(SamResourceTypeNames.billingProject, testContext))
       .thenReturn(Future.successful(userBillingResources))
     val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
-    when(bpmDAO.getAllBillingProfiles(testContext)).thenReturn(Future.successful(Seq(bpmBillingProfile)))
+    when(bpmDAO.getAllBillingProfiles(testContext))
+      .thenReturn(Future.successful(Seq(bpmBillingProfile, bpmProtectedDataBillingProfile)))
     val userService = getUserService(samDAO = samDAO, bpmDAO = bpmDAO, billingRepository = Some(repository))
 
     val expected = Seq(
       RawlsBillingProjectResponse(Set(ProjectRoles.Owner), ownerProject, CloudPlatform.GCP),
-      RawlsBillingProjectResponse(Set(ProjectRoles.User), billingProfileBackedProject, CloudPlatform.AZURE)
+      RawlsBillingProjectResponse(Set(ProjectRoles.User), billingProfileBackedProject, CloudPlatform.AZURE),
+      RawlsBillingProjectResponse(Set(ProjectRoles.Owner),
+                                  protectedDataBillingProfileBackedProject,
+                                  CloudPlatform.AZURE,
+                                  protectedData = true
+      )
     )
 
     Await.result(userService.listBillingProjectsV2(), Duration.Inf) should contain theSameElementsAs expected

--- a/pact4s/README.md
+++ b/pact4s/README.md
@@ -1,3 +1,11 @@
 # pact4s [Under construction]
 
 pact4s is used for contract testing.
+
+## Run Pact tests locally
+Run from Rawls top-level directory
+```
+sbt "project pact4s" test
+```
+
+

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -107,6 +107,23 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     o.stringType("displayName")
     // It appears to be necessary to specify the value because the enum doesn't get translated to string automatically
     o.stringType("cloudPlatform", CloudPlatform.AZURE.toString)
+    o.`object`("policies",
+      po =>
+        po.array("inputs",
+          pio =>
+            pio.`object` { p =>
+              p.stringType("namespace")
+              p.stringType("name")
+              p.array("additionalData",
+                pad =>
+                  pad.`object` { ad =>
+                    ad.stringType("key")
+                    ad.stringType("value")
+                  }
+              )
+            }
+        )
+    )
   }.build()
 
   val profileModelResponse: DslPart = newJsonBody { o =>
@@ -118,6 +135,23 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     o.stringType("biller")
     o.stringType("displayName")
     o.stringType("cloudPlatform", CloudPlatform.AZURE.toString)
+    o.`object`("policies",
+      po =>
+        po.array("inputs",
+          pio =>
+            pio.`object` { p =>
+              p.stringType("namespace")
+              p.stringType("name")
+              p.array("additionalData",
+                pad =>
+                  pad.`object` { ad =>
+                    ad.stringType("key")
+                    ad.stringType("value")
+                  }
+              )
+            }
+        )
+    )
   }.build()
 
   val minimalProfile: Consumer[LambdaDslObject] = o => {

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -335,7 +335,7 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     val profileModel =
       billingProfileManagerDAO.createBillingProfile("billingProfile",
                                                     Right(managedAppCoordinates),
-                                                    Map[String, Map[String, String]](),
+                                                    Map[String, List[(String, String)]](),
                                                     testContext
       )
     profileModel.getSubscriptionId shouldBe dummySubscriptionId

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -331,7 +331,7 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
       multiCloudWorkspaceConfig
     )
     val profileModel =
-      billingProfileManagerDAO.createBillingProfile("billingProfile", Right(managedAppCoordinates), testContext)
+      billingProfileManagerDAO.createBillingProfile("billingProfile", Right(managedAppCoordinates), Map[String, Map[String, String]](), testContext)
     profileModel.getSubscriptionId shouldBe dummySubscriptionId
     profileModel.getTenantId shouldBe dummyTenantId
     profileModel.getManagedResourceGroupId shouldBe dummyMrgId

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.950-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
-  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.221-SNAPSHOT")
+  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client-javax" % "0.1.223-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.93-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-d606036")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client" % "0.254.950-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-client" % "1.379.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
-  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.185-SNAPSHOT")
+  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.221-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.93-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-d606036")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"


### PR DESCRIPTION
Ticket: [WOR-1037](https://broadworkbench.atlassian.net/browse/WOR-1037)
* When the protected data flag is set on an Azure billing project create request, set a `protected-data` policy on the billing profile in BPM
* Switch to the new BPM javax client library

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1037]: https://broadworkbench.atlassian.net/browse/WOR-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ