### PR TITLE
AJ-1549: minor swat test cleanup

### DIFF
--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -139,6 +139,7 @@ jobs:
           # here, commented out, to make it easy to re-instate if/when Analysis Journeys does have some tests to run.
           # { group_name: analysis_journeys, tag: "-n org.broadinstitute.dsde.test.api.DataRepoSnapshotsTest" }
         ] # Rawls test groups
+    name: swat-tests-${{ matrix.test-group.group_name }}
     runs-on: ubuntu-latest
     needs:
       - create-bee-workflow

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -147,7 +147,7 @@ jobs:
           # here, commented out, to make it easy to re-instate if/when Analysis Journeys does have some tests to run.
           # { group_name: analysis_journeys, tag: "-n org.broadinstitute.dsde.test.api.DataRepoSnapshotsTest" }
         ] # Rawls test groups
-    name: swat-tests-${{ matrix.test-group.group_name }}
+    name: ${{ matrix.test-group.group_name }}-owned tests
     runs-on: ubuntu-latest
     needs:
       - create-bee-workflow

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -16,6 +16,9 @@ env:
   BEE_DESTROY_RUN_NAME: 'bee-destroy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:
+  # Attempt to bump the app version.
+  # Compile the Scala code to a jar.
+  # Build the docker image and push that image to GCR.
   rawls-build-tag-publish-job:
     runs-on: ubuntu-latest
     permissions:
@@ -76,6 +79,8 @@ jobs:
           echo "$GITHUB_CONTEXT"
           echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
 
+
+  # Set the test-context: is this a merge to `develop` or is this a PR?
   init-github-context:
     runs-on: ubuntu-latest
     outputs:
@@ -91,7 +96,8 @@ jobs:
           else
             echo 'test-context=pr-test' >> $GITHUB_OUTPUT
           fi
-          
+
+  # Create a BEE to be used by swat tests.
   create-bee-workflow:
     strategy:
       matrix:
@@ -123,6 +129,8 @@ jobs:
             "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
           }'
 
+  # Run swat tests. This kicks off two parallel jobs for Workflows and Workspaces tests, which both run against the BEE
+  # we just created.
   rawls-swat-test-job:
     strategy:
       # set fail-fast: false. We want all test jobs to complete, so we can see their results. If fail-fast were true,
@@ -170,6 +178,7 @@ jobs:
             "test-context": "${{ env.test-context }}"
           }'
 
+  # Delete the BEE, now that swat tests are done.
   destroy-bee-workflow:
     strategy:
       matrix:


### PR DESCRIPTION
Ticket: AJ-1549

A couple small tweaks:
* add some code comments to the workflow yaml
* give the swat-test matrix jobs a shorter, more readable name. Previously these jobs were named `rawls-swat-test-job (dev, qa, workflows, -n org.broadinstitute.dsde.test.api.MethodsTest)` and `rawls-swat-test-job (dev, qa, workspaces, -n org.broadinstitute.dsde.test.api.AuthDomainsTest -n org.broadinstitute.dsde.test.api.BillingsTest -n org.broadinstitute.dsde.test.api.WorkspacesTest)`; they are now `workflows-owned tests` and `workspaces-owned tests` (you can see these names in the checks at the bottom of the PR)


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
