### PR TITLE
AJ-1681: Run `sbt scalafmtAll`

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -52,7 +52,8 @@ class SubmissionSupervisorSpec
 
   val mockServer = RemoteServicesMockServer()
   val gcsDAO = new MockGoogleServicesDAO("test")
-  val mockSamDAO = new HttpSamDAO(mockServer.mockServerBaseUrl, Option(gcsDAO.getPreparedMockGoogleCredential()), 1 minute)
+  val mockSamDAO =
+    new HttpSamDAO(mockServer.mockServerBaseUrl, Option(gcsDAO.getPreparedMockGoogleCredential()), 1 minute)
   val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
[AJ-1681](https://broadworkbench.atlassian.net/browse/AJ-1681): AJ Maintenance

An upstream commit caused the scalafmt check to start failing [sample failure](https://github.com/broadinstitute/rawls/actions/runs/8267834161/job/22619236685?pr=2765).  This re-baselines the code to hopefully pass that format check again.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
~- [ ] Make sure Swagger is updated if API changes~
  ~- [ ] **...and Orchestration's Swagger too!**~
~- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).~
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[AJ-1681]: https://broadworkbench.atlassian.net/browse/AJ-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ