### PR TITLE
AJ-1677: publish to different pub/sub topics for cWDS vs Import Service

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -444,12 +444,12 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
     }
     // publish two status-update messages: one to the deprecated Import Service topic, and a duplicate to the
     // new cWDS topic. When cWDS fully replaces Import Service, we'll return to publishing only one.
-    List(importStatusPubSubTopic, cwdsStatusPubSubTopic).foreach(topicName =>
+    Future.traverse(List(importStatusPubSubTopic, cwdsStatusPubSubTopic)) { topicName =>
       importServicePubSubDAO.publishMessages(
         topicName,
         scala.collection.immutable.Seq(GooglePubSubDAO.MessageRequest("", attributes))
       )
-    )
+    }
   }
 
   private def initUpsert(upsertFile: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -455,11 +455,14 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
         val usableValue = if (attValue.value.length < 1000) attValue.value else attValue.value.take(1000) + " ..."
         (attName, usableValue)
     }
-    // publish the message to the appropriate cWDS or Import Service topic
-    importServicePubSubDAO.publishMessages(
-      targetTopic,
-      scala.collection.immutable.Seq(GooglePubSubDAO.MessageRequest("", attributes))
-    )
+    // publish the message to the appropriate cWDS or Import Service topic. Each topic uses a different dao,
+    // since they are in different projects.
+    val message = scala.collection.immutable.Seq(GooglePubSubDAO.MessageRequest("", attributes))
+    if (isCwds) {
+      pubSubDao.publishMessages(cwdsStatusPubSubTopic, message)
+    } else {
+      importServicePubSubDAO.publishMessages(importStatusPubSubTopic, message)
+    }
   }
 
   private def initUpsert(upsertFile: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BootMonitors.scala
@@ -182,6 +182,7 @@ object BootMonitors extends LazyLogging {
         appConfigManager.conf.getString("avroUpsertMonitor.importRequestPubSubTopic"),
         appConfigManager.conf.getString("avroUpsertMonitor.importRequestPubSubSubscription"),
         appConfigManager.conf.getString("avroUpsertMonitor.updateImportStatusPubSubTopic"),
+        appConfigManager.conf.getString("avroUpsertMonitor.updateCwdsPubSubTopic"),
         appConfigManager.conf.getInt("avroUpsertMonitor.ackDeadlineSeconds"),
         appConfigManager.conf.getInt("avroUpsertMonitor.batchSize"),
         appConfigManager.conf.getInt("avroUpsertMonitor.workerCount")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -61,9 +61,7 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
   case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(
     implicit override val executionContext: ExecutionContext
   ) extends ApiServices
-      with MockUserInfoDirectives {
-    override val startSubmissionMonitor: Boolean = false
-  }
+      with MockUserInfoDirectives
 
   def withApiServices[T](dataSource: SlickDataSource)(testCode: TestApiService => T): T = {
     val apiService = new TestApiService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.ActorMaterializer
-import akka.testkit.TestKitBase
+import akka.testkit.{TestActors, TestKitBase}
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
@@ -157,6 +157,7 @@ trait ApiServiceSpec
     val dataSource: SlickDataSource
     val gcsDAO: MockGoogleServicesDAO
     val gpsDAO: MockGooglePubSubDAO
+    val startSubmissionMonitor: Boolean = false
     val notificationGpsDAO: org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO =
       new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
     val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
@@ -191,21 +192,27 @@ trait ApiServiceSpec
 
     val config = SubmissionMonitorConfig(5 seconds, 30 days, true, 20000, true)
     val testConf = ConfigFactory.load()
-    val submissionSupervisor = system.actorOf(
-      SubmissionSupervisor
-        .props(
-          executionServiceCluster,
-          new UncoordinatedDataSourceAccess(slickDataSource),
-          samDAO,
-          gcsDAO,
-          mockNotificationDAO,
-          gcsDAO.getBucketServiceAccountCredential,
-          config,
-          testConf.getDuration("entities.queryTimeout").toScala,
-          workbenchMetricBaseName
-        )
-        .withDispatcher("submission-monitor-dispatcher")
-    )
+    // for tests that don't need it, don't even start any cromwell submission monitors.
+    // this cuts down on resources and on spurious log messages.
+    val submissionSupervisor = if (startSubmissionMonitor) {
+      system.actorOf(
+        SubmissionSupervisor
+          .props(
+            executionServiceCluster,
+            new UncoordinatedDataSourceAccess(slickDataSource),
+            samDAO,
+            gcsDAO,
+            mockNotificationDAO,
+            gcsDAO.getBucketServiceAccountCredential,
+            config,
+            testConf.getDuration("entities.queryTimeout").toScala,
+            workbenchMetricBaseName
+          )
+          .withDispatcher("submission-monitor-dispatcher")
+      )
+    } else {
+      system.actorOf(TestActors.blackholeProps)
+    }
 
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.ActorMaterializer
-import akka.testkit.{TestActors, TestKitBase}
+import akka.testkit.TestKitBase
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
@@ -157,7 +157,6 @@ trait ApiServiceSpec
     val dataSource: SlickDataSource
     val gcsDAO: MockGoogleServicesDAO
     val gpsDAO: MockGooglePubSubDAO
-    val startSubmissionMonitor: Boolean = false
     val notificationGpsDAO: org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO =
       new org.broadinstitute.dsde.workbench.google.mock.MockGooglePubSubDAO
     val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
@@ -192,27 +191,21 @@ trait ApiServiceSpec
 
     val config = SubmissionMonitorConfig(5 seconds, 30 days, true, 20000, true)
     val testConf = ConfigFactory.load()
-    // for tests that don't need it, don't even start any cromwell submission monitors.
-    // this cuts down on resources and on spurious log messages.
-    val submissionSupervisor = if (startSubmissionMonitor) {
-      system.actorOf(
-        SubmissionSupervisor
-          .props(
-            executionServiceCluster,
-            new UncoordinatedDataSourceAccess(slickDataSource),
-            samDAO,
-            gcsDAO,
-            mockNotificationDAO,
-            gcsDAO.getBucketServiceAccountCredential,
-            config,
-            testConf.getDuration("entities.queryTimeout").toScala,
-            workbenchMetricBaseName
-          )
-          .withDispatcher("submission-monitor-dispatcher")
-      )
-    } else {
-      system.actorOf(TestActors.blackholeProps)
-    }
+    val submissionSupervisor = system.actorOf(
+      SubmissionSupervisor
+        .props(
+          executionServiceCluster,
+          new UncoordinatedDataSourceAccess(slickDataSource),
+          samDAO,
+          gcsDAO,
+          mockNotificationDAO,
+          gcsDAO.getBucketServiceAccountCredential,
+          config,
+          testConf.getDuration("entities.queryTimeout").toScala,
+          workbenchMetricBaseName
+        )
+        .withDispatcher("submission-monitor-dispatcher")
+    )
 
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 

--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -161,6 +161,7 @@ avroUpsertMonitor {
   importRequestPubSubSubscription = "rawls-async-import-topic-sub-local"
   updateImportStatusPubSubProject = "terra-importservice-dev"
   updateImportStatusPubSubTopic = "import-service-notify-local"
+  updateCwdsPubSubTopic = "cwds-notify-local"
 
   batchSize = 1000
   ackDeadlineSeconds = 600


### PR DESCRIPTION
Ticket: AJ-1677

The `AvroUpsertMonitor` publishes pubsub messages so cWDS/Import Service can update status of individual import jobs. Up until now, cWDS and Import Service used subscriptions to the same topic. However, that topic lives in the `terra-importservice-${ENV}` Google project, and we want to (eventually) delete that project.

This PR makes it such that Rawls publishes to different topics based on the specific import job; if the import job originated in cWDS, we publish to a new cWDS topic. And that topic lives in `broad-dsde-${ENV}`.

Requires https://github.com/broadinstitute/terra-helmfile/pull/5455.

I tested this PR branch, along with the cWDS changes in https://github.com/broadinstitute/terra-helmfile/pull/5456, in my bee. I was able to successfully import a large TSV via Import Service and a PFB via cWDS; both worked.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
