### PR TITLE
AJ-1549: add report-to-sherlock and set-version-in-dev jobs to build

### DIFF
--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -26,6 +26,7 @@ jobs:
       id-token: 'write'
     outputs:
       custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: 'actions/checkout@v4'
 
@@ -96,6 +97,31 @@ jobs:
           else
             echo 'test-context=pr-test' >> $GITHUB_OUTPUT
           fi
+
+  # Tell Broad DevOps Sherlock about the build version we just created.
+  report-to-sherlock:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: rawls-build-tag-publish-job
+    with:
+      new-version: ${{ needs.rawls-build-tag-publish-job.outputs.tag }}
+      chart-name: 'rawls'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  # Put new Rawls version in Broad dev environment
+  set-version-in-dev:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [rawls-build-tag-publish-job, report-to-sherlock]
+    if: ${{ github.ref_name == 'develop' }}
+    with:
+      new-version: ${{ needs.rawls-build-tag-publish-job.outputs.tag }}
+      chart-name: 'rawls'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'
 
   # Create a BEE to be used by swat tests.
   create-bee-workflow:

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -98,20 +98,10 @@ jobs:
             echo 'test-context=pr-test' >> $GITHUB_OUTPUT
           fi
 
-  auth-as-tools-sa:
-    runs-on: ubuntu-latest
-    steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
-
   # Tell Broad DevOps Sherlock about the build version we just created.
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: [rawls-build-tag-publish-job, auth-as-tools-sa]
+    needs: rawls-build-tag-publish-job
     with:
       new-version: ${{ needs.rawls-build-tag-publish-job.outputs.tag }}
       chart-name: 'rawls'

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         env:
           DEFAULT_BUMP: patch
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-          RELEASE_BRANCHES: main
+          RELEASE_BRANCHES: develop
           WITH_V: true
 
       - name: Extract branch
@@ -98,10 +98,20 @@ jobs:
             echo 'test-context=pr-test' >> $GITHUB_OUTPUT
           fi
 
+  auth-as-tools-sa:
+    runs-on: ubuntu-latest
+    steps:
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-tools-iap-access@dsp-tools-k8s.iam.gserviceaccount.com'
+
   # Tell Broad DevOps Sherlock about the build version we just created.
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: rawls-build-tag-publish-job
+    needs: [rawls-build-tag-publish-job, auth-as-tools-sa]
     with:
       new-version: ${{ needs.rawls-build-tag-publish-job.outputs.tag }}
       chart-name: 'rawls'


### PR DESCRIPTION
Ticket: AJ-1549

Updates the `rawls-build-tag-publish-and-run-tests` github workflow to include:
* report the new version of Rawls to Sherlock
* if merging to `develop`, also tell Sherlock to promote this version to the dev env

You can check out the GHA runs on this PR. The `report-to-sherlock` job published version `v0.0.1-e93b7ec` to Sherlock. I verified by updating my BEE to that version and smoketesting Rawls through the UI.

I can't really test the `set-version-in-dev` job until we merge a PR, but I will keep an eye on it and address any problems.

![Screenshot 4-1-2024 at 09 18 AM](https://github.com/broadinstitute/rawls/assets/6041577/cb5502ea-e180-47e4-95a5-422ce8cd53f4)

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
