### PR TITLE
[WOR-1514] Rollback workspace creation when given invalid policies

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -660,11 +660,15 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             )
           }
           _ <- dataSource.inTransaction(_.workspaceQuery.delete(workspaceRequest.toWorkspaceName))
-        } yield throw new RawlsExceptionWithErrorReport(
-          ErrorReport(StatusCodes.InternalServerError,
-                      s"Error creating workspace ${workspaceRequest.toWorkspaceName}. Please try again."
-          )
-        )
+        } yield e match {
+          case rawlsException: RawlsExceptionWithErrorReport => throw rawlsException
+          case _ =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.InternalServerError,
+                          s"Error creating workspace ${workspaceRequest.toWorkspaceName}. Please try again."
+              )
+            )
+        }
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -649,21 +649,22 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       // create a WDS application in Leo
       _ <- createWdsAppInWorkspace(workspaceId, parentContext, None, workspaceRequest.attributes)
 
-    } yield savedWorkspace).recoverWith { case e @ (_: ApiException | _: WorkspaceManagerOperationFailureException | _: RawlsExceptionWithErrorReport) =>
-      logger.info(s"Error creating workspace ${workspaceRequest.toWorkspaceName} [workspaceId = ${workspaceId}]", e)
-      for {
-        _ <- deleteWorkspaceInWSM(workspaceId).recover { case e =>
-          logger.info(
-            s"Error cleaning up workspace ${workspaceRequest.toWorkspaceName} in WSM [workspaceId = ${workspaceId}",
-            e
+    } yield savedWorkspace).recoverWith {
+      case e @ (_: ApiException | _: WorkspaceManagerOperationFailureException | _: RawlsExceptionWithErrorReport) =>
+        logger.info(s"Error creating workspace ${workspaceRequest.toWorkspaceName} [workspaceId = ${workspaceId}]", e)
+        for {
+          _ <- deleteWorkspaceInWSM(workspaceId).recover { case e =>
+            logger.info(
+              s"Error cleaning up workspace ${workspaceRequest.toWorkspaceName} in WSM [workspaceId = ${workspaceId}",
+              e
+            )
+          }
+          _ <- dataSource.inTransaction(_.workspaceQuery.delete(workspaceRequest.toWorkspaceName))
+        } yield throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.InternalServerError,
+                      s"Error creating workspace ${workspaceRequest.toWorkspaceName}. Please try again."
           )
-        }
-        _ <- dataSource.inTransaction(_.workspaceQuery.delete(workspaceRequest.toWorkspaceName))
-      } yield throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.InternalServerError,
-                    s"Error creating workspace ${workspaceRequest.toWorkspaceName}. Please try again."
         )
-      )
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -649,7 +649,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       // create a WDS application in Leo
       _ <- createWdsAppInWorkspace(workspaceId, parentContext, None, workspaceRequest.attributes)
 
-    } yield savedWorkspace).recoverWith { case e @ (_: ApiException | _: WorkspaceManagerOperationFailureException) =>
+    } yield savedWorkspace).recoverWith { case e @ (_: ApiException | _: WorkspaceManagerOperationFailureException | _: RawlsExceptionWithErrorReport) =>
       logger.info(s"Error creating workspace ${workspaceRequest.toWorkspaceName} [workspaceId = ${workspaceId}]", e)
       for {
         _ <- deleteWorkspaceInWSM(workspaceId).recover { case e =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -626,6 +626,38 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     verifyWorkspaceCreationRollback(workspaceManagerDAO, request.toWorkspaceName)
   }
 
+  it should "fail on invalid policy inputs and try to rollback workspace creation" in {
+    val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO())
+    val leonardoDAO = new MockLeonardoDAO()
+
+    val mcWorkspaceService = MultiCloudWorkspaceService.constructor(
+      slickDataSource,
+      workspaceManagerDAO,
+      mock[BillingProfileManagerDAO],
+      new MockSamDAO(slickDataSource),
+      activeMcWorkspaceConfig,
+      leonardoDAO,
+      workbenchMetricBaseName
+    )(testContext)
+    val request = WorkspaceRequest(
+      "fake_ns",
+      "fake_name",
+      Map.empty,
+      policies = Option(
+        List(
+          WorkspacePolicy("group-constraint", "terra", List(Map("key" -> "group", "value" -> "invalidPolicyInputs")))
+        )
+      )
+    )
+    intercept[RawlsExceptionWithErrorReport] {
+      Await.result(mcWorkspaceService.createMultiCloudWorkspace(request, new ProfileModel().id(UUID.randomUUID())),
+                   Duration.Inf
+      )
+    }
+
+    verifyWorkspaceCreationRollback(workspaceManagerDAO, request.toWorkspaceName)
+  }
+
   it should "still delete from the database when cleaning up the workspace in WSM fails" in {
     val workspaceManagerDAO = Mockito.spy(new MockWorkspaceManagerDAO() {
       override def createAzureStorageContainer(workspaceId: UUID,


### PR DESCRIPTION
Ticket: [WOR-1514](https://broadworkbench.atlassian.net/browse/WOR-1514)
* During workspace creation, catch the exception thrown when request contains invalid policy inputs and rollback workspace creation

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1514]: https://broadworkbench.atlassian.net/browse/WOR-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ