### PR TITLE
[WOR-1644] Pass additional policies on clone

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAO.scala
@@ -120,15 +120,16 @@ class HttpWorkspaceManagerDAO(apiClientProvider: WorkspaceManagerApiClientProvid
                               spendProfile: Option[ProfileModel],
                               billingProjectNamespace: String,
                               ctx: RawlsRequestContext,
-                              location: Option[String]
+                              additionalPolicyInputs: Option[WsmPolicyInputs]
   ): CloneWorkspaceResult = {
     val request = new CloneWorkspaceRequest()
       .destinationWorkspaceId(workspaceId)
       .displayName(displayName)
-      .location(location.orNull)
       .projectOwnerGroupId(billingProjectNamespace)
 
     spendProfile.map(_.getId.toString).map(request.spendProfile)
+
+    additionalPolicyInputs.map(request.additionalPolicies)
 
     getWorkspaceApi(ctx).cloneWorkspace(
       request,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/WorkspaceManagerDAO.scala
@@ -37,7 +37,7 @@ trait WorkspaceManagerDAO {
                      spendProfile: Option[ProfileModel],
                      billingProjectNamespace: String,
                      ctx: RawlsRequestContext,
-                     location: Option[String] = None
+                     additionalPolicyInputs: Option[WsmPolicyInputs] = None
   ): CloneWorkspaceResult
 
   def getJob(jobControlId: String, ctx: RawlsRequestContext): JobReport

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -368,7 +368,8 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             displayName = request.name,
             spendProfile = Option(profile),
             billingProjectNamespace = request.namespace,
-            context
+            context,
+            buildPolicyInputs(request)
           )
         ) match {
           case Success(cloneResult) =>
@@ -468,7 +469,8 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
               displayName = request.name,
               spendProfile = Option(profile),
               billingProjectNamespace = request.namespace,
-              context
+              context,
+              buildPolicyInputs(request)
             )
           })
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/workspacemanager/HttpWorkspaceManagerDAOSpec.scala
@@ -258,12 +258,22 @@ class HttpWorkspaceManagerDAOSpec
     val wsmDao = new HttpWorkspaceManagerDAO(getApiClientProvider(workspaceApi = workspaceApi))
 
     val billingProjectId = "billing-project-namespace";
+    val expectedPolicy =
+      new WsmPolicyInputs()
+        .inputs(
+          Seq(
+            new WsmPolicyInput()
+              .name("dummy-policy")
+              .namespace("terra")
+              .additionalData(List().asJava)
+          ).asJava
+        );
 
     val expectedRequest = new CloneWorkspaceRequest()
       .displayName("my-workspace-clone")
       .destinationWorkspaceId(workspaceId)
       .spendProfile(testData.azureBillingProfile.getId.toString)
-      .location("the-moon")
+      .additionalPolicies(expectedPolicy)
       .projectOwnerGroupId(billingProjectId);
 
     wsmDao.cloneWorkspace(
@@ -273,7 +283,7 @@ class HttpWorkspaceManagerDAOSpec
       Option(testData.azureBillingProfile),
       billingProjectId,
       testContext,
-      Some("the-moon")
+      Some(expectedPolicy)
     )
 
     verify(workspaceApi).cloneWorkspace(expectedRequest, testData.azureWorkspace.workspaceIdAsUUID)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockWorkspaceManagerDAO.scala
@@ -64,7 +64,7 @@ class MockWorkspaceManagerDAO(
                               spendProfile: Option[ProfileModel],
                               billingProjectNamespace: String,
                               ctx: RawlsRequestContext,
-                              location: Option[String]
+                              additionalPolicyInputs: Option[WsmPolicyInputs]
   ): CloneWorkspaceResult = {
     val clonedWorkspace = new ClonedWorkspace()
       .sourceWorkspaceId(sourceWorkspaceId)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceSpec.scala
@@ -1358,7 +1358,12 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
                 cloneName.name,
                 Map.empty,
                 None,
-                Some("analyses/")
+                Some("analyses/"),
+                policies = Some(
+                  List(
+                    WorkspacePolicy("dummy-policy-name", "terra", List.empty)
+                  )
+                )
               )
             )
             _ = clone.toWorkspaceName shouldBe cloneName
@@ -1376,6 +1381,27 @@ class MultiCloudWorkspaceServiceSpec extends AnyFlatSpec with Matchers with Opti
               } yield jobs
             }
           } yield {
+            verify(mcWorkspaceService.workspaceManagerDAO, times(1))
+              .cloneWorkspace(
+                equalTo(testData.azureWorkspace.workspaceIdAsUUID),
+                equalTo(clone.workspaceIdAsUUID),
+                equalTo(cloneName.name),
+                any(),
+                equalTo(cloneName.namespace),
+                any(),
+                equalTo(
+                  Some(
+                    new WsmPolicyInputs()
+                      .inputs(
+                        Seq(
+                          new WsmPolicyInput()
+                            .name("dummy-policy-name")
+                            .namespace("terra")
+                        ).asJava
+                      )
+                  )
+                )
+              )
             verify(mcWorkspaceService.workspaceManagerDAO, times(1))
               .cloneAzureStorageContainer(
                 equalTo(testData.azureWorkspace.workspaceIdAsUUID),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -12,9 +12,9 @@ import bio.terra.workspace.model.{
   WorkspaceDescription,
   WorkspaceStageModel,
   WsmPolicyInput,
+  WsmPolicyInputs,
   WsmPolicyPair
 }
-import cats.effect.IO
 import cats.implicits.catsSyntaxOptionId
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
@@ -22,7 +22,6 @@ import com.google.api.services.cloudresourcemanager.model.Project
 import com.google.api.services.iam.v1.model.Role
 import com.google.cloud.storage.StorageException
 import com.typesafe.config.ConfigFactory
-import io.opencensus.trace.{Span => OpenCensusSpan}
 import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAOImpl
 import org.broadinstitute.dsde.rawls.config._
 import org.broadinstitute.dsde.rawls.coordination.UncoordinatedDataSourceAccess
@@ -41,7 +40,6 @@ import org.broadinstitute.dsde.rawls.metrics.RawlsStatsDTestUtils
 import org.broadinstitute.dsde.rawls.mock._
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.ProjectPoolType.ProjectPoolType
-import org.broadinstitute.dsde.rawls.model.Workspace.buildMcWorkspace
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectivesWithUser
@@ -2717,7 +2715,7 @@ class WorkspaceServiceSpec
       ArgumentMatchers.eq(None),
       any[String],
       any[RawlsRequestContext],
-      any[Option[String]]
+      any[Option[WsmPolicyInputs]]
     )
   }
 
@@ -2733,7 +2731,7 @@ class WorkspaceServiceSpec
         ArgumentMatchers.eq(None),
         any[String],
         any[RawlsRequestContext],
-        any[Option[String]]
+        any[Option[WsmPolicyInputs]]
       )
     ).thenThrow(new ApiException(StatusCodes.NotFound.intValue, "Rawls stage workspace not found"))
 
@@ -2752,7 +2750,7 @@ class WorkspaceServiceSpec
       ArgumentMatchers.eq(None),
       any[String],
       any[RawlsRequestContext],
-      any[Option[String]]
+      any[Option[WsmPolicyInputs]]
     )
   }
 
@@ -2768,7 +2766,7 @@ class WorkspaceServiceSpec
         ArgumentMatchers.eq(None),
         any[String],
         any[RawlsRequestContext],
-        any[Option[String]]
+        any[Option[WsmPolicyInputs]]
       )
     ).thenThrow(new ApiException(StatusCodes.InternalServerError.intValue, "kablooey"))
 
@@ -2788,7 +2786,7 @@ class WorkspaceServiceSpec
       ArgumentMatchers.eq(None),
       any[String],
       any[RawlsRequestContext],
-      any[Option[String]]
+      any[Option[WsmPolicyInputs]]
     )
     thrown.getCode shouldBe StatusCodes.InternalServerError.intValue
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1644

Pass additional policies supplied during the clone request to WSM. This fixes the case of cloning an Azure workspace without PHI tracking enabled -> a destination workspace with PHI tracking enabled (destination billing project must be protected and enterprise).

Tested locally with locally running terra-ui (support has already been merged there).

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
