### PR TITLE
[WOR-1706] Allow owners to remove themselves from billing projects

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/RawlsApiSpec.scala
@@ -160,7 +160,7 @@ class RawlsApiSpec
       val resourceTypes = Sam.config.listResourceTypes()
 
       resourceTypes.collect {
-        case ResourceType(typeName, roles, actionPatterns, _, _, _) if typeName.equals("workspace") =>
+        case ResourceType(typeName, roles, actionPatterns, _, _, allowLeaving) if typeName.equals("workspace") =>
           roles.collect {
             case ResourceRole(roleName, actions, descendantRoles, _) if roleName.equals("owner") =>
               actions should contain allElementsOf (List(
@@ -194,7 +194,8 @@ class RawlsApiSpec
             case ResourceActionPattern(authDomainConstrainable, _, value) if value.equals("read") =>
               authDomainConstrainable shouldBe true
           }
-        case ResourceType(typeName, roles, _, _, _, _) if typeName.equals("billing-project") =>
+          allowLeaving shouldBe true
+        case ResourceType(typeName, roles, _, _, _, allowLeaving) if typeName.equals("billing-project") =>
           roles.collect {
             case ResourceRole(roleName, actions, _, _) if roleName.equals("owner") =>
               actions should contain allElementsOf (List(
@@ -213,7 +214,8 @@ class RawlsApiSpec
             case ResourceRole(roleName, actions, _, _) if roleName.equals("batch-compute-user") =>
               actions should contain allElementsOf (List("launch_batch_compute"))
           }
-        case ResourceType(typeName, roles, _, _, _, _) if typeName.equals("google-project") =>
+          allowLeaving shouldBe true
+        case ResourceType(typeName, roles, _, _, _, allowLeaving) if typeName.equals("google-project") =>
           roles.collect {
             case ResourceRole(roleName, actions, _, includedRoles) if roleName.equals("owner") =>
               actions should contain allElementsOf (List("delete", "set_parent", "read_policies"))
@@ -224,6 +226,7 @@ class RawlsApiSpec
             case ResourceRole(roleName, actions, _, _) if roleName.equals("pet-creator") =>
               actions should contain allElementsOf (List("create-pet"))
           }
+          allowLeaving shouldBe true
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -79,6 +79,8 @@ trait BillingProfileManagerDAO {
                                 ctx: RawlsRequestContext
   ): Unit
 
+  def leaveProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit
+
   def getStatus(): SystemStatus
 
   @throws(classOf[BpmAzureSpendReportApiException])
@@ -279,6 +281,11 @@ class BillingProfileManagerDAOImpl(
         policy.toString,
         memberEmail
       )
+
+  def leaveProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =
+    apiClientProvider
+      .getProfileApi(ctx)
+      .leaveProfile(billingProfileId)
 
   override def getStatus(): SystemStatus = apiClientProvider.getUnauthenticatedApi().serviceStatus()
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -667,7 +667,7 @@ class UserService(
     requireProjectAction(projectName, SamBillingProjectActions.alterPolicies) {
       for {
         billingProfileId <- billingRepository.getBillingProfileId(projectName)
-        _ <- billingProfileId match {
+        _ = billingProfileId match {
           case Some(billingProfileId) =>
             billingProfileManagerDAO.deleteProfilePolicyMember(
               UUID.fromString(billingProfileId),
@@ -675,8 +675,7 @@ class UserService(
               projectAccessUpdate.email,
               ctx
             )
-            Future.successful()
-          case None => Future.successful()
+          case None => ()
         }
         _ <- removeUserFromBillingProjectInner(projectName, projectAccessUpdate)
       } yield {}

--- a/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
+++ b/pact4s/src/test/scala/org/broadinstitute/dsde/rawls/consumer/BpmClientSpec.scala
@@ -264,6 +264,17 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
 
   pactDslResponse = pactDslResponse
     .`given`("an Azure billing profile")
+    .`given`("a Sam service that supports leaving resources")
+    .uponReceiving("Request to leave a billing profile")
+    .method("DELETE")
+    .pathFromProviderState("/api/profiles/v1/${azureProfileId}/leave",
+                           s"/api/profiles/v1/${dummyBillingProfileId}/leave"
+    )
+    .willRespondWith()
+    .status(204)
+
+  pactDslResponse = pactDslResponse
+    .`given`("an Azure billing profile")
     .`given`("a Sam service that supports profile policy member addition")
     .uponReceiving("Request to add a profile policy member")
     .method("POST")
@@ -378,6 +389,14 @@ class BpmClientSpec extends AnyFlatSpec with Matchers with RequestResponsePactFo
     for {
       billingProfiles <- billingProfileManagerDAO.getAllBillingProfiles(testContext)
     } yield billingProfiles.length shouldBe 2
+  }
+
+  it should "allow leaving a profile" in {
+    val billingProfileManagerDAO = new BillingProfileManagerDAOImpl(
+      new HttpBillingProfileManagerClientProvider(Some(mockServer.getUrl)),
+      multiCloudWorkspaceConfig
+    )
+    billingProfileManagerDAO.leaveProfile(dummyBillingProfileId, testContext)
   }
 
   it should "allow the addition of a profile policy member" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.1139-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.568.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.562-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.565-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.23-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.264")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/WOR-1706](https://broadworkbench.atlassian.net/browse/WOR-1706)

Adds support for a new `leaveProfile` BPM endpoint, which can be used to allow owners to leave billing projects. Rawls additionally contains the logic that determines whether to call `leaveProfile` or the original `deleteProfilePolicyMember` endpoint. This happens outside of BPM because `deleteProfilePolicyMember` returns an updated policy, which is not possible to return to a user who no longer has access. If we want to keep it backwards-compatible, we need a separate way to leave a profile without returning policy information.

There is an added unit test for the Rawls logic, updated contract testing between Rawls and BPM, and updated testing for the necessary Sam configuration (i.e. `allowLeaving` must be turned on for spend profiles and billing projects).

Demo: https://github.com/user-attachments/assets/2e27209d-47a3-4457-a288-25188aed7f88

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
