### PR TITLE
AJ-1797: Cleanup lingering import-service conf

### DIFF
--- a/local-dev/templates/rawls.conf.ctmpl
+++ b/local-dev/templates/rawls.conf.ctmpl
@@ -151,11 +151,10 @@ executionservice {
   cromiamUrl = "https://cromiam-priv.dsde-dev.broadinstitute.org"
 }
 avroUpsertMonitor {
-  pubSubProject = "broad-dsde-dev"
-
+  # read by HttpCwdsDao
   cwds = "https://cwds.dsde-dev.broadinstitute.org"
-  bucketName = "import-service-batchupsert-dev"
 
+  # read by BootMonitors.scala
   importRequestPubSubTopic = "rawls-async-import-topic-local"
   importRequestPubSubSubscription = "rawls-async-import-topic-sub-local"
   updateCwdsPubSubTopic = "cwds-notify-local"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1797

Final cleanup for config used only for now removed connection to import-service.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] ~Make sure Swagger is updated if API changes~
  - [x] ~...and Orchestration's Swagger too!~
- [x] ~If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala)~.
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
