### PR TITLE
WOR-1664 Refactor MulticloudWorkspaceService to use WorkspaceRepository

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceImpl.scala
@@ -7,7 +7,17 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamResourceTypeNames, SamWorkspaceActions, SamWorkspaceRoles, Workspace, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{
+  ErrorReport,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamBillingProjectActions,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  SamWorkspaceRoles,
+  Workspace,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
 import org.broadinstitute.dsde.rawls.monitor.migration._
 import org.broadinstitute.dsde.rawls.util.{RoleSupport, WorkspaceSupport}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/bucketMigration/BucketMigrationServiceImpl.scala
@@ -7,20 +7,11 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{
-  ErrorReport,
-  RawlsBillingProjectName,
-  RawlsRequestContext,
-  SamBillingProjectActions,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
-  SamWorkspaceRoles,
-  Workspace,
-  WorkspaceName
-}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamResourceTypeNames, SamWorkspaceActions, SamWorkspaceRoles, Workspace, WorkspaceName}
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
 import org.broadinstitute.dsde.rawls.monitor.migration._
 import org.broadinstitute.dsde.rawls.util.{RoleSupport, WorkspaceSupport}
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 
 import java.sql.Timestamp
 import java.time.Instant
@@ -36,6 +27,9 @@ class BucketMigrationServiceImpl(val dataSource: SlickDataSource, val samDAO: Sa
     with WorkspaceSupport
     with LazyLogging
     with BucketMigrationService {
+
+  // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
+  val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
 
   /**
     * Helper functions to enforce appropriate authz and load workspace(s) if authz passes

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -346,6 +346,11 @@ trait WorkspaceComponent {
     def listByNames(workspaceNames: List[WorkspaceName]): ReadAction[Seq[Workspace]] =
       loadWorkspaces(findByNamesQuery(workspaceNames))
 
+    def findV2WorkspaceById(workspaceId: UUID,
+                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+    ): ReadAction[Option[Workspace]] =
+      loadWorkspace(findV2WorkspaceByIdQuery(workspaceId), attributeSpecs)
+
     def findV2WorkspaceByName(workspaceName: WorkspaceName,
                               attributeSpecs: Option[WorkspaceAttributeSpecs] = None
     ): ReadAction[Option[Workspace]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -8,28 +8,13 @@ import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityAndAttributesResult, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{
-  DataEntityException,
-  DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException,
-  EntityNotFoundException
-}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{
-  AttributeEntityReference,
-  Entity,
-  EntityCopyDefinition,
-  EntityQuery,
-  ErrorReport,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
-  WorkspaceName,
-  _
-}
+import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityCopyDefinition, EntityQuery, ErrorReport, SamResourceTypeNames, SamWorkspaceActions, WorkspaceName, _}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
-import org.broadinstitute.dsde.rawls.workspace.AttributeUpdateOperationException
+import org.broadinstitute.dsde.rawls.workspace.{AttributeUpdateOperationException, WorkspaceRepository}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
 
@@ -61,6 +46,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
     with JsonFilterUtils {
 
   import dataSource.dataAccess.driver.api._
+
+  // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
+  val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
 
   def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[Entity] =
     withAttributeNamespaceCheck(entity) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -8,11 +8,26 @@ import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityAndAttributesResult, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException
+}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
-import org.broadinstitute.dsde.rawls.model.{AttributeEntityReference, Entity, EntityCopyDefinition, EntityQuery, ErrorReport, SamResourceTypeNames, SamWorkspaceActions, WorkspaceName, _}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeEntityReference,
+  Entity,
+  EntityCopyDefinition,
+  EntityQuery,
+  ErrorReport,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  WorkspaceName,
+  _
+}
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.{AttributeUpdateOperationException, WorkspaceRepository}
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunner.scala
@@ -207,7 +207,7 @@ class WorkspaceDeletionRunner(val samDAO: SamDAO,
         logger.info(
           s"Deleting rawls workspace record [workspaceId=${workspace.workspaceId}, jobControlId=${job.jobControlId}, jobType=${job.jobType}]"
         )
-        workspaceRepository.deleteWorkspaceRecord(workspace).map(_ => Complete)
+        workspaceRepository.deleteWorkspace(workspace).map(_ => Complete)
     }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -8,21 +8,9 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{
-  DataReferenceName,
-  ErrorReport,
-  NamedDataRepoSnapshot,
-  RawlsRequestContext,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
-  SnapshotListResponse,
-  Workspace,
-  WorkspaceAttributeSpecs,
-  WorkspaceCloudPlatform,
-  WorkspaceName
-}
+import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceTypeNames, SamWorkspaceActions, SnapshotListResponse, Workspace, WorkspaceAttributeSpecs, WorkspaceCloudPlatform, WorkspaceName}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
-import org.broadinstitute.dsde.rawls.workspace.{AggregateWorkspaceNotFoundException, AggregatedWorkspaceService}
+import org.broadinstitute.dsde.rawls.workspace.{AggregateWorkspaceNotFoundException, AggregatedWorkspaceService, WorkspaceRepository}
 
 import java.util.UUID
 import scala.annotation.tailrec
@@ -58,6 +46,9 @@ class SnapshotService(protected val ctx: RawlsRequestContext,
     extends FutureSupport
     with WorkspaceSupport
     with LazyLogging {
+
+  // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
+  val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
 
   // Finds a workspace using the workspaceId then calls the createSnapshot method
   def createSnapshotByWorkspaceId(workspaceId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/snapshot/SnapshotService.scala
@@ -8,9 +8,25 @@ import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.datarepo.DataRepoDAO
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{DataReferenceName, ErrorReport, NamedDataRepoSnapshot, RawlsRequestContext, SamResourceTypeNames, SamWorkspaceActions, SnapshotListResponse, Workspace, WorkspaceAttributeSpecs, WorkspaceCloudPlatform, WorkspaceName}
+import org.broadinstitute.dsde.rawls.model.{
+  DataReferenceName,
+  ErrorReport,
+  NamedDataRepoSnapshot,
+  RawlsRequestContext,
+  SamResourceTypeNames,
+  SamWorkspaceActions,
+  SnapshotListResponse,
+  Workspace,
+  WorkspaceAttributeSpecs,
+  WorkspaceCloudPlatform,
+  WorkspaceName
+}
 import org.broadinstitute.dsde.rawls.util.{FutureSupport, WorkspaceSupport}
-import org.broadinstitute.dsde.rawls.workspace.{AggregateWorkspaceNotFoundException, AggregatedWorkspaceService, WorkspaceRepository}
+import org.broadinstitute.dsde.rawls.workspace.{
+  AggregateWorkspaceNotFoundException,
+  AggregatedWorkspaceService,
+  WorkspaceRepository
+}
 
 import java.util.UUID
 import scala.annotation.tailrec

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/BillingProjectSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/BillingProjectSupport.scala
@@ -5,7 +5,18 @@ import cats.{Applicative, ApplicativeThrow}
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.billing.BillingRepository
 import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
-import org.broadinstitute.dsde.rawls.model.{CreationStatuses, ErrorReport, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamBillingProjectRoles, SamResourceAction, SamResourceTypeName, SamResourceTypeNames}
+import org.broadinstitute.dsde.rawls.model.{
+  CreationStatuses,
+  ErrorReport,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamBillingProjectActions,
+  SamBillingProjectRoles,
+  SamResourceAction,
+  SamResourceTypeName,
+  SamResourceTypeNames
+}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -16,12 +27,11 @@ trait BillingProjectSupport {
   protected val ctx: RawlsRequestContext
   implicit protected val executionContext: ExecutionContext
 
-
   def requireCreateWorkspaceAction(project: RawlsBillingProjectName, context: RawlsRequestContext = ctx): Future[Unit] =
     raiseUnlessUserHasAction(SamBillingProjectActions.createWorkspace,
-      SamResourceTypeNames.billingProject,
-      project.value,
-      context
+                             SamResourceTypeNames.billingProject,
+                             project.value,
+                             context
     ) {
       RawlsExceptionWithErrorReport(
         ErrorReport(
@@ -35,7 +45,7 @@ trait BillingProjectSupport {
   // granted on the Workspace's Billing Project
   def requireBillingProjectOwnerAccess(projectName: RawlsBillingProjectName,
                                        parentContext: RawlsRequestContext
-                                      ): Future[Unit] =
+  ): Future[Unit] =
     for {
       billingProjectRoles <- traceFutureWithParent("listUserRolesForResource", parentContext)(context =>
         samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, context)
@@ -50,13 +60,12 @@ trait BillingProjectSupport {
       }
     } yield ()
 
-
   /**
     * Load the specified billing project, throwing if the billing project is not ready.
     */
   def getBillingProjectContext(projectName: RawlsBillingProjectName,
                                context: RawlsRequestContext = ctx
-                              ): Future[RawlsBillingProject] =
+  ): Future[RawlsBillingProject] =
     for {
 
       maybeBillingProject <- traceFutureWithParent("loadBillingProject", context) { _ =>
@@ -84,9 +93,9 @@ trait BillingProjectSupport {
                                        resType: SamResourceTypeName,
                                        resId: String,
                                        context: RawlsRequestContext = ctx
-                                      )(
-                                        throwable: Throwable
-                                      ): Future[Unit] =
+  )(
+    throwable: Throwable
+  ): Future[Unit] =
     samDAO
       .userHasAction(resType, resId, action, context)
       .flatMap(ApplicativeThrow[Future].raiseUnless(_)(throwable))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/BillingProjectSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/BillingProjectSupport.scala
@@ -21,12 +21,19 @@ import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+  * Trait for common functionality for billing projects.
+  * Split from WorkspaceSupport, to better fit scope
+  */
 trait BillingProjectSupport {
   val samDAO: SamDAO
   val billingRepository: BillingRepository
   protected val ctx: RawlsRequestContext
   implicit protected val executionContext: ExecutionContext
 
+  /**
+    * Throws an exception of the user does not have the "create_workspace" permission on the specified billing project
+    */
   def requireCreateWorkspaceAction(project: RawlsBillingProjectName, context: RawlsRequestContext = ctx): Future[Unit] =
     raiseUnlessUserHasAction(SamBillingProjectActions.createWorkspace,
                              SamResourceTypeNames.billingProject,
@@ -80,6 +87,9 @@ trait BillingProjectSupport {
       _ <- failUnlessBillingProjectReady(billingProject)
     } yield billingProject
 
+  /**
+    * Throws an exception if the specified billing project status is not in a Ready state.
+    */
   def failUnlessBillingProjectReady(billingProject: RawlsBillingProject): Future[Unit] =
     Applicative[Future].unlessA(billingProject.status == CreationStatuses.Ready) {
       Future.failed(
@@ -89,6 +99,9 @@ trait BillingProjectSupport {
       )
     }
 
+  /**
+    * Throws the passed exception if the user does not have the specified action on the specified resource
+    */
   private def raiseUnlessUserHasAction(action: SamResourceAction,
                                        resType: SamResourceTypeName,
                                        resId: String,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/BillingProjectSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/BillingProjectSupport.scala
@@ -1,0 +1,94 @@
+package org.broadinstitute.dsde.rawls.util
+
+import akka.http.scaladsl.model.StatusCodes
+import cats.{Applicative, ApplicativeThrow}
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.billing.BillingRepository
+import org.broadinstitute.dsde.rawls.dataaccess.SamDAO
+import org.broadinstitute.dsde.rawls.model.{CreationStatuses, ErrorReport, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamBillingProjectRoles, SamResourceAction, SamResourceTypeName, SamResourceTypeNames}
+import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait BillingProjectSupport {
+  val samDAO: SamDAO
+  val billingRepository: BillingRepository
+  protected val ctx: RawlsRequestContext
+  implicit protected val executionContext: ExecutionContext
+
+
+  def requireCreateWorkspaceAction(project: RawlsBillingProjectName, context: RawlsRequestContext = ctx): Future[Unit] =
+    raiseUnlessUserHasAction(SamBillingProjectActions.createWorkspace,
+      SamResourceTypeNames.billingProject,
+      project.value,
+      context
+    ) {
+      RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.Forbidden,
+          s"You are not authorized to create a workspace in billing project $project"
+        )
+      )
+    }
+
+  // Creating a Workspace without an Owner policy is allowed only if the requesting User has the `owner` role
+  // granted on the Workspace's Billing Project
+  def requireBillingProjectOwnerAccess(projectName: RawlsBillingProjectName,
+                                       parentContext: RawlsRequestContext
+                                      ): Future[Unit] =
+    for {
+      billingProjectRoles <- traceFutureWithParent("listUserRolesForResource", parentContext)(context =>
+        samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, context)
+      )
+      _ <- ApplicativeThrow[Future].raiseUnless(billingProjectRoles.contains(SamBillingProjectRoles.owner)) {
+        RawlsExceptionWithErrorReport(
+          ErrorReport(
+            StatusCodes.Forbidden,
+            s"Missing ${SamBillingProjectRoles.owner} role on billing project '$projectName'."
+          )
+        )
+      }
+    } yield ()
+
+
+  /**
+    * Load the specified billing project, throwing if the billing project is not ready.
+    */
+  def getBillingProjectContext(projectName: RawlsBillingProjectName,
+                               context: RawlsRequestContext = ctx
+                              ): Future[RawlsBillingProject] =
+    for {
+
+      maybeBillingProject <- traceFutureWithParent("loadBillingProject", context) { _ =>
+        billingRepository.getBillingProject(projectName)
+      }
+
+      billingProject = maybeBillingProject.getOrElse(
+        throw RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, s"Billing Project $projectName does not exist")
+        )
+      )
+      _ <- failUnlessBillingProjectReady(billingProject)
+    } yield billingProject
+
+  def failUnlessBillingProjectReady(billingProject: RawlsBillingProject): Future[Unit] =
+    Applicative[Future].unlessA(billingProject.status == CreationStatuses.Ready) {
+      Future.failed(
+        RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, s"Billing Project ${billingProject.projectName} is not ready")
+        )
+      )
+    }
+
+  private def raiseUnlessUserHasAction(action: SamResourceAction,
+                                       resType: SamResourceTypeName,
+                                       resId: String,
+                                       context: RawlsRequestContext = ctx
+                                      )(
+                                        throwable: Throwable
+                                      ): Future[Unit] =
+    samDAO
+      .userHasAction(resType, resId, action, context)
+      .flatMap(ApplicativeThrow[Future].raiseUnless(_)(throwable))
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 trait WorkspaceSupport {
@@ -120,7 +121,7 @@ trait WorkspaceSupport {
     workspaceName: WorkspaceName,
     attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] =
-    workspaceRepository.getWorkspaceContext(workspaceName, attributeSpecs).map {
+    workspaceRepository.getWorkspace(workspaceName, attributeSpecs).map {
       case Some(workspace) => workspace
       case None            => throw NoSuchWorkspaceException(workspaceName)
     }
@@ -149,7 +150,7 @@ trait WorkspaceSupport {
                                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] = for {
     _ <- userEnabledCheck
-    workspaceContext <- workspaceRepository.getV2WorkspaceContextById(workspaceId, attributeSpecs)
+    workspaceContext <- workspaceRepository.getWorkspace(UUID.fromString(workspaceId), attributeSpecs)
   } yield workspaceContext match {
     case Some(workspace) => workspace
     case None            => throw NoSuchWorkspaceException(workspaceId)
@@ -159,7 +160,7 @@ trait WorkspaceSupport {
                             attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] = for {
     _ <- userEnabledCheck
-    workspaceContext <- workspaceRepository.getV2WorkspaceContext(workspaceName, attributeSpecs)
+    workspaceContext <- workspaceRepository.getWorkspace(workspaceName, attributeSpecs)
   } yield workspaceContext match {
     case Some(workspace) => workspace
     case None            => throw NoSuchWorkspaceException(workspaceName)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -6,28 +6,15 @@ import cats.{Applicative, ApplicativeThrow}
 import org.broadinstitute.dsde.rawls._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.model.{
-  CreationStatuses,
-  ErrorReport,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
-  RawlsRequestContext,
-  SamBillingProjectActions,
-  SamBillingProjectRoles,
-  SamResourceAction,
-  SamResourceTypeName,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
-  Workspace,
-  WorkspaceAttributeSpecs,
-  WorkspaceName
-}
+import org.broadinstitute.dsde.rawls.model.{CreationStatuses, ErrorReport, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamBillingProjectActions, SamBillingProjectRoles, SamResourceAction, SamResourceTypeName, SamResourceTypeNames, SamWorkspaceActions, Workspace, WorkspaceAttributeSpecs, WorkspaceName}
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceFutureWithParent}
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait WorkspaceSupport {
   val samDAO: SamDAO
+  val workspaceRepository: WorkspaceRepository
   protected val ctx: RawlsRequestContext
   implicit protected val executionContext: ExecutionContext
   protected val dataSource: SlickDataSource

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -149,7 +149,7 @@ trait WorkspaceSupport {
                                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Workspace] = for {
     _ <- userEnabledCheck
-    workspaceContext <- workspaceRepository.getV2WorkspaceContext(workspaceId, attributeSpecs)
+    workspaceContext <- workspaceRepository.getV2WorkspaceContextById(workspaceId, attributeSpecs)
   } yield workspaceContext match {
     case Some(workspace) => workspace
     case None            => throw NoSuchWorkspaceException(workspaceId)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/WorkspaceSupport.scala
@@ -75,6 +75,7 @@ trait WorkspaceSupport {
       _ <- raiseUnlessUserHasAction(SamWorkspaceActions.compute, SamResourceTypeNames.workspace, workspaceId) {
         WorkspaceAccessDeniedException(workspaceName)
       }.recoverWith { case t: Throwable =>
+        // verify the user has `read` on the workspace to avoid exposing its existence
         raiseUnlessUserHasAction(SamWorkspaceActions.read, SamResourceTypeNames.workspace, workspaceId) {
           NoSuchWorkspaceException(workspaceName)
         } *> Future.failed(t)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -198,7 +198,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
           )
         }
       }
-      _ <- workspaceRepository.deleteWorkspaceRecord(workspace)
+      _ <- workspaceRepository.deleteWorkspace(workspace)
     } yield {
       deletedMultiCloudWorkspaceCounter.inc()
       logger.info(
@@ -379,7 +379,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     for {
       // The call to WSM is asynchronous. Before we fire it off, allocate a new workspace record
       // to avoid naming conflicts - we'll erase it should the clone request to WSM fail.
-      newWorkspace <- workspaceRepository.createNewMCWorkspaceRecord(workspaceId,
+      newWorkspace <- workspaceRepository.createMCWorkspace(workspaceId,
                                                                      mergedRequest,
                                                                      parentContext,
                                                                      WorkspaceState.Cloning
@@ -425,7 +425,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                 s"], Rawls record being deleted.",
               t
             )
-            workspaceRepository.deleteWorkspaceRecord(newWorkspace) >> Future.failed(t)
+            workspaceRepository.deleteWorkspace(newWorkspace) >> Future.failed(t)
 
         }
 
@@ -495,7 +495,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     for {
       // The call to WSM is asynchronous. Before we fire it off, allocate a new workspace record
       // to avoid naming conflicts - we'll erase it should the clone request to WSM fail.
-      newWorkspace <- workspaceRepository.createNewMCWorkspaceRecord(workspaceId, mergedRequest, parentContext)
+      newWorkspace <- workspaceRepository.createMCWorkspace(workspaceId, mergedRequest, parentContext)
 
       containerCloneResult <- (for {
         cloneResult <- traceFutureWithParent("workspaceManagerDAO.cloneWorkspace", parentContext) { context =>
@@ -553,7 +553,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
             s"], Rawls record being deleted.",
           t
         )
-        workspaceRepository.deleteWorkspaceRecord(newWorkspace) >> Future.failed(t)
+        workspaceRepository.deleteWorkspace(newWorkspace) >> Future.failed(t)
       }
       _ = clonedMultiCloudWorkspaceCounter.inc()
       _ = logger.info(
@@ -736,7 +736,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
 
       _ = logger.info(s"Creating workspace record [workspaceId = ${workspaceId}]")
       savedWorkspace <- traceFutureWithParent("saveMultiCloudWorkspaceToDB", parentContext)(_ =>
-        workspaceRepository.createNewMCWorkspaceRecord(workspaceId, workspaceRequest, parentContext)
+        workspaceRepository.createMCWorkspace(workspaceId, workspaceRequest, parentContext)
       )
 
       _ = logger.info(s"Creating workspace with cloud context in WSM [workspaceId = ${workspaceId}]")
@@ -798,7 +798,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
               e
             )
           }
-          _ <- workspaceRepository.deleteWorkspaceRecord(workspaceRequest.toWorkspaceName)
+          _ <- workspaceRepository.deleteWorkspace(workspaceRequest.toWorkspaceName)
         } yield e match {
           case rawlsException: RawlsExceptionWithErrorReport => throw rawlsException
           case _ =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -14,11 +14,33 @@ import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingR
 import org.broadinstitute.dsde.rawls.config.MultiCloudWorkspaceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{LeonardoDAO, SamDAO, SlickDataSource, WorkspaceManagerResourceMonitorRecordDao}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  LeonardoDAO,
+  SamDAO,
+  SlickDataSource,
+  WorkspaceManagerResourceMonitorRecordDao
+}
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.{McWorkspace, RawlsWorkspace}
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeString, ErrorReport, RawlsBillingProject, RawlsBillingProjectName, RawlsRequestContext, SamWorkspaceActions, Workspace, WorkspaceCloudPlatform, WorkspaceDeletionResult, WorkspaceDetails, WorkspaceName, WorkspaceRequest, WorkspaceState, WorkspaceType}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeBoolean,
+  AttributeName,
+  AttributeString,
+  ErrorReport,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsRequestContext,
+  SamWorkspaceActions,
+  Workspace,
+  WorkspaceCloudPlatform,
+  WorkspaceDeletionResult,
+  WorkspaceDetails,
+  WorkspaceName,
+  WorkspaceRequest,
+  WorkspaceState,
+  WorkspaceType
+}
 import org.broadinstitute.dsde.rawls.monitor.workspace.runners.clone.WorkspaceCloningRunner
 import org.broadinstitute.dsde.rawls.util.TracingUtils.{traceDBIOWithParent, traceFutureWithParent}
 import org.broadinstitute.dsde.rawls.util.{BillingProjectSupport, Retry, WorkspaceSupport}
@@ -27,7 +49,7 @@ import org.joda.time.{DateTime, DateTimeZone}
 
 import java.util.UUID
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future, blocking}
+import scala.concurrent.{blocking, ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -489,7 +489,6 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
     val workspaceId = UUID.randomUUID()
 
     // Merge together source workspace and destination request attributes
-    val mergedRequest = request.copy(attributes = sourceWorkspace.attributes ++ request.attributes)
     val mergedAttributes = sourceWorkspace.attributes ++ request.attributes
     for {
       // The call to WSM is asynchronous. Before we fire it off, allocate a new workspace record

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -70,10 +70,10 @@ object MultiCloudWorkspaceService {
       samDAO,
       multiCloudWorkspaceConfig,
       leonardoDAO,
-      dataSource,
       workbenchMetricBaseName,
       WorkspaceManagerResourceMonitorRecordDao(dataSource),
-      new WorkspaceRepository(dataSource)
+      new WorkspaceRepository(dataSource),
+      new BillingRepository(dataSource)
     )
 
   def getStorageContainerName(workspaceId: UUID): String = s"sc-${workspaceId}"
@@ -89,18 +89,16 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                  override val samDAO: SamDAO,
                                  val multiCloudWorkspaceConfig: MultiCloudWorkspaceConfig,
                                  val leonardoDAO: LeonardoDAO,
-                                 override val dataSource: SlickDataSource,
                                  override val workbenchMetricBaseName: String,
                                  workspaceManagerResourceMonitorRecordDao: WorkspaceManagerResourceMonitorRecordDao,
-                                 val workspaceRepository: WorkspaceRepository
+                                 val workspaceRepository: WorkspaceRepository,
+                                 val billingRepository: BillingRepository
 )(implicit override val executionContext: ExecutionContext, val system: ActorSystem)
     extends LazyLogging
     with RawlsInstrumented
     with Retry
     with WorkspaceSupport
     with BillingProjectSupport {
-
-  val billingRepository: BillingRepository = new BillingRepository(dataSource)
 
   /**
     * Deletes a workspace. For legacy "rawls" workspaces,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   RawlsRequestContext,
   Workspace,
+  WorkspaceAttributeSpecs,
   WorkspaceName,
   WorkspaceRequest,
   WorkspaceState
@@ -89,5 +90,11 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
         )
       } yield newWorkspace
     }
+
+  def getWorkspaceContext(workspaceName: WorkspaceName,
+                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Option[Workspace]] = dataSource.inTransaction { dataAccess =>
+    dataAccess.workspaceQuery.findByName(workspaceName, attributeSpecs)
+  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -58,10 +58,7 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
       access.workspaceQuery.updateStateWithErrorMessage(workspaceId, state, message)
     }
 
-  def deleteWorkspace(workspace: Workspace): Future[Boolean] =
-    dataSource.inTransaction { access =>
-      access.workspaceQuery.delete(workspace.toWorkspaceName)
-    }
+  def deleteWorkspace(workspace: Workspace): Future[Boolean] = deleteWorkspace(workspace.toWorkspaceName)
 
   def deleteWorkspace(workspaceName: WorkspaceName): Future[Boolean] =
     dataSource.inTransaction { access =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -46,7 +46,7 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
     }
 
   def getV2WorkspaceContextById(workspaceId: String,
-                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+                                attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Option[Workspace]] =
     dataSource.inTransaction { dataAccess =>
       dataAccess.workspaceQuery.findById(workspaceId, attributeSpecs)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -67,12 +67,12 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
       access.workspaceQuery.updateStateWithErrorMessage(workspaceId, state, message)
     }
 
-  def deleteWorkspaceRecord(workspace: Workspace): Future[Boolean] =
+  def deleteWorkspace(workspace: Workspace): Future[Boolean] =
     dataSource.inTransaction { access =>
       access.workspaceQuery.delete(workspace.toWorkspaceName)
     }
 
-  def deleteWorkspaceRecord(workspaceName: WorkspaceName): Future[Boolean] =
+  def deleteWorkspace(workspaceName: WorkspaceName): Future[Boolean] =
     dataSource.inTransaction { access =>
       access.workspaceQuery.delete(workspaceName)
     }
@@ -80,10 +80,10 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
   def updateCompletedCloneWorkspaceFileTransfer(wsId: UUID, finishTime: DateTime): Future[Int] =
     dataSource.inTransaction(_.workspaceQuery.updateCompletedCloneWorkspaceFileTransfer(wsId, finishTime.toDate))
 
-  def createNewMCWorkspaceRecord(workspaceId: UUID,
-                                 request: WorkspaceRequest,
-                                 parentContext: RawlsRequestContext,
-                                 state: WorkspaceState = WorkspaceState.Ready
+  def createMCWorkspace(workspaceId: UUID,
+                        request: WorkspaceRequest,
+                        parentContext: RawlsRequestContext,
+                        state: WorkspaceState = WorkspaceState.Ready
   )(implicit ex: ExecutionContext): Future[Workspace] =
     dataSource.inTransaction { access =>
       val workspaceName = request.toWorkspaceName

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -3,13 +3,13 @@ package org.broadinstitute.dsde.rawls.workspace
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   RawlsRequestContext,
   Workspace,
   WorkspaceAttributeSpecs,
   WorkspaceName,
-  WorkspaceRequest,
   WorkspaceState
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
@@ -27,29 +27,20 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class WorkspaceRepository(dataSource: SlickDataSource) {
 
-  def getWorkspace(workspaceId: UUID): Future[Option[Workspace]] =
+  def getWorkspace(workspaceId: UUID): Future[Option[Workspace]] = getWorkspace(workspaceId, None)
+
+  def getWorkspace(workspaceId: UUID, attributeSpecs: Option[WorkspaceAttributeSpecs]): Future[Option[Workspace]] =
     dataSource.inTransaction { access =>
-      access.workspaceQuery.findById(workspaceId.toString)
+      access.workspaceQuery.findV2WorkspaceById(workspaceId, attributeSpecs)
     }
 
-  def getWorkspaceContext(workspaceName: WorkspaceName,
-                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Option[Workspace]] = dataSource.inTransaction { dataAccess =>
-    dataAccess.workspaceQuery.findByName(workspaceName, attributeSpecs)
-  }
+  def getWorkspace(workspaceName: WorkspaceName): Future[Option[Workspace]] = getWorkspace(workspaceName, None)
 
-  def getV2WorkspaceContext(workspaceName: WorkspaceName,
-                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  def getWorkspace(workspaceName: WorkspaceName,
+                   attributeSpecs: Option[WorkspaceAttributeSpecs]
   ): Future[Option[Workspace]] =
     dataSource.inTransaction { dataAccess =>
       dataAccess.workspaceQuery.findV2WorkspaceByName(workspaceName, attributeSpecs)
-    }
-
-  def getV2WorkspaceContextById(workspaceId: String,
-                                attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Option[Workspace]] =
-    dataSource.inTransaction { dataAccess =>
-      dataAccess.workspaceQuery.findById(workspaceId, attributeSpecs)
     }
 
   def createWorkspace(workspace: Workspace): Future[Workspace] =
@@ -81,12 +72,12 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
     dataSource.inTransaction(_.workspaceQuery.updateCompletedCloneWorkspaceFileTransfer(wsId, finishTime.toDate))
 
   def createMCWorkspace(workspaceId: UUID,
-                        request: WorkspaceRequest,
+                        workspaceName: WorkspaceName,
+                        attributes: AttributeMap,
                         parentContext: RawlsRequestContext,
                         state: WorkspaceState = WorkspaceState.Ready
   )(implicit ex: ExecutionContext): Future[Workspace] =
     dataSource.inTransaction { access =>
-      val workspaceName = request.toWorkspaceName
       for {
         _ <- access.workspaceQuery.getWorkspaceId(workspaceName).map { workspaceId =>
           if (workspaceId.isDefined)
@@ -102,7 +93,7 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
           createdDate = currentDate,
           lastModified = currentDate,
           createdBy = parentContext.userInfo.userEmail.value,
-          attributes = request.attributes,
+          attributes = attributes,
           state
         )
         newWorkspace <- traceDBIOWithParent("saveMultiCloudWorkspace", parentContext)(_ =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -45,7 +45,7 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
       dataAccess.workspaceQuery.findV2WorkspaceByName(workspaceName, attributeSpecs)
     }
 
-  def getV2WorkspaceContext(workspaceId: String,
+  def getV2WorkspaceContextById(workspaceId: String,
                             attributeSpecs: Option[WorkspaceAttributeSpecs] = None
   ): Future[Option[Workspace]] =
     dataSource.inTransaction { dataAccess =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -32,6 +32,26 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
       access.workspaceQuery.findById(workspaceId.toString)
     }
 
+  def getWorkspaceContext(workspaceName: WorkspaceName,
+                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Option[Workspace]] = dataSource.inTransaction { dataAccess =>
+    dataAccess.workspaceQuery.findByName(workspaceName, attributeSpecs)
+  }
+
+  def getV2WorkspaceContext(workspaceName: WorkspaceName,
+                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Option[Workspace]] =
+    dataSource.inTransaction { dataAccess =>
+      dataAccess.workspaceQuery.findV2WorkspaceByName(workspaceName, attributeSpecs)
+    }
+
+  def getV2WorkspaceContext(workspaceId: String,
+                            attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  ): Future[Option[Workspace]] =
+    dataSource.inTransaction { dataAccess =>
+      dataAccess.workspaceQuery.findById(workspaceId, attributeSpecs)
+    }
+
   def createWorkspace(workspace: Workspace): Future[Workspace] =
     dataSource.inTransaction { access =>
       access.workspaceQuery.createOrUpdate(workspace)
@@ -90,11 +110,5 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
         )
       } yield newWorkspace
     }
-
-  def getWorkspaceContext(workspaceName: WorkspaceName,
-                          attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-  ): Future[Option[Workspace]] = dataSource.inTransaction { dataAccess =>
-    dataAccess.workspaceQuery.findByName(workspaceName, attributeSpecs)
-  }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -266,7 +266,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
             } yield newWorkspace,
           TransactionIsolation.ReadCommitted
         )
-      ) // read committed to avoid deadlocks on workspace attr scratch table
+      ) // read committed to avoid deadlocks on workspace attribute scratch table
       _ <- traceFutureWithParent("FastPassService.setupFastPassNewWorkspace", parentContext)(childContext =>
         fastPassServiceConstructor(childContext, dataSource).syncFastPassesForUserInWorkspace(workspace)
       )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -230,6 +230,9 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
 
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
 
+  // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
+  val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
+
   // Note: this limit is also hard-coded in the terra-ui code to allow client-side validation.
   // If it is changed, it must also be updated in that repository.
   private val UserCommentMaxLength: Int = 1000

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2986,9 +2986,21 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
   private def withWorkspaceContext[T](workspaceName: WorkspaceName,
                                       dataAccess: DataAccess,
                                       attributeSpecs: Option[WorkspaceAttributeSpecs] = None
-                                     )(op: (Workspace) => ReadWriteAction[T]) =
+  )(op: (Workspace) => ReadWriteAction[T]) =
     dataAccess.workspaceQuery.findByName(workspaceName, attributeSpecs) flatMap {
-      case None => throw NoSuchWorkspaceException(workspaceName)
+      case None            => throw NoSuchWorkspaceException(workspaceName)
+      case Some(workspace) => op(workspace)
+    }
+
+  // Finds workspace by workspaceName
+  // moved out of WorkspaceSupport because the only usage was in this file,
+  // and it has raw datasource/dataAccess usage, which is being refactored out of WorkspaceSupport
+  private def withV2WorkspaceContext[T](workspaceName: WorkspaceName,
+                                        dataAccess: DataAccess,
+                                        attributeSpecs: Option[WorkspaceAttributeSpecs] = None
+  )(op: (Workspace) => ReadWriteAction[T]) =
+    dataAccess.workspaceQuery.findV2WorkspaceByName(workspaceName, attributeSpecs) flatMap {
+      case None            => throw NoSuchWorkspaceException(workspaceName)
       case Some(workspace) => op(workspace)
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -339,7 +339,7 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     val wsmAction = mock[WsmDeletionAction](RETURNS_SMART_NULLS)
     when(wsmAction.pollForCompletion(any(), any(), any())(any[ExecutionContext]())).thenReturn(Future.successful(true))
     val repo = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
-    when(repo.deleteWorkspaceRecord(azureWorkspace)).thenReturn(Future.successful(true))
+    when(repo.deleteWorkspace(azureWorkspace)).thenReturn(Future.successful(true))
     val runner = new WorkspaceDeletionRunner(
       mock[SamDAO](RETURNS_SMART_NULLS),
       mock[WorkspaceManagerDAO](RETURNS_SMART_NULLS),
@@ -356,7 +356,7 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
       )
     )(_ shouldBe Complete)
     verify(wsmAction).pollForCompletion(any(), any(), any())(any[ExecutionContext]())
-    verify(repo).deleteWorkspaceRecord(azureWorkspace)
+    verify(repo).deleteWorkspace(azureWorkspace)
 
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
@@ -5,48 +5,18 @@ import bio.terra.profile.model.{CloudPlatform, ProfileModel}
 import bio.terra.workspace.client.ApiException
 import bio.terra.workspace.model.{CloneWorkspaceResult, JobReport, WsmPolicyInputs}
 import org.broadinstitute.dsde.rawls.TestExecutionContext
-import org.broadinstitute.dsde.rawls.billing.BillingProfileManagerDAO
+import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
 import org.broadinstitute.dsde.rawls.config.{MultiCloudWorkspaceConfig, WorkspaceServiceConfig}
 import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{
-  ExecutionServiceCluster,
-  ExecutionServiceDAO,
-  GoogleServicesDAO,
-  LeonardoDAO,
-  MethodRepoDAO,
-  RequesterPaysSetupService,
-  SamDAO,
-  SlickDataSource,
-  SubmissionCostService,
-  WorkspaceManagerResourceMonitorRecordDao
-}
+import org.broadinstitute.dsde.rawls.dataaccess.{ExecutionServiceCluster, ExecutionServiceDAO, GoogleServicesDAO, LeonardoDAO, MethodRepoDAO, RequesterPaysSetupService, SamDAO, SlickDataSource, SubmissionCostService, WorkspaceManagerResourceMonitorRecordDao}
 import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
-import org.broadinstitute.dsde.rawls.model.{
-  AttributeName,
-  AttributeString,
-  CreationStatuses,
-  ManagedGroupRef,
-  RawlsBillingProject,
-  RawlsBillingProjectName,
-  RawlsGroupName,
-  RawlsRequestContext,
-  RawlsUserEmail,
-  SamWorkspaceActions,
-  UserInfo,
-  Workspace,
-  WorkspaceCloudPlatform,
-  WorkspaceDetails,
-  WorkspacePolicy,
-  WorkspaceRequest,
-  WorkspaceState,
-  WorkspaceType
-}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString, CreationStatuses, ManagedGroupRef, RawlsBillingProject, RawlsBillingProjectName, RawlsGroupName, RawlsRequestContext, RawlsUserEmail, SamWorkspaceActions, UserInfo, Workspace, WorkspaceCloudPlatform, WorkspaceDetails, WorkspacePolicy, WorkspaceRequest, WorkspaceState, WorkspaceType}
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService
@@ -300,10 +270,10 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
         mock[SamDAO],
         mock[MultiCloudWorkspaceConfig],
         mock[LeonardoDAO],
-        mock[SlickDataSource],
         "MultiCloudWorkspaceService-test",
         mock[WorkspaceManagerResourceMonitorRecordDao],
-        workspaceRepository
+        workspaceRepository,
+        mock[BillingRepository]
       )
     )
 
@@ -360,10 +330,10 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
         mock[SamDAO],
         mock[MultiCloudWorkspaceConfig],
         mock[LeonardoDAO],
-        mock[SlickDataSource],
         "MultiCloudWorkspaceService-test",
         mock[WorkspaceManagerResourceMonitorRecordDao],
-        workspaceRepository
+        workspaceRepository,
+        mock[BillingRepository]
       )
     )
 
@@ -442,10 +412,10 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
         mock[SamDAO],
         mock[MultiCloudWorkspaceConfig],
         mock[LeonardoDAO],
-        mock[SlickDataSource],
         "MultiCloudWorkspaceService-test",
         workspaceManagerResourceMonitorRecordDao,
-        workspaceRepository
+        workspaceRepository,
+        mock[BillingRepository]
       )
     )
     val destWorkspace = mock[Workspace]
@@ -524,10 +494,10 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
         mock[SamDAO],
         mock[MultiCloudWorkspaceConfig],
         mock[LeonardoDAO],
-        mock[SlickDataSource],
         "MultiCloudWorkspaceService-test",
         workspaceManagerResourceMonitorRecordDao,
-        workspaceRepository
+        workspaceRepository,
+        mock[BillingRepository]
       )
     )
     val destWorkspace = mock[Workspace]

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
@@ -314,14 +314,14 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
 
     doReturn(Future(destWorkspace))
       .when(workspaceRepository)
-      .createNewMCWorkspaceRecord(
+      .createMCWorkspace(
         ArgumentMatchers.any(),
         ArgumentMatchers.eq(destWorkspaceRequest),
         ArgumentMatchers.eq(requestContext),
         ArgumentMatchers.eq(WorkspaceState.Cloning)
       )(ArgumentMatchers.any())
 
-    when(workspaceRepository.deleteWorkspaceRecord(destWorkspace)).thenReturn(Future(true))
+    when(workspaceRepository.deleteWorkspace(destWorkspace)).thenReturn(Future(true))
 
     intercept[ApiException] {
       Await.result(
@@ -330,7 +330,7 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       )
     }
 
-    verify(workspaceRepository).deleteWorkspaceRecord(destWorkspace)
+    verify(workspaceRepository).deleteWorkspace(destWorkspace)
   }
 
   it should "doesn't try to delete the workspace when creating the new db record in rawls fails" in {
@@ -373,7 +373,7 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
     val destWorkspace = mock[Workspace]
     doReturn(Future(new Exception()))
       .when(workspaceRepository)
-      .createNewMCWorkspaceRecord(
+      .createMCWorkspace(
         ArgumentMatchers.any(),
         ArgumentMatchers.eq(destWorkspaceRequest),
         ArgumentMatchers.eq(requestContext),
@@ -387,7 +387,7 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       )
     }
 
-    verify(workspaceRepository, never()).deleteWorkspaceRecord(destWorkspace)
+    verify(workspaceRepository, never()).deleteWorkspace(destWorkspace)
   }
 
   it should "create the async clone job from the result in WSM" in {
@@ -451,7 +451,7 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
     val destWorkspace = mock[Workspace]
     doReturn(Future.successful(destWorkspace))
       .when(workspaceRepository)
-      .createNewMCWorkspaceRecord(
+      .createMCWorkspace(
         ArgumentMatchers.any(),
         ArgumentMatchers.eq(destWorkspaceRequest),
         ArgumentMatchers.eq(requestContext),
@@ -539,7 +539,7 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       WorkspaceRequest("dest-namespace", "dest-name", mergedAttributes, policies = Some(policies))
     doReturn(Future.successful(destWorkspace))
       .when(workspaceRepository)
-      .createNewMCWorkspaceRecord(
+      .createMCWorkspace(
         ArgumentMatchers.any(),
         ArgumentMatchers.eq(mergedWorkspaceRequest),
         ArgumentMatchers.eq(requestContext),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
@@ -316,7 +316,8 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       .when(workspaceRepository)
       .createMCWorkspace(
         ArgumentMatchers.any(),
-        ArgumentMatchers.eq(destWorkspaceRequest),
+        ArgumentMatchers.eq(destWorkspaceRequest.toWorkspaceName),
+        ArgumentMatchers.any(),
         ArgumentMatchers.eq(requestContext),
         ArgumentMatchers.eq(WorkspaceState.Cloning)
       )(ArgumentMatchers.any())
@@ -375,7 +376,8 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       .when(workspaceRepository)
       .createMCWorkspace(
         ArgumentMatchers.any(),
-        ArgumentMatchers.eq(destWorkspaceRequest),
+        ArgumentMatchers.eq(destWorkspaceRequest.toWorkspaceName),
+        ArgumentMatchers.any(),
         ArgumentMatchers.eq(requestContext),
         ArgumentMatchers.eq(WorkspaceState.Cloning)
       )(ArgumentMatchers.any())
@@ -453,7 +455,8 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       .when(workspaceRepository)
       .createMCWorkspace(
         ArgumentMatchers.any(),
-        ArgumentMatchers.eq(destWorkspaceRequest),
+        ArgumentMatchers.eq(destWorkspaceRequest.toWorkspaceName),
+        ArgumentMatchers.any(),
         ArgumentMatchers.eq(requestContext),
         ArgumentMatchers.eq(WorkspaceState.Cloning)
       )(ArgumentMatchers.any())
@@ -541,7 +544,8 @@ class MultiCloudWorkspaceServiceUnitTestsSpec
       .when(workspaceRepository)
       .createMCWorkspace(
         ArgumentMatchers.any(),
-        ArgumentMatchers.eq(mergedWorkspaceRequest),
+        ArgumentMatchers.eq(mergedWorkspaceRequest.toWorkspaceName),
+        ArgumentMatchers.eq(mergedAttributes),
         ArgumentMatchers.eq(requestContext),
         ArgumentMatchers.eq(WorkspaceState.Cloning)
       )(ArgumentMatchers.any())

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceUnitTestsSpec.scala
@@ -11,12 +11,42 @@ import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
-import org.broadinstitute.dsde.rawls.dataaccess.{ExecutionServiceCluster, ExecutionServiceDAO, GoogleServicesDAO, LeonardoDAO, MethodRepoDAO, RequesterPaysSetupService, SamDAO, SlickDataSource, SubmissionCostService, WorkspaceManagerResourceMonitorRecordDao}
+import org.broadinstitute.dsde.rawls.dataaccess.{
+  ExecutionServiceCluster,
+  ExecutionServiceDAO,
+  GoogleServicesDAO,
+  LeonardoDAO,
+  MethodRepoDAO,
+  RequesterPaysSetupService,
+  SamDAO,
+  SlickDataSource,
+  SubmissionCostService,
+  WorkspaceManagerResourceMonitorRecordDao
+}
 import org.broadinstitute.dsde.rawls.entities.EntityManager
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
-import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString, CreationStatuses, ManagedGroupRef, RawlsBillingProject, RawlsBillingProjectName, RawlsGroupName, RawlsRequestContext, RawlsUserEmail, SamWorkspaceActions, UserInfo, Workspace, WorkspaceCloudPlatform, WorkspaceDetails, WorkspacePolicy, WorkspaceRequest, WorkspaceState, WorkspaceType}
+import org.broadinstitute.dsde.rawls.model.{
+  AttributeName,
+  AttributeString,
+  CreationStatuses,
+  ManagedGroupRef,
+  RawlsBillingProject,
+  RawlsBillingProjectName,
+  RawlsGroupName,
+  RawlsRequestContext,
+  RawlsUserEmail,
+  SamWorkspaceActions,
+  UserInfo,
+  Workspace,
+  WorkspaceCloudPlatform,
+  WorkspaceDetails,
+  WorkspacePolicy,
+  WorkspaceRequest,
+  WorkspaceState,
+  WorkspaceType
+}
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterService
 import org.broadinstitute.dsde.rawls.user.UserService

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepositorySpec.scala
@@ -76,7 +76,7 @@ class WorkspaceRepositorySpec extends AnyFlatSpec with TestDriverComponent {
     val ws: Workspace = makeWorkspace()
     Await.result(repo.createWorkspace(ws), Duration.Inf)
 
-    val result = Await.result(repo.deleteWorkspaceRecord(ws), Duration.Inf)
+    val result = Await.result(repo.deleteWorkspace(ws), Duration.Inf)
     val readback = Await.result(repo.getWorkspace(ws.workspaceIdAsUUID), Duration.Inf)
 
     assertResult(readback)(None)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -425,9 +425,9 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
       case WorkspaceType.RawlsWorkspace => GoogleProjectId("fake-project-id")
     }
 
-    when(datasource.inTransaction[Workspace](any(), any())).thenReturn(
+    when(datasource.inTransaction[Option[Workspace]](any(), any())).thenReturn(
       Future.successful(
-        Workspace("fake_namespace",
+        Option(Workspace("fake_namespace",
                   "fake_name",
                   workspaceId.toString,
                   "fake_bucket",
@@ -436,7 +436,7 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
                   DateTime.now(),
                   "creator@example.com",
                   Map.empty
-        ).copy(workspaceType = workspaceType, googleProjectId = googleProjectId)
+        ).copy(workspaceType = workspaceType, googleProjectId = googleProjectId))
       )
     )
     datasource

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -427,16 +427,18 @@ class WorkspaceServiceUnitTests extends AnyFlatSpec with OptionValues with Mocki
 
     when(datasource.inTransaction[Option[Workspace]](any(), any())).thenReturn(
       Future.successful(
-        Option(Workspace("fake_namespace",
-                  "fake_name",
-                  workspaceId.toString,
-                  "fake_bucket",
-                  None,
-                  DateTime.now(),
-                  DateTime.now(),
-                  "creator@example.com",
-                  Map.empty
-        ).copy(workspaceType = workspaceType, googleProjectId = googleProjectId))
+        Option(
+          Workspace("fake_namespace",
+                    "fake_name",
+                    workspaceId.toString,
+                    "fake_bucket",
+                    None,
+                    DateTime.now(),
+                    DateTime.now(),
+                    "creator@example.com",
+                    Map.empty
+          ).copy(workspaceType = workspaceType, googleProjectId = googleProjectId)
+        )
       )
     )
     datasource


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1664

Remove remaining instances of raw slick datasource usage in 'MultiCloudWorkspaceService`.
Tests were changed as little possible, to illustrate the unchanged functionality.

* Move additional functionality to `WorkspaceRepository`
* Use `BillingRepository` for appropriate datasource calls
* Split billing functionality from `WorkspaceSupport` to minimize disruption to unrelated classes


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
