### PR TITLE
[WOR-1567] Add support for specifying properties and cloning semantics

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4411,6 +4411,22 @@ components:
           type: string
           description: A description for the snapshot
           default: ""
+        properties:
+          type: object
+          description: A map of key-value pairs to associate with the snapshot. Optional, defaults to an empty map if not specified.
+          default: {}
+        cloningInstructions:
+          type: string
+          default: COPY_NOTHING
+          description: |
+            Cloning semantics for this snapshot. Optional, defaults to COPY_NOTHING if not specified.
+            COPY_NOTHING: Don't clone the snapshot.
+            COPY_REFERENCE: Create a new referenced snapshot that points to same cloud resource as the source snapshot.
+            COPY_LINK_REFERENCE: Create a new referenced snapshot that points to the same cloud resource as the source resource, AND link the source workspace policy to the destination workspace policy; changes in the source will propagate to the destination.
+          enum:
+            - COPY_NOTHING
+            - COPY_REFERENCE
+            - COPY_LINK_REFERENCE
       description: A Data Repo snapshot
     UpdateDataReferenceRequestBody:
       type: object

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4455,6 +4455,8 @@ components:
           type: string
         cloningInstructions:
           type: string
+        properties:
+          type: object
     DataRepoSnapshotAttributes:
       type: object
       required: [ instanceName, snapshot ]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -37,7 +37,7 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     apiClientProvider.getWorkspaceApi(ctx)
 
   private def getReferencedGcpResourceApi(ctx: RawlsRequestContext): ReferencedGcpResourceApi =
-    new ReferencedGcpResourceApi(getApiClient(ctx))
+    apiClientProvider.getReferencedGcpResourceApi(ctx)
 
   private def getResourceApi(ctx: RawlsRequestContext): ResourceApi =
     apiClientProvider.getResourceApi(ctx)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerApiClientProvider.scala
@@ -5,6 +5,7 @@ import bio.terra.workspace.api.{
   ControlledAzureResourceApi,
   JobsApi,
   LandingZonesApi,
+  ReferencedGcpResourceApi,
   ResourceApi,
   UnauthenticatedApi,
   WorkspaceApi,
@@ -36,6 +37,8 @@ trait WorkspaceManagerApiClientProvider {
 
   def getResourceApi(ctx: RawlsRequestContext): ResourceApi
 
+  def getReferencedGcpResourceApi(ctx: RawlsRequestContext): ReferencedGcpResourceApi
+
   def getUnauthenticatedApi(): UnauthenticatedApi
 
 }
@@ -65,6 +68,9 @@ class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: String) extend
 
   def getResourceApi(ctx: RawlsRequestContext): ResourceApi =
     new ResourceApi(getApiClient(ctx))
+
+  def getReferencedGcpResourceApi(ctx: RawlsRequestContext): ReferencedGcpResourceApi =
+    new ReferencedGcpResourceApi(getApiClient(ctx))
 
   override def getUnauthenticatedApi(): UnauthenticatedApi = {
     val client: ApiClient = new ApiClient()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -64,6 +64,7 @@ trait WorkspaceManagerDAO {
                                       description: Option[DataReferenceDescriptionField],
                                       instanceName: String,
                                       cloningInstructions: CloningInstructionsEnum,
+                                      properties: Option[Map[String, String]],
                                       ctx: RawlsRequestContext
   ): DataRepoSnapshotResource
   def updateDataRepoSnapshotReference(workspaceId: UUID,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiService.scala
@@ -63,8 +63,10 @@ trait SnapshotApiService extends UserInfoDirectives {
           (workspaceNamespace, workspaceName, snapshotId) =>
             get {
               complete {
-                snapshotServiceConstructor(ctx).getSnapshot(WorkspaceName(workspaceNamespace, workspaceName),
-                                                            snapshotId
+                snapshotServiceConstructor(ctx).getSnapshotResourceFromWsm(WorkspaceName(workspaceNamespace,
+                                                                                         workspaceName
+                                                                           ),
+                                                                           snapshotId
                 )
               }
             } ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -1395,6 +1395,7 @@ class SubmissionSpec(_system: ActorSystem)
           dataReferenceDescription,
           dataRepoDAO.getInstanceName,
           CloningInstructionsEnum.NOTHING,
+          None,
           testContext
         )
         runAndWait(methodConfigurationQuery.upsert(minimalTestData.workspace, methodConfig))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -137,6 +137,7 @@ class MockWorkspaceManagerDAO(
                                                description: Option[DataReferenceDescriptionField],
                                                instanceName: String,
                                                cloningInstructions: CloningInstructionsEnum,
+                                               properties: Option[Map[String, String]],
                                                ctx: RawlsRequestContext
   ): DataRepoSnapshotResource =
     if (name.value.contains("fakesnapshot"))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SnapshotApiServiceSpec.scala
@@ -458,6 +458,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         Option(DataReferenceDescriptionField("description")),
         "foo",
         CloningInstructionsEnum.NOTHING,
+        None,
         testContext
       )
       .getMetadata
@@ -543,6 +544,7 @@ class SnapshotApiServiceSpec extends ApiServiceSpec {
         Option(DataReferenceDescriptionField("description")),
         "foo",
         CloningInstructionsEnum.NOTHING,
+        None,
         testContext
       )
       .getMetadata

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -44,11 +44,20 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
                   "description": "hello",
                   "resourceType": "DATA_REPO_SNAPSHOT",
                   "stewardshipType": "REFERENCED",
-                  "cloningInstructions": "COPY_NOTHING"
+                  "cloningInstructions": "COPY_NOTHING",
+                  "properties": {
+                    "key1": "value1",
+                    "key2": "value2"
+                  }
                 }
              }
           """.parseJson
         } {
+          val properties = new Properties()
+          properties.addAll(
+            java.util.List.of(new Property().key("key1").value("value1"), new Property().key("key2").value("value2"))
+          )
+
           new DataRepoSnapshotResource()
             .metadata(
               new ResourceMetadata()
@@ -59,6 +68,7 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
                 .resourceType(ResourceType.DATA_REPO_SNAPSHOT)
                 .stewardshipType(StewardshipType.REFERENCED)
                 .cloningInstructions(CloningInstructionsEnum.NOTHING)
+                .properties(properties)
             )
             .attributes(
               new DataRepoSnapshotAttributes()
@@ -86,7 +96,8 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
                      "resourceId":"$snapshotResourceId",
                      "resourceType":"DATA_REPO_SNAPSHOT",
                      "stewardshipType":"REFERENCED",
-                     "workspaceId":"$workspaceId"
+                     "workspaceId":"$workspaceId",
+                     "properties": {}
                    },
                    "resourceAttributes": {
                      "gcpDataRepoSnapshot": {


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1567)

### Context
Rawls must allow the specification of cloning instructions on a snapshot reference as well as properties.

### This PR
* Adds the following fields to the snapshot V2 creation endpoint request:
  * [cloningInstructions](https://github.com/broadinstitute/rawls/pull/2790/files#diff-6e80a735b01ebcbdc253d755a6078cc1af5a585a6bd04b92b6455a9469988dffR4418) -- these are a subset of the possible cloning instructions for a WSM referenced datarepo snapshot, specifically those that are applicable to referenced resources (i.e., not controlled). **This will default to COPY_NOTHING if no value is provided for this field, which is the current behavior**
  * [properties](https://github.com/broadinstitute/rawls/pull/2790/files#diff-6e80a735b01ebcbdc253d755a6078cc1af5a585a6bd04b92b6455a9469988dffR4414), which is a map of KVPs that thread into the snapshot reference resource creation request. 
  * Updates the response format to expose the properties 


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
