### PR TITLE
AJ-1689: cwds integration in AvroUpsertMonitor (take 2)

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -219,7 +219,8 @@ object Boot extends IOApp with LazyLogging {
         workbenchMetricBaseName = metricsPrefix
       )
 
-      val importServiceDAO = new HttpImportServiceDAO(conf.getString("avroUpsertMonitor.server"))
+      val importServiceDAO =
+        new HttpImportServiceDAO(conf.getString("avroUpsertMonitor.server"), conf.getString("avroUpsertMonitor.cwds"))
 
       val pathToBqJson = gcsConfig.getString("pathToBigQueryJson")
       val bqJsonFileSource = scala.io.Source.fromFile(pathToBqJson)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpImportServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpImportServiceDAO.scala
@@ -21,6 +21,17 @@ object ImportServiceJsonSupport {
   implicit val importServiceResponseFormat: RootJsonFormat[ImportServiceResponse] = jsonFormat2(ImportServiceResponse)
 }
 
+/**
+  * This ImportServiceDAO talks to both cWDS (Java/Spring, new) and Import Service (Python, deprecated). Yes, this
+  * violates encapsulation for a DAO, but it allows for smooth migration from Import Service to cWDS without large
+  * code churn. When Import Service is truly sunset, this DAO will return to form and only talk to one external service.
+  *
+  * @param importServiceUrl base url for Import Service
+  * @param cwdsUrl base url for cWDS
+  * @param system ActorSystem
+  * @param materializer Materializer
+  * @param executionContext ExecutionContext
+  */
 class HttpImportServiceDAO(importServiceUrl: String, cwdsUrl: String)(implicit
   val system: ActorSystem,
   val materializer: Materializer,
@@ -32,30 +43,42 @@ class HttpImportServiceDAO(importServiceUrl: String, cwdsUrl: String)(implicit
   val http = Http(system)
   val httpClientUtils = HttpClientUtilsStandard()
 
-  def getImportStatus(importId: UUID,
-                      workspaceName: WorkspaceName,
-                      userInfo: UserInfo
+  // retrieve an import job's status from Import Service
+  override def getImportStatus(importId: UUID,
+                               workspaceName: WorkspaceName,
+                               userInfo: UserInfo
   ): Future[Option[ImportStatus]] = {
-    import ImportServiceJsonSupport._
-    import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 
     val requestUrl =
       Uri(importServiceUrl).withPath(Path(s"/${workspaceName.namespace}/${workspaceName.name}/imports/$importId"))
 
-    val importStatusResponse: Future[Option[ImportServiceResponse]] = retry[Option[ImportServiceResponse]](when5xx) {
-      () =>
-        executeRequestWithToken[Option[ImportServiceResponse]](userInfo.accessToken)(Get(requestUrl)) recover {
-          case notOK: RawlsExceptionWithErrorReport if notOK.errorReport.statusCode.contains(StatusCodes.NotFound) =>
-            None
-        }
-    }
-
-    importStatusResponse.map { response =>
+    doImportStatusRequest(requestUrl, userInfo).map { response =>
       response.map(statusString => ImportStatuses.withName(statusString.status))
     }
   }
 
-  override def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]] = ???
+  // retrieve an import job's status from cWDS, and translate its status into the known values for Import Service
+  override def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]] = {
+    val requestUrl =
+      Uri(cwdsUrl).withPath(Path(s"/job/v1/$importId"))
+
+    doImportStatusRequest(requestUrl, userInfo).map { response =>
+      response.map(statusString => ImportStatuses.fromCwdsStatus(statusString.status))
+    }
+
+  }
+
+  private def doImportStatusRequest(requestUrl: Uri, userInfo: UserInfo): Future[Option[ImportServiceResponse]] = {
+    import ImportServiceJsonSupport._
+    import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+    retry[Option[ImportServiceResponse]](when5xx) { () =>
+      executeRequestWithToken[Option[ImportServiceResponse]](userInfo.accessToken)(Get(requestUrl)) recover {
+        case notOK: RawlsExceptionWithErrorReport if notOK.errorReport.statusCode.contains(StatusCodes.NotFound) =>
+          None
+      }
+    }
+  }
+
 }
 
 case class ImportServiceResponse(jobId: String, status: String)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpImportServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpImportServiceDAO.scala
@@ -21,7 +21,7 @@ object ImportServiceJsonSupport {
   implicit val importServiceResponseFormat: RootJsonFormat[ImportServiceResponse] = jsonFormat2(ImportServiceResponse)
 }
 
-class HttpImportServiceDAO(url: String)(implicit
+class HttpImportServiceDAO(importServiceUrl: String, cwdsUrl: String)(implicit
   val system: ActorSystem,
   val materializer: Materializer,
   val executionContext: ExecutionContext
@@ -39,7 +39,8 @@ class HttpImportServiceDAO(url: String)(implicit
     import ImportServiceJsonSupport._
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 
-    val requestUrl = Uri(url).withPath(Path(s"/${workspaceName.namespace}/${workspaceName.name}/imports/$importId"))
+    val requestUrl =
+      Uri(importServiceUrl).withPath(Path(s"/${workspaceName.namespace}/${workspaceName.name}/imports/$importId"))
 
     val importStatusResponse: Future[Option[ImportServiceResponse]] = retry[Option[ImportServiceResponse]](when5xx) {
       () =>
@@ -54,6 +55,7 @@ class HttpImportServiceDAO(url: String)(implicit
     }
   }
 
+  override def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]] = ???
 }
 
 case class ImportServiceResponse(jobId: String, status: String)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ImportServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ImportServiceDAO.scala
@@ -9,4 +9,6 @@ import scala.concurrent.Future
 abstract class ImportServiceDAO {
 
   def getImportStatus(importId: UUID, workspaceName: WorkspaceName, userInfo: UserInfo): Future[Option[ImportStatus]]
+
+  def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -103,7 +103,8 @@ case class AvroUpsertAttributes(workspace: WorkspaceName,
                                 userEmail: RawlsUserEmail,
                                 importId: UUID,
                                 upsertFile: String,
-                                isUpsert: Boolean
+                                isUpsert: Boolean,
+                                isCwds: Boolean
 )
 class AvroUpsertMonitorSupervisor(entityService: RawlsRequestContext => EntityService,
                                   googleServicesDAO: GoogleServicesDAO,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
@@ -3,23 +3,27 @@ package org.broadinstitute.dsde.rawls.monitor
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, WorkspaceName}
+import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorMessageParser._
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+
+object AvroUpsertMonitorMessageParser {
+  val workspaceNamespace = "workspaceNamespace"
+  val workspaceName = "workspaceName"
+  val userEmail = "userEmail"
+  val jobId = "jobId"
+  val upsertFile = "upsertFile"
+  val isUpsert = "isUpsert"
+  val isCWDS = "isCWDS"
+  val workspaceId = "workspaceId"
+}
 
 class AvroUpsertMonitorMessageParser(message: PubSubMessage, dataSource: SlickDataSource)(implicit
   executionContext: ExecutionContext
 ) {
 
   def parse: Future[AvroUpsertAttributes] = {
-    val workspaceNamespace = "workspaceNamespace"
-    val workspaceName = "workspaceName"
-    val userEmail = "userEmail"
-    val jobId = "jobId"
-    val upsertFile = "upsertFile"
-    val isUpsert = "isUpsert"
-
-    val workspaceId = "workspaceId"
 
     def attributeNotFoundException(attribute: String): Nothing = throw new Exception(
       s"unable to parse message - attribute $attribute not found in ${message.attributes}"
@@ -52,7 +56,9 @@ class AvroUpsertMonitorMessageParser(message: PubSubMessage, dataSource: SlickDa
         RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
         UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
         message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
-        java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true"))
+        java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true")),
+        // the "isCWDS" key will be missing from Import Service messages, so it should default to false
+        java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isCWDS, "false"))
       )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
@@ -1,12 +1,10 @@
 package org.broadinstitute.dsde.rawls.monitor
 
-import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, WorkspaceName}
 import org.broadinstitute.dsde.rawls.monitor.AvroUpsertMonitorMessageParser._
 
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future}
 
 object AvroUpsertMonitorMessageParser {
   val workspaceNamespace = "workspaceNamespace"
@@ -19,52 +17,37 @@ object AvroUpsertMonitorMessageParser {
   val workspaceId = "workspaceId"
 }
 
-class AvroUpsertMonitorMessageParser(message: PubSubMessage, dataSource: SlickDataSource)(implicit
-  executionContext: ExecutionContext
-) {
+class AvroUpsertMonitorMessageParser(message: PubSubMessage) {
 
-  def parse: Future[AvroUpsertAttributes] = {
+  def parse: AvroUpsertAttributes = {
 
     def attributeNotFoundException(attribute: String): Nothing = throw new Exception(
       s"unable to parse message - attribute $attribute not found in ${message.attributes}"
     )
 
-    // does this message contain a workspaceId? This indicates a message from cWDS instead of a message
-    // from Import Service.
-    val isWdsMessage = message.attributes.contains(workspaceId)
+    // is this message from cWDS or Import Service?
+    val isWdsMessage = java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isCWDS, "false"))
 
-    val workspaceNameFuture: Future[WorkspaceName] = if (isWdsMessage) {
-      // translate the workspaceId into a namespace/name
-      val id = message.attributes.getOrElse(workspaceId, attributeNotFoundException(workspaceId))
-      dataSource.inTransaction { dataAccess =>
-        dataAccess.workspaceQuery.findByIdOrFail(id) map { workspace =>
-          WorkspaceName(workspace.namespace, workspace.name)
-        }
-      } recover { _ =>
-        // if we couldn't find the workspaceId above, pass known-bad values.
-        // later validation within AvroUpsertMonitor will catch these and handle the missing workspace.
-        // the values used here don't pass our validation constraints so they will always be bad.
-        // this is a bit of a hack.
-        WorkspaceName("**!!error!!**", s"workspaceId:$id")
-      }
-    } else {
-      Future.successful(
-        WorkspaceName(
-          message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
-          message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))
-        )
-      )
-    }
-
-    workspaceNameFuture map { workspaceName =>
-      AvroUpsertAttributes(
-        workspaceName,
+    if (isWdsMessage) {
+      CwdsUpsertAttributes(
+        UUID.fromString(message.attributes.getOrElse(workspaceId, attributeNotFoundException(workspaceId))),
         RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
         UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
         message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
         java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true")),
-        // the "isCWDS" key will be missing from Import Service messages, so it should default to false
-        java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isCWDS, "false"))
+        isCwds = true
+      )
+    } else {
+      ImportServiceUpsertAttributes(
+        WorkspaceName(
+          message.attributes.getOrElse(workspaceNamespace, attributeNotFoundException(workspaceNamespace)),
+          message.attributes.getOrElse(workspaceName, attributeNotFoundException(workspaceName))
+        ),
+        RawlsUserEmail(message.attributes.getOrElse(userEmail, attributeNotFoundException(userEmail))),
+        UUID.fromString(message.attributes.getOrElse(jobId, attributeNotFoundException(jobId))),
+        message.attributes.getOrElse(upsertFile, attributeNotFoundException(upsertFile)),
+        java.lang.Boolean.parseBoolean(message.attributes.getOrElse(isUpsert, "true")),
+        isCwds = false
       )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParser.scala
@@ -40,6 +40,12 @@ class AvroUpsertMonitorMessageParser(message: PubSubMessage, dataSource: SlickDa
         dataAccess.workspaceQuery.findByIdOrFail(id) map { workspace =>
           WorkspaceName(workspace.namespace, workspace.name)
         }
+      } recover { _ =>
+        // if we couldn't find the workspaceId above, pass known-bad values.
+        // later validation within AvroUpsertMonitor will catch these and handle the missing workspace.
+        // the values used here don't pass our validation constraints so they will always be bad.
+        // this is a bit of a hack.
+        WorkspaceName("**!!error!!**", s"workspaceId:$id")
       }
     } else {
       Future.successful(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockImportServiceDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockImportServiceDAO.scala
@@ -14,5 +14,6 @@ class MockImportServiceDAO extends ImportServiceDAO {
   def getImportStatus(importId: UUID, workspaceName: WorkspaceName, userInfo: UserInfo): Future[Option[ImportStatus]] =
     Future.successful(imports.get(importId))
 
-  override def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]] = ???
+  override def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]] =
+    Future.successful(imports.get(importId))
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockImportServiceDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockImportServiceDAO.scala
@@ -14,4 +14,5 @@ class MockImportServiceDAO extends ImportServiceDAO {
   def getImportStatus(importId: UUID, workspaceName: WorkspaceName, userInfo: UserInfo): Future[Option[ImportStatus]] =
     Future.successful(imports.get(importId))
 
+  override def getCwdsStatus(importId: UUID, workspaceId: UUID, userInfo: UserInfo): Future[Option[ImportStatus]] = ???
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParserSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorMessageParserSpec.scala
@@ -32,6 +32,7 @@ class AvroUpsertMonitorMessageParserSpec
   /* parsing works when all keys are supplied */
   it should "parse a valid message from Import Service" in {
     val jobId = UUID.randomUUID()
+    // note the "isCWDS" key is missing
     val attributes = Map(
       "workspaceNamespace" -> "my workspaceNamespace",
       "workspaceName" -> "my workspaceName",
@@ -47,7 +48,8 @@ class AvroUpsertMonitorMessageParserSpec
       userEmail = RawlsUserEmail("my userEmail"),
       importId = jobId,
       upsertFile = "my upsertFile",
-      isUpsert = true
+      isUpsert = true,
+      isCwds = false
     )
 
     parser.parse.futureValue shouldBe expected
@@ -60,7 +62,8 @@ class AvroUpsertMonitorMessageParserSpec
       "userEmail" -> "my userEmail",
       "jobId" -> jobId.toString,
       "upsertFile" -> "my upsertFile",
-      "isUpsert" -> "true"
+      "isUpsert" -> "true",
+      "isCWDS" -> "true"
     )
     val parser = parserFor(attributes)
 
@@ -69,7 +72,8 @@ class AvroUpsertMonitorMessageParserSpec
       userEmail = RawlsUserEmail("my userEmail"),
       importId = jobId,
       upsertFile = "my upsertFile",
-      isUpsert = true
+      isUpsert = true,
+      isCwds = true
     )
 
     parser.parse.futureValue shouldBe expected

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -165,6 +165,7 @@ avroUpsertMonitor {
   pubSubProject = "broad-dsde-dev"
 
   server = "https://terra-importservice-dev.appspot.com"
+  cwds = "https://cwds.dsde-dev.broadinstitute.org"
   bucketName = "import-service-batchupsert-dev"
 
   importRequestPubSubTopic = "rawls-async-import-topic-local"

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -427,6 +427,15 @@ object ImportStatuses {
     override def withName(name: String): ImportStatus = ImportStatuses.withName(name)
   }
 
+  // translates cWDS's status values into the values used by Import Service, for compatibility
+  // while both cWDS and Import Service are in use
+  def fromCwdsStatus(name: String): ImportStatus = name.toLowerCase match {
+    case "running"   => ReadyForUpsert
+    case "succeeded" => Done
+    case "error"     => Error
+    case _           => throw new RawlsException(s"invalid cWDS status [$name]")
+  }
+
   def withName(name: String): ImportStatus = name.toLowerCase match {
     case "readyforupsert" => ReadyForUpsert
     case "upserting"      => Upserting


### PR DESCRIPTION
Ticket: [AJ-1689](https://broadworkbench.atlassian.net/browse/AJ-1689)

When (back) Rawls receives a pub/sub message telling it to import a file into some workspace's data tables, it contacts Import Service to check the current status of the import job before performing the import. It does this to protect against potential double-delivery of import requests.

With cWDS slowly replacing Import Service, either cWDS or Import Service may generate the incoming message. If the import originated in cWDS, then naturally Import Service won’t know anything about that import. The status check to Import Service will fail and Rawls will not import anything.

This PR fixes that. Rawls now inspects the inbound message and routes its status query to the appropriate service.

This is "part 2" because it supersedes #2772.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email


[AJ-1689]: https://broadworkbench.atlassian.net/browse/AJ-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ