### PR TITLE
[WOR-1417] Clean up dead config

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -180,11 +180,6 @@ class BillingProfileManagerDAOImpl(
     apiClientProvider.getProfileApi(ctx).deleteProfile(billingProfileId)
 
   def getAllBillingProfiles(ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[ProfileModel]] = {
-
-    if (!config.multiCloudWorkspacesEnabled) {
-      return Future.successful(Seq())
-    }
-
     val profileApi = apiClientProvider.getProfileApi(ctx)
 
     @tailrec

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -110,24 +110,24 @@ class BpmBillingProjectLifecycle(
     // completes and then updates the billing project status accordingly.
     def createLandingZone(profileModel: ProfileModel): Future[CreateLandingZoneResult] = {
       val lzId = createProjectRequest.managedAppCoordinates.get.landingZoneId
-      if (lzId.isDefined && !config.azureConfig.get.landingZoneAllowAttach) {
+      if (lzId.isDefined && !config.azureConfig.landingZoneAllowAttach) {
         throw new LandingZoneCreationException(
           RawlsErrorReport("Landing Zone ID provided but attachment is not permitted in this environment")
         )
       }
 
       val maybeAttach = if (lzId.isDefined) Map("attach" -> "true") else Map.empty
-      val params = config.azureConfig.get.landingZoneParameters ++ maybeAttach
+      val params = config.azureConfig.landingZoneParameters ++ maybeAttach
 
       val lzDefinition = createProjectRequest.protectedData match {
-        case Some(true) => config.azureConfig.get.protectedDataLandingZoneDefinition
-        case _          => config.azureConfig.get.landingZoneDefinition
+        case Some(true) => config.azureConfig.protectedDataLandingZoneDefinition
+        case _          => config.azureConfig.landingZoneDefinition
       }
 
       Future(blocking {
         workspaceManagerDAO.createLandingZone(
           lzDefinition,
-          config.azureConfig.get.landingZoneVersion,
+          config.azureConfig.landingZoneVersion,
           params,
           profileModel.getId,
           ctx,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -9,10 +9,7 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 
-final case class MultiCloudWorkspaceConfig(multiCloudWorkspacesEnabled: Boolean,
-                                           workspaceManager: Option[MultiCloudWorkspaceManagerConfig],
-                                           azureConfig: Option[AzureConfig]
-)
+final case class MultiCloudWorkspaceConfig(workspaceManager: MultiCloudWorkspaceManagerConfig, azureConfig: AzureConfig)
 
 final case class MultiCloudWorkspaceManagerConfig(leonardoWsmApplicationId: String,
                                                   pollTimeout: FiniteDuration,
@@ -28,42 +25,31 @@ final case class AzureConfig(landingZoneDefinition: String,
 
 case object MultiCloudWorkspaceConfig {
   def apply[T <: MultiCloudWorkspaceConfig](conf: Config): MultiCloudWorkspaceConfig = {
-    val azureConfig: Option[AzureConfig] = conf.getConfigOption("multiCloudWorkspaces.azureConfig") match {
-      case Some(azc) =>
-        Some(
-          AzureConfig(
-            azc.getString("landingZoneDefinition"),
-            azc.getString("protectedDataLandingZoneDefinition"),
-            azc.getString("landingZoneVersion"),
-            azc
-              .getConfig("landingZoneParameters")
-              .entrySet()
-              .asScala
-              .map { entry =>
-                entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
-              }
-              .toMap,
-            azc.getBooleanOption("landingZoneAllowAttach").getOrElse(false)
-          )
-        )
-      case _ => None
-    }
+    val azc = conf.getConfig("multiCloudWorkspaces.azureConfig")
+    val azureConfig =
+      AzureConfig(
+        azc.getString("landingZoneDefinition"),
+        azc.getString("protectedDataLandingZoneDefinition"),
+        azc.getString("landingZoneVersion"),
+        azc
+          .getConfig("landingZoneParameters")
+          .entrySet()
+          .asScala
+          .map { entry =>
+            entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
+          }
+          .toMap,
+        azc.getBooleanOption("landingZoneAllowAttach").getOrElse(false)
+      )
 
-    conf.getConfigOption("multiCloudWorkspaces") match {
-      case Some(mc) =>
-        new MultiCloudWorkspaceConfig(
-          mc.getBoolean("enabled"),
-          Some(
-            MultiCloudWorkspaceManagerConfig(
-              mc.getString("workspaceManager.leonardoWsmApplicationId"),
-              util.toScalaDuration(mc.getDuration("workspaceManager.pollTimeoutSeconds")),
-              util.toScalaDuration(mc.getDuration("workspaceManager.deletionPollTimeoutSeconds"))
-            )
-          ),
-          azureConfig
-        )
-      case None =>
-        new MultiCloudWorkspaceConfig(false, None, None)
-    }
+    val mc = conf.getConfig("multiCloudWorkspaces")
+    new MultiCloudWorkspaceConfig(
+      MultiCloudWorkspaceManagerConfig(
+        mc.getString("workspaceManager.leonardoWsmApplicationId"),
+        util.toScalaDuration(mc.getDuration("workspaceManager.pollTimeoutSeconds")),
+        util.toScalaDuration(mc.getDuration("workspaceManager.deletionPollTimeoutSeconds"))
+      ),
+      azureConfig
+    )
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -235,7 +235,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       }
 
       workspaceOpt <- Apply[Option]
-        .product(multiCloudWorkspaceConfig.azureConfig, billingProfileOpt)
+        .product(Option(multiCloudWorkspaceConfig.azureConfig), billingProfileOpt)
         .traverse { case (azureConfig, profileModel) =>
           // "MultiCloud" workspaces are limited to azure-hosted workspaces for now.
           // This will likely change when the functionality for GCP workspaces gets moved out of Rawls
@@ -352,7 +352,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     assertBillingProfileCreationDate(profile)
 
     val wsmConfig = multiCloudWorkspaceConfig.workspaceManager
-      .getOrElse(throw new RawlsException("WSM app config not present"))
     val workspaceId = UUID.randomUUID()
 
     for {
@@ -493,10 +492,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                 profile: ProfileModel,
                                 parentContext: RawlsRequestContext = ctx
   ): Future[Workspace] = {
-    if (!multiCloudWorkspaceConfig.multiCloudWorkspacesEnabled) {
-      throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotImplemented, "MC workspaces are not enabled"))
-    }
-
     assertBillingProfileCreationDate(profile)
 
     traceWithParent("createMultiCloudWorkspace", parentContext)(s1 =>
@@ -526,7 +521,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     */
   def deleteWorkspaceInWSM(workspaceId: UUID): Future[Unit] = {
     val wsmConfig = multiCloudWorkspaceConfig.workspaceManager
-      .getOrElse(throw new RawlsException("WSM app config not present"))
     getWorkspaceFromWsm(workspaceId, ctx).getOrElse(return Future.successful())
     for {
       // kick off the deletion job w/WSM
@@ -595,7 +589,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                               parentContext: RawlsRequestContext
   ): Future[Workspace] = {
     val wsmConfig = multiCloudWorkspaceConfig.workspaceManager
-      .getOrElse(throw new RawlsException("WSM app config not present"))
 
     val spendProfileId = profile.getId.toString
     val workspaceId = UUID.randomUUID()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -9,7 +9,14 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.BpmAzureReportErrorMessageJsonProtocol._
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig, MultiCloudWorkspaceManagerConfig}
-import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, RawlsBillingAccountName, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
+  RawlsBillingAccountName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  UserInfo
+}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.any
@@ -43,7 +50,10 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar with Mo
     None
   )
   val testContext: RawlsRequestContext = RawlsRequestContext(userInfo)
-  val multiCloudWorkspaceConfig: MultiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(MultiCloudWorkspaceManagerConfig("fake_app_id", Duration(1, "second"), Duration(1, "second")), azConfig)
+  val multiCloudWorkspaceConfig: MultiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(
+    MultiCloudWorkspaceManagerConfig("fake_app_id", Duration(1, "second"), Duration(1, "second")),
+    azConfig
+  )
 
   behavior of "getBillingProfile"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -229,7 +229,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     val profileApi = mock[ProfileApi](RETURNS_SMART_NULLS)
     val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
       provider,
-      MultiCloudWorkspaceConfig(true, None, Some(azConfig))
+      multiCloudWorkspaceConfig
     )
     when(profileApi.deleteProfile(profileId)).thenThrow(new ApiException(StatusCodes.NotFound.intValue, "not found"))
     when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -24,7 +24,6 @@ import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
-import org.scalatestplus.mockito.MockitoSugar
 import spray.json._
 
 import java.util.{Date, UUID}
@@ -32,7 +31,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.jdk.CollectionConverters.SeqHasAsJava
 
-class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar with MockitoTestUtils {
+class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
   val azConfig: AzureConfig = AzureConfig(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -6,12 +6,29 @@ import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceCon
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.BpmBillingProjectDelete
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
-import org.broadinstitute.dsde.rawls.model.{CreateRawlsV2BillingProjectFullRequest, CreationStatuses, ErrorReport, ProjectAccessUpdate, ProjectRoles, RawlsBillingAccountName, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SamBillingProjectActions, SamBillingProjectPolicyNames, SamCreateResourceResponse, SamResourceTypeNames, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  CreateRawlsV2BillingProjectFullRequest,
+  CreationStatuses,
+  ErrorReport,
+  ProjectAccessUpdate,
+  ProjectRoles,
+  RawlsBillingAccountName,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  SamBillingProjectActions,
+  SamBillingProjectPolicyNames,
+  SamCreateResourceResponse,
+  SamResourceTypeNames,
+  UserInfo
+}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, never, verify, when}
+import org.mockito.Mockito.{never, verify, when, RETURNS_SMART_NULLS}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
@@ -36,7 +53,10 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   val userInfo: UserInfo =
     UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
   val testContext = RawlsRequestContext(userInfo)
-  val multiCloudWorkspaceConfig: MultiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(MultiCloudWorkspaceManagerConfig("fake_app_id", Duration(1, "second"), Duration(1, "second")), azConfig)
+  val multiCloudWorkspaceConfig: MultiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(
+    MultiCloudWorkspaceManagerConfig("fake_app_id", Duration(1, "second"), Duration(1, "second")),
+    azConfig
+  )
 
   behavior of "creation request validation"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -2,33 +2,16 @@ package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig}
+import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig, MultiCloudWorkspaceManagerConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.BpmBillingProjectDelete
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
-import org.broadinstitute.dsde.rawls.model.{
-  CreateRawlsV2BillingProjectFullRequest,
-  CreationStatuses,
-  ErrorReport,
-  ProjectAccessUpdate,
-  ProjectRoles,
-  RawlsBillingAccountName,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  RawlsUserSubjectId,
-  SamBillingProjectActions,
-  SamBillingProjectPolicyNames,
-  SamCreateResourceResponse,
-  SamResourceTypeNames,
-  UserInfo
-}
+import org.broadinstitute.dsde.rawls.model.{CreateRawlsV2BillingProjectFullRequest, CreationStatuses, ErrorReport, ProjectAccessUpdate, ProjectRoles, RawlsBillingAccountName, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, SamBillingProjectActions, SamBillingProjectPolicyNames, SamCreateResourceResponse, SamResourceTypeNames, UserInfo}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{never, verify, when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito.{RETURNS_SMART_NULLS, never, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
@@ -53,6 +36,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   val userInfo: UserInfo =
     UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
   val testContext = RawlsRequestContext(userInfo)
+  val multiCloudWorkspaceConfig: MultiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(MultiCloudWorkspaceManagerConfig("fake_app_id", Duration(1, "second"), Duration(1, "second")), azConfig)
 
   behavior of "creation request validation"
 
@@ -107,7 +91,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     )
     val bpCreator = mock[BillingProjectLifecycle]
     val bpCreatorReturnedStatus = CreationStatuses.CreatingLandingZone
-    val multiCloudWorkspaceConfig = new MultiCloudWorkspaceConfig(true, None, Some(azConfig))
     when(bpCreator.validateBillingProjectCreationRequest(createRequest, testContext)).thenReturn(Future.successful())
     when(bpCreator.postCreationSteps(createRequest, multiCloudWorkspaceConfig, testContext))
       .thenReturn(Future.successful(bpCreatorReturnedStatus))
@@ -244,7 +227,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       None
     )
     val creator = mock[BillingProjectLifecycle]
-    val multiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(true, None, Some(azConfig))
     when(
       creator.validateBillingProjectCreationRequest(ArgumentMatchers.eq(createRequest),
                                                     ArgumentMatchers.eq(testContext)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -6,7 +6,6 @@ import bio.terra.profile.client.{ApiException => BpmApiException}
 import bio.terra.profile.model.{AzureManagedAppModel, ProfileModel}
 import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZoneResult, ErrorReport, JobReport}
 import org.apache.http.HttpStatus
-import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig, MultiCloudWorkspaceManagerConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
@@ -28,7 +27,6 @@ import org.broadinstitute.dsde.rawls.model.{
   UserInfo
 }
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
-
 import org.mockito.ArgumentMatchers.{any, anyString, argThat}
 import org.mockito.Mockito.{doNothing, doReturn, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -3,20 +3,13 @@ package org.broadinstitute.dsde.rawls.billing
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.{AzureManagedAppModel, ProfileModel}
-import bio.terra.workspace.model.{
-  AzureLandingZoneDefinition,
-  CreateLandingZoneResult,
-  DeleteAzureLandingZoneResult,
-  ErrorReport,
-  JobReport
-}
-import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
+import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZoneResult, ErrorReport, JobReport}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.{AzureConfig, MultiCloudWorkspaceConfig, MultiCloudWorkspaceManagerConfig}
-import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.HttpWorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.{
   AzureManagedAppCoordinates,
   CreateRawlsV2BillingProjectFullRequest,
@@ -31,7 +24,8 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsUserSubjectId,
   UserInfo
 }
-import org.mockito.ArgumentMatchers.{any, anyMap, anyString, argThat}
+import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
+import org.mockito.ArgumentMatchers.{any, anyString, argThat}
 import org.mockito.Mockito.{doNothing, doReturn, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.concurrent.ScalaFutures

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -37,7 +37,7 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
     config.azureConfig.landingZoneDefinition shouldBe "fake_landing_zone_definition"
     config.azureConfig.landingZoneVersion shouldBe "fake_landing_zone_version"
     config.azureConfig.landingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
-                                                              "ANOTHER_FAKE_ONE" -> "still_not_real"
+                                                          "ANOTHER_FAKE_ONE" -> "still_not_real"
     )
     config.workspaceManager.pollTimeout shouldEqual 60.seconds
     config.workspaceManager.leonardoWsmApplicationId shouldEqual "fake_app_id"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -9,13 +9,6 @@ import scala.concurrent.duration._
 class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
   val testConf: Config = ConfigFactory.load()
 
-  it should "default to not enabled if no config is present" in {
-    val config = MultiCloudWorkspaceConfig.apply(ConfigFactory.empty())
-
-    config.multiCloudWorkspacesEnabled shouldBe false
-    config.azureConfig shouldBe None
-  }
-
   it should "Parse config when present" in {
     val enabledConfig =
       """
@@ -41,13 +34,12 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
     val parsed = ConfigFactory.parseString(enabledConfig)
     val config = MultiCloudWorkspaceConfig.apply(parsed)
 
-    config.multiCloudWorkspacesEnabled shouldBe true
-    config.azureConfig.get.landingZoneDefinition shouldBe "fake_landing_zone_definition"
-    config.azureConfig.get.landingZoneVersion shouldBe "fake_landing_zone_version"
-    config.azureConfig.get.landingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
+    config.azureConfig.landingZoneDefinition shouldBe "fake_landing_zone_definition"
+    config.azureConfig.landingZoneVersion shouldBe "fake_landing_zone_version"
+    config.azureConfig.landingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
                                                               "ANOTHER_FAKE_ONE" -> "still_not_real"
     )
-    config.workspaceManager.get.pollTimeout shouldEqual 60.seconds
-    config.workspaceManager.get.leonardoWsmApplicationId shouldEqual "fake_app_id"
+    config.workspaceManager.pollTimeout shouldEqual 60.seconds
+    config.workspaceManager.leonardoWsmApplicationId shouldEqual "fake_app_id"
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -456,7 +456,7 @@ class SubmissionSpec(_system: ActorSystem)
 
       val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
         mock[BillingProfileManagerClientProvider],
-        new MultiCloudWorkspaceConfig(false, None, None)
+        mock[MultiCloudWorkspaceConfig]
       )
 
       val userServiceConstructor = UserService.constructor(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -60,16 +60,13 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
   implicit val workbenchMetricBaseName: ShardId = "test"
 
   def activeMcWorkspaceConfig: MultiCloudWorkspaceConfig = MultiCloudWorkspaceConfig(
-    multiCloudWorkspacesEnabled = true,
-    Some(MultiCloudWorkspaceManagerConfig("fake_app_id", 60 seconds, 120 seconds)),
-    Some(
-      AzureConfig(
-        "fake-landing-zone-definition",
-        "fake-protected-landing-zone-definition",
-        "fake-landing-zone-version",
-        Map("fake_parameter" -> "fake_value"),
-        landingZoneAllowAttach = false
-      )
+    MultiCloudWorkspaceManagerConfig("fake_app_id", 60 seconds, 120 seconds),
+    AzureConfig(
+      "fake-landing-zone-definition",
+      "fake-protected-landing-zone-definition",
+      "fake-landing-zone-version",
+      Map("fake_parameter" -> "fake_value"),
+      landingZoneAllowAttach = false
     )
   )
 
@@ -269,29 +266,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
   }
 
   behavior of "createMultiCloudWorkspace"
-
-  it should "throw an exception if creating a multi-cloud workspace is not enabled" in {
-    val workspaceManagerDAO = new MockWorkspaceManagerDAO()
-    val config = MultiCloudWorkspaceConfig(multiCloudWorkspacesEnabled = false, None, None)
-    val samDAO = new MockSamDAO(slickDataSource)
-    val leonardoDAO: LeonardoDAO = new MockLeonardoDAO()
-    val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
-      slickDataSource,
-      workspaceManagerDAO,
-      mock[BillingProfileManagerDAO],
-      samDAO,
-      config,
-      leonardoDAO,
-      workbenchMetricBaseName
-    )(testContext)
-    val request = WorkspaceRequest("fake", "fake_name", Map.empty)
-
-    val actual = intercept[RawlsExceptionWithErrorReport] {
-      mcWorkspaceService.createMultiCloudWorkspace(request, new ProfileModel().id(UUID.randomUUID()))
-    }
-
-    actual.errorReport.statusCode shouldBe Some(StatusCodes.NotImplemented)
-  }
 
   it should "throw an exception if a workspace with the same name already exists" in {
     val workspaceManagerDAO = new MockWorkspaceManagerDAO()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1417

 The multi cloud workspace config had optional values and a flag to turn off the feature. These values are no longer optional nor is the feature disable-able. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
