### PR TITLE
AJ-1549: streamline GHA swat tests

### DIFF
--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -125,6 +125,8 @@ jobs:
 
   rawls-swat-test-job:
     strategy:
+      # set fail-fast: false. We want all test jobs to complete, so we can see their results. If fail-fast were true,
+      # the first test jobs failure would cancel the other test jobs.
       fail-fast: false
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -125,13 +125,17 @@ jobs:
 
   rawls-swat-test-job:
     strategy:
+      fail-fast: false
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
         test-group: [
           { group_name: workspaces, tag: "-n org.broadinstitute.dsde.test.api.AuthDomainsTest -n org.broadinstitute.dsde.test.api.BillingsTest -n org.broadinstitute.dsde.test.api.WorkspacesTest" },
-          { group_name: analysis_journeys, tag: "-n org.broadinstitute.dsde.test.api.DataRepoSnapshotsTest" },
           { group_name: workflows, tag: "-n org.broadinstitute.dsde.test.api.MethodsTest" }
+          # The Analysis Journeys swat tests (DataRepoSnapshotsTest) are all disabled, so the following matrix value
+          # will run zero tests. Instead of running a noop test job, skip it altogether. We are leaving this value
+          # here, commented out, to make it easy to re-instate if/when Analysis Journeys does have some tests to run.
+          # { group_name: analysis_journeys, tag: "-n org.broadinstitute.dsde.test.api.DataRepoSnapshotsTest" }
         ] # Rawls test groups
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Ticket: AJ-1549

Two changes in this PR:
* add `fail-fast: false`. Swat tests run in a matrix; we run the Workflows and Workspaces test jobs in parallel. If either of the Workflows or Workspaces test jobs fail, we still want the other tests to continue running and get their results. The [default behavior](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures) is `fail-fast: true`, which cancels all jobs as soon as one job fails.
* remove Analysis Journeys tests from the matrix. All Analysis Journeys-owned Rawls swat tests have previously been moved to unit/contract tests, so there's nothing to run here.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
