### PR TITLE
[WOR-1395] Handle 403 when getting a billing profile

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -168,7 +168,8 @@ class BillingProfileManagerDAOImpl(
   def getBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Option[ProfileModel] =
     Try(Option(apiClientProvider.getProfileApi(ctx).getProfile(billingProfileId))) match {
       case Success(value) => value
-      case Failure(e: ApiException) if e.getCode == StatusCodes.NotFound.intValue =>
+      case Failure(e: ApiException)
+          if e.getCode == StatusCodes.NotFound.intValue || e.getCode == StatusCodes.Forbidden.intValue =>
         None
       case Failure(e) => throw new BpmException(billingProfileId, e);
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -84,7 +84,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar with Mo
     val profileApi = mock[ProfileApi](RETURNS_SMART_NULLS)
     val apiProvider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)
     when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
-    when(profileApi.getProfile(any())).thenThrow(new ApiException(StatusCodes.Forbidden.intValue, "forbidden"))
+    when(profileApi.getProfile(any())).thenThrow(new ApiException(StatusCodes.BadRequest.intValue, "bad request"))
     val billingProfileManagerDAO =
       new BillingProfileManagerDAOImpl(apiProvider, MultiCloudWorkspaceConfig(true, None, Some(azConfig)))
 


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1395)
BPM may return a 403 for a billing profile that has been deleted. During billing project deletion, clients are polling rawls for the status of a billing profile. When a 403 is encountered on a poll request to `/api/billing_v2/<billing_project>`, rawls should handle the 403 from BPM and move on. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
