### PR TITLE
AJ-1524: add submissionId to root span in SubmissionMonitorActor trace

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -328,6 +328,8 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     trace("SubmissionMonitorActor.handleStatusResponses") { rootSpan =>
       rootSpan.tracingSpan.foreach { s =>
         s.putAttribute("submissionId", OpenCensusAttributeValue.stringAttributeValue(submissionId.toString))
+        s.putAttribute("workspaceNamespace", OpenCensusAttributeValue.stringAttributeValue(workspaceName.namespace))
+        s.putAttribute("workspaceName", OpenCensusAttributeValue.stringAttributeValue(workspaceName.name))
       }
 
       response.statusResponse.collect { case Failure(t) => t }.foreach { t =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -326,6 +326,10 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     response: ExecutionServiceStatusResponse
   )(implicit executionContext: ExecutionContext): Future[StatusCheckComplete] =
     trace("SubmissionMonitorActor.handleStatusResponses") { rootSpan =>
+      rootSpan.tracingSpan.foreach { s =>
+        s.putAttribute("submissionId", OpenCensusAttributeValue.stringAttributeValue(submissionId.toString))
+      }
+
       response.statusResponse.collect { case Failure(t) => t }.foreach { t =>
         logger.error(s"Failure monitoring workflow in submission $submissionId", t)
       }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1524

A quick enhancement to #2667. This adds a "submissionId" attribute and workspace namespace/name attributes to the root span. We already have "submissionId" attribute on the "handleOutputs" child span, but it's useful to have it on the root span for searching/filtering.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
