### PR TITLE
[WOR-1695] Return policy information for GCP workspaces from list method

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/AggregatedWorkspaceService.scala
@@ -59,6 +59,7 @@ class AggregatedWorkspaceService(workspaceManagerDAO: WorkspaceManagerDAO) exten
             }.get
           )
           .getOrElse {
+            // Rawls workspaces without a RAWLS_STAGE stub workspace have no record in WSM.
             if (workspace.workspaceType == WorkspaceType.RawlsWorkspace) {
               AggregatedWorkspace(workspace,
                                   Some(workspace.googleProjectId),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -3541,7 +3541,7 @@ class WorkspaceServiceSpec
         new WorkspaceDescription()
           .id(googleWorkspace.workspaceIdAsUUID)
           .gcpContext(new GcpContext())
-          .stage(WorkspaceStageModel.MC_WORKSPACE)
+          .stage(WorkspaceStageModel.RAWLS_WORKSPACE)
       )
     )
 
@@ -3626,7 +3626,7 @@ class WorkspaceServiceSpec
           new WorkspaceDescription()
             .id(googleWorkspace.workspaceIdAsUUID)
             .gcpContext(new GcpContext())
-            .stage(WorkspaceStageModel.MC_WORKSPACE)
+            .stage(WorkspaceStageModel.RAWLS_WORKSPACE)
         )
       )
 
@@ -3910,15 +3910,16 @@ class WorkspaceServiceSpec
       .result(services.workspaceService.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
       .convertTo[Seq[WorkspaceListResponse]]
 
-    val matchingWorkspaces = scala.collection.mutable.Set[WorkspaceListResponse]()
-    result.map { ws =>
+    val matchingWorkspaces = result.filter { ws =>
       if (ws.workspace.name == workspaceName) {
         val policies: List[WorkspacePolicy] = ws.policies.get
         policies should not be empty
         val policy: WorkspacePolicy = policies.head
         policy.name shouldBe wsmPolicyInput.getName
         policy.namespace shouldBe wsmPolicyInput.getNamespace
-        matchingWorkspaces += ws
+        true
+      } else {
+        false
       }
     }
     matchingWorkspaces.size should be(1)
@@ -3938,13 +3939,14 @@ class WorkspaceServiceSpec
         .result(services.workspaceService.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
         .convertTo[Seq[WorkspaceListResponse]]
 
-      val matchingWorkspaces = scala.collection.mutable.Set[WorkspaceListResponse]()
-      result.map { ws =>
+      val matchingWorkspaces = result.filter { ws =>
         if (ws.workspace.name == noPoliciesWorkspaceName) {
           ws.policies.get should be(empty)
-          matchingWorkspaces += ws
           // We shouldn't report an error about the workspace not existing in workspace manager.
           ws.workspace.errorMessage should be(empty)
+          true
+        } else {
+          false
         }
       }
       matchingWorkspaces.size should be(1)
@@ -3966,15 +3968,16 @@ class WorkspaceServiceSpec
       .result(services.workspaceService.listWorkspaces(WorkspaceFieldSpecs(), -1), Duration.Inf)
       .convertTo[Seq[WorkspaceListResponse]]
 
-    val matchingWorkspaces = scala.collection.mutable.Set[WorkspaceListResponse]()
-    result.map { ws =>
+    val matchingWorkspaces = result.filter { ws =>
       if (ws.workspace.name == workspace.name) {
         val policies: List[WorkspacePolicy] = ws.policies.get
         policies should not be empty
         val policy: WorkspacePolicy = policies.head
         policy.name shouldBe wsmPolicyInput.getName
         policy.namespace shouldBe wsmPolicyInput.getNamespace
-        matchingWorkspaces += ws
+        true
+      } else {
+        false
       }
     }
     matchingWorkspaces.size should be(1)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1695

This is related to https://github.com/broadinstitute/rawls/pull/2825, which added the functionality to the details endpoint.

Tested manually with [this workspace](https://bvdp-saturn-dev.appspot.com/#workspaces/general-dev-billing-account/import-test) in a locally running Rawls.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
