### PR TITLE
AJ-1540: local dev to mysql 8

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessSpec.scala
@@ -75,16 +75,19 @@ class DataAccessSpec extends TestDriverComponentWithFlatSpecAndMatchers with Sca
     }
   }
 
-  it should "be testing against MySQL 8.0.35" in withEmptyTestDatabase {
+  // The docker version installed on DSP Jenkins does not like the "mysql" docker image, so we use "mysql/mysql-server"
+  //    instead, which only has a 8.0.32 tag. See /docker/run-mysql.sh.
+  //    TODO: Move to mysql:8.0.35 once we no longer depend on Jenkins.
+  it should "be testing against MySQL 8.0.32" in withEmptyTestDatabase {
     val versionLookup =
       runAndWait(sql"""select version();""".as[String])
     versionLookup should have size 1
     val actual = versionLookup.head
     info(s"actual version string: $actual")
     withClue(
-      "is the mysql against which these unit tests running 8.0.35?"
+      "is the mysql against which these unit tests running 8.0.32?"
     ) {
-      actual should startWith("8.0.35")
+      actual should startWith("8.0.32")
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccessSpec.scala
@@ -32,11 +32,14 @@ class DataAccessSpec extends TestDriverComponentWithFlatSpecAndMatchers with Sca
     }
   }
 
-  it should "use utf8 for MySQL's character_set_server" in withEmptyTestDatabase {
+  it should "use utf8mb3 (via the utf8 alias) for MySQL's character_set_server" in withEmptyTestDatabase {
     /* Our live-environment CloudSQL instances, including production, use character_set_server=utf8.
        This setting is critical for SQL queries that specify/override a collation, such as to make a
        case-sensitive query against a column that is case-insensitive by default, e.g. the column
        uses utf8_general_ci collation.
+
+       In MySQL 8, "utf8" is an alias for "utf8mb3". So, while we specify "utf8" because CloudSQL restricts our options,
+       MySQL reports that it is running with "utf8mb3". This test looks for a value of "utf8mb3".
 
        A failure of this test likely means that our test environment is not set up correctly; the mysql
        instance used by tests does not have the right setting. If the test-instance mysql is not set up
@@ -50,20 +53,38 @@ class DataAccessSpec extends TestDriverComponentWithFlatSpecAndMatchers with Sca
     withClue(
       "is the mysql against which these unit tests ran set up correctly with --character-set-server=utf8 or equivalent?"
     ) {
-      actual shouldBe "utf8"
+      actual shouldBe "utf8mb3"
     }
   }
 
-  it should "be testing against MySQL 5.7" in withEmptyTestDatabase {
+  it should "use utf8mb3_general_ci (via the utf8_general_ci alias) for MySQL's collation_server" in withEmptyTestDatabase {
+    /* See previous test for more details. utf8_general_ci is the collation associated with a character set of utf8.
+
+       Similar to how "utf8" is an alias for "utf8mb3", "utf8_general_ci" is an alias for "utf8mb3_general_ci". So, this
+       test looks for "utf8mb3_general_ci".
+     */
+    val collationLookup =
+      runAndWait(sql"""SHOW VARIABLES WHERE Variable_name = 'collation_server';""".as[(String, String)])
+    collationLookup should have size 1
+    val actual = collationLookup.head._2
+    info(s"actual collation set: $actual")
+    withClue(
+      "is the mysql against which these unit tests ran set up correctly with --collation_server=utf8_general_ci or equivalent?"
+    ) {
+      actual shouldBe "utf8mb3_general_ci"
+    }
+  }
+
+  it should "be testing against MySQL 8.0.35" in withEmptyTestDatabase {
     val versionLookup =
       runAndWait(sql"""select version();""".as[String])
     versionLookup should have size 1
     val actual = versionLookup.head
     info(s"actual version string: $actual")
     withClue(
-      "is the mysql against which these unit tests running 5.7?"
+      "is the mysql against which these unit tests running 8.0.35?"
     ) {
-      actual should startWith("5.7")
+      actual should startWith("8.0.35")
     }
   }
 

--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# The CloudSQL console simply states "MySQL 5.7" so we may not match the minor version number
+# TODO davidan: is the following comment still true?
 # The docker version installed on DSP Jenkins does not like the "mysql" docker image, so we use "mysql/mysql-server"
 #     instead. Re-evaluate this sometime after Jenkins is no longer in use.
-MYSQL_IMAGE=mysql/mysql-server
-MYSQL_VERSION=5.7
+MYSQL_IMAGE=mysql
+MYSQL_VERSION=8.0.35
 start() {
 
 
@@ -21,7 +21,8 @@ start() {
                   -e MYSQL_PASSWORD=rawls-test -e MYSQL_DATABASE=testdb \
                   -d -p 3310:3306 $MYSQL_IMAGE:$MYSQL_VERSION \
                   --character-set-server=utf8 \
-                  --binlog-format=ROW \
+                  --collation_server=utf8_general_ci \
+                  --sql_mode=STRICT_ALL_TABLES \
                   --log_bin_trust_function_creators=ON
 
     # validate mysql

--- a/docker/run-mysql.sh
+++ b/docker/run-mysql.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# TODO davidan: is the following comment still true?
 # The docker version installed on DSP Jenkins does not like the "mysql" docker image, so we use "mysql/mysql-server"
-#     instead. Re-evaluate this sometime after Jenkins is no longer in use.
-MYSQL_IMAGE=mysql
-MYSQL_VERSION=8.0.35
+#     instead.
+#     TODO: Move to mysql:8.0.35 once we no longer depend on Jenkins.
+MYSQL_IMAGE=mysql/mysql-server
+MYSQL_VERSION=8.0.32
 start() {
 
 


### PR DESCRIPTION
Ticket: AJ-1540

* Update the local-development environment to MySQL 8, via the `run-mysql.sh` script.
* Update GHA unit tests to MySQL 8, also via the `run-mysql.sh` script.
* Update unit tests to check for the presence of MySQL 8

Note that in your local dev environment, if you already have mysql running via ./docker/run-mysql.sh, you'll have to stop it and start it to get the upgrade.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
