### PR TITLE
AJ-1836 Expose bpm's limits

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -90,7 +90,7 @@ case class WorkspaceBillingAccount(
   currentBillingAccountOnGoogleProject: Option[RawlsBillingAccountName]
 )
 
-case class RawlsBillingProjectOrganization(enterprise: Boolean)
+case class RawlsBillingProjectOrganization(enterprise: Boolean, limits: Map[String, String])
 
 case class RawlsBillingProjectResponse(
   projectName: RawlsBillingProjectName,
@@ -327,7 +327,7 @@ class UserAuthJsonSupport extends JsonSupport {
     WorkspaceBillingAccount
   )
 
-  implicit val BillingProjectOrganizationFormat: RootJsonFormat[RawlsBillingProjectOrganization] = jsonFormat1(
+  implicit val BillingProjectOrganizationFormat: RootJsonFormat[RawlsBillingProjectOrganization] = jsonFormat2(
     RawlsBillingProjectOrganization.apply
   )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -348,7 +348,9 @@ class UserService(
         platform,
         protectedData,
         region = maybeRegion,
-        organization = Option(p.getOrganization).map(org => RawlsBillingProjectOrganization(org.isEnterprise))
+        organization = Option(p.getOrganization).map(org =>
+          RawlsBillingProjectOrganization(org.isEnterprise, org.getLimits.asScala.toMap)
+        )
       )
     case (Some(id), None) =>
       val message = Some(s"Unable to find billing profile in Billing Profile Manager for billing profile id: $id")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1284,7 +1284,7 @@ class UserServiceSpec
     val billingProfile = new ProfileModel()
       .id(UUID.randomUUID())
       .cloudPlatform(BPMCloudPlatform.AZURE)
-      .organization(new Organization().enterprise(true))
+      .organization(new Organization().enterprise(true).limits(Map.empty[String, String].asJava))
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val landingZoneId = UUID.randomUUID()
     val lzRegion = "dummy-region"
@@ -1322,7 +1322,7 @@ class UserServiceSpec
                                     CloudPlatform.AZURE,
                                     Option(false),
                                     Option(lzRegion),
-                                    Option(RawlsBillingProjectOrganization(true))
+                                    Option(RawlsBillingProjectOrganization(true, Map()))
         )
       )
     Await.result(userService.getBillingProject(projectName), Duration.Inf) shouldEqual expected
@@ -1362,7 +1362,7 @@ class UserServiceSpec
     val billingProfile = new ProfileModel()
       .id(UUID.randomUUID())
       .cloudPlatform(BPMCloudPlatform.AZURE)
-      .organization(new Organization().enterprise(false))
+      .organization(new Organization().enterprise(false).limits(Map("autoPause" -> "30").asJava))
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val landingZoneId = UUID.randomUUID()
     val lzRegion = "dummy-region"
@@ -1403,7 +1403,7 @@ class UserServiceSpec
         CloudPlatform.AZURE,
         Option(false),
         Option(lzRegion),
-        Option(RawlsBillingProjectOrganization(false))
+        Option(RawlsBillingProjectOrganization(false, Map("autoPause" -> "30")))
       )
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.1111-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.547-20240522.143920-1")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.547-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.23-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,7 +129,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.1111-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.544-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.547-20240522.143920-1")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.23-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-70fda75")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1836
Includes the new `limits` field in a BPM organization.  Verified on my BEE that it is returned and everything seems to function correctly.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
