### PR TITLE
AJ-1905: dont log inTransactionWithAttrTempTable exceptions at ERROR level

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -2,13 +2,11 @@ package org.broadinstitute.dsde.rawls.dataaccess
 
 import _root_.slick.basic.DatabaseConfig
 import _root_.slick.jdbc.{JdbcProfile, TransactionIsolation}
-import akka.http.scaladsl.model.StatusCodes.ClientError
 import com.google.common.base.Throwables
 import com.typesafe.scalalogging.LazyLogging
 import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.{ClassLoaderResourceAccessor, ResourceAccessor}
 import liquibase.{Contexts, Liquibase}
-import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, DataAccessComponent, ReadWriteAction}
 import sun.security.provider.certpath.SunCertPathBuilderException
 
@@ -77,32 +75,14 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
     }
 
     database.run(callerActionWithTempTables.withPinnedSession).recover { case t: Throwable =>
-      logTransactionError(t, tempTableTypes)
+      // log the transaction error at WARN level. Since we rethrow the error, calling code is responsible for handling
+      // it and, if appropriate, logging at ERROR level. Only ERROR-level logs are picked up as Sentry alerts.
+      logger.warn(
+        s"Transaction with temporary tables failed for (${tempTableTypes.mkString(",")}). ${t.getClass.getName}: ${t.getMessage}"
+      )
       throw t
     }
   }
-
-  // conditionally log the transaction error. We don't want to log bad requests at ERROR level, as that will spam
-  // Sentry alerts.
-  private def logTransactionError(t: Throwable, tempTableTypes: Set[AttributeTempTableType.Value]): Unit =
-    t match {
-      case withErrorReport: RawlsExceptionWithErrorReport =>
-        withErrorReport.errorReport.statusCode match {
-          case Some(ce: ClientError) =>
-            logger.warn(
-              s"Client error in transaction (${tempTableTypes.mkString(",")}): ${t.getMessage}"
-            )
-          case otherStatusCode =>
-            logger.error(
-              s"Error in transaction (${tempTableTypes
-                  .mkString(",")}). ${t.getClass.getName} with status $otherStatusCode: ${t.getMessage}"
-            )
-        }
-      case _ =>
-        logger.error(
-          s"Transaction with temporary tables failed for (${tempTableTypes.mkString(",")}). ${t.getClass.getName}: ${t.getMessage}"
-        )
-    }
 
   def initWithLiquibase(liquibaseChangeLog: String, parameters: Map[String, AnyRef]) = {
     val dbConnection = database.source.createConnection()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/DataSource.scala
@@ -75,9 +75,9 @@ class SlickDataSource(val databaseConfig: DatabaseConfig[JdbcProfile])(implicit 
     }
 
     database.run(callerActionWithTempTables.withPinnedSession).recover { case t: Throwable =>
-      // log the transaction error at WARN level. Since we rethrow the error, calling code is responsible for handling
+      // log the transaction error at DEBUG level. Since we rethrow the error, calling code is responsible for handling
       // it and, if appropriate, logging at ERROR level. Only ERROR-level logs are picked up as Sentry alerts.
-      logger.warn(
+      logger.debug(
         s"Transaction with temporary tables failed for (${tempTableTypes.mkString(",")}). ${t.getClass.getName}: ${t.getMessage}"
       )
       throw t


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1905

We were logging and rethrowing errors in `DataSource.inTransactionWithAttrTempTable`. This led to many cases of double-logging, which led to many cases of double-alerting via Sentry.

This PR keeps the [log-and-rethrow anti-pattern](https://softwareengineering.stackexchange.com/questions/365427/try-catch-log-rethrow-is-anti-pattern), but changes the log to DEBUG level; debug-level logs are currently filtered out by our logback.xml.

Because I haven't audited EVERY place that calls `DataSource.inTransactionWithAttrTempTable`, I left the logging in; it would be trivial to turn on debug logs for `DataSource` if we needed them.



---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
