### PR TITLE
AJ-1788: no stack trace in response for create-snapshot-reference on TDR API exception

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -170,8 +170,8 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
         )
       // else, propagate by wrapping in an error report
       case Failure(other) =>
-        logger.warn(s"Unexpected error when retrieving snapshot: ${other.getMessage}")
-        throw new RawlsExceptionWithErrorReport(ErrorReport(other))
+        logger.warn(s"Unexpected error when retrieving snapshot: ${other.getMessage}", other)
+        throw new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, other.getMessage))
     }
 
   def getSnapshotResourceFromWsm(workspaceName: WorkspaceName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -158,10 +158,17 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
   private def getSnapshotFromDataRepo(snapshotIdentifiers: NamedDataRepoSnapshot) =
     Try(dataRepoDAO.getSnapshot(snapshotIdentifiers.snapshotId, ctx.userInfo.accessToken)) match {
       case Success(snapshot) => snapshot
+      // if snapshot not found in TDR, this is a bad request
       case Failure(ex: ApiException) if ex.getCode == StatusCodes.NotFound.intValue =>
         throw new RawlsExceptionWithErrorReport(
           ErrorReport(StatusCodes.BadRequest, s"Snapshot ${snapshotIdentifiers.snapshotId} not found.")
         )
+      // on some other TDR API exception, strip the stack trace and propagate
+      case Failure(ex: ApiException) =>
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(ex.getCode, ex.getMessage)
+        )
+      // else, propagate by wrapping in an error report
       case Failure(other) =>
         logger.warn(s"Unexpected error when retrieving snapshot: ${other.getMessage}")
         throw new RawlsExceptionWithErrorReport(ErrorReport(other))


### PR DESCRIPTION
Ticket: AJ-1788

For the API create-snapshot-reference API: if we encounter an ApiException retrieving the snapshot from TDR, don't include a stack trace in the error response.

This should address a low-priority security finding about verbose error messages in CWDS. CWDS is just propagating the stack trace up the chain from Rawls.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
