### PR TITLE
Allow deleting of a workspace in CloningFailed state (WOR-1676).

### DIFF
--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.rawls.model;
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class WorkspaceModelSpec extends AnyFlatSpec with Matchers {
+  "WorkspaceState" should "indicate whether it is deletable" in {
+    WorkspaceState.Creating.isDeletable shouldBe false
+    WorkspaceState.CreateFailed.isDeletable shouldBe true
+    WorkspaceState.Cloning.isDeletable shouldBe false
+    WorkspaceState.CloningContainer.isDeletable shouldBe false
+    WorkspaceState.CloningFailed.isDeletable shouldBe true
+    WorkspaceState.Ready.isDeletable shouldBe true
+    WorkspaceState.Updating.isDeletable shouldBe false
+    WorkspaceState.UpdateFailed.isDeletable shouldBe true
+    WorkspaceState.Deleting.isDeletable shouldBe false
+    WorkspaceState.DeleteFailed.isDeletable shouldBe true
+  }
+}

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -499,6 +499,12 @@ object WorkspaceState {
   sealed trait WorkspaceState extends RawlsEnumeration[WorkspaceState] {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
     override def withName(name: String): WorkspaceState = WorkspaceState.withName(name)
+    def isDeletable: Boolean = this match {
+      case WorkspaceState.Ready | WorkspaceState.CreateFailed | WorkspaceState.DeleteFailed |
+          WorkspaceState.UpdateFailed | WorkspaceState.CloningFailed =>
+        true
+      case _ => false
+    }
   }
 
   def withName(name: String): WorkspaceState = name.toLowerCase match {

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -500,10 +500,14 @@ object WorkspaceState {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
     override def withName(name: String): WorkspaceState = WorkspaceState.withName(name)
     def isDeletable: Boolean = this match {
+      // Ensure all states are explicitly matched on to avoid accidentally adding a new state without
+      // defining if it is deletable.
       case WorkspaceState.Ready | WorkspaceState.CreateFailed | WorkspaceState.DeleteFailed |
           WorkspaceState.UpdateFailed | WorkspaceState.CloningFailed =>
         true
-      case _ => false
+      case WorkspaceState.Creating | WorkspaceState.Cloning | WorkspaceState.CloningContainer |
+          WorkspaceState.Deleting | WorkspaceState.Updating =>
+        false
     }
   }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1676

This was an oversight when the new Clone states were added (used in the Azure cloning workflow).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
