### PR TITLE
AJ-1526: process workflows individually inside submission monitor

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -729,7 +729,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
       val outputs = outputsResponse.outputs
       logger.debug(
         s"attaching outputs for ${submissionId.toString}/${workflowRecord.externalId
-            .getOrElse("MISSING_WORKFLOW")}: ${outputExpressionMap.size} expressions, ${outputs.size} outputs"
+            .getOrElse("MISSING_WORKFLOW")}: ${outputExpressionMap.size} expressions, ${outputs.size} attribute values"
       )
 
       val parsedExpressions: Seq[Try[OutputExpression]] = outputExpressionMap.map { case (outputName, outputExprStr) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -763,7 +763,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
 
         val entityAttributeCount = optEntityUpdates map { update: WorkflowEntityUpdate =>
           val cnt = attributeCount(update.upserts.values)
-          logger.debug(
+          logger.trace(
             s"Updating $cnt attribute values for entity ${update.entityRef.entityName} of type ${update.entityRef.entityType} in ${submissionId.toString}/${workflowRecord.externalId
                 .getOrElse("MISSING_WORKFLOW")}. ${safePrint(update.upserts)}"
           )
@@ -772,7 +772,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
 
         val workspaceAttributeCount = optWs map { workspace: Workspace =>
           val cnt = attributeCount(workspace.attributes.values)
-          logger.debug(
+          logger.trace(
             s"Updating $cnt attribute values for workspace in ${submissionId.toString}/${workflowRecord.externalId
                 .getOrElse("MISSING_WORKFLOW")}. ${safePrint(workspace.attributes)}"
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -351,8 +351,8 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
         .partition(_._2.isDefined)
 
       // extra logic just for logging
-      val noOutputsGrouped = noOutputs.groupBy(_._1.status).view.mapValues(v => v.size)
-      val yesOutputsGrouped = yesOutputs.groupBy(_._1.status).view.mapValues(v => v.size)
+      val noOutputsGrouped = noOutputs.groupBy(_._1.status).view.mapValues(v => v.size).toMap
+      val yesOutputsGrouped = yesOutputs.groupBy(_._1.status).view.mapValues(v => v.size).toMap
 
       logger.info(
         s"will process ${noOutputs.size} workflow(s) without outputs ($noOutputsGrouped) and ${yesOutputs.size} workflow(s) with outputs ($yesOutputsGrouped) for submission $submissionId"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -108,36 +108,6 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       }
   }
 
-  Set((5, 1000), (5, 1002), (5000, 1002), (5000, 0)).foreach { case (workflowsPerBatch, workflowCount) =>
-    it should s"batchWorkflowsWithOutputs workflowsPerBatch=$workflowsPerBatch, workflowCount=$workflowCount" in withDefaultTestDatabase {
-      dataSource: SlickDataSource =>
-        val status = WorkflowStatuses.Succeeded
-        val attributesPerWorkflow = outputs.outputs.size * workflowsPerBatch
-        val monitor = createSubmissionMonitor(
-          dataSource,
-          mockSamDAO,
-          mockGoogleServicesDAO,
-          testData.submissionUpdateEntity,
-          testData.wsName,
-          new SubmissionTestExecutionServiceDAO(status.toString),
-          attributesPerWorkflow
-        )
-
-        val workflowsRecs = runAndWait(
-          workflowQuery.listWorkflowRecsForSubmission(UUID.fromString(testData.submissionUpdateEntity.submissionId))
-        )
-        val result = monitor.batchWorkflowsWithOutputs(Seq.fill(workflowCount)((workflowsRecs.head, outputs))).size
-        val expected = if (workflowCount % workflowsPerBatch == 0) {
-          workflowCount / workflowsPerBatch
-        } else {
-          workflowCount / workflowsPerBatch + 1
-        }
-        assertResult(expected) {
-          result
-        }
-    }
-  }
-
   it should "queryExecutionServiceForStatus submitted" in withDefaultTestDatabase { dataSource: SlickDataSource =>
     val monitor = createSubmissionMonitor(
       dataSource,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1526

Behavior of the submission monitor before this PR:
* write all outputs for all workflows in this submission, batching into transactions of up to 20,000 attributes
* once outputs are completely written, update statuses for all workflows in a single transaction
* once workflow statuses are updated, update the status of the submission if it is complete

Behavior after this PR:
* loop through all workflows in this submission. For each workflow, in a transaction just for that workflow:
    * write the outputs, if any
    * update the status for this workflow
* once this loop is complete, update the status of the submission if it is complete

Imagine a case where a submission has 600 running workflows, all with outputs, and each of those workflows has large outputs that require 2 minutes to write. In this case, we previously required 1200 minutes (20 hours) to write outputs before any workflow changed status. After this PR, we'll see one workflow move to `Succeeded` every 2 minutes.

Now also imagine a case in which back Rawls is restarted - or in which we hit an unrecoverable error - after processing 400 of those workflows. Before this PR, we'd start back from square one and try to write all 600 workflow's outputs again. After this PR, we'll notice that 400 workflows have completed and pick up where we left off at workflow 401.

This PR moves from a smaller number of large db transactions to a large number of smaller db transactions. I think that's the right move. DB transactions are now per-workflow instead of spanning workflows, which feels correct.

Still TODO: This optimizes `handleStatusResponses`. I also see a smaller opportunity to optimize `queryExecutionServiceForStatus`, but would prefer to save that for a separate PR.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
