### PR TITLE
AJ-1438: disable most entity APIs for Azure workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities
 
+import bio.terra.workspace.model.CloudPlatform
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.config.DataRepoEntityProviderConfig
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
@@ -9,7 +10,7 @@ import org.broadinstitute.dsde.rawls.entities.base.{EntityProvider, EntityProvid
 import org.broadinstitute.dsde.rawls.entities.datarepo.{DataRepoEntityProvider, DataRepoEntityProviderBuilder}
 import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.entities.local.{LocalEntityProvider, LocalEntityProviderBuilder}
-import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, WorkspaceType}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.runtime.universe._
@@ -41,6 +42,10 @@ import scala.util.{Failure, Try}
 class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvider]]) {
 
   def resolveProvider(requestArguments: EntityRequestArguments): Try[EntityProvider] = {
+
+    if (!WorkspaceType.RawlsWorkspace.equals(requestArguments.workspace.workspaceType)) {
+      throw new DataEntityException(s"This functionality only available to ${CloudPlatform.GCP} workspaces.")
+    }
 
     // soon: look up the reference name to ensure it exists.
     // for now, this simplistic logic illustrates the approach: choose the right builder for the job.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -44,7 +44,9 @@ class EntityManager(providerBuilders: Set[EntityProviderBuilder[_ <: EntityProvi
   def resolveProvider(requestArguments: EntityRequestArguments): Try[EntityProvider] = {
 
     if (!WorkspaceType.RawlsWorkspace.equals(requestArguments.workspace.workspaceType)) {
-      throw new DataEntityException(s"This functionality only available to ${CloudPlatform.GCP} workspaces.")
+      throw new DataEntityException(
+        s"This API is disabled for ${CloudPlatform.AZURE} workspaces. Contact support for alternatives."
+      )
     }
 
     // soon: look up the reference name to ensure it exists.

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -7,11 +7,14 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeValue,
   Entity,
+  EntityCopyDefinition,
+  EntityCopyResponse,
   EntityQuery,
   EntityQueryResponse,
   EntityTypeMetadata,
   RawlsRequestContext,
-  SubmissionValidationEntityInputs
+  SubmissionValidationEntityInputs,
+  Workspace
 }
 
 import scala.concurrent.Future
@@ -70,4 +73,12 @@ trait EntityProvider {
   def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
 
   def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+
+  def copyEntities(sourceWorkspaceContext: Workspace,
+                   destWorkspaceContext: Workspace,
+                   entityType: String,
+                   entityNames: Seq[String],
+                   linkExistingEntities: Boolean,
+                   parentContext: RawlsRequestContext
+  ): Future[EntityCopyResponse]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -38,13 +38,16 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeValueList,
   AttributeValueRawJson,
   Entity,
+  EntityCopyDefinition,
+  EntityCopyResponse,
   EntityQuery,
   EntityQueryResponse,
   EntityTypeMetadata,
   ErrorReport,
   GoogleProjectId,
   RawlsRequestContext,
-  SubmissionValidationEntityInputs
+  SubmissionValidationEntityInputs,
+  Workspace
 }
 import org.broadinstitute.dsde.rawls.util.CollectionUtils
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
@@ -524,4 +527,13 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
+
+  override def copyEntities(sourceWorkspaceContext: Workspace,
+                            destWorkspaceContext: Workspace,
+                            entityType: String,
+                            entityNames: Seq[String],
+                            linkExistingEntities: Boolean,
+                            parentContext: RawlsRequestContext
+  ): Future[EntityCopyResponse] =
+    throw new UnsupportedEntityOperationException("copy entities not supported by this provider.")
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -26,15 +26,20 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeValue,
   Entity,
+  EntityCopyDefinition,
+  EntityCopyResponse,
   EntityQuery,
   EntityQueryResponse,
   EntityQueryResultMetadata,
   EntityTypeMetadata,
   ErrorReport,
   RawlsRequestContext,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
   SubmissionValidationEntityInputs,
   SubmissionValidationValue,
-  Workspace
+  Workspace,
+  WorkspaceAttributeSpecs
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, CollectionUtils, EntitySupport}
@@ -386,4 +391,22 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
     batchUpdateEntitiesImpl(entityUpdates, upsert = true)
 
+  override def copyEntities(sourceWorkspaceContext: Workspace,
+                            destWorkspaceContext: Workspace,
+                            entityType: String,
+                            entityNames: Seq[String],
+                            linkExistingEntities: Boolean,
+                            parentContext: RawlsRequestContext
+  ): Future[EntityCopyResponse] =
+    traceWithParent("checkAndCopyEntities", parentContext)(_ =>
+      dataSource.inTransaction { dataAccess =>
+        dataAccess.entityQuery.checkAndCopyEntities(sourceWorkspaceContext,
+                                                    destWorkspaceContext,
+                                                    entityType,
+                                                    entityNames,
+                                                    linkExistingEntities,
+                                                    parentContext
+        )
+      }
+    )
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -132,14 +132,14 @@ trait WorkspaceSupport {
     } yield ()
 
   // can't use withClonedAuthDomain because the Auth Domain -> no Auth Domain logic is different
-  def authDomainCheck(sourceWorkspaceADs: Set[String], destWorkspaceADs: Set[String]): ReadWriteAction[Boolean] =
+  def authDomainCheck(sourceWorkspaceADs: Set[String], destWorkspaceADs: Set[String]): Boolean =
     // if the source has any auth domains, the dest must also *at least* have those auth domains
-    if (sourceWorkspaceADs.subsetOf(destWorkspaceADs)) DBIO.successful(true)
+    if (sourceWorkspaceADs.subsetOf(destWorkspaceADs)) true
     else {
       val missingGroups = sourceWorkspaceADs -- destWorkspaceADs
       val errorMsg =
         s"Source workspace has an Authorization Domain containing the groups ${missingGroups.mkString(", ")}, which are missing on the destination workspace"
-      DBIO.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.UnprocessableEntity, errorMsg)))
+      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.UnprocessableEntity, errorMsg))
     }
 
   // WorkspaceContext helpers

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/EntityApiService.scala
@@ -317,7 +317,7 @@ trait EntityApiService extends UserInfoDirectives {
                   entity(as[EntityCopyDefinition]) { copyDefinition =>
                     complete {
                       entityServiceConstructor(ctx)
-                        .copyEntities(copyDefinition, request.uri, linkExistingEntitiesBool)
+                        .copyEntities(copyDefinition, linkExistingEntitiesBool)
                         .map { response =>
                           if (
                             response.hardConflicts.isEmpty && (response.softConflicts.isEmpty || linkExistingEntitiesBool)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1438

This PR disables all writable entity APIs and most read-only entity APIs for Azure workspaces. Azure workspaces use WDS instead of Rawls for data tables; the APIs in Rawls are misleading and should not be used for Azure workspaces.

This check is implemented by using `EntityManager` as a bottleneck. Inside `EntityManager.resolveProvider()`, we check the target workspace and throw an error if it is not a GCP (non-MC) workspace. As part of this, I needed to move the `copyEntities` implementation inside the `EntityManager`/`EntityProvider` structure, instead of its previous implementation directly in `EntityService`.

There are still a few read-only APIs that are implemented directly in `EntityService` and won't throw an error for Azure workspaces. However, all write APIs are now protected, so there's no way to get data IN to the system for those read APIs to return. I think this satisfies the intent of the Jira ticket, without blowing up scope too much.

_Update 8-Dec:_ I tested this in a BEE with the latest UI code, and all works as expected.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
