### PR TITLE
AJ-1937: use ReadCommitted for more data table transactions

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -229,18 +229,20 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                                    gatherInputsResult: GatherInputsResult,
                                    workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]
   ): Future[Stream[SubmissionValidationEntityInputs]] =
-    dataSource.inTransaction { dataAccess =>
-      withEntityRecsForExpressionEval(expressionEvaluationContext, workspaceContext, dataAccess) { jobEntityRecs =>
-        // Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
-        evaluateExpressionsInternal(workspaceContext,
-                                    gatherInputsResult.processableInputs,
-                                    jobEntityRecs,
-                                    dataAccess
-        ) map { valuesByEntity =>
-          createSubmissionValidationEntityInputs(valuesByEntity)
-        }
-      }
-    }
+    dataSource.inTransaction(
+      dataAccess =>
+        withEntityRecsForExpressionEval(expressionEvaluationContext, workspaceContext, dataAccess) { jobEntityRecs =>
+          // Parse out the entity -> results map to a tuple of (successful, failed) SubmissionValidationEntityInputs
+          evaluateExpressionsInternal(workspaceContext,
+                                      gatherInputsResult.processableInputs,
+                                      jobEntityRecs,
+                                      dataAccess
+          ) map { valuesByEntity =>
+            createSubmissionValidationEntityInputs(valuesByEntity)
+          }
+        },
+      TransactionIsolation.ReadCommitted
+    )
 
   override def expressionValidator: ExpressionValidator = new LocalEntityExpressionValidator
 
@@ -286,11 +288,12 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
   }
 
   override def getEntity(entityType: String, entityName: String): Future[Entity] =
-    dataSource.inTransaction { dataAccess =>
-      withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-        DBIO.successful(entity)
-      }
-    }
+    dataSource.inTransaction(dataAccess =>
+                               withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+                                 DBIO.successful(entity)
+                               },
+                             TransactionIsolation.ReadCommitted
+    )
 
   /**
     * Returns the components needed to stream a EntityQueryResponse to an end user in response to the entityQuery API.
@@ -325,9 +328,10 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     // if filtering by name, retrieve that entity directly, else do the full query:
     nameFilter match {
       case Some(entityName) =>
-        dataSource.inTransaction { dataAccess =>
-          dataAccess.entityQuery.loadSingleEntityForPage(workspaceContext, entityType, entityName, query)
-        } map { case (unfilteredCount, filteredCount, entity) =>
+        dataSource.inTransaction(
+          dataAccess => dataAccess.entityQuery.loadSingleEntityForPage(workspaceContext, entityType, entityName, query),
+          TransactionIsolation.ReadCommitted
+        ) map { case (unfilteredCount, filteredCount, entity) =>
           val pageCount = if (entity.nonEmpty) 1 else 0
           val entitySource = if (entity.nonEmpty) Source.single(entity.head) else Source.empty
 
@@ -367,25 +371,27 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                                query: EntityQuery,
                                parentContext: RawlsRequestContext
   ): Future[EntityQueryResultMetadata] =
-    dataSource.inTransaction { dataAccess =>
-      for {
-        (unfilteredCount, filteredCount) <- dataAccess.entityQuery.loadEntityPageCounts(workspaceContext,
-                                                                                        entityType,
-                                                                                        query,
-                                                                                        parentContext
-        )
-      } yield {
-        val pageCount: Int = Math.ceil(filteredCount.toFloat / query.pageSize).toInt
-        if (filteredCount > 0 && query.page > pageCount) {
-          throw new DataEntityException(
-            code = StatusCodes.BadRequest,
-            message = s"requested page ${query.page} is greater than the number of pages $pageCount"
+    dataSource.inTransaction(
+      dataAccess =>
+        for {
+          (unfilteredCount, filteredCount) <- dataAccess.entityQuery.loadEntityPageCounts(workspaceContext,
+                                                                                          entityType,
+                                                                                          query,
+                                                                                          parentContext
           )
-        }
+        } yield {
+          val pageCount: Int = Math.ceil(filteredCount.toFloat / query.pageSize).toInt
+          if (filteredCount > 0 && query.page > pageCount) {
+            throw new DataEntityException(
+              code = StatusCodes.BadRequest,
+              message = s"requested page ${query.page} is greater than the number of pages $pageCount"
+            )
+          }
 
-        EntityQueryResultMetadata(unfilteredCount, filteredCount, pageCount)
-      }
-    }
+          EntityQueryResultMetadata(unfilteredCount, filteredCount, pageCount)
+        },
+      TransactionIsolation.ReadCommitted
+    )
 
   /**
    * generates a Source[Entity, _] representing the individual Entity results for the incoming query.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1937

I reviewed the use of `dataSource.inTransaction` and `dataSource.inTransactionWithAttrTempTable` in data table-related queries. This PR changes all read-only queries which were not already set to `ReadCommitted` isolation level to use `ReadCommitted`.

I have not touched write queries. Those will typically use `RepeatableRead` isolation level, which is the default.

So, this PR should be a fairly conservative change - I'm only lowering isolation level on a few read-only queries.

_Reviewer: you'll want to ignore whitespace in the diff!_


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
