### PR TITLE
AJ-1710 Increase query timeout

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -118,7 +118,7 @@ entityStatisticsCache {
 entities {
   pageSizeLimit = 300000
   # certain SQL queries are set to have a maximum run time
-  queryTimeout = 15 minutes
+  queryTimeout = 30 minutes
 }
 
 akka.http.host-connection-pool.max-open-requests = 16384


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1710
We've been seeing a lot of query interrupted errors since a SQL timeout was added.  This PR increases the timeout in an attempt to reduce the errors.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
