### PR TITLE
[WOR-1774] Add canShare and canCompute to workspaces list response

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6026,10 +6026,12 @@ components:
             The AzureManagedAppCoordinates of the billing project, if this is an Azure workspace.
         bucketOptions:
           $ref: '#/components/schemas/WorkspaceBucketOptions'
-        canCompute:
-          type: boolean
         canShare:
           type: boolean
+          description: True if the user can share the workspace with others, false otherwise
+        canCompute:
+          type: boolean
+          description: True if the user can launch compute in this workspace, false otherwise
         catalog:
           type: boolean
         owners:
@@ -6063,6 +6065,12 @@ components:
           $ref: '#/components/schemas/WorkspaceAccessLevel'
         public:
           type: boolean
+        canShare:
+          type: boolean
+          description: True if the user can share the workspace with others, false otherwise
+        canCompute:
+          type: boolean
+          description: True if the user can launch compute in this workspace, false otherwise
         workspace:
           $ref: '#/components/schemas/WorkspaceDetails'
         workspaceSubmissionStats:

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
-import io.opencensus.trace.Span
 import io.opentelemetry.context.Context
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestData
@@ -230,6 +229,8 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
             Set(
               WorkspaceListResponse(
                 WorkspaceAccessLevels.Owner,
+                Some(true),
+                Some(true),
                 WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime),
                                                          Option(Set.empty),
                                                          true,
@@ -241,6 +242,8 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
               ),
               WorkspaceListResponse(
                 WorkspaceAccessLevels.Owner,
+                Some(true),
+                Some(true),
                 WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime),
                                                          Option(Set.empty),
                                                          true,
@@ -273,6 +276,8 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
             Set(
               WorkspaceListResponse(
                 WorkspaceAccessLevels.Owner,
+                Some(true),
+                Some(true),
                 WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime),
                                                          Option(Set.empty),
                                                          true,
@@ -284,6 +289,8 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
               ),
               WorkspaceListResponse(
                 WorkspaceAccessLevels.Owner,
+                Some(true),
+                Some(true),
                 WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime),
                                                          Option(Set.empty),
                                                          true,
@@ -427,15 +434,15 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
   }
 
   it should "throw error with unrecognized field value" in withTestWorkspacesApiServices { services =>
-    // NB: "canShare" is valid for get-workspace but not list-workspaces.
-    Get("/workspaces?fields=accessLevel,somethingNotRecognized,canShare") ~>
+    // NB: "workspaceType" is valid for get-workspace but not list-workspaces.
+    Get("/workspaces?fields=accessLevel,workspaceType,somethingNotRecognized") ~>
       sealRoute(services.workspaceRoutes()) ~>
       check {
         assertResult(StatusCodes.BadRequest)(status)
         val actual = responseAs[ErrorReport]
 
         // NB: field names in error response are alphabetized for deterministic behavior
-        assertResult("Unrecognized field names: canShare, somethingNotRecognized")(actual.message)
+        assertResult("Unrecognized field names: somethingNotRecognized, workspaceType")(actual.message)
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -1264,6 +1264,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
           Set(
             WorkspaceListResponse(
               WorkspaceAccessLevels.Owner,
+              Some(true),
+              Some(true),
               WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace.copy(lastModified = dateTime),
                                                        Option(Set.empty),
                                                        true,
@@ -1275,6 +1277,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             ),
             WorkspaceListResponse(
               WorkspaceAccessLevels.Owner,
+              Some(true),
+              Some(true),
               WorkspaceDetails.fromWorkspaceAndOptions(testWorkspaces.workspace2.copy(lastModified = dateTime),
                                                        Option(Set.empty),
                                                        true,
@@ -1343,6 +1347,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
             Set(
               WorkspaceListResponse(
                 WorkspaceAccessLevels.Owner,
+                Some(true),
+                Some(true),
                 WorkspaceDetails.fromWorkspaceAndOptions(testData.workspace.copy(lastModified = dateTime),
                                                          Option(Set.empty),
                                                          true,
@@ -1354,6 +1360,8 @@ class WorkspaceApiServiceSpec extends ApiServiceSpec {
               ),
               WorkspaceListResponse(
                 WorkspaceAccessLevels.Owner,
+                Some(true),
+                Some(true),
                 WorkspaceDetails.fromWorkspaceAndOptions(
                   testData.workspaceFailedSubmission.copy(lastModified = dateTime),
                   Option(Set.empty),

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -798,6 +798,8 @@ case class MethodRepoConfigurationExport(
 )
 
 case class WorkspaceListResponse(accessLevel: WorkspaceAccessLevel,
+                                 canShare: Option[Boolean],
+                                 canCompute: Option[Boolean],
                                  workspace: WorkspaceDetails,
                                  workspaceSubmissionStats: Option[WorkspaceSubmissionStats],
                                  public: Boolean,
@@ -1312,7 +1314,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspaceDetailsFormat: RootJsonFormat[WorkspaceDetails] = jsonFormat21(WorkspaceDetails.apply)
 
-  implicit val WorkspaceListResponseFormat: RootJsonFormat[WorkspaceListResponse] = jsonFormat5(WorkspaceListResponse)
+  implicit val WorkspaceListResponseFormat: RootJsonFormat[WorkspaceListResponse] = jsonFormat7(WorkspaceListResponse)
 
   implicit val WorkspaceResponseFormat: RootJsonFormat[WorkspaceResponse] = jsonFormat10(WorkspaceResponse)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1774

Need `canCompute` for https://github.com/DataBiosphere/terra-ui/pull/4978, and adding `canShare` at the same time so we can reduce complexity in terra-ui with regard to the dynamic workspace menu (displayed from the workspaces list view).

I will need to publish a new rawls model and update orchestration.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
