### PR TITLE
[WOR-161] Stop trying to clone workspace files if it hasn't succeeded within a day

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -125,4 +125,5 @@
     <include file="changesets/20230810_track_mrb_sts_progress.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20230829_mrb_add_sts_project.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20231013_submission_monitor_script.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20231130_limit_clone_workspace_file_transfer.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20231130_limit_clone_workspace_file_transfer.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20231130_limit_clone_workspace_file_transfer.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet logicalFilePath="dummy" author="mtalbott" id="add_timestamps_outcome_CLONE_WORKSPACE_FILE_TRANSFER">
+        <addColumn tableName="CLONE_WORKSPACE_FILE_TRANSFER">
+            <column name="CREATED" type="DATETIME" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+        <addColumn tableName="CLONE_WORKSPACE_FILE_TRANSFER">
+            <column name="FINISHED" type="DATETIME">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="CLONE_WORKSPACE_FILE_TRANSFER">
+            <column name="OUTCOME" type="VARCHAR(254)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5851,6 +5851,13 @@ components:
           description: timestamp (UTC) marking the date that the bucket usage was last updated (YYYY-MM-DDThh:mm:ss.fffZ)
       description: ""
     PendingCloneWorkspaceFileTransfer:
+      required:
+        - destWorkspaceId
+        - sourceWorkspaceBucketName
+        - destWorkspaceBucketName
+        - copyFilesWithPrefix
+        - destWorkspaceGoogleProjectId
+        - created
       type: object
       properties:
         destWorkspaceId:
@@ -5868,6 +5875,22 @@ components:
         destWorkspaceGoogleProjectId:
           type: string
           description: "The Google project that the destination workspace belongs to"
+        created:
+          type: string
+          description: "The time the file transfer started in yyyy-MM-ddTHH:mm:ss.SSSZZ
+            format."
+          format: date-time
+        finished:
+          type: string
+          description: "The time the file transfer finished in yyyy-MM-ddTHH:mm:ss.SSSZZ
+            format."
+          format: date-time
+        outcome:
+          type: string
+          description: "The outcome of a finished file transfer."
+          enum:
+            - Success
+            - Failure
     Attribute:
       type: object
       properties:

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
@@ -214,7 +214,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val failureMessage = "because I feel like it"
-      val exception = new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).build
+      val exception =
+        new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
         mockGcsDAO.listObjectsWithPrefix(sourceBucketName, copyFilesWithPrefix, Option(destWorkspace.googleProjectId))
       )
@@ -303,7 +304,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val failureMessage = "because I feel like it"
-      val exception = new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).build
+      val exception =
+        new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
         mockGcsDAO.listObjectsWithPrefix(sourceBucketName, copyFilesWithPrefix, Option(destWorkspace.googleProjectId))
       )
@@ -404,7 +406,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val failureMessage = "because I feel like it"
-      val exception = new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).build
+      val exception =
+        new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
         mockGcsDAO.listObjectsWithPrefix(sourceBucketName, copyFilesWithPrefix, Option(destWorkspace.googleProjectId))
       )
@@ -424,7 +427,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
                             destinationBucketName,
                             goodObjectToCopy.getName,
                             Option(destWorkspace.googleProjectId)
-        )
+        )(system.dispatchers.defaultGlobalDispatcher)
       )
         .thenReturn(Future.successful(Option(goodObjectToCopy)))
 
@@ -547,7 +550,8 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val failureMessage = "because I feel like it"
-      val exception = new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).build
+      val exception =
+        new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
         mockGcsDAO.listObjectsWithPrefix(sourceBucketName,
                                          copyFilesWithPrefix,
@@ -707,6 +711,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
           .completedCloneWorkspaceFileTransfer
           .isDefined shouldBe true
         runAndWait(cloneWorkspaceFileTransferQuery.listPendingTransfers()) shouldBe empty
+
         val allWorkspaceTransfers = runAndWait(
           cloneWorkspaceFileTransferQuery
             .filter(_.destWorkspaceId === destWorkspace.workspaceIdAsUUID)
@@ -714,6 +719,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
             .result
         )
         allWorkspaceTransfers should have size 1
+
         val transferResult = allWorkspaceTransfers.head
         transferResult._1 shouldBe defined
         transferResult._2 shouldBe Some("Failure")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
@@ -17,6 +17,7 @@ import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar
 
+import java.sql.Timestamp
 import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -605,6 +606,117 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
           .isDefined shouldBe true
         runAndWait(cloneWorkspaceFileTransferQuery.listPendingTransfers())
           .map(_.destWorkspaceBucketName) should contain theSameElementsAs Seq(badDestinationBucketName)
+      }
+
+      system.stop(actor)
+    }
+  }
+
+  it should "eventually stop trying to copy files" in {
+    withEmptyTestDatabase { dataSource: SlickDataSource =>
+      val billingProject = RawlsBillingProject(defaultBillingProjectName,
+                                               CreationStatuses.Ready,
+                                               Option(defaultBillingAccountName),
+                                               None,
+                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      )
+      val sourceBucketName = "sourceBucket"
+      val destinationBucketName = "destinationBucket"
+      val copyFilesWithPrefix = "prefix"
+      val objectToCopy = new StorageObject().setName("copy-me")
+      val sourceWorkspace = Workspace(
+        billingProject.projectName.value,
+        "source",
+        UUID.randomUUID().toString,
+        sourceBucketName,
+        None,
+        DateTime.now,
+        DateTime.now,
+        "creator@example.com",
+        Map.empty,
+        false,
+        WorkspaceVersions.V2,
+        GoogleProjectId("some-project"),
+        Option(GoogleProjectNumber("43")),
+        billingProject.billingAccount,
+        None,
+        Option(DateTime.now),
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
+      )
+      val destWorkspace = Workspace(
+        billingProject.projectName.value,
+        "destination",
+        UUID.randomUUID().toString,
+        destinationBucketName,
+        None,
+        DateTime.now,
+        DateTime.now,
+        "creator@example.com",
+        Map.empty,
+        false,
+        WorkspaceVersions.V2,
+        GoogleProjectId("different-project"),
+        Option(GoogleProjectNumber("44")),
+        billingProject.billingAccount,
+        None,
+        None,
+        WorkspaceType.RawlsWorkspace,
+        WorkspaceState.Ready
+      )
+
+      runAndWait(rawlsBillingProjectQuery.create(billingProject))
+      runAndWait(workspaceQuery.createOrUpdate(sourceWorkspace))
+      runAndWait(workspaceQuery.createOrUpdate(destWorkspace))
+      runAndWait(
+        cloneWorkspaceFileTransferQuery.save(destWorkspace.workspaceIdAsUUID,
+                                             sourceWorkspace.workspaceIdAsUUID,
+                                             copyFilesWithPrefix
+        )
+      )
+
+      val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      val failureMessage = "because I feel like it"
+      val exception = new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).build
+      when(
+        mockGcsDAO.listObjectsWithPrefix(sourceBucketName, copyFilesWithPrefix, Option(destWorkspace.googleProjectId))
+      )
+        .thenReturn(Future.successful(List(objectToCopy)))
+      when(
+        mockGcsDAO.copyFile(sourceBucketName,
+                            objectToCopy.getName,
+                            destinationBucketName,
+                            objectToCopy.getName,
+                            Option(destWorkspace.googleProjectId)
+        )(system.dispatchers.defaultGlobalDispatcher)
+      )
+        .thenReturn(Future.failed(exception))
+
+      val actor = createCloneWorkspaceFileTransferMonitor(dataSource, mockGcsDAO)
+      import driver.api._
+      runAndWait(
+        cloneWorkspaceFileTransferQuery
+          .filter(_.destWorkspaceId === destWorkspace.workspaceIdAsUUID)
+          .map(_.created)
+          .update(new Timestamp(DateTime.now().minusDays(2).getMillis))
+      )
+
+      eventually(timeout = timeout(Span(10, Seconds))) {
+        runAndWait(workspaceQuery.findById(destWorkspace.workspaceIdAsUUID.toString))
+          .getOrElse(fail(s"${destWorkspace.name} not found"))
+          .completedCloneWorkspaceFileTransfer
+          .isDefined shouldBe true
+        runAndWait(cloneWorkspaceFileTransferQuery.listPendingTransfers()) shouldBe empty
+        val allWorkspaceTransfers = runAndWait(
+          cloneWorkspaceFileTransferQuery
+            .filter(_.destWorkspaceId === destWorkspace.workspaceIdAsUUID)
+            .map(r => (r.finished, r.outcome))
+            .result
+        )
+        allWorkspaceTransfers should have size 1
+        val transferResult = allWorkspaceTransfers.head
+        transferResult._1 shouldBe defined
+        transferResult._2 shouldBe Some("Failure")
       }
 
       system.stop(actor)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
@@ -213,7 +213,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
       )
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      val failureMessage = "because I feel like it"
+      val failureMessage = "expected test exception"
       val exception =
         new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
@@ -303,7 +303,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
       )
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      val failureMessage = "because I feel like it"
+      val failureMessage = "expected test exception"
       val exception =
         new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
@@ -405,7 +405,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
       )
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      val failureMessage = "because I feel like it"
+      val failureMessage = "expected test exception"
       val exception =
         new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
@@ -549,7 +549,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
       )
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      val failureMessage = "because I feel like it"
+      val failureMessage = "expected test exception"
       val exception =
         new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).setMessage(failureMessage).build
       when(
@@ -680,7 +680,7 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
       )
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
-      val failureMessage = "because I feel like it"
+      val failureMessage = "expected test exception"
       val exception = new HttpResponseException.Builder(403, failureMessage, new HttpHeaders()).build
       when(
         mockGcsDAO.listObjectsWithPrefix(sourceBucketName, copyFilesWithPrefix, Option(destWorkspace.googleProjectId))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -2696,14 +2696,15 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
         }
 
       val clonedWorkspaceResult = runAndWait(workspaceQuery.findByName(clonedWorkspaceName)).get
-      val expected = Seq(
-        PendingCloneWorkspaceFileTransfer(
-          clonedWorkspaceResult.workspaceIdAsUUID,
-          testData.workspace.bucketName,
-          clonedWorkspaceResult.bucketName,
-          workspaceCopy.copyFilesWithPrefix.get,
-          clonedWorkspaceResult.googleProjectId
-        )
+      val expected = PendingCloneWorkspaceFileTransfer(
+        clonedWorkspaceResult.workspaceIdAsUUID,
+        testData.workspace.bucketName,
+        clonedWorkspaceResult.bucketName,
+        workspaceCopy.copyFilesWithPrefix.get,
+        clonedWorkspaceResult.googleProjectId,
+        DateTime.now(),
+        None,
+        None
       )
 
       Get(s"${clonedWorkspaceName.path}/fileTransfers") ~>
@@ -2712,9 +2713,16 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           assertResult(StatusCodes.OK) {
             status
           }
-          assertResult(expected) {
-            responseAs[Seq[PendingCloneWorkspaceFileTransfer]]
-          }
+
+          val allTransfers = responseAs[Seq[PendingCloneWorkspaceFileTransfer]]
+          allTransfers should have size 1
+
+          val res = allTransfers.headOption.getOrElse(fail("pending transfer expected but not found"))
+          res.destWorkspaceId shouldBe expected.destWorkspaceId
+          res.sourceWorkspaceBucketName shouldBe expected.sourceWorkspaceBucketName
+          res.destWorkspaceBucketName shouldBe expected.destWorkspaceBucketName
+          res.copyFilesWithPrefix shouldBe expected.copyFilesWithPrefix
+          res.destWorkspaceGoogleProjectId shouldBe expected.destWorkspaceGoogleProjectId
         }
   }
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -938,7 +938,10 @@ case class PendingCloneWorkspaceFileTransfer(destWorkspaceId: UUID,
                                              sourceWorkspaceBucketName: String,
                                              destWorkspaceBucketName: String,
                                              copyFilesWithPrefix: String,
-                                             destWorkspaceGoogleProjectId: GoogleProjectId
+                                             destWorkspaceGoogleProjectId: GoogleProjectId,
+                                             created: DateTime,
+                                             finished: Option[DateTime],
+                                             outcome: Option[String]
 )
 
 case class ManagedGroupAccessInstructions(groupName: String, instructions: String)
@@ -1263,7 +1266,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceResponseFormat: RootJsonFormat[WorkspaceResponse] = jsonFormat10(WorkspaceResponse)
 
-  implicit val PendingCloneWorkspaceFileTransferFormat: RootJsonFormat[PendingCloneWorkspaceFileTransfer] = jsonFormat5(
+  implicit val PendingCloneWorkspaceFileTransferFormat: RootJsonFormat[PendingCloneWorkspaceFileTransfer] = jsonFormat8(
     PendingCloneWorkspaceFileTransfer
   )
 


### PR DESCRIPTION
Ticket: [WOR-161](https://broadworkbench.atlassian.net/browse/WOR-161)
In some cases, the asynchronous file transfer process never succeeds. This clogs up the logs and results in Rawls performing unnecessary work. This PR introduces some guardrails to prevent Rawls from endlessly retrying.

* Add columns to `CLONE_WORKSPACE_FILE_TRANSFER`
    * `created` tracks when a workspace is cloned and the file transfer attempts begin. If a file transfer is still pending after 1 day, it will be marked as failed.
    * `finished` tracks when a workspace file transfer has completed. 
    * `outcome` indicates whether a workspace file transfer succeeded or failed.
* Completed file transfers are no longer removed from the DB. This has the added benefit of allowing us to track a workspace's cloning lineage going forward.
* A couple of small changes to existing tests to clean up their logs and make it easier to identify real failures

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-161]: https://broadworkbench.atlassian.net/browse/WOR-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ