### PR TITLE
AJ-1905: improved logging for Transaction with temporary tables failed

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -94,7 +94,8 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
             )
           case otherStatusCode =>
             logger.error(
-              s"Error in transaction (${tempTableTypes.mkString(",")}): $otherStatusCode: ${t.getMessage}"
+              s"Error in transaction (${tempTableTypes
+                  .mkString(",")}). ${t.getClass.getName} with status $otherStatusCode: ${t.getMessage}"
             )
         }
       case _ =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1905

We log all transaction errors the same way; this makes it hard to categorize them.

This PR improves logging of those errors, at least somewhat … there may be more to do on this front as we keep analyzing problems.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
