### PR TITLE
WOR-1403: add error handling for missing billing profile and for missing landing zone

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -154,7 +154,12 @@ trait WorkspaceManagerDAO {
 
   def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult
 
-  def deleteLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): DeleteAzureLandingZoneResult
+  /**
+   * Initiate deletion of a landing zone.
+    * This will either return the delete result, which will contain a job ID that can be used to check the status of the deletion,
+    * or None if there is no job to wait for (such as the landing zone already being deleted, if WSM returns a 404).
+   */
+  def deleteLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): Option[DeleteAzureLandingZoneResult]
 
   def getDeleteLandingZoneResult(jobId: String,
                                  landingZoneId: UUID,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -223,6 +223,22 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar with Mo
     verify(profileApi).deleteProfile(profileId)
   }
 
+  it should "not fail if BPM returns a 404" in {
+    val profileId = UUID.randomUUID()
+
+    val provider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)
+    val profileApi = mock[ProfileApi](RETURNS_SMART_NULLS)
+    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
+      provider,
+      MultiCloudWorkspaceConfig(true, None, Some(azConfig))
+    )
+    when(profileApi.deleteProfile(profileId)).thenThrow(new ApiException(StatusCodes.NotFound.intValue, "not found"))
+    when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
+
+    billingProfileManagerDAO.deleteBillingProfile(profileId, testContext)
+    verify(profileApi).deleteProfile(profileId)
+  }
+
   behavior of "listManagedApps"
 
   it should "return the list of managed apps from billing profile manager" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -4,7 +4,6 @@ import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.client.{ApiException => BpmApiException}
 import bio.terra.profile.model.{AzureManagedAppModel, ProfileModel}
-import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZoneResult, ErrorReport, JobReport}
 import org.apache.http.HttpStatus
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
@@ -28,8 +27,8 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsUserSubjectId,
   UserInfo
 }
-import org.mockito.ArgumentMatchers.{any, anyMap, anyString, argThat}
-import org.mockito.Mockito.{doNothing, doReturn, doThrow, verify, when}
+import org.mockito.ArgumentMatchers.{any, anyString, argThat}
+import org.mockito.Mockito.{doNothing, doReturn, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -599,7 +598,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         .landingZoneId(landingZoneId)
     )
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
-      .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
+      .thenReturn(Some(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id"))))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
@@ -712,7 +711,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         .jobReport(new JobReport().id(landingZoneJobId.toString))
     )
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
-      .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
+      .thenReturn(Some(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id"))))
     when(repo.updateLandingZoneId(createRequest.projectName, Option(landingZoneId)))
       .thenReturn(Future.failed(new RuntimeException(billingRepoError)))
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
@@ -779,7 +778,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     // Deletion of landing zone during cleanup does not error.
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
-      .thenReturn(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id")))
+      .thenReturn(Some(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id("fake-id"))))
     // Exception thrown after creation of billing profile and landing zone.
     // This exception should be visible to the user.
     when(repo.updateLandingZoneId(createRequest.projectName, Option(landingZoneId)))
@@ -852,7 +851,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val jobReportId = UUID.randomUUID()
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
       .thenReturn(
-        new DeleteAzureLandingZoneResult().jobReport(new JobReport().id(jobReportId.toString))
+        Some(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id(jobReportId.toString)))
       )
     val bp =
       new BpmBillingProjectLifecycle(mock[SamDAO],
@@ -874,8 +873,9 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
 
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
+    // The WSM DAO will return None if the landing zone deletion returns 404 or 403, indicating the landing zone does not exist
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
-      .thenAnswer(_ => throw new ApiException(403, "Forbidden"))
+      .thenAnswer(_ => None)
     val bp =
       new BpmBillingProjectLifecycle(mock[SamDAO],
                                      repo,
@@ -913,9 +913,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext)).thenReturn(
-      new DeleteAzureLandingZoneResult()
-        .landingZoneId(UUID.randomUUID())
-        .errorReport(new ErrorReport().statusCode(500).message(landingZoneErrorMessage))
+      Some(
+        new DeleteAzureLandingZoneResult()
+          .landingZoneId(UUID.randomUUID())
+          .errorReport(new ErrorReport().statusCode(500).message(landingZoneErrorMessage))
+      )
     )
     val bp =
       new BpmBillingProjectLifecycle(mock[SamDAO],
@@ -1034,45 +1036,6 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
 
     verify(bpm, Mockito.never()).deleteBillingProfile(ArgumentMatchers.any[UUID], ArgumentMatchers.eq(testContext))
     verify(repo).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
-  }
-
-  it should "succeed if the billing profile does not exist in BPM" in {
-    val billingProjectName = RawlsBillingProjectName("fake_name")
-    val billingProfileId = profileModel.getId
-    val repo = mock[BillingRepository]
-    when(repo.getCreationStatus(billingProjectName)).thenReturn(Future.successful(CreationStatuses.Ready))
-    when(repo.getLandingZoneId(billingProjectName)).thenReturn(Future.successful(None))
-    when(repo.getBillingProfileId(billingProjectName)).thenReturn(Future.successful(Some(billingProfileId.toString)))
-    when(repo.deleteBillingProject(ArgumentMatchers.any())).thenReturn(Future.successful(true))
-    when(repo.getBillingProjectsWithProfile(Some(billingProfileId))).thenReturn(
-      Future.successful(
-        Seq(
-          RawlsBillingProject(
-            billingProjectName,
-            CreationStatuses.Ready,
-            None,
-            None,
-            billingProfileId = Some(billingProfileId.toString)
-          )
-        )
-      )
-    )
-    val bpm = mock[BillingProfileManagerDAO]
-
-    when(bpm.deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext)))
-      .thenAnswer(_ => throw new BpmApiException(HttpStatus.SC_NOT_FOUND, "not found"))
-
-    val bp = new BpmBillingProjectLifecycle(
-      mock[SamDAO],
-      repo,
-      bpm,
-      mock[HttpWorkspaceManagerDAO],
-      mock[WorkspaceManagerResourceMonitorRecordDao]
-    )
-
-    Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
-
-    verify(bpm).deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext))
   }
 
   it should "fail on non-404 errors from BPM" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDaoUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDaoUnitTests.scala
@@ -17,7 +17,12 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
 
-class HttpWorkspaceManagerDaoUnitTests extends AnyFlatSpec with OptionValues with MockitoSugar with MockitoTestUtils with Matchers {
+class HttpWorkspaceManagerDaoUnitTests
+    extends AnyFlatSpec
+    with OptionValues
+    with MockitoSugar
+    with MockitoTestUtils
+    with Matchers {
 
   implicit val actorSystem: ActorSystem = ActorSystem("HttpWorkspaceManagerDAOSpec")
   implicit val executionContext: TestExecutionContext = TestExecutionContext.testExecutionContext
@@ -41,7 +46,7 @@ class HttpWorkspaceManagerDaoUnitTests extends AnyFlatSpec with OptionValues wit
     wsmDao.deleteLandingZone(landingZoneId, testContext) shouldBe None
 
     verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
-      ArgumentMatchers.eq(landingZoneId)
+                                                   ArgumentMatchers.eq(landingZoneId)
     )
 
   }
@@ -63,11 +68,10 @@ class HttpWorkspaceManagerDaoUnitTests extends AnyFlatSpec with OptionValues wit
     wsmDao.deleteLandingZone(landingZoneId, testContext) shouldBe None
 
     verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
-      ArgumentMatchers.eq(landingZoneId)
+                                                   ArgumentMatchers.eq(landingZoneId)
     )
 
   }
-
 
   it should "rethrow an API exception that is not a 404 or 403" in {
 
@@ -83,10 +87,10 @@ class HttpWorkspaceManagerDaoUnitTests extends AnyFlatSpec with OptionValues wit
 
     val testContext = mock[RawlsRequestContext]
 
-    intercept[ApiException] { wsmDao.deleteLandingZone(landingZoneId, testContext) } shouldBe a[ApiException]
+    intercept[ApiException](wsmDao.deleteLandingZone(landingZoneId, testContext)) shouldBe a[ApiException]
 
     verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
-      ArgumentMatchers.eq(landingZoneId)
+                                                   ArgumentMatchers.eq(landingZoneId)
     )
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDaoUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDaoUnitTests.scala
@@ -1,0 +1,94 @@
+package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
+
+import akka.actor.ActorSystem
+import bio.terra.workspace.api.LandingZonesApi
+import bio.terra.workspace.client.ApiException
+import bio.terra.workspace.model.DeleteAzureLandingZoneRequestBody
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
+import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.util.UUID
+
+class HttpWorkspaceManagerDaoUnitTests extends AnyFlatSpec with OptionValues with MockitoSugar with MockitoTestUtils with Matchers {
+
+  implicit val actorSystem: ActorSystem = ActorSystem("HttpWorkspaceManagerDAOSpec")
+  implicit val executionContext: TestExecutionContext = TestExecutionContext.testExecutionContext
+
+  behavior of "deleteLandingZone"
+
+  it should "return None a 404 is returned when deleting a landing zone" in {
+
+    val landingZonesApi = mock[LandingZonesApi]
+    when(landingZonesApi.deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody], any[UUID]))
+      .thenThrow(new ApiException(404, "Not found"))
+
+    val apiClientProvider = mock[WorkspaceManagerApiClientProvider]
+    when(apiClientProvider.getLandingZonesApi(any)).thenReturn(landingZonesApi)
+    val wsmDao =
+      new HttpWorkspaceManagerDAO(apiClientProvider)
+    val landingZoneId = UUID.randomUUID()
+
+    val testContext = mock[RawlsRequestContext]
+
+    wsmDao.deleteLandingZone(landingZoneId, testContext) shouldBe None
+
+    verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
+      ArgumentMatchers.eq(landingZoneId)
+    )
+
+  }
+
+  it should "return None if a 403 is returned to indicate the landing zone is not present when deleting" in {
+
+    val landingZonesApi = mock[LandingZonesApi]
+    when(landingZonesApi.deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody], any[UUID]))
+      .thenThrow(new ApiException(403, "Forbidden"))
+
+    val apiClientProvider = mock[WorkspaceManagerApiClientProvider]
+    when(apiClientProvider.getLandingZonesApi(any)).thenReturn(landingZonesApi)
+    val wsmDao =
+      new HttpWorkspaceManagerDAO(apiClientProvider)
+    val landingZoneId = UUID.randomUUID()
+
+    val testContext = mock[RawlsRequestContext]
+
+    wsmDao.deleteLandingZone(landingZoneId, testContext) shouldBe None
+
+    verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
+      ArgumentMatchers.eq(landingZoneId)
+    )
+
+  }
+
+
+  it should "rethrow an API exception that is not a 404 or 403" in {
+
+    val landingZonesApi = mock[LandingZonesApi]
+    when(landingZonesApi.deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody], any[UUID]))
+      .thenThrow(new ApiException(500, "error"))
+
+    val apiClientProvider = mock[WorkspaceManagerApiClientProvider]
+    when(apiClientProvider.getLandingZonesApi(any)).thenReturn(landingZonesApi)
+    val wsmDao =
+      new HttpWorkspaceManagerDAO(apiClientProvider)
+    val landingZoneId = UUID.randomUUID()
+
+    val testContext = mock[RawlsRequestContext]
+
+    intercept[ApiException] { wsmDao.deleteLandingZone(landingZoneId, testContext) } shouldBe a[ApiException]
+
+    verify(landingZonesApi).deleteAzureLandingZone(any[DeleteAzureLandingZoneRequestBody],
+      ArgumentMatchers.eq(landingZoneId)
+    )
+
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -241,7 +241,8 @@ class MockWorkspaceManagerDAO(
 
   override def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult = ???
 
-  def deleteLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): DeleteAzureLandingZoneResult = ???
+  override def deleteLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): Some[DeleteAzureLandingZoneResult] =
+    ???
 
   override def getDeleteLandingZoneResult(jobId: String,
                                           landingZoneId: UUID,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1403

Continue deletion if either the landing zone or billing profile is missing.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
