### PR TITLE
[WOR-1555] Restore original order of operations

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -489,7 +489,6 @@ object Boot extends IOApp with LazyLogging {
         shardedExecutionServiceCluster,
         conf.getInt("executionservice.batchSize"),
         workspaceManagerDAO,
-        new LeonardoService(leonardoDAO),
         methodConfigResolver,
         gcsDAO,
         samDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -16,7 +16,6 @@ import org.broadinstitute.dsde.rawls._
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import slick.jdbc.TransactionIsolation
 import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
@@ -39,7 +38,6 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model.WorkspaceVersions.WorkspaceVersion
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.monadThrowDBIOAction
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500OrProcessingException
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
@@ -58,7 +56,7 @@ import spray.json._
 
 import java.io.IOException
 import java.util.UUID
-import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.control.NonFatal
@@ -75,7 +73,6 @@ object WorkspaceService {
                   executionServiceCluster: ExecutionServiceCluster,
                   execServiceBatchSize: Int,
                   workspaceManagerDAO: WorkspaceManagerDAO,
-                  leonardoService: LeonardoService,
                   methodConfigResolver: MethodConfigResolver,
                   gcsDAO: GoogleServicesDAO,
                   samDAO: SamDAO,
@@ -113,7 +110,6 @@ object WorkspaceService {
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,
@@ -189,7 +185,6 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                        executionServiceCluster: ExecutionServiceCluster,
                        execServiceBatchSize: Int,
                        val workspaceManagerDAO: WorkspaceManagerDAO,
-                       val leonardoService: LeonardoService,
                        val methodConfigResolver: MethodConfigResolver,
                        protected val gcsDAO: GoogleServicesDAO,
                        val samDAO: SamDAO,
@@ -660,14 +655,12 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   private def deleteWorkspaceInternal(workspaceContext: Workspace,
                                       maybeMcWorkspace: Option[WorkspaceDescription],
                                       parentContext: RawlsRequestContext
-  ): Future[WorkspaceDeletionResult] = {
-    if (isAzureMcWorkspace(maybeMcWorkspace)) {
-      return Future.failed(
-        new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "MC workspaces not supported"))
-      )
-    }
-
+  ): Future[WorkspaceDeletionResult] =
     for {
+      _ <- Applicative[Future].unlessA(isAzureMcWorkspace(maybeMcWorkspace))(
+        assertNoGoogleChildrenBlockingWorkspaceDeletion(workspaceContext)
+      )
+
       _ <- traceFutureWithParent("requesterPaysSetupService.deleteAllRecordsForWorkspace", parentContext)(_ =>
         requesterPaysSetupService.deleteAllRecordsForWorkspace(workspaceContext) recoverWith { case t: Throwable =>
           logger.warn(
@@ -708,36 +701,20 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         fastPassServiceConstructor(childContext, dataSource).removeFastPassGrantsForWorkspace(workspaceContext)
       )
 
-      // Delete Google Project but not the project's Sam record
+      // Delete Google Project
       _ <- traceFutureWithParent("maybeDeleteGoogleProject", parentContext)(_ =>
-        maybeDeleteGoogleProject(workspaceContext.googleProjectId,
-                                 workspaceContext.workspaceVersion,
-                                 ctx.userInfo
-        ) recoverWith { case t: Throwable =>
-          logger.error(
-            s"Unexpected failure deleting workspace (while deleting google project) for workspace `${workspaceContext.toWorkspaceName}`",
-            t
-          )
-          Future.failed(t)
-        }
-      )
-
-      // notify leonardo so it can cleanup any dangling sam resources and other non-cloud state
-      // note this must take place _after_ google project deletion but _before_ the deletion of the project in sam
-      // to avoid orphaning any cloud resources
-      _ <- traceFutureWithParent("notifyLeonardo", parentContext)(_ =>
-        leonardoService.cleanupResources(workspaceContext.googleProjectId, workspaceContext.workspaceIdAsUUID, ctx)
-      )
-
-      // delete the google project's sam record
-      _ <- traceFutureWithParent("maybeDeleteGoogleProjectInSam", parentContext)(_ =>
-        deleteGoogleProjectInSam(workspaceContext.googleProjectId, ctx.userInfo) recoverWith { case t: Throwable =>
-          logger.error(
-            s"Unexpected failure deleting workspace (while deleting google project in Sam) for workspace `${workspaceContext.toWorkspaceName}`",
-            t
-          )
-          Future.failed(t)
-        }
+        if (!isAzureMcWorkspace(maybeMcWorkspace)) {
+          maybeDeleteGoogleProject(workspaceContext.googleProjectId,
+                                   workspaceContext.workspaceVersion,
+                                   ctx.userInfo
+          ) recoverWith { case t: Throwable =>
+            logger.error(
+              s"Unexpected failure deleting workspace (while deleting google project) for workspace `${workspaceContext.toWorkspaceName}`",
+              t
+            )
+            Future.failed(t)
+          }
+        } else Future.successful()
       )
 
       _ <- traceFutureWithParent("deleteWorkspaceInWSM", parentContext) { _ =>
@@ -800,9 +777,11 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
           logger.info(s"failure aborting workflows while deleting workspace ${workspaceContext.toWorkspaceName}", t)
         case _ => /* ok */
       }
-      WorkspaceDeletionResult.fromGcpBucketName(workspaceContext.bucketName)
+
+      if (!isAzureMcWorkspace(maybeMcWorkspace)) {
+        WorkspaceDeletionResult.fromGcpBucketName(workspaceContext.bucketName)
+      } else WorkspaceDeletionResult(None, None)
     }
-  }
 
   private def maybeDeleteWsmWorkspace(workspaceContext: Workspace) =
     Future(workspaceManagerDAO.deleteWorkspace(workspaceContext.workspaceIdAsUUID, ctx)).recoverWith {
@@ -849,17 +828,16 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
     for {
       _ <- deletePetsInProject(googleProjectId, userInfoForSam)
       _ <- gcsDAO.deleteGoogleProject(googleProjectId)
+      _ <- samDAO
+        .deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, ctx.copy(userInfo = userInfoForSam))
+        .recover {
+          case regrets: RawlsExceptionWithErrorReport
+              if regrets.errorReport.statusCode == Option(StatusCodes.NotFound) =>
+            logger.info(
+              s"google-project resource ${googleProjectId.value} not found in Sam. Continuing with workspace deletion"
+            )
+        }
     } yield ()
-
-  private def deleteGoogleProjectInSam(googleProjectId: GoogleProjectId, userInfoForSam: UserInfo): Future[Unit] =
-    samDAO
-      .deleteResource(SamResourceTypeNames.googleProject, googleProjectId.value, ctx.copy(userInfo = userInfoForSam))
-      .recover {
-        case regrets: RawlsExceptionWithErrorReport if regrets.errorReport.statusCode == Option(StatusCodes.NotFound) =>
-          logger.info(
-            s"google-project resource ${googleProjectId.value} not found in Sam. Continuing with workspace deletion"
-          )
-      }
 
   private def deletePetsInProject(projectName: GoogleProjectId, userInfo: UserInfo): Future[Unit] =
     for {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -278,7 +278,6 @@ class FastPassMonitorSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -307,7 +307,6 @@ class FastPassServiceSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -534,7 +534,6 @@ class SubmissionSpec(_system: ActorSystem)
         execServiceCluster,
         execServiceBatchSize,
         workspaceManagerDAO,
-        leonardoService,
         methodConfigResolver,
         gcsDAO,
         samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -363,7 +363,6 @@ trait ApiServiceSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -301,7 +301,6 @@ class WorkspaceServiceSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -110,7 +110,6 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1555

Leo is calling sam as the user's pet to delete resources during the workspace deletion flow. However, with the previous change the google project housing the Pet SA is being deleted *before* the call to Leo, so there is concern that the leo call will fail out. In my testing I have not been able to reproduce this, but until we can get a firm grasp on the situation I am going to revert the changes to the WorkspaceService to their original flow. 

Note this isn't a full revert as there was some scalafmt'ing that has taken place since the original PR. This just restores the original `WorkspaceService` code flow. 


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
