### PR TITLE
WOR-1682 - set max timeout on job retries

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordComponent.scala
@@ -155,7 +155,7 @@ final case class WorkspaceManagerResourceMonitorRecord(
   args: Option[Map[String, String]] = None
 ) {
 
-  def retryOrTimeout(onTimeout: () => Future[Unit] = () => Future.successful())(implicit
+  def retryOrTimeout(onTimeout: () => Future[Any] = () => Future.successful())(implicit
     executionContext: ExecutionContext
   ): Future[JobStatus] = {
     val expireTime = Instant.ofEpochMilli(createdTime.getTime).plus(1, ChronoUnit.DAYS)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunner.scala
@@ -74,7 +74,7 @@ class BPMBillingProjectDeleteRunner(
       case Failure(t) =>
         val msg = s"Unable to complete billing project deletion: unable to retrieve request context for $userEmail"
         logger.error(s"${job.jobType} job ${job.jobControlId} for billing project: $projectName failed: $msg", t)
-        job.retryOrTimeout(() => billingRepository.updateCreationStatus(projectName, Deleting, Some(msg)))
+        job.retryOrTimeout(() => billingRepository.updateCreationStatus(projectName, DeletionFailed, Some(msg)))
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
@@ -46,10 +46,10 @@ class CloneWorkspaceAwaitStorageContainerStep(
           // Don't retry 4xx codes
           case code if code < 500 => fail(operationName, e.getMessage).map(_ => Complete)
           // Retry non-4xx
-          case _ => Future.successful(Incomplete)
+          case _ => job.retryOrTimeout(() => fail(operationName, e.getMessage))
         }
-      case Failure(t) =>
-        Future.successful(Incomplete)
+      case Failure(t) => job.retryOrTimeout(() => fail(operationName, t.getMessage))
+
     }
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
@@ -11,8 +11,8 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMo
   JobType
 }
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.model.{RawlsRequestContext, WorkspaceState}
-import org.broadinstitute.dsde.rawls.workspace.{WorkspaceManagerPollingOperationException, WorkspaceRepository}
+import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/WorkspaceCloningRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/WorkspaceCloningRunner.scala
@@ -1,11 +1,7 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone
 
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
-  Complete,
-  Incomplete,
-  JobType
-}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, JobType}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   WorkspaceManagerResourceJobRunner,
   WorkspaceManagerResourceMonitorRecord
@@ -125,7 +121,7 @@ class WorkspaceCloningRunner(
         val msg =
           s"Unable to retrieve clone workspace results for workspace $workspaceId: unable to retrieve request context for $userEmail"
         logFailure(msg, Some(t))
-        Future.successful(Incomplete)
+        job.retryOrTimeout(() => cloneFail(workspaceId, msg))
       case Success(userCtx) =>
         val step = getStep(job, workspaceId)
         step.runStep(userCtx)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordSpec.scala
@@ -1,0 +1,50 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.TestExecutionContext
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, Incomplete, JobType}
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+
+class WorkspaceManagerResourceMonitorRecordSpec extends AnyFlatSpec with MockitoSugar with Matchers with ScalaFutures {
+
+  implicit val executionContext: ExecutionContext = TestExecutionContext.testExecutionContext
+
+  behavior of "WorkspaceManagerResourceMonitorRecord.retryOrTimeout"
+
+  it should "return incomplete if a full day has not passed since the record was created" in {
+    val createTime = Timestamp.from(Instant.now().minus(23, ChronoUnit.HOURS))
+    val record = WorkspaceManagerResourceMonitorRecord(
+      UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime
+    )
+    whenReady(record.retryOrTimeout())(_ shouldBe Incomplete)
+  }
+
+  it should "return complete if a full day has passed since the record was created" in {
+    val createTime = Timestamp.from(Instant.now().minus(25, ChronoUnit.HOURS))
+    val record = WorkspaceManagerResourceMonitorRecord(
+      UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime)
+    whenReady(record.retryOrTimeout())(_ shouldBe Complete)
+  }
+
+
+  it should "call the passed onTimeout function before returning on timeout" in {
+    val createTime = Timestamp.from(Instant.now().minus(25, ChronoUnit.HOURS))
+    val callbackFn = mock[() => Future[Unit]]
+    when(callbackFn()).thenReturn(Future.successful())
+    val record = WorkspaceManagerResourceMonitorRecord(
+      UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime)
+
+    whenReady(record.retryOrTimeout(callbackFn))(_ shouldBe Complete)
+    verify(callbackFn)()
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceManagerResourceMonitorRecordSpec.scala
@@ -1,7 +1,11 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import org.broadinstitute.dsde.rawls.TestExecutionContext
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, Incomplete, JobType}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
+  Complete,
+  Incomplete,
+  JobType
+}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -23,25 +27,29 @@ class WorkspaceManagerResourceMonitorRecordSpec extends AnyFlatSpec with Mockito
   it should "return incomplete if a full day has not passed since the record was created" in {
     val createTime = Timestamp.from(Instant.now().minus(23, ChronoUnit.HOURS))
     val record = WorkspaceManagerResourceMonitorRecord(
-      UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime
+      UUID.randomUUID(),
+      JobType.CloneWorkspaceInit,
+      None,
+      None,
+      None,
+      createTime
     )
     whenReady(record.retryOrTimeout())(_ shouldBe Incomplete)
   }
 
   it should "return complete if a full day has passed since the record was created" in {
     val createTime = Timestamp.from(Instant.now().minus(25, ChronoUnit.HOURS))
-    val record = WorkspaceManagerResourceMonitorRecord(
-      UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime)
+    val record =
+      WorkspaceManagerResourceMonitorRecord(UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime)
     whenReady(record.retryOrTimeout())(_ shouldBe Complete)
   }
-
 
   it should "call the passed onTimeout function before returning on timeout" in {
     val createTime = Timestamp.from(Instant.now().minus(25, ChronoUnit.HOURS))
     val callbackFn = mock[() => Future[Unit]]
     when(callbackFn()).thenReturn(Future.successful())
-    val record = WorkspaceManagerResourceMonitorRecord(
-      UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime)
+    val record =
+      WorkspaceManagerResourceMonitorRecord(UUID.randomUUID(), JobType.CloneWorkspaceInit, None, None, None, createTime)
 
     whenReady(record.retryOrTimeout(callbackFn))(_ shouldBe Complete)
     verify(callbackFn)()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunnerSpec.scala
@@ -123,7 +123,7 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
     when(
       billingRepository.updateCreationStatus(
         ArgumentMatchers.eq(billingProjectName),
-        ArgumentMatchers.eq(Deleting),
+        ArgumentMatchers.eq(DeletionFailed),
         ArgumentMatchers.any[Some[String]]()
       )
     ).thenAnswer { invocation =>
@@ -158,7 +158,7 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
     whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
-      ArgumentMatchers.eq(Deleting),
+      ArgumentMatchers.eq(DeletionFailed),
       ArgumentMatchers.any[Some[String]]()
     )
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/BPMBillingProjectDeleteRunnerSpec.scala
@@ -19,6 +19,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.sql.Timestamp
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -89,7 +90,35 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
 
   }
 
-  it should "set an error in the billing project and return job as incomplete if the user context cannot be created" in {
+  it should "return job as incomplete if the user context cannot be created before timeout" in {
+    val billingRepository = mock[BillingRepository]
+    val runner =
+      spy(
+        new BPMBillingProjectDeleteRunner(
+          mock[SamDAO],
+          mock[GoogleServicesDAO],
+          mock[WorkspaceManagerDAO],
+          billingRepository,
+          mock[BillingProjectDeletion]
+        )
+      )
+    doReturn(Future.failed(new org.broadinstitute.dsde.workbench.client.sam.ApiException()))
+      .when(runner)
+      .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
+    val monitorRecord: WorkspaceManagerResourceMonitorRecord =
+      WorkspaceManagerResourceMonitorRecord(UUID.randomUUID(),
+                                            JobType.BpmBillingProjectDelete,
+                                            None,
+                                            Some(billingProjectName.value),
+                                            Some(userEmail),
+                                            Timestamp.from(Instant.now())
+      )
+
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+
+  }
+
+  it should "set an error in the billing project and return job as complete if the user context cannot be created after timing out" in {
     val billingRepository = mock[BillingRepository]
     when(
       billingRepository.updateCreationStatus(
@@ -116,16 +145,17 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
     doReturn(Future.failed(new org.broadinstitute.dsde.workbench.client.sam.ApiException()))
       .when(runner)
       .getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
+    val createTime = Timestamp.from(Instant.now().minus(25, ChronoUnit.HOURS))
     val monitorRecord: WorkspaceManagerResourceMonitorRecord =
       WorkspaceManagerResourceMonitorRecord(UUID.randomUUID(),
                                             JobType.BpmBillingProjectDelete,
                                             None,
                                             Some(billingProjectName.value),
                                             Some(userEmail),
-                                            Timestamp.from(Instant.now())
+                                            createTime
       )
 
-    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
       ArgumentMatchers.eq(Deleting),
@@ -133,7 +163,7 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
     )
   }
 
-  it should "set an error status and message on the project and return incomplete when landing zone call returns 500" in {
+  it should "return incomplete when landing zone call returns 500 before the timeout" in {
     val ctx = mock[RawlsRequestContext]
     val wsmDao = mock[WorkspaceManagerDAO]
     val wsmExceptionMessage = "looking for this to be reported in the billing project message"
@@ -158,10 +188,51 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
     val billingRepository = mock[BillingRepository]
     when(billingRepository.getLandingZoneId(ArgumentMatchers.eq(billingProjectName))(any()))
       .thenReturn(Future.successful(Some(landingZoneId)))
+
+    val runner = spy(
+      new BPMBillingProjectDeleteRunner(
+        mock[SamDAO],
+        mock[GoogleServicesDAO],
+        wsmDao,
+        billingRepository,
+        mock[BillingProjectDeletion]
+      )
+    )
+    doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
+
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+  }
+
+  it should "set an error status and message on the project and return complete when landing zone call returns 500 after timing out" in {
+    val ctx = mock[RawlsRequestContext]
+    val wsmDao = mock[WorkspaceManagerDAO]
+    val wsmExceptionMessage = "looking for this to be reported in the billing project message"
+    val landingZoneId = "7db89d7c-ef8b-4eaa-aef8-a62bd66cb095"
+    val createTime = Timestamp.from(Instant.now().minus(25, ChronoUnit.HOURS))
+    val monitorRecord: WorkspaceManagerResourceMonitorRecord = WorkspaceManagerResourceMonitorRecord(
+      UUID.randomUUID(),
+      JobType.BpmBillingProjectDelete,
+      None,
+      Some(billingProjectName.value),
+      Some(userEmail),
+      createTime
+    )
+
+    when(
+      wsmDao.getDeleteLandingZoneResult(
+        ArgumentMatchers.eq(monitorRecord.jobControlId.toString),
+        ArgumentMatchers.eq(UUID.fromString(landingZoneId)),
+        ArgumentMatchers.any()
+      )
+    )
+      .thenAnswer(_ => throw new bio.terra.workspace.client.ApiException(500, wsmExceptionMessage))
+    val billingRepository = mock[BillingRepository]
+    when(billingRepository.getLandingZoneId(ArgumentMatchers.eq(billingProjectName))(any()))
+      .thenReturn(Future.successful(Some(landingZoneId)))
     when(
       billingRepository.updateCreationStatus(
         ArgumentMatchers.eq(billingProjectName),
-        ArgumentMatchers.eq(Deleting),
+        ArgumentMatchers.eq(DeletionFailed),
         ArgumentMatchers.any[Some[String]]()
       )
     ).thenAnswer { invocation =>
@@ -180,11 +251,11 @@ class BPMBillingProjectDeleteRunnerSpec extends AnyFlatSpec with MockitoSugar wi
     )
     doReturn(Future.successful(ctx)).when(runner).getUserCtx(ArgumentMatchers.eq(userEmail))(ArgumentMatchers.any())
 
-    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Incomplete)
+    whenReady(runner(monitorRecord))(_ shouldBe WorkspaceManagerResourceMonitorRecord.Complete)
 
     verify(billingRepository).updateCreationStatus(
       ArgumentMatchers.eq(billingProjectName),
-      ArgumentMatchers.eq(Deleting),
+      ArgumentMatchers.eq(DeletionFailed),
       ArgumentMatchers.any[Some[String]]()
     )
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1682
<Put notes here to help reviewer understand this PR>

* create a method on the monitor record to handle timeout
* switch places where we were returning Incomplete on errors to use timeout function

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
