### PR TITLE
AJ-1027: simplify saveEntityPatch signature

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -708,7 +708,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
         traceDBIOWithParent("saveEntityPatchSequence", span) { innerSpan =>
           DBIO.sequence(entityUpdates map { entityUpd =>
             dataAccess.entityQuery
-              .saveEntityPatch(workspace, entityUpd.entityRef, entityUpd.upserts, Seq(), innerSpan)
+              .saveEntityPatch(workspace, entityUpd.entityRef, entityUpd.upserts, innerSpan)
               .withStatementParameters(statementInit = _.setQueryTimeout(queryTimeout.toSeconds.toInt))
           })
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponentSpec.scala
@@ -1873,7 +1873,6 @@ class AttributeComponentSpec
             context,
             testData.sample1.toReference,
             inserts,
-            Seq.empty[AttributeName],
             RawlsTracingContext(None)
           )
         )
@@ -1888,12 +1887,7 @@ class AttributeComponentSpec
         val expectedAfterUpdate = testData.sample1.attributes ++ updates
 
         runAndWait(
-          entityQuery.saveEntityPatch(context,
-                                      testData.sample1.toReference,
-                                      updates,
-                                      Seq.empty[AttributeName],
-                                      RawlsTracingContext(None)
-          )
+          entityQuery.saveEntityPatch(context, testData.sample1.toReference, updates, RawlsTracingContext(None))
         )
 
         val resultAfterUpdate = runAndWait(entityQuery.get(context, "Sample", "sample1")).head.attributes


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-1027

found while looking at AJ-1027; does not resolve that ticket.

The `saveEntityPatch()` method accepted an argument `deletes`. This argument was hardcoded to always be `Seq()`. It was only called from one place - `SubmissionMonitorActor` - and that place always sent `Seq()`.

In this PR, I remove the `deletes` argument entirely, along with any logic that looked at that argument. I've updated unit tests as appropriate.

Hopefully this simplifies the method, if only by a little bit.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
