### PR TITLE
AJ-1514: tweak logging for unit tests

### DIFF
--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -24,32 +24,8 @@ object Testing {
 
   val testSettingsWithoutDb: Seq[Setting[_]] = List(
     Test / testOptions += Tests.Setup(() => sys.props += "mockserver.logLevel" -> "WARN"),
-    // SLF4J initializes itself upon the first logging call.  Because sbt
-    // runs tests in parallel it is likely that a second thread will
-    // invoke a second logging call before SLF4J has completed
-    // initialization from the first thread's logging call, leading to
-    // these messages:
-    //   SLF4J: The following loggers will not work because they were created
-    //   SLF4J: during the default configuration phase of the underlying logging system.
-    //   SLF4J: See also http://www.slf4j.org/codes.html#substituteLogger
-    //   SLF4J: com.imageworks.common.concurrent.SingleThreadInfiniteLoopRunner
-    //
-    // As a workaround, load SLF4J's root logger before starting the unit
-    // tests
-
-    // Source: https://github.com/typesafehub/scalalogging/issues/23#issuecomment-17359537
-    // References:
-    //   http://stackoverflow.com/a/12095245
-    //   http://jira.qos.ch/browse/SLF4J-167
-    //   http://jira.qos.ch/browse/SLF4J-97
-    Test / testOptions += Tests.Setup(classLoader =>
-      classLoader
-        .loadClass("org.slf4j.LoggerFactory")
-        .getMethod("getLogger", classLoader.loadClass("java.lang.String"))
-        .invoke(null, "ROOT")
-    ),
     Test / testOptions ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
-    Test / testOptions += Tests.Argument("-oDG"), // D = individual test durations, G = stack trace reminders at end
+    Test / testOptions += Tests.Argument("-oD"), // D = individual test durations
     IntegrationTest / testOptions := Seq(Tests.Filter(s => isIntegrationTest(s))),
     Test / parallelExecution := false
   )


### PR DESCRIPTION
Ticket: [AJ-1514](https://broadworkbench.atlassian.net/browse/AJ-1514)

Two changes to logging in unit tests:
1. Remove the -oG flag (see "Configuring Reporters" [here](https://www.scalatest.org/user_guide/using_the_runner)). This included full stack traces in the summary of failed tests at the end of a test run. I find this useful when a single test fails, but if more than a couple tests have failed it causes so much noise as to make it difficult to see problems. I am open to reverting this if others feel differently.
2. Disable the proactive initialization of the SLF4J root logger as suggested in [this comment](https://github.com/typesafehub/scalalogging/issues/23#issuecomment-17359537). This initialization somehow made it such that our logback-test.xml could not be found and therefore had no effect. This initialization is also moot because we have `Test / parallelExecution := false`. So, it can go.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-1514]: https://broadworkbench.atlassian.net/browse/AJ-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ