### PR TITLE
AJ-1664: AvroUpsertMonitor can accept workspaceId instead of namespace/name

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -290,90 +290,89 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
       self ! None
   }
 
-  private def importEntities(message: PubSubMessage) = {
-    val attributes = new AvroUpsertMonitorMessageParser(message).parse
-
-    val importFuture = for {
-      workspace <- dataSource.inTransaction { dataAccess =>
-        dataAccess.workspaceQuery.findByName(attributes.workspace).map {
-          case Some(workspace) => workspace
-          case None =>
-            throw new RawlsException(s"Workspace ${attributes.workspace} not found while importing entities")
+  private def importEntities(message: PubSubMessage) =
+    new AvroUpsertMonitorMessageParser(message, dataSource).parse flatMap { attributes =>
+      val importFuture = for {
+        workspace <- dataSource.inTransaction { dataAccess =>
+          dataAccess.workspaceQuery.findByName(attributes.workspace).map {
+            case Some(workspace) => workspace
+            case None =>
+              throw new RawlsException(s"Workspace ${attributes.workspace} not found while importing entities")
+          }
         }
-      }
-      petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, attributes.userEmail)
-      importStatus <- importServiceDAO.getImportStatus(attributes.importId, attributes.workspace, petUserInfo)
-      _ <- importStatus match {
-        // Currently, there is only one upsert monitor thread - but if we decide to make more threads, we might
-        // end up with a race condition where multiple threads are attempting the same import / updating the status
-        // of the same import.
-        case Some(status) if status == ImportStatuses.ReadyForUpsert =>
-          publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Upserting, None)
-          toFutureTry(
-            initUpsert(attributes.upsertFile,
-                       attributes.importId,
-                       message.ackId,
-                       workspace,
-                       attributes.userEmail,
-                       attributes.isUpsert
-            )
-          ) map {
-            case Success(importUpsertResults) =>
-              val failureMessages = stringMessageFromFailures(importUpsertResults.failures, 100)
-              val baseMsg =
-                s"Successfully updated ${importUpsertResults.successes} entities; ${importUpsertResults.failures.size} updates failed."
-              if (importUpsertResults.failures.isEmpty)
-                publishMessageToUpdateImportStatus(attributes.importId,
-                                                   Option(status),
-                                                   ImportStatuses.Done,
-                                                   Option(baseMsg)
-                )
-              else {
-                val msg = baseMsg + s" First 100 failures are: $failureMessages"
+        petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, attributes.userEmail)
+        importStatus <- importServiceDAO.getImportStatus(attributes.importId, attributes.workspace, petUserInfo)
+        _ <- importStatus match {
+          // Currently, there is only one upsert monitor thread - but if we decide to make more threads, we might
+          // end up with a race condition where multiple threads are attempting the same import / updating the status
+          // of the same import.
+          case Some(status) if status == ImportStatuses.ReadyForUpsert =>
+            publishMessageToUpdateImportStatus(attributes.importId, Option(status), ImportStatuses.Upserting, None)
+            toFutureTry(
+              initUpsert(attributes.upsertFile,
+                         attributes.importId,
+                         message.ackId,
+                         workspace,
+                         attributes.userEmail,
+                         attributes.isUpsert
+              )
+            ) map {
+              case Success(importUpsertResults) =>
+                val failureMessages = stringMessageFromFailures(importUpsertResults.failures, 100)
+                val baseMsg =
+                  s"Successfully updated ${importUpsertResults.successes} entities; ${importUpsertResults.failures.size} updates failed."
+                if (importUpsertResults.failures.isEmpty)
+                  publishMessageToUpdateImportStatus(attributes.importId,
+                                                     Option(status),
+                                                     ImportStatuses.Done,
+                                                     Option(baseMsg)
+                  )
+                else {
+                  val msg = baseMsg + s" First 100 failures are: $failureMessages"
+                  publishMessageToUpdateImportStatus(attributes.importId,
+                                                     Option(status),
+                                                     ImportStatuses.Error,
+                                                     Option(msg)
+                  )
+                }
+              case Failure(t) =>
+                val errMsg = t match {
+                  case errRpt: RawlsExceptionWithErrorReport => errRpt.errorReport.message
+                  case x                                     => x.getMessage
+                }
                 publishMessageToUpdateImportStatus(attributes.importId,
                                                    Option(status),
                                                    ImportStatuses.Error,
-                                                   Option(msg)
+                                                   Option(errMsg)
                 )
-              }
-            case Failure(t) =>
-              val errMsg = t match {
-                case errRpt: RawlsExceptionWithErrorReport => errRpt.errorReport.message
-                case x                                     => x.getMessage
-              }
-              publishMessageToUpdateImportStatus(attributes.importId,
-                                                 Option(status),
-                                                 ImportStatuses.Error,
-                                                 Option(errMsg)
-              )
-          }
-        case Some(status) =>
-          logger.warn(
-            s"Received a double message delivery for import ID [${attributes.importId}] which is already in status [$status].  Acking message."
-          )
-          acknowledgeMessage(message.ackId)
-        case None =>
-          publishMessageToUpdateImportStatus(attributes.importId,
-                                             None,
-                                             ImportStatuses.Error,
-                                             Option("Import status not found")
-          )
-      }
-    } yield ()
+            }
+          case Some(status) =>
+            logger.warn(
+              s"Received a double message delivery for import ID [${attributes.importId}] which is already in status [$status].  Acking message."
+            )
+            acknowledgeMessage(message.ackId)
+          case None =>
+            publishMessageToUpdateImportStatus(attributes.importId,
+                                               None,
+                                               ImportStatuses.Error,
+                                               Option("Import status not found")
+            )
+        }
+      } yield ()
 
-    // Make sure message is acknowledged in the case of any failure while trying to construct importFuture
-    importFuture.map(_ => ImportComplete) recover { case t =>
-      logger.error(s"unexpected error in importFuture for ${attributes.importId}: ${t.getMessage}", t)
-      publishMessageToUpdateImportStatus(
-        attributes.importId,
-        None,
-        ImportStatuses.Error,
-        Option(s"Failed to import data. The underlying error message is: ${t.getMessage}")
-      )
-      acknowledgeMessage(message.ackId)
-    } pipeTo self
+      // Make sure message is acknowledged in the case of any failure while trying to construct importFuture
+      importFuture.map(_ => ImportComplete) recover { case t =>
+        logger.error(s"unexpected error in importFuture for ${attributes.importId}: ${t.getMessage}", t)
+        publishMessageToUpdateImportStatus(
+          attributes.importId,
+          None,
+          ImportStatuses.Error,
+          Option(s"Failed to import data. The underlying error message is: ${t.getMessage}")
+        )
+        acknowledgeMessage(message.ackId)
+      } pipeTo self
 
-  }
+    }
 
   private def publishMessageToUpdateImportStatus(importId: UUID,
                                                  currentImportStatus: Option[ImportStatus],

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
@@ -1,0 +1,34 @@
+package org.broadinstitute.dsde.rawls.monitor
+
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
+import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, WorkspaceName}
+
+import java.util.UUID
+
+class AvroUpsertMonitorMessageParser(message: PubSubMessage) {
+
+  def parse: AvroUpsertAttributes = {
+    val workspaceNamespace = "workspaceNamespace"
+    val workspaceName = "workspaceName"
+    val userEmail = "userEmail"
+    val jobId = "jobId"
+    val upsertFile = "upsertFile"
+    val isUpsert = "isUpsert"
+
+    def attributeNotFoundException(attribute: String): Nothing = throw new Exception(
+      s"unable to parse message - attribute $attribute not found in ${message.attributes}"
+    )
+
+    AvroUpsertAttributes(
+      WorkspaceName(
+        message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
+        message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))
+      ),
+      RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
+      UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
+      message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
+      java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true"))
+    )
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
@@ -1,13 +1,17 @@
 package org.broadinstitute.dsde.rawls.monitor
 
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, WorkspaceName}
 
 import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
 
-class AvroUpsertMonitorMessageParser(message: PubSubMessage) {
+class AvroUpsertMonitorMessageParser(message: PubSubMessage, dataSource: SlickDataSource)(implicit
+  executionContext: ExecutionContext
+) {
 
-  def parse: AvroUpsertAttributes = {
+  def parse: Future[AvroUpsertAttributes] = {
     val workspaceNamespace = "workspaceNamespace"
     val workspaceName = "workspaceName"
     val userEmail = "userEmail"
@@ -15,20 +19,42 @@ class AvroUpsertMonitorMessageParser(message: PubSubMessage) {
     val upsertFile = "upsertFile"
     val isUpsert = "isUpsert"
 
+    val workspaceId = "workspaceId"
+
     def attributeNotFoundException(attribute: String): Nothing = throw new Exception(
       s"unable to parse message - attribute $attribute not found in ${message.attributes}"
     )
 
-    AvroUpsertAttributes(
-      WorkspaceName(
-        message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
-        message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))
-      ),
-      RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
-      UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
-      message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
-      java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true"))
-    )
+    // does this message contain a workspaceId? This indicates a message from cWDS instead of a message
+    // from Import Service.
+    val isWdsMessage = message.attributes.contains(workspaceId)
+
+    val workspaceNameFuture: Future[WorkspaceName] = if (isWdsMessage) {
+      // translate the workspaceId into a namespace/name
+      val id = message.attributes.getOrElse(workspaceId, attributeNotFoundException(workspaceId))
+      dataSource.inTransaction { dataAccess =>
+        dataAccess.workspaceQuery.findByIdOrFail(id) map { workspace =>
+          WorkspaceName(workspace.namespace, workspace.name)
+        }
+      }
+    } else {
+      Future.successful(
+        WorkspaceName(
+          message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
+          message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))
+        )
+      )
+    }
+
+    workspaceNameFuture map { workspaceName =>
+      AvroUpsertAttributes(
+        workspaceName,
+        RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
+        UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
+        message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
+        java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true"))
+      )
+    }
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParserSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParserSpec.scala
@@ -1,0 +1,61 @@
+package org.broadinstitute.dsde.rawls.monitor
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
+import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, WorkspaceName}
+
+import java.util.UUID
+
+class AvroUpsertMonitorMessageParserSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "AvroUpsertMonitorMessageParser"
+
+  /* parsing works when all keys are supplied */
+  it should "parse a valid message" in {
+    val jobId = UUID.randomUUID()
+    val attributes = Map(
+      "workspaceNamespace" -> "my workspaceNamespace",
+      "workspaceName" -> "my workspaceName",
+      "userEmail" -> "my userEmail",
+      "jobId" -> jobId.toString,
+      "upsertFile" -> "my upsertFile",
+      "isUpsert" -> "true"
+    )
+    val input = buildMessage(attributes)
+    val parser = new AvroUpsertMonitorMessageParser(input)
+
+    val expected = AvroUpsertAttributes(
+      workspace = WorkspaceName("my workspaceNamespace", "my workspaceName"),
+      userEmail = RawlsUserEmail("my userEmail"),
+      importId = jobId,
+      upsertFile = "my upsertFile",
+      isUpsert = true
+    )
+
+    val actual = parser.parse
+
+    actual shouldBe expected
+  }
+
+  /* when expected keys are missing, parsing fails  */
+  it should "throw error when missing keys" in {
+    val attributes = Map(
+      "invalid" -> "doesn't matter"
+    )
+    val input = buildMessage(attributes)
+    val parser = new AvroUpsertMonitorMessageParser(input)
+
+    assertThrows[Exception] {
+      parser.parse
+    }
+  }
+
+  /* helper to create a PubSubMessage */
+  private def buildMessage(attributes: Map[String, String]): PubSubMessage = {
+    val ackId = UUID.randomUUID().toString
+    val contents = "message content"
+    PubSubMessage(ackId, contents, attributes)
+  }
+
+}


### PR DESCRIPTION
Ticket: AJ-1664

Rawls accepts a pub/sub message from Import Service to trigger imports into data tables. This message contains the workspace namespace/name into which to import.

As we are replacing Import Service with cWDS, we'd prefer to send a workspaceId instead of namespace/name, and have Rawls do the right thing internally.

This PR implements that.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
