### PR TITLE
AJ-1776: disable cromwell monitors for AvroUpsertMonitorSpec

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -61,7 +61,9 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
   case class TestApiService(dataSource: SlickDataSource, gcsDAO: MockGoogleServicesDAO, gpsDAO: MockGooglePubSubDAO)(
     implicit override val executionContext: ExecutionContext
   ) extends ApiServices
-      with MockUserInfoDirectives
+      with MockUserInfoDirectives {
+    override val submissionMonitorsEnabled: Boolean = false
+  }
 
   def withApiServices[T](dataSource: SlickDataSource)(testCode: TestApiService => T): T = {
     val apiService = new TestApiService(dataSource, new MockGoogleServicesDAO("test"), new MockGooglePubSubDAO)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -195,25 +195,24 @@ trait ApiServiceSpec
 
     // if a test doesn't need the Cromwell monitor actors, it can override submissionMonitorsEnabled to false,
     // and we'll spin up a simple TestKit blackhole actor instead of the heavyweight Rawls actors.
-    def submissionSupervisor = if (submissionMonitorsEnabled) {
-      system.actorOf(
-        SubmissionSupervisor
-          .props(
-            executionServiceCluster,
-            new UncoordinatedDataSourceAccess(slickDataSource),
-            samDAO,
-            gcsDAO,
-            mockNotificationDAO,
-            gcsDAO.getBucketServiceAccountCredential,
-            config,
-            testConf.getDuration("entities.queryTimeout").toScala,
-            workbenchMetricBaseName
-          )
-          .withDispatcher("submission-monitor-dispatcher")
-      )
+    val submissionSupervisorProps = if (submissionMonitorsEnabled) {
+      SubmissionSupervisor
+        .props(
+          executionServiceCluster,
+          new UncoordinatedDataSourceAccess(slickDataSource),
+          samDAO,
+          gcsDAO,
+          mockNotificationDAO,
+          gcsDAO.getBucketServiceAccountCredential,
+          config,
+          testConf.getDuration("entities.queryTimeout").toScala,
+          workbenchMetricBaseName
+        )
+        .withDispatcher("submission-monitor-dispatcher")
     } else {
-      system.actorOf(TestActors.blackholeProps)
+      TestActors.blackholeProps
     }
+    val submissionSupervisor = system.actorOf(submissionSupervisorProps)
 
     override val batchUpsertMaxBytes = testConf.getLong("entityUpsert.maxContentSizeBytes")
 


### PR DESCRIPTION
Ticket: <Link to Jira ticket>

draft/experiment: can we disable cromwell monitor actors in certain tests?



---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
