### PR TITLE
AJ-1498: tracing and isolation level for updateStatisticsCache 

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitor.scala
@@ -6,11 +6,13 @@ import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue}
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.DataAccess
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.monitor.EntityStatisticsCacheMonitor._
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import slick.dbio.DBIO
 import slick.jdbc.TransactionIsolation
+import slick.jdbc.TransactionIsolation.ReadCommitted
 
 import java.sql.Timestamp
 import java.util.concurrent.TimeUnit
@@ -105,6 +107,9 @@ trait EntityStatisticsCacheMonitor extends LazyLogging with RawlsInstrumented {
   val workspaceCooldown: FiniteDuration
   val timeoutPerWorkspace: Duration
 
+  // default isolation level for queries in this trait
+  final val isolationLevel: TransactionIsolation = TransactionIsolation.ReadCommitted
+
   def sweep(): Future[EntityStatisticsCacheMessage] =
     trace("EntityStatisticsCacheMonitor.sweep") { rootContext =>
       dataSource.inTransaction(
@@ -138,42 +143,47 @@ trait EntityStatisticsCacheMonitor extends LazyLogging with RawlsInstrumented {
             }
           }
         },
-        TransactionIsolation.ReadCommitted
+        isolationLevel
       )
     }
 
-  def updateStatisticsCache(workspaceId: UUID, timestamp: Timestamp): Future[Unit] = {
+  private def updateStatisticsCache(workspaceId: UUID, timestamp: Timestamp): Future[Unit] = {
     // allow 80% of the per-workspace timeout to be spent calculating the attribute names.
     // note that other statements do not have timeouts and are unbounded.
     val attrNamesTimeout = (timeoutPerWorkspace * .8).toSeconds.toInt
 
-    val updateFuture = dataSource.inTransaction { dataAccess =>
-      // TODO: beware contention on the approach of delete-all and batch-insert all below
-      // if we see contention we could move to encoding the entire metadata object as json
-      // and storing in a single column on WORKSPACE_ENTITY_CACHE
-      for {
-        // calculate entity statistics
-        entityTypesWithCounts <- dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)
-        // calculate entity attribute statistics
-        entityTypesWithAttrNames <- dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceId, attrNamesTimeout)
-        _ <- dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId,
-                                                                   entityTypesWithCounts,
-                                                                   entityTypesWithAttrNames,
-                                                                   timestamp
-        )
-      } yield entityCacheSaveCounter.inc()
-    }
+    val updateFuture = dataSource.inTransaction(
+      dataAccess =>
+        // TODO: beware contention on the approach of delete-all and batch-insert all below
+        // if we see contention we could move to encoding the entire metadata object as json
+        // and storing in a single column on WORKSPACE_ENTITY_CACHE
+        for {
+          // calculate entity statistics
+          entityTypesWithCounts <- dataAccess.entityQuery.getEntityTypesWithCounts(workspaceId)
+          // calculate entity attribute statistics
+          entityTypesWithAttrNames <- dataAccess.entityQuery.getAttrNamesAndEntityTypes(workspaceId, attrNamesTimeout)
+          _ <- dataAccess.entityCacheManagementQuery.saveEntityCache(workspaceId,
+                                                                     entityTypesWithCounts,
+                                                                     entityTypesWithAttrNames,
+                                                                     timestamp
+          )
+        } yield entityCacheSaveCounter.inc(),
+      isolationLevel
+    )
 
     updateFuture.recover { case t: Throwable =>
       logger.error(s"Error updating statistics cache for workspaceId $workspaceId: ${t.getMessage}", t)
-      dataSource.inTransaction { dataAccess =>
-        logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
-        // We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
-        // This is a "magic" value that allows the monitor to skip this problematic workspace
-        // so it does not get caught in a loop. These workspaces will require manual intervention.
-        val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
-        dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
-      }
+      dataSource.inTransaction(
+        { dataAccess =>
+          logger.error(s"Workspace $workspaceId will be ignored by the entity cache monitor: ${t.getMessage}")
+          // We will set the cacheLastUpdated timestamp to the lowest possible value in MySQL.
+          // This is a "magic" value that allows the monitor to skip this problematic workspace
+          // so it does not get caught in a loop. These workspaces will require manual intervention.
+          val errMsg = s"${t.getMessage} ${ExceptionUtils.getStackTrace(t)}"
+          dataAccess.entityCacheQuery.updateCacheLastUpdated(workspaceId, MIN_CACHE_TIME, Some(errMsg))
+        },
+        isolationLevel
+      )
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1498

More optimizations and debuggability for the entity statistics cache.
* explicitly set the transactions in `updateStatisticsCache` to be ReadCommitted. This is probably moot, since this method is only called from `sweep()`, and we set the outer transaction in `sweep()` to ReadCommitted in #2650. But, it helps for code readability and future-proofing.
* move the declaration of ReadCommitted to a trait-level variable for consistency
* add more detail to the tracing spans under `sweep()`. This is likely to confirm previous knowledge that `getAttrNamesAndEntityTypes` is slow, but it'll be good to see empirical data.

Reviewer: I suggest ignoring whitespace in the diff; auto-formatter changed a bunch


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
