### PR TITLE
[WOR-1365] Make input argument handling consistent.

### DIFF
--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -19,13 +19,13 @@ on:
   workflow_dispatch:
     inputs:
       build-branch:
-        description: 'Build a custom image of Rawls from the specified branch. Default is true; if false, the tests run against the version specified by bee-version-template.'
+        description: 'Build a custom image of Rawls from the specified branch. Default is false, meaning tests are run against the version specified by bee-version-template.'
         required: true
-        default: true
+        default: false
         type: boolean
       branch:
         description: 'Branch of Rawls to build a custom image from. Ignored if custom image option is false.'
-        required: true
+        required: false
         default: 'develop'
         type: string
       bee-version-template:
@@ -72,7 +72,9 @@ jobs:
   init-github-context:
     runs-on: ubuntu-latest
     outputs:
+      build-branch: ${{ steps.extract-inputs.outputs.build-branch }}
       branch: ${{ steps.extract-inputs.outputs.branch }}
+      bee-version-template: ${{ steps.extract-inputs.outputs.bee-version-template }}
       fully-specified-branch: refs/heads/${{ steps.extract-inputs.outputs.branch }}
       delete-bee: ${{ steps.extract-inputs.outputs.delete-bee }}
       student-subjects: ${{ steps.extract-inputs.outputs.student-subjects }}
@@ -82,7 +84,9 @@ jobs:
       - name: Get inputs or use defaults
         id: extract-inputs
         run: |
+          echo "build-branch=${{ inputs.build-branch                || false }}" >> "$GITHUB_OUTPUT"
           echo "branch=${{ inputs.branch                            || 'develop' }}" >> "$GITHUB_OUTPUT"
+          echo "bee-version-template=${{ inputs.bee-version-template || 'dev' }}" >> "$GITHUB_OUTPUT"
           echo "delete-bee=${{ inputs.delete-bee                    || false }}" >> "$GITHUB_OUTPUT"
           echo "owner-subject=${{ inputs.owner-subject              || 'hermione.owner@quality.firecloud.org' }}" >> "$GITHUB_OUTPUT"
           echo "student-subjects=${{ toJson(inputs.student-subjects || '["harry.potter@quality.firecloud.org","ron.weasley@quality.firecloud.org"]') }}" >> "$GITHUB_OUTPUT"
@@ -96,16 +100,16 @@ jobs:
       contents: 'read'
       id-token: 'write'
     outputs:
-      custom-version-json: ${{ inputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
+      custom-version-json: ${{ needs.init-github-context.outputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
     steps:
       - uses: 'actions/checkout@v3'
-        if: ${{ inputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch }}
         with:
           ref: ${{ needs.init-github-context.outputs.branch }}
 
       - name: Bump the tag to a new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
-        if: ${{ inputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch }}
         id: tag
         env:
           DEFAULT_BUMP: patch
@@ -115,7 +119,7 @@ jobs:
 
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
-        if: ${{ inputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch }}
         with:
           run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
           workflow: rawls-build
@@ -131,7 +135,7 @@ jobs:
             }
 
       - name: Render Rawls version
-        if: ${{ inputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch }}
         id: render-rawls-version
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
@@ -142,6 +146,7 @@ jobs:
   create-bee-workflow:
     runs-on: ubuntu-latest
     needs:
+      - init-github-context
       - rawls-build-tag-publish-job
     permissions:
       contents: 'read'
@@ -149,9 +154,9 @@ jobs:
     steps:
       - name: Echo Rawls version and version template
         run: |
-          echo "built custom Rawls=${{ inputs.build-branch}}"
+          echo "built custom Rawls=${{ needs.init-github-context.outputs.build-branch}}"
           echo "custom build Rawls version=${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
-          echo "version-template=${{ inputs.bee-version-template }}"
+          echo "version-template=${{ needs.init-github-context.outputs.bee-version-template }}"
 
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -165,7 +170,7 @@ jobs:
             "run-name": "${{ env.BEE_CREATE_RUN_NAME }}",
             "bee-name": "${{ env.BEE_NAME }}",
             "bee-template-name": "rawls-e2e-azure-tests",
-            "version-template": "${{ inputs.bee-version-template }}",
+            "version-template": "${{ needs.init-github-context.outputs.bee-version-template }}",
             "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
           }'
 
@@ -237,7 +242,7 @@ jobs:
               "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
               "bee-name": "${{ env.BEE_NAME }}",
               "ENV": "qa",
-              "ref": "${{ inputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "ref": "${{ needs.init-github-context.outputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
               "test-group-name": "workspaces_azure",
               "test-command": "${{ env.rawls_test_command }}",
               "e2e-env": "${{ env.E2E_ENV }}",
@@ -294,13 +299,14 @@ jobs:
   notify-slack-on-success:
     runs-on: ubuntu-latest
     needs:
+      - init-github-context
       - destroy-bee-workflow
     if: ${{ success() }}
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
             {
               "blocks": [
@@ -316,7 +322,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
                     },
                     {
                       "type": "mrkdwn",
@@ -336,13 +342,14 @@ jobs:
   notify-slack-on-failure:
     runs-on: ubuntu-latest
     needs:
+      - init-github-context
       - destroy-bee-workflow
     if: ${{ failure() }}
     steps:
       - name: Notify slack
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ inputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
           payload: |
             {
               "blocks": [
@@ -358,7 +365,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ inputs.build-branch && needs.init-github-context.outputs.branch || inputs.bee-version-template }}"
+                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -21,8 +21,11 @@ on:
       build-branch:
         description: 'Build a custom image of Rawls from the specified branch. Default is false, meaning tests are run against the version specified by bee-version-template.'
         required: true
-        default: false
-        type: boolean
+        default: 'false'
+        type: choice
+        options:
+          - true
+          - false
       branch:
         description: 'Branch of Rawls to build a custom image from. Ignored if custom image option is false.'
         required: false
@@ -87,10 +90,10 @@ jobs:
       - name: Get inputs or use defaults
         id: extract-inputs
         run: |
-          echo "build-branch=${{ inputs.build-branch                || false }}" >> "$GITHUB_OUTPUT"
+          echo "build-branch=${{ inputs.build-branch                || 'false' }}" >> "$GITHUB_OUTPUT"
           echo "branch=${{ inputs.branch                            || 'develop' }}" >> "$GITHUB_OUTPUT"
           echo "bee-version-template=${{ inputs.bee-version-template || 'dev' }}" >> "$GITHUB_OUTPUT"
-          echo "delete-bee=${{ inputs.delete-bee                    || true }}" >> "$GITHUB_OUTPUT"
+          echo "delete-bee=${{ inputs.delete-bee                    || 'true' }}" >> "$GITHUB_OUTPUT"
           echo "owner-subject=${{ inputs.owner-subject              || 'hermione.owner@quality.firecloud.org' }}" >> "$GITHUB_OUTPUT"
           echo "student-subjects=${{ toJson(inputs.student-subjects || '["harry.potter@quality.firecloud.org","ron.weasley@quality.firecloud.org"]') }}" >> "$GITHUB_OUTPUT"
           echo "service-account=${{ inputs.service-account          || 'firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com' }}" >> "$GITHUB_OUTPUT"
@@ -103,16 +106,16 @@ jobs:
       contents: 'read'
       id-token: 'write'
     outputs:
-      custom-version-json: ${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && steps.render-rawls-version.outputs.custom-version-json || ''}}
+      custom-version-json: ${{ needs.init-github-context.outputs.build-branch == 'true' && steps.render-rawls-version.outputs.custom-version-json || ''}}
     steps:
       - uses: 'actions/checkout@v3'
-        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
+        if: ${{ needs.init-github-context.outputs.build-branch == 'true' }}
         with:
           ref: ${{ needs.init-github-context.outputs.branch }}
 
       - name: Bump the tag to a new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
-        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
+        if: ${{ needs.init-github-context.outputs.build-branch == 'true' }}
         id: tag
         env:
           DEFAULT_BUMP: patch
@@ -122,7 +125,7 @@ jobs:
 
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
-        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
+        if: ${{ needs.init-github-context.outputs.build-branch == 'true' }}
         with:
           run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
           workflow: rawls-build
@@ -138,7 +141,7 @@ jobs:
             }
 
       - name: Render Rawls version
-        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
+        if: ${{ needs.init-github-context.outputs.build-branch == 'true' }}
         id: render-rawls-version
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
@@ -245,7 +248,7 @@ jobs:
               "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
               "bee-name": "${{ env.BEE_NAME }}",
               "ENV": "qa",
-              "ref": "${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "ref": "${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.fully-specified-branch || '' }}",
               "test-group-name": "workspaces_azure",
               "test-command": "${{ env.rawls_test_command }}",
               "e2e-env": "${{ env.E2E_ENV }}",
@@ -283,7 +286,7 @@ jobs:
       - init-github-context
       - rawls-swat-e2e-test-job
       - delete-billing-project-v2-from-bee-workflow
-    if: ${{ needs.init-github-context.outputs.delete-bee == true || needs.init-github-context.outputs.delete-bee == 'true' }}
+    if: ${{ needs.init-github-context.outputs.delete-bee == 'true' }}
     steps:
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -325,7 +328,7 @@ jobs:
 #                  "fields": [
 #                    {
 #                      "type": "mrkdwn",
-#                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+#                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
 #                    },
 #                    {
 #                      "type": "mrkdwn",
@@ -368,7 +371,7 @@ jobs:
 #                  "fields": [
 #                    {
 #                      "type": "mrkdwn",
-#                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+#                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
 #                    },
 #                    {
 #                      "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -72,7 +72,7 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
   STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
-  DEV_CHANNELS: 'C03F21QEWV7' #dsp-workspaces-test-alerts
+  DEV_CHANNELS: 'C01GBDNLH18' #dsp-workspaces-test-alerts
 
 jobs:
   init-github-context:
@@ -302,88 +302,88 @@ jobs:
           }'
           wait-for-completion: false
 
-#  notify-slack-on-success:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#      - destroy-bee-workflow
-#    if: ${{ success() }}
-#    steps:
-#      - name: Notify slack
-#        uses: slackapi/slack-github-action@v1.23.0
-#        with:
-#          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "*Azure Workspaces E2E Test*"
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "fields": [
-#                    {
-#                      "type": "mrkdwn",
-#                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
-#                    },
-#                    {
-#                      "type": "mrkdwn",
-#                      "text": "*Result:*\n✅ PASSED"
-#                    },
-#                    {
-#                      "type": "mrkdwn",
-#                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-#                    }
-#                  ]
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-#
-#  notify-slack-on-failure:
-#    runs-on: ubuntu-latest
-#    needs:
-#      - init-github-context
-#      - destroy-bee-workflow
-#    if: ${{ failure() }}
-#    steps:
-#      - name: Notify slack
-#        uses: slackapi/slack-github-action@v1.23.0
-#        with:
-#          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-#          payload: |
-#            {
-#              "blocks": [
-#                {
-#                  "type": "section",
-#                  "text": {
-#                    "type": "mrkdwn",
-#                    "text": "*Azure Workspaces E2E Test*"
-#                  }
-#                },
-#                {
-#                  "type": "section",
-#                  "fields": [
-#                    {
-#                      "type": "mrkdwn",
-#                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
-#                    },
-#                    {
-#                      "type": "mrkdwn",
-#                      "text": "*Result:*\n❌ FAILED"
-#                    },
-#                    {
-#                      "type": "mrkdwn",
-#                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-#                    }
-#                  ]
-#                }
-#              ]
-#            }
-#        env:
-#          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+  notify-slack-on-success:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+      - destroy-bee-workflow
+    if: ${{ success() }}
+    steps:
+      - name: Notify slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Azure Workspaces E2E Test*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Result:*\n✅ PASSED"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+
+  notify-slack-on-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - init-github-context
+      - destroy-bee-workflow
+    if: ${{ failure() }}
+    steps:
+      - name: Notify slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Azure Workspaces E2E Test*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch == 'true' && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Result:*\n❌ FAILED"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -84,10 +84,10 @@ jobs:
       - name: Get inputs or use defaults
         id: extract-inputs
         run: |
-          echo "build-branch=${{ inputs.build-branch ==  'true'     || false }}" >> "$GITHUB_OUTPUT"
+          echo "build-branch=${{ inputs.build-branch                || false }}" >> "$GITHUB_OUTPUT"
           echo "branch=${{ inputs.branch                            || 'develop' }}" >> "$GITHUB_OUTPUT"
           echo "bee-version-template=${{ inputs.bee-version-template || 'dev' }}" >> "$GITHUB_OUTPUT"
-          echo "delete-bee=${{ inputs.delete-bee == 'true'          || false }}" >> "$GITHUB_OUTPUT"
+          echo "delete-bee=${{ inputs.delete-bee                    || true }}" >> "$GITHUB_OUTPUT"
           echo "owner-subject=${{ inputs.owner-subject              || 'hermione.owner@quality.firecloud.org' }}" >> "$GITHUB_OUTPUT"
           echo "student-subjects=${{ toJson(inputs.student-subjects || '["harry.potter@quality.firecloud.org","ron.weasley@quality.firecloud.org"]') }}" >> "$GITHUB_OUTPUT"
           echo "service-account=${{ inputs.service-account          || 'firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com' }}" >> "$GITHUB_OUTPUT"
@@ -100,16 +100,16 @@ jobs:
       contents: 'read'
       id-token: 'write'
     outputs:
-      custom-version-json: ${{ needs.init-github-context.outputs.build-branch && steps.render-rawls-version.outputs.custom-version-json || ''}}
+      custom-version-json: ${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && steps.render-rawls-version.outputs.custom-version-json || ''}}
     steps:
       - uses: 'actions/checkout@v3'
-        if: ${{ needs.init-github-context.outputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
         with:
           ref: ${{ needs.init-github-context.outputs.branch }}
 
       - name: Bump the tag to a new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0
-        if: ${{ needs.init-github-context.outputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
         id: tag
         env:
           DEFAULT_BUMP: patch
@@ -119,7 +119,7 @@ jobs:
 
       - name: dispatch build to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
-        if: ${{ needs.init-github-context.outputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
         with:
           run-name: "${{ env.RAWLS_BUILD_RUN_NAME }}"
           workflow: rawls-build
@@ -135,7 +135,7 @@ jobs:
             }
 
       - name: Render Rawls version
-        if: ${{ needs.init-github-context.outputs.build-branch }}
+        if: ${{ needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true' }}
         id: render-rawls-version
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
@@ -242,7 +242,7 @@ jobs:
               "run-name": "${{ env.RAWLS_SWAT_TESTS_RUN_NAME }}",
               "bee-name": "${{ env.BEE_NAME }}",
               "ENV": "qa",
-              "ref": "${{ needs.init-github-context.outputs.build-branch && needs.init-github-context.outputs.fully-specified-branch || '' }}",
+              "ref": "${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.fully-specified-branch || '' }}",
               "test-group-name": "workspaces_azure",
               "test-command": "${{ env.rawls_test_command }}",
               "e2e-env": "${{ env.E2E_ENV }}",
@@ -280,7 +280,7 @@ jobs:
       - init-github-context
       - rawls-swat-e2e-test-job
       - delete-billing-project-v2-from-bee-workflow
-    if: ${{ needs.init-github-context.outputs.delete-bee && always() }} # always run to confirm bee is destroyed unless explicitly requested not to
+    if: ${{ needs.init-github-context.outputs.delete-bee == true || needs.init-github-context.outputs.delete-bee == 'true' }}
     steps:
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -322,7 +322,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
                     },
                     {
                       "type": "mrkdwn",
@@ -365,7 +365,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ needs.init-github-context.outputs.build-branch && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -72,7 +72,7 @@ env:
   TOKEN: '${{ secrets.BROADBOT_TOKEN }}' # github token for access to kick off a job in the private repo
   E2E_ENV: 'azure_e2e.env'
   STAGING_CHANNELS: 'C03F21QEWV7,C53JYBV9A' # C53JYBV9A channel is for #dsde-qa
-  DEV_CHANNELS: 'C01GBDNLH18' #dsp-workspaces-test-alerts
+  DEV_CHANNELS: 'C03F21QEWV7' #dsp-workspaces-test-alerts
 
 jobs:
   init-github-context:

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -296,88 +296,88 @@ jobs:
           }'
           wait-for-completion: false
 
-  notify-slack-on-success:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - destroy-bee-workflow
-    if: ${{ success() }}
-    steps:
-      - name: Notify slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Azure Workspaces E2E Test*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Result:*\n✅ PASSED"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
-
-  notify-slack-on-failure:
-    runs-on: ubuntu-latest
-    needs:
-      - init-github-context
-      - destroy-bee-workflow
-    if: ${{ failure() }}
-    steps:
-      - name: Notify slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Azure Workspaces E2E Test*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Result:*\n❌ FAILED"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+#  notify-slack-on-success:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - destroy-bee-workflow
+#    if: ${{ success() }}
+#    steps:
+#      - name: Notify slack
+#        uses: slackapi/slack-github-action@v1.23.0
+#        with:
+#          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "*Azure Workspaces E2E Test*"
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "fields": [
+#                    {
+#                      "type": "mrkdwn",
+#                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+#                    },
+#                    {
+#                      "type": "mrkdwn",
+#                      "text": "*Result:*\n✅ PASSED"
+#                    },
+#                    {
+#                      "type": "mrkdwn",
+#                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+#                    }
+#                  ]
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}
+#
+#  notify-slack-on-failure:
+#    runs-on: ubuntu-latest
+#    needs:
+#      - init-github-context
+#      - destroy-bee-workflow
+#    if: ${{ failure() }}
+#    steps:
+#      - name: Notify slack
+#        uses: slackapi/slack-github-action@v1.23.0
+#        with:
+#          channel-id: ${{ needs.init-github-context.outputs.bee-version-template == 'staging' && env.STAGING_CHANNELS || env.DEV_CHANNELS }}
+#          payload: |
+#            {
+#              "blocks": [
+#                {
+#                  "type": "section",
+#                  "text": {
+#                    "type": "mrkdwn",
+#                    "text": "*Azure Workspaces E2E Test*"
+#                  }
+#                },
+#                {
+#                  "type": "section",
+#                  "fields": [
+#                    {
+#                      "type": "mrkdwn",
+#                      "text": "*Environment:*\n${{ (needs.init-github-context.outputs.build-branch == true || needs.init-github-context.outputs.build-branch == 'true') && needs.init-github-context.outputs.branch || needs.init-github-context.outputs.bee-version-template }}"
+#                    },
+#                    {
+#                      "type": "mrkdwn",
+#                      "text": "*Result:*\n❌ FAILED"
+#                    },
+#                    {
+#                      "type": "mrkdwn",
+#                      "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Link to workflow run>"
+#                    }
+#                  ]
+#                }
+#              ]
+#            }
+#        env:
+#          SLACK_BOT_TOKEN: ${{ secrets.SLACKBOT_TOKEN }}

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -36,8 +36,11 @@ on:
       delete-bee:
         description: 'Delete created bee after running tests'
         required: true
-        default: true
-        type: boolean
+        default: 'true'
+        type: choice
+        options:
+          - true
+          - false
       owner-subject:
         description: 'Owner subject (used for creating billing project in E2E testing)'
         required: true

--- a/.github/workflows/rawls-run-azure-e2e-tests.yaml
+++ b/.github/workflows/rawls-run-azure-e2e-tests.yaml
@@ -84,10 +84,10 @@ jobs:
       - name: Get inputs or use defaults
         id: extract-inputs
         run: |
-          echo "build-branch=${{ inputs.build-branch                || false }}" >> "$GITHUB_OUTPUT"
+          echo "build-branch=${{ inputs.build-branch ==  'true'     || false }}" >> "$GITHUB_OUTPUT"
           echo "branch=${{ inputs.branch                            || 'develop' }}" >> "$GITHUB_OUTPUT"
           echo "bee-version-template=${{ inputs.bee-version-template || 'dev' }}" >> "$GITHUB_OUTPUT"
-          echo "delete-bee=${{ inputs.delete-bee                    || false }}" >> "$GITHUB_OUTPUT"
+          echo "delete-bee=${{ inputs.delete-bee == 'true'          || false }}" >> "$GITHUB_OUTPUT"
           echo "owner-subject=${{ inputs.owner-subject              || 'hermione.owner@quality.firecloud.org' }}" >> "$GITHUB_OUTPUT"
           echo "student-subjects=${{ toJson(inputs.student-subjects || '["harry.potter@quality.firecloud.org","ron.weasley@quality.firecloud.org"]') }}" >> "$GITHUB_OUTPUT"
           echo "service-account=${{ inputs.service-account          || 'firecloud-qa@broad-dsde-qa.iam.gserviceaccount.com' }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Minor cleanup to #2668.

When the test is run twice a day via the chron trigger, input arguments are not present. This ended up meaning that we ran against dev by default because `create-bee` defaults to dev if no version template is supplied (and we ended up not building a custom Rawls version, which isn't needed in this case anyway). So while this behavior was correct, it was a bit difficult to reason about and caused the notification message to not include the Rawls version tested against.

For consistency, I am making the argument default handling the same as the other input parameters. I'm also changing the "build custom image" default to false, since it's actually uncommon that we need to build a custom Rawls image (and not building it reduces total time by about 10 minutes). Previously we would build a custom image from `develop` on every scheduled run, even though we were telling the bee to use dev versions.

Also changed the boolean options to choices because booleans are not well supported.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
