### PR TITLE
AJ-1326: enforce query timeouts for some data table queries

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -117,6 +117,8 @@ entityStatisticsCache {
 
 entities {
   pageSizeLimit = 300000
+  # certain SQL queries are set to have a maximum run time
+  queryTimeout = 15 minutes
 }
 
 akka.http.host-connection-pool.max-open-requests = 16384

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -426,6 +426,7 @@ object Boot extends IOApp with LazyLogging {
         appDependencies.bigQueryServiceFactory,
         DataRepoEntityProviderConfig(conf.getConfig("dataRepoEntityProvider")),
         conf.getBoolean("entityStatisticsCache.enabled"),
+        conf.getDuration("entities.queryTimeout"),
         metricsPrefix
       )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -75,6 +75,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.jdk.CollectionConverters._
 import scala.language.{higherKinds, postfixOps}
 
@@ -417,6 +418,8 @@ object Boot extends IOApp with LazyLogging {
       val requesterPaysSetupService: RequesterPaysSetupService =
         new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole)
 
+      val entityQueryTimeout = conf.getDuration("entities.queryTimeout")
+
       // create the entity manager.
       val entityManager = EntityManager.defaultEntityManager(
         slickDataSource,
@@ -426,7 +429,7 @@ object Boot extends IOApp with LazyLogging {
         appDependencies.bigQueryServiceFactory,
         DataRepoEntityProviderConfig(conf.getConfig("dataRepoEntityProvider")),
         conf.getBoolean("entityStatisticsCache.enabled"),
-        conf.getDuration("entities.queryTimeout"),
+        entityQueryTimeout,
         metricsPrefix
       )
 
@@ -607,6 +610,7 @@ object Boot extends IOApp with LazyLogging {
           methodRepoDAO,
           drsResolver,
           entityServiceConstructor,
+          entityQueryTimeout.toScala,
           workspaceServiceConstructor,
           shardedExecutionServiceCluster,
           maxActiveWorkflowsTotal,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityManager.scala
@@ -11,6 +11,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.DataEntityException
 import org.broadinstitute.dsde.rawls.entities.local.{LocalEntityProvider, LocalEntityProviderBuilder}
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 
+import java.time.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.runtime.universe._
 import scala.util.{Failure, Try}
@@ -82,13 +83,14 @@ object EntityManager {
                            bqServiceFactory: GoogleBigQueryServiceFactory,
                            config: DataRepoEntityProviderConfig,
                            cacheEnabled: Boolean,
+                           queryTimeout: Duration,
                            metricsPrefix: String
   )(implicit ec: ExecutionContext): EntityManager = {
     // create the EntityManager along with its associated provider-builders. Since entities are only accessed
     // in the context of a workspace, this is safe/correct to do here. We also want to use the same dataSource
     // and execution context for the rawls entity provider that the entity service uses.
     val defaultEntityProviderBuilder =
-      new LocalEntityProviderBuilder(dataSource, cacheEnabled, metricsPrefix) // implicit executionContext
+      new LocalEntityProviderBuilder(dataSource, cacheEnabled, queryTimeout, metricsPrefix) // implicit executionContext
     val dataRepoEntityProviderBuilder = new DataRepoEntityProviderBuilder(workspaceManagerDAO,
                                                                           dataRepoDAO,
                                                                           samDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -40,6 +40,7 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, CollectionUtils, EntitySupport}
 import slick.jdbc.TransactionIsolation
 
+import java.time.Duration
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -50,6 +51,7 @@ import scala.util.{Failure, Success, Try}
 class LocalEntityProvider(requestArguments: EntityRequestArguments,
                           implicit protected val dataSource: SlickDataSource,
                           cacheEnabled: Boolean,
+                          queryTimeout: Duration,
                           override val workbenchMetricBaseName: String
 )(implicit protected val executionContext: ExecutionContext)
     extends EntityProvider

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderBuilder.scala
@@ -4,6 +4,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
 import org.broadinstitute.dsde.rawls.entities.base.EntityProviderBuilder
 
+import java.time.Duration
 import scala.concurrent.ExecutionContext
 import scala.reflect.runtime.universe._
 import scala.util.{Success, Try}
@@ -11,12 +12,16 @@ import scala.util.{Success, Try}
 /**
  * Builder for the Terra default entity provider
  */
-class LocalEntityProviderBuilder(dataSource: SlickDataSource, cacheEnabled: Boolean, metricsPrefix: String)(implicit
+class LocalEntityProviderBuilder(dataSource: SlickDataSource,
+                                 cacheEnabled: Boolean,
+                                 queryTimeout: Duration,
+                                 metricsPrefix: String
+)(implicit
   protected val executionContext: ExecutionContext
 ) extends EntityProviderBuilder[LocalEntityProvider] {
 
   override def builds: TypeTag[LocalEntityProvider] = typeTag[LocalEntityProvider]
 
   override def build(requestArguments: EntityRequestArguments): Try[LocalEntityProvider] =
-    Success(new LocalEntityProvider(requestArguments, dataSource, cacheEnabled, metricsPrefix))
+    Success(new LocalEntityProvider(requestArguments, dataSource, cacheEnabled, queryTimeout, metricsPrefix))
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -57,17 +57,20 @@ object SubmissionSupervisor {
             notificationDAO: NotificationDAO,
             bucketCredential: Credential,
             submissionMonitorConfig: SubmissionMonitorConfig,
+            entityQueryTimeout: Duration,
             workbenchMetricBaseName: String
   ): Props =
     Props(
-      new SubmissionSupervisor(executionServiceCluster,
-                               datasource,
-                               samDAO,
-                               googleServicesDAO,
-                               notificationDAO,
-                               bucketCredential,
-                               submissionMonitorConfig,
-                               workbenchMetricBaseName
+      new SubmissionSupervisor(
+        executionServiceCluster,
+        datasource,
+        samDAO,
+        googleServicesDAO,
+        notificationDAO,
+        bucketCredential,
+        submissionMonitorConfig,
+        entityQueryTimeout,
+        workbenchMetricBaseName
       )
     )
 }
@@ -87,6 +90,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
                            notificationDAO: NotificationDAO,
                            bucketCredential: Credential,
                            submissionMonitorConfig: SubmissionMonitorConfig,
+                           entityQueryTimeout: Duration,
                            override val workbenchMetricBaseName: String
 ) extends Actor
     with LazyLogging
@@ -195,6 +199,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
           executionServiceCluster,
           credential,
           submissionMonitorConfig,
+          entityQueryTimeout,
           workbenchMetricBaseName
         )
         .withDispatcher("submission-monitor-dispatcher"),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -116,6 +116,7 @@ object BootMonitors extends LazyLogging {
       gcsDAO,
       notificationDAO,
       shardedExecutionServiceCluster,
+      conf.getDuration("entities.queryTimeout").toScala,
       metricsPrefix
     )
 
@@ -286,6 +287,7 @@ object BootMonitors extends LazyLogging {
                                                gcsDAO: GoogleServicesDAO,
                                                notificationDAO: NotificationDAO,
                                                shardedExecutionServiceCluster: ExecutionServiceCluster,
+                                               entityQueryTimeout: Duration,
                                                metricsPrefix: String
   ) =
     system.actorOf(
@@ -297,6 +299,7 @@ object BootMonitors extends LazyLogging {
         notificationDAO,
         gcsDAO.getBucketServiceAccountCredential,
         submissionMonitorConfig,
+        entityQueryTimeout,
         workbenchMetricBaseName = metricsPrefix
       ),
       "rawls-submission-supervisor"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -81,6 +81,7 @@ object BootMonitors extends LazyLogging {
                    methodRepoDAO: MethodRepoDAO,
                    drsResolver: DrsResolver,
                    entityService: RawlsRequestContext => EntityService,
+                   entityQueryTimeout: Duration,
                    workspaceService: RawlsRequestContext => WorkspaceService,
                    shardedExecutionServiceCluster: ExecutionServiceCluster,
                    maxActiveWorkflowsTotal: Int,
@@ -116,7 +117,7 @@ object BootMonitors extends LazyLogging {
       gcsDAO,
       notificationDAO,
       shardedExecutionServiceCluster,
-      conf.getDuration("entities.queryTimeout").toScala,
+      entityQueryTimeout,
       metricsPrefix
     )
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -20,7 +20,7 @@
 
     <root level="info">
         <appender-ref ref="FILE"/>
-        <appender-ref ref="console"/>
+        <appender-ref ref="console"/>
     </root>
 
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -68,6 +68,8 @@ entityStatisticsCache {
 
 entities {
   pageSizeLimit = 300000
+  # certain SQL queries are set to have a maximum run time
+  queryTimeout = 2 minutes
 }
 
 gcs {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -145,6 +145,7 @@ class EntityServiceSpec
         bigQueryServiceFactory,
         DataRepoEntityProviderConfig(100, 10, 0),
         testConf.getBoolean("entityStatisticsCache.enabled"),
+        testConf.getDuration("entities.queryTimeout"),
         workbenchMetricBaseName
       ),
       7 // <-- specifically chosen to be lower than the number of samples in "workspace" within testData

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityShardingSpec.scala
@@ -77,6 +77,7 @@ class EntityShardingSpec
         bigQueryServiceFactory,
         DataRepoEntityProviderConfig(100, 10, 0),
         testConf.getBoolean("entityStatisticsCache.enabled"),
+        testConf.getDuration("entities.queryTimeout"),
         workbenchMetricBaseName
       ),
       1000

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/BatchUpsertScalingSpec.scala
@@ -116,6 +116,7 @@ class BatchUpsertScalingSpec
         bigQueryServiceFactory,
         DataRepoEntityProviderConfig(100, 10, 0),
         testConf.getBoolean("entityStatisticsCache.enabled"),
+        testConf.getDuration("entities.queryTimeout"),
         workbenchMetricBaseName
       ),
       1000

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -50,6 +50,8 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
 
   implicit val actorSystem = ActorSystem() // needed for stream materialization
 
+  val testConf = ConfigFactory.load()
+
   // ===================================================================================================================
   // exemplar data used in multiple tests
   // ===================================================================================================================
@@ -99,6 +101,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                  slickDataSource,
                                                  false,
+                                                 testConf.getDuration("entities.queryTimeout"),
                                                  "metricsBaseName"
           )
           // get metadata
@@ -172,6 +175,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
             provider.deleteEntitiesOfType(typeUnderTest).futureValue
@@ -241,6 +245,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
             // get results for one specific type
@@ -287,6 +292,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                  slickDataSource,
                                                  false,
+                                                 testConf.getDuration("entities.queryTimeout"),
                                                  "metricsBaseName"
           )
           // test gets
@@ -305,6 +311,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -340,6 +347,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -378,6 +386,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
               val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                      slickDataSource,
                                                      false,
+                                                     testConf.getDuration("entities.queryTimeout"),
                                                      "metricsBaseName"
               )
 
@@ -416,6 +425,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -464,6 +474,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -514,6 +525,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -557,6 +569,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -603,6 +616,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                false,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
         // get metadata
@@ -622,6 +636,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
         provider.entityTypeMetadata(true).futureValue
@@ -642,6 +657,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
 
@@ -664,6 +680,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
 
@@ -683,6 +700,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
 
@@ -755,6 +773,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
 
@@ -794,6 +813,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
 
@@ -821,6 +841,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                slickDataSource,
                                                true,
+                                               testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
 
@@ -853,6 +874,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val provider = new LocalEntityProvider(EntityRequestArguments(testWorkspace.workspace, testContext),
                                                    slickDataSource,
                                                    false,
+                                                   testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
 
@@ -926,6 +948,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         bigQueryServiceFactory,
         DataRepoEntityProviderConfig(100, 10, 0),
         testConf.getBoolean("entityStatisticsCache.enabled"),
+        testConf.getDuration("entities.queryTimeout"),
         "testMetricBaseName"
       ),
       1000

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -58,10 +58,12 @@ class LocalEntityProviderSpec
                         dataAccess: DataAccess
   )(implicit executionContext: ExecutionContext): ReadWriteAction[Map[String, Seq[SubmissionValidationValue]]] = {
 
-    val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                      slickDataSource,
-                                                      testConf.getBoolean("entityStatisticsCache.enabled"),
-                                                      workbenchMetricBaseName
+    val localEntityProvider = new LocalEntityProvider(
+      EntityRequestArguments(workspaceContext, testContext),
+      slickDataSource,
+      testConf.getBoolean("entityStatisticsCache.enabled"),
+      testConf.getDuration("entities.queryTimeout"),
+      workbenchMetricBaseName
     )
 
     dataAccess.entityQuery
@@ -324,10 +326,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         val multiUpsert = Seq(
@@ -393,10 +397,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
@@ -425,10 +431,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
@@ -458,10 +466,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
@@ -493,6 +503,7 @@ class LocalEntityProviderSpec
         val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
                                                           slickDataSource,
                                                           false,
+                                                          testConf.getDuration("entities.queryTimeout"),
                                                           workbenchMetricBaseName
         )
 
@@ -522,10 +533,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
@@ -588,10 +601,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
@@ -646,10 +661,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // Update the entityCacheLastUpdated field to be prior to lastModified, so we can test our scenario of having a fresh cache
@@ -933,10 +950,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
         val wsid = workspaceContext.workspaceIdAsUUID
         val workspaceFilter = entityCacheQuery.filter(_.workspaceId === wsid)
@@ -971,10 +990,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // create the first entity with name "myname"
@@ -1005,10 +1026,12 @@ class LocalEntityProviderSpec
         val workspaceContext = runAndWait(
           dataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
         ).get
-        val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                          slickDataSource,
-                                                          cacheEnabled = true,
-                                                          workbenchMetricBaseName
+        val localEntityProvider = new LocalEntityProvider(
+          EntityRequestArguments(workspaceContext, testContext),
+          slickDataSource,
+          cacheEnabled = true,
+          testConf.getDuration("entities.queryTimeout"),
+          workbenchMetricBaseName
         )
 
         // create the first entity with name "myname"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
@@ -72,22 +72,22 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
 
   "LocalEntityProvider query timeouts" should {
 
-    "enforce on deleteEntities" in withLocalEntityProviderTestDatabase { ds =>
-      lockedEntitiesTest(ds, a[MySQLTimeoutException]) { localEntityProvider =>
+    "enforce on deleteEntities" in withLocalEntityProviderTestDatabase { dataSource =>
+      lockedEntitiesTest(dataSource, a[MySQLTimeoutException]) { localEntityProvider =>
         localEntityProvider.deleteEntities(
           Seq(AttributeEntityReference(entityType = "unitTestType", entityName = "deleteTimeoutTest"))
         )
       }
     }
 
-    "enforce on deleteEntitiesOfType" in withLocalEntityProviderTestDatabase { ds =>
-      lockedEntitiesTest(ds, a[MySQLTimeoutException]) { localEntityProvider =>
+    "enforce on deleteEntitiesOfType" in withLocalEntityProviderTestDatabase { dataSource =>
+      lockedEntitiesTest(dataSource, a[MySQLTimeoutException]) { localEntityProvider =>
         localEntityProvider.deleteEntitiesOfType("unitTestType")
       }
     }
 
-    "enforce on batchUpsert" in withLocalEntityProviderTestDatabase { ds =>
-      lockedEntitiesTest(ds, a[RawlsExceptionWithErrorReport]) { localEntityProvider =>
+    "enforce on batchUpsert" in withLocalEntityProviderTestDatabase { dataSource =>
+      lockedEntitiesTest(dataSource, a[RawlsExceptionWithErrorReport]) { localEntityProvider =>
         val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
         val entityUpdate =
           EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
@@ -95,8 +95,8 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
       }
     }
 
-    "enforce on batchUpdate" in withLocalEntityProviderTestDatabase { ds =>
-      lockedEntitiesTest(ds, a[RawlsExceptionWithErrorReport]) { localEntityProvider =>
+    "enforce on batchUpdate" in withLocalEntityProviderTestDatabase { dataSource =>
+      lockedEntitiesTest(dataSource, a[RawlsExceptionWithErrorReport]) { localEntityProvider =>
         val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
         val entityUpdate =
           EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
@@ -1,0 +1,110 @@
+package org.broadinstitute.dsde.rawls.entities.local
+
+import com.mysql.cj.jdbc.exceptions.MySQLTimeoutException
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.entities.EntityRequestArguments
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, EntityUpdateDefinition}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, AttributeString, Entity}
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.dsl.ResultOfATypeInvocation
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Milliseconds, Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpecLike
+import slick.jdbc.TransactionIsolation
+
+import scala.concurrent.Future
+
+class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with ScalaFutures with TestDriverComponent {
+
+  import driver.api._
+
+  /** Locks all rows of the ENTITY table for ${lockSeconds} seconds. Use this to simulate database contention. */
+  private def lockAllEntities(dataSource: SlickDataSource, lockSeconds: Int): Future[Unit] = {
+    val locker = for {
+      _ <- sql"""select * from ENTITY for update;""".as[Unit]
+      _ <- sql"""select sleep($lockSeconds);""".as[Unit]
+    } yield ()
+    dataSource.database.run(locker.transactionally.withTransactionIsolation(TransactionIsolation.Serializable))
+  }
+
+  /** Implementation for all of the tests in this class. They share a lot of setup and assertion code. */
+  private def lockedEntitiesTest(dataSource: SlickDataSource, expectedClass: ResultOfATypeInvocation[_])(
+    futureToTest: LocalEntityProvider => Future[_]
+  ): Unit =
+    withWorkspaceContext(localEntityProviderTestData.workspace) { workspaceContext =>
+      // create a single entity
+      val testEntity = Entity("deleteTimeoutTest", "unitTestType", Map.empty)
+      runAndWait(entityQuery.save(localEntityProviderTestData.workspace, testEntity))
+
+      // create entity provider, configured with a 1-second timeout
+      val localEntityProvider = new LocalEntityProvider(
+        EntityRequestArguments(workspaceContext, testContext),
+        slickDataSource,
+        false, // <-- statistics cache disabled, but probably irrelevant for this test
+        java.time.Duration.ofSeconds(1), // <----- one-second timeout
+        "testMetricsBaseName"
+      )
+
+      val lockTime = 3 // seconds
+
+      // ensure the wait-time for the futureValue is longer than the timeout set on the query
+      val timeout: Timeout = Timeout(scaled(Span(lockTime, Seconds)))
+      val interval: Interval = Interval(scaled(Span(250, Milliseconds)))
+
+      // lock the entity table. Note this is a Future and we don't wait on it here.
+      val lockFuture: Future[Unit] = lockAllEntities(dataSource, lockTime)
+
+      // now attempt to execute the "futureToTest" code under test, using the provider configured
+      // with a timeout of 1 second. Because the table is locked, the underlying query should wait
+      // trying to get the lock, then time out after 1 second.
+      val actual: Throwable = futureToTest(localEntityProvider).failed
+        .futureValue(timeout, interval)
+
+      actual shouldBe expectedClass
+
+      // finally, ensure we wait for the previous lock to commit - and therefore unlock - before
+      // ending the test, so we don't leave locks on the db for any other tests
+      val _ = lockFuture.futureValue(timeout, interval)
+    }
+
+  "LocalEntityProvider query timeouts" should {
+
+    "enforce on deleteEntities" in withLocalEntityProviderTestDatabase { ds =>
+      lockedEntitiesTest(ds, a[MySQLTimeoutException]) { localEntityProvider =>
+        localEntityProvider.deleteEntities(
+          Seq(AttributeEntityReference(entityType = "unitTestType", entityName = "deleteTimeoutTest"))
+        )
+      }
+    }
+
+    "enforce on deleteEntitiesOfType" in withLocalEntityProviderTestDatabase { ds =>
+      lockedEntitiesTest(ds, a[MySQLTimeoutException]) { localEntityProvider =>
+        localEntityProvider.deleteEntitiesOfType("unitTestType")
+      }
+    }
+
+    "enforce on batchUpsert" in withLocalEntityProviderTestDatabase { ds =>
+      lockedEntitiesTest(ds, a[RawlsExceptionWithErrorReport]) { localEntityProvider =>
+        val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
+        val entityUpdate =
+          EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
+        localEntityProvider.batchUpsertEntities(Seq(entityUpdate))
+      }
+    }
+
+    "enforce on batchUpdate" in withLocalEntityProviderTestDatabase { ds =>
+      lockedEntitiesTest(ds, a[RawlsExceptionWithErrorReport]) { localEntityProvider =>
+        val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
+        val entityUpdate =
+          EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
+        localEntityProvider.batchUpdateEntities(Seq(entityUpdate))
+      }
+    }
+//    "enforce on batchUpdateEntitiesImpl" ignore fail()
+
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -227,6 +227,7 @@ class FastPassMonitorSpec
       bigQueryServiceFactory,
       DataRepoEntityProviderConfig(100, 10, 0),
       testConf.getBoolean("entityStatisticsCache.enabled"),
+      testConf.getDuration("entities.queryTimeout"),
       workbenchMetricBaseName
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -51,6 +51,7 @@ import org.scalatest.{BeforeAndAfterAll, OptionValues}
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 
 //noinspection NameBooleanParameters,TypeAnnotation,EmptyParenMethodAccessedAsParameterless,ScalaUnnecessaryParentheses,RedundantNewCaseClass,ScalaUnusedSymbol
@@ -147,6 +148,7 @@ class FastPassMonitorSpec
           mockNotificationDAO,
           gcsDAO.getBucketServiceAccountCredential,
           SubmissionMonitorConfig(1 second, 30 days, true, 20000, true),
+          testConf.getDuration("entities.queryTimeout").toScala,
           workbenchMetricBaseName = "test"
         )
         .withDispatcher("submission-monitor-dispatcher")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -255,6 +255,7 @@ class FastPassServiceSpec
       bigQueryServiceFactory,
       DataRepoEntityProviderConfig(100, 10, 0),
       testConf.getBoolean("entityStatisticsCache.enabled"),
+      testConf.getDuration("entities.queryTimeout"),
       workbenchMetricBaseName
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -59,6 +59,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 
 //noinspection NameBooleanParameters,TypeAnnotation,EmptyParenMethodAccessedAsParameterless,ScalaUnnecessaryParentheses,RedundantNewCaseClass,ScalaUnusedSymbol
@@ -175,6 +176,7 @@ class FastPassServiceSpec
           mockNotificationDAO,
           gcsDAO.getBucketServiceAccountCredential,
           SubmissionMonitorConfig(1 second, 30 days, true, 20000, true),
+          testConf.getDuration("entities.queryTimeout").toScala,
           workbenchMetricBaseName = "test"
         )
         .withDispatcher("submission-monitor-dispatcher")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActorTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActorTimeoutSpec.scala
@@ -1,0 +1,114 @@
+package org.broadinstitute.dsde.rawls.jobexec
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestActorRef, TestKit}
+import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential.Builder
+import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  MockGoogleServicesDAO,
+  MockShardedExecutionServiceCluster,
+  SlickDataSource
+}
+import org.broadinstitute.dsde.rawls.model.WorkflowStatuses
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.mock.MockSamDAO
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.BatchUpdateException
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, AttributeString}
+import slick.jdbc.TransactionIsolation
+
+import java.util.UUID
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class SubmissionMonitorActorTimeoutSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with AnyFlatSpecLike
+    with Matchers
+    with MockitoTestUtils
+    with TestDriverComponent {
+
+  import driver.api._
+
+  def this() = this(ActorSystem("WorkflowMonitorSpec"))
+
+  val mockGoogleServicesDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO("test")
+  val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
+  val mockSamDAO = new MockSamDAO(slickDataSource)
+
+  // copied from LocalEntityProviderTimeoutSpec
+  /** Locks all rows of the ENTITY table for ${lockSeconds} seconds. Use this to simulate database contention. */
+  private def lockAllEntities(dataSource: SlickDataSource, lockSeconds: Int): Future[Unit] = {
+    val locker = for {
+      _ <- sql"""select * from ENTITY for update;""".as[Unit]
+      _ <- sql"""select sleep($lockSeconds);""".as[Unit]
+    } yield ()
+    dataSource.database.run(locker.transactionally.withTransactionIsolation(TransactionIsolation.Serializable))
+
+    // .withTransactionIsolation(TransactionIsolation.Serializable)
+  }
+
+  behavior of "SubmissionMonitorActor query timeouts"
+
+  it should "should enforce on saveEntities()" in withDefaultTestDatabase { dataSource: SlickDataSource =>
+    withWorkspaceContext(testData.workspace) { workspaceContext =>
+      // create a SubmissionMonitorActor with a long poll interval
+      val config = SubmissionMonitorConfig(1 day,
+                                           30 days,
+                                           trackDetailedSubmissionMetrics = false,
+                                           10,
+                                           enableEmailNotifications = false
+      )
+      val submissionMonitorActorRef = TestActorRef[SubmissionMonitorActor](
+        SubmissionMonitorActor.props(
+          testData.wsName,
+          UUID.fromString(testData.submission1.submissionId),
+          new UncoordinatedDataSourceAccess(dataSource),
+          mockSamDAO,
+          mockGoogleServicesDAO,
+          mockNotificationDAO,
+          MockShardedExecutionServiceCluster
+            .fromDAO(new SubmissionTestExecutionServiceDAO(WorkflowStatuses.Submitted.toString), dataSource),
+          new Builder().build(),
+          config,
+          Duration.create(1, SECONDS), // <-- 1 second timeout for entity queries
+          "test"
+        )
+      )
+
+      // generate a workflow entity update
+      val entityRef = AttributeEntityReference(testData.sample1.entityType, testData.sample1.name)
+      val entityUpdate =
+        WorkflowEntityUpdate(
+          entityRef,
+          Map(AttributeName.withDefaultNS("SubmissionMonitorActorTimeoutSpec") -> AttributeString("updated value"))
+        )
+      val updatedEntitiesAndWorkspace = Seq(Left(Option(entityUpdate), Option(workspaceContext)))
+
+      // lock the entity table
+      val lockTime = 3 // seconds
+      val lockFuture: Future[Unit] = lockAllEntities(dataSource, lockTime)
+
+      val actual = intercept[BatchUpdateException] {
+        runAndWait(
+          submissionMonitorActorRef.underlyingActor.saveEntities(dataSource.dataAccess,
+                                                                 workspaceContext,
+                                                                 updatedEntitiesAndWorkspace
+          ),
+          Duration.create(lockTime, SECONDS)
+        )
+      }
+
+      actual.getMessage shouldBe "Statement cancelled due to timeout or client request"
+
+      // finally, ensure we wait for the previous lock to commit - and therefore unlock - before
+      // ending the test, so we don't leave locks on the db for any other tests
+      val _ = Await.result(lockFuture, Duration.create(lockTime, SECONDS))
+    }
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -5,6 +5,7 @@ import akka.stream.ActorMaterializer
 import akka.testkit.{TestActorRef, TestKit}
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential.Builder
+import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.coordination.{DataSourceAccess, UncoordinatedDataSourceAccess}
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -30,6 +31,7 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 import scala.util.{Success, Try}
 
@@ -1888,6 +1890,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         MockShardedExecutionServiceCluster.fromDAO(execSvcDAO, dataSource),
         new Builder().build(),
         config,
+        ConfigFactory.load().getDuration("entities.queryTimeout").toScala,
         "test"
       )
     )
@@ -1911,6 +1914,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       MockShardedExecutionServiceCluster.fromDAO(execSvcDAO, dataSource),
       new Builder().build(),
       config,
+      ConfigFactory.load().getDuration("entities.queryTimeout").toScala,
       "test"
     )
   }
@@ -1988,5 +1992,6 @@ class TestSubmissionMonitor(val workspaceName: WorkspaceName,
                             val executionServiceCluster: ExecutionServiceCluster,
                             val credential: Credential,
                             val config: SubmissionMonitorConfig,
+                            val queryTimeout: Duration,
                             override val workbenchMetricBaseName: String
 ) extends SubmissionMonitor {}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -496,6 +496,7 @@ class SubmissionSpec(_system: ActorSystem)
         bigQueryServiceFactory,
         DataRepoEntityProviderConfig(100, 10000, 0),
         testConf.getBoolean("entityStatisticsCache.enabled"),
+        testConf.getDuration("entities.queryTimeout"),
         workbenchMetricBaseName
       )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -51,6 +51,7 @@ import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 import scala.util.Try
 
@@ -427,6 +428,9 @@ class SubmissionSpec(_system: ActorSystem)
       val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
       val samDAO = new MockSamDAO(dataSource)
       val gpsDAO = new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
+
+      val testConf = ConfigFactory.load()
+
       val submissionSupervisor = system.actorOf(
         SubmissionSupervisor
           .props(
@@ -437,13 +441,12 @@ class SubmissionSpec(_system: ActorSystem)
             mockNotificationDAO,
             gcsDAO.getBucketServiceAccountCredential,
             config,
+            testConf.getDuration("entities.queryTimeout").toScala,
             workbenchMetricBaseName = workbenchMetricBaseName
           )
           .withDispatcher("submission-monitor-dispatcher"),
         submissionSupervisorActorName
       )
-
-      val testConf = ConfigFactory.load()
 
       val notificationDAO = new PubSubNotificationDAO(gpsDAO, "test-notification-topic")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.jobexec
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
@@ -29,6 +30,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.util.UUID
 import scala.concurrent.duration._
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 
 //noinspection NameBooleanParameters,TypeAnnotation
@@ -78,6 +80,7 @@ class SubmissionSupervisorSpec
           mockNotificationDAO,
           gcsDAO.getBucketServiceAccountCredential,
           config,
+          ConfigFactory.load().getDuration("entities.queryTimeout").toScala,
           workbenchMetricBaseName
         )
         .withDispatcher("submission-monitor-dispatcher"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -150,10 +150,12 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       val workspaceContext = runAndWait(
         slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
       ).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                        slickDataSource,
-                                                        cacheEnabled = true,
-                                                        workbenchMetricBaseName
+      val localEntityProvider = new LocalEntityProvider(
+        EntityRequestArguments(workspaceContext, testContext),
+        slickDataSource,
+        cacheEnabled = true,
+        testConf.getDuration("entities.queryTimeout"),
+        workbenchMetricBaseName
       )
 
       // Update the entityCacheLastUpdated field to be identical to lastModified, so we can test our scenario of having a fresh cache
@@ -201,10 +203,12 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       val workspaceContext = runAndWait(
         slickDataSource.dataAccess.workspaceQuery.findById(localEntityProviderTestData.workspace.workspaceId)
       ).get
-      val localEntityProvider = new LocalEntityProvider(EntityRequestArguments(workspaceContext, testContext),
-                                                        slickDataSource,
-                                                        cacheEnabled = true,
-                                                        workbenchMetricBaseName
+      val localEntityProvider = new LocalEntityProvider(
+        EntityRequestArguments(workspaceContext, testContext),
+        slickDataSource,
+        cacheEnabled = true,
+        testConf.getDuration("entities.queryTimeout"),
+        workbenchMetricBaseName
       )
 
       // Update the entityCacheLastUpdated field to be older than lastModified, so we can test our scenario of having a stale cache

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -318,6 +318,7 @@ trait ApiServiceSpec
       bigQueryServiceFactory,
       DataRepoEntityProviderConfig(100, 10, 0),
       testConf.getBoolean("entityStatisticsCache.enabled"),
+      testConf.getDuration("entities.queryTimeout"),
       workbenchMetricBaseName
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -70,6 +70,7 @@ import spray.json._
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 
 //noinspection TypeAnnotation
@@ -188,6 +189,7 @@ trait ApiServiceSpec
     )
 
     val config = SubmissionMonitorConfig(5 seconds, 30 days, true, 20000, true)
+    val testConf = ConfigFactory.load()
     val submissionSupervisor = system.actorOf(
       SubmissionSupervisor
         .props(
@@ -198,12 +200,11 @@ trait ApiServiceSpec
           mockNotificationDAO,
           gcsDAO.getBucketServiceAccountCredential,
           config,
+          testConf.getDuration("entities.queryTimeout").toScala,
           workbenchMetricBaseName
         )
         .withDispatcher("submission-monitor-dispatcher")
     )
-
-    val testConf = ConfigFactory.load()
 
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -80,6 +80,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
 import scala.util.Try
 
@@ -170,6 +171,7 @@ class WorkspaceServiceSpec
           mockNotificationDAO,
           gcsDAO.getBucketServiceAccountCredential,
           SubmissionMonitorConfig(1 second, 30 days, true, 20000, true),
+          testConf.getDuration("entities.queryTimeout").toScala,
           workbenchMetricBaseName = "test"
         )
         .withDispatcher("submission-monitor-dispatcher")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -250,6 +250,7 @@ class WorkspaceServiceSpec
       bigQueryServiceFactory,
       DataRepoEntityProviderConfig(100, 10, 0),
       testConf.getBoolean("entityStatisticsCache.enabled"),
+      testConf.getDuration("entities.queryTimeout"),
       workbenchMetricBaseName
     )
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1326

This PR adds a 15-minute timeout to multiple data table queries. 15 minutes is awfully long. We've seen some queries that legitimately require multiple minutes (which I'd love to fix but is way more work than this PR). With this timeout, we're aiming to clamp down on any runaway queries that hold a database lock for an infinite amount of time, and thus recover from locking problems.

The 15-minute duration is configurable in Rawls' conf file. In this PR I've only set it in reference.conf, but we could easily update it in rawls.conf later if desired.

There's a lot of small method-signature changes in this PR for compatibility. The goal is:
* define the timeout duration in config
* read the duration from config only in Boot.scala (or in unit tests), then pass the duration as argument through the code. This sticks with the general Rawls paradigm for where to read conf.
* in a few places, add a `.withStatementParameters` to enforce the timeout on database actions 

Sifting through the noise of all the code changes, if you look for `setQueryTimeout`, you can see that this PR adds a timeout in 4 places:
1. SubmissionMonitorActor.saveEntities
2. LocalEntityProvider.deleteEntities
3. LocalEntityProvider.deleteEntitiesOfType
4. LocalEntityProvider.batchUpdateEntitiesImpl




---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
