### PR TITLE
[WOR-693] Delete problematic workspace records when service perimeter update fails due to missing Google projects

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterService.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsde.rawls.serviceperimeter
 
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.model.ServicePerimeterName
 import org.broadinstitute.dsde.rawls.util.Retry
 
 trait ServicePerimeterService extends LazyLogging with Retry {
   def overwriteGoogleProjectsInPerimeter(servicePerimeterName: ServicePerimeterName,
                                          dataAccess: DataAccess
-  ): ReadAction[Unit]
+  ): ReadWriteAction[Unit]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -17,7 +17,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManage
 import org.broadinstitute.dsde.rawls.model.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.monadThrowDBIOAction
-import org.broadinstitute.dsde.rawls.serviceperimeter.{ServicePerimeterService, ServicePerimeterServiceImpl}
+import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService._
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, RoleSupport, UserUtils, UserWiths}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, StringValidationUtils}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3207,7 +3207,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   private def maybeUpdateGoogleProjectsInPerimeter(billingProject: RawlsBillingProject,
                                                    dataAccess: DataAccess,
                                                    requestContext: RawlsRequestContext = ctx
-  ): ReadAction[Unit] =
+  ): ReadWriteAction[Unit] =
     billingProject.servicePerimeter.traverse_ { servicePerimeterName =>
       servicePerimeterService.overwriteGoogleProjectsInPerimeter(servicePerimeterName, dataAccess)
     }


### PR DESCRIPTION
Ticket: [WOR-693]
* If a service perimeter update operation fails because some of the Google projects have been deleted, delete the relevant workspace records and retry the update operation without the problematic workspaces.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-693]: https://broadworkbench.atlassian.net/browse/WOR-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ