### PR TITLE
[WOR-1385] Lower FP monitor log msgs to warn

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitor.scala
@@ -87,7 +87,7 @@ class FastPassMonitor private (dataSource: SlickDataSource,
           errors.foreach { errorTuple =>
             val (error, grants) = errorTuple
             val users = grants.map(_.accountEmail.value).toSet.mkString("(", ", ", ")")
-            logger.error(
+            logger.warn(
               s"Encountered error while removing FastPass for users: $users in ${googleProjectId.value}. Continuing sweep.",
               error
             )
@@ -102,7 +102,7 @@ class FastPassMonitor private (dataSource: SlickDataSource,
         }
         .cleanUp {
           case Some(e) =>
-            logger.error(
+            logger.warn(
               s"Encountered an error while removing FastPass grants in ${googleProjectId.value}. Continuing sweep.",
               e
             )


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1385)
These log messages do not seem actionable but emit error spam to sentry.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
