### PR TITLE
AJ-1697 Separate tag.yml to its own workflow

### DIFF
--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -17,29 +17,25 @@ env:
 
 jobs:
   # Attempt to bump the app version.
+
+  tag-job:
+    uses: ./.github/workflows/tag.yml
+    with:
+      release-branches: develop
+    secrets: inherit
+  
   # Compile the Scala code to a jar.
   # Build the docker image and push that image to GCR.
-  rawls-build-tag-publish-job:
+  rawls-build-publish-job:
     runs-on: ubuntu-latest
+    needs: tag-job
     permissions:
       contents: 'read'
       id-token: 'write'
     outputs:
       custom-version-json: ${{ steps.render-rawls-version.outputs.custom-version-json }}
-      tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - uses: 'actions/checkout@v4'
-
-      - name: Bump the tag to a new version
-        id: tag
-        uses: ./.github/workflows/tag.yml
-        with:
-          # The 'ref' parameter ensures that the provider version is postfixed with the HEAD commit of the PR branch,
-          # facilitating cross-referencing of a pact between Pact Broker and GitHub.
-          ref: ${{ github.head_ref || '' }}
-          dry-run: true
-          release-branches: develop
-        
+      - uses: 'actions/checkout@v4'        
 
       - name: Extract branch
         id: extract-branch
@@ -71,7 +67,7 @@ jobs:
             "run-name": "${{ env.RAWLS_BUILD_RUN_NAME }}",
             "repository": "${{ github.event.repository.full_name }}",
             "ref": "${{ steps.extract-branch.outputs.ref }}",
-            "rawls-release-tag": "${{ steps.tag.outputs.tag }}"
+            "rawls-release-tag": "${{ needs.tag-job.outputs.tag }}"
           }'
 
       - name: Render Rawls version
@@ -80,7 +76,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: |
           echo "$GITHUB_CONTEXT"
-          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ steps.tag.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
+          echo "custom-version-json={\\\"rawls\\\":{\\\"appVersion\\\":\\\"${{ needs.tag-job.outputs.tag }}\\\"}}" >> $GITHUB_OUTPUT
 
 
   # Set the test-context: is this a merge to `develop` or is this a PR?
@@ -103,9 +99,9 @@ jobs:
   # Tell Broad DevOps Sherlock about the build version we just created.
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: rawls-build-tag-publish-job
+    needs: rawls-build-publish-job
     with:
-      new-version: ${{ needs.rawls-build-tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.rawls-build-publish-job.outputs.tag }}
       chart-name: 'rawls'
     permissions:
       contents: 'read'
@@ -114,10 +110,10 @@ jobs:
   # Put new Rawls version in Broad dev environment
   set-version-in-dev:
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: [rawls-build-tag-publish-job, report-to-sherlock]
+    needs: [rawls-build-publish-job, report-to-sherlock]
     if: ${{ github.ref_name == 'develop' }}
     with:
-      new-version: ${{ needs.rawls-build-tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.rawls-build-publish-job.outputs.tag }}
       chart-name: 'rawls'
       environment-name: 'dev'
     secrets:
@@ -132,14 +128,14 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
     needs:
-      - rawls-build-tag-publish-job
+      - rawls-build-publish-job
     permissions:
       contents: 'read'
       id-token: 'write'
     steps:
       - name: Echo Rawls version
         run: |
-          echo '${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}'
+          echo '${{ needs.rawls-build-publish-job.outputs.custom-version-json }}'
 
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4.0.0
@@ -154,7 +150,7 @@ jobs:
             "run-name": "${{ env.BEE_CREATE_RUN_NAME }}-${{ matrix.terra-env }}",
             "bee-name": "${{ env.BEE_NAME }}-${{ matrix.terra-env }}",
             "version-template": "${{ matrix.terra-env }}",
-            "custom-version-json": "${{ needs.rawls-build-tag-publish-job.outputs.custom-version-json }}"
+            "custom-version-json": "${{ needs.rawls-build-publish-job.outputs.custom-version-json }}"
           }'
 
   # Run swat tests. This kicks off two parallel jobs for Workflows and Workspaces tests, which both run against the BEE

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -36,10 +36,11 @@ jobs:
           # The 'ref' parameter ensures that the provider version is postfixed with the HEAD commit of the PR branch,
           # facilitating cross-referencing of a pact between Pact Broker and GitHub.
           ref: ${{ github.head_ref || '' }}
-        id: tag
-        dry-run: true
-        release-branches: develop
+          dry-run: true
+          release-branches: develop
         secrets: inherit
+        id: tag
+        
 
       - name: Extract branch
         id: extract-branch

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: 'actions/checkout@v4'
 
       - name: Bump the tag to a new version
+        id: tag
         uses: ./.github/workflows/tag.yml
         with:
           # The 'ref' parameter ensures that the provider version is postfixed with the HEAD commit of the PR branch,
@@ -38,8 +39,6 @@ jobs:
           ref: ${{ github.head_ref || '' }}
           dry-run: true
           release-branches: develop
-        secrets: inherit
-        id: tag
         
 
       - name: Extract branch

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -99,9 +99,9 @@ jobs:
   # Tell Broad DevOps Sherlock about the build version we just created.
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: rawls-build-publish-job
+    needs: [tag-job, rawls-build-publish-job]
     with:
-      new-version: ${{ needs.rawls-build-publish-job.outputs.tag }}
+      new-version: ${{ needs.tag-job.outputs.tag }}
       chart-name: 'rawls'
     permissions:
       contents: 'read'
@@ -110,10 +110,10 @@ jobs:
   # Put new Rawls version in Broad dev environment
   set-version-in-dev:
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: [rawls-build-publish-job, report-to-sherlock]
+    needs: [tag-job, rawls-build-publish-job, report-to-sherlock]
     if: ${{ github.ref_name == 'develop' }}
     with:
-      new-version: ${{ needs.rawls-build-publish-job.outputs.tag }}
+      new-version: ${{ needs.tag-job.outputs.tag }}
       chart-name: 'rawls'
       environment-name: 'dev'
     secrets:

--- a/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
+++ b/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml
@@ -31,13 +31,15 @@ jobs:
       - uses: 'actions/checkout@v4'
 
       - name: Bump the tag to a new version
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
+        uses: ./.github/workflows/tag.yml
+        with:
+          # The 'ref' parameter ensures that the provider version is postfixed with the HEAD commit of the PR branch,
+          # facilitating cross-referencing of a pact between Pact Broker and GitHub.
+          ref: ${{ github.head_ref || '' }}
         id: tag
-        env:
-          DEFAULT_BUMP: patch
-          GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
-          RELEASE_BRANCHES: develop
-          WITH_V: true
+        dry-run: true
+        release-branches: develop
+        secrets: inherit
 
       - name: Extract branch
         id: extract-branch

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -27,16 +27,23 @@ on:
       tag:
         description: "The value of the latest tag after running this action"
         value: ${{ jobs.tag-job.outputs.tag }}
+      new-tag:
+        description: "The value of the newly created tag"
+        value: ${{ jobs.tag-job.outputs.new-tag }}
     secrets:
       BROADBOT_TOKEN:
         required: true
 
 jobs:
+  # On tag vs. new-tag.
+  # The new-tag is always the tag resulting from a bump to the original tag.
+  # However, the tag is by definition the value of the latest tag after running the action,
+  # which might not change if dry run is used, and remains same as the original tag.
   tag-job:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      
+      new-tag: ${{ steps.tag.outputs.new_tag }}
     steps:
     - name: Checkout current code
       uses: actions/checkout@v4
@@ -56,4 +63,4 @@ jobs:
     - name: Echo generated tag to console
       if: ${{ inputs.print-tag == 'true' }}
       run: |
-        echo "Newly created version tag: '${{ steps.tag.outputs.tag }}'"
+        echo "Newly created version tag: '${{ steps.tag.outputs.new-tag }}'"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,59 @@
+name: Tag
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout"
+        default: ''
+        required: false
+        type: string
+      dry-run:
+        description: "Determine the next version without tagging the branch. The workflow can use the outputs new_tag and tag in subsequent steps. Possible values are true and false (default)"
+        default: false
+        required: false
+        type: string
+      print-tag:
+        description: "Echo generated tag to console"
+        default: "true"
+        required: false
+        type: string
+      release-branches:
+        description: "Default branch (main, develop, etc)"
+        default: 'develop'
+        required: false
+        type: string
+    outputs:
+      tag:
+        description: "The value of the latest tag after running this action"
+        value: ${{ jobs.tag-job.outputs.tag }}
+    secrets:
+      BROADBOT_TOKEN:
+        required: true
+
+jobs:
+  tag-job:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      
+    steps:
+    - name: Checkout current code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
+    - name: Bump the tag to a new version
+      # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
+      uses: databiosphere/github-actions/actions/bumper@bumper-0.3.0
+      id: tag
+      env:
+        DEFAULT_BUMP: patch
+        GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        RELEASE_BRANCHES: ${{ inputs.release-branches }}
+        WITH_V: true
+    - name: Echo generated tag to console
+      if: ${{ inputs.print-tag == 'true' }}
+      run: |
+        echo "Newly created version tag: '${{ steps.tag.outputs.tag }}'"


### PR DESCRIPTION
Ticket: AJ-1697
The new verify_consumer_pacts in https://github.com/broadinstitute/rawls/pull/2806 requires the new tag, which was buried as a step in rawls-build-tag-publish-and-run-tests.yaml.  This PR pulls it out into its own workflow.  Putting in a separate PR for testing purposes and to avoid confusion.
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
