### PR TITLE
WOR-1373 Billing Project user feedback: Update cost groupings in ToA Billing Project spend report.

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -153,10 +153,11 @@ object TerraSpendCategories {
   }
 
   def withName(name: String): TerraSpendCategory = name.toLowerCase match {
-    case "storage" => Storage
-    case "compute" => Compute
-    case "other"   => Other
-    case _         => throw new RawlsException(s"invalid TerraSpendCategory [${name}]")
+    case "storage"                 => Storage
+    case "compute"                 => Compute
+    case "other"                   => Other
+    case "workspaceinfrastructure" => WorkspaceInfrastructure
+    case _                         => throw new RawlsException(s"invalid TerraSpendCategory [${name}]")
   }
 
   def categorize(service: String): TerraSpendCategory = service.toLowerCase.replace(" ", "") match {
@@ -166,6 +167,7 @@ object TerraSpendCategories {
     case _                  => Other
   }
 
+  case object WorkspaceInfrastructure extends TerraSpendCategory
   case object Storage extends TerraSpendCategory
   case object Compute extends TerraSpendCategory
   case object Other extends TerraSpendCategory

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -26,10 +26,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
       new SpendReport()
         .spendSummary(
           buildSpendReportingForDateRange("0.00",
-            "n/a",
-            null,
-            from.toString(ISODateTimeFormat.date()),
-            to.toString(ISODateTimeFormat.date())
+                                          "n/a",
+                                          null,
+                                          from.toString(ISODateTimeFormat.date()),
+                                          to.toString(ISODateTimeFormat.date())
           )
         )
         .spendDetails(
@@ -45,10 +45,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
       new SpendReport()
         .spendSummary(
           buildSpendReportingForDateRange(costs.values.sum.toString(),
-            defaultCurrency,
-            null,
-            from.toString(ISODateTimeFormat.date()),
-            to.toString(ISODateTimeFormat.date())
+                                          defaultCurrency,
+                                          null,
+                                          from.toString(ISODateTimeFormat.date()),
+                                          to.toString(ISODateTimeFormat.date())
           )
         )
         .spendDetails(
@@ -62,7 +62,7 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
                                         category: SpendReportingForDateRangeBPM.CategoryEnum,
                                         from: String,
                                         to: String
-                                       ): SpendReportingForDateRangeBPM =
+    ): SpendReportingForDateRangeBPM =
       new SpendReportingForDateRangeBPM()
         .cost(cost)
         .credits(defaultAzureCredits)
@@ -75,10 +75,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
       val categoriesCosts = costs
         .map(costPerCategoryKvp =>
           buildSpendReportingForDateRange(costPerCategoryKvp._2.toString,
-            defaultCurrency,
-            costPerCategoryKvp._1,
-            null,
-            null
+                                          defaultCurrency,
+                                          costPerCategoryKvp._1,
+                                          null,
+                                          null
           )
         )
         .asJavaCollection
@@ -107,7 +107,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     val computeCost: BigDecimal = 100.20
     val storageCost: BigDecimal = 54.32
     val k8sInfrastructureCost: BigDecimal = 75.15
-    val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost, CategoryEnum.STORAGE -> storageCost, CategoryEnum.WORKSPACEINFRASTRUCTURE -> k8sInfrastructureCost)
+    val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost,
+                              CategoryEnum.STORAGE -> storageCost,
+                              CategoryEnum.WORKSPACEINFRASTRUCTURE -> k8sInfrastructureCost
+    )
     val someReport = TestData.someBPMNonEmptyReport(from, to, categoriesCosts)
 
     val result = SpendReportingResults(someReport)
@@ -116,12 +119,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     result.spendSummary shouldNot equal(null)
     result.spendSummary.cost shouldBe categoriesCosts.values.sum.toString()
     result.spendDetails shouldNot equal(null)
-    result.spendDetails(0) shouldNot equal(null)
-    result.spendDetails(0).spendData should have size categoriesCosts.size
+    result.spendDetails.head shouldNot equal(null)
+    result.spendDetails.head.spendData should have size categoriesCosts.size
 
-    val computeDetails = result
-      .spendDetails(0)
-      .spendData
+    val computeDetails = result.spendDetails.head.spendData
       .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.Compute))
     computeDetails.nonEmpty shouldBe true
     computeDetails.get.cost shouldBe computeCost.toString()
@@ -129,9 +130,7 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     computeDetails.get.currency shouldBe TestData.defaultCurrency
     computeDetails.get.category.get shouldBe TerraSpendCategories.Compute
 
-    val storageDetails = result
-      .spendDetails(0)
-      .spendData
+    val storageDetails = result.spendDetails.head.spendData
       .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.Storage))
     storageDetails.nonEmpty shouldBe true
     storageDetails.get.cost shouldBe storageCost.toString()
@@ -139,9 +138,7 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     storageDetails.get.currency shouldBe TestData.defaultCurrency
     storageDetails.get.category.get shouldBe TerraSpendCategories.Storage
 
-    val k8sDetails = result
-      .spendDetails(0)
-      .spendData
+    val k8sDetails = result.spendDetails.head.spendData
       .find(v => v.category.nonEmpty && v.category.get.equals(TerraSpendCategories.WorkspaceInfrastructure))
     k8sDetails.nonEmpty shouldBe true
     k8sDetails.get.cost shouldBe k8sInfrastructureCost.toString()
@@ -160,10 +157,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
 
     val spendReportingForDateRangeBPM =
       TestData.buildSpendReportingForDateRange(cost,
-        TestData.defaultCurrency,
-        category,
-        from.toString(ISODateTimeFormat.date()),
-        to.toString(ISODateTimeFormat.date())
+                                               TestData.defaultCurrency,
+                                               category,
+                                               from.toString(ISODateTimeFormat.date()),
+                                               to.toString(ISODateTimeFormat.date())
       )
 
     val result = SpendReportingForDateRange(spendReportingForDateRangeBPM)
@@ -186,7 +183,10 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     val computeCost: BigDecimal = 1000.20
     val storageCost: BigDecimal = 900.32
     val workspaceInfrastructureCost: BigDecimal = 2500.01
-    val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost, CategoryEnum.STORAGE -> storageCost, CategoryEnum.WORKSPACEINFRASTRUCTURE -> workspaceInfrastructureCost)
+    val categoriesCosts = Map(CategoryEnum.COMPUTE -> computeCost,
+                              CategoryEnum.STORAGE -> storageCost,
+                              CategoryEnum.WORKSPACEINFRASTRUCTURE -> workspaceInfrastructureCost
+    )
 
     val spendReportingAggregationBPM = TestData.buildSpendReportingAggregation(categoriesCosts)
     val result = SpendReportingAggregation(spendReportingAggregationBPM)
@@ -212,7 +212,9 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     storageCategory.get.category.get shouldBe TerraSpendCategories.Storage
 
     val workspaceInfrastructureCategory =
-      result.spendData.find(sd => sd.category.nonEmpty && sd.category.get.equals(TerraSpendCategories.WorkspaceInfrastructure))
+      result.spendData.find(sd =>
+        sd.category.nonEmpty && sd.category.get.equals(TerraSpendCategories.WorkspaceInfrastructure)
+      )
     workspaceInfrastructureCategory.nonEmpty shouldBe true
     workspaceInfrastructureCategory.get.cost shouldBe workspaceInfrastructureCost.toString()
     workspaceInfrastructureCategory.get.credits shouldBe TestData.defaultAzureCredits

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModelSpec.scala
@@ -4,11 +4,12 @@ import bio.terra.profile.model.SpendReport
 import bio.terra.profile.model.SpendReportingForDateRange.CategoryEnum
 import bio.terra.profile.model.{SpendReportingForDateRange => SpendReportingForDateRangeBPM}
 import bio.terra.profile.model.{SpendReportingAggregation => SpendReportingAggregationBPM}
+import org.broadinstitute.dsde.rawls.RawlsException
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.scalatest.flatspec.AnyFlatSpecLike
-import org.scalatest.matchers.must.Matchers.have
-import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
+import org.scalatest.matchers.must.Matchers.{be, have}
+import org.scalatest.matchers.should.Matchers.{an, convertToAnyShouldWrapper, equal}
 
 import scala.jdk.CollectionConverters._
 
@@ -220,6 +221,25 @@ class SpendReportingModelSpec extends AnyFlatSpecLike {
     workspaceInfrastructureCategory.get.credits shouldBe TestData.defaultAzureCredits
     workspaceInfrastructureCategory.get.currency shouldBe TestData.defaultCurrency
     workspaceInfrastructureCategory.get.category.get shouldBe TerraSpendCategories.WorkspaceInfrastructure
+  }
+
+  behavior of "TerraSpendCategories mapping"
+
+  it should "convert correct string into specific category" in {
+    TerraSpendCategories.withName("compute") shouldBe TerraSpendCategories.Compute
+    TerraSpendCategories.withName("Compute") shouldBe TerraSpendCategories.Compute
+    TerraSpendCategories.withName("storage") shouldBe TerraSpendCategories.Storage
+    TerraSpendCategories.withName("Storage") shouldBe TerraSpendCategories.Storage
+    TerraSpendCategories.withName("other") shouldBe TerraSpendCategories.Other
+    TerraSpendCategories.withName("Other") shouldBe TerraSpendCategories.Other
+    TerraSpendCategories.withName("workspaceinfrastructure") shouldBe TerraSpendCategories.WorkspaceInfrastructure
+    TerraSpendCategories.withName("WorkspaceInfrastructure") shouldBe TerraSpendCategories.WorkspaceInfrastructure
+  }
+
+  it should "throw exception in case of invalid string representation of a category" in {
+    an[RawlsException] should be thrownBy TerraSpendCategories.withName("test")
+    an[RawlsException] should be thrownBy TerraSpendCategories.withName("ai")
+    an[RawlsException] should be thrownBy TerraSpendCategories.withName("unexpectedCategory")
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.998-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.507-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.506-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.9-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.998-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.502-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.507-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.9-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"


### PR DESCRIPTION
Rawls uses BPM as a source of Azure spend report. All the required data come from BPM. Rawls works as a proxy in this case and also as a data mapper. New category was introduced for the Azure spend report. The same category should be introduce here for valid mapping.

Thit PR:
-extends enum for Azure spend report - add "WorkspaceInfrastructure" category.

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
