### PR TITLE
RW-12554  Retry 400 from Sam during workspace deletion

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DsdeHttpDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DsdeHttpDAO.scala
@@ -59,5 +59,6 @@ object DsdeHttpDAO {
   }
 
   def when5xx: Throwable => Boolean = statusCodePredicate(_.intValue / 100 == 5)
+  def when400: Throwable => Boolean = statusCodePredicate(_.intValue == 400)
   def whenUnauthorized: Throwable => Boolean = statusCodePredicate(_.intValue == 401)
 }


### PR DESCRIPTION
Many AoU workspaces are in bad state because of incomplete workspace deletion.

Most of them failed due to 
```
[INFO] [04/18/2024 18:18:32.509] [scala-execution-context-global-2163] [akka.actor.ActorSystemImpl(sam)] HttpMethod(DELETE) http://localhost:8080/api/resources/v2/google-project/terra-vpc-sc-dev-0e5e9bc4: 400 Bad Request entity: {"causes":[],"message":"Cannot delete a resource with children. Delete the children first then try again.","source":"sam","stackTrace":[],"statusCode":400}
```

Looking at the current code, I think what happened is by the time we issue the Sam request for deleting project resource, the previous leo call for cleaning up resources may have not cleaned up Sam resources yet. Hence adding retry on 400 when we attempting to clean up Sam project resource

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
