### PR TITLE
WOR-1776: don't fail on 404s from leo when deleting workspace resources

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunner.scala
@@ -4,6 +4,8 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
+
+import org.broadinstitute.dsde.workbench.client.leonardo.{ApiException => LeoException}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceManagerResourceMonitorRecord.JobType.{
   LeoAppDeletionPoll,
   LeoRuntimeDeletionPoll,
@@ -121,6 +123,7 @@ class WorkspaceDeletionRunner(val samDAO: SamDAO,
       case WorkspaceDeleteInit => completeStep(job, workspace, ctx)
       case LeoAppDeletionPoll =>
         leoService.pollAppDeletion(workspace, ctx).transformWith {
+          case Failure(e: LeoException) if e.getCode == 404 => completeStep(job, workspace, ctx)
           case Failure(t) =>
             Future.failed(
               new WorkspaceDeletionException(
@@ -133,6 +136,7 @@ class WorkspaceDeletionRunner(val samDAO: SamDAO,
         }
       case LeoRuntimeDeletionPoll =>
         leoService.pollRuntimeDeletion(workspace, ctx).transformWith {
+          case Failure(e: LeoException) if e.getCode == 404 => completeStep(job, workspace, ctx)
           case Failure(t) =>
             Future.failed(
               new WorkspaceDeletionException(
@@ -190,12 +194,17 @@ class WorkspaceDeletionRunner(val samDAO: SamDAO,
     job.jobType match {
       case WorkspaceDeleteInit =>
         for {
-          _ <- leoService.deleteApps(workspace, ctx)
+          _ <- leoService.deleteApps(workspace, ctx).recover {
+            case e: LeoException if e.getCode == 404 =>
+              logger.warn(s"No runtime found when deleting workspace ${workspace.workspaceId}", e)
+          }
           _ <- monitorRecordDao.update(job.copy(jobType = LeoAppDeletionPoll))
         } yield Incomplete
       case LeoAppDeletionPoll =>
         for {
-          _ <- leoService.deleteRuntimes(workspace, ctx)
+          _ <- leoService.deleteRuntimes(workspace, ctx).recover {
+            case e: LeoException => logger.warn(s"No runtime found when deleting workspace ${workspace.workspaceId}", e)
+          }
           _ <- monitorRecordDao.update(job.copy(jobType = LeoRuntimeDeletionPoll))
         } yield Incomplete
       case LeoRuntimeDeletionPoll =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunner.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunner.scala
@@ -202,8 +202,8 @@ class WorkspaceDeletionRunner(val samDAO: SamDAO,
         } yield Incomplete
       case LeoAppDeletionPoll =>
         for {
-          _ <- leoService.deleteRuntimes(workspace, ctx).recover {
-            case e: LeoException => logger.warn(s"No runtime found when deleting workspace ${workspace.workspaceId}", e)
+          _ <- leoService.deleteRuntimes(workspace, ctx).recover { case e: LeoException =>
+            logger.warn(s"No runtime found when deleting workspace ${workspace.workspaceId}", e)
           }
           _ <- monitorRecordDao.update(job.copy(jobType = LeoRuntimeDeletionPoll))
         } yield Incomplete

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -202,8 +202,8 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     )
     whenReady(
       runner.runStep(monitorRecord.copy(jobType = JobType.WorkspaceDeleteInit),
-        azureWorkspace,
-        RawlsRequestContext(null, null)
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
       )
     )(_ shouldBe Incomplete)
     verify(leoDeletion).deleteApps(any, any)(any)
@@ -259,8 +259,8 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     )
     whenReady(
       runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll),
-        azureWorkspace,
-        RawlsRequestContext(null, null)
+                     azureWorkspace,
+                     RawlsRequestContext(null, null)
       )
     )(_ shouldBe Incomplete)
     verify(leoDeletion).pollAppDeletion(any, any)(any)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -184,7 +184,7 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     }
   }
 
-  it should "return complete when leo returns a 404 for the workspace when deleting apps" in {
+  it should "continue on when leo returns a 404 for the workspace when deleting apps" in {
     val leoDeletion = mock[LeonardoService]
     when(leoDeletion.deleteApps(any, any)(any))
       .thenReturn(Future.failed(new ApiException(404, "Workspace Not Found")))
@@ -239,7 +239,7 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     verify(leoDeletion).deleteRuntimes(any(), any())(any[ExecutionContext]())
   }
 
-  it should "return complete when leo returns a 404 for the workspace when deleting runtimes or polling for app deletion" in {
+  it should "continue on when leo returns a 404 for the workspace when deleting runtimes or polling for app deletion" in {
     val leoDeletion = mock[LeonardoService]
     when(leoDeletion.pollAppDeletion(any, any)(any))
       .thenReturn(Future.failed(new ApiException(404, "Workspace Not Found")))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/workspace/runners/deletion/WorkspaceDeletionRunnerSpec.scala
@@ -184,6 +184,32 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     }
   }
 
+  it should "return complete when leo returns a 404 for the workspace when deleting apps" in {
+    val leoDeletion = mock[LeonardoService]
+    when(leoDeletion.deleteApps(any, any)(any))
+      .thenReturn(Future.failed(new ApiException(404, "Workspace Not Found")))
+    val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
+    when(recordDao.update(any)).thenReturn(Future.successful(1))
+
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO],
+      mock[WorkspaceManagerDAO],
+      mock[WorkspaceRepository],
+      leoDeletion,
+      mock[WsmDeletionAction],
+      mock[GoogleServicesDAO],
+      recordDao
+    )
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.WorkspaceDeleteInit),
+        azureWorkspace,
+        RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Incomplete)
+    verify(leoDeletion).deleteApps(any, any)(any)
+    verify(recordDao).update(any)
+  }
+
   behavior of "leo runtime deletion orchestration"
 
   it should "delete leo runtimes and update the job after leo apps are deleted" in {
@@ -211,6 +237,35 @@ class WorkspaceDeletionRunnerSpec extends AnyFlatSpec with MockitoSugar with Mat
     verify(leoDeletion).pollAppDeletion(any(), any())(any[ExecutionContext]())
     verify(recordDao).update(jobUpdate)
     verify(leoDeletion).deleteRuntimes(any(), any())(any[ExecutionContext]())
+  }
+
+  it should "return complete when leo returns a 404 for the workspace when deleting runtimes or polling for app deletion" in {
+    val leoDeletion = mock[LeonardoService]
+    when(leoDeletion.pollAppDeletion(any, any)(any))
+      .thenReturn(Future.failed(new ApiException(404, "Workspace Not Found")))
+    when(leoDeletion.deleteRuntimes(any, any)(any))
+      .thenReturn(Future.failed(new ApiException(404, "Workspace Not Found")))
+    val recordDao = mock[WorkspaceManagerResourceMonitorRecordDao]
+    when(recordDao.update(any)).thenReturn(Future.successful(1))
+
+    val runner = new WorkspaceDeletionRunner(
+      mock[SamDAO],
+      mock[WorkspaceManagerDAO],
+      mock[WorkspaceRepository],
+      leoDeletion,
+      mock[WsmDeletionAction],
+      mock[GoogleServicesDAO],
+      recordDao
+    )
+    whenReady(
+      runner.runStep(monitorRecord.copy(jobType = JobType.LeoAppDeletionPoll),
+        azureWorkspace,
+        RawlsRequestContext(null, null)
+      )
+    )(_ shouldBe Incomplete)
+    verify(leoDeletion).pollAppDeletion(any, any)(any)
+    verify(leoDeletion).deleteRuntimes(any, any)(any)
+    verify(recordDao).update(any)
   }
 
   it should "return incomplete when leo runtimes are not deleted" in {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1776

If all runtimes/apps for a workspace are already gone, or they are all in an inactive state, leo will throw a 404 when deleting all of that resource for a workspace.

If this happens, we should continue deleting the workspace.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
