### PR TITLE
[WOR-1537] Remove incorrect usages of invalidBillingAccount

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/migration/MultiregionalBucketMigrationActor.scala
@@ -288,16 +288,6 @@ object MultiregionalBucketMigrationActor {
           throw makeError("no billing account on billing project", Map("billingProject" -> billingProject.projectName))
         )
 
-        _ <- raiseWhen(billingProject.invalidBillingAccount) {
-          makeError(
-            "invalid billing account on billing project",
-            Map(
-              "billingProject" -> billingProject.projectName,
-              "billingProjectBillingAccount" -> billingProjectBillingAccount
-            )
-          )
-        }
-
         _ <- raiseWhen(workspaceBillingAccount != billingProjectBillingAccount) {
           makeError(
             "billing account on workspace differs from billing account on billing project",

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3382,15 +3382,14 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           identity
         )
       )
-      // We should never get here with a missing or invalid Billing Account, but we still need to get the value out of the
-      // Option, so we are being thorough
+
       billingAccount <- billingProject.billingAccount match {
-        case Some(ba) if !billingProject.invalidBillingAccount => DBIO.successful(ba)
+        case Some(ba) => DBIO.successful(ba)
         case _ =>
           DBIO.failed(
             RawlsExceptionWithErrorReport(
               ErrorReport(StatusCodes.BadRequest,
-                          s"Billing Account is missing or invalid for Billing Project: ${billingProject}"
+                          s"Billing Account is missing: ${billingProject}"
               )
             )
           )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -871,7 +871,7 @@ class UserServiceSpec
       when(
         mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
                                  billingProject.projectName.value,
-                                 SamBillingProjectActions.updateBillingAccount,
+                                 SamBillingProjectActions.updateBillingAccount,†
                                  testContext
         )
       ).thenReturn(Future.successful(true))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -871,7 +871,7 @@ class UserServiceSpec
       when(
         mockSamDAO.userHasAction(SamResourceTypeNames.billingProject,
                                  billingProject.projectName.value,
-                                 SamBillingProjectActions.updateBillingAccount,†
+                                 SamBillingProjectActions.updateBillingAccount,
                                  testContext
         )
       ).thenReturn(Future.successful(true))


### PR DESCRIPTION
Ticket: [WOR-1537](https://broadworkbench.atlassian.net/browse/WOR-1537)
### Context
- `invalidBillingAccount` indicates whether or not Terra had `billing.resourceAssociations.create` on a given billing account the last time it checked. Rawls needs this permission to attach a Google project to a billing account, so it's a requirement to create or clone a workspace. We make a live call to Google before creating or cloning a workspace to check whether we have the required permission, after which we update `invalidBillingAccount` accordingly. 
    - Note that a billing account and any workspaces attached to it will be _usable_ even if Terra doesn't have access to it as long as the bills are getting paid.

#### This PR
- Removes an unnecessary check in `WorkspaceService` of `invalidBillingAccount` before creating or cloning a workspace. This check used the value stored on the billing project record that may be out of date since it is loaded into memory from the DB _before_ we make the live call to Google to verify our permissions. If a billing project's billing account had been previously marked as invalid, but the user had since restored Terra's access to the billing account, the live call would succeed but this check would wrongfully fail the workspace create/clone operation based on the outdated value in memory.
- Removes check in the Multiregional Bucket Migration pipeline. This check was incorrectly ported over from the PPW migration pipeline. Checking billing account permissions was required for PPW since that migration involved provisioning a new Google project which would fail if Terra was missing permissions on the billing account. For bucket migrations, Terra is not attaching any new Google projects to the user's billing account -- a migration can succeed even if Terra doesn't have the `billing.resourceAssociations.create` permission. All this check does is fail bucket migrations that may have succeeded.


With these changes removed, the `invalidBillingAccount` flag will no longer be used for anything in Rawls. It is still used in the Terra UI to prevent users from selecting billing projects that we believe we lack the required access to. I'd argue that using outdated information to prevent users from selecting a billing project for workspace creation/cloning can do as much harm as it does good. Until we can develop a process to keep this information up-to-date, we may as well let users submit the create/clone request and return a helpful error message should the request fail.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1537]: https://broadworkbench.atlassian.net/browse/WOR-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ