### PR TITLE
AJ-1549: update github action versions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,13 +11,17 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: coursier-cache-action
-        uses: coursier/cache-action@v6
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: sbt
 
       - name: Check formatting for modified files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,21 +14,18 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
-
-      # coursier cache action caches both coursier and sbt caches
-      - name: coursier-cache-action
-        uses: coursier/cache-action@v6
+      - uses: actions/checkout@v4
 
       - name: Start MySQL
         run: |
           sh docker/run-mysql.sh start
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
+          cache: sbt
 
       - name: Run tests
         id: tests
@@ -47,7 +44,7 @@ jobs:
       # https://github.com/ScaCap/action-surefire-report/issues/39
       # https://github.community/t/specify-check-suite-when-creating-a-checkrun/118380
       - name: Upload Test Report
-        uses: mikepenz/action-junit-report@v2.0.3
+        uses: mikepenz/action-junit-report@v4
         if: ${{ always() }}
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
@@ -55,7 +52,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Codecov upload
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: ${{ always() }}
 
       - name: Stop MySQL

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,7 +6,7 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # The Dockerfile copies this, so it needs to exist for the build to succeed
       - run: touch rawls.jar


### PR DESCRIPTION
Ticket: AJ-1549

Found during AJ-1549; does not complete that ticket.

Update a handful of github actions to latest versions. Replace the `coursier/cache-action` with the built-in sbt cache from `setup-java`.

this PR does not attempt to update ALL outdated github actions to latest; it's just tackling a few important ones.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
