### PR TITLE
AJ-1485: Ignore redundant `AvroUpsert` messages.

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.rawls.model.{
   ImportStatuses,
   RawlsRequestContext,
   RawlsUserEmail,
-  UserInfo,
   Workspace,
   WorkspaceName
 }
@@ -342,9 +341,11 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
                                                  Option(errMsg)
               )
           }
-        case Some(_) =>
-          logger.warn(s"Received a double message delivery for import ID [${attributes.importId}]")
-          Future.unit
+        case Some(status) =>
+          logger.warn(
+            s"Received a double message delivery for import ID [${attributes.importId}] which is already in status [$status].  Acking message."
+          )
+          acknowledgeMessage(message.ackId)
         case None =>
           publishMessageToUpdateImportStatus(attributes.importId,
                                              None,


### PR DESCRIPTION
[AJ-1485](https://broadworkbench.atlassian.net/browse/AJ-1485) Maintenance Ticket

Double deliveries can happen occasionally, per:
https://cloud.google.com/pubsub/docs/subscription-overview#default_properties

Rather than let such redundant messages get stuck in the queue, ack them to clear them out.

This is done as a response to a `Rawls import pub/sub message` [alert](https://broadinstitute.slack.com/archives/C031KGQUVB4/p1701822121418369) to prevent future such messages from getting stuck in the queue.

[AJ-1485]: https://broadworkbench.atlassian.net/browse/AJ-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ