### PR TITLE
[AJ-1525] Pass Cost Saving Params to LZ when creating Billing Project

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -148,8 +148,8 @@ prometheus {
 multiCloudWorkspaces {
     azureConfig {
         costSavingLandingZoneParameters = {
-          "AKS_COST_SAVING_SPOT_NODES_ENABLED": "false"
-          "AKS_COST_SAVING_VPA_ENABLED": "false"
+          "AKS_COST_SAVING_SPOT_NODES_ENABLED": "true"
+          "AKS_COST_SAVING_VPA_ENABLED": "true"
         }
     }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -144,3 +144,12 @@ sam.timeout = 3 minutes
 prometheus {
   endpointPort = 9098
 }
+
+multiCloudWorkspaces {
+    azureConfig {
+        costSavingLandingZoneParameters = {
+          "AKS_COST_SAVING_SPOT_NODES_ENABLED": "true"
+          "AKS_COST_SAVING_VPA_ENABLED": "true"
+        }
+    }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -148,8 +148,8 @@ prometheus {
 multiCloudWorkspaces {
     azureConfig {
         costSavingLandingZoneParameters = {
-          "AKS_COST_SAVING_SPOT_NODES_ENABLED": "true"
-          "AKS_COST_SAVING_VPA_ENABLED": "true"
+          "AKS_COST_SAVING_SPOT_NODES_ENABLED": "false"
+          "AKS_COST_SAVING_VPA_ENABLED": "false"
         }
     }
 }

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6258,6 +6258,10 @@ components:
           description: Optional, false if not specified. Applicable only for azure
             billing projects. When set, a billing project with suitable infrastructure
             for protected data workspaces will be created.
+        costSavings:
+          type: boolean
+          description: Optional, false if not specified. Applicable only for azure
+            billing projects. When set, this enables Vertical Pod Autoscaling and Spot Nodes in Azure Kubernetes.
       description: ""
     ProjectRole:
       description: the role on the billing project

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -119,7 +119,10 @@ class BpmBillingProjectLifecycle(
       }
 
       val maybeAttach = if (lzId.isDefined) Map("attach" -> "true") else Map.empty
-      val params = config.azureConfig.get.landingZoneParameters ++ maybeAttach
+      val costSavingParams =
+        if (createProjectRequest.costSavings.getOrElse(false)) config.azureConfig.get.costSavingLandingZoneParameters
+        else Map.empty
+      val params = config.azureConfig.get.landingZoneParameters ++ maybeAttach ++ costSavingParams
 
       val lzDefinition = createProjectRequest.protectedData match {
         case Some(true) => config.azureConfig.get.protectedDataLandingZoneDefinition

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycle.scala
@@ -120,7 +120,7 @@ class BpmBillingProjectLifecycle(
 
       val maybeAttach = if (lzId.isDefined) Map("attach" -> "true") else Map.empty
       val costSavingParams =
-        if (createProjectRequest.costSavings.getOrElse(false)) config.azureConfig.get.costSavingLandingZoneParameters
+        if (createProjectRequest.costSavings.contains(true)) config.azureConfig.get.costSavingLandingZoneParameters
         else Map.empty
       val params = config.azureConfig.get.landingZoneParameters ++ maybeAttach ++ costSavingParams
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -44,6 +44,14 @@ case object MultiCloudWorkspaceConfig {
                 entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
               }
               .toMap,
+            azc
+              .getConfig("costSavingLandingZoneParameters")
+              .entrySet()
+              .asScala
+              .map { entry =>
+                entry.getKey -> entry.getValue.unwrapped().asInstanceOf[String]
+              }
+              .toMap,
             azc.getBooleanOption("landingZoneAllowAttach").getOrElse(false)
           )
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceConfig.scala
@@ -23,6 +23,7 @@ final case class AzureConfig(landingZoneDefinition: String,
                              protectedDataLandingZoneDefinition: String,
                              landingZoneVersion: String,
                              landingZoneParameters: Map[String, String],
+                             costSavingLandingZoneParameters: Map[String, String],
                              landingZoneAllowAttach: Boolean
 )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -194,7 +194,7 @@ case class CreateRawlsV2BillingProjectFullRequest(
   members: Option[Set[ProjectAccessUpdate]],
   inviteUsersNotFound: Option[Boolean],
   protectedData: Option[Boolean] = Option(false),
-  costSavings: Option[Boolean] = Option(false),
+  costSavings: Option[Boolean] = Option(false)
 ) {
 
   def billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -193,7 +193,8 @@ case class CreateRawlsV2BillingProjectFullRequest(
   managedAppCoordinates: Option[AzureManagedAppCoordinates],
   members: Option[Set[ProjectAccessUpdate]],
   inviteUsersNotFound: Option[Boolean],
-  protectedData: Option[Boolean] = Option(false)
+  protectedData: Option[Boolean] = Option(false),
+  costSavings: Option[Boolean] = Option(false),
 ) {
 
   def billingInfo: Either[RawlsBillingAccountName, AzureManagedAppCoordinates] = {
@@ -294,7 +295,7 @@ class UserAuthJsonSupport extends JsonSupport {
   )
 
   implicit val CreateRawlsV2BillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsV2BillingProjectFullRequest] =
-    jsonFormat7(CreateRawlsV2BillingProjectFullRequest)
+    jsonFormat8(CreateRawlsV2BillingProjectFullRequest)
 
   implicit val UpdateRawlsBillingAccountRequestFormat: RootJsonFormat[UpdateRawlsBillingAccountRequest] = jsonFormat1(
     UpdateRawlsBillingAccountRequest

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -112,6 +112,10 @@ multiCloudWorkspaces {
             "FAKE_PARAMETER": "fake_value",
             "ANOTHER_FAKE_ONE": "still_not_real"
         }
+        costSavingLandingZoneParameters = {
+            "FAKE_PARAMETER": "fake_value",
+            "ANOTHER_FAKE_ONE": "still_not_real"
+        }
     }
     workspaceManager {
         pollTimeoutSeconds = 60

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -113,8 +113,8 @@ multiCloudWorkspaces {
             "ANOTHER_FAKE_ONE": "still_not_real"
         }
         costSavingLandingZoneParameters = {
-            "FAKE_PARAMETER": "fake_value",
-            "ANOTHER_FAKE_ONE": "still_not_real"
+            "FAKE_PARAMETER": "false",
+            "ANOTHER_FAKE_ONE": "false"
         }
     }
     workspaceManager {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -40,6 +40,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoSugar with Mo
     "fake-protected-landing-zone-definition",
     "fake-landing-zone-version",
     Map("fake_parameter" -> "fake_value"),
+    Map("fake_parameter" -> "fake_value"),
     landingZoneAllowAttach = false
   )
   val userInfo: UserInfo = UserInfo(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -47,6 +47,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     "fake-protected-landing-zone-definition",
     "fake-landing-zone-version",
     Map("fake_parameter" -> "fake_value"),
+    Map("fake_parameter" -> "fake_value"),
     landingZoneAllowAttach = false
   )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -215,12 +215,13 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val lzId = UUID.randomUUID()
     val lzAttachAzConfig =
-      AzureConfig(landingZoneDefinition,
-                  protectedLandingZoneDefinition,
-                  landingZoneVersion,
-                  landingZoneParameters,
-                  costSavingLandingZoneParameters,
-                  landingZoneAllowAttach = true
+      AzureConfig(
+        landingZoneDefinition,
+        protectedLandingZoneDefinition,
+        landingZoneVersion,
+        landingZoneParameters,
+        costSavingLandingZoneParameters,
+        landingZoneAllowAttach = true
       )
     val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
       billingProjectName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -70,7 +70,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   val protectedLandingZoneDefinition = "fake-protected-landing-zone-definition"
   val landingZoneVersion = "fake-landing-zone-version"
   val landingZoneParameters = Map("fake_parameter" -> "fake_value")
-  val costSavingLandingZoneParameters = Map("fake_parameter" -> "fake_value")
+  val costSavingLandingZoneParameters = Map("fake_parameter" -> "false")
   val azConfig: AzureConfig = AzureConfig(
     landingZoneDefinition,
     protectedLandingZoneDefinition,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BpmBillingProjectLifecycleSpec.scala
@@ -70,11 +70,13 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   val protectedLandingZoneDefinition = "fake-protected-landing-zone-definition"
   val landingZoneVersion = "fake-landing-zone-version"
   val landingZoneParameters = Map("fake_parameter" -> "fake_value")
+  val costSavingLandingZoneParameters = Map("fake_parameter" -> "fake_value")
   val azConfig: AzureConfig = AzureConfig(
     landingZoneDefinition,
     protectedLandingZoneDefinition,
     landingZoneVersion,
     landingZoneParameters,
+    costSavingLandingZoneParameters,
     false
   )
   val landingZoneId = UUID.randomUUID()
@@ -217,6 +219,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
                   protectedLandingZoneDefinition,
                   landingZoneVersion,
                   landingZoneParameters,
+                  costSavingLandingZoneParameters,
                   landingZoneAllowAttach = true
       )
     val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -31,8 +31,8 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
         |        "ANOTHER_FAKE_ONE": "still_not_real"
         |      }
         |      costSavingLandingZoneParameters = {
-        |        "FAKE_PARAMETER": "fake_value",
-        |        "ANOTHER_FAKE_ONE": "still_not_real"
+        |        "FAKE_PARAMETER": "false",
+        |        "ANOTHER_FAKE_ONE": "false"
         |      }
         |    },
         |    workspaceManager {
@@ -51,8 +51,8 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
     config.azureConfig.get.landingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
                                                               "ANOTHER_FAKE_ONE" -> "still_not_real"
     )
-    config.azureConfig.get.costSavingLandingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
-                                                                        "ANOTHER_FAKE_ONE" -> "still_not_real"
+    config.azureConfig.get.costSavingLandingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "false",
+                                                                        "ANOTHER_FAKE_ONE" -> "false"
     )
     config.workspaceManager.get.pollTimeout shouldEqual 60.seconds
     config.workspaceManager.get.leonardoWsmApplicationId shouldEqual "fake_app_id"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -31,6 +31,11 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
         |        "ANOTHER_FAKE_ONE": "still_not_real"
         |      }
         |    },
+        |      costSavingLandingZoneParameters = {
+        |        "FAKE_PARAMETER": "fake_value",
+        |        "ANOTHER_FAKE_ONE": "still_not_real"
+        |      }
+        |    },
         |    workspaceManager {
         |      pollTimeoutSeconds = 60 seconds,
         |      deletionPollTimeoutSeconds = 120 seconds,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -47,6 +47,9 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
     config.azureConfig.get.landingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
                                                               "ANOTHER_FAKE_ONE" -> "still_not_real"
     )
+    config.azureConfig.get.costSavingLandingZoneParameters shouldBe Map("FAKE_PARAMETER" -> "fake_value",
+                                                                        "ANOTHER_FAKE_ONE" -> "still_not_real"
+    )
     config.workspaceManager.get.pollTimeout shouldEqual 60.seconds
     config.workspaceManager.get.leonardoWsmApplicationId shouldEqual "fake_app_id"
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/config/MultiCloudWorkspaceServiceConfigSpec.scala
@@ -30,7 +30,6 @@ class MultiCloudWorkspaceServiceConfigSpec extends AnyFlatSpec with Matchers {
         |        "FAKE_PARAMETER": "fake_value",
         |        "ANOTHER_FAKE_ONE": "still_not_real"
         |      }
-        |    },
         |      costSavingLandingZoneParameters = {
         |        "FAKE_PARAMETER": "fake_value",
         |        "ANOTHER_FAKE_ONE": "still_not_real"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -68,6 +68,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         "fake-protected-landing-zone-definition",
         "fake-landing-zone-version",
         Map("fake_parameter" -> "fake_value"),
+        Map("fake_parameter" -> "fake_value"),
         landingZoneAllowAttach = false
       )
     )

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -401,6 +401,10 @@ multiCloudWorkspaces {
       "AKS_AUTOSCALING_MAX": "100"
       "AKS_MACHINE_TYPE": "Standard_D4as_v5"
     }
+    costSavingLandingZoneParameters = {
+      "AKS_COST_SAVING_SPOT_NODES_ENABLED": "true"
+      "AKS_COST_SAVING_VPA_ENABLED": "true"
+    }
   },
   workspaceManager {
     pollTimeoutSeconds = 80 seconds,

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -401,10 +401,6 @@ multiCloudWorkspaces {
       "AKS_AUTOSCALING_MAX": "100"
       "AKS_MACHINE_TYPE": "Standard_D4as_v5"
     }
-    costSavingLandingZoneParameters = {
-      "AKS_COST_SAVING_SPOT_NODES_ENABLED": "true"
-      "AKS_COST_SAVING_VPA_ENABLED": "true"
-    }
   },
   workspaceManager {
     pollTimeoutSeconds = 80 seconds,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1525

This PR adds an extra optional argument when creating a billing project that enables cost saving parameters in Landing Zone (specifically, Vertical Pod Autoscaling and Spot Nodes). 
Note: This is a quick PR that unblocks our ability to create workspaces with these features. If we were ever to enable this in the UI we would want to reorchestrate to allow us to pass custom parameters to LZ, which would allow us to enable any number of features on LZ in the future. 

Orchestration's API update: https://github.com/broadinstitute/firecloud-orchestration/pull/1266

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
