### PR TITLE
WOR-1754 Update Bard Client and use Spring Web 6

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/BardService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/BardService.scala
@@ -4,8 +4,8 @@ import bio.terra.bard.api.DefaultApi
 import bio.terra.bard.client.ApiClient
 import bio.terra.bard.model.EventsEventLogRequest
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.http.impl.client.HttpClients
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+import org.apache.hc.client5.http.impl.classic.HttpClients
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager
 import org.broadinstitute.dsde.rawls.metrics.logEvents.BardEvent
 import org.broadinstitute.dsde.rawls.model.UserInfo
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   // allowing for Rawls to upgrade its Scala version without requiring any changes to this artifact.
   val cromwellClient: ModuleID =    "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP"
 
-  val bardClient: ModuleID = "bio.terra" % "bard-client-resttemplate" % "1.0.6" exclude("org.springframework", "spring-aop") exclude("org.springframework", "spring-jcl")
+  val bardClient: ModuleID = "bio.terra" % "bard-client-resttemplate" % "1.0.7" exclude("org.springframework", "spring-aop") exclude("org.springframework", "spring-jcl")
   val httpComponents5: ModuleID = "org.apache.httpcomponents.client5" % "httpclient5" % "5.3.1" // Needed for connection pooling with the Bard client
 
   val googleApiClient: ModuleID =             excludeGuavaJDK5("com.google.api-client"  % "google-api-client"                         % googleV)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,8 @@ object Dependencies {
   // allowing for Rawls to upgrade its Scala version without requiring any changes to this artifact.
   val cromwellClient: ModuleID =    "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP"
 
-  val bardClient: ModuleID = "bio.terra" % "bard-client-resttemplate-javax" % "1.0.6" exclude("org.springframework", "spring-aop") exclude("org.springframework", "spring-jcl")
+  val bardClient: ModuleID = "bio.terra" % "bard-client-resttemplate" % "1.0.6" exclude("org.springframework", "spring-aop") exclude("org.springframework", "spring-jcl")
+  val httpComponents5: ModuleID = "org.apache.httpcomponents.client5" % "httpclient5" % "5.3.1" // Needed for connection pooling with the Bard client
 
   val googleApiClient: ModuleID =             excludeGuavaJDK5("com.google.api-client"  % "google-api-client"                         % googleV)
   val googleCloudBilling: ModuleID =          excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudbilling"          % ("v1-rev20220908-" + googleV))
@@ -232,6 +233,7 @@ object Dependencies {
     typesafeConfig,
     sentryLogback,
     bardClient,
+    httpComponents5,
     slick,
     slickHikariCP,
     akkaHttp,

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -25,6 +25,8 @@ object Merging {
     case x if x.endsWith("kotlin_module")                => MergeStrategy.first
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.concat
     case x if x.endsWith("arrow-git.properties")         => MergeStrategy.concat
+    case x if x.endsWith("aot.factories")                => MergeStrategy.first
+    case x if x.endsWith("public-suffix-list.txt")       => MergeStrategy.first
     case x                                               => oldStrategy(x)
   }
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1754
Rawls was pulling in a javax version of Bard, which is needed for java versions below 17 (like Cromwell). Since Rawls is on Java 17, it should be using the Jakarta version of Bard!

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
