### PR TITLE
AJ-1910: ignore non-5xx errors logged by workbench-libs when talking to Google

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilter.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.rawls.util
 
+import com.google.api.client.http.HttpResponseException
+import com.google.cloud.http.BaseHttpServiceException
 import io.sentry.SentryEvent
 
 object SentryEventFilter {
@@ -22,10 +24,24 @@ object SentryEventFilter {
                   if throwable.getMessage.contains("requester pays bucket but no user project provided") ||
                     throwable.getMessage.contains("billing account for the owning project is disabled") =>
                 null
+              // workbench-libs logs all error responses from Google APIs at ERROR level, including 4xx client errors.
+              // these would get picked up by Sentry, but we don't want them to. Check the status code returned by
+              // Google and filter out client errors.
+              //
+              // HttpResponseException covers GoogleJsonResponseException and TokenResponseException
+              case Some(googleResponse: HttpResponseException) if isStatusCodeIgnorable(googleResponse.getStatusCode) =>
+                null
+              // BaseHttpServiceException covers BigQueryException, ResourceManagerException, StorageException
+              case Some(googleService: BaseHttpServiceException) if isStatusCodeIgnorable(googleService.getCode) =>
+                null
               case _ =>
                 event
             }
           case _ => event
         }
     }
+
+  private def isStatusCodeIgnorable(code: Int): Boolean =
+    Option(code).nonEmpty && code > 0 && code / 100 < 5
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilter.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/SentryEventFilter.scala
@@ -42,6 +42,6 @@ object SentryEventFilter {
     }
 
   private def isStatusCodeIgnorable(code: Int): Boolean =
-    Option(code).nonEmpty && code > 0 && code / 100 < 5
+    Option(code).nonEmpty && code > 0 && code < 500
 
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1910

Rawls sends a lot of alerts to Sentry that are actually 4xx errors from Google.

Turns out that workbench-libs, which Rawls relies on, logs all errors from Google at ERROR level. This happens even if the response from Google is a 4xx status code:

https://github.com/broadinstitute/workbench-libs/blob/5d1d38da768d1c1779877362a6fbb64b30c6aba0/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/package.scala#L87

The code referenced above has a "warnOnError" flag, but that flag is mostly unused within workbench-libs, much less Rawls.

This PR adds filtering of Sentry events. It looks for specific Google exception classes, extracts their status codes, and prevents sending to Sentry for non-5xx errors. It also sends exceptions of code 0 to Sentry; 0 indicates an unknown status code.

Tested by running locally, setting a Sentry DSN in my local env, and monitoring results.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
