### PR TITLE
AJ-1604: update commons-codec

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -152,7 +152,9 @@ object Dependencies {
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides = Seq(
     //Override for reactor-netty to address CVE-2023-34054 and CVE-2023-34062
-    "io.projectreactor.netty"                 % "reactor-netty-http"         % "1.0.39",
+    "io.projectreactor.netty"       % "reactor-netty-http"    % "1.0.39",
+    // override commons-codec to address a non-CVE warning from DefectDojo
+    "commons-codec"                 % "commons-codec"         % "1.16.1"
   )
 
   val extraOpenTelemetryDependencies = Seq(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1604

`commons-codec` is a deeply-nested transitive dependency, seen often as a child of `org.apache.httpcomponents:httpclient:4.5.14`. In the Rawls tree, we see this 5 or 6 levels deep. It feels impractical to update parent libraries, so I'm setting a transitive override.

DefectDojo only requires we update to 1.13, but I figured I'd update to latest while I'm in there.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
