### PR TITLE
[WOR-1568] Deprecate workspaceSubmissionStats on Workspace list response

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5757,7 +5757,7 @@ components:
         runningSubmissionsCount:
           type: integer
           description: Count of all the running submissions
-      description: Statistics about submissions in a workspace
+      description: Statistics about submissions in a workspace (only supported for GCP workspaces)
     WorkspaceRequest:
       required:
         - attributes
@@ -5988,7 +5988,7 @@ components:
         workspace:
           $ref: '#/components/schemas/WorkspaceDetails'
         workspaceSubmissionStats:
-          description: Statistics about submissions in the workspace, deprecated as part of the list response due to slow performance. This field will continue to be supported on individual workspace details.
+          description: GCP workspace submission statistics, deprecated as part of the list response due to slow performance. This field will continue to be supported on individual workspace details.
           deprecated: true
         policies:
           type: array

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5988,7 +5988,8 @@ components:
         workspace:
           $ref: '#/components/schemas/WorkspaceDetails'
         workspaceSubmissionStats:
-          $ref: '#/components/schemas/WorkspaceSubmissionStats'
+          description: Statistics about submissions in the workspace, deprecated as part of the list response due to slow performance. This field will continue to be supported on individual workspace details.
+          deprecated: true
         policies:
           type: array
           items:


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1568

Swagger looks like this:

![image](https://github.com/broadinstitute/rawls/assets/484484/c1704548-a6ba-4dc8-aa76-b0af133ac8a2)

![image](https://github.com/broadinstitute/rawls/assets/484484/cb84606e-e7d6-4d03-babf-d4f1bb4a6b23)


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
