### PR TITLE
[WOR-1693] Add swat test to verify Sam resource type definitions

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.17.2"
 
-  val workbenchLibsHash = "9138393"
+  val workbenchLibsHash = "d47b6d4"
   val serviceTestV = s"5.0-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.withTemporaryBi
 import org.broadinstitute.dsde.workbench.fixture._
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName}
-import org.broadinstitute.dsde.workbench.service.SamModel.{AccessPolicyMembership, AccessPolicyResponseEntry}
+import org.broadinstitute.dsde.workbench.service.SamModel.{AccessPolicyMembership, AccessPolicyResponseEntry, ResourceRole, ResourceType}
 import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.service.test.{CleanUp, RandomUtil}
 import org.broadinstitute.dsde.workbench.util.Retry
@@ -149,6 +149,51 @@ class RawlsApiSpec
     Rawls.parseResponse(Rawls.getRequest(s"${Rawls.url}api/submissions/queueStatus"))
 
   "Rawls" - {
+    "should agree with Sam on the permissions it sets on its resources" in {
+      implicit val token: AuthToken = owner.makeAuthToken()
+      val resourceTypes = Sam.config.listResourceTypes()
+
+      resourceTypes.collect {
+        case ResourceType(typeName, roles, _, _, _, _) if typeName.equals("workspace") =>
+          roles.collect {
+            case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("owner") =>
+              actions should contain allElementsOf(List("share_policy::reader", "share_policy::share-reader", "share_policy::writer", "share_policy::share-writer", "share_policy::can-compute", "share_policy::owner", "write", "own", "compute", "delete", "read_auth_domain", "update_auth_domain"))
+              descendantRoles.get("google-project") shouldBe Option(Set("owner"))
+            case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("reader") =>
+              actions should contain allElementsOf(List("read", "read_policy::owner", "read_auth_domain"))
+              actions should not contain allElementsOf(List("write", "compute"))
+              descendantRoles.get("google-project") shouldBe Option(Set("pet-creator"))
+            case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("writer") =>
+              actions should contain allElementsOf(List("write", "read", "read_policy::owner", "read_auth_domain"))
+              actions should not contain allElementsOf(List("compute"))
+              descendantRoles.get("google-project") shouldBe Option(Set("pet-creator"))
+            case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("can-compute") =>
+              actions should contain allElementsOf(List("compute"))
+              descendantRoles.get("google-project") shouldBe Option(Set("notebook-user"))
+          }
+        case ResourceType(typeName, roles, _, _, _, _) if typeName.equals("billing-project") =>
+          roles.collect {
+            case ResourceRole(roleName, actions, _, _) if roleName.equals("owner") =>
+              actions should contain allElementsOf(List("view_status", "create_workspace", "alter_policies", "add_to_service_perimeter", "delete", "update_billing_account", "alter_spend_report_configuration", "read_spend_report_configuration", "read_spend_report"))
+            case ResourceRole(roleName, actions, _, _) if roleName.equals("workspace-creator") =>
+              actions should contain allElementsOf(List("view_status", "create_workspace"))
+            case ResourceRole(roleName, actions, _, _) if roleName.equals("batch-compute-user") =>
+              actions should contain allElementsOf(List("launch_batch_compute"))
+          }
+        case ResourceType(typeName, roles, _, _, _, _) if typeName.equals("google-project") =>
+          roles.collect {
+            case ResourceRole(roleName, actions, _, includedRoles) if roleName.equals("owner") =>
+              actions should contain allElementsOf(List("delete", "set_parent", "read_policies"))
+              includedRoles should contain allElementsOf(List("notebook-user", "pet-creator"))
+            case ResourceRole(roleName, actions, _, includedRoles) if roleName.equals("notebook-user") =>
+              actions should contain allElementsOf(List("add_child"))
+              includedRoles should contain allElementsOf(List("pet-creator"))
+            case ResourceRole(roleName, actions, _, _) if roleName.equals("pet-creator") =>
+              actions should contain allElementsOf(List("create-pet"))
+          }
+      }
+    }
+
     "should retrieve sub-workflow metadata and outputs from Cromwell" taggedAs MethodsTest in {
       implicit val token: AuthToken = studentB.makeAuthToken()
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -161,11 +161,11 @@ class RawlsApiSpec
               descendantRoles.get("google-project") shouldBe Option(Set("owner"))
             case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("reader") =>
               actions should contain allElementsOf(List("read", "read_policy::owner", "read_auth_domain"))
-              actions should not contain allElementsOf(List("write", "compute"))
+              actions should contain noElementsOf(List("write", "compute"))
               descendantRoles.get("google-project") shouldBe Option(Set("pet-creator"))
             case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("writer") =>
               actions should contain allElementsOf(List("write", "read", "read_policy::owner", "read_auth_domain"))
-              actions should not contain allElementsOf(List("compute"))
+              actions should contain noElementsOf(List("compute"))
               descendantRoles.get("google-project") shouldBe Option(Set("pet-creator"))
             case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("can-compute") =>
               actions should contain allElementsOf(List("compute"))


### PR DESCRIPTION
Ticket: [WOR-1693](https://broadworkbench.atlassian.net/browse/WOR-1693)
* These aren't all the actions that are included in each role. Instead, I selected the list based on what the current automated tests are checking as well as a few other actions that Rawls checks. I largely omitted actions that Leo uses as those are best tested by Leo.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1693]: https://broadworkbench.atlassian.net/browse/WOR-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ