### PR TITLE
AJ-1549: use GHA-provided version string in builds

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -103,15 +103,12 @@ function make_jar()
         bash ./docker/run-mysql.sh start
     fi
 
-    # Get the last commit hash and set it as an environment variable
-    GIT_HASH=$(git log -n 1 --pretty=format:%h)
-
     # make jar.  cache sbt dependencies. capture output and stop db before returning.
     DOCKER_RUN="docker run --rm"
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e GIT_HASH=$GIT_HASH -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e DOCKER_TAG=$DOCKER_TAG -e GIT_COMMIT=$GIT_COMMIT -e BUILD_NUMBER=$BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/install.sh /working"
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -108,7 +108,7 @@ function make_jar()
     if [ "$SKIP_TESTS" != "skip-tests" ]; then
         DOCKER_RUN="$DOCKER_RUN --link mysql:mysql"
     fi
-    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e DOCKER_TAG=$DOCKER_TAG -e GIT_COMMIT=$GIT_COMMIT -e BUILD_NUMBER=$BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/install.sh /working"
+    DOCKER_RUN="$DOCKER_RUN -e SKIP_TESTS=$SKIP_TESTS -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/install.sh /working"
     JAR_CMD=$($DOCKER_RUN 1>&2)
     EXIT_CODE=$?
 

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -5,9 +5,6 @@
 # chmod +x must be set for this script
 set -e
 
-# Get the last commit hash and set it as an environment variable
-GIT_HASH=$(git log -n 1 --pretty=format:%h)
-
 # make jar.  cache sbt dependencies. capture output and stop db before returning.
 docker run --rm -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/clean_install.sh /working
 EXIT_CODE=$?

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -6,7 +6,7 @@
 set -e
 
 # make jar.  cache sbt dependencies. capture output and stop db before returning.
-docker run --rm -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/clean_install.sh /working
+docker run --rm -e DOCKER_TAG -e GIT_COMMIT -e BUILD_NUMBER -v $PWD:/working -v sbt-cache:/root/.sbt -v jar-cache:/root/.ivy2 -v coursier-cache:/root/.cache/coursier hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/docker/clean_install.sh /working
 EXIT_CODE=$?
 
 if [ $EXIT_CODE != 0 ]; then

--- a/project/Compiling.scala
+++ b/project/Compiling.scala
@@ -5,10 +5,11 @@ object Compiling {
   // generate version.conf
   val writeVersionConf = Def.task {
     val file = (Compile / resourceManaged).value / "version.conf"
-    // jenkins sets BUILD_NUMBER and GIT_COMMIT environment variables
+    // the terra-github-workflows/rawls-build GHA workflow sets BUILD_NUMBER, GIT_COMMIT, and DOCKER_TAG environment variables
     val buildNumber = sys.env.getOrElse("BUILD_NUMBER", default = "None")
     val gitHash = sys.env.getOrElse("GIT_COMMIT", default = "None")
-    val contents = "version {\nbuild.number=%s\ngit.hash=%s\nversion=%s\n}".format(buildNumber, gitHash, version.value)
+    val versionString = sys.env.getOrElse("DOCKER_TAG", version.value)
+    val contents = "version {\nbuild.number=%s\ngit.hash=%s\nversion=%s\n}".format(buildNumber, gitHash, versionString)
     IO.write(file, contents)
     Seq(file)
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -133,9 +133,8 @@ object Settings {
   //thus commonSettings needs to be added first.
   val rawlsCoreSettings = commonSettings ++ List(
     name := "rawls-core",
-    version := "0.1",
     libraryDependencies ++= rawlsCoreDependencies
-  ) ++ antlr4CodeGenerationSettings ++ rawlsAssemblySettings ++ noPublishSettings ++ rawlsCompileSettings ++ java17BuildSettings
+  ) ++ versionSettings ++ antlr4CodeGenerationSettings ++ rawlsAssemblySettings ++ noPublishSettings ++ rawlsCompileSettings ++ java17BuildSettings
   //NOTE: rawlsCoreCompileSettings above has to be last, because something in commonSettings or rawlsAssemblySettings
   //overwrites it if it's before them. I (hussein) don't know what that is and I don't care to poke the bear to find out.
 
@@ -144,8 +143,7 @@ object Settings {
   //thus commonSettings needs to be added first.
   val rootSettings = commonSettings ++ List(
     name := "rawls",
-    version := "0.1"
-  ) ++ rawlsAssemblySettings ++ noPublishSettings ++ rawlsCompileSettings ++ java17BuildSettings
+  ) ++ versionSettings ++ rawlsAssemblySettings ++ noPublishSettings ++ rawlsCompileSettings ++ java17BuildSettings
   //See immediately above NOTE.
 
   val pact4sSettings = commonSettingsWithoutDb ++ List(

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,15 +4,11 @@ import sbt.Setting
 import scala.sys.process._
 
 object Version {
-  val baseModelVersion = "0.1"
-
   def getVersionString = {
     def getLastCommitHashFromGit = s"""git log -n 1 --pretty=format:%h""" !!
-    // jenkins builds will pass the last commit hash in as an env variable because we currently build rawls
-    // inside a docker container that doesn't know the code is a git repo.
-    // if building from the hseeberger/scala-sbt docker image use env var (since hseeberger/scala-sbt doesn't have git in it)
-    val gitHash = sys.env.getOrElse("GIT_HASH", getLastCommitHashFromGit).trim()
-    val version = baseModelVersion + "-" + gitHash
+
+    // the terra-github-workflows/rawls-build GHA workflow sets BUILD_NUMBER, GIT_COMMIT, and DOCKER_TAG environment variables
+    val version = sys.env.getOrElse("DOCKER_TAG", getLastCommitHashFromGit).trim()
 
     // The project isSnapshot string passed in via command line settings, if desired.
     val isSnapshot = sys.props.getOrElse("project.isSnapshot", "true").toBoolean


### PR DESCRIPTION
Ticket: AJ-1549

This hopefully brings versioning into a more consistent state. With these changes:
* the [GHA build](https://github.com/broadinstitute/terra-github-workflows/blob/main/.github/workflows/rawls-build.yaml), which relies on the bumper action, should be the source of truth for versioning. It passes env vars into the sbt build.
* the /version API should report all of its values based on what the GHA build reports
* the internal sbt `version` should respect the semantic version string from the GHA build
* the version used to publish rawls-model to artifactory should respect the semantic version string from the GHA build


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
