### PR TITLE
[WOR-1613] Set CORS policy on workspace bucket to allow notebooks.firecloud.org

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -18,7 +18,12 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException, InputStreamContent}
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.cloudbilling.Cloudbilling
-import com.google.api.services.cloudbilling.model.{BillingAccount, ListBillingAccountsResponse, ProjectBillingInfo, TestIamPermissionsRequest}
+import com.google.api.services.cloudbilling.model.{
+  BillingAccount,
+  ListBillingAccountsResponse,
+  ProjectBillingInfo,
+  TestIamPermissionsRequest
+}
 import com.google.api.services.cloudresourcemanager.CloudResourceManager
 import com.google.api.services.cloudresourcemanager.model._
 import com.google.api.services.compute.{Compute, ComputeScopes}
@@ -47,7 +52,11 @@ import org.broadinstitute.dsde.rawls.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.TracingUtils.{setTraceSpanAttribute, traceFutureWithParent, traceNakedWithParent}
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{
+  setTraceSpanAttribute,
+  traceFutureWithParent,
+  traceNakedWithParent
+}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, HttpClientUtilsStandard}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleIamDAO}
@@ -211,7 +220,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
     // setupWorkspace main logic
     val traceId = TraceId(UUID.randomUUID())
     val cors = List(
-      Cors.newBuilder()
+      Cors
+        .newBuilder()
         .setOrigins(List(Cors.Origin.of("https://notebooks.firecloud.org")).asJava)
         .setMethods(List(HttpMethod.GET).asJava)
         .setResponseHeaders(List("*").asJava)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -225,7 +225,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
         .setOrigins(List(Cors.Origin.of("https://notebooks.firecloud.org")).asJava)
         .setMethods(List(HttpMethod.GET).asJava)
         .setResponseHeaders(List("*").asJava)
-        .setMaxAgeSeconds(3600)
+        .setMaxAgeSeconds(0)
         .build()
     )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -18,12 +18,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException, InputStreamContent}
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.cloudbilling.Cloudbilling
-import com.google.api.services.cloudbilling.model.{
-  BillingAccount,
-  ListBillingAccountsResponse,
-  ProjectBillingInfo,
-  TestIamPermissionsRequest
-}
+import com.google.api.services.cloudbilling.model.{BillingAccount, ListBillingAccountsResponse, ProjectBillingInfo, TestIamPermissionsRequest}
 import com.google.api.services.cloudresourcemanager.CloudResourceManager
 import com.google.api.services.cloudresourcemanager.model._
 import com.google.api.services.compute.{Compute, ComputeScopes}
@@ -41,7 +36,7 @@ import com.google.api.services.storage.{Storage, StorageScopes}
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.Identity
 import com.google.cloud.storage.Storage.BucketSourceOption
-import com.google.cloud.storage.{StorageClass, StorageException}
+import com.google.cloud.storage.{Cors, HttpMethod, StorageClass, StorageException}
 import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.rawls.dataaccess.CloudResourceManagerV2Model.{Folder, FolderSearchResponse}
@@ -52,11 +47,7 @@ import org.broadinstitute.dsde.rawls.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.rawls.model.UserAuthJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.TracingUtils.{
-  setTraceSpanAttribute,
-  traceFutureWithParent,
-  traceNakedWithParent
-}
+import org.broadinstitute.dsde.rawls.util.TracingUtils.{setTraceSpanAttribute, traceFutureWithParent, traceNakedWithParent}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, HttpClientUtilsStandard}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleIamDAO}
@@ -219,6 +210,14 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
 
     // setupWorkspace main logic
     val traceId = TraceId(UUID.randomUUID())
+    val cors = List(
+      Cors.newBuilder()
+        .setOrigins(List(Cors.Origin.of("https://notebooks.firecloud.org")).asJava)
+        .setMethods(List(HttpMethod.GET).asJava)
+        .setResponseHeaders(List("*").asJava)
+        .setMaxAgeSeconds(3600)
+        .build()
+    )
 
     for {
       _ <- traceFutureWithParent("insertBucket", requestContext)(_ =>
@@ -233,7 +232,8 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
             logBucket = Option(GcsBucketName(GoogleServicesDAO.getStorageLogsBucketName(googleProject))),
             location = bucketLocation,
             autoclassEnabled = true,
-            autoclassTerminalStorageClass = Option(StorageClass.ARCHIVE)
+            autoclassTerminalStorageClass = Option(StorageClass.ARCHIVE),
+            cors = cors
           )
           .compile
           .drain

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -222,7 +222,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
     val cors = List(
       Cors
         .newBuilder()
-        .setOrigins(List(Cors.Origin.of("https://notebooks.firecloud.org")).asJava)
+        .setOrigins(List(Cors.Origin.of("*")).asJava)
         .setMethods(List(HttpMethod.GET).asJava)
         .setResponseHeaders(List("*").asJava)
         .setMaxAgeSeconds(0)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -154,10 +154,10 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
     val expectedCorsPolicy = List(
       Cors
         .newBuilder()
-        .setOrigins(List(Cors.Origin.of("https://notebooks.firecloud.org")).asJava)
+        .setOrigins(List(Cors.Origin.of("*")).asJava)
         .setMethods(List(HttpMethod.GET).asJava)
         .setResponseHeaders(List("*").asJava)
-        .setMaxAgeSeconds(3600)
+        .setMaxAgeSeconds(0)
         .build()
     )
     when(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -9,13 +9,20 @@ import com.google.api.client.json.gson.GsonFactory
 import com.google.cloud.storage.{Cors, HttpMethod, StorageClass}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
 import org.broadinstitute.dsde.rawls.dataaccess.HttpGoogleServicesDAO._
-import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, RawlsBillingAccount, RawlsRequestContext, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{
+  GoogleProjectId,
+  RawlsBillingAccount,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  RawlsUserSubjectId,
+  UserInfo
+}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{RETURNS_SMART_NULLS, times, verify, when}
+import org.mockito.Mockito.{times, verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -145,7 +152,8 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
     val googleProjectId = "project-id"
     val bucketName = GcsBucketName("fc-bucket-name")
     val expectedCorsPolicy = List(
-      Cors.newBuilder()
+      Cors
+        .newBuilder()
         .setOrigins(List(Cors.Origin.of("https://notebooks.firecloud.org")).asJava)
         .setMethods(List(HttpMethod.GET).asJava)
         .setResponseHeaders(List("*").asJava)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.cloud.Identity
-import com.google.cloud.storage.{ServiceAccount, _}
+import com.google.cloud.storage.{Acl, BucketInfo, Cors, Storage, StorageClass}
 import com.google.rpc.Code
 import com.google.storagetransfer.v1.proto.TransferTypes._
 import io.grpc.{Status, StatusRuntimeException}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.cloud.Identity
-import com.google.cloud.storage.{Acl, BucketInfo, Storage, StorageClass}
+import com.google.cloud.storage.{Acl, BucketInfo, Cors, Storage, StorageClass}
 import com.google.rpc.Code
 import com.google.storagetransfer.v1.proto.TransferTypes._
 import io.grpc.{Status, StatusRuntimeException}
@@ -17,12 +17,7 @@ import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome._
 import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationActor._
-import org.broadinstitute.dsde.rawls.monitor.migration.{
-  MultiregionalBucketMigration,
-  MultiregionalBucketMigrationFailureModes,
-  MultiregionalBucketMigrationStep,
-  MultiregionalStorageTransferJob
-}
+import org.broadinstitute.dsde.rawls.monitor.migration.{MultiregionalBucketMigration, MultiregionalBucketMigrationFailureModes, MultiregionalBucketMigrationStep, MultiregionalStorageTransferJob}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceServiceSpec
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO
@@ -595,7 +590,8 @@ class MultiregionalBucketMigrationActorSpec extends AnyFlatSpecLike with Matcher
                                     location: Option[String],
                                     bucketTargetOptions: List[Storage.BucketTargetOption],
                                     autoclassEnabled: Boolean,
-                                    autoclassTerminalStorageClass: Option[StorageClass]
+                                    autoclassTerminalStorageClass: Option[StorageClass],
+                                    cors: List[Cors]
           ): fs2.Stream[IO, Unit] =
             fs2.Stream.raiseError[IO](error)
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/MultiregionalBucketMigrationActorSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.IORuntime
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import com.google.cloud.Identity
-import com.google.cloud.storage.{Acl, BucketInfo, Cors, Storage, StorageClass}
+import com.google.cloud.storage.{ServiceAccount, _}
 import com.google.rpc.Code
 import com.google.storagetransfer.v1.proto.TransferTypes._
 import io.grpc.{Status, StatusRuntimeException}
@@ -17,7 +17,12 @@ import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits.
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Outcome._
 import org.broadinstitute.dsde.rawls.monitor.migration.MultiregionalBucketMigrationActor._
-import org.broadinstitute.dsde.rawls.monitor.migration.{MultiregionalBucketMigration, MultiregionalBucketMigrationFailureModes, MultiregionalBucketMigrationStep, MultiregionalStorageTransferJob}
+import org.broadinstitute.dsde.rawls.monitor.migration.{
+  MultiregionalBucketMigration,
+  MultiregionalBucketMigrationFailureModes,
+  MultiregionalBucketMigrationStep,
+  MultiregionalStorageTransferJob
+}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceServiceSpec
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,10 +81,10 @@ object Dependencies {
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.7"
 
-  val workbenchLibsHash = "3631a6f"
+  val workbenchLibsHash = "568d60ef-SNAP"
 
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.30-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.7-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,7 +81,7 @@ object Dependencies {
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.7"
 
-  val workbenchLibsHash = "568d60ef-SNAP"
+  val workbenchLibsHash = "49b30c1"
 
   val workbenchModelV  = s"0.19-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.32-${workbenchLibsHash}"


### PR DESCRIPTION
Ticket: [WOR-1613](https://broadworkbench.atlassian.net/browse/WOR-1613)
* Set CORS policy to allow https://notebooks.firecloud.org origin
* Depends on https://github.com/broadinstitute/workbench-libs/pull/1689

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1613]: https://broadworkbench.atlassian.net/browse/WOR-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ