### PR TITLE
[WOR-1555] Restore original Google workspace deletion order of operations 

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -42,7 +42,6 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.{DrsHubResolver, MarthaResolver}
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.entities.{EntityManager, EntityService}
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
@@ -489,7 +488,6 @@ object Boot extends IOApp with LazyLogging {
         shardedExecutionServiceCluster,
         conf.getInt("executionservice.batchSize"),
         workspaceManagerDAO,
-        new LeonardoService(leonardoDAO),
         methodConfigResolver,
         gcsDAO,
         samDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAO.scala
@@ -1,12 +1,19 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
 import org.broadinstitute.dsde.rawls.config.LeonardoConfig
-import org.broadinstitute.dsde.rawls.model.GoogleProjectId
-import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient
-import org.broadinstitute.dsde.workbench.client.leonardo.api.{AppsApi, ResourcesApi, RuntimesApi}
-import org.broadinstitute.dsde.workbench.client.leonardo.model._
+import org.broadinstitute.dsde.workbench.client.leonardo.api.{AppsApi, RuntimesApi}
+import org.broadinstitute.dsde.workbench.client.leonardo.model.{
+  AppAccessScope,
+  AppType,
+  CreateAppRequest,
+  ListAppResponse,
+  ListRuntimeResponse
+}
 
 import java.util.UUID
+import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient
+
+import java.util
 import scala.jdk.CollectionConverters._
 
 class HttpLeonardoDAO(leonardoConfig: LeonardoConfig) extends LeonardoDAO {
@@ -18,19 +25,13 @@ class HttpLeonardoDAO(leonardoConfig: LeonardoConfig) extends LeonardoDAO {
     new AppsApi(apiClient)
   }
 
-  private def getResourcesLeonardoApi(accessToken: String) = {
-    val apiClient = new ApiClient()
-    apiClient.setAccessToken(accessToken)
-    apiClient.setBasePath(leonardoConfig.baseUrl)
-    new ResourcesApi(apiClient)
-  }
-
   private def getRuntimesV2LeonardoApi(accessToken: String): RuntimesApi = {
     val apiClient = new ApiClient()
     apiClient.setAccessToken(accessToken)
     apiClient.setBasePath(leonardoConfig.baseUrl)
     new RuntimesApi(apiClient)
   }
+
   override def deleteApps(token: String, workspaceId: UUID, deleteDisk: Boolean) =
     getAppsV2LeonardoApi(token).deleteAllAppsV2(workspaceId.toString, deleteDisk)
 
@@ -55,9 +56,6 @@ class HttpLeonardoDAO(leonardoConfig: LeonardoConfig) extends LeonardoDAO {
     val createAppRequest = buildAppRequest(appType, sourceWorkspaceId)
     getAppsV2LeonardoApi(token).createAppV2(workspaceId.toString, appName, createAppRequest)
   }
-
-  override def cleanupAllResources(token: String, googleProjectId: GoogleProjectId): Unit =
-    getResourcesLeonardoApi(token).cleanupAllResources(googleProjectId.value)
 
   protected[dataaccess] def buildAppRequest(appType: String, sourceWorkspaceId: Option[UUID]): CreateAppRequest = {
     val createAppRequest = new CreateAppRequest()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/LeonardoDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/LeonardoDAO.scala
@@ -1,9 +1,8 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 import org.broadinstitute.dsde.workbench.client.leonardo.api.AppsApi
 
-import scala.concurrent.{ExecutionContext, Future}
-import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, WorkspaceName}
-import org.broadinstitute.dsde.workbench.client.leonardo.ApiException
+import scala.concurrent.Future
+import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.broadinstitute.dsde.workbench.client.leonardo.model.{ListAppResponse, ListRuntimeResponse}
 
 import java.util.UUID
@@ -19,14 +18,12 @@ trait LeonardoDAO {
                 sourceWorkspaceId: Option[UUID]
   ): Unit
 
-  def deleteApps(token: String, workspaceId: UUID, deleteDisk: Boolean): Unit
+  def deleteApps(token: String, workspaceId: UUID, deleteDisk: Boolean)
 
   def listApps(token: String, workspaceId: UUID): Seq[ListAppResponse]
 
   def listAzureRuntimes(token: String, workspaceId: UUID): Seq[ListRuntimeResponse]
 
-  def deleteAzureRuntimes(token: String, workspaceId: UUID, deleteDisk: Boolean): Unit
+  def deleteAzureRuntimes(token: String, workspaceId: UUID, deleteDisk: Boolean)
 
-  @throws(classOf[ApiException])
-  def cleanupAllResources(token: String, googleProjectId: GoogleProjectId): Unit
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -16,7 +16,6 @@ import org.broadinstitute.dsde.rawls.coordination.{
 }
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsResolver
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityService
@@ -33,7 +32,10 @@ import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorSupervisor.AvroUps
 import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationActor
 import org.broadinstitute.dsde.rawls.monitor.workspace.WorkspaceResourceMonitor
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.WorkspaceDeletionRunner
-import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.WsmDeletionAction
+import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.{
+  LeonardoResourceDeletionAction,
+  WsmDeletionAction
+}
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.{
   BPMBillingProjectDeleteRunner,
   CloneWorkspaceContainerRunner,
@@ -46,6 +48,7 @@ import org.broadinstitute.dsde.workbench.google.{GoogleIamDAO, GoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, GoogleStorageTransferService}
 import spray.json._
 
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -442,13 +445,13 @@ object BootMonitors extends LazyLogging {
   ) = {
     val billingRepo = new BillingRepository(dataSource)
 
-    val leoService = new LeonardoService(leonardoDAO)(system)
+    val leoDeletionAction = new LeonardoResourceDeletionAction(leonardoDAO)(system)
     val wsmDeletionAction = new WsmDeletionAction(workspaceManagerDAO)(system)
     val monitorRecordDao = WorkspaceManagerResourceMonitorRecordDao(dataSource)
     val workspaceDeletionRunner = new WorkspaceDeletionRunner(samDAO,
                                                               workspaceManagerDAO,
                                                               workspaceRepository,
-                                                              leoService,
+                                                              leoDeletionAction,
                                                               wsmDeletionAction,
                                                               gcsDAO,
                                                               monitorRecordDao

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/actions/LeonardoDeletionActions.scala
@@ -1,11 +1,10 @@
-package org.broadinstitute.dsde.rawls.dataaccess.leonardo
+package org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.LeonardoDAO
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, GoogleProjectId, RawlsRequestContext, Workspace}
+import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, Workspace}
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.deletion.actions.DeletionAction.when500OrProcessingException
 import org.broadinstitute.dsde.rawls.util.Retry
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiException
@@ -15,18 +14,12 @@ import org.broadinstitute.dsde.workbench.client.leonardo.model.{
   ListAppResponse,
   ListRuntimeResponse
 }
-import org.broadinstitute.dsde.workbench.model.Notifications.WorkspaceName
 
 import java.util.UUID
 import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-/**
- * Wraps the leonardo DAO with retry logic and error handling
- * @param leonardoDAO Instance of a LeonardoDAO
- * @param system Instance of an ActorSystem
- */
-class LeonardoService(leonardoDAO: LeonardoDAO)(implicit
+class LeonardoResourceDeletionAction(leonardoDAO: LeonardoDAO)(implicit
   val system: ActorSystem
 ) extends Retry
     with LazyLogging {
@@ -128,38 +121,7 @@ class LeonardoService(leonardoDAO: LeonardoDAO)(implicit
       }
     }
 
-  /**
-   * Notifies leonardo that it should delete any resource records related to the given google project ID *without*
-   * deleting the actual cloud resources.
-   *
-   * NB: This should only be called after a workspace's google project has been deleted and we want to ensure there
-   * are no further dangling references from Leo to resources within that google project.
-   *
-   * @param googleProjectId ID of the workspace's google project
-   * @param workspaceId ID of the workspace
-   * @param ctx RawlsRequestContext containing auth info
-   */
-  def cleanupResources(googleProjectId: GoogleProjectId, workspaceId: UUID, ctx: RawlsRequestContext)(implicit
-    ec: ExecutionContext
-  ): Future[Unit] =
-    retry(when500OrProcessingException) { () =>
-      Future {
-        blocking {
-          logger.info(
-            s"Sending resource cleanup request to Leonardo [workspaceId=$workspaceId, googleProjectId=${googleProjectId.value}]"
-          )
-          leonardoDAO.cleanupAllResources(ctx.userInfo.accessToken.token, googleProjectId)
-        }
-      }.recoverWith { case t: ApiException =>
-        if (t.getCode != StatusCodes.NotFound.intValue) {
-          logger.warn(
-            s"Unexpected failure cleaning up leonardo workspace resources for workspaceId=$workspaceId . Received ${t.getCode}: [${t.getResponseBody}]"
-          )
-          Future.failed(t)
-        } else {
-          Future.successful()
-        }
-      }
-    }
-
 }
+
+class LeonardoOperationFailureException(message: String, val workspaceId: UUID)
+    extends WorkspaceDeletionActionFailureException(message)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3388,9 +3388,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
         case _ =>
           DBIO.failed(
             RawlsExceptionWithErrorReport(
-              ErrorReport(StatusCodes.BadRequest,
-                          s"Billing Account is missing: ${billingProject}"
-              )
+              ErrorReport(StatusCodes.BadRequest, s"Billing Account is missing: ${billingProject}")
             )
           )
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockLeonardoDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockLeonardoDAO.scala
@@ -1,12 +1,10 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
-import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.client.leonardo.model.{ListAppResponse, ListRuntimeResponse}
 
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future}
 
-class MockLeonardoDAO extends LeonardoDAO {
+class MockLeonardoDAO() extends LeonardoDAO {
 
   override def createApp(token: String,
                          workspaceId: UUID,
@@ -24,6 +22,4 @@ class MockLeonardoDAO extends LeonardoDAO {
   override def listAzureRuntimes(token: String, workspaceId: UUID): Seq[ListRuntimeResponse] = ???
 
   override def deleteAzureRuntimes(token: String, workspaceId: UUID, deleteDisk: Boolean): Unit = ???
-
-  override def cleanupAllResources(token: String, googleProjectId: GoogleProjectId): Unit = ???
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassMonitorSpec.scala
@@ -11,7 +11,6 @@ import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -126,7 +125,6 @@ class FastPassMonitorSpec
     val gpsDAO = new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
     val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
-    val leonardoService = mock[LeonardoService](RETURNS_SMART_NULLS)
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
     val leonardoDAO: LeonardoDAO = new MockLeonardoDAO()
 
@@ -278,7 +276,6 @@ class FastPassMonitorSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -11,7 +11,6 @@ import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -153,10 +152,8 @@ class FastPassServiceSpec
     val googleStorageDAO: MockGoogleStorageDAO = Mockito.spy(new SlowGoogleStorageDAO(slowIam))
     val samDAO = Mockito.spy(new MockSamDAO(dataSource))
     val gpsDAO = new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
-    val mockNotificationDAO: NotificationDAO = mock[NotificationDAO](RETURNS_SMART_NULLS)
+    val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
-    val leonardoService = mock[LeonardoService](RETURNS_SMART_NULLS)
-    val leonardoDAO = Mockito.spy(new MockLeonardoDAO())
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
 
     val notificationTopic = "test-notification-topic"
@@ -307,7 +304,6 @@ class FastPassServiceSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -15,7 +15,6 @@ import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{TestData, TestDriverComponent}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -491,7 +490,6 @@ class SubmissionSpec(_system: ActorSystem)
         new RequesterPaysSetupService(slickDataSource, gcsDAO, bondApiDAO, requesterPaysRole = "requesterPaysRole")
 
       val workspaceManagerDAO = new MockWorkspaceManagerDAO
-      val leonardoService = mock[LeonardoService](RETURNS_SMART_NULLS)
       val entityManager = EntityManager.defaultEntityManager(
         dataSource,
         workspaceManagerDAO,
@@ -534,7 +532,6 @@ class SubmissionSpec(_system: ActorSystem)
         execServiceCluster,
         execServiceBatchSize,
         workspaceManagerDAO,
-        leonardoService,
         methodConfigResolver,
         gcsDAO,
         samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -26,7 +26,6 @@ import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsHubResolver
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.resourcebuffer.ResourceBufferDAO
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponentWithFlatSpecAndMatchers
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
@@ -41,11 +40,9 @@ import org.broadinstitute.dsde.rawls.model.{
   Agora,
   ApplicationVersion,
   Dockstore,
-  GoogleProjectId,
   RawlsBillingAccountName,
   RawlsRequestContext,
-  RawlsUser,
-  Workspace
+  RawlsUser
 }
 import org.broadinstitute.dsde.rawls.monitor.HealthMonitor
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
@@ -65,16 +62,13 @@ import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNoti
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
-import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
+import org.mockito.Mockito.RETURNS_SMART_NULLS
 import org.mockito.ArgumentMatcher
-import org.mockito.ArgumentMatchers.any
 import org.scalatest.concurrent.Eventually
 import spray.json._
 
 import java.time.temporal.ChronoUnit
-import java.util.UUID
 import java.util.concurrent.TimeUnit
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters.JavaDurationOps
 import scala.language.postfixOps
@@ -180,12 +174,6 @@ trait ApiServiceSpec
     val samDAO: SamDAO = new MockSamDAO(dataSource)
 
     val workspaceManagerDAO: WorkspaceManagerDAO = new MockWorkspaceManagerDAO()
-
-    val leonardoService: LeonardoService = mock[LeonardoService](RETURNS_SMART_NULLS)
-    when(
-      leonardoService.cleanupResources(any[GoogleProjectId], any[UUID], any[RawlsRequestContext])(any[ExecutionContext])
-    )
-      .thenReturn(Future.successful())
 
     val dataRepoDAO: DataRepoDAO = new MockDataRepoDAO(mockServer.mockServerBaseUrl)
 
@@ -363,7 +351,6 @@ trait ApiServiceSpec
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -7,7 +7,6 @@ import bio.terra.workspace.model.{AzureContext, GcpContext, IamRole, RoleBinding
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
@@ -74,7 +73,6 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
     executionServiceCluster: ExecutionServiceCluster = mock[ExecutionServiceCluster](RETURNS_SMART_NULLS),
     execServiceBatchSize: Int = 1,
     workspaceManagerDAO: WorkspaceManagerDAO = mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
-    leonardoService: LeonardoService = mock[LeonardoService](RETURNS_SMART_NULLS),
     methodConfigResolver: MethodConfigResolver = mock[MethodConfigResolver](RETURNS_SMART_NULLS),
     gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
     samDAO: SamDAO = mock[SamDAO],
@@ -110,7 +108,6 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
       executionServiceCluster,
       execServiceBatchSize,
       workspaceManagerDAO,
-      leonardoService,
       methodConfigResolver,
       gcsDAO,
       samDAO,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -130,7 +130,7 @@ object Dependencies {
   val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.511-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.11-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
-  val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"
+  val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-acbd45d"
 
   // OpenTelemetry
   val openTelemetryInstrumentationVersion = "2.0.0"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1555

Leo is calling sam as the user's pet to delete resources during the workspace deletion flow. However, with the previous change the google project housing the Pet SA is being deleted before the call to Leo, so there is concern that the leo call will fail out. In my testing I have not been able to reproduce this, but until we can get a firm grasp on the situation I am going to revert the changes to the WorkspaceService to their original flow.

(This is a full revert via the git cli, there were intervening scalafmt commits that caused conflicts which I resolved manually)

This reverts https://github.com/broadinstitute/rawls/pull/2745

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
