### PR TITLE
AJ-1524: tracing for submission monitor

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -707,81 +707,83 @@ trait AttributeComponent {
     def rewriteAttrsAction(attributesToSave: Traversable[RECORD],
                            existingAttributes: Traversable[RECORD],
                            insertFunction: Seq[RECORD] => String => WriteAction[Int]
-    ): ReadWriteAction[Set[OWNER_ID]] = {
-      val toSaveAttrMap = toPrimaryKeyMap(attributesToSave)
-      val existingAttrMap = toPrimaryKeyMap(existingAttributes)
+    ): ReadWriteAction[Set[OWNER_ID]] =
+      traceDBIOWithParent("AttributeComponent.rewriteAttrsAction", RawlsTracingContext(Option.empty)) {
+        tracingContext =>
+          val toSaveAttrMap = toPrimaryKeyMap(attributesToSave)
+          val existingAttrMap = toPrimaryKeyMap(existingAttributes)
 
-      // note that currently-existing attributes will have a populated id e.g. "1234", but to-save will have an id of "0"
-      // therefore, we use this ComparableRecord class which omits the id when checking equality between existing and to-save.
-      // note this does not include transactionId for AttributeScratchRecords. We do not expect AttributeScratchRecords
-      // here, and transactionId will eventually be going away, so don't bother
-      object ComparableRecord {
-        def fromRecord(rec: RECORD): ComparableRecord =
-          new ComparableRecord(
-            rec.ownerId,
-            rec.namespace,
-            rec.name,
-            rec.valueString,
-            rec.valueNumber,
-            rec.valueBoolean,
-            rec.valueJson,
-            rec.valueEntityRef,
-            rec.listIndex,
-            rec.listLength,
-            rec.deleted,
-            rec.deletedDate
+          // note that currently-existing attributes will have a populated id e.g. "1234", but to-save will have an id of "0"
+          // therefore, we use this ComparableRecord class which omits the id when checking equality between existing and to-save.
+          // note this does not include transactionId for AttributeScratchRecords. We do not expect AttributeScratchRecords
+          // here, and transactionId will eventually be going away, so don't bother
+          object ComparableRecord {
+            def fromRecord(rec: RECORD): ComparableRecord =
+              new ComparableRecord(
+                rec.ownerId,
+                rec.namespace,
+                rec.name,
+                rec.valueString,
+                rec.valueNumber,
+                rec.valueBoolean,
+                rec.valueJson,
+                rec.valueEntityRef,
+                rec.listIndex,
+                rec.listLength,
+                rec.deleted,
+                rec.deletedDate
+              )
+          }
+
+          case class ComparableRecord(
+            ownerId: OWNER_ID,
+            namespace: String,
+            name: String,
+            valueString: Option[String],
+            valueNumber: Option[Double],
+            valueBoolean: Option[Boolean],
+            valueJson: Option[String],
+            valueEntityRef: Option[Long],
+            listIndex: Option[Int],
+            listLength: Option[Int],
+            deleted: Boolean,
+            deletedDate: Option[Timestamp]
           )
+
+          // create a set of ComparableRecords representing the existing attributes
+          val existingAttributesSet: Set[ComparableRecord] =
+            existingAttributes.toSet.map(r => ComparableRecord.fromRecord(r))
+
+          val existingKeys = existingAttrMap.keySet
+
+          // insert attributes which are in save but not exists
+          val attributesToInsert = toSaveAttrMap.filterKeys(!existingKeys.contains(_))
+
+          // delete attributes which are in exists but not save
+          val attributesToDelete = existingAttrMap.filterKeys(!toSaveAttrMap.keySet.contains(_))
+
+          val attributesToUpdate = toSaveAttrMap.filter { case (k, v) =>
+            existingKeys.contains(k) && // if the attribute doesn't already exist, don't attempt to update it
+            !existingAttributesSet.contains(
+              ComparableRecord.fromRecord(v)
+            ) // if the attribute exists and is unchanged, don't update it
+          }
+
+          // collect the parent objects (e.g. entity, workspace) that have writes, so we know which object rows to re-calculate
+          val ownersWithWrites: Set[OWNER_ID] = (attributesToInsert.values.map(_.ownerId) ++
+            attributesToUpdate.values.map(_.ownerId) ++
+            attributesToDelete.values.map(_.ownerId)).toSet
+
+          // perform the inserts/updates/deletes
+          patchAttributesAction(
+            attributesToInsert.values,
+            attributesToUpdate.values,
+            attributesToDelete.values.map(_.id),
+            insertFunction,
+            tracingContext
+          )
+            .map(_ => ownersWithWrites)
       }
-
-      case class ComparableRecord(
-        ownerId: OWNER_ID,
-        namespace: String,
-        name: String,
-        valueString: Option[String],
-        valueNumber: Option[Double],
-        valueBoolean: Option[Boolean],
-        valueJson: Option[String],
-        valueEntityRef: Option[Long],
-        listIndex: Option[Int],
-        listLength: Option[Int],
-        deleted: Boolean,
-        deletedDate: Option[Timestamp]
-      )
-
-      // create a set of ComparableRecords representing the existing attributes
-      val existingAttributesSet: Set[ComparableRecord] =
-        existingAttributes.toSet.map(r => ComparableRecord.fromRecord(r))
-
-      val existingKeys = existingAttrMap.keySet
-
-      // insert attributes which are in save but not exists
-      val attributesToInsert = toSaveAttrMap.filterKeys(!existingKeys.contains(_))
-
-      // delete attributes which are in exists but not save
-      val attributesToDelete = existingAttrMap.filterKeys(!toSaveAttrMap.keySet.contains(_))
-
-      val attributesToUpdate = toSaveAttrMap.filter { case (k, v) =>
-        existingKeys.contains(k) && // if the attribute doesn't already exist, don't attempt to update it
-        !existingAttributesSet.contains(
-          ComparableRecord.fromRecord(v)
-        ) // if the attribute exists and is unchanged, don't update it
-      }
-
-      // collect the parent objects (e.g. entity, workspace) that have writes, so we know which object rows to re-calculate
-      val ownersWithWrites: Set[OWNER_ID] = (attributesToInsert.values.map(_.ownerId) ++
-        attributesToUpdate.values.map(_.ownerId) ++
-        attributesToDelete.values.map(_.ownerId)).toSet
-
-      // perform the inserts/updates/deletes
-      patchAttributesAction(
-        attributesToInsert.values,
-        attributesToUpdate.values,
-        attributesToDelete.values.map(_.id),
-        insertFunction,
-        RawlsTracingContext(Option(startSpan("rewriteAttrsAction")))
-      )
-        .map(_ => ownersWithWrites)
-    }
 
     // noinspection SqlDialectInspection
     object AlterAttributesUsingScratchTableQueries extends RawSqlQuery {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1053,27 +1053,31 @@ trait EntityComponent {
     private def applyEntityPatch(workspaceContext: Workspace,
                                  entityRecord: EntityRecord,
                                  upserts: AttributeMap,
-                                 deletes: Traversable[AttributeName]
-    ) =
-      // yank the attribute list for this entity to determine what to do with upserts
-      entityAttributeShardQuery(workspaceContext)
-        .findByOwnerQuery(Seq(entityRecord.id))
-        .map(attr => (attr.namespace, attr.name, attr.id))
-        .result flatMap { attrCols =>
-        val existingAttrsToRecordIds: Map[AttributeName, Set[Long]] =
-          attrCols
-            .groupBy { case (namespace, name, _) =>
-              (namespace, name)
-            }
-            .map { case ((namespace, name), ids) =>
-              AttributeName(namespace, name) -> ids
-                .map(_._3)
-                .toSet // maintain the full list of attribute ids since list members are stored as individual attributes
-            }
+                                 deletes: Traversable[AttributeName],
+                                 tracingContext: RawlsTracingContext
+    ) = {
+      traceDBIOWithParent("applyEntityPatch", tracingContext) { span =>
+        // yank the attribute list for this entity to determine what to do with upserts
+        traceDBIOWithParent("findByOwnerQuery", span)(_ =>
+          entityAttributeShardQuery(workspaceContext)
+            .findByOwnerQuery(Seq(entityRecord.id))
+            .map(attr => (attr.namespace, attr.name, attr.id))
+            .result
+        ) flatMap { attrCols =>
+          val existingAttrsToRecordIds: Map[AttributeName, Set[Long]] =
+            attrCols
+              .groupBy { case (namespace, name, _) =>
+                (namespace, name)
+              }
+              .map { case ((namespace, name), ids) =>
+                AttributeName(namespace, name) -> ids
+                  .map(_._3)
+                  .toSet // maintain the full list of attribute ids since list members are stored as individual attributes
+              }
 
-        val entityRefsToLookup = upserts.valuesIterator.collect { case e: AttributeEntityReference => e }.toSet
+          val entityRefsToLookup = upserts.valuesIterator.collect { case e: AttributeEntityReference => e }.toSet
 
-        /*
+          /*
           Additional check for resizing entities whose Attribute value type is AttributeList[_] in response to bugs
           mentioned in WA-32 and WA-153. Currently the update query is such that it matches the listIndex of each
           attribute value and updates the list index and list size. Previously if the size of the list changes, those
@@ -1084,45 +1088,46 @@ trait EntityComponent {
           or delete extra records from the entity table respectively.
 
           NOTE: Attributes that are not lists are treated as a list of size one.
-         */
+           */
 
-        // Tuple of
-        // insertRecs: Seq[EntityAttributeRecord]
-        // updateRecs: Seq[EntityAttributeRecord]
-        // extraDeleteIds: Seq[Long]
-        type AttributeModifications = (Seq[EntityAttributeRecord], Seq[EntityAttributeRecord], Seq[Long])
+          // Tuple of
+          // insertRecs: Seq[EntityAttributeRecord]
+          // updateRecs: Seq[EntityAttributeRecord]
+          // extraDeleteIds: Seq[Long]
+          type AttributeModifications = (Seq[EntityAttributeRecord], Seq[EntityAttributeRecord], Seq[Long])
 
-        def checkAndUpdateRecSize(name: AttributeName,
-                                  existingAttrSize: Int,
-                                  updateAttrSize: Int,
-                                  attrRecords: Seq[EntityAttributeRecord]
-        ): AttributeModifications =
-          if (updateAttrSize > existingAttrSize) {
-            // since the size of the "list" has increased, move these new records to insertRecs
-            val (newInsertRecs, newUpdateRecs) = attrRecords.partition {
-              _.listIndex.getOrElse(0) > (existingAttrSize - 1)
+          def checkAndUpdateRecSize(name: AttributeName,
+                                    existingAttrSize: Int,
+                                    updateAttrSize: Int,
+                                    attrRecords: Seq[EntityAttributeRecord]
+          ): AttributeModifications =
+            if (updateAttrSize > existingAttrSize) {
+              // since the size of the "list" has increased, move these new records to insertRecs
+              val (newInsertRecs, newUpdateRecs) = attrRecords.partition {
+                _.listIndex.getOrElse(0) > (existingAttrSize - 1)
+              }
+
+              (newInsertRecs, newUpdateRecs, Seq.empty[Long])
+            } else if (updateAttrSize < existingAttrSize) {
+              // since the size of the list has decreased, delete the extra rows from table
+              val deleteIds = existingAttrsToRecordIds(name).toSeq.takeRight(existingAttrSize - updateAttrSize)
+              (Seq.empty[EntityAttributeRecord], attrRecords, deleteIds)
+            } else (Seq.empty[EntityAttributeRecord], attrRecords, Seq.empty[Long]) // the list size hasn't changed
+
+          def recordsForUpdateAttribute(name: AttributeName,
+                                        attribute: Attribute,
+                                        attrRecords: Seq[EntityAttributeRecord]
+          ): AttributeModifications = {
+            val existingAttrSize = existingAttrsToRecordIds.get(name).map(_.size).getOrElse(0)
+            attribute match {
+              case list: AttributeList[_] => checkAndUpdateRecSize(name, existingAttrSize, list.list.size, attrRecords)
+              case _                      => checkAndUpdateRecSize(name, existingAttrSize, 1, attrRecords)
             }
-
-            (newInsertRecs, newUpdateRecs, Seq.empty[Long])
-          } else if (updateAttrSize < existingAttrSize) {
-            // since the size of the list has decreased, delete the extra rows from table
-            val deleteIds = existingAttrsToRecordIds(name).toSeq.takeRight(existingAttrSize - updateAttrSize)
-            (Seq.empty[EntityAttributeRecord], attrRecords, deleteIds)
-          } else (Seq.empty[EntityAttributeRecord], attrRecords, Seq.empty[Long]) // the list size hasn't changed
-
-        def recordsForUpdateAttribute(name: AttributeName,
-                                      attribute: Attribute,
-                                      attrRecords: Seq[EntityAttributeRecord]
-        ): AttributeModifications = {
-          val existingAttrSize = existingAttrsToRecordIds.get(name).map(_.size).getOrElse(0)
-          attribute match {
-            case list: AttributeList[_] => checkAndUpdateRecSize(name, existingAttrSize, list.list.size, attrRecords)
-            case _                      => checkAndUpdateRecSize(name, existingAttrSize, 1, attrRecords)
           }
-        }
 
-        lookupNotYetLoadedReferences(workspaceContext, entityRefsToLookup, Seq(entityRecord.toReference)) flatMap {
-          entityRefRecs =>
+          traceDBIOWithParent("lookupNotYetLoadedReferences", span)(_ =>
+            lookupNotYetLoadedReferences(workspaceContext, entityRefsToLookup, Seq(entityRecord.toReference))
+          ) flatMap { entityRefRecs =>
             val allTheEntityRefs = entityRefRecs ++ Seq(entityRecord) // re-add the current entity
             val refsToIds = allTheEntityRefs.map(e => e.toReference -> e.id).toMap
 
@@ -1156,48 +1161,69 @@ trait EntityComponent {
               insertRecs,
               updateRecs,
               totalDeleteIds,
-              entityAttributeTempQuery.insertScratchAttributes
+              entityAttributeTempQuery.insertScratchAttributes,
+              span
             )
+          }
         }
       }
+    }
 
     // "patch" this entity by applying the upserts and the deletes to its attributes, then save. a little more database efficient than a "full" save, but requires the entity already exist.
     def saveEntityPatch(workspaceContext: Workspace,
                         entityRef: AttributeEntityReference,
                         upserts: AttributeMap,
-                        deletes: Traversable[AttributeName]
-    ) = {
-      val deleteIntersectUpsert = deletes.toSet intersect upserts.keySet
-      if (upserts.isEmpty && deletes.isEmpty) {
-        DBIO.successful(()) // no-op
-      } else if (deleteIntersectUpsert.nonEmpty) {
-        DBIO.failed(
-          new RawlsException(
-            s"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"
+                        deletes: Traversable[AttributeName],
+                        tracingContext: RawlsTracingContext
+    ) =
+      traceDBIOWithParent("saveEntityPatch", tracingContext) { span =>
+        span.tracingSpan.foreach { s =>
+          s.putAttribute("workspaceId", OpenCensusAttributeValue.stringAttributeValue(workspaceContext.workspaceId))
+          s.putAttribute("workspace",
+                         OpenCensusAttributeValue.stringAttributeValue(workspaceContext.toWorkspaceName.toString)
           )
-        )
-      } else {
-        getEntityRecords(workspaceContext.workspaceIdAsUUID, Set(entityRef)) flatMap { entityRecs =>
-          if (entityRecs.length != 1) {
-            throw new RawlsException(
-              s"saveEntityPatch looked up $entityRef expecting 1 record, got ${entityRecs.length} instead"
+          s.putAttribute("entityType", OpenCensusAttributeValue.stringAttributeValue(entityRef.entityType))
+          s.putAttribute("entityName", OpenCensusAttributeValue.stringAttributeValue(entityRef.entityName))
+          s.putAttribute("numUpserts", OpenCensusAttributeValue.longAttributeValue(upserts.size))
+          s.putAttribute("numDeletes", OpenCensusAttributeValue.longAttributeValue(deletes.size))
+        }
+        val deleteIntersectUpsert = deletes.toSet intersect upserts.keySet
+        if (upserts.isEmpty && deletes.isEmpty) {
+          DBIO.successful(()) // no-op
+        } else if (deleteIntersectUpsert.nonEmpty) {
+          DBIO.failed(
+            new RawlsException(
+              s"Can't saveEntityPatch on $entityRef because upserts and deletes share attributes $deleteIntersectUpsert"
             )
-          }
+          )
+        } else {
+          traceDBIOWithParent("getEntityRecords", span)(_ =>
+            getEntityRecords(workspaceContext.workspaceIdAsUUID, Set(entityRef))
+          ) flatMap { entityRecs =>
+            if (entityRecs.length != 1) {
+              throw new RawlsException(
+                s"saveEntityPatch looked up $entityRef expecting 1 record, got ${entityRecs.length} instead"
+              )
+            }
 
-          val entityRecord = entityRecs.head
-          upserts.keys.foreach { attrName =>
-            validateUserDefinedString(attrName.name)
-            validateAttributeName(attrName, entityRecord.entityType)
-          }
+            val entityRecord = entityRecs.head
+            upserts.keys.foreach { attrName =>
+              validateUserDefinedString(attrName.name)
+              validateAttributeName(attrName, entityRecord.entityType)
+            }
 
-          for {
-            _ <- applyEntityPatch(workspaceContext, entityRecord, upserts, deletes)
-            updatedEntities <- entityQuery.getEntities(workspaceContext.workspaceIdAsUUID, Seq(entityRecord.id))
-            _ <- entityQueryWithInlineAttributes.optimisticLockUpdate(entityRecs, updatedEntities.map(elem => elem._2))
-          } yield {}
+            for {
+              _ <- applyEntityPatch(workspaceContext, entityRecord, upserts, deletes, span)
+              updatedEntities <- traceDBIOWithParent("getEntities", span)(_ =>
+                entityQuery.getEntities(workspaceContext.workspaceIdAsUUID, Seq(entityRecord.id))
+              )
+              _ <- traceDBIOWithParent("optimisticLockUpdate", span)(_ =>
+                entityQueryWithInlineAttributes.optimisticLockUpdate(entityRecs, updatedEntities.map(elem => elem._2))
+              )
+            } yield {}
+          }
         }
       }
-    }
 
     private def lookupNotYetLoadedReferences(workspaceContext: Workspace,
                                              entities: Traversable[Entity],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -262,9 +262,12 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
       case MonitoredSubmissionException(workspaceName, submissionId, cause) =>
         // increment smaRestart counter
         restartCounter(workspaceName, submissionId, cause) += 1
-        logger.error(s"error monitoring submission $submissionId in workspace $workspaceName after $count times", cause)
+        logger.error(
+          s"error monitoring submission $submissionId in workspace $workspaceName after $count times: ${cause.getMessage}",
+          cause
+        )
       case _ =>
-        logger.error(s"error monitoring submission after $count times", throwable)
+        logger.error(s"error monitoring submission after $count times: ${throwable.getMessage}", throwable)
     }
 
     new ThresholdOneForOneStrategy(thresholdLimit = 3)(alwaysRestart)(thresholdFunc)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -1665,7 +1665,8 @@ class AttributeComponentSpec
       workspaceAttributeQuery.patchAttributesAction(Seq(insert),
                                                     Seq(update),
                                                     Seq(),
-                                                    workspaceAttributeTempQuery.insertScratchAttributes
+                                                    workspaceAttributeTempQuery.insertScratchAttributes,
+                                                    RawlsTracingContext(None)
       )
     )
     assertExpectedRecords(Seq(existing.head, update, insert): _*)
@@ -1675,7 +1676,8 @@ class AttributeComponentSpec
       workspaceAttributeQuery.patchAttributesAction(Seq(),
                                                     Seq(),
                                                     existing.map(_.id),
-                                                    workspaceAttributeTempQuery.insertScratchAttributes
+                                                    workspaceAttributeTempQuery.insertScratchAttributes,
+                                                    RawlsTracingContext(None)
       )
     )
     assertExpectedRecords(Seq(insert): _*)
@@ -1871,7 +1873,8 @@ class AttributeComponentSpec
             context,
             testData.sample1.toReference,
             inserts,
-            Seq.empty[AttributeName]
+            Seq.empty[AttributeName],
+            RawlsTracingContext(None)
           )
         )
 
@@ -1885,7 +1888,12 @@ class AttributeComponentSpec
         val expectedAfterUpdate = testData.sample1.attributes ++ updates
 
         runAndWait(
-          entityQuery.saveEntityPatch(context, testData.sample1.toReference, updates, Seq.empty[AttributeName])
+          entityQuery.saveEntityPatch(context,
+                                      testData.sample1.toReference,
+                                      updates,
+                                      Seq.empty[AttributeName],
+                                      RawlsTracingContext(None)
+          )
         )
 
         val resultAfterUpdate = runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes
@@ -1988,6 +1996,7 @@ class AttributeComponentSpec
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
                                                            updatesCaptor.capture(),
                                                            deletesCaptor.capture(),
+                                                           any(),
                                                            any()
     )
 
@@ -2050,6 +2059,7 @@ class AttributeComponentSpec
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
                                                            updatesCaptor.capture(),
                                                            deletesCaptor.capture(),
+                                                           any(),
                                                            any()
     )
 
@@ -2112,6 +2122,7 @@ class AttributeComponentSpec
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
                                                            updatesCaptor.capture(),
                                                            deletesCaptor.capture(),
+                                                           any(),
                                                            any()
     )
 
@@ -2170,6 +2181,7 @@ class AttributeComponentSpec
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
                                                            updatesCaptor.capture(),
                                                            deletesCaptor.capture(),
+                                                           any(),
                                                            any()
     )
 
@@ -2236,6 +2248,7 @@ class AttributeComponentSpec
     verify(spiedAttrQuery, times(1)).patchAttributesAction(insertsCaptor.capture(),
                                                            updatesCaptor.capture(),
                                                            deletesCaptor.capture(),
+                                                           any(),
                                                            any()
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -176,7 +176,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
             context,
             AttributeEntityReference("Sample", "nonexistent"),
             Map(AttributeName.withDefaultNS("newAttribute") -> AttributeNumber(2)),
-            Seq(AttributeName.withDefaultNS("type"))
+            Seq(AttributeName.withDefaultNS("type")),
+            RawlsTracingContext(None)
           )
         )
       }
@@ -194,7 +195,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
             context,
             AttributeEntityReference("Sample", "sample1"),
             Map(AttributeName.withDefaultNS("type") -> AttributeNumber(2)),
-            Seq(AttributeName.withDefaultNS("type"))
+            Seq(AttributeName.withDefaultNS("type")),
+            RawlsTracingContext(None)
           )
         )
       }
@@ -237,7 +239,12 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
       val expected = testData.sample1.attributes ++ inserts ++ updates -- deletes
 
       runAndWait {
-        entityQuery.saveEntityPatch(context, AttributeEntityReference("Sample", "sample1"), inserts ++ updates, deletes)
+        entityQuery.saveEntityPatch(context,
+                                    AttributeEntityReference("Sample", "sample1"),
+                                    inserts ++ updates,
+                                    deletes,
+                                    RawlsTracingContext(None)
+        )
       }
 
       assertSameElements(
@@ -282,7 +289,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(context,
                                     AttributeEntityReference("Sample", "sample1"),
                                     inserts,
-                                    Seq.empty[AttributeName]
+                                    Seq.empty[AttributeName],
+                                    RawlsTracingContext(None)
         )
       )
 
@@ -307,7 +315,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(context,
                                     AttributeEntityReference("Sample", "sample1"),
                                     updates,
-                                    Seq.empty[AttributeName]
+                                    Seq.empty[AttributeName],
+                                    RawlsTracingContext(None)
         )
       )
 
@@ -328,7 +337,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(context,
                                     AttributeEntityReference("Sample", "sample1"),
                                     inserts,
-                                    Seq.empty[AttributeName]
+                                    Seq.empty[AttributeName],
+                                    RawlsTracingContext(None)
         )
       )
 
@@ -354,7 +364,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(context,
                                     AttributeEntityReference("Sample", "sample1"),
                                     updates,
-                                    Seq.empty[AttributeName]
+                                    Seq.empty[AttributeName],
+                                    RawlsTracingContext(None)
         )
       )
 
@@ -382,7 +393,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(context,
                                     AttributeEntityReference("Sample", "sample1"),
                                     inserts,
-                                    Seq.empty[AttributeName]
+                                    Seq.empty[AttributeName],
+                                    RawlsTracingContext(None)
         )
       )
 
@@ -399,7 +411,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(context,
                                     AttributeEntityReference("Sample", "sample1"),
                                     updates,
-                                    Seq.empty[AttributeName]
+                                    Seq.empty[AttributeName],
+                                    RawlsTracingContext(None)
         )
       )
 
@@ -1614,7 +1627,8 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
         entityQuery.saveEntityPatch(wsctx,
                                     entityToSave.toReference,
                                     Map.empty,
-                                    List(AttributeName.withDefaultNS("attributeListToDelete"))
+                                    List(AttributeName.withDefaultNS("attributeListToDelete")),
+                                    RawlsTracingContext(None)
         )
       )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActorTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActorTimeoutSpec.scala
@@ -9,7 +9,13 @@ import org.broadinstitute.dsde.rawls.dataaccess.{
   MockShardedExecutionServiceCluster,
   SlickDataSource
 }
-import org.broadinstitute.dsde.rawls.model.WorkflowStatuses
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  AttributeName,
+  AttributeString,
+  RawlsTracingContext,
+  WorkflowStatuses
+}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
@@ -18,7 +24,6 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import java.sql.BatchUpdateException
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, AttributeName, AttributeString}
 import slick.jdbc.TransactionIsolation
 
 import java.util.UUID
@@ -98,7 +103,8 @@ class SubmissionMonitorActorTimeoutSpec(_system: ActorSystem)
         runAndWait(
           submissionMonitorActorRef.underlyingActor.saveEntities(dataSource.dataAccess,
                                                                  workspaceContext,
-                                                                 updatedEntitiesAndWorkspace
+                                                                 updatedEntitiesAndWorkspace,
+                                                                 RawlsTracingContext(None)
           ),
           Duration.create(lockTime, SECONDS)
         )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -828,7 +828,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         workflowRecs.map(r =>
           (r, ExecutionServiceOutputs(r.externalId.get, Map("o1" -> Left(AttributeString("result")))))
         ),
-        this
+        this,
+        RawlsTracingContext(Option.empty)
       )
     )
 
@@ -891,7 +892,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           workflowRecs.map(r =>
             (r, ExecutionServiceOutputs(r.externalId.get, Map("o1_lib" -> Left(AttributeString("result")))))
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -947,7 +949,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           workflowRecs2.map(r =>
             (r, ExecutionServiceOutputs(r.externalId.get, Map("o2_lib" -> Left(AttributeString("result2")))))
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -985,7 +988,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
            )
           )
         ),
-        this
+        this,
+        RawlsTracingContext(Option.empty)
       )
     )
 
@@ -1030,7 +1034,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
              )
             )
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1055,7 +1060,10 @@ class SubmissionMonitorSpec(_system: ActorSystem)
         "o1" -> Left(AttributeValueList(Vector(AttributeString("123"), AttributeString("456"), AttributeString("789"))))
       )
       runAndWait(
-        monitor.handleOutputs(workflowRecs.map(r => (r, ExecutionServiceOutputs(r.externalId.get, newOutputs))), this)
+        monitor.handleOutputs(workflowRecs.map(r => (r, ExecutionServiceOutputs(r.externalId.get, newOutputs))),
+                              this,
+                              RawlsTracingContext(Option.empty)
+        )
       )
 
       assertResult(
@@ -1103,7 +1111,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
              )
             )
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1133,7 +1142,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
              )
             )
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1344,7 +1354,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
 
       runAndWait(
         monitor.handleOutputs(Seq((workflowRec, ExecutionServiceOutputs(workflowRec.externalId.get, execOutputs))),
-                              this
+                              this,
+                              RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1428,7 +1439,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           workflowRecs.map(r =>
             (r, ExecutionServiceOutputs(r.externalId.get, Map("bad1" -> Left(AttributeString("result")))))
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1575,7 +1587,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
              )
             )
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 
@@ -1648,7 +1661,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
              )
             )
           ),
-          this
+          this,
+          RawlsTracingContext(Option.empty)
         )
       )
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1524

Adds hopefully comprehensive tracing for the submission monitor `handleOutputs` method . Given that we see pretty long transactions related to workflows, hopefully this tracing helps us figure out what's taking so much time.

_Reviewers: the auto-formatter reformatted a bunch of code, I suggest ignoring whitespace when viewing the diff._


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
