### PR TITLE
[WOR-1192] Change terminal storage class for autoclass-managed workspace buckets

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -41,7 +41,7 @@ import com.google.api.services.storage.{Storage, StorageScopes}
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.Identity
 import com.google.cloud.storage.Storage.BucketSourceOption
-import com.google.cloud.storage.StorageException
+import com.google.cloud.storage.{StorageClass, StorageException}
 import io.opencensus.scala.Tracing._
 import io.opencensus.trace.{AttributeValue, Span}
 import org.apache.commons.lang3.StringUtils
@@ -228,7 +228,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
             bucketPolicyOnlyEnabled = true,
             logBucket = Option(GcsBucketName(GoogleServicesDAO.getStorageLogsBucketName(googleProject))),
             location = bucketLocation,
-            autoclassEnabled = true
+            autoclassEnabled = true,
+            autoclassTerminalStorageClass = Option(StorageClass.ARCHIVE)
           )
           .compile
           .drain

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -11,7 +11,7 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.cloud.Identity
 import com.google.cloud.Identity.serviceAccount
-import com.google.cloud.storage.Storage
+import com.google.cloud.storage.{Storage, StorageClass}
 import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption, BucketTargetOption}
 import com.google.storagetransfer.v1.proto.TransferTypes.{TransferJob, TransferOperation}
 import net.ceedubs.ficus.Ficus.{finiteDurationReader, toFicusConfig}
@@ -776,7 +776,8 @@ object MultiregionalBucketMigrationActor {
                 GoogleServicesDAO.getStorageLogsBucketName(workspace.googleProjectId)
               ).some,
               location = env.defaultBucketLocation.some,
-              autoclassEnabled = true
+              autoclassEnabled = true,
+              autoclassTerminalStorageClass = Option(StorageClass.ARCHIVE)
             )
             .compile
             .drain

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -6,6 +6,7 @@ import akka.stream.ActorMaterializer
 import cats.effect.IO
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.json.gson.GsonFactory
+import com.google.cloud.storage.StorageClass
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.HttpGoogleServicesDAO._
 import org.broadinstitute.dsde.rawls.model.{
@@ -160,7 +161,8 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
         any(),
         any(),
         any(),
-        autoclassEnabled = ArgumentMatchers.eq(true)
+        autoclassEnabled = ArgumentMatchers.eq(true),
+        autoclassTerminalStorageClass = ArgumentMatchers.eq(Option(StorageClass.ARCHIVE))
       )
     ).thenReturn(fs2.Stream.unit)
 
@@ -208,7 +210,8 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
         any(),
         any(),
         any(),
-        autoclassEnabled = ArgumentMatchers.eq(true)
+        autoclassEnabled = ArgumentMatchers.eq(true),
+        autoclassTerminalStorageClass = ArgumentMatchers.eq(Option(StorageClass.ARCHIVE))
       ),
       times(1)
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.cloud.Identity
-import com.google.cloud.storage.{Acl, BucketInfo, Storage}
+import com.google.cloud.storage.{Acl, BucketInfo, Storage, StorageClass}
 import com.google.rpc.Code
 import com.google.storagetransfer.v1.proto.TransferTypes._
 import io.grpc.{Status, StatusRuntimeException}
@@ -618,7 +618,8 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
                                     retryConfig: RetryConfig,
                                     location: Option[String],
                                     bucketTargetOptions: List[Storage.BucketTargetOption],
-                                    autoclassEnabled: Boolean
+                                    autoclassEnabled: Boolean,
+                                    autoclassTerminalStorageClass: Option[StorageClass]
           ): fs2.Stream[IO, Unit] =
             fs2.Stream.raiseError[IO](error)
         }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,12 +81,12 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.1.0"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "3d9bda9"
+  val workbenchLibsHash = "015a3074-SNAP"
 
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.30-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
-  val workbenchGoogle2V = s"0.34-${workbenchLibsHash}"
+  val workbenchGoogle2V = s"0.35-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.5-${workbenchLibsHash}"
   val workbenchOpenTelemetryV = s"0.7-$workbenchLibsHash"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,14 +81,14 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.1.0"
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2"
 
-  val workbenchLibsHash = "015a3074-SNAP"
+  val workbenchLibsHash = "8ccaa6d"
 
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.30-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.35-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.5-${workbenchLibsHash}"
-  val workbenchOpenTelemetryV = s"0.7-$workbenchLibsHash"
+  val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
 
   def excludeWorkbenchGoogle = ExclusionRule("org.broadinstitute.dsde.workbench", "workbench-google_2.13")
 


### PR DESCRIPTION
Ticket: [WOR-1192](https://broadworkbench.atlassian.net/browse/WOR-1192)
* Pull in new changes from https://github.com/broadinstitute/workbench-libs/pull/1622 and explicitly set autoclass terminal storage class to `ARCHIVE`

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1192]: https://broadworkbench.atlassian.net/browse/WOR-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ