### PR TITLE
add handler for SQL exceptions

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -67,7 +67,7 @@ object RawlsApiService extends LazyLogging {
           s"Unhandled SQL exception with sentry id [$sentryId]: ${sql.getMessage} [${sql.getErrorCode} ${sql.getSQLState}] ${sql.getNextException}",
           sql
         )
-        val message = s"Internal server exception with sentry id: [${sentryId.toString}]"
+        val message = s"Internal server exception [sentryId=${sentryId.toString}]"
         complete(StatusCodes.InternalServerError -> ErrorReport(message))
       case wsmApiException: ApiException =>
         if (wsmApiException.getCode >= 500) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -48,10 +48,14 @@ trait WorkspaceApiService extends UserInfoDirectives {
             parameterSeq { allParams =>
               parameter("stringAttributeMaxLength".as[Int].withDefault(-1)) { stringAttributeMaxLength =>
                 complete {
-                  throw new SQLException("Super Secret Message")
-                  //workspaceServiceConstructor(ctx).listWorkspaces(
-                   // WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
-                    //stringAttributeMaxLength
+                  val fields =  WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
+                  val fieldParams = fields.fields.getOrElse(Set.empty)
+                  if(fieldParams.contains("testException")) {
+                    throw new SQLException("Super Secret Message")
+                  }
+                  workspaceServiceConstructor(ctx).listWorkspaces(
+                    WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                    stringAttributeMaxLength
                   )
                 }
               }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -14,7 +14,6 @@ import org.broadinstitute.dsde.rawls.webservice.CustomDirectives._
 import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceService, WorkspaceService}
 import spray.json.DefaultJsonProtocol._
 
-import java.sql.SQLException
 import scala.concurrent.ExecutionContext
 
 /**
@@ -48,11 +47,6 @@ trait WorkspaceApiService extends UserInfoDirectives {
             parameterSeq { allParams =>
               parameter("stringAttributeMaxLength".as[Int].withDefault(-1)) { stringAttributeMaxLength =>
                 complete {
-                  val fields =  WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
-                  val fieldParams = fields.fields.getOrElse(Set.empty)
-                  if(fieldParams.contains("testException")) {
-                    throw new SQLException("Super Secret Message")
-                  }
                   workspaceServiceConstructor(ctx).listWorkspaces(
                     WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
                     stringAttributeMaxLength

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.rawls.webservice.CustomDirectives._
 import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceService, WorkspaceService}
 import spray.json.DefaultJsonProtocol._
 
+import java.sql.SQLException
 import scala.concurrent.ExecutionContext
 
 /**
@@ -47,9 +48,10 @@ trait WorkspaceApiService extends UserInfoDirectives {
             parameterSeq { allParams =>
               parameter("stringAttributeMaxLength".as[Int].withDefault(-1)) { stringAttributeMaxLength =>
                 complete {
-                  workspaceServiceConstructor(ctx).listWorkspaces(
-                    WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
-                    stringAttributeMaxLength
+                  throw new SQLException("Super Secret Message")
+                  //workspaceServiceConstructor(ctx).listWorkspaces(
+                   // WorkspaceFieldSpecs.fromQueryParams(allParams, "fields"),
+                    //stringAttributeMaxLength
                   )
                 }
               }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiServiceSpec.scala
@@ -1,11 +1,29 @@
 package org.broadinstitute.dsde.rawls.webservice
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import akka.http.scaladsl.server.Directives._
+import io.sentry.Sentry
+import io.sentry.protocol.SentryId
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.mockito.ArgumentMatchers.any
+import spray.json.RootJsonFormat
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+
+import java.sql.SQLException
+import java.util.UUID
 import org.broadinstitute.dsde.rawls.dataaccess.{HttpExecutionServiceDAO, MockShardedExecutionServiceCluster}
 import org.broadinstitute.dsde.rawls.model.ExecutionJsonSupport.ExecutionServiceVersionFormat
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ApplicationVersionFormat
 import org.broadinstitute.dsde.rawls.model.{ApplicationVersion, ExecutionServiceVersion}
+import spray.json.DefaultJsonProtocol._
+
+import scala.language.postfixOps
+import java.sql.SQLTransactionRollbackException
+import scala.concurrent.ExecutionContext
+import scala.util.Using
 
 /**
  * Created by dvoet on 1/26/16.
@@ -39,4 +57,72 @@ class RawlsApiServiceSpec extends ApiServiceSpec with VersionApiService {
         responseAs[ExecutionServiceVersion]
       }
   }
+
+  behavior of "ExceptionHandler"
+
+  import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+
+  def testRoute(callback: () => Unit = () => ()): server.Route = {
+    implicit val ec: ExecutionContext = ExecutionContext.global
+    case class TestResponse(ok: Boolean)
+    implicit val TestResponseFormat: RootJsonFormat[TestResponse] = jsonFormat1(TestResponse)
+    path("test") {
+      get {
+        complete {
+          callback()
+          StatusCodes.OK -> TestResponse(true)
+        }
+      }
+    }
+  }
+
+  it should "does not trigger for normal completion" in {
+    val routes = sealRoute(handleExceptions(RawlsApiService.exceptionHandler) {
+      testRoute()
+    })
+    Get("/test") ~>
+      routes ~>
+      check {
+        status shouldBe StatusCodes.OK
+      }
+  }
+
+  it should "wrap a SQLTransactionRollbackException in an ErrorReport" in {
+    val sqlException = new SQLTransactionRollbackException("some message")
+    val routes = sealRoute(handleExceptions(RawlsApiService.exceptionHandler) {
+      testRoute(() => throw sqlException)
+    })
+    Get("/test") ~>
+      routes ~>
+      check {
+        status shouldBe StatusCodes.InternalServerError
+        val report = responseAs[ErrorReport]
+        report.message should include("some message")
+      }
+  }
+
+  it should "expose a generic error message with an errorId for an SQLException" in
+    Using(mockStatic(classOf[Sentry])) { sentry =>
+      val errorId = UUID.randomUUID()
+      // we need to explicitly de-sugar the mocking setup,
+      // because the scala compiler doesn't do the same implicit casting as java
+      sentry
+        .when(new MockedStatic.Verification {
+          override def apply(): Unit = Sentry.captureException(any[Throwable])
+        })
+        .thenReturn(new SentryId(errorId))
+      val sqlException = new SQLException("some message")
+      val routes = sealRoute(handleExceptions(RawlsApiService.exceptionHandler) {
+        testRoute(() => throw sqlException)
+      })
+      Get("/test") ~>
+        routes ~>
+        check {
+          status shouldBe StatusCodes.InternalServerError
+          val report = responseAs[ErrorReport]
+          report.message should not include "some message"
+          report.message should include(errorId.toString.replace("-", ""))
+        }
+    }
+
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-654
<Put notes here to help reviewer understand this PR>

Adds a top level exception handler to handle `SQLException`s:
 * Don't return the raw exception or include a stacktrace
 * Log original exception
 * Include an ID to look up the error in the logs


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
