### PR TITLE
[WOR-1580] Tolerate unknown properties in BPM response

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
@@ -1,18 +1,11 @@
 package org.broadinstitute.dsde.rawls.billing
 
-import bio.terra.common.tracing.JakartaTracingFilter
 import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi, UnauthenticatedApi}
-import bio.terra.profile.client.{ApiClient, RFC3339DateFormat}
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.opencensus.trace.Tracing
-import io.opentelemetry.api.GlobalOpenTelemetry
+import bio.terra.profile.client.ApiClient
 import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
-import org.broadinstitute.dsde.rawls.util.{TracingUtils, WithOtelContextFilter}
+import org.broadinstitute.dsde.rawls.util.TracingUtils
 import org.glassfish.jersey.client.ClientConfig
-import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider
 import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 
 /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerClientProvider.scala
@@ -2,13 +2,17 @@ package org.broadinstitute.dsde.rawls.billing
 
 import bio.terra.common.tracing.JakartaTracingFilter
 import bio.terra.profile.api.{AzureApi, ProfileApi, SpendReportingApi, UnauthenticatedApi}
-import bio.terra.profile.client.ApiClient
+import bio.terra.profile.client.{ApiClient, RFC3339DateFormat}
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import io.opencensus.trace.Tracing
 import io.opentelemetry.api.GlobalOpenTelemetry
 import jakarta.ws.rs.client.ClientBuilder
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 import org.broadinstitute.dsde.rawls.util.{TracingUtils, WithOtelContextFilter}
 import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider
 import org.glassfish.jersey.jnh.connector.JavaNetHttpConnectorProvider
 
 /**
@@ -36,6 +40,7 @@ class HttpBillingProfileManagerClientProvider(baseBpmUrl: Option[String]) extend
     // allows us to call PATCH endpoints in BPM.
     val clientConfig = new ClientConfig()
     clientConfig.connectorProvider(new JavaNetHttpConnectorProvider())
+    clientConfig.register(client.getJSON)
     client.setHttpClient(ClientBuilder.newClient(clientConfig))
 
     TracingUtils.enableCrossServiceTracing(client.getHttpClient, ctx)

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -98,8 +98,6 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     o.stringType("managedResourceGroupId")
     o.stringType("biller")
     o.stringType("displayName")
-    o.stringValue("billingAccountId", null)
-    o.stringValue("description", null)
     // It appears to be necessary to specify the value because the enum doesn't get translated to string automatically
     o.stringType("cloudPlatform", CloudPlatform.AZURE.toString)
     o.`object`("policies", po => po.array("inputs", arr => arr.getPactDslJsonArray))


### PR DESCRIPTION
Ticket: [WOR-1580](https://broadworkbench.atlassian.net/browse/WOR-1580)
* Merging https://github.com/DataBiosphere/terra-billing-profile-manager/pull/436 uncovered a bug in Rawls that prevented it from deserializing BPM responses with unknown properties. Configuring the new client to get around the PATCH bug (see comment in code) was overriding the `ObjectMapper` used to deserialize BPM responses. This configures the new client to use the `ObjectMapper` included in the BPM generated client.
* Tested by running against a local BPM that includes the new `organization` field in its response and verifying that Rawls was successfully deserializing the response. Confirmed that Rawls is still able to issue PATCH requests to BPM as well.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1580]: https://broadworkbench.atlassian.net/browse/WOR-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ