### PR TITLE
[WOR-1717] 400 when auth domain requested for Azure workspace instead of ignoring it

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5851,7 +5851,8 @@ components:
         authorizationDomain:
           type: array
           description: The list of groups in the Authorization Domain (empty if no
-            AD is set)
+            AD is set). Not supported for Azure workspaces. To limit Azure workspace 
+            access to members of a set of Terra groups, use a group-constraint policy instead.
           items:
             $ref: '#/components/schemas/ManagedGroupRef'
         attributes:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -388,6 +388,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
   ): Future[Workspace] = {
 
     assertBillingProfileCreationDate(profile)
+    validateWorkspaceRequest(request)
     val workspaceId = UUID.randomUUID()
     // Merge together source workspace and destination request attributes
     val mergedAttributes = sourceWorkspace.attributes ++ request.attributes
@@ -499,6 +500,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
   ): Future[Workspace] = {
 
     assertBillingProfileCreationDate(profile)
+    validateWorkspaceRequest(request)
 
     val wsmConfig = multiCloudWorkspaceConfig.workspaceManager
     val workspaceId = UUID.randomUUID()
@@ -649,6 +651,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
                                 parentContext: RawlsRequestContext = ctx
   ): Future[Workspace] = {
     assertBillingProfileCreationDate(profile)
+    validateWorkspaceRequest(workspaceRequest)
 
     traceFutureWithParent("createMultiCloudWorkspace", parentContext)(s1 =>
       createMultiCloudWorkspaceInt(workspaceRequest, UUID.randomUUID(), profile, s1) andThen { case Success(_) =>
@@ -656,6 +659,16 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
       }
     )
   }
+
+  private def validateWorkspaceRequest(request: WorkspaceRequest): Unit =
+    if (request.authorizationDomain.exists(authDomain => authDomain.nonEmpty)) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(
+          StatusCodes.BadRequest,
+          "Azure workspaces do not support authorization domains. To limit workspace access to members of a set of Terra groups, use a group-constraint policy."
+        )
+      )
+    }
 
   def assertBillingProfileCreationDate(profile: ProfileModel): Unit = {
     val previewDate = new DateTime(2023, 9, 12, 0, 0, DateTimeZone.UTC)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceService.scala
@@ -661,7 +661,7 @@ class MultiCloudWorkspaceService(override val ctx: RawlsRequestContext,
   }
 
   private def validateWorkspaceRequest(request: WorkspaceRequest): Unit =
-    if (request.authorizationDomain.exists(authDomain => authDomain.nonEmpty)) {
+    if (request.authorizationDomain.exists(_.nonEmpty)) {
       throw new RawlsExceptionWithErrorReport(
         ErrorReport(
           StatusCodes.BadRequest,


### PR DESCRIPTION
Ticket: [WOR-1717](https://broadworkbench.atlassian.net/browse/WOR-1717)
* Return a 400 if any groups are passed in the `authorizationDomain` field of a create or clone workspace request. Rawls used to just ignore these groups which isn't a very clear user experience. Users can set an auth domain on the workspace in Sam by using a `group-constraint` policy

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1717]: https://broadworkbench.atlassian.net/browse/WOR-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ