### PR TITLE
[WOR-852] Update billing profile when updating billing account

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
@@ -5,9 +5,11 @@ import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi, Unauthent
 import bio.terra.profile.client.ApiClient
 import io.opencensus.trace.Tracing
 import io.opentelemetry.api.GlobalOpenTelemetry
+import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 import org.broadinstitute.dsde.rawls.util.{TracingUtils, WithOtelContextFilter}
 import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.jdk.connector.JdkConnectorProvider
 
 /**
  * Implementors of this trait know how to instantiate billing profile manager client
@@ -28,6 +30,11 @@ trait BillingProfileManagerClientProvider {
 class HttpBillingProfileManagerClientProvider(baseBpmUrl: Option[String]) extends BillingProfileManagerClientProvider {
   def getApiClient(ctx: RawlsRequestContext): ApiClient = {
     val client: ApiClient = new ApiClient()
+
+    val clientConfig = new ClientConfig()
+    clientConfig.connectorProvider(new JdkConnectorProvider)
+    client.setHttpClient(ClientBuilder.newClient(clientConfig))
+
     TracingUtils.enableCrossServiceTracing(client.getHttpClient, ctx)
     client.setBasePath(basePath)
     client.setAccessToken(ctx.userInfo.accessToken.token)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -222,15 +222,13 @@ class BillingProfileManagerDAOImpl(
   def updateBillingProfile(billingProfileId: UUID,
                            rawlsBillingAccountName: RawlsBillingAccountName,
                            ctx: RawlsRequestContext
-  ): ProfileModel = {
-    logger.info(s"updating profile $billingProfileId to billing account $rawlsBillingAccountName")
+  ): ProfileModel =
     apiClientProvider
       .getProfileApi(ctx)
       .updateProfile(
         new UpdateProfileRequest().billingAccountId(rawlsBillingAccountName.withoutPrefix()),
         billingProfileId
       )
-  }
 
   override def removeBillingAccountFromBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =
     apiClientProvider

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -56,6 +56,13 @@ trait BillingProfileManagerDAO {
 
   def getAllBillingProfiles(ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[ProfileModel]]
 
+  def updateBillingProfile(billingProfileId: UUID,
+                           rawlsBillingAccountName: RawlsBillingAccountName,
+                           ctx: RawlsRequestContext
+  ): ProfileModel
+
+  def removeBillingAccountFromBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit
+
   def addProfilePolicyMember(billingProfileId: UUID,
                              policy: ProfilePolicy,
                              memberEmail: String,
@@ -211,6 +218,24 @@ class BillingProfileManagerDAOImpl(
 
     Future.successful(callListProfiles())
   }
+
+  def updateBillingProfile(billingProfileId: UUID,
+                           rawlsBillingAccountName: RawlsBillingAccountName,
+                           ctx: RawlsRequestContext
+  ): ProfileModel = {
+    logger.info(s"updating profile $billingProfileId to billing account $rawlsBillingAccountName")
+    apiClientProvider
+      .getProfileApi(ctx)
+      .updateProfile(
+        new UpdateProfileRequest().billingAccountId(rawlsBillingAccountName.withoutPrefix()),
+        billingProfileId
+      )
+  }
+
+  override def removeBillingAccountFromBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =
+    apiClientProvider
+      .getProfileApi(ctx)
+      .removeBillingAccount(billingProfileId)
 
   def addProfilePolicyMember(billingProfileId: UUID,
                              policy: ProfilePolicy,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -56,11 +56,13 @@ trait BillingProfileManagerDAO {
 
   def getAllBillingProfiles(ctx: RawlsRequestContext)(implicit ec: ExecutionContext): Future[Seq[ProfileModel]]
 
+  @throws[ApiException]
   def updateBillingProfile(billingProfileId: UUID,
                            rawlsBillingAccountName: RawlsBillingAccountName,
                            ctx: RawlsRequestContext
   ): ProfileModel
 
+  @throws[ApiException]
   def removeBillingAccountFromBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit
 
   def addProfilePolicyMember(billingProfileId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.rawls.user
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import bio.terra.profile.client.ApiException
 import bio.terra.profile.model.ProfileModel
 import cats.Applicative
 import cats.effect.unsafe.implicits.global
@@ -880,7 +879,7 @@ class UserService(
         billingProfileManagerDAO.removeBillingAccountFromBillingProfile(UUID.fromString(billingProfileId), ctx)
     }).recover {
       // Until BPM is the system of record for Terra billing information, Rawls will not throw an exception if BPM fails to update
-      case e: ApiException =>
+      case e: Exception =>
         val message =
           s"Failed to update billing account in BPM [billingProfile=$billingProfileId, billingAccount=${billingAccount
               .map(_.value)}]"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -881,11 +881,11 @@ class UserService(
     }).recover {
       // Until BPM is the system of record for Terra billing information, Rawls will not throw an exception if BPM fails to update
       case e: ApiException =>
-        logger.warn(
-          s"Failed to update billing account in BPM [billingProfile=$billingProfileId]",
-          e
-        )
-        Sentry.captureException(e)
+        val message =
+          s"Failed to update billing account in BPM [billingProfile=$billingProfileId, billingAccount=${billingAccount
+              .map(_.value)}]"
+        logger.warn(message, e)
+        Sentry.captureException(new RawlsException(message, cause = e))
     }
 
   private def updateBillingAccountInDatabase(billingProjectName: RawlsBillingProjectName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -9,6 +9,7 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.api.client.http.HttpResponseException
 import com.typesafe.scalalogging.LazyLogging
+import io.sentry.Sentry
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO.ProfilePolicy
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.dataaccess._
@@ -870,23 +871,21 @@ class UserService(
   private def updateBillingAccountInBillingProfile(billingProfileId: String,
                                                    billingAccount: Option[RawlsBillingAccountName]
   ): Future[Unit] =
-    try
-      billingAccount match {
-        case Some(newBillingAccount) =>
-          billingProfileManagerDAO
-            .updateBillingProfile(UUID.fromString(billingProfileId), newBillingAccount, ctx)
-            .flatMap(_ => Future.unit)
-        case None =>
-          billingProfileManagerDAO.removeBillingAccountFromBillingProfile(UUID.fromString(billingProfileId), ctx)
-      }
-    catch {
+    (billingAccount match {
+      case Some(newBillingAccount) =>
+        billingProfileManagerDAO
+          .updateBillingProfile(UUID.fromString(billingProfileId), newBillingAccount, ctx)
+          .flatMap(_ => Future.unit)
+      case None =>
+        billingProfileManagerDAO.removeBillingAccountFromBillingProfile(UUID.fromString(billingProfileId), ctx)
+    }).recover {
       // Until BPM is the system of record for Terra billing information, Rawls will not throw an exception if BPM fails to update
       case e: ApiException =>
         logger.warn(
           s"Failed to update billing account in BPM [billingProfile=$billingProfileId]",
           e
         )
-        Future.unit
+        Sentry.captureException(e)
     }
 
   private def updateBillingAccountInDatabase(billingProjectName: RawlsBillingProjectName,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.billing
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi}
@@ -33,6 +34,7 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
   implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
+  implicit val actor: ActorSystem = ActorSystem("BillingProfileManagerDAOSpec")
 
   val azConfig: AzureConfig = AzureConfig(
     "fake-landing-zone-definition",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -2023,10 +2023,12 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   }
 
   class MinimalTestData() extends TestData {
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("myNamespace"),
-                                             CreationStatuses.Ready,
-                                             Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
-                                             None
+    val billingProject = RawlsBillingProject(
+      RawlsBillingProjectName("myNamespace"),
+      CreationStatuses.Ready,
+      Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
+      None,
+      billingProfileId = Some(UUID.randomUUID().toString)
     )
     val wsName = WorkspaceName(billingProject.projectName.value, "myWorkspace")
     val wsName2 = WorkspaceName(billingProject.projectName.value, "myWorkspace2")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -842,7 +842,7 @@ class UserServiceSpec
           ArgumentMatchers.eq(newBillingAccountRequest.billingAccount),
           any()
         )
-      ).thenReturn(new ProfileModel())
+      ).thenReturn(Future.successful(new ProfileModel()))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
 
@@ -893,6 +893,7 @@ class UserServiceSpec
 
       val mockGcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val mockBpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+      when(mockBpmDAO.removeBillingAccountFromBillingProfile(any(), any())).thenReturn(Future.unit)
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
 
@@ -1141,13 +1142,13 @@ class UserServiceSpec
           ArgumentMatchers.eq(newBillingAccountRequest.billingAccount),
           any()
         )
-      ).thenThrow(new ApiException("oh no"))
+      ).thenReturn(Future.failed(new ApiException("oh no")))
       when(
         mockBpmDAO.removeBillingAccountFromBillingProfile(
           ArgumentMatchers.eq(UUID.fromString(billingProject.billingProfileId.getOrElse(fail()))),
           any()
         )
-      ).thenThrow(new ApiException("oh no"))
+      ).thenReturn(Future.failed(new ApiException("oh no")))
 
       val userService = getUserService(dataSource, mockSamDAO, mockGcsDAO, bpmDAO = mockBpmDAO)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -127,7 +127,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.998-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.506-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.508-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.11-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-d0bf371"


### PR DESCRIPTION
Ticket: [WOR-852](https://broadworkbench.atlassian.net/browse/WOR-852)
* When Rawls updates or removes the billing account on a billing project, perform the same operation on the billing project's billing profile if it exists
* Add workaround for PATCH requests to BPM API client

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-852]: https://broadworkbench.atlassian.net/browse/WOR-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ