### PR TITLE
[WOR-1365] Expose the bee template version so we can trigger the workflow on promotions  to staging.

### DIFF
--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -313,18 +313,19 @@ jobs:
 #        if: ${{ success() }}
 #        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
-  notify-slack-success:
+  notify-slack:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
-#      - rawls-build-tag-publish-job
-#      - create-bee-workflow
-#      - rawls-swat-e2e-test-job
-#      - destroy-bee-workflow
-    if: success()
+    #      - rawls-build-tag-publish-job
+    #      - create-bee-workflow
+    #      - rawls-swat-e2e-test-job
+    #      - destroy-bee-workflow
+    if: always()
     steps:
-      - name: Notify slack
+      - name: Notify slack on success
         uses: slackapi/slack-github-action@v1.23.0
+        if: success()
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
@@ -346,7 +347,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*✅ PASSED"
+                      "text": "*Result:*\n✅ PASSED"
                     },
                     {
                       "type": "mrkdwn",
@@ -358,19 +359,9 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-
-  notify-slack-failure:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-    #      - rawls-build-tag-publish-job
-    #      - create-bee-workflow
-    #      - rawls-swat-e2e-test-job
-    #      - destroy-bee-workflow
-    if: failure()
-    steps:
-      - name: Notify slack
+      - name: Notify slack on failure
         uses: slackapi/slack-github-action@v1.23.0
+        if: failure()
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
@@ -392,7 +383,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*❌ FAILED"
+                      "text": "*Result:*\n❌ FAILED"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -142,10 +142,11 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Echo Rawls version if branch is being built
-        if: ${{ inputs.build-branch}}
+      - name: Echo Rawls version and environment template
         run: |
-          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
+          echo "built custom Rawls=${{ inputs.build-branch}}"
+          echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
+          echo "version-template=${{ inputs.bee-version-template }}"
 
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -230,7 +231,7 @@ jobs:
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "ENV": "qa",
-            "ref": "",
+            "ref": "${{ (inputs.build-branch && refs/heads/${{ needs.init-github-context.outputs.branch }}) || '' }}",
             "test-group-name": "workspaces_azure",
             "test-command": "${{ env.rawls_test_command }}",
             "e2e-env": "${{ env.E2E_ENV }}",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -67,7 +67,7 @@ env:
   E2E_ENV: 'azure_e2e.env'
   STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
   DEV_CHANNELS: 'C01GBDNLH18' #dsp-workspaces-test-alerts C03F21QEWV7
-  NOTIFICATION_TEXT: |
+  NOTIFICATION_TEXT: >
     {
       "blocks": [
         {

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.extract-inputs.outputs.branch }}
+      fully-specified-branch: refs/heads/${{ steps.extract-inputs.outputs.branch }}
       delete-bee: ${{ steps.extract-inputs.outputs.delete-bee }}
       student-subjects: ${{ steps.extract-inputs.outputs.student-subjects }}
       owner-subject: ${{ steps.extract-inputs.outputs.owner-subject }}
@@ -96,6 +97,7 @@ jobs:
       custom-version-json: ${{ (inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json) || ''}}
     steps:
       - uses: 'actions/checkout@v3'
+        if: ${{ inputs.build-branch }}
         with:
           ref: ${{ needs.init-github-context.outputs.branch }}
 
@@ -121,7 +123,7 @@ jobs:
           inputs: '{
             "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
             "repository": "${{ github.event.repository.full_name }}",
-            "ref": "refs/heads/${{ needs.init-github-context.outputs.branch }}",
+            "ref": "${{ (inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch) || ''}}",
             "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
           }'
 
@@ -231,7 +233,7 @@ jobs:
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "ENV": "qa",
-            "ref": "${{ (inputs.build-branch && refs/heads/${{ needs.init-github-context.outputs.branch }}) || '' }}",
+            "ref": "${{ (inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch ) || '' }}",
             "test-group-name": "workspaces_azure",
             "test-command": "${{ env.rawls_test_command }}",
             "e2e-env": "${{ env.E2E_ENV }}",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -315,35 +315,34 @@ jobs:
           # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
           # C53JYBV9A channel is for #dsde-qa
           channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
-          slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Azure Workspaces E2E Test*"
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
                     "type": "mrkdwn",
-                    "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Result:*\n${{ steps.render-slack-status-icon.outputs.result }} ${{ job.status }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    "text": "*Azure Workspaces E2E Test*"
                   }
-                ]
-              }
-            ]
-          }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Result:*\n${{ steps.render-slack-status-icon.outputs.result }} ${{ job.status }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -23,6 +23,11 @@ on:
         required: true
         default: 'develop'
         type: string
+      bee-version-template:
+        description: 'The version of services to install on the bee, default is dev'
+        required: true
+        default: 'dev'
+        type: string
       delete-bee:
         description: 'Delete created bee after running tests'
         required: true
@@ -145,7 +150,7 @@ jobs:
             "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "bee-template-name": "rawls-e2e-azure-tests",
-            "version-template": "dev",
+            "version-template": "${{ inputs.bee-version-template }}",
             "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
           }'
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -65,6 +65,7 @@ env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
+  WORKFLOW_STATUS: ''
 
 jobs:
   init-github-context:
@@ -291,23 +292,23 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
+    needs:
+      - init-github-context
 #      - rawls-build-tag-publish-job
 #      - create-bee-workflow
 #      - rawls-swat-e2e-test-job
 #      - destroy-bee-workflow
     if: always()
-    env:
-      WORKFLOW_STATUS: ''
     steps:
       - name: Set workflow status on failure
         if: ${{ failure() }}
+        run: echo "FAILED" >> "$GITHUB_OUTPUT"
         env:
           WORKFLOW_STATUS: '❌ FAILED'
 
       - name: Set workflow status on success
         if: ${{ success() }}
+        run: echo "PASSED" "$GITHUB_OUTPUT"
         env:
           WORKFLOW_STATUS: '✅ PASSED'
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -86,217 +86,217 @@ jobs:
           echo "student-subjects=${{ toJson(inputs.student-subjects || '["harry.potter@quality.firecloud.org","ron.weasley@quality.firecloud.org"]') }}" >> "$GITHUB_OUTPUT"
           echo "service-account=${{ inputs.service-account          || 'firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com' }}" >> "$GITHUB_OUTPUT"
 
-  rawls-build-tag-publish-job:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    outputs:
-      custom-version-json: ${{ inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
-    steps:
-      - uses: 'actions/checkout@v3'
-        if: ${{ inputs.build-branch }}
-        with:
-          ref: ${{ needs.init-github-context.outputs.branch }}
-
-      - name: Bump the tag to a new version
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
-        if: ${{ inputs.build-branch }}
-        id: tag
-        env:
-          DEFAULT_BUMP: patch
-          GITHUB_TOKEN: ${{ env.TOKEN }}
-          RELEASE_BRANCHES: main
-          WITH_V: true
-
-      - name: dispatch build to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        if: ${{ inputs.build-branch }}
-        with:
-          run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
-          workflow: rawls-build
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ env.TOKEN }}
-          inputs: |
-            {
-              "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
-              "repository": "${{ github.event.repository.full_name }}",
-              "ref": "${{ needs.init-github-context.outputs.fully-specified-branch }}",
-              "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
-            }
-
-      - name: Render Rawls version
-        if: ${{ inputs.build-branch }}
-        id: render-rawls-version
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
-          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
-
-  create-bee-workflow:
-    runs-on: ubuntu-latest
-    needs:
-      - rawls-build-tag-publish-job
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    steps:
-      - name: Echo Rawls version and version template
-        run: |
-          echo "built custom Rawls=${{ inputs.build-branch}}"
-          echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
-          echo "version-template=${{ inputs.bee-version-template }}"
-
-      - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        with:
-          run-name: "${{ env.BEE_CREATE_RUN_NAME }}"
-          workflow: bee-create
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ env.TOKEN }}
-          inputs: '{
-            "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
-            "bee-name": "${{ env.BEE_NAME }}",
-            "bee-template-name": "rawls-e2e-azure-tests",
-            "version-template": "${{ inputs.bee-version-template }}",
-            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
-          }'
-
-  # This job can be used for generating parameters for E2E tests (e.g. a random project name).
-  params-gen:
-    runs-on: ubuntu-latest
-    outputs:
-      project-name: ${{ steps.gen.outputs.project_name }}
-    steps:
-      - uses: 'actions/checkout@v3'
-
-      - name: Generate a random billing project name
-        id: 'gen'
-        run: |
-          project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
-          echo "project_name=${project_name}" >> $GITHUB_OUTPUT
-
-  # Azure Managed App Coordinates are defined in the following workflow:
-  #   https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-landing-zone-to-bee.yaml
-  attach-billing-project-to-landing-zone-workflow:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - create-bee-workflow
-      - params-gen
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        with:
-          run-name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
-          workflow: attach-billing-project-to-landing-zone.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ env.TOKEN }}
-          inputs: '{
-            "run-name": "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}",
-            "bee-name": "${{ env.BEE_NAME }}",
-            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
-            "billing-project-creator": "${{ needs.init-github-context.outputs.owner-subject }}",
-            "service-account": "${{ needs.init-github-context.outputs.service-account }}"
-          }'
-
-  rawls-swat-e2e-test-job:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - create-bee-workflow
-      - params-gen
-      - attach-billing-project-to-landing-zone-workflow
-    steps:
-      - name: Configure the user subjects for the test
-        run: |
-          escapedJSON=$(echo '${{ needs.init-github-context.outputs.student-subjects }}' | sed 's/"/\"/g')
-          echo "USER_SUBJECTS={\"service_account\":\"${{ needs.init-github-context.outputs.service-account }}\", \"owners\": [\"${{ needs.init-github-context.outputs.owner-subject }}\"], \"students\": $escapedJSON}" >> $GITHUB_ENV
-
-      - name: dispatch to terra-github-workflows
-        env:
-          rawls_test_command: "testOnly -- -l ProdTest -l NotebooksCanaryTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest"
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        with:
-          run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}"
-          workflow: .github/workflows/rawls-swat-tests.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ env.TOKEN }}
-          inputs: |
-            {
-              "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"${{ needs.params-gen.outputs.project-name }}\"}",
-              "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
-              "bee-name": "${{ env.BEE_NAME }}",
-              "ENV": "qa",
-              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
-              "test-group-name": "workspaces_azure",
-              "test-command": "${{ env.rawls_test_command }}",
-              "e2e-env": "${{ env.E2E_ENV }}",
-              "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
-            }
-
-  delete-billing-project-v2-from-bee-workflow:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - params-gen
-      - rawls-swat-e2e-test-job
-    if: always()
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        with:
-          run-name: "${{ env.DEL_BP_V2_RUN_NAME }}"
-          workflow: .github/workflows/delete-billing-project-v2-from-bee.yaml
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ env.TOKEN }}
-          inputs: '{
-            "run-name": "${{ env.DEL_BP_V2_RUN_NAME }}",
-            "bee-name": "${{ env.BEE_NAME }}",
-            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
-            "billing-project-owner": "${{ needs.init-github-context.outputs.owner-subject }}",
-            "service-account": "${{ needs.init-github-context.outputs.service-account }}",
-            "silent-on-failure": "false"
-          }'
-
-  destroy-bee-workflow:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - rawls-swat-e2e-test-job
-      - delete-billing-project-v2-from-bee-workflow
-    if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
-    steps:
-      - name: dispatch to terra-github-workflows
-        uses: broadinstitute/workflow-dispatch@v4.0.0
-        with:
-          run-name: "${{ env.BEE_DESTROY_RUN_NAME }}"
-          workflow: bee-destroy
-          repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
-          token: ${{ env.TOKEN }}
-          inputs: '{
-            "run-name": "${{ env.BEE_DESTROY_RUN_NAME }}",
-            "bee-name": "${{ env.BEE_NAME }}"
-          }'
-          wait-for-completion: false
+#  rawls-build-tag-publish-job:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#    permissions:
+#      contents: 'read'
+#      id-token: 'write'
+#    outputs:
+#      custom-version-json: ${{ inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
+#    steps:
+#      - uses: 'actions/checkout@v3'
+#        if: ${{ inputs.build-branch }}
+#        with:
+#          ref: ${{ needs.init-github-context.outputs.branch }}
+#
+#      - name: Bump the tag to a new version
+#        uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
+#        if: ${{ inputs.build-branch }}
+#        id: tag
+#        env:
+#          DEFAULT_BUMP: patch
+#          GITHUB_TOKEN: ${{ env.TOKEN }}
+#          RELEASE_BRANCHES: main
+#          WITH_V: true
+#
+#      - name: dispatch build to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        if: ${{ inputs.build-branch }}
+#        with:
+#          run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
+#          workflow: rawls-build
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ env.TOKEN }}
+#          inputs: |
+#            {
+#              "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
+#              "repository": "${{ github.event.repository.full_name }}",
+#              "ref": "${{ needs.init-github-context.outputs.fully-specified-branch }}",
+#              "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
+#            }
+#
+#      - name: Render Rawls version
+#        if: ${{ inputs.build-branch }}
+#        id: render-rawls-version
+#        env:
+#          GITHUB_CONTEXT: ${{ toJSON(github) }}
+#        run: |
+#          echo "$GITHUB_CONTEXT"
+#          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
+#
+#  create-bee-workflow:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - rawls-build-tag-publish-job
+#    permissions:
+#      contents: 'read'
+#      id-token: 'write'
+#    steps:
+#      - name: Echo Rawls version and version template
+#        run: |
+#          echo "built custom Rawls=${{ inputs.build-branch}}"
+#          echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
+#          echo "version-template=${{ inputs.bee-version-template }}"
+#
+#      - name: dispatch to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        with:
+#          run-name: "${{ env.BEE_CREATE_RUN_NAME }}"
+#          workflow: bee-create
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ env.TOKEN }}
+#          inputs: '{
+#            "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
+#            "bee-name": "${{ env.BEE_NAME }}",
+#            "bee-template-name": "rawls-e2e-azure-tests",
+#            "version-template": "${{ inputs.bee-version-template }}",
+#            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
+#          }'
+#
+#  # This job can be used for generating parameters for E2E tests (e.g. a random project name).
+#  params-gen:
+#    runs-on: ubuntu-latest
+#    outputs:
+#      project-name: ${{ steps.gen.outputs.project_name }}
+#    steps:
+#      - uses: 'actions/checkout@v3'
+#
+#      - name: Generate a random billing project name
+#        id: 'gen'
+#        run: |
+#          project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
+#          echo "project_name=${project_name}" >> $GITHUB_OUTPUT
+#
+#  # Azure Managed App Coordinates are defined in the following workflow:
+#  #   https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-landing-zone-to-bee.yaml
+#  attach-billing-project-to-landing-zone-workflow:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - create-bee-workflow
+#      - params-gen
+#    steps:
+#      - name: dispatch to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        with:
+#          run-name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
+#          workflow: attach-billing-project-to-landing-zone.yaml
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ env.TOKEN }}
+#          inputs: '{
+#            "run-name": "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}",
+#            "bee-name": "${{ env.BEE_NAME }}",
+#            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
+#            "billing-project-creator": "${{ needs.init-github-context.outputs.owner-subject }}",
+#            "service-account": "${{ needs.init-github-context.outputs.service-account }}"
+#          }'
+#
+#  rawls-swat-e2e-test-job:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - create-bee-workflow
+#      - params-gen
+#      - attach-billing-project-to-landing-zone-workflow
+#    steps:
+#      - name: Configure the user subjects for the test
+#        run: |
+#          escapedJSON=$(echo '${{ needs.init-github-context.outputs.student-subjects }}' | sed 's/"/\"/g')
+#          echo "USER_SUBJECTS={\"service_account\":\"${{ needs.init-github-context.outputs.service-account }}\", \"owners\": [\"${{ needs.init-github-context.outputs.owner-subject }}\"], \"students\": $escapedJSON}" >> $GITHUB_ENV
+#
+#      - name: dispatch to terra-github-workflows
+#        env:
+#          rawls_test_command: "testOnly -- -l ProdTest -l NotebooksCanaryTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest"
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        with:
+#          run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}"
+#          workflow: .github/workflows/rawls-swat-tests.yaml
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ env.TOKEN }}
+#          inputs: |
+#            {
+#              "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"${{ needs.params-gen.outputs.project-name }}\"}",
+#              "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
+#              "bee-name": "${{ env.BEE_NAME }}",
+#              "ENV": "qa",
+#              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+#              "test-group-name": "workspaces_azure",
+#              "test-command": "${{ env.rawls_test_command }}",
+#              "e2e-env": "${{ env.E2E_ENV }}",
+#              "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
+#            }
+#
+#  delete-billing-project-v2-from-bee-workflow:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - params-gen
+#      - rawls-swat-e2e-test-job
+#    if: always()
+#    steps:
+#      - name: dispatch to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        with:
+#          run-name: "${{ env.DEL_BP_V2_RUN_NAME }}"
+#          workflow: .github/workflows/delete-billing-project-v2-from-bee.yaml
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ env.TOKEN }}
+#          inputs: '{
+#            "run-name": "${{ env.DEL_BP_V2_RUN_NAME }}",
+#            "bee-name": "${{ env.BEE_NAME }}",
+#            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
+#            "billing-project-owner": "${{ needs.init-github-context.outputs.owner-subject }}",
+#            "service-account": "${{ needs.init-github-context.outputs.service-account }}",
+#            "silent-on-failure": "false"
+#          }'
+#
+#  destroy-bee-workflow:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - rawls-swat-e2e-test-job
+#      - delete-billing-project-v2-from-bee-workflow
+#    if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+#    steps:
+#      - name: dispatch to terra-github-workflows
+#        uses: broadinstitute/workflow-dispatch@v4.0.0
+#        with:
+#          run-name: "${{ env.BEE_DESTROY_RUN_NAME }}"
+#          workflow: bee-destroy
+#          repo: broadinstitute/terra-github-workflows
+#          ref: refs/heads/main
+#          token: ${{ env.TOKEN }}
+#          inputs: '{
+#            "run-name": "${{ env.BEE_DESTROY_RUN_NAME }}",
+#            "bee-name": "${{ env.BEE_NAME }}"
+#          }'
+#          wait-for-completion: false
 
   notify-slack:
     runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - rawls-build-tag-publish-job
-      - create-bee-workflow
-      - rawls-swat-e2e-test-job
-      - destroy-bee-workflow
+#    needs:
+#      - init-github-context
+#      - rawls-build-tag-publish-job
+#      - create-bee-workflow
+#      - rawls-swat-e2e-test-job
+#      - destroy-bee-workflow
     if: always()
     env:
       WORKFLOW_STATUS: ''

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -67,35 +67,6 @@ env:
   E2E_ENV: 'azure_e2e.env'
   STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
   DEV_CHANNELS: 'C01GBDNLH18' #dsp-workspaces-test-alerts C03F21QEWV7
-  NOTIFICATION_TEXT: >
-    {
-      "blocks": [
-        {
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "*Azure Workspaces E2E Test*"
-          }
-        },
-        {
-          "type": "section",
-          "fields": [
-            {
-              "type": "mrkdwn",
-              "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
-            },
-            {
-              "type": "mrkdwn",
-              "text": "*Result:*\nREPLACE_STATUS"
-            },
-            {
-              "type": "mrkdwn",
-              "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-            }
-          ]
-        }
-      ]
-    }
 
 jobs:
   init-github-context:
@@ -320,27 +291,6 @@ jobs:
 #          }'
 #          wait-for-completion: false
 #
-#  status-icon:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#    #      - rawls-build-tag-publish-job
-#    #      - create-bee-workflow
-#    #      - rawls-swat-e2e-test-job
-#    #      - destroy-bee-workflow
-#    if: always()
-#    outputs:
-#      workflow-status: ${{ steps.status-icon.outputs.workflow-status }}
-#    steps:
-#      - name: Set workflow status on failure
-#        id: status-icon
-#        if: ${{ failure() }}
-#        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
-#
-#      - name: Set workflow status on success
-#        id: status-icon
-#        if: ${{ success() }}
-#        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
   notify-slack:
     runs-on: ubuntu-latest
@@ -357,8 +307,35 @@ jobs:
         if: success()
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-          payload: ${{ env.NOTIFICATION_TEXT }}
-
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Azure Workspaces E2E Test*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Result:*\n✅ PASSED"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Notify slack on failure

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -290,69 +290,70 @@ jobs:
 #          }'
 #          wait-for-completion: false
 
-  notify-slack:
+  status-icon:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
-      #      - rawls-build-tag-publish-job
-      #      - create-bee-workflow
-      #      - rawls-swat-e2e-test-job
-      #      - destroy-bee-workflow
+    #      - rawls-build-tag-publish-job
+    #      - create-bee-workflow
+    #      - rawls-swat-e2e-test-job
+    #      - destroy-bee-workflow
     if: always()
     outputs:
-      steps: ${{ steps.workspace.outputs }}
-    jobs:
-      set-status:
-        runs-on: ubuntu-latest
-        outputs:
-          steps: ${{ toJson(steps) }}
-        steps:
-          - name: Set workflow status on failure
-            if: ${{ failure() }}
-            run: echo "::set-output name=workflow_status::❌ FAILED"
+      workflow-status: 'unset'
+    steps:
+      - name: Set workflow status on failure
+        if: ${{ failure() }}
+        run: echo "workflow-status=❌ FAILED" >> "$GITHUB_OUTPUT"
 
-          - name: Set workflow status on success
-            if: ${{ success() }}
-            run: echo "::set-output name=workflow_status::✅ PASSED"
+      - name: Set workflow status on success
+        if: ${{ success() }}
+        run: echo "workflow-status=✅ PASSED" >> "$GITHUB_OUTPUT"
 
-      notify:
-        needs: set-status
-        runs-on: ubuntu-latest
-        steps:
-          - name: Notify slack
-            uses: slackapi/slack-github-action@v1.23.0
-            with:
-              # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
-              # C53JYBV9A channel is for #dsde-qa
-              channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
-              payload: |
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs:
+      - status-icon
+#      - rawls-build-tag-publish-job
+#      - create-bee-workflow
+#      - rawls-swat-e2e-test-job
+#      - destroy-bee-workflow
+    if: always()
+    steps:
+      - name: Notify slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
+          # C53JYBV9A channel is for #dsde-qa
+          channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
+          payload: |
+            {
+              "blocks": [
                 {
-                  "blocks": [
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Azure Workspaces E2E Test*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
                     {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Azure Workspaces E2E Test*"
-                      }
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
                     },
                     {
-                      "type": "section",
-                      "fields": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Result:*\n${{ needs.set-status.outputs.workflow_status }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-                        }
-                      ]
+                      "type": "mrkdwn",
+                      "text": "*Result:*\n${{ needs.status-icon.outputs.workflow-status }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
                     }
                   ]
                 }
-            env:
-              SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -299,12 +299,9 @@ jobs:
       - destroy-bee-workflow
     if: always()
     steps:
-      - name: Notify slack of failure
-        if: ${{ failure() }}
+      - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
-          # C53JYBV9A channel is for #dsde-qa
           channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
           payload: |
             {
@@ -325,45 +322,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n ❌ FAILED"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-      - name: Notify slack of success
-        if: ${{ success() }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
-          # C53JYBV9A channel is for #dsde-qa
-          channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Azure Workspaces E2E Test*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Result:*\n ✅ PASSED"
+                      "text": "*Result:*\n${{ failure() && '❌ FAILED' || '✅ PASSED' }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -359,48 +359,48 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
 
-    notify-slack-failure:
-      runs-on: ubuntu-latest
-      needs:
-        - init-github-context
-      #      - rawls-build-tag-publish-job
-      #      - create-bee-workflow
-      #      - rawls-swat-e2e-test-job
-      #      - destroy-bee-workflow
-      if: failure()
-      steps:
-        - name: Notify slack
-          uses: slackapi/slack-github-action@v1.23.0
-          with:
-            channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-            payload: |
-              {
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*Azure Workspaces E2E Test*"
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "fields": [
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Result:*❌ FAILED"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-                      }
-                    ]
+  notify-slack-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+    #      - rawls-build-tag-publish-job
+    #      - create-bee-workflow
+    #      - rawls-swat-e2e-test-job
+    #      - destroy-bee-workflow
+    if: failure()
+    steps:
+      - name: Notify slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Azure Workspaces E2E Test*"
                   }
-                ]
-              }
-          env:
-            SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Result:*❌ FAILED"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -211,6 +211,9 @@ jobs:
   rawls-swat-e2e-test-job:
     runs-on: ubuntu-latest
     needs:
+      - init-github-context
+      - create-bee-workflow
+      - params-gen
       - attach-billing-project-to-landing-zone-workflow
     steps:
       - name: Configure the user subjects for the test
@@ -244,6 +247,8 @@ jobs:
   delete-billing-project-v2-from-bee-workflow:
     runs-on: ubuntu-latest
     needs:
+      - init-github-context
+      - params-gen
       - rawls-swat-e2e-test-job
     if: always()
     steps:
@@ -268,9 +273,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
+      - rawls-swat-e2e-test-job
       - delete-billing-project-v2-from-bee-workflow
-      # - rawls-swat-e2e-test-job
-      # - delete-billing-project-v2-from-bee-workflow
     if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
     steps:
       - name: dispatch to terra-github-workflows

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -303,13 +303,11 @@ jobs:
     steps:
       - name: Set workflow status on failure
         if: ${{ failure() }}
-        run: echo "FAILED" >> "$GITHUB_OUTPUT"
         env:
           WORKFLOW_STATUS: '❌ FAILED'
 
       - name: Set workflow status on success
         if: ${{ success() }}
-        run: echo "PASSED" "$GITHUB_OUTPUT"
         env:
           WORKFLOW_STATUS: '✅ PASSED'
 

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -134,8 +134,9 @@ jobs:
 
   create-bee-workflow:
     runs-on: ubuntu-latest
-    needs:
-      - rawls-build-tag-publish-job
+#    needs:
+#      - rawls-build-tag-publish-job
+    if: ${{ inputs.build-branch && steps.rawls-build-tag-publish-job.outputs.custom-version-json }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -301,11 +301,11 @@ jobs:
     #      - create-bee-workflow
     #      - rawls-swat-e2e-test-job
     #      - destroy-bee-workflow
-    if: always()
+    if: ${{ failure() }}
     steps:
       - name: Notify slack on success
         uses: slackapi/slack-github-action@v1.23.0
-        if: success()
+        if: ${{ success() }}
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
@@ -341,7 +341,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Notify slack on failure
         uses: slackapi/slack-github-action@v1.23.0
-        if: failure()
+        if: ${{ failure() }}
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -299,19 +299,19 @@ jobs:
       - destroy-bee-workflow
     if: always()
     env:
-      STATUS: ''
+      WORKFLOW_STATUS: ''
     steps:
-      - name: Set status on failure
+      - name: Set workflow status on failure
         if: ${{ failure() }}
-        run: echo "FAILED" >> $GITHUB_ENV
+        run: echo "FAILED" >> "$GITHUB_OUTPUT"
         env:
-          STATUS: '❌ FAILED'
+          WORKFLOW_STATUS: '❌ FAILED'
 
-      - name: Set status on success
+      - name: Set workflow status on success
         if: ${{ success() }}
-        run: echo "PASSED" >> $GITHUB_ENV
+        run: echo "PASSED" "$GITHUB_OUTPUT"
         env:
-          STATUS: '✅ PASSED'
+          WORKFLOW_STATUS: '✅ PASSED'
 
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
@@ -338,7 +338,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n${{ env.STATUS }}"
+                      "text": "*Result:*\n${{ env.WORKFLOW_STATUS }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -93,8 +93,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     outputs:
-      custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
-    if: ${{ inputs.build-branch }}
+      custom-version-json: ${{ (inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json) || ''}}
     steps:
       - uses: 'actions/checkout@v3'
         with:
@@ -102,6 +101,7 @@ jobs:
 
       - name: Bump the tag to a new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
+        if: ${{ inputs.build-branch }}
         id: tag
         env:
           DEFAULT_BUMP: patch
@@ -111,6 +111,7 @@ jobs:
 
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
+        if: ${{ inputs.build-branch }}
         with:
           run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
           workflow: rawls-build
@@ -125,6 +126,7 @@ jobs:
           }'
 
       - name: Render Rawls version
+        if: ${{ inputs.build-branch }}
         id: render-rawls-version
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
@@ -136,14 +138,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - rawls-build-tag-publish-job
-    if: always()
     permissions:
       contents: 'read'
       id-token: 'write'
     steps:
-#      - name: Echo Rawls version
-#        run: |
-#          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
+      - name: Echo Rawls version if branch is being built
+        if: ${{ inputs.build-branch}}
+        run: |
+          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
 
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -157,7 +159,8 @@ jobs:
             "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "bee-template-name": "rawls-e2e-azure-tests",
-            "version-template": "${{ inputs.bee-version-template }}"
+            "version-template": "${{ inputs.bee-version-template }}",
+            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
           }'
 
   # This job can be used for generating parameters for E2E tests (e.g. a random project name).

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -288,37 +288,51 @@ jobs:
 #            "bee-name": "${{ env.BEE_NAME }}"
 #          }'
 #          wait-for-completion: false
-
-  status-icon:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-    #      - rawls-build-tag-publish-job
-    #      - create-bee-workflow
-    #      - rawls-swat-e2e-test-job
-    #      - destroy-bee-workflow
-    if: always()
-    outputs:
-      workflow-status: 'unset'
-    steps:
-      - name: Set workflow status on failure
-        if: ${{ failure() }}
-        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
-
-      - name: Set workflow status on success
-        if: ${{ success() }}
-        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
+#
+#  status-icon:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#    #      - rawls-build-tag-publish-job
+#    #      - create-bee-workflow
+#    #      - rawls-swat-e2e-test-job
+#    #      - destroy-bee-workflow
+#    if: always()
+#    outputs:
+#      workflow-status: ${{ steps.status-icon.outputs.workflow-status }}
+#    steps:
+#      - name: Set workflow status on failure
+#        id: status-icon
+#        if: ${{ failure() }}
+#        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
+#
+#      - name: Set workflow status on success
+#        id: status-icon
+#        if: ${{ success() }}
+#        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
   notify-slack:
     runs-on: ubuntu-latest
     needs:
-      - status-icon
+      - init-github-context
 #      - rawls-build-tag-publish-job
 #      - create-bee-workflow
 #      - rawls-swat-e2e-test-job
 #      - destroy-bee-workflow
     if: always()
+    outputs:
+      workflow-status: ${{ steps.status-icon.outputs.workflow-status }}
     steps:
+      - name: Set workflow status on failure
+        id: status-icon
+        if: ${{ failure() }}
+        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
+
+      - name: Set workflow status on success
+        id: status-icon
+        if: ${{ success() }}
+        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
+
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
@@ -344,7 +358,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n${{ needs.status-icon.outputs.workflow-status }}"
+                      "text": "*Result:*\n${{ steps.status-icon.outputs.workflow-status }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -120,12 +120,13 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{
-            "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
-            "repository": "${{ github.event.repository.full_name }}",
-            "ref": "${{ (inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch) || ''}}",
-            "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
-          }'
+          inputs: |
+            {
+              "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
+              "repository": "${{ github.event.repository.full_name }}",
+              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
+            }
 
       - name: Render Rawls version
         if: ${{ inputs.build-branch }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -136,7 +136,6 @@ jobs:
     runs-on: ubuntu-latest
 #    needs:
 #      - rawls-build-tag-publish-job
-    if: ${{ inputs.build-branch && steps.rawls-build-tag-publish-job.outputs.custom-version-json }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -65,7 +65,6 @@ env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
-  WORKFLOW_STATUS: ''
 
 jobs:
   init-github-context:
@@ -304,11 +303,11 @@ jobs:
     steps:
       - name: Set workflow status on failure
         if: ${{ failure() }}
-        run: echo "workflow-status=❌ FAILED" >> "$GITHUB_OUTPUT"
+        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
 
       - name: Set workflow status on success
         if: ${{ success() }}
-        run: echo "workflow-status=✅ PASSED" >> "$GITHUB_OUTPUT"
+        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -299,16 +299,8 @@ jobs:
       - destroy-bee-workflow
     if: always()
     steps:
-      - id: render-slack-status-icon
-        name: Render slack result status icon
-        run: |
-          if [ ${{ failure() }} ]; then
-            RESULT="✅ PASSED";
-          else
-            RESULT="❌ FAILED"
-          fi
-          echo "result=$RESULT" >> $GITHUB_OUTPUT
-      - name: Notify slack
+      - name: Notify slack of failure
+        if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
@@ -333,7 +325,45 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n${{ steps.render-slack-status-icon.outputs.result }}"
+                      "text": "*Result:*\n ❌ FAILED"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+      - name: Notify slack of success
+        if: ${{ success() }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
+          # C53JYBV9A channel is for #dsde-qa
+          channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Azure Workspaces E2E Test*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Result:*\n ✅ PASSED"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -244,35 +244,36 @@ jobs:
 #              "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
 #            }
 #
-#  delete-billing-project-v2-from-bee-workflow:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#      - params-gen
-#      - rawls-swat-e2e-test-job
-#    if: always()
-#    steps:
-#      - name: dispatch to terra-github-workflows
-#        uses: broadinstitute/workflow-dispatch@v4.0.0
-#        with:
-#          run-name: "${{ env.DEL_BP_V2_RUN_NAME }}"
-#          workflow: .github/workflows/delete-billing-project-v2-from-bee.yaml
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/main
-#          token: ${{ env.TOKEN }}
-#          inputs: '{
-#            "run-name": "${{ env.DEL_BP_V2_RUN_NAME }}",
-#            "bee-name": "${{ env.BEE_NAME }}",
-#            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
-#            "billing-project-owner": "${{ needs.init-github-context.outputs.owner-subject }}",
-#            "service-account": "${{ needs.init-github-context.outputs.service-account }}",
-#            "silent-on-failure": "false"
-#          }'
-#
+  delete-billing-project-v2-from-bee-workflow:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+      - params-gen
+      - rawls-swat-e2e-test-job
+    if: always()
+    steps:
+      - name: dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: "${{ env.DEL_BP_V2_RUN_NAME }}"
+          workflow: .github/workflows/delete-billing-project-v2-from-bee.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ env.TOKEN }}
+          inputs: '{
+            "run-name": "${{ env.DEL_BP_V2_RUN_NAME }}",
+            "bee-name": "${{ env.BEE_NAME }}",
+            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
+            "billing-project-owner": "${{ needs.init-github-context.outputs.owner-subject }}",
+            "service-account": "${{ needs.init-github-context.outputs.service-account }}",
+            "silent-on-failure": "false"
+          }'
+
   destroy-bee-workflow:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
+      - delete-billing-project-v2-from-bee-workflow
       # - rawls-swat-e2e-test-job
       # - delete-billing-project-v2-from-bee-workflow
     if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -301,12 +301,11 @@ jobs:
     steps:
       - id: render-slack-status-icon
         name: Render slack result status icon
-        if: always()
         run: |
-          if [ ${{ job.status }} == 'success' ]; then
-            RESULT="✅";
+          if [ ${{ failure() }} ]; then
+            RESULT="✅ PASSED";
           else
-            RESULT="❌"
+            RESULT="❌ FAILED"
           fi
           echo "result=$RESULT" >> $GITHUB_OUTPUT
       - name: Notify slack
@@ -334,7 +333,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n${{ steps.render-slack-status-icon.outputs.result }} ${{ job.status }}"
+                      "text": "*Result:*\n${{ steps.render-slack-status-icon.outputs.result }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -66,7 +66,36 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
   STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
-  DEV_CHANNELS: 'C03F21QEWV7' #dsp-workspaces-test-alerts
+  DEV_CHANNELS: 'C01GBDNLH18' #dsp-workspaces-test-alerts C03F21QEWV7
+  NOTIFICATION_TEXT: |
+    {
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*Azure Workspaces E2E Test*"
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            {
+              "type": "mrkdwn",
+              "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Result:*\nREPLACE_STATUS"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+            }
+          ]
+        }
+      ]
+    }
 
 jobs:
   init-github-context:
@@ -328,35 +357,8 @@ jobs:
         if: success()
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Azure Workspaces E2E Test*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Result:*\n✅ PASSED"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-                    }
-                  ]
-                }
-              ]
-            }
+          payload: ${{ env.NOTIFICATION_TEXT }}
+
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
       - name: Notify slack on failure

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -280,21 +280,21 @@ jobs:
           }'
           wait-for-completion: false
 
-  notify-slack-on-failure:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - rawls-build-tag-publish-job
-      - create-bee-workflow
-      - rawls-swat-e2e-test-job
-      - destroy-bee-workflow
-    if: ${{ never() }} # Want to notify regardless of which step fails
-    steps:
-      - name: Notify slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          # Channel is for #dsp-workspaces-test-alerts
-          channel-id: 'C03F21QEWV7'
-          slack-message: "Azure E2E Tests FAILED, branch: ${{ needs.init-github-context.outputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+#  notify-slack-on-failure:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - rawls-build-tag-publish-job
+#      - create-bee-workflow
+#      - rawls-swat-e2e-test-job
+#      - destroy-bee-workflow
+#    if: ${{ never() }} # Want to notify regardless of which step fails
+#    steps:
+#      - name: Notify slack
+#        uses: slackapi/slack-github-action@v1.23.0
+#        with:
+#          # Channel is for #dsp-workspaces-test-alerts
+#          channel-id: 'C03F21QEWV7'
+#          slack-message: "Azure E2E Tests FAILED, branch: ${{ needs.init-github-context.outputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - rawls-build-tag-publish-job
-    if: ${{ (inputs.build-branch && needs.rawls-build-tag-publish-job.outputs.custom-version-json) || !inputs.build-branch }}
+    if: always()
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -289,7 +289,7 @@ jobs:
           }'
           wait-for-completion: false
 
-  notify-slack-on-failure:
+  notify-slack:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
@@ -297,8 +297,18 @@ jobs:
       - create-bee-workflow
       - rawls-swat-e2e-test-job
       - destroy-bee-workflow
-    if: ${{ failure() }} # Want to notify regardless of which step fails
+    if: always()
     steps:
+      - id: render-slack-status-icon
+        name: Render slack result status icon
+        if: always()
+        run: |
+          if [ ${{ job.status }} == 'success' ]; then
+            RESULT="✅";
+          else
+            RESULT="❌"
+          fi
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
@@ -306,5 +316,34 @@ jobs:
           # C53JYBV9A channel is for #dsde-qa
           channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
           slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Azure Workspaces E2E Test*"
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Result:*\n${{ steps.render-slack-status-icon.outputs.result }} ${{ job.status }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                  }
+                ]
+              }
+            ]
+          }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -18,18 +18,18 @@ on:
     - cron: "0 10/12 * * *"
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch of rawls to run tests on (ignored if build-rawls is false)'
-        required: true
-        default: 'develop'
-        type: string
       build-branch:
-        description: 'Whether to build a custom image of Rawls from the branch argument specified (default is true). If false, the version installed on the bee is used.'
+        description: 'Build a custom image of Rawls from the branch specified (default is true). If false, the version installed on the bee is used.'
         required: true
         default: true
         type: boolean
+      branch:
+        description: 'Branch of rawls to build a custom image from and run tests on (ignored if custom image option is false)'
+        required: true
+        default: 'develop'
+        type: string
       bee-version-template:
-        description: 'The version of services to install on the bee, default is dev'
+        description: 'The version of services to install on the bee (default is dev, staging is supported).'
         required: true
         default: 'dev'
         type: string
@@ -94,7 +94,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     outputs:
-      custom-version-json: ${{ (inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json) || ''}}
+      custom-version-json: ${{ inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
     steps:
       - uses: 'actions/checkout@v3'
         if: ${{ inputs.build-branch }}
@@ -124,7 +124,7 @@ jobs:
             {
               "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
               "repository": "${{ github.event.repository.full_name }}",
-              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "ref": "${{ needs.init-github-context.outputs.fully-specified-branch }}",
               "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
             }
 
@@ -145,7 +145,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Echo Rawls version and environment template
+      - name: Echo Rawls version and version template
         run: |
           echo "built custom Rawls=${{ inputs.build-branch}}"
           echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
@@ -289,21 +289,21 @@ jobs:
           }'
           wait-for-completion: false
 
-#  notify-slack-on-failure:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#      - rawls-build-tag-publish-job
-#      - create-bee-workflow
-#      - rawls-swat-e2e-test-job
-#      - destroy-bee-workflow
-#    if: ${{ never() }} # Want to notify regardless of which step fails
-#    steps:
-#      - name: Notify slack
-#        uses: slackapi/slack-github-action@v1.23.0
-#        with:
-#          # Channel is for #dsp-workspaces-test-alerts
-#          channel-id: 'C03F21QEWV7'
-#          slack-message: "Azure E2E Tests FAILED, branch: ${{ needs.init-github-context.outputs.branch }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-#        env:
-#          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+  notify-slack-on-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+      - rawls-build-tag-publish-job
+      - create-bee-workflow
+      - rawls-swat-e2e-test-job
+      - destroy-bee-workflow
+    if: ${{ always() }} # Want to notify regardless of which step fails
+    steps:
+      - name: Notify slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          # Channel is for #dsp-workspaces-test-alerts
+          channel-id: 'C03F21QEWV7'
+          slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -169,19 +169,19 @@ jobs:
 #            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
 #          }'
 #
-#  # This job can be used for generating parameters for E2E tests (e.g. a random project name).
-#  params-gen:
-#    runs-on: ubuntu-latest
-#    outputs:
-#      project-name: ${{ steps.gen.outputs.project_name }}
-#    steps:
-#      - uses: 'actions/checkout@v3'
-#
-#      - name: Generate a random billing project name
-#        id: 'gen'
-#        run: |
-#          project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
-#          echo "project_name=${project_name}" >> $GITHUB_OUTPUT
+  # This job can be used for generating parameters for E2E tests (e.g. a random project name).
+  params-gen:
+    runs-on: ubuntu-latest
+    outputs:
+      project-name: ${{ steps.gen.outputs.project_name }}
+    steps:
+      - uses: 'actions/checkout@v3'
+
+      - name: Generate a random billing project name
+        id: 'gen'
+        run: |
+          project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
+          echo "project_name=${project_name}" >> $GITHUB_OUTPUT
 #
 #  # Azure Managed App Coordinates are defined in the following workflow:
 #  #   https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-landing-zone-to-bee.yaml
@@ -249,7 +249,7 @@ jobs:
     needs:
       - init-github-context
       - params-gen
-      - rawls-swat-e2e-test-job
+      # - rawls-swat-e2e-test-job
     if: always()
     steps:
       - name: dispatch to terra-github-workflows

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -65,6 +65,8 @@ env:
   BEE_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}-dev'
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
+  STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
+  DEV_CHANNELS: 'C03F21QEWV7' #dsp-workspaces-test-alerts
 
 jobs:
   init-github-context:
@@ -311,7 +313,7 @@ jobs:
 #        if: ${{ success() }}
 #        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
-  notify-slack:
+  notify-slack-success:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
@@ -319,26 +321,12 @@ jobs:
 #      - create-bee-workflow
 #      - rawls-swat-e2e-test-job
 #      - destroy-bee-workflow
-    if: always()
-    outputs:
-      workflow-status: ${{ steps.status-icon.outputs.workflow-status }}
+    if: success()
     steps:
-      - name: Set workflow status on failure
-        id: status-icon
-        if: ${{ failure() }}
-        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
-
-      - name: Set workflow status on success
-        id: status-icon
-        if: ${{ success() }}
-        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
-
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
-          # C53JYBV9A channel is for #dsde-qa
-          channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
+          channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
             {
               "blocks": [
@@ -358,7 +346,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n${{ steps.status-icon.outputs.workflow-status }}"
+                      "text": "*Result:*✅ PASSED"
                     },
                     {
                       "type": "mrkdwn",
@@ -370,3 +358,49 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+
+    notify-slack-failure:
+      runs-on: ubuntu-latest
+      needs:
+        - init-github-context
+      #      - rawls-build-tag-publish-job
+      #      - create-bee-workflow
+      #      - rawls-swat-e2e-test-job
+      #      - destroy-bee-workflow
+      if: failure()
+      steps:
+        - name: Notify slack
+          uses: slackapi/slack-github-action@v1.23.0
+          with:
+            channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+            payload: |
+              {
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Azure Workspaces E2E Test*"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Result:*❌ FAILED"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                      }
+                    ]
+                  }
+                ]
+              }
+          env:
+            SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch of rawls to run tests on'
+        description: 'Branch of rawls to run tests on (can be empty string to run against rawls version deployed in bee)'
         required: true
         default: 'develop'
         type: string
@@ -89,6 +89,7 @@ jobs:
       id-token: 'write'
     outputs:
       custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
+    if: ${{ (inputs.branch != '') }}
     steps:
       - uses: 'actions/checkout@v3'
         with:
@@ -134,9 +135,9 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Echo Rawls version
-        run: |
-          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
+#      - name: Echo Rawls version
+#        run: |
+#          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
 
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -151,7 +152,6 @@ jobs:
             "bee-name": "${{ env.BEE_NAME }}",
             "bee-template-name": "rawls-e2e-azure-tests",
             "version-template": "${{ inputs.bee-version-template }}",
-            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
           }'
 
   # This job can be used for generating parameters for E2E tests (e.g. a random project name).
@@ -221,7 +221,7 @@ jobs:
             "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "ENV": "qa",
-            "ref": "refs/heads/${{ needs.init-github-context.outputs.branch }}",
+            "ref": "",
             "test-group-name": "workspaces_azure",
             "test-command": "${{ env.rawls_test_command }}",
             "e2e-env": "${{ env.E2E_ENV }}",
@@ -283,7 +283,7 @@ jobs:
       - create-bee-workflow
       - rawls-swat-e2e-test-job
       - destroy-bee-workflow
-    if: ${{ failure() }} # Want to notify regardless of which step fails
+    if: ${{ never() }} # Want to notify regardless of which step fails
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -290,14 +290,14 @@ jobs:
 #          }'
 #          wait-for-completion: false
 
-  notify-slack:
+  status-icon:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
-#      - rawls-build-tag-publish-job
-#      - create-bee-workflow
-#      - rawls-swat-e2e-test-job
-#      - destroy-bee-workflow
+    #      - rawls-build-tag-publish-job
+    #      - create-bee-workflow
+    #      - rawls-swat-e2e-test-job
+    #      - destroy-bee-workflow
     if: always()
     steps:
       - name: Set workflow status on failure
@@ -312,6 +312,16 @@ jobs:
         env:
           WORKFLOW_STATUS: '✅ PASSED'
 
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs:
+      - status-icon
+#      - rawls-build-tag-publish-job
+#      - create-bee-workflow
+#      - rawls-swat-e2e-test-job
+#      - destroy-bee-workflow
+    if: always()
+    steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -229,17 +229,18 @@ jobs:
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ env.TOKEN }}
-          inputs: '{
-            "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"${{ needs.params-gen.outputs.project-name }}\"}",
-            "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
-            "bee-name": "${{ env.BEE_NAME }}",
-            "ENV": "qa",
-            "ref": "${{ (inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch ) || '' }}",
-            "test-group-name": "workspaces_azure",
-            "test-command": "${{ env.rawls_test_command }}",
-            "e2e-env": "${{ env.E2E_ENV }}",
-            "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
-          }'
+          inputs: |
+            {
+              "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"${{ needs.params-gen.outputs.project-name }}\"}",
+              "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
+              "bee-name": "${{ env.BEE_NAME }}",
+              "ENV": "qa",
+              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "test-group-name": "workspaces_azure",
+              "test-command": "${{ env.rawls_test_command }}",
+              "e2e-env": "${{ env.E2E_ENV }}",
+              "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
+            }
 
   delete-billing-project-v2-from-bee-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -19,10 +19,15 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch of rawls to run tests on (can be empty string to run against rawls version deployed in bee)'
+        description: 'Branch of rawls to run tests on (ignored if build-rawls is false)'
         required: true
         default: 'develop'
         type: string
+      build-branch:
+        description: 'Whether to build a custom image of Rawls from the branch argument specified (default is true). If false, the version installed on the bee is used.'
+        required: true
+        default: true
+        type: boolean
       bee-version-template:
         description: 'The version of services to install on the bee, default is dev'
         required: true
@@ -89,7 +94,7 @@ jobs:
       id-token: 'write'
     outputs:
       custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
-    if: ${{ (inputs.branch != '') }}
+    if: ${{ inputs.build-branch }}
     steps:
       - uses: 'actions/checkout@v3'
         with:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -298,7 +298,21 @@ jobs:
       - rawls-swat-e2e-test-job
       - destroy-bee-workflow
     if: always()
+    env:
+      STATUS: ''
     steps:
+      - name: Set status on failure
+        if: ${{ failure() }}
+        run: echo "FAILED" >> $GITHUB_ENV
+        env:
+          STATUS: '❌ FAILED'
+
+      - name: Set status on success
+        if: ${{ success() }}
+        run: echo "PASSED" >> $GITHUB_ENV
+        env:
+          STATUS: '✅ PASSED'
+
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
@@ -322,7 +336,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Result:*\n${{ failure() && '❌ FAILED' || '✅ PASSED' }}"
+                      "text": "*Result:*\n${{ env.STATUS }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -88,87 +88,87 @@ jobs:
           echo "student-subjects=${{ toJson(inputs.student-subjects || '["harry.potter@quality.firecloud.org","ron.weasley@quality.firecloud.org"]') }}" >> "$GITHUB_OUTPUT"
           echo "service-account=${{ inputs.service-account          || 'firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com' }}" >> "$GITHUB_OUTPUT"
 
-#  rawls-build-tag-publish-job:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#    permissions:
-#      contents: 'read'
-#      id-token: 'write'
-#    outputs:
-#      custom-version-json: ${{ inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
-#    steps:
-#      - uses: 'actions/checkout@v3'
-#        if: ${{ inputs.build-branch }}
-#        with:
-#          ref: ${{ needs.init-github-context.outputs.branch }}
-#
-#      - name: Bump the tag to a new version
-#        uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
-#        if: ${{ inputs.build-branch }}
-#        id: tag
-#        env:
-#          DEFAULT_BUMP: patch
-#          GITHUB_TOKEN: ${{ env.TOKEN }}
-#          RELEASE_BRANCHES: main
-#          WITH_V: true
-#
-#      - name: dispatch build to terra-github-workflows
-#        uses: broadinstitute/workflow-dispatch@v4.0.0
-#        if: ${{ inputs.build-branch }}
-#        with:
-#          run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
-#          workflow: rawls-build
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/main
-#          token: ${{ env.TOKEN }}
-#          inputs: |
-#            {
-#              "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
-#              "repository": "${{ github.event.repository.full_name }}",
-#              "ref": "${{ needs.init-github-context.outputs.fully-specified-branch }}",
-#              "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
-#            }
-#
-#      - name: Render Rawls version
-#        if: ${{ inputs.build-branch }}
-#        id: render-rawls-version
-#        env:
-#          GITHUB_CONTEXT: ${{ toJSON(github) }}
-#        run: |
-#          echo "$GITHUB_CONTEXT"
-#          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
-#
-#  create-bee-workflow:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - rawls-build-tag-publish-job
-#    permissions:
-#      contents: 'read'
-#      id-token: 'write'
-#    steps:
-#      - name: Echo Rawls version and version template
-#        run: |
-#          echo "built custom Rawls=${{ inputs.build-branch}}"
-#          echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
-#          echo "version-template=${{ inputs.bee-version-template }}"
-#
-#      - name: dispatch to terra-github-workflows
-#        uses: broadinstitute/workflow-dispatch@v4.0.0
-#        with:
-#          run-name: "${{ env.BEE_CREATE_RUN_NAME }}"
-#          workflow: bee-create
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/main
-#          token: ${{ env.TOKEN }}
-#          inputs: '{
-#            "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
-#            "bee-name": "${{ env.BEE_NAME }}",
-#            "bee-template-name": "rawls-e2e-azure-tests",
-#            "version-template": "${{ inputs.bee-version-template }}",
-#            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
-#          }'
-#
+  rawls-build-tag-publish-job:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    outputs:
+      custom-version-json: ${{ inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
+    steps:
+      - uses: 'actions/checkout@v3'
+        if: ${{ inputs.build-branch }}
+        with:
+          ref: ${{ needs.init-github-context.outputs.branch }}
+
+      - name: Bump the tag to a new version
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
+        if: ${{ inputs.build-branch }}
+        id: tag
+        env:
+          DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ env.TOKEN }}
+          RELEASE_BRANCHES: main
+          WITH_V: true
+
+      - name: dispatch build to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        if: ${{ inputs.build-branch }}
+        with:
+          run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
+          workflow: rawls-build
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ env.TOKEN }}
+          inputs: |
+            {
+              "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
+              "repository": "${{ github.event.repository.full_name }}",
+              "ref": "${{ needs.init-github-context.outputs.fully-specified-branch }}",
+              "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
+            }
+
+      - name: Render Rawls version
+        if: ${{ inputs.build-branch }}
+        id: render-rawls-version
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
+
+  create-bee-workflow:
+    runs-on: ubuntu-latest
+    needs:
+      - rawls-build-tag-publish-job
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Echo Rawls version and version template
+        run: |
+          echo "built custom Rawls=${{ inputs.build-branch}}"
+          echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
+          echo "version-template=${{ inputs.bee-version-template }}"
+
+      - name: dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: "${{ env.BEE_CREATE_RUN_NAME }}"
+          workflow: bee-create
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ env.TOKEN }}
+          inputs: '{
+            "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
+            "bee-name": "${{ env.BEE_NAME }}",
+            "bee-template-name": "rawls-e2e-azure-tests",
+            "version-template": "${{ inputs.bee-version-template }}",
+            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
+          }'
+
   # This job can be used for generating parameters for E2E tests (e.g. a random project name).
   params-gen:
     runs-on: ubuntu-latest
@@ -182,74 +182,69 @@ jobs:
         run: |
           project_name=$(echo "tmp-billing-project-$(uuidgen)" | cut -c -30)
           echo "project_name=${project_name}" >> $GITHUB_OUTPUT
-#
-#  # Azure Managed App Coordinates are defined in the following workflow:
-#  #   https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-landing-zone-to-bee.yaml
-#  attach-billing-project-to-landing-zone-workflow:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#      - create-bee-workflow
-#      - params-gen
-#    steps:
-#      - name: dispatch to terra-github-workflows
-#        uses: broadinstitute/workflow-dispatch@v4.0.0
-#        with:
-#          run-name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
-#          workflow: attach-billing-project-to-landing-zone.yaml
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/main
-#          token: ${{ env.TOKEN }}
-#          inputs: '{
-#            "run-name": "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}",
-#            "bee-name": "${{ env.BEE_NAME }}",
-#            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
-#            "billing-project-creator": "${{ needs.init-github-context.outputs.owner-subject }}",
-#            "service-account": "${{ needs.init-github-context.outputs.service-account }}"
-#          }'
-#
-#  rawls-swat-e2e-test-job:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#      - create-bee-workflow
-#      - params-gen
-#      - attach-billing-project-to-landing-zone-workflow
-#    steps:
-#      - name: Configure the user subjects for the test
-#        run: |
-#          escapedJSON=$(echo '${{ needs.init-github-context.outputs.student-subjects }}' | sed 's/"/\"/g')
-#          echo "USER_SUBJECTS={\"service_account\":\"${{ needs.init-github-context.outputs.service-account }}\", \"owners\": [\"${{ needs.init-github-context.outputs.owner-subject }}\"], \"students\": $escapedJSON}" >> $GITHUB_ENV
-#
-#      - name: dispatch to terra-github-workflows
-#        env:
-#          rawls_test_command: "testOnly -- -l ProdTest -l NotebooksCanaryTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest"
-#        uses: broadinstitute/workflow-dispatch@v4.0.0
-#        with:
-#          run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}"
-#          workflow: .github/workflows/rawls-swat-tests.yaml
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/main
-#          token: ${{ env.TOKEN }}
-#          inputs: |
-#            {
-#              "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"${{ needs.params-gen.outputs.project-name }}\"}",
-#              "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
-#              "bee-name": "${{ env.BEE_NAME }}",
-#              "ENV": "qa",
-#              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
-#              "test-group-name": "workspaces_azure",
-#              "test-command": "${{ env.rawls_test_command }}",
-#              "e2e-env": "${{ env.E2E_ENV }}",
-#              "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
-#            }
-#
-  delete-billing-project-v2-from-bee-workflow:
+
+  # Azure Managed App Coordinates are defined in the following workflow:
+  #   https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/attach-landing-zone-to-bee.yaml
+  attach-billing-project-to-landing-zone-workflow:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
+      - create-bee-workflow
       - params-gen
-      # - rawls-swat-e2e-test-job
+    steps:
+      - name: dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}"
+          workflow: attach-billing-project-to-landing-zone.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ env.TOKEN }}
+          inputs: '{
+            "run-name": "${{ env.ATTACH_BP_TO_LZ_RUN_NAME }}",
+            "bee-name": "${{ env.BEE_NAME }}",
+            "billing-project": "${{ needs.params-gen.outputs.project-name }}",
+            "billing-project-creator": "${{ needs.init-github-context.outputs.owner-subject }}",
+            "service-account": "${{ needs.init-github-context.outputs.service-account }}"
+          }'
+
+  rawls-swat-e2e-test-job:
+    runs-on: ubuntu-latest
+    needs:
+      - attach-billing-project-to-landing-zone-workflow
+    steps:
+      - name: Configure the user subjects for the test
+        run: |
+          escapedJSON=$(echo '${{ needs.init-github-context.outputs.student-subjects }}' | sed 's/"/\"/g')
+          echo "USER_SUBJECTS={\"service_account\":\"${{ needs.init-github-context.outputs.service-account }}\", \"owners\": [\"${{ needs.init-github-context.outputs.owner-subject }}\"], \"students\": $escapedJSON}" >> $GITHUB_ENV
+
+      - name: dispatch to terra-github-workflows
+        env:
+          rawls_test_command: "testOnly -- -l ProdTest -l NotebooksCanaryTest -n org.broadinstitute.dsde.test.api.WorkspacesAzureTest"
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}"
+          workflow: .github/workflows/rawls-swat-tests.yaml
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ env.TOKEN }}
+          inputs: |
+            {
+              "additional-args": "{\"logging\":\"true\",\"java-version\":\"17\",\"billing-project\":\"${{ needs.params-gen.outputs.project-name }}\"}",
+              "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
+              "bee-name": "${{ env.BEE_NAME }}",
+              "ENV": "qa",
+              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "test-group-name": "workspaces_azure",
+              "test-command": "${{ env.rawls_test_command }}",
+              "e2e-env": "${{ env.E2E_ENV }}",
+              "user-subjects": ${{ toJson(env.USER_SUBJECTS) }}
+            }
+
+  delete-billing-project-v2-from-bee-workflow:
+    runs-on: ubuntu-latest
+    needs:
+      - rawls-swat-e2e-test-job
     if: always()
     steps:
       - name: dispatch to terra-github-workflows
@@ -295,12 +290,7 @@ jobs:
   notify-slack-on-success:
     runs-on: ubuntu-latest
     needs:
-      - init-github-context
       - destroy-bee-workflow
-    #      - rawls-build-tag-publish-job
-    #      - create-bee-workflow
-    #      - rawls-swat-e2e-test-job
-    #      - destroy-bee-workflow
     if: ${{ success() }}
     steps:
       - name: Notify slack
@@ -342,12 +332,7 @@ jobs:
   notify-slack-on-failure:
     runs-on: ubuntu-latest
     needs:
-      - init-github-context
       - destroy-bee-workflow
-    #      - rawls-build-tag-publish-job
-    #      - create-bee-workflow
-    #      - rawls-swat-e2e-test-job
-    #      - destroy-bee-workflow
     if: ${{ failure() }}
     steps:
       - name: Notify slack

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -290,72 +290,69 @@ jobs:
 #          }'
 #          wait-for-completion: false
 
-  status-icon:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-    #      - rawls-build-tag-publish-job
-    #      - create-bee-workflow
-    #      - rawls-swat-e2e-test-job
-    #      - destroy-bee-workflow
-    if: always()
-    steps:
-      - name: Set workflow status on failure
-        if: ${{ failure() }}
-        run: echo "FAILED" >> "$GITHUB_OUTPUT"
-        env:
-          WORKFLOW_STATUS: '❌ FAILED'
-
-      - name: Set workflow status on success
-        if: ${{ success() }}
-        run: echo "PASSED" "$GITHUB_OUTPUT"
-        env:
-          WORKFLOW_STATUS: '✅ PASSED'
-
   notify-slack:
     runs-on: ubuntu-latest
     needs:
-      - status-icon
-#      - rawls-build-tag-publish-job
-#      - create-bee-workflow
-#      - rawls-swat-e2e-test-job
-#      - destroy-bee-workflow
+      - init-github-context
+      #      - rawls-build-tag-publish-job
+      #      - create-bee-workflow
+      #      - rawls-swat-e2e-test-job
+      #      - destroy-bee-workflow
     if: always()
-    steps:
-      - name: Notify slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
-          # C53JYBV9A channel is for #dsde-qa
-          channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
-          payload: |
-            {
-              "blocks": [
+    outputs:
+      steps: ${{ steps.workspace.outputs }}
+    jobs:
+      set-status:
+        runs-on: ubuntu-latest
+        outputs:
+          steps: ${{ toJson(steps) }}
+        steps:
+          - name: Set workflow status on failure
+            if: ${{ failure() }}
+            run: echo "::set-output name=workflow_status::❌ FAILED"
+
+          - name: Set workflow status on success
+            if: ${{ success() }}
+            run: echo "::set-output name=workflow_status::✅ PASSED"
+
+      notify:
+        needs: set-status
+        runs-on: ubuntu-latest
+        steps:
+          - name: Notify slack
+            uses: slackapi/slack-github-action@v1.23.0
+            with:
+              # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
+              # C53JYBV9A channel is for #dsde-qa
+              channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
+              payload: |
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Azure Workspaces E2E Test*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
+                  "blocks": [
                     {
-                      "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Azure Workspaces E2E Test*"
+                      }
                     },
                     {
-                      "type": "mrkdwn",
-                      "text": "*Result:*\n${{ env.WORKFLOW_STATUS }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Result:*\n${{ needs.set-status.outputs.workflow_status }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                        }
+                      ]
                     }
                   ]
                 }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+            env:
+              SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -66,7 +66,7 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
   STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
-  DEV_CHANNELS: 'C01GBDNLH18' #dsp-workspaces-test-alerts C03F21QEWV7
+  DEV_CHANNELS: 'C03F21QEWV7' #dsp-workspaces-test-alerts
 
 jobs:
   init-github-context:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -134,8 +134,9 @@ jobs:
 
   create-bee-workflow:
     runs-on: ubuntu-latest
-#    needs:
-#      - rawls-build-tag-publish-job
+    needs:
+      - rawls-build-tag-publish-job
+    if: ${{ (inputs.build-branch && needs.rawls-build-tag-publish-job.outputs.custom-version-json) || !inputs.build-branch }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -292,7 +292,7 @@ jobs:
           }'
           wait-for-completion: false
 
-  notify-slack:
+  notify-slack-on-success:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
@@ -301,11 +301,10 @@ jobs:
     #      - create-bee-workflow
     #      - rawls-swat-e2e-test-job
     #      - destroy-bee-workflow
-    if: ${{ failure() }}
+    if: ${{ success() }}
     steps:
-      - name: Notify slack on success
+      - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
-        if: ${{ success() }}
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
@@ -339,9 +338,20 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-      - name: Notify slack on failure
+
+  notify-slack-on-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+      - destroy-bee-workflow
+    #      - rawls-build-tag-publish-job
+    #      - create-bee-workflow
+    #      - rawls-swat-e2e-test-job
+    #      - destroy-bee-workflow
+    if: ${{ failure() }}
+    steps:
+      - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
-        if: ${{ failure() }}
         with:
           channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -269,28 +269,49 @@ jobs:
 #            "silent-on-failure": "false"
 #          }'
 #
-#  destroy-bee-workflow:
+  destroy-bee-workflow:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+      # - rawls-swat-e2e-test-job
+      # - delete-billing-project-v2-from-bee-workflow
+    if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+    steps:
+      - name: dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          run-name: "${{ env.BEE_DESTROY_RUN_NAME }}"
+          workflow: bee-destroy
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ env.TOKEN }}
+          inputs: '{
+            "run-name": "${{ env.BEE_DESTROY_RUN_NAME }}",
+            "bee-name": "${{ env.BEE_NAME }}"
+          }'
+          wait-for-completion: false
+#
+#  status-icon:
 #    runs-on: ubuntu-latest
 #    needs:
 #      - init-github-context
-#      - rawls-swat-e2e-test-job
-#      - delete-billing-project-v2-from-bee-workflow
-#    if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+#    #      - rawls-build-tag-publish-job
+#    #      - create-bee-workflow
+#    #      - rawls-swat-e2e-test-job
+#    #      - destroy-bee-workflow
+#    if: always()
+#    outputs:
+#      workflow-status: ${{ steps.status-icon.outputs.workflow-status }}
 #    steps:
-#      - name: dispatch to terra-github-workflows
-#        uses: broadinstitute/workflow-dispatch@v4.0.0
-#        with:
-#          run-name: "${{ env.BEE_DESTROY_RUN_NAME }}"
-#          workflow: bee-destroy
-#          repo: broadinstitute/terra-github-workflows
-#          ref: refs/heads/main
-#          token: ${{ env.TOKEN }}
-#          inputs: '{
-#            "run-name": "${{ env.BEE_DESTROY_RUN_NAME }}",
-#            "bee-name": "${{ env.BEE_NAME }}"
-#          }'
-#          wait-for-completion: false
+#      - name: Set workflow status on failure
+#        id: status-icon
+#        if: ${{ failure() }}
+#        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
 #
+#      - name: Set workflow status on success
+#        id: status-icon
+#        if: ${{ success() }}
+#        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -19,17 +19,17 @@ on:
   workflow_dispatch:
     inputs:
       build-branch:
-        description: 'Build a custom image of Rawls from the branch specified (default is true). If false, the version installed on the bee is used.'
+        description: 'Build a custom image of Rawls from the specified branch. Default is true; if false, the tests run against the version specified by bee-version-template.'
         required: true
         default: true
         type: boolean
       branch:
-        description: 'Branch of rawls to build a custom image from and run tests on (ignored if custom image option is false)'
+        description: 'Branch of Rawls to build a custom image from. Ignored if custom image option is false.'
         required: true
         default: 'develop'
         type: string
       bee-version-template:
-        description: 'The version of services to install on the bee (default is dev, staging is supported).'
+        description: 'The version of services to install on the bee (default is dev, staging is supported). If the custom image option is false, this will also specify the Rawls version.'
         required: true
         default: 'dev'
         type: string
@@ -297,13 +297,14 @@ jobs:
       - create-bee-workflow
       - rawls-swat-e2e-test-job
       - destroy-bee-workflow
-    if: ${{ always() }} # Want to notify regardless of which step fails
+    if: ${{ failure() }} # Want to notify regardless of which step fails
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          # Channel is for #dsp-workspaces-test-alerts
-          channel-id: 'C03F21QEWV7'
+          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
+          # C53JYBV9A channel is for #dsde-qa
+          channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
           slack-message: "Azure E2E Tests FAILED, branch: ${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -290,33 +290,12 @@ jobs:
             "bee-name": "${{ env.BEE_NAME }}"
           }'
           wait-for-completion: false
-#
-#  status-icon:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#    #      - rawls-build-tag-publish-job
-#    #      - create-bee-workflow
-#    #      - rawls-swat-e2e-test-job
-#    #      - destroy-bee-workflow
-#    if: always()
-#    outputs:
-#      workflow-status: ${{ steps.status-icon.outputs.workflow-status }}
-#    steps:
-#      - name: Set workflow status on failure
-#        id: status-icon
-#        if: ${{ failure() }}
-#        run: echo "workflow-status=❌ FAILED" >> $GITHUB_OUTPUT
-#
-#      - name: Set workflow status on success
-#        id: status-icon
-#        if: ${{ success() }}
-#        run: echo "workflow-status=✅ PASSED" >> $GITHUB_OUTPUT
 
   notify-slack:
     runs-on: ubuntu-latest
     needs:
       - init-github-context
+      - destroy-bee-workflow
     #      - rawls-build-tag-publish-job
     #      - create-bee-workflow
     #      - rawls-swat-e2e-test-job

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -316,6 +316,8 @@ jobs:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
+          # C03F21QEWV7 channel is for #dsp-workspaces-test-alerts
+          # C53JYBV9A channel is for #dsde-qa
           channel-id: ${{ inputs.bee-version-template == 'staging' && 'C03F21QEWV7,C53JYBV9A' || 'C03F21QEWV7' }}
           payload: |
             {

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -156,7 +156,7 @@ jobs:
             "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "bee-template-name": "rawls-e2e-azure-tests",
-            "version-template": "${{ inputs.bee-version-template }}",
+            "version-template": "${{ inputs.bee-version-template }}"
           }'
 
   # This job can be used for generating parameters for E2E tests (e.g. a random project name).


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1365

I have set up a trigger from Beehive, which I tested. I will update it to run from `develop` after this PR merges, and also add triggers for BPM and WSM promotions to staging: https://beehive.dsp-devops.broadinstitute.org/environments/staging/chart-releases/rawls/deploy-hooks/github-actions/22

Example of not building a Rawls custom image and just running the test against staging versions:

![image](https://github.com/broadinstitute/rawls/assets/484484/f88b221b-a734-4fbf-a2d3-19f0f775b4ed)

