### PR TITLE
Swattomation test improvements

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/CleanUp.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/CleanUp.scala
@@ -1,0 +1,127 @@
+package org.broadinstitute.dsde.test
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, WorkbenchExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
+import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
+import spray.json._
+
+import java.util.concurrent.ConcurrentLinkedDeque
+import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * Mix-in for cleaning up data created during a test.
+  */
+trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { self: TestSuite =>
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(self.suiteName)
+
+  private val cleanUpFunctions = new ConcurrentLinkedDeque[() => Any]()
+
+  /**
+    * Verb object for the DSL for registering clean-up functions.
+    */
+  object register {
+
+    /**
+      * Register a function to be executed at the end of the test to undo any
+      * side effects of the test.
+      *
+      * @param f the clean-up function
+      */
+    def cleanUp(f: => Any): Unit =
+      cleanUpFunctions.addFirst(f _)
+  }
+
+  /**
+    * Function for controlling when the clean-up functions will be run.
+    * Clean-up functions are usually run at the end of the test, which includes
+    * clean-up from loan-fixture methods. This can cause problems if there are
+    * dependencies, such as foreign key references, between test data created
+    * in a loan-fixture method and the test itself:
+    *
+    * <pre>
+    * "tries to clean-up parent before child" in {
+    *   withParent { parent =>  // withParent loan-fixture clean-up will run before registered clean-up functions
+    *     child = Child(parent)
+    *     register cleanUp { delete child }
+    *     ...
+    *   }
+    * }
+    * </pre>
+    *
+    * Use withCleanUp to explicitly control when the registered clean-up
+    * methods will be called:
+    *
+    * <pre>
+    * "clean-up child before parent" in {
+    *   withParent { parent =>
+    *     withCleanUp {  // registered clean-up functions will run before enclosing loan-fixture clean-up
+    *       child = Child(parent)
+    *       register cleanUp { delete child }
+    *       ...
+    *     }
+    *   }
+    * }
+    * </pre>
+    *
+    * Note that this is not needed if the dependent objects are contributed by
+    * separate loan-fixture methods whose execution order can be explicitly
+    * controlled:
+    *
+    * <pre>
+    * "clean-up inner loan-fixtures first" in {
+    *   withParent { parent =>
+    *     withChild(parent) { child =>
+    *       ...
+    *     }
+    *   }
+    * }
+    *
+    * @param testCode the test code to run
+    */
+  def withCleanUp(testCode: => Any): Unit = {
+    val testTrial = Try(testCode)
+    val cleanupTrial = Try(runCleanUpFunctions())
+    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+  }
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
+    val testTrial = Try(super.withFixture(test))
+    val cleanupTrial = Try(runCleanUpFunctions())
+    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+  }
+
+  private def runCleanUpFunctions(): Unit = {
+    val cleanups = cleanUpFunctions.asScala.map { f =>
+      Try(f())
+    }
+    cleanUpFunctions.clear()
+    val errorReports = cleanups.collect { case Failure(t) =>
+      ErrorReport(t)
+    }
+
+    if (errorReports.nonEmpty) {
+      throw new Exception(ErrorReport("cleanup failed", errorReports.toSeq).toJson.prettyPrint)
+    }
+  }
+
+
+  def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
+    (testTrial, cleanupTrial) match {
+      case (Success(outcome), Success(_)) => outcome
+      case (Failure(t), Success(_)) => throw t
+      case (Success(outcome), Failure(t)) =>
+        logger.error(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
+        outcome
+      case (Failure(t), Failure(c)) =>
+        throw new WorkbenchExceptionWithErrorReport(
+          ErrorReport(
+            "Test and CleanUp both failed. This ErrorReport's causes contain the test and cleanup exceptions, in that order",
+            Seq(ErrorReport(t), ErrorReport(c))
+          )
+        )
+    }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/CleanUp.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/CleanUp.scala
@@ -84,14 +84,14 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   def withCleanUp(testCode: => Any): Unit = {
     val testTrial = Try(testCode)
     val cleanupTrial = Try(runCleanUpFunctions())
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+    runCodeWithCleanup(testTrial, cleanupTrial)
   }
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
     if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
     val testTrial = Try(super.withFixture(test))
     val cleanupTrial = Try(runCleanUpFunctions())
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+    runCodeWithCleanup(testTrial, cleanupTrial)
   }
 
   private def runCleanUpFunctions(): Unit = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupApiSpec.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig,
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBillingProject
 import org.broadinstitute.dsde.workbench.fixture.{GroupFixtures, WorkspaceFixtures}
 import org.broadinstitute.dsde.workbench.service._
+import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,7 +23,8 @@ class AuthDomainGroupApiSpec
     with Matchers
     with WorkspaceFixtures
     with GroupFixtures
-    with Eventually {
+    with Eventually
+    with CancelAfterFailure {
 
   /*
    * Unless otherwise declared, this auth token will be used for API calls.

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupRoleSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainGroupRoleSpec.scala
@@ -10,11 +10,12 @@ import org.broadinstitute.dsde.workbench.fixture.{GroupFixtures, WorkspaceFixtur
 import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service.Orchestration.groups.GroupRole
 import org.broadinstitute.dsde.workbench.service.{Rawls, Sam}
+import org.scalatest.CancelAfterFailure
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 
 @AuthDomainsTest
-class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with GroupFixtures with Matchers {
+class AuthDomainGroupRoleSpec extends AnyFreeSpec with WorkspaceFixtures with GroupFixtures with Matchers with CancelAfterFailure {
 
   val billingAccountId: String = ServiceTestConfig.Projects.billingAccountId
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainMultiGroupApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainMultiGroupApiSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig,
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBillingProject
 import org.broadinstitute.dsde.workbench.fixture.{GroupFixtures, WorkspaceFixtures}
 import org.broadinstitute.dsde.workbench.service.{AclEntry, Orchestration, Rawls, WorkspaceAccessLevel}
+import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -20,7 +21,8 @@ class AuthDomainMultiGroupApiSpec
     with Matchers
     with WorkspaceFixtures
     with GroupFixtures
-    with Eventually {
+    with Eventually
+    with CancelAfterFailure {
 
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(150, Seconds)), interval = scaled(Span(10, Seconds)))

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/AuthDomainSpec.scala
@@ -7,13 +7,14 @@ import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBi
 import org.broadinstitute.dsde.workbench.fixture.{GroupFixtures, WorkspaceFixtures}
 import org.broadinstitute.dsde.workbench.service.Orchestration.groups.GroupRole
 import org.broadinstitute.dsde.workbench.service.{AclEntry, Orchestration, RestException, WorkspaceAccessLevel}
+import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 
 @AuthDomainsTest
-class AuthDomainSpec extends AnyFlatSpec with Matchers with WorkspaceFixtures with GroupFixtures with Eventually {
+class AuthDomainSpec extends AnyFlatSpec with Matchers with WorkspaceFixtures with GroupFixtures with Eventually with CancelAfterFailure{
 
   implicit override val patienceConfig =
     PatienceConfig(timeout = scaled(Span(150, Seconds)), interval = scaled(Span(2, Seconds)))

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/BillingApiSpec.scala
@@ -5,12 +5,13 @@ import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes}
 import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.service.Rawls
+import org.scalatest.CancelAfterFailure
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 //noinspection NoTailRecursionAnnotation,RedundantBlock,ScalaUnusedSymbol
 @BillingsTest
-class BillingApiSpec extends AnyFreeSpec with MethodFixtures with Matchers with TestReporterFixture with LazyLogging {
+class BillingApiSpec extends AnyFreeSpec with MethodFixtures with Matchers with TestReporterFixture with LazyLogging with CancelAfterFailure {
 
   "A user with a billing account" - {
     "can create a new billing project with v2 api" in {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodConfigApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodConfigApiSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBi
 import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.service.test.{CleanUp, RandomUtil}
 import org.broadinstitute.dsde.workbench.service.{Orchestration, Rawls}
+import org.scalatest.CancelAfterFailure
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import spray.json.{JsValue, JsonParser}
@@ -20,7 +21,8 @@ class MethodConfigApiSpec
     with RandomUtil
     with MethodFixtures
     with Matchers
-    with CleanUp {
+    with CleanUp
+      with CancelAfterFailure {
 
   val billingAccountId: String = ServiceTestConfig.Projects.billingAccountId
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/MethodLaunchSpec.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.workbench.config.{ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBillingProject
 import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.service.{AclEntry, Rawls, RestException, WorkspaceAccessLevel}
+import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.Eventually
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -25,7 +26,8 @@ class MethodLaunchSpec
     with Matchers
     with Eventually
     with WorkspaceFixtures
-    with MethodFixtures {
+    with MethodFixtures
+    with CancelAfterFailure {
 
   def createMethodConfigName: String = SimpleMethodConfig.configName + "_" + UUID.randomUUID().toString
   val operations = Array(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.workbench.service.SamModel.{AccessPolicyMembershi
 import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.service.test.{CleanUp, RandomUtil}
 import org.broadinstitute.dsde.workbench.util.Retry
+import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpecLike
@@ -47,7 +48,8 @@ class RawlsApiSpec
     with WorkspaceFixtures
     with SubWorkflowFixtures
     with RawlsTestSuite
-    with MethodFixtures {
+    with MethodFixtures
+    with CancelAfterFailure {
 
   // We only want to see the users' workspaces so we can't be Project Owners
   val Seq(studentA, studentB) = UserPool.chooseStudents(2)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.workbench.service.SamModel.{AccessPolicyMembershi
 import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.service.test.{CleanUp, RandomUtil}
 import org.broadinstitute.dsde.workbench.util.Retry
+import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -46,7 +47,8 @@ class WorkspaceApiSpec
     with Retry
     with ScalaFutures
     with WorkspaceFixtures
-    with MethodFixtures {
+    with MethodFixtures
+    with CancelAfterFailure {
 
   val Seq(studentA, studentB) = UserPool.chooseStudents(2)
   val studentAToken: AuthToken = studentA.makeAuthToken()

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.test.CleanUp
 import org.broadinstitute.dsde.workbench.auth.AuthTokenScopes.billingScopes
 import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes}
 import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
@@ -16,7 +17,7 @@ import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoog
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.broadinstitute.dsde.workbench.service.SamModel.{AccessPolicyMembership, CreateResourceRequest}
 import org.broadinstitute.dsde.workbench.service._
-import org.broadinstitute.dsde.workbench.service.test.{CleanUp, RandomUtil}
+import org.broadinstitute.dsde.workbench.service.test.RandomUtil
 import org.broadinstitute.dsde.workbench.util.Retry
 import org.scalatest.CancelAfterFailure
 import org.scalatest.concurrent.{Eventually, ScalaFutures}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspacesAzureApiSpec.scala
@@ -9,16 +9,11 @@ import akka.testkit.TestKit.awaitCond
 import akka.util.ByteString
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.ProjectOwner
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
-import org.broadinstitute.dsde.rawls.model.{
-  WorkspaceCloudPlatform,
-  WorkspaceListResponse,
-  WorkspaceResponse,
-  WorkspaceType
-}
+import org.broadinstitute.dsde.rawls.model.{WorkspaceCloudPlatform, WorkspaceListResponse, WorkspaceResponse, WorkspaceType}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.service.test.CleanUp
 import org.broadinstitute.dsde.workbench.service.{Orchestration, Rawls, RestException, WorkspaceAccessLevel}
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, CancelAfterFailure}
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -34,7 +29,7 @@ import org.broadinstitute.dsde.test.pipeline._
 import scala.util.{Failure, Try}
 
 @WorkspacesAzureTest
-class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with CleanUp {
+class WorkspacesAzureApiSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with CleanUp with CancelAfterFailure {
   // The values of the following vars are injected from the pipeline.
   var billingProject: String = _
   var ownerAuthToken: ProxyAuthToken = _


### PR DESCRIPTION
Ticket: <Link to Jira ticket>
* add CancelAfterFailure to make swat tests fail fast
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
