### PR TITLE
ID-1023 Use new listResourcesV2 endpoint.

### DIFF
--- a/pact4s/README.md
+++ b/pact4s/README.md
@@ -3,9 +3,13 @@
 pact4s is used for contract testing.
 
 ## Run Pact tests locally
-Run from Rawls top-level directory
-```
+On the command line, from the Rawls top-level directory run the following:
+
+
+```shell
+export PACT_BROKER_URL="https://pact-broker.dsp-eng-tools.broadinstitute.org/"
+export PACT_BROKER_USERNAME=$(vault read -field=basic_auth_read_only_username secret/dsp/pact-broker/users/read-only)
+export PACT_BROKER_PASSWORD=$(vault read -field=basic_auth_read_only_password secret/dsp/pact-broker/users/read-only)
 sbt "project pact4s" test
 ```
-
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,6 +81,7 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.2.0"
   // Update warning for liquibase-core: Here be dragons! See https://broadworkbench.atlassian.net/browse/WOR-1197
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2" // scala-steward:off
+  val jaxrs: ModuleID =  "org.apache.cxf" % "cxf-bundle-jaxrs" % "2.7.18"
 
   val workbenchLibsHash = "8ccaa6d"
 
@@ -132,7 +133,7 @@ object Dependencies {
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client-javax" % "0.1.502-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.95-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-d606036")
+  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-802eb68")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"
@@ -265,6 +266,7 @@ object Dependencies {
     workbenchOpenTelemetryTests,
     terraCommonLib,
     sam,
+    jaxrs,
     leonardo
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,7 +131,7 @@ object Dependencies {
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client-javax" % "0.254.998-SNAPSHOT")
   val dataRepo = excludeJakarta("bio.terra" % "datarepo-jakarta-client" % "1.583.0-SNAPSHOT")
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
-  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client-javax" % "0.1.502-SNAPSHOT")
+  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.504-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.95-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-c76687f-SNAP")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -122,16 +122,20 @@ object Dependencies {
   def excludeSpringData = ExclusionRule("org.springframework.data")
   def excludeSpringFramework = ExclusionRule("org.springframework")
   def excludeOpenCensus = ExclusionRule("io.opencensus")
+  def excludeOpenTelemetry = ExclusionRule("io.opentelemetry")
+  def excludeOpenTelemetryInstrumentation = ExclusionRule("io.opentelemetry.instrumentation")
   def excludeGoogleFindBugs = ExclusionRule("com.google.code.findbugs")
   def excludeBroadWorkbench = ExclusionRule("org.broadinstitute.dsde.workbench")
   def excludeSlf4j = ExclusionRule("org.slf4j")
   // "Terra Common Lib" Exclusions:
-  def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j)
+
+  def springExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeOpenTelemetry, excludeOpenTelemetryInstrumentation)
+  def tclExclusions(m: ModuleID): ModuleID = springExclusions(m.excludeAll(excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j))
 
   val workspaceManager = excludeJakarta("bio.terra" % "workspace-manager-client-javax" % "0.254.998-SNAPSHOT")
-  val dataRepo = excludeJakarta("bio.terra" % "datarepo-jakarta-client" % "1.583.0-SNAPSHOT")
+  val dataRepo = springExclusions(excludeJakarta("bio.terra" % "datarepo-jakarta-client" % "1.583.0-SNAPSHOT"))
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
-  val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.504-SNAPSHOT")
+  val billingProfileManager = springExclusions(excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.504-SNAPSHOT"))
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.95-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-c76687f-SNAP")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -137,7 +137,7 @@ object Dependencies {
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = springExclusions(excludeJakarta("bio.terra" % "billing-profile-manager-client" % "0.1.504-SNAPSHOT"))
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.95-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-c76687f-SNAP")
+  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-98683ff")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,6 +81,7 @@ object Dependencies {
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "8.2.0"
   // Update warning for liquibase-core: Here be dragons! See https://broadworkbench.atlassian.net/browse/WOR-1197
   val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2" // scala-steward:off
+  val jaxrs: ModuleID =  "org.apache.cxf" % "cxf-bundle-jaxrs" % "2.7.18"
 
   val workbenchLibsHash = "8ccaa6d"
 
@@ -132,7 +133,7 @@ object Dependencies {
   val resourceBufferService = excludeJakarta("bio.terra" % "terra-resource-buffer-client" % "0.4.3-SNAPSHOT")
   val billingProfileManager = excludeJakarta("bio.terra" % "billing-profile-manager-client-javax" % "0.1.502-SNAPSHOT")
   val terraCommonLib = tclExclusions(excludeJakarta("bio.terra" % "terra-common-lib" % "0.0.95-SNAPSHOT" classifier "plain"))
-  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-d606036")
+  val sam: ModuleID = excludeJakarta("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-c76687f-SNAP")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"
 
   val opencensusScalaCode: ModuleID = "com.github.sebruck" %% "opencensus-scala-core" % "0.7.2"
@@ -265,6 +266,7 @@ object Dependencies {
     workbenchOpenTelemetryTests,
     terraCommonLib,
     sam,
+    jaxrs,
     leonardo
   )
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -18,6 +18,8 @@ object Merging {
     case x if x.endsWith("kotlin_module")                => MergeStrategy.first
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")         => MergeStrategy.concat
+    case PathList("javax", "servlet", _@_*) => MergeStrategy.first // This should be resolved in dependencies
+    case PathList("mozilla", _@_*) => MergeStrategy.first // This should be resolved in dependencies
     case x                                               => oldStrategy(x)
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/ID-1023

Updates the sam client and uses the new listResourcesV2 endpoint that is more performant. There is still work to be done to lazily load public resources in the ui which will further reduce load on sam.

(the branch name is referring to a duplicate ticket we have since closed)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
