### PR TITLE
[WOR-1410] remove AKS_MACHINE_TYPE from local-dev config

### DIFF
--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -399,7 +399,6 @@ multiCloudWorkspaces {
       "AKS_AUTOSCALING_ENABLED": "true"
       "AKS_AUTOSCALING_MIN": "1"
       "AKS_AUTOSCALING_MAX": "100"
-      "AKS_MACHINE_TYPE": "Standard_D4as_v5"
     }
   },
   workspaceManager {


### PR DESCRIPTION
Ticket: [WOR-1410](https://broadworkbench.atlassian.net/browse/WOR-1410)
* Remove `AKS_MACHINE_TYPE` from LZ creation parameters rendered in local-dev configuration since this is now set by LZS config (see https://github.com/DataBiosphere/terra-workspace-manager/pull/1612)

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1410]: https://broadworkbench.atlassian.net/browse/WOR-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ