### PR TITLE
[DDO-3704] Make bucketUsage fail faster for inactive projects

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -3010,7 +3010,7 @@ class WorkspaceService(protected val ctx: RawlsRequestContext,
       requireAccessIgnoreLockF(workspaceContext, SamWorkspaceActions.write) {
         // if we get here, we passed all the hoops, otherwise an exception would have been thrown
         gcsDAO.getBucketUsage(workspaceContext.googleProjectId, workspaceContext.bucketName).recoverWith {
-          // Throw with the status code of the google exception (for example 403 for invalid billing, 400 for requester pays)
+          // Throw with the status code of the google exception (for example 403 for invalid billing, 404 for inactive project)
           // instead of a 500 to avoid Sentry notifications.
           case t: GoogleJsonResponseException =>
             val code = getStatusCodeHandlingUnknown(t.getStatusCode)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-3704

This PR improves error handling for the `getBucketUsage` API: if the project is inactive, it will now fail fast with the google status code, instead of retrying and eventually returning 500/502 with a stack trace in the error message.

This is needed to allow deletion of GCP workspaces whose projects have been deleted by Janitor. Terra UI calls `getBucketUsage` in the path of workspace deletion, and this change allows Terra UI to recover from the error.

See https://github.com/DataBiosphere/terra-ui/pull/4950

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
