### PR TITLE
AJ-268: update to latest workbench-libs, which removes trial billing references

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,11 +7,11 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.17.1"
 
-  val workbenchLibsHash = "3a8f98c"
-  val serviceTestV = s"4.4-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.30-${workbenchLibsHash}"
+  val workbenchLibsHash = "9138393"
+  val serviceTestV = s"5.0-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
-  val workbenchModelV  = s"0.19-${workbenchLibsHash}"
+  val workbenchModelV  = s"0.20-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.8-${workbenchLibsHash}"
 
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,9 +83,9 @@ object Dependencies {
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.7"
 
-  val workbenchLibsHash = "49b30c1"
+  val workbenchLibsHash = "9138393"
 
-  val workbenchModelV  = s"0.19-${workbenchLibsHash}"
+  val workbenchModelV  = s"0.20-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-268

This updates Rawls's automation subdirectory (swat tests) to the latest versions of workbench-libs libraries. The latest version of service-test removes knowledge of the trial-billing SA. This is a prerequisite for removing knowledge of trial-billing from the github workflows that run the swat tests, which in turn unblocks removing that unused SA entirely.

This pulls in https://github.com/broadinstitute/workbench-libs/pull/1692

I am making this change across Sam, Leo, Rawls, and Orch:
* https://github.com/DataBiosphere/leonardo/pull/4685
* https://github.com/broadinstitute/sam/pull/1471
* https://github.com/broadinstitute/rawls/pull/2940
* https://github.com/broadinstitute/firecloud-orchestration/pull/1385

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
