### PR TITLE
RW-12655 Compare the right message for reporting Cannot delete children resources

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -791,7 +791,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
                 t
               )
 
-              if (t.getMessage.contains("Cannot delete a resource with children")) {
+              if (t.errorReport.message.contains("Cannot delete a resource with children")) {
                 MetricsHelper
                   .incrementCounter("leakingSamResourceError",
                                     labels = Map("cloud" -> "gcp", "projectType" -> workspaceContext.projectType)


### PR DESCRIPTION
Ticket: https://precisionmedicineinitiative.atlassian.net/browse/RW-12655
<Put notes here to help reviewer understand this PR>

Error in the log. So think it needs to be `t.errorReport.message`
```
org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport: ErrorReport(sam,Cannot delete a resource with children. Delete the children first then try again.,Some(400 Bad Request),List(),List(),None)
```
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
