### PR TITLE
AJ-1904: dont send /status 5xx responses to Sentry

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -173,9 +173,9 @@ trait RawlsApiService
         case Complete(resp) =>
           val logLevel: LogLevel = resp.status.intValue / 100 match {
             case 5 if ignorableErrorPaths.contains(req.uri.path.toString()) => Logging.WarningLevel
-            case 5 => Logging.ErrorLevel
-            case 4 => Logging.InfoLevel
-            case _ => Logging.DebugLevel
+            case 5                                                          => Logging.ErrorLevel
+            case 4                                                          => Logging.InfoLevel
+            case _                                                          => Logging.DebugLevel
           }
           entityAsString(resp.entity).map(data =>
             LogEntry(s"${req.method} ${req.uri}: ${resp.status} entity: $data", logLevel)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1904

This PR changes logging for errors from `/status` to be WARN, not ERROR. We fully expect to see many errors from `/status` as k8s pods start … this happens at every Rawls release and every time k8s needs to rebalance a node or otherwise perform pod maintenance.

ERROR-level logs get picked up by Sentry. This PR prevents spamming Sentry for these frequent errors.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
