### PR TITLE
[WOR-849][WOR-850][WOR-852] Create BPM billing profile for GCP billing projects.

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -539,11 +539,11 @@ object Boot extends IOApp with LazyLogging {
           notificationDAO,
           billingRepository,
           new GoogleBillingProjectLifecycle(billingRepository, billingProfileManagerDAO, samDAO, gcsDAO),
-          new BpmBillingProjectLifecycle(samDAO,
-                                         billingRepository,
-                                         billingProfileManagerDAO,
-                                         workspaceManagerDAO,
-                                         workspaceManagerResourceMonitorRecordDao
+          new AzureBillingProjectLifecycle(samDAO,
+                                           billingRepository,
+                                           billingProfileManagerDAO,
+                                           workspaceManagerDAO,
+                                           workspaceManagerResourceMonitorRecordDao
           ),
           workspaceManagerResourceMonitorRecordDao,
           multiCloudWorkspaceConfig

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -538,7 +538,7 @@ object Boot extends IOApp with LazyLogging {
           samDAO,
           notificationDAO,
           billingRepository,
-          new GoogleBillingProjectLifecycle(billingRepository, samDAO, gcsDAO),
+          new GoogleBillingProjectLifecycle(billingRepository, billingProfileManagerDAO, samDAO, gcsDAO),
           new BpmBillingProjectLifecycle(samDAO,
                                          billingRepository,
                                          billingProfileManagerDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycle.scala
@@ -4,10 +4,8 @@ import akka.http.scaladsl.model.StatusCodes.InternalServerError
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.client.ApiException
-import bio.terra.profile.client.{ApiException => BpmApiException}
 import bio.terra.workspace.model.{CreateLandingZoneResult, DeleteAzureLandingZoneResult}
 import cats.implicits.{catsSyntaxFlatMapOps, toTraverseOps}
-import org.apache.http.HttpStatus
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
@@ -34,7 +32,7 @@ import scala.util.{Failure, Success, Try}
   * This class knows how to validate Rawls billing project requests and instantiate linked billing profiles in the
   * billing profile manager service.
   */
-class BpmBillingProjectLifecycle(
+class AzureBillingProjectLifecycle(
   val samDAO: SamDAO,
   val billingRepository: BillingRepository,
   billingProfileManagerDAO: BillingProfileManagerDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
@@ -5,9 +5,11 @@ import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi, Unauthent
 import bio.terra.profile.client.ApiClient
 import io.opencensus.trace.Tracing
 import io.opentelemetry.api.GlobalOpenTelemetry
+import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 import org.broadinstitute.dsde.rawls.util.{TracingUtils, WithOtelContextFilter}
 import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.jdk.connector.JdkConnectorProvider
 
 /**
  * Implementors of this trait know how to instantiate billing profile manager client
@@ -28,6 +30,11 @@ trait BillingProfileManagerClientProvider {
 class HttpBillingProfileManagerClientProvider(baseBpmUrl: Option[String]) extends BillingProfileManagerClientProvider {
   def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient()
+
+    val clientConfig = new ClientConfig()
+    clientConfig.connectorProvider(new JdkConnectorProvider)
+    client.setHttpClient(ClientBuilder.newClient(clientConfig))
+
     TracingUtils.enableCrossServiceTracing(client.getHttpClient, ctx)
     client.setBasePath(basePath)
     client.setAccessToken(ctx.userInfo.accessToken.token)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -154,7 +154,7 @@ class BillingProfileManagerDAOImpl(
       case Left(billingAccountName) =>
         val rawlsBillingAccountName = billingAccountName
         new CreateProfileRequest()
-          .billingAccountId(rawlsBillingAccountName.value)
+          .billingAccountId(rawlsBillingAccountName.withoutPrefix())
           .displayName(displayName)
           .id(UUID.randomUUID())
           .biller("direct") // community terra is always 'direct' (i.e., no reseller)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -151,7 +151,7 @@ class BillingProfileManagerDAOImpl(
     // create the profile
     val profileApi = apiClientProvider.getProfileApi(ctx)
     val createProfileRequest = billingInfo match {
-      case Left(billingAccountName) => {
+      case Left(billingAccountName) =>
         val rawlsBillingAccountName = billingAccountName
         new CreateProfileRequest()
           .billingAccountId(rawlsBillingAccountName.value)
@@ -160,7 +160,7 @@ class BillingProfileManagerDAOImpl(
           .biller("direct") // community terra is always 'direct' (i.e., no reseller)
           .cloudPlatform(CloudPlatform.GCP)
           .policies(policyInputs)
-      } // OH, BUT IT COULD BE!!!!
+
       case Right(coords) =>
         val azureManagedAppCoordinates = coords
         new CreateProfileRequest()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -150,28 +150,28 @@ class BillingProfileManagerDAOImpl(
 
     // create the profile
     val profileApi = apiClientProvider.getProfileApi(ctx)
+
+    val commonCreateProfileRequest =
+      new CreateProfileRequest()
+        .displayName(displayName)
+        .id(UUID.randomUUID())
+        .biller("direct") // community terra is always 'direct' (i.e., no reseller)
+        .policies(policyInputs)
+
     val createProfileRequest = billingInfo match {
       case Left(billingAccountName) =>
         val rawlsBillingAccountName = billingAccountName
-        new CreateProfileRequest()
+        commonCreateProfileRequest
           .billingAccountId(rawlsBillingAccountName.withoutPrefix())
-          .displayName(displayName)
-          .id(UUID.randomUUID())
-          .biller("direct") // community terra is always 'direct' (i.e., no reseller)
           .cloudPlatform(CloudPlatform.GCP)
-          .policies(policyInputs)
 
       case Right(coords) =>
         val azureManagedAppCoordinates = coords
-        new CreateProfileRequest()
+        commonCreateProfileRequest
           .tenantId(azureManagedAppCoordinates.tenantId)
           .subscriptionId(azureManagedAppCoordinates.subscriptionId)
           .managedResourceGroupId(azureManagedAppCoordinates.managedResourceGroupId)
-          .displayName(displayName)
-          .id(UUID.randomUUID())
-          .biller("direct") // community terra is always 'direct' (i.e., no reseller)
           .cloudPlatform(CloudPlatform.AZURE)
-          .policies(policyInputs)
     }
 
     logger.info(s"Creating billing profile [id=${createProfileRequest.getId}]")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -50,7 +50,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
                                  notificationDAO: NotificationDAO,
                                  billingRepository: BillingRepository,
                                  googleBillingProjectLifecycle: BillingProjectLifecycle,
-                                 bpmBillingProjectLifecycle: BillingProjectLifecycle,
+                                 azureBillingProjectLifecycle: BillingProjectLifecycle,
                                  config: MultiCloudWorkspaceConfig,
                                  resourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao
 )(implicit val executionContext: ExecutionContext)
@@ -73,7 +73,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
 
     val billingProjectLifecycle = createProjectRequest.billingInfo match {
       case Left(_)  => googleBillingProjectLifecycle
-      case Right(_) => bpmBillingProjectLifecycle
+      case Right(_) => azureBillingProjectLifecycle
     }
     val billingProjectName = createProjectRequest.projectName
 
@@ -184,10 +184,10 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
               )
             )
         }
-      billingProfileId <- billingRepository.getBillingProfileId(projectName)
-      projectLifecycle = billingProfileId match {
+      azureManagedAppCoordinates <- billingRepository.getAzureManagedAppCoordinates(projectName)
+      projectLifecycle = azureManagedAppCoordinates match {
         case None    => googleBillingProjectLifecycle
-        case Some(_) => bpmBillingProjectLifecycle
+        case Some(_) => azureBillingProjectLifecycle
       }
       _ <- billingRepository.failUnlessHasNoWorkspaces(projectName)
       _ <- billingRepository.getCreationStatus(projectName).map { status =>
@@ -223,7 +223,7 @@ object BillingProjectOrchestrator {
     notificationDAO: NotificationDAO,
     billingRepository: BillingRepository,
     googleBillingProjectLifecycle: GoogleBillingProjectLifecycle,
-    bpmBillingProjectLifecycle: AzureBillingProjectLifecycle,
+    azureBillingProjectLifecycle: AzureBillingProjectLifecycle,
     resourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao,
     config: MultiCloudWorkspaceConfig
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): BillingProjectOrchestrator =
@@ -233,7 +233,7 @@ object BillingProjectOrchestrator {
       notificationDAO,
       billingRepository,
       googleBillingProjectLifecycle,
-      bpmBillingProjectLifecycle,
+      azureBillingProjectLifecycle,
       config,
       resourceMonitorRecordDao
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -223,7 +223,7 @@ object BillingProjectOrchestrator {
     notificationDAO: NotificationDAO,
     billingRepository: BillingRepository,
     googleBillingProjectLifecycle: GoogleBillingProjectLifecycle,
-    bpmBillingProjectLifecycle: BpmBillingProjectLifecycle,
+    bpmBillingProjectLifecycle: AzureBillingProjectLifecycle,
     resourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao,
     config: MultiCloudWorkspaceConfig
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): BillingProjectOrchestrator =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -4,10 +4,10 @@ import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
   ErrorReport,
   RawlsBillingProject,
-  RawlsBillingProjectName,
-  WorkspaceVersions
+  RawlsBillingProjectName
 }
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 
@@ -49,6 +49,17 @@ class BillingRepository(dataSource: SlickDataSource) {
           throw new RawlsException(s"Billing Project ${projectName.value} does not exist in Rawls database")
         )
         .billingProfileId
+    }
+
+  def getAzureManagedAppCoordinates(
+    projectName: RawlsBillingProjectName
+  )(implicit executionContext: ExecutionContext): Future[Option[AzureManagedAppCoordinates]] =
+    getBillingProject(projectName) map { billingProjectOpt =>
+      billingProjectOpt
+        .getOrElse(
+          throw new RawlsException(s"Billing Project ${projectName.value} does not exist in Rawls database")
+        )
+        .azureManagedAppCoordinates
     }
 
   def deleteBillingProject(projectName: RawlsBillingProjectName): Future[Boolean] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -81,6 +81,6 @@ class GoogleBillingProjectLifecycle(
   override def finalizeDelete(projectName: RawlsBillingProjectName, ctx: RawlsRequestContext)(implicit
     executionContext: ExecutionContext
   ): Future[Unit] =
-    unregisterBillingProject(projectName, ctx)
-
+    // Should change this to expecting a billing profile once we have migrated all billing projects (WOR-866)
+    deleteBillingProfileAndUnregisterBillingProject(projectName, billingProfileExpected = false, ctx)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -65,6 +65,7 @@ class GoogleBillingProjectLifecycle(
     for {
       - <- createBillingProfile(createProjectRequest, ctx).flatMap { profileModel =>
         addMembersToBillingProfile(profileModel, createProjectRequest, ctx)
+        billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
       }
       _ <- syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO, createProjectRequest.projectName)
     } yield CreationStatuses.Ready

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -1,8 +1,6 @@
 package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
-import bio.terra.profile.model.ProfileModel
-import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
   GoogleBillingProjectDelete,
@@ -25,7 +23,7 @@ import org.broadinstitute.dsde.rawls.user.UserService.{
 }
 
 import java.util.UUID
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 class GoogleBillingProjectLifecycle(
   val billingRepository: BillingRepository,
@@ -63,47 +61,13 @@ class GoogleBillingProjectLifecycle(
   override def postCreationSteps(createProjectRequest: CreateRawlsV2BillingProjectFullRequest,
                                  config: MultiCloudWorkspaceConfig,
                                  ctx: RawlsRequestContext
-  ): Future[CreationStatus] = {
-    val projectName = createProjectRequest.projectName
-
-    // This is where we create a billing profile in the BPM case.
-    def createBillingProfile: Future[ProfileModel] =
-      Future(blocking {
-        val policies: Map[String, List[(String, String)]] =
-          if (createProjectRequest.protectedData.getOrElse(false)) Map("protected-data" -> List[(String, String)]())
-          else Map.empty
-        val profileModel = billingProfileManagerDAO.createBillingProfile(
-          projectName.value,
-          createProjectRequest.billingInfo,
-          policies,
-          ctx
-        )
-        logger.info(
-          s"Creating BPM-backed billing project ${projectName.value}, created profile with ID ${profileModel.getId}."
-        )
-        profileModel
-      })
-
-    def addMembersToBillingProfile(profileModel: ProfileModel): Future[Set[Unit]] = {
-      val members = createProjectRequest.members.getOrElse(Set.empty)
-      Future.traverse(members) { member =>
-        Future(blocking {
-          billingProfileManagerDAO.addProfilePolicyMember(profileModel.getId,
-                                                          ProfilePolicy.fromProjectRole(member.role),
-                                                          member.email,
-                                                          ctx
-          )
-        })
-      }
-    }
-
+  ): Future[CreationStatus] =
     for {
-      - <- createBillingProfile.flatMap { profileModel =>
-        addMembersToBillingProfile(profileModel)
+      - <- createBillingProfile(createProjectRequest, ctx).flatMap { profileModel =>
+        addMembersToBillingProfile(profileModel, createProjectRequest, ctx)
       }
       _ <- syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO, createProjectRequest.projectName)
     } yield CreationStatuses.Ready
-  }
 
   override def initiateDelete(projectName: RawlsBillingProjectName, ctx: RawlsRequestContext)(implicit
     executionContext: ExecutionContext

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -63,10 +63,9 @@ class GoogleBillingProjectLifecycle(
                                  ctx: RawlsRequestContext
   ): Future[CreationStatus] =
     for {
-      - <- createBillingProfile(createProjectRequest, ctx).flatMap { profileModel =>
-        addMembersToBillingProfile(profileModel, createProjectRequest, ctx)
-        billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
-      }
+      profileModel <- createBillingProfile(createProjectRequest, ctx)
+      _ <- addMembersToBillingProfile(profileModel, createProjectRequest, ctx)
+      _ <- billingRepository.setBillingProfileId(createProjectRequest.projectName, profileModel.getId)
       _ <- syncBillingProjectOwnerPolicyToGoogleAndGetEmail(samDAO, createProjectRequest.projectName)
     } yield CreationStatuses.Ready
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 import com.typesafe.config.{Config, ConfigRenderOptions}
 import com.typesafe.scalalogging.LazyLogging
 import net.ceedubs.ficus.Ficus.{optionValueReader, toFicusConfig}
-import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmBillingProjectLifecycle}
+import org.broadinstitute.dsde.rawls.billing.{AzureBillingProjectLifecycle, BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.config.FastPassConfig
 import org.broadinstitute.dsde.rawls.coordination.{
   CoordinatedDataSourceAccess,
@@ -476,11 +476,11 @@ object BootMonitors extends LazyLogging {
             gcsDAO,
             workspaceManagerDAO,
             billingRepo,
-            new BpmBillingProjectLifecycle(samDAO,
-                                           billingRepo,
-                                           billingProfileManagerDAO,
-                                           workspaceManagerDAO,
-                                           monitorRecordDao
+            new AzureBillingProjectLifecycle(samDAO,
+                                             billingRepo,
+                                             billingProfileManagerDAO,
+                                             workspaceManagerDAO,
+                                             monitorRecordDao
             )
           )
         )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -879,7 +879,8 @@ class UserService(
       .listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx)
       .map(resourceRoles => samRolesToProjectRoles(resourceRoles))
   } yield project.flatMap { p =>
-    if (projectRoles.nonEmpty) Some(RawlsBillingProjectResponse(projectRoles, p, platform = CloudPlatform.GCP)) else None
+    if (projectRoles.nonEmpty) Some(RawlsBillingProjectResponse(projectRoles, p, platform = CloudPlatform.GCP))
+    else None
   }
 
   private def updateBillingAccountInBillingProfile(billingProfileId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -8,6 +8,7 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.api.client.http.HttpResponseException
 import com.typesafe.scalalogging.LazyLogging
+import io.sentry.Sentry
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -851,12 +852,40 @@ class UserService(
     billingAccount: Option[RawlsBillingAccountName]
   ): Future[Option[RawlsBillingProjectResponse]] = for {
     project <- updateBillingAccountInDatabase(projectName, billingAccount)
+    _ <- project
+      .collect { p =>
+        p.billingProfileId.collect { pf =>
+          updateBillingAccountInBillingProfile(pf, billingAccount)
+        }
+      }
+      .flatten
+      .sequence
     projectRoles <- samDAO
       .listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx)
       .map(resourceRoles => samRolesToProjectRoles(resourceRoles))
   } yield project.flatMap { p =>
     if (projectRoles.nonEmpty) Some(RawlsBillingProjectResponse(projectRoles, p)) else None
   }
+
+  private def updateBillingAccountInBillingProfile(billingProfileId: String,
+                                                   billingAccount: Option[RawlsBillingAccountName]
+  ): Future[Unit] =
+    (billingAccount match {
+      case Some(newBillingAccount) =>
+        billingProfileManagerDAO
+          .updateBillingProfile(UUID.fromString(billingProfileId), newBillingAccount, ctx)
+          .flatMap(_ => Future.unit)
+      case None =>
+        billingProfileManagerDAO.removeBillingAccountFromBillingProfile(UUID.fromString(billingProfileId), ctx)
+    }).recover {
+      // Until BPM is the system of record for Terra billing information, Rawls will not throw an exception if BPM fails to update
+      case e: Exception =>
+        val message =
+          s"Failed to update billing account in BPM [billingProfile=$billingProfileId, billingAccount=${billingAccount
+              .map(_.value)}]"
+        logger.warn(message, e)
+        Sentry.captureException(new RawlsException(message, cause = e))
+    }
 
   private def updateBillingAccountInDatabase(billingProjectName: RawlsBillingProjectName,
                                              billingAccountName: Option[RawlsBillingAccountName]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -879,7 +879,7 @@ class UserService(
       .listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx)
       .map(resourceRoles => samRolesToProjectRoles(resourceRoles))
   } yield project.flatMap { p =>
-    if (projectRoles.nonEmpty) Some(RawlsBillingProjectResponse(projectRoles, p)) else None
+    if (projectRoles.nonEmpty) Some(RawlsBillingProjectResponse(projectRoles, p, platform = CloudPlatform.GCP)) else None
   }
 
   private def updateBillingAccountInBillingProfile(billingProfileId: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -986,6 +986,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
 
     verify(bpm).deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext))
+    verify(repo).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
   }
 
   it should "not delete the billing profile if other projects reference it" in {
@@ -1029,6 +1030,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
 
     verify(bpm, Mockito.never).deleteBillingProfile(billingProfileId, testContext)
+    // Billing project is still deleted
+    verify(repo).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
   }
 
   it should "succeed if the billing profile id does not exist" in {
@@ -1091,5 +1094,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
       Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
     }
     verify(bpm).deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext))
+    verify(repo, Mockito.never).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -418,16 +418,23 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
                  Duration.Inf
     )
 
-    verify(bpm, Mockito.times(2)).addProfilePolicyMember(
+    verify(bpm).addProfilePolicyMember(
       ArgumentMatchers.eq(profileModel.getId),
       ArgumentMatchers.eq(ProfilePolicy.Owner),
-      ArgumentMatchers.argThat(arg => Set(user1Email, user2Email).contains(arg)),
-      any[RawlsRequestContext]
+      ArgumentMatchers.eq(user1Email),
+      ArgumentMatchers.any[RawlsRequestContext]
     )
-    verify(bpm, Mockito.times(1)).addProfilePolicyMember(ArgumentMatchers.eq(profileModel.getId),
-                                                         ArgumentMatchers.eq(ProfilePolicy.User),
-                                                         ArgumentMatchers.eq(user3Email),
-                                                         any[RawlsRequestContext]
+    verify(bpm).addProfilePolicyMember(
+      ArgumentMatchers.eq(profileModel.getId),
+      ArgumentMatchers.eq(ProfilePolicy.Owner),
+      ArgumentMatchers.eq(user2Email),
+      ArgumentMatchers.any[RawlsRequestContext]
+    )
+    verify(bpm).addProfilePolicyMember(
+      ArgumentMatchers.eq(profileModel.getId),
+      ArgumentMatchers.eq(ProfilePolicy.User),
+      ArgumentMatchers.eq(user3Email),
+      ArgumentMatchers.any[RawlsRequestContext]
     )
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -40,7 +40,7 @@ import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
-class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
+class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
 
   val userInfo: UserInfo =
@@ -89,7 +89,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
   behavior of "validateBillingProjectCreationRequest"
 
   it should "fail when provided GCP billing info" in {
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       mock[BillingRepository],
       mock[BillingProfileManagerDAO],
@@ -114,7 +114,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     when(bpm.listManagedApps(coords.subscriptionId, false, testContext))
       .thenReturn(Seq())
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       mock[BillingRepository],
       bpm,
@@ -132,7 +132,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(bpm.listManagedApps(coords.subscriptionId, false, testContext))
       .thenThrow(new RuntimeException("failed"))
 
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       mock[BillingRepository],
       bpm,
@@ -156,7 +156,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
             .tenantId(coords.tenantId)
         )
       )
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       mock[BillingRepository],
       bpm,
@@ -192,7 +192,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       .thenReturn(profileModel)
     val monitorRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
 
-    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, monitorRecordDao)
+    val bp = new AzureBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, monitorRecordDao)
 
     intercept[LandingZoneCreationException] {
       Await.result(bp.postCreationSteps(
@@ -268,7 +268,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     doReturn(Future.successful())
       .when(monitorRecordDao)
       .create(any)
-    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, monitorRecordDao)
+    val bp = new AzureBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, monitorRecordDao)
 
     assertResult(CreationStatuses.CreatingLandingZone) {
       Await.result(bp.postCreationSteps(
@@ -325,7 +325,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       .when(wsmResouceRecordDao)
       .create(any)
 
-    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, wsmResouceRecordDao)
+    val bp = new AzureBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, wsmResouceRecordDao)
 
     assertResult(CreationStatuses.CreatingLandingZone) {
       Await.result(bp.postCreationSteps(
@@ -363,7 +363,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val wsmResourceRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
-    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, wsmResourceRecordDao)
+    val bp = new AzureBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, wsmResourceRecordDao)
 
     val user1Email = "user1@foo.bar"
     val user2Email = "user2@foo.bar"
@@ -443,7 +443,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
       .thenThrow(new RuntimeException(thrownExceptionMessage))
 
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       mock[BillingRepository],
       bpm,
@@ -500,7 +500,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       .when(wsmResouceRecordDao)
       .create(any)
 
-    val bp = new BpmBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, wsmResouceRecordDao)
+    val bp = new AzureBillingProjectLifecycle(mock[SamDAO], repo, bpm, workspaceManagerDAO, wsmResouceRecordDao)
 
     assertResult(CreationStatuses.CreatingLandingZone) {
       Await.result(bp.postCreationSteps(
@@ -562,11 +562,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       )
     )
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
     val result = bp.postCreationSteps(
       createRequest,
@@ -620,11 +620,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       )
     )
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
     val result = bp.postCreationSteps(
       createRequest,
@@ -673,11 +673,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       )
     )
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
     val result = bp.postCreationSteps(
       createRequest,
@@ -736,11 +736,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
 
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
     val result = bp.postCreationSteps(
       createRequest,
@@ -805,11 +805,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
 
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
     val result = bp.postCreationSteps(
       createRequest,
@@ -834,11 +834,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
 
     val jobId = Await.result(bp.initiateDelete(billingProjectName, testContext), Duration.Inf)
@@ -862,11 +862,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
         Some(new DeleteAzureLandingZoneResult().jobReport(new JobReport().id(jobReportId.toString)))
       )
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
 
     Await.result(bp.initiateDelete(billingProjectName, testContext), Duration.Inf) shouldBe (Some(jobReportId))
@@ -885,11 +885,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(workspaceManagerDAO.deleteLandingZone(landingZoneId, testContext))
       .thenAnswer(_ => None)
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
 
     Await.result(bp.initiateDelete(billingProjectName, testContext), Duration.Inf) shouldBe None
@@ -928,11 +928,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
       )
     )
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
 
     val e = intercept[RawlsExceptionWithErrorReport](
@@ -968,7 +968,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     val bpm = mock[BillingProfileManagerDAO]
     doNothing().when(bpm).deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext))
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       repo,
       bpm,
@@ -1012,11 +1012,11 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val bp =
-      new BpmBillingProjectLifecycle(mock[SamDAO],
-                                     repo,
-                                     bpm,
-                                     workspaceManagerDAO,
-                                     mock[WorkspaceManagerResourceMonitorRecordDao]
+      new AzureBillingProjectLifecycle(mock[SamDAO],
+                                       repo,
+                                       bpm,
+                                       workspaceManagerDAO,
+                                       mock[WorkspaceManagerResourceMonitorRecordDao]
       )
 
     Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
@@ -1032,7 +1032,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val bp =
-      new BpmBillingProjectLifecycle(
+      new AzureBillingProjectLifecycle(
         mock[SamDAO],
         repo,
         bpm,
@@ -1072,7 +1072,7 @@ class BpmBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(bpm.deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext)))
       .thenAnswer(_ => throw new BpmApiException(HttpStatus.SC_FORBIDDEN, "forbidden"))
 
-    val bp = new BpmBillingProjectLifecycle(
+    val bp = new AzureBillingProjectLifecycle(
       mock[SamDAO],
       repo,
       bpm,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -128,15 +128,6 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
 
   behavior of "createBillingProfile"
 
-  it should "fail when provided with Google billing account information" in {
-    val provider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)
-    val bpmDAO = new BillingProfileManagerDAOImpl(provider, multiCloudWorkspaceConfig)
-
-    intercept[NotImplementedError] {
-      bpmDAO.createBillingProfile("fake", Left(RawlsBillingAccountName("fake")), Map.empty, testContext)
-    }
-  }
-
   it should "create a GCP profile in billing profile manager if given RawlsBillingAccountName" in {
     val provider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)
     val profileApi = mock[ProfileApi](RETURNS_SMART_NULLS)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.billing
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi}
@@ -33,6 +34,7 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
+  implicit val actor: ActorSystem = ActorSystem("BillingProfileManagerDAOSpec")
 
   val azConfig: AzureConfig = AzureConfig(
     "fake-landing-zone-definition",
@@ -301,6 +303,84 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
 
     result.length should be(BillingProfileManagerDAO.BillingProfileRequestBatchSize + 1)
 
+  }
+
+  behavior of "updateBillingProfile"
+
+  it should "retry 5xx errors" in {
+    val profileApi = mock[ProfileApi]
+    when(profileApi.updateProfile(any(), any()))
+      .thenThrow(new ApiException(StatusCodes.InternalServerError.intValue, "internal server error"))
+      .thenReturn(new ProfileModel().id(UUID.randomUUID()))
+
+    val apiProvider = mock[BillingProfileManagerClientProvider]
+    when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
+
+    val bpmDAO = new BillingProfileManagerDAOImpl(apiProvider, multiCloudWorkspaceConfig)
+
+    Await.result(bpmDAO.updateBillingProfile(UUID.randomUUID(), RawlsBillingAccountName("billingAccount"), testContext),
+                 Duration.Inf
+    )
+
+    verify(profileApi, times(2)).updateProfile(any(), any())
+  }
+
+  it should "throw 4xx errors" in {
+    val profileApi = mock[ProfileApi]
+    when(profileApi.updateProfile(any(), any()))
+      .thenThrow(new ApiException(StatusCodes.Forbidden.intValue, "forbidden"))
+      .thenReturn(new ProfileModel().id(UUID.randomUUID()))
+
+    val apiProvider = mock[BillingProfileManagerClientProvider]
+    when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
+
+    val bpmDAO = new BillingProfileManagerDAOImpl(apiProvider, multiCloudWorkspaceConfig)
+
+    assertThrows[ApiException] {
+      Await.result(
+        bpmDAO.updateBillingProfile(UUID.randomUUID(), RawlsBillingAccountName("billingAccount"), testContext),
+        Duration.Inf
+      )
+    }
+    verify(profileApi, times(1)).updateProfile(any(), any())
+  }
+
+  behavior of "removeBillingAccount"
+
+  it should "retry 5xx errors" in {
+    val profileApi = mock[ProfileApi]
+    doThrow(new ApiException(StatusCodes.InternalServerError.intValue, "internal server error"))
+      .doNothing()
+      .when(profileApi)
+      .removeBillingAccount(any())
+
+    val apiProvider = mock[BillingProfileManagerClientProvider]
+    when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
+
+    val bpmDAO = new BillingProfileManagerDAOImpl(apiProvider, multiCloudWorkspaceConfig)
+
+    Await.result(bpmDAO.removeBillingAccountFromBillingProfile(UUID.randomUUID(), testContext), Duration.Inf)
+
+    verify(profileApi, times(2)).removeBillingAccount(any())
+  }
+
+  it should "throw 4xx errors" in {
+    val profileApi = mock[ProfileApi]
+    doThrow(new ApiException(StatusCodes.Forbidden.intValue, "internal server error"))
+      .doNothing()
+      .when(profileApi)
+      .removeBillingAccount(any())
+
+    val apiProvider = mock[BillingProfileManagerClientProvider]
+    when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
+
+    val bpmDAO = new BillingProfileManagerDAOImpl(apiProvider, multiCloudWorkspaceConfig)
+
+    assertThrows[ApiException] {
+      Await.result(bpmDAO.removeBillingAccountFromBillingProfile(UUID.randomUUID(), testContext), Duration.Inf)
+    }
+
+    verify(profileApi, times(1)).removeBillingAccount(any())
   }
 
   behavior of "addProfilePolicyMember"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -132,7 +132,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     val provider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)
     val profileApi = mock[ProfileApi](RETURNS_SMART_NULLS)
     val expectedProfile = new ProfileModel().id(UUID.randomUUID())
-    val billingAccountName = RawlsBillingAccountName("fake")
+    val billingAccountName = RawlsBillingAccountName("billingAccounts/billingAccountName")
     when(profileApi.createProfile(ArgumentMatchers.any[CreateProfileRequest])).thenReturn(expectedProfile)
     when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
     val bpmDAO = new BillingProfileManagerDAOImpl(provider, multiCloudWorkspaceConfig)
@@ -143,7 +143,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     val createProfileRequestCaptor = captor[CreateProfileRequest]
     verify(profileApi).createProfile(createProfileRequestCaptor.capture)
     assertResult(CloudPlatform.GCP)(createProfileRequestCaptor.getValue.getCloudPlatform)
-    assertResult(billingAccountName.value)(createProfileRequestCaptor.getValue.getBillingAccountId)
+    assertResult("billingAccountName")(createProfileRequestCaptor.getValue.getBillingAccountId)
   }
 
   it should "create an Azure profile in billing profile manager if given AzureManagedAppCoordinates" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -173,7 +173,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     assertResult(coords.managedResourceGroupId)(createProfileRequestCaptor.getValue.getManagedResourceGroupId)
     assertResult(coords.tenantId)(createProfileRequestCaptor.getValue.getTenantId)
     assertResult(coords.subscriptionId)(createProfileRequestCaptor.getValue.getSubscriptionId)
-}
+  }
 
   it should "include an empty set of policy inputs if no policies are present" in {
     val provider = mock[BillingProfileManagerClientProvider](RETURNS_SMART_NULLS)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectLifecycleSpec.scala
@@ -49,9 +49,12 @@ class BillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.deleteBillingProject(billingProjectName)).thenReturn(Future.successful(true))
     when(repo.getBillingProfileId(billingProjectName)(executionContext)).thenReturn(Future.successful(None))
 
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
     val billingLifecycle = new BillingProjectLifecycle {
       override val samDAO: SamDAO = samDAOMock
       override val billingRepository: BillingRepository = repo
+      override val billingProfileManagerDAO: BillingProfileManagerDAO = bpmDAO
       override val deleteJobType: JobType = GoogleBillingProjectDelete
 
       override def validateBillingProjectCreationRequest(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -81,7 +81,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       mock[NotificationDAO],
       billingRepository,
       gbp,
-      mock[BpmBillingProjectLifecycle],
+      mock[AzureBillingProjectLifecycle],
       mock[MultiCloudWorkspaceConfig],
       mock[WorkspaceManagerResourceMonitorRecordDao]
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMo
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.BpmBillingProjectDelete
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
   ErrorReport,
@@ -50,6 +51,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     Map("fake_parameter" -> "fake_value"),
     landingZoneAllowAttach = false
   )
+  val azureManagedAppCoordinates: AzureManagedAppCoordinates =
+    AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
 
   val userInfo: UserInfo =
     UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
@@ -333,12 +336,14 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     billingProjectLifecycle
   }
 
-  def happyBillingRepository(profileId: Option[String]): BillingRepository = {
+  def happyBillingRepository(azureManagedAppCoordinates: Option[AzureManagedAppCoordinates]): BillingRepository = {
     val billingRepository = mock[BillingRepository]
     when(billingRepository.failUnlessHasNoWorkspaces(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(ArgumentMatchers.any())(ArgumentMatchers.any()))
-      .thenReturn(Future.successful(profileId))
+      .thenReturn(Future.successful(Some(UUID.randomUUID().toString)))
+    when(billingRepository.getAzureManagedAppCoordinates(ArgumentMatchers.any())(ArgumentMatchers.any()))
+      .thenReturn(Future.successful(azureManagedAppCoordinates))
     when(billingRepository.updateCreationStatus(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(Future.successful(1))
     when(billingRepository.getCreationStatus(ArgumentMatchers.any())(ArgumentMatchers.any()))
@@ -399,7 +404,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
         )
       )
     // Mock Google project
-    when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
       .thenReturn(Future.successful(None))
 
     val bpo = new BillingProjectOrchestrator(
@@ -429,6 +434,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
       .thenReturn(Future.successful(Some("fake-id")))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
+      .thenReturn(Future.successful(Some(azureManagedAppCoordinates)))
     when(billingRepository.getCreationStatus(billingProjectName)(executionContext))
       .thenReturn(Future.successful(CreationStatuses.Ready))
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
@@ -455,7 +462,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     verify(billingRepository, never()).deleteBillingProject(billingProjectName)
   }
 
-  it should "call initiateDelete and finializeDelete for the google lifecycle for a google project" in {
+  it should "call initiateDelete and finalizeDelete for the google lifecycle for a google project" in {
     val billingProjectName = RawlsBillingProjectName("fake_billing_account_name")
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
     when(billingProjectLifecycle.initiateDelete(billingProjectName, testContext)).thenReturn(Future.successful(None))
@@ -477,7 +484,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     verify(billingProjectLifecycle).finalizeDelete(billingProjectName, testContext)
   }
 
-  it should "call initiateDelete and finializeDelete when the BPM lifecyle returns a jobId of None" in {
+  it should "call initiateDelete and finalizeDelete when the BPM lifecycle returns a jobId of None" in {
     val billingProjectName = RawlsBillingProjectName("fake_billing_account_name")
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
     when(billingProjectLifecycle.initiateDelete(billingProjectName, testContext)).thenReturn(Future.successful(None))
@@ -486,7 +493,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some(UUID.randomUUID().toString)),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       billingProjectLifecycle, // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -511,7 +518,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some("inconsequential_id")),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       billingProjectLifecycle, // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -538,7 +545,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some("inconsequential_id")),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       initiateDeleteLifecycle(Future.successful(Some(jobId))), // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -557,7 +564,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some("inconsequential_id")),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       initiateDeleteLifecycle(Future.failed(new Exception)), // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -577,6 +584,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
       .thenReturn(Future.successful(Some("inconsequential_id")))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
+      .thenReturn(Future.successful(Some(azureManagedAppCoordinates)))
     when(billingRepository.updateCreationStatus(billingProjectName, CreationStatuses.Deleting, None))
       .thenReturn(Future.successful(1))
     when(billingRepository.getCreationStatus(billingProjectName)(executionContext))
@@ -605,6 +614,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
       .thenReturn(Future.successful(Some("inconsequential_id")))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
+      .thenReturn(Future.successful(Some(azureManagedAppCoordinates)))
     when(billingRepository.getCreationStatus(billingProjectName)(executionContext))
       .thenReturn(Future.successful(CreationStatuses.Deleting))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
@@ -24,9 +24,8 @@ import org.broadinstitute.dsde.rawls.model.{
   UserInfo
 }
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{doReturn, verify, when}
-import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
@@ -134,9 +133,9 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     when(
       samDAO.syncPolicyToGoogle(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+        SamResourceTypeNames.billingProject,
+        createRequest.projectName.value,
+        SamBillingProjectPolicyNames.owner
       )
     ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
     val gbp = new GoogleBillingProjectLifecycle(repo, bpm, samDAO, mock[GoogleServicesDAO])
@@ -148,7 +147,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequest.projectName.value),
         ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+        ArgumentMatchers.any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -158,11 +157,11 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
       Await.result(gbp.postCreationSteps(createRequest, mock[MultiCloudWorkspaceConfig], testContext), Duration.Inf)
     }
 
-    verify(samDAO, Mockito.times(1))
+    verify(samDAO)
       .syncPolicyToGoogle(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+        SamResourceTypeNames.billingProject,
+        createRequest.projectName.value,
+        SamBillingProjectPolicyNames.owner
       )
   }
 
@@ -186,7 +185,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequest.projectName.value),
         ArgumentMatchers.eq(createRequest.billingInfo),
-        any(),
+        ArgumentMatchers.any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -194,9 +193,9 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
     when(
       samDAO.syncPolicyToGoogle(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+        SamResourceTypeNames.billingProject,
+        createRequest.projectName.value,
+        SamBillingProjectPolicyNames.owner
       )
     ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
 
@@ -205,7 +204,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
     doReturn(Future.successful())
       .when(wsmResourceRecordDao)
-      .create(any)
+      .create(ArgumentMatchers.any)
 
     Await.result(bp.postCreationSteps(
                    createRequest,
@@ -215,7 +214,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
                  Duration.Inf
     )
 
-    verify(repo, Mockito.times(1)).setBillingProfileId(
+    verify(repo).setBillingProfileId(
       createRequest.projectName,
       profileModel.getId
     )
@@ -246,7 +245,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
       bpm.createBillingProfile(
         ArgumentMatchers.eq(createRequestWithMembers.projectName.value),
         ArgumentMatchers.eq(createRequestWithMembers.billingInfo),
-        any(),
+        ArgumentMatchers.any(),
         ArgumentMatchers.eq(testContext)
       )
     )
@@ -254,9 +253,9 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
     when(
       samDAO.syncPolicyToGoogle(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+        SamResourceTypeNames.billingProject,
+        createRequest.projectName.value,
+        SamBillingProjectPolicyNames.owner
       )
     ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
 
@@ -265,7 +264,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
     doReturn(Future.successful())
       .when(wsmResourceRecordDao)
-      .create(any)
+      .create(ArgumentMatchers.any)
 
     Await.result(bp.postCreationSteps(
                    createRequestWithMembers,
@@ -275,16 +274,23 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
                  Duration.Inf
     )
 
-    verify(bpm, Mockito.times(2)).addProfilePolicyMember(
+    verify(bpm).addProfilePolicyMember(
       ArgumentMatchers.eq(profileModel.getId),
       ArgumentMatchers.eq(ProfilePolicy.Owner),
-      ArgumentMatchers.argThat(arg => Set(user1Email, user2Email).contains(arg)),
-      any[RawlsRequestContext]
+      ArgumentMatchers.eq(user1Email),
+      ArgumentMatchers.any[RawlsRequestContext]
     )
-    verify(bpm, Mockito.times(1)).addProfilePolicyMember(ArgumentMatchers.eq(profileModel.getId),
-                                                         ArgumentMatchers.eq(ProfilePolicy.User),
-                                                         ArgumentMatchers.eq(user3Email),
-                                                         any[RawlsRequestContext]
+    verify(bpm).addProfilePolicyMember(
+      ArgumentMatchers.eq(profileModel.getId),
+      ArgumentMatchers.eq(ProfilePolicy.Owner),
+      ArgumentMatchers.eq(user2Email),
+      ArgumentMatchers.any[RawlsRequestContext]
+    )
+    verify(bpm).addProfilePolicyMember(
+      ArgumentMatchers.eq(profileModel.getId),
+      ArgumentMatchers.eq(ProfilePolicy.User),
+      ArgumentMatchers.eq(user3Email),
+      ArgumentMatchers.any[RawlsRequestContext]
     )
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
@@ -138,11 +138,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
         ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
       )
     ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
-    val gbp = new GoogleBillingProjectLifecycle(mock[BillingRepository],
-                                                bpm,
-                                                samDAO,
-                                                mock[GoogleServicesDAO]
-    )
+    val gbp = new GoogleBillingProjectLifecycle(mock[BillingRepository], bpm, samDAO, mock[GoogleServicesDAO])
 
     when(
       bpm.createBillingProfile(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
@@ -162,7 +162,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
       )
   }
 
-  it should "add additional members to the BPM policy if specified during billing project creation" in {
+  it should "store the billing profile ID add additional members to the BPM policy during billing project creation" in {
     val repo = mock[BillingRepository]
     val bpm = mock[BillingProfileManagerDAO]
     val samDAO = mock[SamDAO]
@@ -226,6 +226,10 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
                                                          ArgumentMatchers.eq(ProfilePolicy.User),
                                                          ArgumentMatchers.eq(user3Email),
                                                          any[RawlsRequestContext]
+    )
+    verify(repo, Mockito.times(1)).setBillingProfileId(
+      createRequestWithMembers.projectName,
+      profileModel.getId
     )
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
@@ -2,12 +2,16 @@ package org.broadinstitute.dsde.rawls.billing
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import bio.terra.profile.model.ProfileModel
 import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.{
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
+  ProjectAccessUpdate,
+  ProjectRoles,
   RawlsBillingAccountName,
   RawlsBillingProjectName,
   RawlsRequestContext,
@@ -20,11 +24,13 @@ import org.broadinstitute.dsde.rawls.model.{
   UserInfo
 }
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.mockito.Mockito.{verify, when}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{doReturn, verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -34,6 +40,17 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
   val userInfo: UserInfo =
     UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
   val testContext = RawlsRequestContext(userInfo)
+
+  val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
+  val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
+    billingProjectName,
+    Some(RawlsBillingAccountName("fake_billing_account_name")),
+    None,
+    None,
+    None,
+    None
+  )
+  val profileModel: ProfileModel = new ProfileModel().id(UUID.randomUUID())
 
   behavior of "validateBillingProjectCreationRequest"
 
@@ -53,7 +70,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
                                                   ArgumentMatchers.eq(userInfo)
       )
     ).thenReturn(Future.successful(false))
-    val gbp = new GoogleBillingProjectLifecycle(mock[BillingRepository], samDAO, gcsDAO)
+    val gbp = new GoogleBillingProjectLifecycle(mock[BillingRepository], mock[BillingProfileManagerDAO], samDAO, gcsDAO)
 
     val ex = intercept[GoogleBillingAccountAccessException] {
       Await.result(gbp.validateBillingProjectCreationRequest(createRequest, testContext), Duration.Inf)
@@ -87,6 +104,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     )
     val bpo = new GoogleBillingProjectLifecycle(
       mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
       samDAO,
       mock[GoogleServicesDAO]
     )
@@ -104,6 +122,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
   it should "sync the policy to google and return creation status Ready" in {
     val samDAO = mock[SamDAO]
+    val bpm = mock[BillingProfileManagerDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
@@ -119,7 +138,21 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
         ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
       )
     ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
-    val gbp = new GoogleBillingProjectLifecycle(mock[BillingRepository], samDAO, mock[GoogleServicesDAO])
+    val gbp = new GoogleBillingProjectLifecycle(mock[BillingRepository],
+                                                bpm,
+                                                samDAO,
+                                                mock[GoogleServicesDAO]
+    )
+
+    when(
+      bpm.createBillingProfile(
+        ArgumentMatchers.eq(createRequest.projectName.value),
+        ArgumentMatchers.eq(createRequest.billingInfo),
+        any(),
+        ArgumentMatchers.eq(testContext)
+      )
+    )
+      .thenReturn(profileModel)
 
     assertResult(CreationStatuses.Ready) {
       Await.result(gbp.postCreationSteps(createRequest, mock[MultiCloudWorkspaceConfig], testContext), Duration.Inf)
@@ -131,5 +164,72 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
         ArgumentMatchers.eq(createRequest.projectName.value),
         ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
       )
+  }
+
+  it should "add additional members to the BPM policy if specified during billing project creation" in {
+    val repo = mock[BillingRepository]
+    val bpm = mock[BillingProfileManagerDAO]
+    val samDAO = mock[SamDAO]
+    val wsmResourceRecordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
+    val bp = new GoogleBillingProjectLifecycle(repo, bpm, samDAO, mock[GoogleServicesDAO])
+
+    val user1Email = "user1@foo.bar"
+    val user2Email = "user2@foo.bar"
+    val user3Email = "user3@foo.bar"
+
+    val createRequestWithMembers = createRequest.copy(members =
+      Some(
+        Set(
+          ProjectAccessUpdate(user1Email, ProjectRoles.Owner),
+          ProjectAccessUpdate(user2Email, ProjectRoles.Owner),
+          ProjectAccessUpdate(user3Email, ProjectRoles.User)
+        )
+      )
+    )
+
+    when(
+      bpm.createBillingProfile(
+        ArgumentMatchers.eq(createRequestWithMembers.projectName.value),
+        ArgumentMatchers.eq(createRequestWithMembers.billingInfo),
+        any(),
+        ArgumentMatchers.eq(testContext)
+      )
+    )
+      .thenReturn(profileModel)
+
+    when(
+      samDAO.syncPolicyToGoogle(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(createRequest.projectName.value),
+        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+      )
+    ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
+
+    when(repo.setBillingProfileId(createRequestWithMembers.projectName, profileModel.getId))
+      .thenReturn(Future.successful(1))
+
+    doReturn(Future.successful())
+      .when(wsmResourceRecordDao)
+      .create(any)
+
+    Await.result(bp.postCreationSteps(
+                   createRequestWithMembers,
+                   mock[MultiCloudWorkspaceConfig],
+                   testContext
+                 ),
+                 Duration.Inf
+    )
+
+    verify(bpm, Mockito.times(2)).addProfilePolicyMember(
+      ArgumentMatchers.eq(profileModel.getId),
+      ArgumentMatchers.eq(ProfilePolicy.Owner),
+      ArgumentMatchers.argThat(arg => Set(user1Email, user2Email).contains(arg)),
+      any[RawlsRequestContext]
+    )
+    verify(bpm, Mockito.times(1)).addProfilePolicyMember(ArgumentMatchers.eq(profileModel.getId),
+                                                         ArgumentMatchers.eq(ProfilePolicy.User),
+                                                         ArgumentMatchers.eq(user3Email),
+                                                         any[RawlsRequestContext]
+    )
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -2023,10 +2023,12 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   }
 
   class MinimalTestData() extends TestData {
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("myNamespace"),
-                                             CreationStatuses.Ready,
-                                             Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
-                                             None
+    val billingProject = RawlsBillingProject(
+      RawlsBillingProjectName("myNamespace"),
+      CreationStatuses.Ready,
+      Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
+      None,
+      billingProfileId = Some(UUID.randomUUID().toString)
     )
     val wsName = WorkspaceName(billingProject.projectName.value, "myWorkspace")
     val wsName2 = WorkspaceName(billingProject.projectName.value, "myWorkspace2")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.rawls.user
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import bio.terra.profile.client.ApiException
 import bio.terra.profile.model.{BpmApiPolicyInput, BpmApiPolicyInputs, CloudPlatform => BPMCloudPlatform, ProfileModel}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.cloudresourcemanager.model.Project
@@ -834,7 +835,16 @@ class UserServiceSpec
       when(mockGcsDAO.testTerraAndUserBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
         .thenReturn(Future.successful(true))
 
-      val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
+      val mockBpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+      when(
+        mockBpmDAO.updateBillingProfile(
+          ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+          ArgumentMatchers.eq(newBillingAccountRequest.billingAccount),
+          any()
+        )
+      ).thenReturn(Future.successful(new ProfileModel()))
+
+      val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
 
       Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest),
                    Duration.Inf
@@ -853,6 +863,12 @@ class UserServiceSpec
         .getOrElse(fail("project not found"))
       project.billingAccount shouldEqual Option(billingAccountName)
       project.invalidBillingAccount shouldBe false
+
+      verify(mockBpmDAO).updateBillingProfile(
+        ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+        ArgumentMatchers.eq(newBillingAccountRequest.billingAccount),
+        any()
+      )
     }
   }
 
@@ -876,8 +892,10 @@ class UserServiceSpec
       ).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      val mockBpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+      when(mockBpmDAO.removeBillingAccountFromBillingProfile(any(), any())).thenReturn(Future.unit)
 
-      val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO)
+      val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
 
       Await.result(userService.deleteBillingAccount(billingProject.projectName), Duration.Inf)
 
@@ -894,6 +912,11 @@ class UserServiceSpec
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
         .getOrElse(fail("project not found"))
         .billingAccount shouldEqual None
+
+      verify(mockBpmDAO).removeBillingAccountFromBillingProfile(
+        ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+        any()
+      )
     }
   }
 
@@ -1041,6 +1064,108 @@ class UserServiceSpec
       runAndWait(rawlsBillingProjectQuery.load(billingProject.projectName))
         .getOrElse(fail("project not found"))
         .billingAccount shouldEqual billingProject.billingAccount
+    }
+  }
+
+  it should "not call BPM when updating or removing a billing account if the billing project has no billing profile" in {
+    withMinimalTestDatabase { dataSource: SlickDataSource =>
+      val billingProject =
+        minimalTestData.billingProject.copy(projectName = RawlsBillingProjectName("noProfile"), billingProfileId = None)
+      val billingAccountName = RawlsBillingAccountName("billingAccounts/111111-111111-111111")
+      val newBillingAccountRequest = UpdateRawlsBillingAccountRequest(billingAccountName)
+
+      runAndWait(
+        dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject)
+      )
+
+      val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 testContext
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                            billingProject.projectName.value,
+                                            testContext
+        )
+      ).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
+
+      val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      when(mockGcsDAO.testTerraAndUserBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(true))
+
+      val mockBpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
+      val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
+
+      Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest),
+                   Duration.Inf
+      )
+      Await.result(userService.deleteBillingAccount(billingProject.projectName), Duration.Inf)
+
+      verifyNoInteractions(mockBpmDAO)
+    }
+  }
+
+  it should "not throw if BPM errors while updating the billing profile" in {
+    withMinimalTestDatabase { dataSource: SlickDataSource =>
+      val billingProject = minimalTestData.billingProject
+      val billingAccountName = RawlsBillingAccountName("billingAccounts/111111-111111-111111")
+      val newBillingAccountRequest = UpdateRawlsBillingAccountRequest(billingAccountName)
+
+      val mockSamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+      when(
+        mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                 billingProject.projectName.value,
+                                 SamBillingProjectActions.updateBillingAccount,
+                                 testContext
+        )
+      ).thenReturn(Future.successful(true))
+      when(
+        mockSamDAO.listUserRolesForResource(SamResourceTypeNames.billingProject,
+                                            billingProject.projectName.value,
+                                            testContext
+        )
+      ).thenReturn(Future.successful(Set(SamBillingProjectRoles.owner)))
+
+      val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      when(mockGcsDAO.testTerraAndUserBillingAccountAccess(ArgumentMatchers.eq(billingAccountName), any[UserInfo]))
+        .thenReturn(Future.successful(true))
+
+      val mockBpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+      when(
+        mockBpmDAO.updateBillingProfile(
+          ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+          ArgumentMatchers.eq(newBillingAccountRequest.billingAccount),
+          any()
+        )
+      ).thenReturn(Future.failed(new ApiException("oh no")))
+      when(
+        mockBpmDAO.removeBillingAccountFromBillingProfile(
+          ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+          any()
+        )
+      ).thenReturn(Future.failed(new ApiException("oh no")))
+
+      val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
+
+      Await.result(userService.updateBillingProjectBillingAccount(billingProject.projectName, newBillingAccountRequest),
+                   Duration.Inf
+      )
+      Await.result(userService.deleteBillingAccount(billingProject.projectName), Duration.Inf)
+
+      verify(mockBpmDAO).updateBillingProfile(
+        ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+        ArgumentMatchers.eq(newBillingAccountRequest.billingAccount),
+        any()
+      )
+      verify(mockBpmDAO).removeBillingAccountFromBillingProfile(
+        ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
+        any()
+      )
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -14,10 +14,10 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
 import org.broadinstitute.dsde.rawls.billing.{
+  AzureBillingProjectLifecycle,
   BillingProfileManagerDAO,
   BillingProjectOrchestrator,
   BillingRepository,
-  BpmBillingProjectLifecycle,
   GoogleBillingProjectLifecycle
 }
 import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
@@ -227,7 +227,7 @@ trait ApiServiceSpec
       mock[NotificationDAO],
       billingRepository,
       googleBillingProjectLifecycle,
-      mock[BpmBillingProjectLifecycle],
+      mock[AzureBillingProjectLifecycle],
       workspaceManagerResourceMonitorRecordDao,
       mock[MultiCloudWorkspaceConfig]
     )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.rawls.webservice
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.rawls.billing.{
+  BillingProfileManagerDAO,
   BillingProjectOrchestrator,
   GoogleBillingAccountAccessException,
   GoogleBillingProjectLifecycle
@@ -39,7 +40,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     when(workspaceManagerResourceMonitorRecordDao.create(ArgumentMatchers.any())).thenReturn(Future.successful())
 
     override val googleBillingProjectLifecycle: GoogleBillingProjectLifecycle = spy(
-      new GoogleBillingProjectLifecycle(billingRepository, samDAO, gcsDAO)
+      new GoogleBillingProjectLifecycle(billingRepository, mock[BillingProfileManagerDAO], samDAO, gcsDAO)
     )
     when(
       samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -98,6 +98,8 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     o.stringType("managedResourceGroupId")
     o.stringType("biller")
     o.stringType("displayName")
+    o.stringValue("billingAccountId", null)
+    o.stringValue("description", null)
     // It appears to be necessary to specify the value because the enum doesn't get translated to string automatically
     o.stringType("cloudPlatform", CloudPlatform.AZURE.toString)
     o.`object`("policies", po => po.array("inputs", arr => arr.getPactDslJsonArray))

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.consumer
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
 import au.com.dius.pact.consumer.dsl._
@@ -12,19 +13,8 @@ import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAOImpl, HttpBillingProfileManagerClientProvider}
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
-import org.broadinstitute.dsde.rawls.consumer.PactHelper.{
-  buildInteraction,
-  jsonRequestHeaders,
-  jsonRequestHeadersWithBody,
-  jsonResponseHeaders
-}
-import org.broadinstitute.dsde.rawls.model.{
-  AzureManagedAppCoordinates,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  RawlsUserSubjectId,
-  UserInfo
-}
+import org.broadinstitute.dsde.rawls.consumer.PactHelper.{buildInteraction, jsonRequestHeaders, jsonRequestHeadersWithBody, jsonResponseHeaders}
+import org.broadinstitute.dsde.rawls.model.{AzureManagedAppCoordinates, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
 import org.joda.time.DateTime
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -37,6 +27,9 @@ import java.util.function.Consumer
 import scala.concurrent.ExecutionContext
 
 class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactForger {
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
+  implicit val actor: ActorSystem = ActorSystem("BpmClientSpec")
+
   /*
     Define the folder that the pact contracts get written to upon completion of this test suite.
    */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,7 +127,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.998-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.506-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.508-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.11-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-849

This is the first in a group of tickets that will need to merge together, so keep on a feature branch. 

Testing: in addition to the unit tests, I created a GCP billing project using my locally running Rawls. We don't return the billing profile ID when fetching billing project details, but I was able to check in the debugger that we have persisted the ID and thus can fetch the billing profile (which we do to [add policies and Azure MRG information](https://github.com/broadinstitute/rawls/blob/f8c0f1df40bc33301c041df36fce68ba78292fa6/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala#L315)). 

![image](https://github.com/broadinstitute/rawls/assets/484484/f5647196-3a67-4191-acac-15dbbe5595ad)


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
