### PR TITLE
WOR-1567: ResourceMetadata Properties serialization

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4456,7 +4456,9 @@ components:
         cloningInstructions:
           type: string
         properties:
-          type: object
+          type: array
+          items:
+            type: object
     DataRepoSnapshotAttributes:
       type: object
       required: [ instanceName, snapshot ]

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/DataReferenceModelSpec.scala
@@ -45,10 +45,16 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
                   "resourceType": "DATA_REPO_SNAPSHOT",
                   "stewardshipType": "REFERENCED",
                   "cloningInstructions": "COPY_NOTHING",
-                  "properties": {
-                    "key1": "value1",
-                    "key2": "value2"
-                  }
+                  "properties": [
+                    {
+                      "key": "key1",
+                      "value": "value1"
+                    },
+                    {
+                      "key": "key2",
+                      "value": "value2"
+                    }
+                  ]
                 }
              }
           """.parseJson
@@ -97,7 +103,7 @@ class DataReferenceModelSpec extends AnyFreeSpec with Matchers {
                      "resourceType":"DATA_REPO_SNAPSHOT",
                      "stewardshipType":"REFERENCED",
                      "workspaceId":"$workspaceId",
-                     "properties": {}
+                     "properties": []
                    },
                    "resourceAttributes": {
                      "gcpDataRepoSnapshot": {


### PR DESCRIPTION
Ticket: WOR-1567

Followup to #2790

This adjusts the json de/serialization for `ResourceMetadata.properties`, which is used when retrieving/listing snapshot references.

Before this PR, the json codec explicitly changed serialization to return a map (i.e. JsObject), whereas the native format for this is an array of maps (i.e. JsArray). When using the `ResourceMetadata` model class from WSM's client library, this broke deserialization and caused problems in cWDS. After this PR, the response payloads for `ResourceMetadata` match what is returned by WSM and should therefore work with the WSM client models.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
