### PR TITLE
[WOR-1679] Don't update workspace or billing project state until async job polling completes

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunner.scala
@@ -106,9 +106,7 @@ class BPMBillingProjectDeleteRunner(
           case _ =>
             billingRepository.updateCreationStatus(projectName, Deleting, Some(msg)).map(_ => Incomplete)
         }
-      case Failure(e) =>
-        val msg = s"Api call to get landing zone delete job $jobId from workspace manager failed: ${e.getMessage}"
-        billingRepository.updateCreationStatus(projectName, DeletionFailed, Some(msg)).map(_ => Incomplete)
+      case Failure(_) => Future.successful(Incomplete)
       case Success(result) =>
         Option(result.getJobReport).map(_.getStatus) match {
           case Some(JobReport.StatusEnum.RUNNING) => Future.successful(Incomplete)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunner.scala
@@ -67,7 +67,7 @@ class CloneWorkspaceContainerRunner(
         val msg =
           s"Unable to retrieve clone workspace results for workspace $workspaceId: unable to retrieve request context for $userEmail"
         logFailure(msg, Some(t))
-        cloneFail(workspaceId, msg).map(_ => Incomplete)
+        Future.successful(Incomplete)
       case Success(ctx) =>
         Try(workspaceManagerDAO.getJob(job.jobControlId.toString, ctx)) match {
           case Success(result) => handleCloneResult(workspaceId, result)
@@ -90,7 +90,7 @@ class CloneWorkspaceContainerRunner(
           case Failure(t) =>
             val msg = s"API call to get clone result from workspace manager failed with: ${t.getMessage}"
             logFailure(msg, Some(t))
-            cloneFail(workspaceId, msg).map(_ => Incomplete)
+            Future.successful(Incomplete)
         }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
 }
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
-import org.broadinstitute.dsde.rawls.model.{CreationStatuses, RawlsBillingProjectName, RawlsRequestContext}
+import org.broadinstitute.dsde.rawls.model.{CreationStatuses, RawlsBillingProjectName}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -58,17 +58,13 @@ class LandingZoneCreationStatusRunner(
           s"AzureLandingZoneResult job ${job.jobControlId} for billing project: $billingProjectName failed: $msg",
           t
         )
-        billingRepository
-          .updateCreationStatus(billingProjectName, CreationStatuses.Error, Some(msg))
-          .map(_ => Incomplete)
+        Future.successful(Incomplete)
       case Success(userCtx) =>
         Try(workspaceManagerDAO.getCreateAzureLandingZoneResult(job.jobControlId.toString, userCtx)) match {
           case Failure(exception) =>
             val message =
               Some(s"Api call to get landing zone result from workspace manager failed: ${exception.getMessage}")
-            billingRepository
-              .updateCreationStatus(billingProjectName, CreationStatuses.Error, message)
-              .map(_ => Incomplete)
+            Future.successful(Incomplete)
           case Success(result) =>
             Option(result.getJobReport).map(_.getStatus) match {
               case Some(JobReport.StatusEnum.RUNNING) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunner.scala
@@ -61,9 +61,7 @@ class LandingZoneCreationStatusRunner(
         Future.successful(Incomplete)
       case Success(userCtx) =>
         Try(workspaceManagerDAO.getCreateAzureLandingZoneResult(job.jobControlId.toString, userCtx)) match {
-          case Failure(exception) =>
-            val message =
-              Some(s"Api call to get landing zone result from workspace manager failed: ${exception.getMessage}")
+          case Failure(_) =>
             Future.successful(Incomplete)
           case Success(result) =>
             Option(result.getJobReport).map(_.getStatus) match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
@@ -46,10 +46,9 @@ class CloneWorkspaceAwaitStorageContainerStep(
           // Don't retry 4xx codes
           case code if code < 500 => fail(operationName, e.getMessage).map(_ => Complete)
           // Retry non-4xx
-          case code => Future.successful(Incomplete)
+          case _ => Future.successful(Incomplete)
         }
       case Failure(t) =>
-        val msg = s"API call to get clone result from workspace manager failed with: ${t.getMessage}"
         Future.successful(Incomplete)
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
@@ -2,16 +2,15 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone
 
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport
-import bio.terra.workspace.model.JobReport.StatusEnum
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
   Complete,
   Incomplete,
   JobStatus,
   JobType
 }
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, WorkspaceState}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
@@ -47,13 +46,11 @@ class CloneWorkspaceAwaitStorageContainerStep(
           // Don't retry 4xx codes
           case code if code < 500 => fail(operationName, e.getMessage).map(_ => Complete)
           // Retry non-4xx
-          case code =>
-            fail(operationName, s"API call to get clone result failed with status code $code: ${e.getMessage}")
-              .map(_ => Incomplete)
+          case code => Future.successful(Incomplete)
         }
       case Failure(t) =>
         val msg = s"API call to get clone result from workspace manager failed with: ${t.getMessage}"
-        fail(operationName, msg).map(_ => Incomplete)
+        Future.successful(Incomplete)
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/WorkspaceCloningRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/WorkspaceCloningRunner.scala
@@ -1,12 +1,6 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone
 
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.{
-  GoogleServicesDAO,
-  LeonardoDAO,
-  SamDAO,
-  WorkspaceManagerResourceMonitorRecordDao
-}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
   Complete,
   Incomplete,
@@ -17,6 +11,12 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   WorkspaceManagerResourceMonitorRecord
 }
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  GoogleServicesDAO,
+  LeonardoDAO,
+  SamDAO,
+  WorkspaceManagerResourceMonitorRecordDao
+}
 import org.broadinstitute.dsde.rawls.model.{
   AttributeBoolean,
   AttributeName,
@@ -125,7 +125,7 @@ class WorkspaceCloningRunner(
         val msg =
           s"Unable to retrieve clone workspace results for workspace $workspaceId: unable to retrieve request context for $userEmail"
         logFailure(msg, Some(t))
-        cloneFail(workspaceId, msg).map(_ => Incomplete)
+        Future.successful(Incomplete)
       case Success(userCtx) =>
         val step = getStep(job, workspaceId)
         step.runStep(userCtx)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/CloneWorkspaceContainerRunnerSpec.scala
@@ -3,10 +3,10 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.JobReport
 import org.broadinstitute.dsde.rawls.TestExecutionContext
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, Workspace}
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceContainerRunnerSpec.{
   monitorRecord,
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.rawls.monitor.workspace.runners.CloneWorkspaceCon
 }
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{doAnswer, doReturn, spy, verify}
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -151,7 +151,9 @@ class CloneWorkspaceContainerRunnerSpec extends AnyFlatSpecLike with MockitoSuga
       .cloneFail(ArgumentMatchers.eq(workspaceId), ArgumentMatchers.any())(ArgumentMatchers.any[ExecutionContext]())
 
     whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
-    verify(runner).cloneFail(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any[ExecutionContext]())
+    verify(runner, never).cloneFail(ArgumentMatchers.any(), ArgumentMatchers.any())(
+      ArgumentMatchers.any[ExecutionContext]()
+    )
   }
 
   it should "report errors from api response and complete the job for jobs failed with a 500" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/LandingZoneCreationStatusRunnerSpec.scala
@@ -3,9 +3,9 @@ package org.broadinstitute.dsde.rawls.monitor.workspace.runners
 import bio.terra.workspace.model.{AzureLandingZoneDetails, AzureLandingZoneResult, JobReport}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.billing.BillingRepository
-import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
+import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.model.{
   CreationStatuses,
   RawlsBillingProjectName,
@@ -14,14 +14,12 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.LandingZoneCreationStatusRunnerSpec._
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{doReturn, spy, verify, when}
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-import java.sql.Timestamp
-import java.time.Instant
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -87,7 +85,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
 
   }
 
-  it should "set an error in the billing project and return job as incomplete if the user context cannot be created" in {
+  it should "return the job status as incomplete and not set an error status and message on the project if the user context cannot be created" in {
     val billingRepository = mock[BillingRepository]
     when(
       billingRepository.updateCreationStatus(
@@ -115,14 +113,14 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
       .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
     whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
-    verify(billingRepository).updateCreationStatus(
+    verify(billingRepository, never).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
       ArgumentMatchers.any[Some[String]]()
     )
   }
 
-  it should "set an error status and message on the project and return the job status as incomplete if the call to get the landing zone job results fail" in {
+  it should "return the job status as incomplete and not set an error status and message on the project if the call to get the landing zone job results fail" in {
     val ctx = mock[RawlsRequestContext]
     val wsmDao = mock[WorkspaceManagerDAO]
     val wsmExceptionMessage = "looking for this to be reported in the billing project message"
@@ -149,7 +147,7 @@ class LandingZoneCreationStatusRunnerSpec extends AnyFlatSpecLike with MockitoSu
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
     whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
-    verify(billingRepository).updateCreationStatus(
+    verify(billingRepository, never).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(CreationStatuses.Error),
       ArgumentMatchers.any[Some[String]]()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStepSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStepSpec.scala
@@ -33,7 +33,7 @@ class CloneWorkspaceAwaitStorageContainerStepSpec
 
   behavior of "retrieving the report for the container cloning job"
 
-  it should "report errors from api response and return Incomplete for jobs failed with a 500" in {
+  it should "return Incomplete for jobs failed with a 500" in {
     val ctx = mock[RawlsRequestContext]
     val wsmDao = mock[WorkspaceManagerDAO]
     val apiMessage = "some failure message"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStepSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStepSpec.scala
@@ -7,11 +7,11 @@ import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorR
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, Workspace, WorkspaceState}
+import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, RawlsUserEmail, WorkspaceState}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{doAnswer, spy, verify, when}
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -69,7 +69,7 @@ class CloneWorkspaceAwaitStorageContainerStepSpec
       monitorRecord
     )
     whenReady(runner.runStep(ctx))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
-    verify(workspaceRepository).setFailedState(
+    verify(workspaceRepository, never).setFailedState(
       ArgumentMatchers.eq(workspaceId),
       ArgumentMatchers.any(),
       ArgumentMatchers.contains(apiMessage)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/WorkspaceCloningRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/WorkspaceCloningRunnerSpec.scala
@@ -1,25 +1,26 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone
 
 import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
+import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{
   GoogleServicesDAO,
   LeonardoDAO,
   SamDAO,
   WorkspaceManagerResourceMonitorRecordDao
 }
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
-import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.{RawlsUserEmail, Workspace, WorkspaceState}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.joda.time.DateTime
-import org.scalatest.concurrent.ScalaFutures
 import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.{spy, verify, when}
+import org.mockito.Mockito.{never, spy, verify, when}
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+
 import java.sql.Timestamp
 import java.time.Instant
 import java.util.UUID
@@ -179,7 +180,7 @@ class WorkspaceCloningRunnerSpec extends AnyFlatSpecLike with MockitoSugar with 
     )
   }
 
-  it should "return Incomplete when the if the user context cannot be created" in {
+  it should "return Incomplete when the user context cannot be created" in {
     val workspaceRepository = mock[WorkspaceRepository]
     when(
       workspaceRepository.setFailedState(ArgumentMatchers.eq(workspaceId),
@@ -203,7 +204,7 @@ class WorkspaceCloningRunnerSpec extends AnyFlatSpecLike with MockitoSugar with 
 
     whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
 
-    verify(workspaceRepository).setFailedState(
+    verify(workspaceRepository, never).setFailedState(
       ArgumentMatchers.eq(workspaceId),
       ArgumentMatchers.eq(WorkspaceState.CloningFailed),
       ArgumentMatchers.any[String]


### PR DESCRIPTION
Ticket: [WOR-1679](https://broadworkbench.atlassian.net/browse/WOR-1679)
* When polling on an async workspace or billing project operation (LZ create, workspace clone, etc.), don't update the state on the resource until the job is complete. 

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1679]: https://broadworkbench.atlassian.net/browse/WOR-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ