### PR TITLE
[WOR-1581] Bump rawls-model version in automation

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-9de70db23"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "1824ef0eb"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("bio.terra", "workspace-manager-client"),

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -8,4 +8,4 @@ Added:
 - Support 2.13
 - ExecutionModel classes moved from core to model
 
-SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "0.1-3891e8393"`
+SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "1824ef0eb"`


### PR DESCRIPTION
Ticket: [WOR-1581](https://broadworkbench.atlassian.net/browse/WOR-1581)
* Bump rawls-model to pull in new rawls-model version
* See https://github.com/broadinstitute/rawls/pull/2834 and https://github.com/broadinstitute/rawls/pull/2840 
* `workbench-libs` bumped to latest in https://github.com/broadinstitute/rawls/pull/2857

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1581]: https://broadworkbench.atlassian.net/browse/WOR-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ