### PR TITLE
[WOR-1680] Mark Rawls workspace state as CloningFailed if Azure workspace resource failed to clone

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceAwaitStorageContainerStep.scala
@@ -29,7 +29,7 @@ class CloneWorkspaceAwaitStorageContainerStep(
 )(implicit executionContext: ExecutionContext)
     extends WorkspaceCloningStep(workspaceRepository, monitorRecordDao, workspaceId, job) {
 
-  override val jobType: JobType = JobType.CloneWorkspaceContainerInit
+  override val jobType: JobType = JobType.CloneWorkspaceAwaitContainerResult
 
   override def runStep(userCtx: RawlsRequestContext): Future[JobStatus] = {
     val operationName = "Await Storage Container Clone"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone
 
+import bio.terra.workspace.model.CloneResourceResult
 import bio.terra.workspace.model.JobReport.StatusEnum
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
@@ -40,10 +40,10 @@ class CloneWorkspaceInitStep(
           for (resource <- workspaceResult.getResources().asScala)
             if (resource.getResult() == CloneResourceResult.FAILED) {
               if (errorMessages.nonEmpty) {
-                errorMessages.append("\n");
+                errorMessages.append(", ");
               }
-              errorMessages.append(s"Workspace resource (${resource.getName()}, ${resource
-                  .getResourceType()}) failed to clone with the following error: ${resource.getErrorMessage()}.");
+              errorMessages.append(s"resource (${resource.getName()}, ${resource
+                  .getResourceType()}) failed to clone with error \"${resource.getErrorMessage()}\"");
             }
         }
         if (errorMessages.nonEmpty) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStep.scala
@@ -5,7 +5,12 @@ import bio.terra.workspace.model.JobReport.StatusEnum
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.JobType
-import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{Complete, Incomplete, JobStatus, JobType}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.{
+  Complete,
+  Incomplete,
+  JobStatus,
+  JobType
+}
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.model.RawlsRequestContext
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStepSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStepSpec.scala
@@ -168,7 +168,7 @@ class CloneWorkspaceInitStepSpec extends AnyFlatSpecLike with MockitoSugar with 
       ArgumentMatchers.eq(workspaceId),
       ArgumentMatchers.eq(CloningFailed),
       ArgumentMatchers.eq(
-        s"Workspace Clone Operation [Initial Workspace Clone], source workspace: [Unknown], dest workspace [$workspaceId] failed for jobId [$jobId]: Workspace resource (failedResource1, AZURE_VM) failed to clone with the following error: error1.\nWorkspace resource (failedResource2, AZURE_DATABASE) failed to clone with the following error: error2."
+        s"Workspace Clone Operation [Initial Workspace Clone], source workspace: [Unknown], dest workspace [$workspaceId] failed for jobId [$jobId]: resource (failedResource1, AZURE_VM) failed to clone with error \"error1\", resource (failedResource2, AZURE_DATABASE) failed to clone with error \"error2\""
       )
     )
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStepSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/clone/CloneWorkspaceInitStepSpec.scala
@@ -1,6 +1,13 @@
 package org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone
 
-import bio.terra.workspace.model.{CloneWorkspaceResult, JobReport}
+import bio.terra.workspace.model.{
+  CloneResourceResult,
+  CloneWorkspaceResult,
+  ClonedWorkspace,
+  JobReport,
+  ResourceCloneDetails,
+  ResourceType
+}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.WorkspaceManagerResourceMonitorRecordDao
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
@@ -22,6 +29,7 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
 class CloneWorkspaceInitStepSpec extends AnyFlatSpecLike with MockitoSugar with Matchers with ScalaFutures {
 
@@ -96,6 +104,75 @@ class CloneWorkspaceInitStepSpec extends AnyFlatSpecLike with MockitoSugar with 
     )
   }
 
+  it should "complete and update the workspace as CloningFailed when resources failed to clone" in {
+    val jobId = UUID.randomUUID()
+    val cloneJobId = "not-a-real-uuid"
+    val monitorRecord = WorkspaceManagerResourceMonitorRecord.forCloneWorkspace(
+      jobId,
+      workspaceId,
+      RawlsUserEmail(userEmail),
+      Some(Map(WorkspaceCloningRunner.WORKSPACE_INITIAL_CLONE_JOBID_KEY -> cloneJobId)),
+      JobType.CloneWorkspaceInit
+    )
+    val ctx = mock[RawlsRequestContext]
+    val workspaceManagerDAO = mock[WorkspaceManagerDAO]
+    when(workspaceManagerDAO.getCloneWorkspaceResult(workspaceId, cloneJobId, ctx))
+      .thenReturn(
+        new CloneWorkspaceResult()
+          .workspace(
+            new ClonedWorkspace().resources(
+              Set(
+                new ResourceCloneDetails()
+                  .name("failedResource1")
+                  .resourceType(ResourceType.AZURE_VM)
+                  .result(CloneResourceResult.FAILED)
+                  .errorMessage("error1"),
+                new ResourceCloneDetails()
+                  .name("succeededResource")
+                  .resourceType(ResourceType.AZURE_VM)
+                  .result(CloneResourceResult.SUCCEEDED),
+                new ResourceCloneDetails()
+                  .name("skippedResource")
+                  .resourceType(ResourceType.AZURE_VM)
+                  .result(CloneResourceResult.SKIPPED),
+                new ResourceCloneDetails()
+                  .name("failedResource2")
+                  .resourceType(ResourceType.AZURE_DATABASE)
+                  .result(CloneResourceResult.FAILED)
+                  .errorMessage("error2")
+              ).toList.asJava
+            )
+          )
+          .jobReport(new JobReport().status(JobReport.StatusEnum.SUCCEEDED))
+      )
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(
+      workspaceRepository.setFailedState(
+        ArgumentMatchers.eq(workspaceId),
+        ArgumentMatchers.eq(CloningFailed),
+        ArgumentMatchers.anyString()
+      )
+    ).thenReturn(Future(1))
+    val step = new CloneWorkspaceInitStep(
+      workspaceManagerDAO,
+      workspaceRepository,
+      mock[WorkspaceManagerResourceMonitorRecordDao],
+      workspaceId,
+      monitorRecord
+    )
+
+    whenReady(step.runStep(ctx)) {
+      _ shouldBe Complete
+    }
+    verify(workspaceRepository).setFailedState(
+      ArgumentMatchers.eq(workspaceId),
+      ArgumentMatchers.eq(CloningFailed),
+      ArgumentMatchers.eq(
+        s"Workspace Clone Operation [Initial Workspace Clone], source workspace: [Unknown], dest workspace [$workspaceId] failed for jobId [$jobId]: Workspace resource (failedResource1, AZURE_VM) failed to clone with the following error: error1.\nWorkspace resource (failedResource2, AZURE_DATABASE) failed to clone with the following error: error2."
+      )
+    )
+  }
+
   it should "complete and schedule the next job when the job report status is SUCCEEDED" in {
     val jobId = UUID.randomUUID()
     val cloneJobId = "not-a-real-uuid"
@@ -109,7 +186,24 @@ class CloneWorkspaceInitStepSpec extends AnyFlatSpecLike with MockitoSugar with 
     val ctx = mock[RawlsRequestContext]
     val workspaceManagerDAO = mock[WorkspaceManagerDAO]
     when(workspaceManagerDAO.getCloneWorkspaceResult(workspaceId, cloneJobId, ctx))
-      .thenReturn(new CloneWorkspaceResult().jobReport(new JobReport().status(JobReport.StatusEnum.SUCCEEDED)))
+      .thenReturn(
+        new CloneWorkspaceResult()
+          .workspace(
+            new ClonedWorkspace().resources(
+              Set(
+                new ResourceCloneDetails()
+                  .name("succeededResource")
+                  .resourceType(ResourceType.AZURE_VM)
+                  .result(CloneResourceResult.SUCCEEDED),
+                new ResourceCloneDetails()
+                  .name("skippedResource")
+                  .resourceType(ResourceType.AZURE_VM)
+                  .result(CloneResourceResult.SKIPPED)
+              ).toList.asJava
+            )
+          )
+          .jobReport(new JobReport().status(JobReport.StatusEnum.SUCCEEDED))
+      )
     val workspaceRepository = mock[WorkspaceRepository]
     val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
     doAnswer { a =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1680

This ticket improves our error visibility/handling for Azure workspace cloning. If one of the workspace resources that is meant to clone fails to clone, store the error message for that and mark the Rawls workspace as `CloningFailed`. This handling is necessary because WSM resource cloning subflights do not fail the parent clone flight.

Example display for a Workspace that has the CBAS database issue (which is now fixed for new workspaces): 

<img width="1227" alt="image" src="https://github.com/broadinstitute/rawls/assets/484484/602c526a-dfcb-46f6-b821-18b401ec7743">

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
