### PR TITLE
[WOR-1297] Continue workspace deletion if all apps/runtimes in are ERROR status

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
@@ -68,9 +68,10 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
         blocking {
           val allApps = leonardoDAO.listApps(ctx.userInfo.accessToken.token, workspace.workspaceIdAsUUID)
           val nonErroredApps = allApps.filter(_.getStatus != AppStatus.ERROR)
-          if (nonErroredApps.nonEmpty) {
+          val erroredAppCount = allApps.size - nonErroredApps.size
+          if (erroredAppCount > 0) {
             logger.info(
-              s"Filtering out ${allApps.size - nonErroredApps.size} errored apps for [workspaceId=${workspace.workspaceIdAsUUID}]"
+              s"Filtering out ${erroredAppCount} errored apps for [workspaceId=${workspace.workspaceIdAsUUID}]"
             )
           }
           nonErroredApps
@@ -86,9 +87,12 @@ class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
         blocking {
           val allRuntimes = leonardoDAO.listAzureRuntimes(ctx.userInfo.accessToken.token, workspace.workspaceIdAsUUID)
           val nonErroredRuntimes = allRuntimes.filter(_.getStatus != ClusterStatus.ERROR)
-          logger.info(
-            s"Filtering out ${allRuntimes.size - nonErroredRuntimes.size} errored runtimes for [workspaceId=${workspace.workspaceIdAsUUID}]"
-          )
+          val erroredRuntimeCount = allRuntimes.size - nonErroredRuntimes.size
+          if (erroredRuntimeCount > 0) {
+            logger.info(
+              s"Filtering out ${erroredRuntimeCount} errored runtimes for [workspaceId=${workspace.workspaceIdAsUUID}]"
+            )
+          }
           nonErroredRuntimes
         }
       }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1297

If runtimes are apps are in an ERROR state, Leo will not be able to delete them. Go ahead and attempt to delete the workspace. I ran this past IA in https://broadinstitute.slack.com/archives/CA3NP1733/p1706723414160159.

I was not able to manually test this beyond ensuring that deleting of GCP workspaces succeeds in the usual happy cases… I don't have any Azure workspaces with apps or runtimes stuck in an ERROR state.