### PR TITLE
[WOR-1645] Handle 403s when polling landing zone deletion results and move on

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunner.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 
+import akka.http.scaladsl.model.StatusCodes
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.{DeleteAzureLandingZoneJobResult, JobReport}
 import com.typesafe.scalalogging.LazyLogging
@@ -92,13 +93,21 @@ class BPMBillingProjectDeleteRunner(
   ): Future[JobStatus] =
     Try(workspaceManagerDAO.getDeleteLandingZoneResult(jobId.toString, lzId, ctx)) match {
       case Failure(e: ApiException) =>
-        val msg =
-          s"API call to get Landing Zone deletion operation failed with status code ${e.getCode}: ${e.getMessage}"
-        e.getCode match {
-          case code if code >= 400 && code < 500 =>
-            billingRepository.updateCreationStatus(projectName, DeletionFailed, Some(msg)).map(_ => Complete)
-          case _ =>
-            billingRepository.updateCreationStatus(projectName, Deleting, Some(msg)).map(_ => Incomplete)
+        if (e.getCode == StatusCodes.Forbidden.intValue) {
+          // WSM may give back a 403 during polling if the LZ is not present or already deleted.
+          logger.info(
+            s"LZ deletion result status = ${e.getCode} for LZ ID ${lzId}, LZ record is gone. Proceeding with rawls billing project deletion"
+          )
+          billingProjectDeletion.finalizeDelete(projectName, ctx).map(_ => Complete)
+        } else {
+          val msg =
+            s"API call to get Landing Zone deletion operation failed with status code ${e.getCode}: ${e.getMessage}"
+          e.getCode match {
+            case code if code >= 400 && code < 500 =>
+              billingRepository.updateCreationStatus(projectName, DeletionFailed, Some(msg)).map(_ => Complete)
+            case _ =>
+              billingRepository.updateCreationStatus(projectName, Deleting, Some(msg)).map(_ => Incomplete)
+          }
         }
       case Failure(e) =>
         val msg = s"Api call to get landing zone delete job $jobId from workspace manager failed: ${e.getMessage}"


### PR DESCRIPTION
[Ticket](https://broadworkbench.atlassian.net/browse/WOR-1645)

Rawls will fail during LZ deletion if the deletion result job returns a 403. This is possible during a small slice of time between the same resource being deleted and the lz record being deleted in the DB. 


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
