### PR TITLE
Shift to WARN on these log messages as there is no action to be taken

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassService.scala
@@ -144,7 +144,7 @@ object FastPassService extends LazyLogging {
                              googleStorageDAO
         ).transform {
           case Failure(e) =>
-            logger.error(
+            logger.warn(
               s"Encountered an error while removing FastPass grants for ${accountEmail.value} in ${googleProjectId.value}",
               e
             )
@@ -282,7 +282,7 @@ class FastPassService(protected val ctx: RawlsRequestContext,
       }
       .transform {
         case Failure(e) =>
-          logger.error(s"Failed to setup FastPass grants in cloned workspace ${parentWorkspace.toWorkspaceName}", e)
+          logger.warn(s"Failed to setup FastPass grants in cloned workspace ${parentWorkspace.toWorkspaceName}", e)
           openTelemetry.incrementCounter("fastpass-failure").unsafeRunSync()
           Success()
         case Success(_) => Success()
@@ -346,7 +346,7 @@ class FastPassService(protected val ctx: RawlsRequestContext,
           openTelemetry.incrementCounter("fastpass-failure").unsafeRunSync()
           Success()
         case Failure(e: Throwable) =>
-          logger.error(s"Failed to sync FastPass grants for $email in ${workspace.toWorkspaceName}", e)
+          logger.warn(s"Failed to sync FastPass grants for $email in ${workspace.toWorkspaceName}", e)
           openTelemetry.incrementCounter("fastpass-failure").unsafeRunSync()
           Success()
         case Success(_) => Success()
@@ -415,7 +415,7 @@ class FastPassService(protected val ctx: RawlsRequestContext,
       }
       .transform {
         case Failure(e) =>
-          logger.error(s"Failed to remove FastPass grants in ${workspace.toWorkspaceName}", e)
+          logger.warn(s"Failed to remove FastPass grants in ${workspace.toWorkspaceName}", e)
           openTelemetry.incrementCounter("fastpass-failure").unsafeRunSync()
           Success()
         case Success(_) => Success()


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1367)
These are not actionable errors, shifting to warn to reduce the sentry noise.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
