### PR TITLE
AJ-1247: prefactoring for mysql 8: log_bin_trust_function_creators

### DIFF
--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -24,7 +24,10 @@ start() {
 
     # validate mysql
     echo "running mysql validation..."
-    docker run --rm --link $CONTAINER:mysql -v $PWD/docker/sql_validate.sh:/working/sql_validate.sh broadinstitute/dsde-toolbox:mysql8 /working/sql_validate.sh rawls
+    docker run --rm --link $CONTAINER:mysql \
+                  -v $PWD/docker/sql_validate.sh:/working/sql_validate.sh \
+                  broadinstitute/dsde-toolbox:mysql8 \
+                  /working/sql_validate.sh rawls
     if [ 0 -eq $? ]; then
         echo "mysql validation succeeded."
     else

--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # The CloudSQL console simply states "MySQL 5.7" so we may not match the minor version number
+MYSQL_IMAGE=mysql
 MYSQL_VERSION=5.7
 start() {
 
@@ -10,11 +11,20 @@ start() {
 
     # start up mysql
     echo "starting up mysql container..."
-    docker run --name $CONTAINER -e MYSQL_ROOT_HOST='%' -e MYSQL_ROOT_PASSWORD=rawls-test -e MYSQL_USER=rawls-test -e MYSQL_PASSWORD=rawls-test -e MYSQL_DATABASE=testdb -d -p 3310:3306 mysql/mysql-server:$MYSQL_VERSION --character-set-server=utf8
+    # flags for this mysql server:
+    #   binlog-format=ROW matches CloudSQL: https://cloud.google.com/sql/docs/mysql/flags#system_flags_changed_in
+    #   log_bin_trust_function_creators=ON enables create function and create trigger without the SUPER privilege
+    docker run --name $CONTAINER \
+                  -e MYSQL_ROOT_HOST='%' -e MYSQL_ROOT_PASSWORD=rawls-test -e MYSQL_USER=rawls-test \
+                  -e MYSQL_PASSWORD=rawls-test -e MYSQL_DATABASE=testdb \
+                  -d -p 3310:3306 $MYSQL_IMAGE:$MYSQL_VERSION \
+                  --character-set-server=utf8 \
+                  --binlog-format=ROW \
+                  --log_bin_trust_function_creators=ON
 
     # validate mysql
     echo "running mysql validation..."
-    docker run --rm --link $CONTAINER:mysql -v $PWD/docker/sql_validate.sh:/working/sql_validate.sh broadinstitute/dsde-toolbox /working/sql_validate.sh rawls
+    docker run --rm --link $CONTAINER:mysql -v $PWD/docker/sql_validate.sh:/working/sql_validate.sh broadinstitute/dsde-toolbox:mysql8 /working/sql_validate.sh rawls
     if [ 0 -eq $? ]; then
         echo "mysql validation succeeded."
     else


### PR DESCRIPTION
Ticket: [AJ-1247](https://broadworkbench.atlassian.net/browse/AJ-1247)

This tweaks the script which starts MySQL, used by unit tests. Changes to the script:
* move from the `mysql/mysql-server` docker image to the `mysql` image. [`mysql`](https://hub.docker.com/_/mysql) is the official image, while [`mysql/mysql-server`](https://hub.docker.com/r/mysql/mysql-server) is "Created, maintained and supported by the MySQL team at Oracle". They seem to run on different OSes ([link](https://stackoverflow.com/questions/44854843/docker-is-there-any-difference-between-the-two-mysql-docker-images)).
* adds `--binlog-format=ROW`, since that is [set by Google for CloudSQL and not changeable](https://cloud.google.com/sql/docs/mysql/flags#system_flags_changed_in).
* adds `--log_bin_trust_function_creators=ON`. This has no effect on 5.7, but will be required when we move to MySQL 8.  We have some `create function` and `create trigger` calls in Liquibase changesets which will cause errors otherwise. Because Google requires `--binlog-format=ROW`, I do not believe these functions and triggers cause any problem, so it is safe to set `--log_bin_trust_function_creators=ON`. For (lots) more detail, start at https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_log_bin_trust_function_creators.
* switch from the `dsde-toolbox` image to `dsde-toolbox:mysql8`. This works just fine against mysql 5.7, and will be required when we move to MySQL 8.
* formatting.

At some point after this PR merges, we will need to set `log_bin_trust_function_creators=ON` for the live CloudSQL databases.

FWIW, I poked at ways to rewrite our `create trigger` and `create function` calls to avoid adding `--log_bin_trust_function_creators=ON`. I do not believe this is possible, without also giving the `rawls` db user the `SUPER` privilege. I would rather set `--log_bin_trust_function_creators=ON` than grant SUPER.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-1247]: https://broadworkbench.atlassian.net/browse/AJ-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ