### PR TITLE
[WOR-1788] Fix metrics reporting for failed requests

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/InstrumentationDirectives.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/InstrumentationDirectives.scala
@@ -98,7 +98,6 @@ trait InstrumentationDirectives extends RawlsInstrumented with TracingDirectives
   private lazy val globalRequestCounter = ExpandedMetricBuilder.empty.asCounter("request")
   private lazy val globalRequestTimer = ExpandedMetricBuilder.empty.asTimer("latency")
 
-
   /**
     * Captures elapsed time of request and increments counter.
     * Important note: the route passed into this directive in test code must be sealed

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/InstrumentationDirectives.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/InstrumentationDirectives.scala
@@ -98,6 +98,12 @@ trait InstrumentationDirectives extends RawlsInstrumented with TracingDirectives
   private lazy val globalRequestCounter = ExpandedMetricBuilder.empty.asCounter("request")
   private lazy val globalRequestTimer = ExpandedMetricBuilder.empty.asTimer("latency")
 
+
+  /**
+    * Captures elapsed time of request and increments counter.
+    * Important note: the route passed into this directive in test code must be sealed
+    * otherwise exceptions escape and are not instrumented appropriately.
+    */
   def captureRequestMetrics: Directive0 = extractRequest.tflatMap { request =>
     val timeStamp = System.currentTimeMillis
     mapResponse { response =>
@@ -111,9 +117,7 @@ trait InstrumentationDirectives extends RawlsInstrumented with TracingDirectives
   }
 
   /**
-    * Captures elapsed time of request and increments counter.
-    * Important note: the route passed into this directive in test code must be sealed
-    * otherwise exceptions escape and are not instrumented appropriately.
+    * Traces requests and provides the OpenTelemetry Context.
     */
   def traceRequests: Directive1[Context] =
     traceRequest.tflatMap(otelContext => provide(otelContext._1))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/InstrumentationDirectives.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/InstrumentationDirectives.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.server.Directives.provide
 import akka.http.scaladsl.server.PathMatchers.Segment
 import akka.http.scaladsl.server.directives.BasicDirectives.{extractRequest, mapResponse}
 import akka.http.scaladsl.server.directives.PathDirectives._
-import akka.http.scaladsl.server.{Directive1, PathMatcher, PathMatcher0}
+import akka.http.scaladsl.server.{Directive0, Directive1, PathMatcher, PathMatcher0}
 import io.opentelemetry.context.Context
 
 import java.util.concurrent.TimeUnit
@@ -98,21 +98,23 @@ trait InstrumentationDirectives extends RawlsInstrumented with TracingDirectives
   private lazy val globalRequestCounter = ExpandedMetricBuilder.empty.asCounter("request")
   private lazy val globalRequestTimer = ExpandedMetricBuilder.empty.asTimer("latency")
 
+  def captureRequestMetrics: Directive0 = extractRequest.tflatMap { request =>
+    val timeStamp = System.currentTimeMillis
+    mapResponse { response =>
+      val elapsed = System.currentTimeMillis - timeStamp
+      globalRequestCounter.inc()
+      globalRequestTimer.update(elapsed, TimeUnit.MILLISECONDS)
+      httpRequestCounter(ExpandedMetricBuilder.empty)(request._1, response).inc()
+      httpRequestTimer(ExpandedMetricBuilder.empty)(request._1, response).update(elapsed, TimeUnit.MILLISECONDS)
+      response
+    }
+  }
+
   /**
     * Captures elapsed time of request and increments counter.
     * Important note: the route passed into this directive in test code must be sealed
     * otherwise exceptions escape and are not instrumented appropriately.
     */
-  def instrumentRequest: Directive1[Context] =
-    (traceRequest & extractRequest).tflatMap { case (otelContext, request) =>
-      val timeStamp = System.currentTimeMillis
-      mapResponse { response =>
-        val elapsed = System.currentTimeMillis - timeStamp
-        globalRequestCounter.inc()
-        globalRequestTimer.update(elapsed, TimeUnit.MILLISECONDS)
-        httpRequestCounter(ExpandedMetricBuilder.empty)(request, response).inc()
-        httpRequestTimer(ExpandedMetricBuilder.empty)(request, response).update(elapsed, TimeUnit.MILLISECONDS)
-        response
-      } & provide(otelContext)
-    }
+  def traceRequests: Directive1[Context] =
+    traceRequest.tflatMap(otelContext => provide(otelContext._1))
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -140,15 +140,13 @@ trait RawlsApiService
       servicePerimeterRoutes(otelContext) ~
       snapshotRoutes(otelContext)
 
-  val instrumentedRoutes = instrumentRequest(baseApiRoutes)
-
   def apiRoutes =
     options(complete(OK)) ~
       withExecutionContext(ExecutionContext.global) { // Serve real work off the global EC to free up the dispatcher to run more routes, including status
-        instrumentedRoutes
+        traceRequests(baseApiRoutes)
       }
 
-  def route: server.Route = (logRequestResult & handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(
+  def route: server.Route = (logRequestResult & captureRequestMetrics & handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(
     RawlsApiService.rejectionHandler
   )) {
     openIDConnectConfiguration.swaggerRoutes("swagger/api-docs.yaml") ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -146,15 +146,16 @@ trait RawlsApiService
         traceRequests(baseApiRoutes)
       }
 
-  def route: server.Route = (logRequestResult & captureRequestMetrics & handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(
-    RawlsApiService.rejectionHandler
-  )) {
-    openIDConnectConfiguration.swaggerRoutes("swagger/api-docs.yaml") ~
-      openIDConnectConfiguration.oauth2Routes(materializer.system) ~
-      versionRoutes ~
-      statusRoute ~
-      pathPrefix("api")(apiRoutes)
-  }
+  def route: server.Route =
+    (logRequestResult & captureRequestMetrics & handleExceptions(RawlsApiService.exceptionHandler) & handleRejections(
+      RawlsApiService.rejectionHandler
+    )) {
+      openIDConnectConfiguration.swaggerRoutes("swagger/api-docs.yaml") ~
+        openIDConnectConfiguration.oauth2Routes(materializer.system) ~
+        versionRoutes ~
+        statusRoute ~
+        pathPrefix("api")(apiRoutes)
+    }
 
   // basis for logRequestResult lifted from http://stackoverflow.com/questions/32475471/how-does-one-log-akka-http-client-requests
   private def logRequestResult: Directive0 = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -58,7 +58,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
     withStatsD {
       Get("/admin/submissions") ~>
-        sealRoute(instrumentRequest(services.adminRoutes)) ~>
+        sealRoute(traceRequests(services.adminRoutes)) ~>
         check {
           assertResult(StatusCodes.OK) {
             status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -58,7 +58,7 @@ class AdminApiServiceSpec extends ApiServiceSpec {
 
     withStatsD {
       Get("/admin/submissions") ~>
-        sealRoute(traceRequests(services.adminRoutes)) ~>
+        sealRoute(captureRequestMetrics(traceRequests(services.adminRoutes))) ~>
         check {
           assertResult(StatusCodes.OK) {
             status

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -411,7 +411,7 @@ trait ApiServiceSpec
     val appVersion = ApplicationVersion("dummy", "dummy", "dummy")
 
     // for metrics testing
-    val sealedInstrumentedRoutes: Route = instrumentRequest { otelContext =>
+    val sealedInstrumentedRoutes: Route = traceRequests { otelContext =>
       sealRoute(
         adminRoutes(otelContext) ~
           billingRoutesV2(otelContext) ~

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -411,19 +411,21 @@ trait ApiServiceSpec
     val appVersion = ApplicationVersion("dummy", "dummy", "dummy")
 
     // for metrics testing
-    val sealedInstrumentedRoutes: Route = traceRequests { otelContext =>
-      sealRoute(
-        adminRoutes(otelContext) ~
-          billingRoutesV2(otelContext) ~
-          billingRoutes(otelContext) ~
-          entityRoutes(otelContext) ~
-          methodConfigRoutes(otelContext) ~
-          notificationsRoutes ~
-          statusRoute ~
-          submissionRoutes(otelContext) ~
-          userRoutes(otelContext) ~
-          workspaceRoutes(otelContext)
-      )
+    val sealedInstrumentedRoutes: Route = captureRequestMetrics {
+      traceRequests { otelContext =>
+        sealRoute(
+          adminRoutes(otelContext) ~
+            billingRoutesV2(otelContext) ~
+            billingRoutes(otelContext) ~
+            entityRoutes(otelContext) ~
+            methodConfigRoutes(otelContext) ~
+            notificationsRoutes ~
+            statusRoute ~
+            submissionRoutes(otelContext) ~
+            userRoutes(otelContext) ~
+            workspaceRoutes(otelContext)
+        )
+      }
     }
 
     override val openIDConnectConfiguration = FakeOpenIDConnectConfiguration

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiServiceSpec.scala
@@ -20,7 +20,7 @@ class RawlsApiServiceSpec extends ApiServiceSpec with VersionApiService {
   "RootRawlsApiService" should "get a version" in {
     withStatsD {
       Get("/version") ~>
-        sealRoute(instrumentRequest(_ => versionRoutes)) ~>
+        sealRoute(traceRequests(_ => versionRoutes)) ~>
         check {
           assertResult(StatusCodes.OK)(status)
           assertResult(appVersion)(responseAs[ApplicationVersion])

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiServiceSpec.scala
@@ -20,7 +20,7 @@ class RawlsApiServiceSpec extends ApiServiceSpec with VersionApiService {
   "RootRawlsApiService" should "get a version" in {
     withStatsD {
       Get("/version") ~>
-        sealRoute(traceRequests(_ => versionRoutes)) ~>
+        sealRoute(captureRequestMetrics(traceRequests(_ => versionRoutes))) ~>
         check {
           assertResult(StatusCodes.OK)(status)
           assertResult(appVersion)(responseAs[ApplicationVersion])


### PR DESCRIPTION
Ticket: [WOR-1788](https://broadworkbench.atlassian.net/browse/WOR-1788)
* When a request resulted in an exception caught by the `RawlsApiService.exceptionHandler`, it would not count towards any metrics. I separated out the metrics from the trace to make the refactor a little simpler, and moved the metrics directive up a level so that it will always execute on a request, even if that request ends up being handled by the exception handler.
* Tested by running Rawls locally and verifying that I could get an error code request counter (`dev_firecloud_rawls_httpRequestMethod_post_httpRequestUri_api_workspaces_httpResponseStatusCode_409_request`) to increment using this code and that the same counter was not incremented when running `develop`.
* Also verified that tracing still works by setting the sampling probability to 1 and making sure traces were being emitted to GCP correctly.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1788]: https://broadworkbench.atlassian.net/browse/WOR-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ