### PR TITLE
[WX-1800] Fix Rawls not returning 404 when method version doesn't exist

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/methods/MethodConfigurationService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/methods/MethodConfigurationService.scala
@@ -478,32 +478,6 @@ class MethodConfigurationService(
       vmc <- entityProvider.expressionValidator.validateMCExpressions(methodConfiguration, gatherInputsResult)
     } yield vmc
 
-//  private def gatherMethodConfigInputs(
-//    methodConfig: MethodConfiguration
-//  ): Future[MethodConfigResolver.GatherInputsResult] =
-//    toFutureTry(methodRepoDAO.getMethod(methodConfig.methodRepoMethod, ctx.userInfo)).map {
-//      case Success(None) =>
-//        throw new RawlsExceptionWithErrorReport(
-//          errorReport = ErrorReport(StatusCodes.NotFound,
-//                                    s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."
-//          )
-//        )
-//      case Success(Some(wdl)) =>
-//        methodConfigResolver
-//          .gatherInputs(ctx.userInfo, methodConfig, wdl)
-//          .recoverWith { case regrets =>
-//            Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
-//          }
-//          .get
-//      case Failure(throwable) =>
-//        throw new RawlsExceptionWithErrorReport(
-//          errorReport = ErrorReport(StatusCodes.BadGateway,
-//                                    s"Unable to query the method repo.",
-//                                    methodRepoDAO.toErrorReport(throwable)
-//          )
-//        )
-//    }
-
   private def getEntityProviderForMethodConfig(workspaceContext: Workspace,
                                                methodConfiguration: MethodConfiguration
   ): Future[EntityProvider] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/methods/MethodConfigurationUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/methods/MethodConfigurationUtils.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.rawls.methods
+
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.dataaccess.MethodRepoDAO
+import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, MethodConfiguration, RawlsRequestContext}
+import org.broadinstitute.dsde.workbench.util.FutureSupport.toFutureTry
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+object MethodConfigurationUtils {
+
+  def gatherMethodConfigInputs(ctx: RawlsRequestContext,
+                               methodRepoDAO: MethodRepoDAO,
+                               methodConfig: MethodConfiguration,
+                               methodConfigResolver: MethodConfigResolver
+  )(implicit executionContext: ExecutionContext): Future[MethodConfigResolver.GatherInputsResult] =
+    toFutureTry(methodRepoDAO.getMethod(methodConfig.methodRepoMethod, ctx.userInfo)).map {
+      case Success(None) =>
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(StatusCodes.NotFound,
+            s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."
+          )
+        )
+      case Success(Some(wdl)) =>
+        methodConfigResolver
+          .gatherInputs(ctx.userInfo, methodConfig, wdl)
+          .recoverWith { case regrets =>
+            Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
+          }
+          .get
+      case Failure(throwable) =>
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(StatusCodes.BadGateway,
+            s"Unable to query the method repo.",
+            methodRepoDAO.toErrorReport(throwable)
+          )
+        )
+    }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -804,32 +804,6 @@ class SubmissionsService(
       EntityRequestArguments(workspaceContext, ctx, methodConfiguration.dataReferenceName, None)
     )
 
-//  private def gatherMethodConfigInputs(
-//    methodConfig: MethodConfiguration
-//  ): Future[MethodConfigResolver.GatherInputsResult] =
-//    toFutureTry(methodRepoDAO.getMethod(methodConfig.methodRepoMethod, ctx.userInfo)).map {
-//      case Success(None) =>
-//        throw new RawlsExceptionWithErrorReport(
-//          errorReport = ErrorReport(StatusCodes.NotFound,
-//                                    s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."
-//          )
-//        )
-//      case Success(Some(wdl)) =>
-//        methodConfigResolver
-//          .gatherInputs(ctx.userInfo, methodConfig, wdl)
-//          .recoverWith { case regrets =>
-//            Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
-//          }
-//          .get
-//      case Failure(throwable) =>
-//        throw new RawlsExceptionWithErrorReport(
-//          errorReport = ErrorReport(StatusCodes.BadGateway,
-//                                    s"Unable to query the method repo.",
-//                                    methodRepoDAO.toErrorReport(throwable)
-//          )
-//        )
-//    }
-
   private def saveSubmission(workspaceContext: Workspace,
                              submissionId: UUID,
                              submissionRequest: SubmissionRequest,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -22,6 +22,7 @@ import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.genomics.GenomicsService
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
+import org.broadinstitute.dsde.rawls.methods.MethodConfigurationUtils
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureMode
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
@@ -566,7 +567,11 @@ class SubmissionsService(
 
       _ = submissionRequest.userComment.map(validateMaxStringLength(_, "userComment", UserCommentMaxLength))
 
-      gatherInputsResult <- gatherMethodConfigInputs(methodConfig)
+      gatherInputsResult <- MethodConfigurationUtils.gatherMethodConfigInputs(ctx,
+                                                                              methodRepoDAO,
+                                                                              methodConfig,
+                                                                              methodConfigResolver
+      )
 
       validationResult <- entityProvider.expressionValidator.validateExpressionsForSubmission(methodConfig,
                                                                                               gatherInputsResult
@@ -799,31 +804,31 @@ class SubmissionsService(
       EntityRequestArguments(workspaceContext, ctx, methodConfiguration.dataReferenceName, None)
     )
 
-  private def gatherMethodConfigInputs(
-    methodConfig: MethodConfiguration
-  ): Future[MethodConfigResolver.GatherInputsResult] =
-    toFutureTry(methodRepoDAO.getMethod(methodConfig.methodRepoMethod, ctx.userInfo)).map {
-      case Success(None) =>
-        throw new RawlsExceptionWithErrorReport(
-          errorReport = ErrorReport(StatusCodes.NotFound,
-                                    s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."
-          )
-        )
-      case Success(Some(wdl)) =>
-        methodConfigResolver
-          .gatherInputs(ctx.userInfo, methodConfig, wdl)
-          .recoverWith { case regrets =>
-            Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
-          }
-          .get
-      case Failure(throwable) =>
-        throw new RawlsExceptionWithErrorReport(
-          errorReport = ErrorReport(StatusCodes.BadGateway,
-                                    s"Unable to query the method repo.",
-                                    methodRepoDAO.toErrorReport(throwable)
-          )
-        )
-    }
+//  private def gatherMethodConfigInputs(
+//    methodConfig: MethodConfiguration
+//  ): Future[MethodConfigResolver.GatherInputsResult] =
+//    toFutureTry(methodRepoDAO.getMethod(methodConfig.methodRepoMethod, ctx.userInfo)).map {
+//      case Success(None) =>
+//        throw new RawlsExceptionWithErrorReport(
+//          errorReport = ErrorReport(StatusCodes.NotFound,
+//                                    s"Cannot get ${methodConfig.methodRepoMethod.methodUri} from method repo."
+//          )
+//        )
+//      case Success(Some(wdl)) =>
+//        methodConfigResolver
+//          .gatherInputs(ctx.userInfo, methodConfig, wdl)
+//          .recoverWith { case regrets =>
+//            Failure(new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regrets)))
+//          }
+//          .get
+//      case Failure(throwable) =>
+//        throw new RawlsExceptionWithErrorReport(
+//          errorReport = ErrorReport(StatusCodes.BadGateway,
+//                                    s"Unable to query the method repo.",
+//                                    methodRepoDAO.toErrorReport(throwable)
+//          )
+//        )
+//    }
 
   private def saveSubmission(workspaceContext: Workspace,
                              submissionId: UUID,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/methods/MethodConfigurationUtilsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/methods/MethodConfigurationUtilsSpec.scala
@@ -1,0 +1,82 @@
+package org.broadinstitute.dsde.rawls.methods
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import com.typesafe.config.ConfigFactory
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext, jobexec}
+import org.broadinstitute.dsde.rawls.config.{MethodRepoConfig, WDLParserConfig}
+import org.broadinstitute.dsde.rawls.dataaccess.{HttpMethodRepoDAO, MockCromwellSwaggerClient}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver
+import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
+import org.broadinstitute.dsde.rawls.jobexec.wdlparsing.CachingWDLParser
+import org.broadinstitute.dsde.rawls.mock.RemoteServicesMockServer
+import org.broadinstitute.dsde.rawls.model.{Agora, AgoraMethod, Dockstore, ErrorReport, ErrorReportSource, MethodConfiguration, RawlsRequestContext, RawlsUser, RawlsUserEmail, RawlsUserSubjectId, UserInfo}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+import slick.lifted.Functions.user
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+import scala.util.Success
+
+class MethodConfigurationUtilsSpec extends AnyFlatSpec with Matchers with TestDriverComponent {
+
+  implicit val actorSystem: ActorSystem = ActorSystem()
+
+  val mockServer: RemoteServicesMockServer = RemoteServicesMockServer()
+  val methodRepoDAO: HttpMethodRepoDAO = mock[HttpMethodRepoDAO]
+  val ctx: RawlsRequestContext = RawlsRequestContext(UserInfo(testData.userProjectOwner.userEmail, OAuth2BearerToken("foo"), 0, testData.userProjectOwner.userSubjectId))
+
+  val agoraMethodConf: MethodConfiguration = MethodConfiguration("dsde",
+    "no_input",
+    Some("Sample"),
+    None,
+    Map.empty,
+    Map.empty,
+    AgoraMethod("dsde", "no_input", 1))
+
+  behavior of "MethodConfigurationUtils"
+
+  it should "return results when method when found" in {
+    when(methodRepoDAO.getMethod(any(), any())).thenReturn(Future.successful(Option(meth1WDL)))
+
+    val future = MethodConfigurationUtils.gatherMethodConfigInputs(ctx, methodRepoDAO, agoraMethodConf, methodConfigResolver)
+    Await.ready(future, 30.seconds)
+    val Success(result) = future.value.get
+
+    // verify that it returns GatherInputsResult
+    result shouldBe a [GatherInputsResult]
+    result.missingInputs shouldBe Set("meth1.method1.i1")
+  }
+
+  it should "return 404 if method is not found" in {
+    when(methodRepoDAO.getMethod(any(), any())).thenReturn(Future.successful(None))
+
+    val exception = intercept[RawlsExceptionWithErrorReport](Await.result(MethodConfigurationUtils.gatherMethodConfigInputs(ctx, methodRepoDAO, agoraMethodConf, methodConfigResolver), 30.seconds))
+
+    // assert that if method is not found it returns 404
+    exception shouldBe a[RawlsExceptionWithErrorReport]
+    exception.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+    exception.errorReport.message shouldBe "Cannot get agora://dsde/no_input/1 from method repo."
+  }
+
+  it should "return 502 when something unexpected happens" in {
+    when(methodRepoDAO.getMethod(any(), any())).thenReturn(Future.failed(new RawlsException("exception thrown for testing purposes")))
+    when(methodRepoDAO.errorReportSource).thenReturn(ErrorReportSource("agora"))
+    when(methodRepoDAO.toErrorReport(any())).thenCallRealMethod()
+
+    val exception = intercept[RawlsExceptionWithErrorReport](Await.result(MethodConfigurationUtils.gatherMethodConfigInputs(ctx, methodRepoDAO, agoraMethodConf, methodConfigResolver), 30.seconds))
+
+    // assert that when Future fails, a 502 is returned with wrapped exception
+    exception shouldBe a[RawlsExceptionWithErrorReport]
+    exception.errorReport.statusCode shouldBe Option(StatusCodes.BadGateway)
+    exception.errorReport.message shouldBe "Unable to query the method repo."
+    exception.errorReport.causes.head.message shouldBe "exception thrown for testing purposes"
+    exception.errorReport.causes.head.source shouldBe "agora"
+  }
+}


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WX-1800
<Put notes here to help reviewer understand this PR>

This PR fixes the issue users were seeing in WX-1800. Details:
- fix for the bug are in commits https://github.com/broadinstitute/rawls/commit/ea10d5aac3fc39e8ad8e78bb66bd75962853282e and https://github.com/broadinstitute/rawls/commit/bc8e14f8178d8f3933f3adbbf3ef58acc3f5c898
- `gatherMethodConfigInputs()` was called in 2 services - MethodConfigurationService and SubmissionService. At both places the method body was same. Hence I extracted the method and put it in a new  `MethodConfigurationUtils` class
- added unit tests for `MethodConfigurationUtils.gatherMethodConfigInputs()`

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
