### PR TITLE
Update to disabled services for Rawls on Azure without google dependencies 

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsde.rawls.serviceFactory
 
-import java.lang.reflect.Proxy
-import scala.reflect.{classTag, ClassTag}
+import cats.effect.IO
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import java.lang.reflect.{Method, Proxy}
+import scala.reflect.{ClassTag, classTag}
 
 object DisabledServiceFactory {
 
@@ -19,5 +22,27 @@ object DisabledServiceFactory {
         (_, method, _) =>
           throw new UnsupportedOperationException(s"${method.toString} is not supported in Azure control plane.")
       )
+      .asInstanceOf[T]
+
+  /**
+   * Create a new instance of a service that throws UnsupportedOperationException for all non-Unit methods.
+   * For Unit methods, an error is not explicitly thrown but instead logged and does not block dependent processes.
+   * Implemented using a dynamic proxy.
+   * @tparam T the type of the service, must be a trait
+   * @return a new instance of the service that throws UnsupportedOperationException for all non-Unit methods
+   */
+  def newSilentDisabledService[T: ClassTag]: T =
+    Proxy
+      .newProxyInstance(
+        classTag[T].runtimeClass.getClassLoader,
+        Array(classTag[T].runtimeClass),
+         (_, method, _) =>
+          if (method.getReturnType().equals(Unit.getClass())) {
+            implicit val log4CatsLogger = Slf4jLogger.getLogger[IO]
+            log4CatsLogger.error(s"${method.toString} is not supported in Azure control plane. Service has been identified to be non-blocking while inoperable and will silently fail.")
+          } else {
+            throw new UnsupportedOperationException(s"${method.toString} is not supported in Azure control plane.")
+          }
+  )
       .asInstanceOf[T]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
@@ -37,7 +37,7 @@ object DisabledServiceFactory {
         classTag[T].runtimeClass.getClassLoader,
         Array(classTag[T].runtimeClass),
          (_, method, _) =>
-          if (method.getReturnType().equals(Unit.getClass())) {
+          if (method.getReturnType().equals(().getClass())) {
             implicit val log4CatsLogger = Slf4jLogger.getLogger[IO]
             log4CatsLogger.error(s"${method.toString} is not supported in Azure control plane. Service has been identified to be non-blocking while inoperable and will silently fail.")
           } else {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
@@ -1,12 +1,11 @@
 package org.broadinstitute.dsde.rawls.serviceFactory
 
-import cats.effect.IO
-import org.typelevel.log4cats.slf4j.Slf4jLogger
+import com.typesafe.scalalogging.LazyLogging
 
 import java.lang.reflect.{Method, Proxy}
 import scala.reflect.{ClassTag, classTag}
 
-object DisabledServiceFactory {
+object DisabledServiceFactory extends LazyLogging {
 
   /**
    * Create a new instance of a service that throws UnsupportedOperationException for all methods.
@@ -38,8 +37,8 @@ object DisabledServiceFactory {
         Array(classTag[T].runtimeClass),
          (_, method, _) =>
           if (method.getReturnType().equals(().getClass())) {
-            implicit val log4CatsLogger = Slf4jLogger.getLogger[IO]
-            log4CatsLogger.error(s"${method.toString} is not supported in Azure control plane. Service has been identified to be non-blocking while inoperable and will silently fail.")
+            logger.error(s"${method.toString} is not supported in Azure control plane. Service has been identified to be non-blocking while inoperable and will silently fail.")
+            None
           } else {
             throw new UnsupportedOperationException(s"${method.toString} is not supported in Azure control plane.")
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/DisabledServiceFactory.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.rawls.serviceFactory
 import com.typesafe.scalalogging.LazyLogging
 
 import java.lang.reflect.{Method, Proxy}
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{classTag, ClassTag}
 
 object DisabledServiceFactory extends LazyLogging {
 
@@ -35,13 +35,15 @@ object DisabledServiceFactory extends LazyLogging {
       .newProxyInstance(
         classTag[T].runtimeClass.getClassLoader,
         Array(classTag[T].runtimeClass),
-         (_, method, _) =>
+        (_, method, _) =>
           if (method.getReturnType().equals(().getClass())) {
-            logger.error(s"${method.toString} is not supported in Azure control plane. Service has been identified to be non-blocking while inoperable and will silently fail.")
+            logger.error(
+              s"${method.toString} is not supported in Azure control plane. Service has been identified to be non-blocking while inoperable and will silently fail."
+            )
             None
           } else {
             throw new UnsupportedOperationException(s"${method.toString} is not supported in Azure control plane.")
           }
-  )
+      )
       .asInstanceOf[T]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/NotificationDAOFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/NotificationDAOFactory.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.rawls.serviceFactory
 
 import org.broadinstitute.dsde.rawls.config.RawlsConfigManager
-import org.broadinstitute.dsde.rawls.serviceFactory.DisabledServiceFactory.newDisabledService
+import org.broadinstitute.dsde.rawls.serviceFactory.DisabledServiceFactory.newSilentDisabledService
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
 
@@ -16,6 +16,6 @@ object NotificationDAOFactory {
           gcsConfig.getString("notifications.topicName")
         )
       case None =>
-        newDisabledService[NotificationDAO]
+        newSilentDisabledService[NotificationDAO]
     }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-359
Added option for disabled services to only log instead of throw errors when proxied methods are called when deployed in Azure
Specifically needed for services which are called but the result doesn't block the current operation
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
