### PR TITLE
Rawls attempts to fetch "rawls" workspaces from WSM in addition to "MC"

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
@@ -103,20 +103,6 @@ class AggregatedWorkspaceService(workspaceManagerDAO: WorkspaceManagerDAO) exten
       }
     }
 
-  /**
-   * Optimized version of [[fetchAggregatedWorkspace]]
-   *
-   * If the provided workspace is not of type "MC", returns the provided "rawls" workspace with no WSM information, as
-   * it can be assumed to be GCP and does not need to call out to WSM for this.
-   */
-  def optimizedFetchAggregatedWorkspace(workspace: Workspace, ctx: RawlsRequestContext): AggregatedWorkspace =
-    workspace.workspaceType match {
-      case WorkspaceType.RawlsWorkspace =>
-        AggregatedWorkspace(workspace, Some(workspace.googleProjectId), azureCloudContext = None, policies = List.empty)
-      case WorkspaceType.McWorkspace =>
-        fetchAggregatedWorkspace(workspace, ctx)
-    }
-
   private def aggregateMCWorkspaceWithWSMInfo(workspace: Workspace,
                                               wsmInfo: WorkspaceDescription
   ): AggregatedWorkspace =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -316,13 +316,18 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
               try
                 wsmService.fetchAggregatedWorkspace(workspaceContext, ctx)
               catch {
-                case _: Exception =>
-                  // return workspace with no WSM information
-                  AggregatedWorkspace(workspaceContext,
-                                      Some(workspaceContext.googleProjectId),
-                                      azureCloudContext = None,
-                                      policies = List.empty
-                  )
+                case e: AggregateWorkspaceNotFoundException =>
+                  // return workspace with no WSM information for gcp workspace
+                  if (workspaceContext.workspaceType == WorkspaceType.RawlsWorkspace) {
+                    AggregatedWorkspace(workspaceContext,
+                                        Some(workspaceContext.googleProjectId),
+                                        azureCloudContext = None,
+                                        policies = List.empty
+                    )
+                  } else {
+                    // bubble up an MC workspace exception
+                    throw e
+                  }
               }
 
             // maximum access level is required to calculate canCompute and canShare. Therefore, if any of

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceServiceSpec.scala
@@ -217,24 +217,6 @@ class AggregatedWorkspaceServiceSpec extends AnyFlatSpec with MockitoTestUtils {
     verify(wsmDao).getWorkspace(ArgumentMatchers.eq(legacyRawlsWorkspace.workspaceIdAsUUID), any[RawlsRequestContext])
   }
 
-  behavior of "optimizedFetchAggregatedWorkspace"
-
-  it should "not reach out to WSM for legacy GCP Rawls workspaces" in {
-    val wsmDao = mock[WorkspaceManagerDAO]
-    when(wsmDao.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
-      new WorkspaceDescription().stage(WorkspaceStageModel.RAWLS_WORKSPACE)
-    )
-    val svc = new AggregatedWorkspaceService(wsmDao)
-
-    val aggregatedWorkspace = svc.optimizedFetchAggregatedWorkspace(legacyRawlsWorkspace, defaultRequestContext)
-
-    aggregatedWorkspace.baseWorkspace shouldBe legacyRawlsWorkspace
-    aggregatedWorkspace.getCloudPlatform shouldBe Some(WorkspaceCloudPlatform.Gcp)
-    aggregatedWorkspace.azureCloudContext shouldBe None
-    aggregatedWorkspace.googleProjectId shouldBe Some(legacyRawlsWorkspace.googleProjectId)
-    verify(wsmDao, never()).getWorkspace(any[UUID], any[RawlsRequestContext])
-  }
-
   behavior of "fetchAggregatedWorkspaces"
 
   it should "match an MC workspace with the correct WSM information" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3042,6 +3042,27 @@ class WorkspaceServiceSpec
     )
   }
 
+  private def createGcpWorkspaceStub(services: TestApiService,
+                                     workspaceName: String,
+                                     policies: List[WsmPolicyInput] = List()
+  ): Workspace = {
+    val workspaceRequest = WorkspaceRequest(
+      testData.testProject1Name.value,
+      workspaceName,
+      Map.empty
+    )
+    when(services.workspaceManagerDAO.getWorkspace(any[UUID], any[RawlsRequestContext])).thenReturn(
+      new WorkspaceDescription()
+        .stage(WorkspaceStageModel.RAWLS_WORKSPACE)
+        .policies(policies.asJava)
+    )
+
+    Await.result(
+      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest, new ProfileModel().id(UUID.randomUUID())),
+      Duration.Inf
+    )
+  }
+
   it should "get the details of an Azure workspace" in withTestDataServices { services =>
     val managedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID(), UUID.randomUUID(), "fake_mrg_id")
     val workspace = createAzureWorkspace(services, managedAppCoordinates)
@@ -3136,6 +3157,47 @@ class WorkspaceServiceSpec
     )
 
     val response = readWorkspace.convertTo[WorkspaceResponse]
+    response.policies should not be empty
+    val policies: List[WorkspacePolicy] = response.policies.get
+    policies should not be empty
+    val policy: WorkspacePolicy = policies.head
+    policy.name shouldBe wsmPolicyInput.getName
+    policy.namespace shouldBe wsmPolicyInput.getNamespace
+    val additionalData = policy.additionalData
+    additionalData.length shouldEqual 2
+    additionalData.head.getOrElse("pair1Key", "fail") shouldEqual "pair1Val"
+    additionalData.tail.head.getOrElse("pair2Key", "fail") shouldEqual "pair2Val"
+  }
+
+  it should "return the policies of a GCP workspace" in withTestDataServices { services =>
+    val workspaceName = s"rawls-test-workspace-${UUID.randomUUID().toString}"
+    val workspaceRequest = WorkspaceRequest(
+      testData.testProject1Name.value,
+      workspaceName,
+      Map.empty
+    )
+    val wsmPolicyInput = new WsmPolicyInput()
+      .name("test_name")
+      .namespace("test_namespace")
+      .additionalData(
+        List(
+          new WsmPolicyPair().value("pair1Val").key("pair1Key"),
+          new WsmPolicyPair().value("pair2Val").key("pair2Key")
+        ).asJava
+      )
+    val workspace = createGcpWorkspaceStub(services, workspaceName, List(wsmPolicyInput))
+    val readWorkspace = Await.result(services.workspaceService.getWorkspace(
+                                       WorkspaceName(workspace.namespace, workspace.name),
+                                       WorkspaceFieldSpecs()
+                                     ),
+                                     Duration.Inf
+    )
+
+    val response = readWorkspace.convertTo[WorkspaceResponse]
+
+    response.workspace.name shouldBe workspaceName
+    response.azureContext shouldEqual None
+    response.workspace.cloudPlatform shouldBe Some(WorkspaceCloudPlatform.Gcp)
     response.policies should not be empty
     val policies: List[WorkspacePolicy] = response.policies.get
     policies should not be empty

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3044,7 +3044,8 @@ class WorkspaceServiceSpec
 
   private def createGcpWorkspaceStub(services: TestApiService,
                                      workspaceName: String,
-                                     policies: List[WsmPolicyInput] = List()
+                                     policies: List[WsmPolicyInput] = List(),
+                                     workspaceService: WorkspaceService
   ): Workspace = {
     val workspaceRequest = WorkspaceRequest(
       testData.testProject1Name.value,
@@ -3058,7 +3059,7 @@ class WorkspaceServiceSpec
     )
 
     Await.result(
-      services.mcWorkspaceService.createMultiCloudWorkspace(workspaceRequest, new ProfileModel().id(UUID.randomUUID())),
+      services.mcWorkspaceService.createMultiCloudOrRawlsWorkspace(workspaceRequest, workspaceService),
       Duration.Inf
     )
   }
@@ -3185,7 +3186,7 @@ class WorkspaceServiceSpec
           new WsmPolicyPair().value("pair2Val").key("pair2Key")
         ).asJava
       )
-    val workspace = createGcpWorkspaceStub(services, workspaceName, List(wsmPolicyInput))
+    val workspace = createGcpWorkspaceStub(services, workspaceName, List(wsmPolicyInput), services.workspaceService)
     val readWorkspace = Await.result(services.workspaceService.getWorkspace(
                                        WorkspaceName(workspace.namespace, workspace.name),
                                        WorkspaceFieldSpecs()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1750

Currently, Rawls only returns policies for Azure workspaces, and an empty list for GCP ("rawls") workspaces. This is because GCP workspaces usually don't have a corresponding entry in WSM. However, GCP workspaces with linked snapshots do, and we need to try and retrieve that to display policies in the UI. 

This PR attempts to make the WSM fetch call for all workspaces, and returns a default entry if it doesn't exist. It's a similar method to what we're doing in the [snapshot code here](https://github.com/broadinstitute/rawls/pull/2570/files#diff-3fb111d317a44913c11c6b540e6a2d05fdf5715c28ae0a0bb87921bb8e1057eeR80).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
