### PR TITLE
AJ-1247: revert mysql docker image change

### DIFF
--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # The CloudSQL console simply states "MySQL 5.7" so we may not match the minor version number
-MYSQL_IMAGE=mysql
+# The docker version installed on DSP Jenkins does not like the "mysql" docker image, so we use "mysql/mysql-server"
+#     instead. Re-evaluate this sometime after Jenkins is no longer in use.
+MYSQL_IMAGE=mysql/mysql-server
 MYSQL_VERSION=5.7
 start() {
 


### PR DESCRIPTION
Ticket: [AJ-1247](https://broadworkbench.atlassian.net/browse/AJ-1247)

Reverts back to using the `mysql/mysql-server` docker image instead of `mysql` - see #2693.

DSP Jenkins does not like the `mysql` image.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-1247]: https://broadworkbench.atlassian.net/browse/AJ-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ