### PR TITLE
AJ-1347: remove obsolete validateEntityIdOrdering method

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponentSpec.scala
@@ -1722,46 +1722,4 @@ class EntityComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
     }
   }
 
-  behavior of "validateEntityIdOrdering"
-
-  it should "return ok when everything is ordered correctly" in {
-    val dummyUuid = UUID.randomUUID()
-    val entityAttributeRecords: Seq[EntityAndAttributesResult] = Seq(
-      EntityAndAttributesResult(EntityRecord(2, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(2, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(3, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(3, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(1, "name", "type", dummyUuid, 1, deleted = false, None), None, None)
-    )
-
-    val isProperlyOrdered: Option[EntityRecord] =
-      entityQuery.validateEntityIdOrdering(-1,
-                                           entityAttributeRecords.head,
-                                           Set.empty[Long],
-                                           entityAttributeRecords.tail
-      )
-
-    isProperlyOrdered shouldBe None
-  }
-
-  it should "return the offending EntityRecord when not ordered correctly" in {
-    val dummyUuid = UUID.randomUUID()
-    val entityAttributeRecords: Seq[EntityAndAttributesResult] = Seq(
-      EntityAndAttributesResult(EntityRecord(2, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(1, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(3, "name", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(1, "offender", "type", dummyUuid, 1, deleted = false, None), None, None),
-      EntityAndAttributesResult(EntityRecord(1, "name", "type", dummyUuid, 1, deleted = false, None), None, None)
-    )
-
-    val isProperlyOrdered: Option[EntityRecord] =
-      entityQuery.validateEntityIdOrdering(-1,
-                                           entityAttributeRecords.head,
-                                           Set.empty[Long],
-                                           entityAttributeRecords.tail
-      )
-
-    isProperlyOrdered shouldBe Some(EntityRecord(1, "offender", "type", dummyUuid, 1, deleted = false, None))
-  }
-
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1347

Followup from #2665. This PR removes the `validateEntityIdOrdering` method, which is no longer needed. That method was in place to validate our approach to streaming the `entityQuery` API. Now that we have merged the streaming - which contains its own internal validation - this method is obsolete.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
