### PR TITLE
[WOR-850] Delete billing profile during billing project deletion (GCP)

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -184,8 +184,8 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
               )
             )
         }
-      billingProfileId <- billingRepository.getBillingProfileId(projectName)
-      projectLifecycle = billingProfileId match {
+      azureManagedAppCoordinates <- billingRepository.getAzureManagedAppCoordinates(projectName)
+      projectLifecycle = azureManagedAppCoordinates match {
         case None    => googleBillingProjectLifecycle
         case Some(_) => bpmBillingProjectLifecycle
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -50,7 +50,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
                                  notificationDAO: NotificationDAO,
                                  billingRepository: BillingRepository,
                                  googleBillingProjectLifecycle: BillingProjectLifecycle,
-                                 bpmBillingProjectLifecycle: BillingProjectLifecycle,
+                                 azureBillingProjectLifecycle: BillingProjectLifecycle,
                                  config: MultiCloudWorkspaceConfig,
                                  resourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao
 )(implicit val executionContext: ExecutionContext)
@@ -73,7 +73,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
 
     val billingProjectLifecycle = createProjectRequest.billingInfo match {
       case Left(_)  => googleBillingProjectLifecycle
-      case Right(_) => bpmBillingProjectLifecycle
+      case Right(_) => azureBillingProjectLifecycle
     }
     val billingProjectName = createProjectRequest.projectName
 
@@ -187,7 +187,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
       azureManagedAppCoordinates <- billingRepository.getAzureManagedAppCoordinates(projectName)
       projectLifecycle = azureManagedAppCoordinates match {
         case None    => googleBillingProjectLifecycle
-        case Some(_) => bpmBillingProjectLifecycle
+        case Some(_) => azureBillingProjectLifecycle
       }
       _ <- billingRepository.failUnlessHasNoWorkspaces(projectName)
       _ <- billingRepository.getCreationStatus(projectName).map { status =>
@@ -223,7 +223,7 @@ object BillingProjectOrchestrator {
     notificationDAO: NotificationDAO,
     billingRepository: BillingRepository,
     googleBillingProjectLifecycle: GoogleBillingProjectLifecycle,
-    bpmBillingProjectLifecycle: AzureBillingProjectLifecycle,
+    azureBillingProjectLifecycle: AzureBillingProjectLifecycle,
     resourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao,
     config: MultiCloudWorkspaceConfig
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): BillingProjectOrchestrator =
@@ -233,7 +233,7 @@ object BillingProjectOrchestrator {
       notificationDAO,
       billingRepository,
       googleBillingProjectLifecycle,
-      bpmBillingProjectLifecycle,
+      azureBillingProjectLifecycle,
       config,
       resourceMonitorRecordDao
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -4,10 +4,10 @@ import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
   ErrorReport,
   RawlsBillingProject,
-  RawlsBillingProjectName,
-  WorkspaceVersions
+  RawlsBillingProjectName
 }
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 
@@ -49,6 +49,17 @@ class BillingRepository(dataSource: SlickDataSource) {
           throw new RawlsException(s"Billing Project ${projectName.value} does not exist in Rawls database")
         )
         .billingProfileId
+    }
+
+  def getAzureManagedAppCoordinates(
+    projectName: RawlsBillingProjectName
+  )(implicit executionContext: ExecutionContext): Future[Option[AzureManagedAppCoordinates]] =
+    getBillingProject(projectName) map { billingProjectOpt =>
+      billingProjectOpt
+        .getOrElse(
+          throw new RawlsException(s"Billing Project ${projectName.value} does not exist in Rawls database")
+        )
+        .azureManagedAppCoordinates
     }
 
   def deleteBillingProject(projectName: RawlsBillingProjectName): Future[Boolean] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -82,5 +82,5 @@ class GoogleBillingProjectLifecycle(
     executionContext: ExecutionContext
   ): Future[Unit] =
     // Should change this to expecting a billing profile once we have migrated all billing projects (WOR-866)
-    deleteBillingProfileAndUnregisterBillingProject(projectName, billingProfileExpected = true, ctx)
+    deleteBillingProfileAndUnregisterBillingProject(projectName, billingProfileExpected = false, ctx)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycle.scala
@@ -81,6 +81,6 @@ class GoogleBillingProjectLifecycle(
   override def finalizeDelete(projectName: RawlsBillingProjectName, ctx: RawlsRequestContext)(implicit
     executionContext: ExecutionContext
   ): Future[Unit] =
-    unregisterBillingProject(projectName, ctx)
-
+    // Should change this to expecting a billing profile once we have migrated all billing projects (WOR-866)
+    deleteBillingProfileAndUnregisterBillingProject(projectName, billingProfileExpected = true, ctx)
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -986,6 +986,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
 
     verify(bpm).deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext))
+    verify(repo).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
   }
 
   it should "not delete the billing profile if other projects reference it" in {
@@ -1029,6 +1030,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
 
     verify(bpm, Mockito.never).deleteBillingProfile(billingProfileId, testContext)
+    // Billing project is still deleted
+    verify(repo).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
   }
 
   it should "succeed if the billing profile id does not exist" in {
@@ -1091,5 +1094,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
       Await.result(bp.finalizeDelete(billingProjectName, testContext), Duration.Inf)
     }
     verify(bpm).deleteBillingProfile(ArgumentMatchers.eq(billingProfileId), ArgumentMatchers.eq(testContext))
+    verify(repo, Mockito.never).deleteBillingProject(ArgumentMatchers.eq(billingProjectName))
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -336,8 +336,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     billingProjectLifecycle
   }
 
-  def happyBillingRepository(azureManagedAppCoordinates: Option[AzureManagedAppCoordinates]
-  ): BillingRepository = {
+  def happyBillingRepository(azureManagedAppCoordinates: Option[AzureManagedAppCoordinates]): BillingRepository = {
     val billingRepository = mock[BillingRepository]
     when(billingRepository.failUnlessHasNoWorkspaces(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful())

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMo
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.BpmBillingProjectDelete
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.model.{
+  AzureManagedAppCoordinates,
   CreateRawlsV2BillingProjectFullRequest,
   CreationStatuses,
   ErrorReport,
@@ -50,6 +51,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     Map("fake_parameter" -> "fake_value"),
     landingZoneAllowAttach = false
   )
+  val azureManagedAppCoordinates: AzureManagedAppCoordinates =
+    AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
 
   val userInfo: UserInfo =
     UserInfo(RawlsUserEmail("fake@example.com"), OAuth2BearerToken("fake_token"), 0, RawlsUserSubjectId("sub"), None)
@@ -333,12 +336,15 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     billingProjectLifecycle
   }
 
-  def happyBillingRepository(profileId: Option[String]): BillingRepository = {
+  def happyBillingRepository(azureManagedAppCoordinates: Option[AzureManagedAppCoordinates]
+  ): BillingRepository = {
     val billingRepository = mock[BillingRepository]
     when(billingRepository.failUnlessHasNoWorkspaces(ArgumentMatchers.any())(ArgumentMatchers.any()))
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(ArgumentMatchers.any())(ArgumentMatchers.any()))
-      .thenReturn(Future.successful(profileId))
+      .thenReturn(Future.successful(Some(UUID.randomUUID().toString)))
+    when(billingRepository.getAzureManagedAppCoordinates(ArgumentMatchers.any())(ArgumentMatchers.any()))
+      .thenReturn(Future.successful(azureManagedAppCoordinates))
     when(billingRepository.updateCreationStatus(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(Future.successful(1))
     when(billingRepository.getCreationStatus(ArgumentMatchers.any())(ArgumentMatchers.any()))
@@ -399,7 +405,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
         )
       )
     // Mock Google project
-    when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
       .thenReturn(Future.successful(None))
 
     val bpo = new BillingProjectOrchestrator(
@@ -429,6 +435,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
       .thenReturn(Future.successful(Some("fake-id")))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
+      .thenReturn(Future.successful(Some(azureManagedAppCoordinates)))
     when(billingRepository.getCreationStatus(billingProjectName)(executionContext))
       .thenReturn(Future.successful(CreationStatuses.Ready))
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
@@ -455,7 +463,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     verify(billingRepository, never()).deleteBillingProject(billingProjectName)
   }
 
-  it should "call initiateDelete and finializeDelete for the google lifecycle for a google project" in {
+  it should "call initiateDelete and finalizeDelete for the google lifecycle for a google project" in {
     val billingProjectName = RawlsBillingProjectName("fake_billing_account_name")
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
     when(billingProjectLifecycle.initiateDelete(billingProjectName, testContext)).thenReturn(Future.successful(None))
@@ -477,7 +485,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     verify(billingProjectLifecycle).finalizeDelete(billingProjectName, testContext)
   }
 
-  it should "call initiateDelete and finializeDelete when the BPM lifecyle returns a jobId of None" in {
+  it should "call initiateDelete and finalizeDelete when the BPM lifecycle returns a jobId of None" in {
     val billingProjectName = RawlsBillingProjectName("fake_billing_account_name")
     val billingProjectLifecycle = mock[BillingProjectLifecycle]
     when(billingProjectLifecycle.initiateDelete(billingProjectName, testContext)).thenReturn(Future.successful(None))
@@ -486,7 +494,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some(UUID.randomUUID().toString)),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       billingProjectLifecycle, // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -511,7 +519,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some("inconsequential_id")),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       billingProjectLifecycle, // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -538,7 +546,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some("inconsequential_id")),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       initiateDeleteLifecycle(Future.successful(Some(jobId))), // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -557,7 +565,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       testContext,
       alwaysGiveAccessSamDao,
       mock[NotificationDAO],
-      happyBillingRepository(Some("inconsequential_id")),
+      happyBillingRepository(Some(azureManagedAppCoordinates)),
       mock[BillingProjectLifecycle], // google
       initiateDeleteLifecycle(Future.failed(new Exception)), // bpm
       mock[MultiCloudWorkspaceConfig],
@@ -577,6 +585,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
       .thenReturn(Future.successful(Some("inconsequential_id")))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
+      .thenReturn(Future.successful(Some(azureManagedAppCoordinates)))
     when(billingRepository.updateCreationStatus(billingProjectName, CreationStatuses.Deleting, None))
       .thenReturn(Future.successful(1))
     when(billingRepository.getCreationStatus(billingProjectName)(executionContext))
@@ -605,6 +615,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful())
     when(billingRepository.getBillingProfileId(billingProjectName)(executionContext))
       .thenReturn(Future.successful(Some("inconsequential_id")))
+    when(billingRepository.getAzureManagedAppCoordinates(billingProjectName)(executionContext))
+      .thenReturn(Future.successful(Some(azureManagedAppCoordinates)))
     when(billingRepository.getCreationStatus(billingProjectName)(executionContext))
       .thenReturn(Future.successful(CreationStatuses.Deleting))
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-850

This PR adds the code for GCP billing project deletion to also delete the associated billing profile, if it exists. Note that this is against a feature branch (which creates the billing profile during GCP billing project creation).

Tested running Rawls locally to create and delete GCP billing projects.
