### PR TITLE
[WOR-1226] For Azure billing projects, return the region of the landing zone

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val workbenchGoogle2: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google2" % workbenchGoogle2V exclude ("org.slf4j", "slf4j-api")
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % serviceTestV % "test" classifier "tests" excludeAll(workbenchExclusions :+ rawlsModelExclusion:_*)
 
-  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client-javax" % "0.254.998-SNAPSHOT"
+  val workspaceManager: ModuleID = "bio.terra" % "workspace-manager-client-javax" % "0.254.1030-SNAPSHOT"
   val dataRepo: ModuleID         = "bio.terra" % "datarepo-client" % "1.41.0-SNAPSHOT"
   val dataRepoJersey : ModuleID  = "org.glassfish.jersey.inject" % "jersey-hk2" % "2.32" // scala-steward:off (must match TDR)
 

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6484,6 +6484,9 @@ components:
           type: string
           format: uuid
           description: the UUID of the landing zone associated with the project (cloudPlatform AZURE only)
+        region:
+          type: string
+          description: the region that the landing zone is in (cloudPlatform AZURE only)
         protectedData:
           type: boolean
           description: whether this billing project supports protected data (cloudPlatform AZURE only)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess.workspacemanager
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.StatusCode
 import akka.stream.Materializer
 import bio.terra.profile.model.ProfileModel
 import bio.terra.workspace.api.{ReferencedGcpResourceApi, ResourceApi, WorkspaceApi}
@@ -9,7 +8,6 @@ import bio.terra.workspace.client.{ApiClient, ApiException}
 import bio.terra.workspace.model._
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.http.HttpStatus
-import org.broadinstitute.dsde.rawls.billing.LandingZoneDeletionException
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model.{
   DataReferenceDescriptionField,
@@ -18,7 +16,6 @@ import org.broadinstitute.dsde.rawls.model.{
   WorkspaceType
 }
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.rawls.model.{ErrorReport => RawlsErrorReport}
 
 import java.util.UUID
 import scala.annotation.tailrec
@@ -323,6 +320,9 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
 
   override def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult =
     getLandingZonesApi(ctx).getCreateAzureLandingZoneResult(jobId)
+
+  override def getLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): AzureLandingZone =
+    getLandingZonesApi(ctx).getAzureLandingZone(landingZoneId)
 
   /**
     *

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -154,6 +154,8 @@ trait WorkspaceManagerDAO {
 
   def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult
 
+  def getLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): AzureLandingZone
+
   /**
    * Initiate deletion of a landing zone.
     * This will either return the delete result, which will contain a job ID that can be used to check the status of the deletion,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -101,7 +101,8 @@ case class RawlsBillingProjectResponse(
   managedAppCoordinates: Option[AzureManagedAppCoordinates], // remove after ui is updated  to use cloud context
   cloudPlatform: String,
   landingZoneId: Option[String],
-  protectedData: Option[Boolean]
+  protectedData: Option[Boolean],
+  region: Option[String]
 )
 
 object RawlsBillingProjectResponse {
@@ -109,7 +110,8 @@ object RawlsBillingProjectResponse {
     roles: Set[ProjectRole],
     project: RawlsBillingProject,
     platform: CloudPlatform = CloudPlatform.UNKNOWN,
-    protectedData: Option[Boolean] = None
+    protectedData: Option[Boolean] = None,
+    region: Option[String] = None
   ): RawlsBillingProjectResponse = this(
     project.projectName,
     project.billingAccount,
@@ -121,7 +123,8 @@ object RawlsBillingProjectResponse {
     project.azureManagedAppCoordinates,
     platform.toString,
     project.landingZoneId,
-    protectedData
+    protectedData,
+    region
   )
 }
 
@@ -320,7 +323,7 @@ class UserAuthJsonSupport extends JsonSupport {
   )
 
   implicit val RawlsBillingProjectResponseFormat: RootJsonFormat[RawlsBillingProjectResponse] =
-    jsonFormat11(RawlsBillingProjectResponse.apply)
+    jsonFormat12(RawlsBillingProjectResponse.apply)
 }
 
 object UserAuthJsonSupport extends UserAuthJsonSupport

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 /**
  * Created by dvoet on 10/27/15.
@@ -64,7 +64,7 @@ object UserService {
       workspaceManagerDAO,
       billingProfileManagerDAO,
       new BillingRepository(dataSource),
-      new WorkspaceManagerResourceMonitorRecordDao(dataSource),
+      WorkspaceManagerResourceMonitorRecordDao(dataSource),
       notificationDAO
     )
 
@@ -178,10 +178,10 @@ class UserService(
   requesterPaysRole: String,
   servicePerimeterService: ServicePerimeterService,
   adminRegisterBillingAccountId: RawlsBillingAccountName,
-  workspaceManagerDAO: WorkspaceManagerDAO,
+  val workspaceManagerDAO: WorkspaceManagerDAO,
   billingProfileManagerDAO: BillingProfileManagerDAO,
   val billingRepository: BillingRepository,
-  val workspaceResourceRecordDao: WorkspaceManagerResourceMonitorRecordDao,
+  workspaceResourceRecordDao: WorkspaceManagerResourceMonitorRecordDao,
   notificationDAO: NotificationDAO
 )(implicit protected val executionContext: ExecutionContext)
     extends RoleSupport
@@ -285,7 +285,7 @@ class UserService(
       _.billingProfileId.flatMap(id => billingProfileManagerDAO.getBillingProfile(UUID.fromString(id), ctx))
     }
   } yield billingProject.flatMap(p =>
-    if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(p, billingProfile, roles)) else None
+    if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(p, billingProfile, roles, workspaceManagerDAO)) else None
   )
 
   def listBillingProjectsV2(): Future[List[RawlsBillingProjectResponse]] = for {
@@ -298,11 +298,12 @@ class UserService(
     resourceIds = rolesByResourceId.keySet
     billingProfiles <- billingProfileManagerDAO.getAllBillingProfiles(ctx)
     projectsInDB <- billingRepository.getBillingProjects(resourceIds.map(RawlsBillingProjectName))
+    workspaceManagerDao = workspaceManagerDAO
   } yield projectsInDB.toList
     .map { p =>
       val roles = rolesByResourceId.getOrElse(p.projectName.value, Set())
       val billingProfile = p.billingProfileId.flatMap(id => billingProfiles.find(_.getId == UUID.fromString(id)))
-      mapCloudPlatformAndPolicies(p, billingProfile, roles)
+      mapCloudPlatformAndPolicies(p, billingProfile, roles, workspaceManagerDao)
     }
     .filter(p => p.roles.nonEmpty)
 
@@ -315,15 +316,30 @@ class UserService(
   def mapCloudPlatformAndPolicies(
     project: RawlsBillingProject,
     billingProfile: Option[ProfileModel],
-    roles: Set[ProjectRole]
+    roles: Set[ProjectRole],
+    workspaceManagerDao: WorkspaceManagerDAO
   ): RawlsBillingProjectResponse = (project.billingProfileId, billingProfile) match {
     case (None, _) => RawlsBillingProjectResponse(roles, project, CloudPlatform.GCP, protectedData = None)
     case (Some(_), Some(p)) =>
       val platform = CloudPlatform(p)
-      val responseProject = if (platform == CloudPlatform.AZURE) {
+      val (responseProject, maybeRegion) = if (platform == CloudPlatform.AZURE) {
         val c = AzureManagedAppCoordinates(p.getTenantId, p.getSubscriptionId, p.getManagedResourceGroupId)
-        project.copy(azureManagedAppCoordinates = Some(c))
-      } else project
+        val projectWithCoords = project.copy(azureManagedAppCoordinates = Some(c))
+        val landingZoneRegion = project.landingZoneId match {
+          case Some(landingZoneId) =>
+            Try(workspaceManagerDao.getLandingZone(UUID.fromString(landingZoneId), ctx)) match {
+              case Success(landingZone) => Some(landingZone.getRegion)
+              case Failure(exception) =>
+                logger.debug(
+                  s"landing zone ${landingZoneId} could not be retrieved from the workspaceManagerDao",
+                  exception
+                )
+                None
+            }
+          case None => None
+        }
+        (projectWithCoords, landingZoneRegion)
+      } else (project, None)
       val protectedData = Option(p.getPolicies) match {
         case Some(policies) =>
           Option(
@@ -333,8 +349,7 @@ class UserService(
           )
         case None => Option(false)
       }
-
-      RawlsBillingProjectResponse(roles, responseProject, platform, protectedData)
+      RawlsBillingProjectResponse(roles, responseProject, platform, protectedData, region = maybeRegion)
     case (Some(id), None) =>
       val message = Some(s"Unable to find billing profile in Billing Profile Manager for billing profile id: $id")
       RawlsBillingProjectResponse(roles, project.copy(message = message, status = CreationStatuses.Error))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -328,7 +328,7 @@ class UserService(
         val landingZoneRegion = project.landingZoneId match {
           case Some(landingZoneId) =>
             Try(workspaceManagerDao.getLandingZone(UUID.fromString(landingZoneId), ctx)) match {
-              case Success(landingZone) => Some(landingZone.getRegion)
+              case Success(landingZone) => Option(landingZone.getRegion)
               case Failure(exception) =>
                 logger.debug(
                   s"landing zone ${landingZoneId} could not be retrieved from the workspaceManagerDao",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -241,6 +241,8 @@ class MockWorkspaceManagerDAO(
 
   override def getCreateAzureLandingZoneResult(jobId: String, ctx: RawlsRequestContext): AzureLandingZoneResult = ???
 
+  override def getLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): AzureLandingZone = ???
+
   override def deleteLandingZone(landingZoneId: UUID, ctx: RawlsRequestContext): Some[DeleteAzureLandingZoneResult] =
     ???
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1348,7 +1348,7 @@ class UserServiceSpec
     Await.result(userService.listBillingProjectsV2(), Duration.Inf) should contain theSameElementsAs expected
   }
 
-  it should "map handle the landing zone being missing in BPM project" in {
+  it should "handle the landing zone being missing in BPM project" in {
     val billingProfile = new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BPMCloudPlatform.AZURE)
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val landingZoneId = UUID.randomUUID()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,7 +124,7 @@ object Dependencies {
   // "Terra Common Lib" Exclusions:
   def tclExclusions(m: ModuleID): ModuleID = m.excludeAll(excludeSpringBoot, excludeSpringAop, excludeSpringData, excludeSpringFramework, excludeOpenCensus, excludeGoogleFindBugs, excludeBroadWorkbench, excludePostgresql, excludeSnakeyaml, excludeSlf4j)
 
-  val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.998-SNAPSHOT")
+  val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.1030-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
   val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.506-SNAPSHOT")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1226

This passes through the region for Azure landing zones in the billing projects response (both list and single billing project signatures). Note that regions have been backfilled yet for existing landing zones, so old landing zones will temporarily return an empty string for region.

Response when running this branch locally against dev databases:

```
{
        "cloudPlatform": "AZURE",
        "invalidBillingAccount": false,
        "landingZoneId": "43217cdd-8037-463c-b119-3e8bdf6b0b97",
        "managedAppCoordinates": {
            "managedResourceGroupId": "mrg-terra-dev-previ-20240212144940",
            "subscriptionId": "df547342-9cfd-44ef-a6dd-df0ede32f1e3",
            "tenantId": "fad90753-2022-4456-9b0a-c7e5b934e408"
        },
        "projectName": "CARFeb12West",
        "protectedData": false,
        "region": "westus2", <-- newly created landing zone
        "roles": [
            "Owner"
        ],
        "status": "Ready"
    },
    {
        "cloudPlatform": "AZURE",
        "invalidBillingAccount": false,
        "landingZoneId": "2afef35f-991f-41ed-8dde-12a846ab9dd0",
        "managedAppCoordinates": {
            "managedResourceGroupId": "mrg-terra-dev-previ-20230119110658",
            "subscriptionId": "df547342-9cfd-44ef-a6dd-df0ede32f1e3",
            "tenantId": "fad90753-2022-4456-9b0a-c7e5b934e408"
        },
        "projectName": "CARJan19bemis",
        "protectedData": false,
        "region": "", <-- old landing zone that hasn't been backfilled
        "roles": [
            "Owner"
        ],
        "status": "Ready"
    },
    {
        "cloudPlatform": "AZURE",
        "invalidBillingAccount": false,
        "landingZoneId": "5723f447-aaca-47e7-9b55-07c349cd7544",
        "managedAppCoordinates": {
            "managedResourceGroupId": "mrg-terra-dev-previ-20230607135519",
            "subscriptionId": "df547342-9cfd-44ef-a6dd-df0ede32f1e3",
            "tenantId": "fad90753-2022-4456-9b0a-c7e5b934e408"
        },
        "message": "Landing Zone deletion failed: Landing Zone 5723f447-aaca-47e7-9b55-07c349cd7544 not found.",
        "projectName": "CARJan7Local",
        "protectedData": false, <-- No region field because landing zone no longer exists
        "roles": [
            "Owner"
        ],
        "status": "DeletionFailed"
    },
  

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
