### PR TITLE
[WOR-1627] Switch to V2 workspace creation API

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -142,23 +142,6 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
   ): CloneWorkspaceResult =
     getWorkspaceApi(ctx).getCloneWorkspaceResult(workspaceId, jobControlId)
 
-  override def createAzureWorkspaceCloudContext(workspaceId: UUID,
-                                                ctx: RawlsRequestContext
-  ): CreateCloudContextResult = {
-    val jobControlId = UUID.randomUUID().toString
-    getWorkspaceApi(ctx).createCloudContext(new CreateCloudContextRequest()
-                                              .cloudPlatform(CloudPlatform.AZURE)
-                                              .jobControl(new JobControl().id(jobControlId)),
-                                            workspaceId
-    )
-  }
-
-  override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
-                                                    jobControlId: String,
-                                                    ctx: RawlsRequestContext
-  ): CreateCloudContextResult =
-    getWorkspaceApi(ctx).getCreateCloudContextResult(workspaceId, jobControlId)
-
   override def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
     getWorkspaceApi(ctx).getCreateWorkspaceV2Result(jobControlId)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -111,6 +111,9 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
     getWorkspaceApi(ctx).createWorkspaceV2(request)
   }
 
+  override def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
+    getWorkspaceApi(ctx).getCreateWorkspaceV2Result(jobControlId)
+
   override def cloneWorkspace(sourceWorkspaceId: UUID,
                               workspaceId: UUID,
                               displayName: String,
@@ -141,9 +144,6 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                        ctx: RawlsRequestContext
   ): CloneWorkspaceResult =
     getWorkspaceApi(ctx).getCloneWorkspaceResult(workspaceId, jobControlId)
-
-  override def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
-    getWorkspaceApi(ctx).getCreateWorkspaceV2Result(jobControlId)
 
   override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit =
     getWorkspaceApi(ctx).deleteWorkspace(workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -92,20 +92,23 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                spendProfileId: String,
                                                billingProjectNamespace: String,
                                                applicationIds: Seq[String],
+                                               cloudPlatform: CloudPlatform,
                                                policyInputs: Option[WsmPolicyInputs],
                                                ctx: RawlsRequestContext
-  ): CreatedWorkspace = {
-    val request = new CreateWorkspaceRequestBody()
+  ): CreateWorkspaceV2Result = {
+    val request = new CreateWorkspaceV2Request()
       .id(workspaceId)
       .displayName(displayName)
       .spendProfile(spendProfileId)
       .stage(WorkspaceStageModel.MC_WORKSPACE)
       .projectOwnerGroupId(billingProjectNamespace)
       .applicationIds(applicationIds.asJava)
+      .cloudPlatform(cloudPlatform)
+      .jobControl(new JobControl().id(UUID.randomUUID().toString))
 
     policyInputs.map(request.policies)
 
-    getWorkspaceApi(ctx).createWorkspace(request)
+    getWorkspaceApi(ctx).createWorkspaceV2(request)
   }
 
   override def cloneWorkspace(sourceWorkspaceId: UUID,
@@ -155,6 +158,9 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                                                     ctx: RawlsRequestContext
   ): CreateCloudContextResult =
     getWorkspaceApi(ctx).getCreateCloudContextResult(workspaceId, jobControlId)
+
+  override def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
+    getWorkspaceApi(ctx).getCreateWorkspaceV2Result(jobControlId)
 
   override def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit =
     getWorkspaceApi(ctx).deleteWorkspace(workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -29,6 +29,8 @@ trait WorkspaceManagerDAO {
                                       ctx: RawlsRequestContext
   ): CreateWorkspaceV2Result
 
+  def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result
+
   def cloneWorkspace(sourceWorkspaceId: UUID,
                      workspaceId: UUID,
                      displayName: String,
@@ -41,7 +43,7 @@ trait WorkspaceManagerDAO {
   def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport
 
   def getCloneWorkspaceResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CloneWorkspaceResult
-  def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result
+
   def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit
 
   def deleteWorkspaceV2(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): JobResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -24,9 +24,10 @@ trait WorkspaceManagerDAO {
                                       spendProfileId: String,
                                       billingProjectNamespace: String,
                                       applicationIds: Seq[String],
+                                      cloudPlatform: CloudPlatform,
                                       policyInputs: Option[WsmPolicyInputs],
                                       ctx: RawlsRequestContext
-  ): CreatedWorkspace
+  ): CreateWorkspaceV2Result
 
   def cloneWorkspace(sourceWorkspaceId: UUID,
                      workspaceId: UUID,
@@ -47,6 +48,8 @@ trait WorkspaceManagerDAO {
                                            jobControlId: String,
                                            ctx: RawlsRequestContext
   ): CreateCloudContextResult
+
+  def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result
   def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit
 
   def deleteWorkspaceV2(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): JobResult

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -41,14 +41,6 @@ trait WorkspaceManagerDAO {
   def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport
 
   def getCloneWorkspaceResult(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): CloneWorkspaceResult
-
-  def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult
-
-  def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
-                                           jobControlId: String,
-                                           ctx: RawlsRequestContext
-  ): CreateCloudContextResult
-
   def getCreateWorkspaceResult(jobControlId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result
   def deleteWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): Unit
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -34,7 +34,7 @@ class MockWorkspaceManagerDAO(
 
   def mockInitialCreateWorkspaceResult() =
     MockWorkspaceManagerDAO.getCreateWorkspaceResult(StatusEnum.RUNNING)
-  def mockCreateWorkspaceV2Response() = createWorkspaceResult
+  def mockCreateWorkspaceV2Result() = createWorkspaceResult
 
   def mockReferenceResponse(workspaceId: UUID, referenceId: UUID) = references.getOrElse(
     (workspaceId, referenceId),
@@ -227,15 +227,7 @@ class MockWorkspaceManagerDAO(
     mockInitialCreateWorkspaceResult()
 
   override def getCreateWorkspaceResult(workspaceId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
-    mockCreateWorkspaceV2Response()
-
-  override def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult =
-    ???
-
-  override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
-                                                    jobControlId: String,
-                                                    ctx: RawlsRequestContext
-  ): CreateCloudContextResult = ???
+    mockCreateWorkspaceV2Result()
 
   override def createAzureStorageContainer(workspaceId: UUID,
                                            storageContainerName: String,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -22,8 +22,8 @@ import scala.collection.concurrent.TrieMap
 import scala.jdk.CollectionConverters._
 
 class MockWorkspaceManagerDAO(
-  val createCloudContextResult: CreateCloudContextResult =
-    MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.SUCCEEDED)
+  val createWorkspaceResult: CreateWorkspaceV2Result =
+    MockWorkspaceManagerDAO.getCreateWorkspaceResult(StatusEnum.SUCCEEDED)
 ) extends WorkspaceManagerDAO {
 
   val references: TrieMap[(UUID, UUID), DataRepoSnapshotResource] = TrieMap()
@@ -31,6 +31,11 @@ class MockWorkspaceManagerDAO(
   def mockGetWorkspaceResponse(workspaceId: UUID) =
     new WorkspaceDescription().id(workspaceId).stage(WorkspaceStageModel.RAWLS_WORKSPACE)
   def mockCreateWorkspaceResponse(workspaceId: UUID) = new CreatedWorkspace().id(workspaceId)
+
+  def mockInitialCreateWorkspaceResult() =
+    MockWorkspaceManagerDAO.getCreateWorkspaceResult(StatusEnum.RUNNING)
+  def mockCreateWorkspaceV2Response() = createWorkspaceResult
+
   def mockReferenceResponse(workspaceId: UUID, referenceId: UUID) = references.getOrElse(
     (workspaceId, referenceId),
     throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "Not found"))
@@ -38,9 +43,6 @@ class MockWorkspaceManagerDAO(
   def mockEnumerateReferenceResponse(workspaceId: UUID) = references.collect {
     case ((wsId, _), refDescription) if wsId == workspaceId => refDescription
   }
-  def mockInitialCreateAzureCloudContextResult() =
-    MockWorkspaceManagerDAO.getCreateCloudContextResult(StatusEnum.RUNNING)
-  def mockCreateAzureCloudContextResult() = createCloudContextResult
   def mockCreateAzureStorageContainerResult() = new CreatedControlledAzureStorageContainer()
 
   override def getWorkspace(workspaceId: UUID, ctx: RawlsRequestContext): WorkspaceDescription =
@@ -218,18 +220,22 @@ class MockWorkspaceManagerDAO(
                                                spendProfileId: String,
                                                billingProjectNamespace: String,
                                                applicationIds: Seq[String],
+                                               cloudPlatform: CloudPlatform,
                                                policyInputs: Option[WsmPolicyInputs],
                                                ctx: RawlsRequestContext
-  ): CreatedWorkspace =
-    mockCreateWorkspaceResponse(workspaceId)
+  ): CreateWorkspaceV2Result =
+    mockInitialCreateWorkspaceResult()
+
+  override def getCreateWorkspaceResult(workspaceId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
+    mockCreateWorkspaceV2Response()
 
   override def createAzureWorkspaceCloudContext(workspaceId: UUID, ctx: RawlsRequestContext): CreateCloudContextResult =
-    mockInitialCreateAzureCloudContextResult()
+    ???
 
   override def getWorkspaceCreateCloudContextResult(workspaceId: UUID,
                                                     jobControlId: String,
                                                     ctx: RawlsRequestContext
-  ): CreateCloudContextResult = mockCreateAzureCloudContextResult()
+  ): CreateCloudContextResult = ???
 
   override def createAzureStorageContainer(workspaceId: UUID,
                                            storageContainerName: String,
@@ -278,14 +284,14 @@ class MockWorkspaceManagerDAO(
 }
 
 object MockWorkspaceManagerDAO {
-  def getCreateCloudContextResult(status: StatusEnum): CreateCloudContextResult =
-    new CreateCloudContextResult().jobReport(new JobReport().id("fake_id").status(status))
+  def getCreateWorkspaceResult(status: StatusEnum): CreateWorkspaceV2Result =
+    new CreateWorkspaceV2Result().jobReport(new JobReport().id("fake_id").status(status))
 
   def getCloneWorkspaceResult(status: StatusEnum): CloneWorkspaceResult =
     new CloneWorkspaceResult().jobReport(new JobReport().id("fake_id").status(status))
 
-  def buildWithAsyncCloudContextResult(createCloudContextStatus: StatusEnum) =
+  def buildWithAsyncCreateWorkspaceResult(createWorkspaceStatus: StatusEnum) =
     new MockWorkspaceManagerDAO(
-      getCreateCloudContextResult(createCloudContextStatus)
+      getCreateWorkspaceResult(createWorkspaceStatus)
     )
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -32,7 +32,7 @@ class MockWorkspaceManagerDAO(
     new WorkspaceDescription().id(workspaceId).stage(WorkspaceStageModel.RAWLS_WORKSPACE)
   def mockCreateWorkspaceResponse(workspaceId: UUID) = new CreatedWorkspace().id(workspaceId)
 
-  def mockInitialCreateWorkspaceResult() =
+  def mockInitialCreateWorkspaceV2Result() =
     MockWorkspaceManagerDAO.getCreateWorkspaceResult(StatusEnum.RUNNING)
   def mockCreateWorkspaceV2Result() = createWorkspaceResult
 
@@ -224,7 +224,7 @@ class MockWorkspaceManagerDAO(
                                                policyInputs: Option[WsmPolicyInputs],
                                                ctx: RawlsRequestContext
   ): CreateWorkspaceV2Result =
-    mockInitialCreateWorkspaceResult()
+    mockInitialCreateWorkspaceV2Result()
 
   override def getCreateWorkspaceResult(workspaceId: String, ctx: RawlsRequestContext): CreateWorkspaceV2Result =
     mockCreateWorkspaceV2Result()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -398,13 +398,8 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         any(), // spend profile id
         ArgumentMatchers.eq(namespace),
         any[Seq[String]],
+        ArgumentMatchers.eq(CloudPlatform.AZURE),
         any[Option[WsmPolicyInputs]],
-        ArgumentMatchers.eq(testContext)
-      )
-    Mockito
-      .verify(workspaceManagerDAO)
-      .createAzureWorkspaceCloudContext(
-        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
         ArgumentMatchers.eq(testContext)
       )
     Mockito
@@ -453,12 +448,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     result.name shouldBe "fake_name"
     result.workspaceType shouldBe WorkspaceType.McWorkspace
     result.namespace shouldEqual namespace
-    Mockito
-      .verify(workspaceManagerDAO)
-      .createAzureWorkspaceCloudContext(
-        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-        ArgumentMatchers.eq(testContext)
-      )
     Mockito
       .verify(leonardoDAO, never())
       .createWDSInstance(
@@ -509,12 +498,6 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     result.workspaceType shouldBe WorkspaceType.McWorkspace
     result.namespace shouldEqual namespace
     Mockito
-      .verify(workspaceManagerDAO)
-      .createAzureWorkspaceCloudContext(
-        ArgumentMatchers.eq(UUID.fromString(result.workspaceId)),
-        ArgumentMatchers.eq(testContext)
-      )
-    Mockito
       .verify(leonardoDAO)
       .createWDSInstance(
         ArgumentMatchers.eq("token"),
@@ -537,9 +520,10 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
                                                    spendProfileId: String,
                                                    billingProjectNamespace: String,
                                                    applicationIds: Seq[String],
+                                                   cloudPlatform: CloudPlatform,
                                                    policyInputs: Option[WsmPolicyInputs],
                                                    ctx: RawlsRequestContext
-      ): CreatedWorkspace = throw new ApiException(500, "whoops")
+      ): CreateWorkspaceV2Result = throw new ApiException(500, "whoops")
 
       override def deleteWorkspaceV2(workspaceId: UUID, jobControlId: String, ctx: RawlsRequestContext): JobResult =
         throw new ApiException(404, "i've never seen that workspace in my life")
@@ -567,9 +551,9 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
     verifyWorkspaceCreationRollback(workspaceManagerDAO, request.toWorkspaceName)
   }
 
-  it should "fail on cloud context creation failure and try to rollback workspace creation" in {
+  it should "fail on workspace creation failure and try to rollback workspace creation" in {
     val workspaceManagerDAO =
-      Mockito.spy(MockWorkspaceManagerDAO.buildWithAsyncCloudContextResult(StatusEnum.FAILED))
+      Mockito.spy(MockWorkspaceManagerDAO.buildWithAsyncCreateWorkspaceResult(StatusEnum.FAILED))
 
     val leonardoDAO: LeonardoDAO = new MockLeonardoDAO()
 
@@ -738,6 +722,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         ArgumentMatchers.anyString(),
         ArgumentMatchers.eq(namespace),
         any[Seq[String]],
+        ArgumentMatchers.eq(CloudPlatform.AZURE),
         ArgumentMatchers.eq(
           Some(
             new WsmPolicyInputs()
@@ -771,6 +756,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         ArgumentMatchers.anyString(),
         ArgumentMatchers.anyString(),
         ArgumentMatchers.eq(namespace),
+        any(),
         any(),
         ArgumentMatchers.eq(None),
         ArgumentMatchers.any()
@@ -815,6 +801,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         ArgumentMatchers.anyString(),
         ArgumentMatchers.eq(namespace),
         any[Seq[String]],
+        ArgumentMatchers.eq(CloudPlatform.AZURE),
         ArgumentMatchers.eq(
           Some(
             new WsmPolicyInputs()
@@ -838,6 +825,7 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
         ArgumentMatchers.anyString(),
         ArgumentMatchers.anyString(),
         ArgumentMatchers.eq(namespace),
+        any(),
         any(),
         ArgumentMatchers.eq(None),
         ArgumentMatchers.any()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1627

The WSM v2 Create Workspace API allows the creation of the cloud context as part of the workspace creation. To somewhat simplify or workspace creation code, I have switched us to the newer API (which was are also using for the cloning path).

This wasn't quite as satisfying as I hoped, in that [SnapshotService](https://github.com/broadinstitute/rawls/blob/0f4b788b257f324d4df684d80ff36a6ee0bfcd27/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala#L142) is still calling `createWorkspace` (which uses the synchronous V1 API) to create a RAWLS stage workspace. I can't really justify making the SnapshotService code poll for workspace creation completion, so we will continue to use both the V1 and V2 APIs from Rawls.

Successful run of workspace e2e tests using this branch: https://github.com/broadinstitute/rawls/actions/runs/8652411416

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
