### PR TITLE
[NO TICKET] Improving logging of Azure e2e test and increase WDS timeout

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -63,8 +63,9 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   def logFailure[T](message: String)(fun: => T): T =
     try {
       logger.info("in logFailure")
-      fun
-      logger.info("after function call in logger.info");
+      val result = fun
+      logger.info("after function call in logger.info")
+      result
     } catch {
       case e: Exception =>
         logger.info(message)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -64,9 +64,8 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     try {
       fun
     } catch {
-      logger.info("in catch");
-      case e =>
-        logger.info("in case");
+      case e: Throwable =>
+        logger.info("in case")
         logger.info(message)
         throw e
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -62,12 +62,11 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   def logFailure[T](message: String)(fun: => T): T =
     try {
-      logger.info("in logFailure")
-      val result = fun
-      logger.info("after function call in logger.info")
-      result
+      fun
     } catch {
-      case e: Exception =>
+      logger.info("in catch");
+      case e =>
+        logger.info("in case");
         logger.info(message)
         throw e
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -58,11 +58,17 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     }
   }
 
+  def logFailure(String message, f: Future[_]): Unit = {
+    f.onFailure {
+      case t => logger.error(message, t)
+    }
+  }
+
   "Other Terra services" should "include Leonardo" in {
     implicit val token = ownerAuthToken
     val statusRequest = Rawls.getRequest(leoUrl + "status")
 
-    withClue(s"Leo status API returned ${statusRequest.status.intValue()} ${statusRequest.status.reason()}!") {
+    logFailure(s"Leo status API returned ${statusRequest.status.intValue()} ${statusRequest.status.reason()}!") {
       statusRequest.status shouldBe StatusCodes.OK
     }
   }
@@ -71,7 +77,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     implicit val token = ownerAuthToken
     val statusRequest = Rawls.getRequest(wsmUrl + "status")
 
-    withClue(s"WSM status API returned ${statusRequest.status.intValue()} ${statusRequest.status.reason()}!") {
+    logFailure(s"WSM status API returned ${statusRequest.status.intValue()} ${statusRequest.status.reason()}!") {
       statusRequest.status shouldBe StatusCodes.OK
     }
   }
@@ -123,14 +129,14 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       // Upload the blob that will be cloned
       uploadBlob(sasUrl, analysesFilename, analysesContents)
       val downloadContents = downloadBlob(sasUrl, analysesFilename)
-      withClue(s"testing uploaded blob ${analysesFilename}") {
+      logFailure(s"testing uploaded blob ${analysesFilename}") {
         downloadContents shouldBe analysesContents
       }
 
       // Upload the blob that should not be cloned
       uploadBlob(sasUrl, nonAnalysesFilename, nonAnalysesContents)
       val downloadNonAnalysesContents = downloadBlob(sasUrl, nonAnalysesFilename)
-      withClue(s"testing uploaded blob ${nonAnalysesFilename}") {
+      logFailure(s"testing uploaded blob ${nonAnalysesFilename}") {
         downloadNonAnalysesContents shouldBe nonAnalysesContents
       }
 
@@ -150,7 +156,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
         clonedResponse.workspace.workspaceType should be(Some(WorkspaceType.McWorkspace))
         clonedResponse.accessLevel should be(Some(ProjectOwner))
 
-        withClue(s"Verifying container cloning has completed") {
+        logFailure(s"Verifying container cloning has completed") {
           awaitCond(
             isCloneCompleted(projectName, workspaceCloneName),
             60 seconds,
@@ -160,19 +166,19 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
         val cloneSasUrl = getSasUrl(projectName, workspaceCloneName, token)
         val downloadCloneContents = downloadBlob(cloneSasUrl, analysesFilename)
-        withClue(s"testing blob ${analysesFilename} cloned") {
+        logFailure(s"testing blob ${analysesFilename} cloned") {
           downloadCloneContents shouldBe analysesContents
         }
-        withClue(s"testing blob ${nonAnalysesFilename} did not clone") {
+        logFailure(s"testing blob ${nonAnalysesFilename} did not clone") {
           verifyBlobNotCloned(cloneSasUrl, nonAnalysesFilename)
         }
       } finally
-        withClue(s"deleting the cloned workspace ${workspaceCloneName} failed") {
+        logFailure(s"deleting the cloned workspace ${workspaceCloneName} failed") {
           Rawls.workspaces.delete(projectName, workspaceCloneName)
           assertNoAccessToWorkspace(projectName, workspaceCloneName)
         }
     } finally
-      withClue(s"deleting the original workspace ${workspaceName} failed") {
+      logFailure(s"deleting the original workspace ${workspaceName} failed") {
         Rawls.workspaces.delete(projectName, workspaceName)
         assertNoAccessToWorkspace(projectName, workspaceName)
       }
@@ -276,9 +282,9 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       response.workspace.name should be(workspaceName)
       response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
       val workspaceId = response.workspace.workspaceId
-      val creationTimeout = 600
+      val creationTimeout = 100 //900
 
-      withClue(s"WDS did not become deletable within the timeout period of ${creationTimeout} seconds") {
+      logFailure(s"WDS did not become deletable within the timeout period of ${creationTimeout} seconds") {
         awaitCond(
           isWdsDeletable(workspaceId, token),
           creationTimeout seconds,
@@ -338,14 +344,14 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       HttpRequest(HttpMethods.PUT, fullBlobUrl, headers, HttpEntity(ContentTypes.`text/plain(UTF-8)`, contents))
     val uploadResponse = Await.result(Http().singleRequest(uploadRequest), 2.minutes)
 
-    withClue(s"Upload blob ${blobName}") {
+    logFailure(s"Upload blob ${blobName}") {
       uploadResponse.status shouldBe StatusCodes.Created
     }
   }
 
   private def downloadBlob(containerUrl: String, blobName: String): String = {
     val downloadResponse = getBlobResponse(containerUrl, blobName)
-    withClue(s"Download blob ${blobName}") {
+    logFailure(s"Download blob ${blobName}") {
       downloadResponse.status shouldBe StatusCodes.OK
     }
     val byteStringSink: Sink[ByteString, Future[ByteString]] = Sink.fold(ByteString("")) { (z, i) =>
@@ -357,7 +363,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
 
   private def verifyBlobNotCloned(containerUrl: String, blobName: String): Unit = {
     val downloadResponse = getBlobResponse(containerUrl, blobName)
-    withClue(s"Check blob ${blobName} does not exist") {
+    logFailure(s"Check blob ${blobName} does not exist") {
       downloadResponse.status shouldBe StatusCodes.NotFound
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -287,7 +287,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       response.workspace.name should be(workspaceName)
       response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
       val workspaceId = response.workspace.workspaceId
-      val creationTimeout = 100 // 900
+      val creationTimeout = 60 // 900
 
       logFailure(s"WDS did not become deletable within the timeout period of ${creationTimeout} seconds") {
         awaitCond(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -65,7 +65,6 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       fun
     } catch {
       case e: Throwable =>
-        logger.info("in case")
         logger.info(message)
         throw e
     }
@@ -288,9 +287,7 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       response.workspace.name should be(workspaceName)
       response.workspace.cloudPlatform should be(Some(WorkspaceCloudPlatform.Azure))
       val workspaceId = response.workspace.workspaceId
-      val creationTimeout = 60 // 900
-
-      logger.info(s"creationTimeout is ${creationTimeout} seconds")
+      val creationTimeout = 900
 
       logFailure(s"WDS did not become deletable within the timeout period of ${creationTimeout} seconds") {
         awaitCond(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -289,6 +289,8 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
       val workspaceId = response.workspace.workspaceId
       val creationTimeout = 60 // 900
 
+      logger.info(s"creationTimeout is ${creationTimeout} seconds")
+
       logFailure(s"WDS did not become deletable within the timeout period of ${creationTimeout} seconds") {
         awaitCond(
           isWdsDeletable(workspaceId, token),

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -61,11 +61,13 @@ class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAft
   }
 
   def logFailure[T](message: String)(fun: => T): T =
-    try
+    try {
+      logger.info("in logFailure")
       fun
-    catch {
+      logger.info("after function call in logger.info");
+    } catch {
       case e: Exception =>
-        logger.error(message)
+        logger.info(message)
         throw e
     }
 


### PR DESCRIPTION
I have noticed that the message being passed to `withClue` doesn't appear in the test execution log in the case of these tests. Therefore I created a different method that logs the message (instead of just appending it).

And I am increasing the timeout for WDS to be out of PROVISIONING to 15 minutes; it's not clear if this will help at all with the sporadic "over 10 minute" failures we have seen (it's possible that WDS is in a state will it will never succeed), but we can at least get more data.

I have run this workflow, both with a short timeout to ensure that the log message does indeed print in the log (see screenshot below), and with the final version to ensure [everything passes](https://github.com/broadinstitute/rawls/actions/runs/7613555945).
<img width="1398" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/35c57724-8712-44c8-82a0-2604b8072f69">
