### PR TITLE
TSPS-276 update openapi yaml

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4548,8 +4548,7 @@ components:
           default: ""
         properties:
           type: object
-          description: A map of key-value pairs to associate with the snapshot. Optional, defaults to an empty map if not specified.
-          default: {}
+          description: A map of key-value pairs to associate with the snapshot.
         cloningInstructions:
           type: string
           default: COPY_NOTHING
@@ -5035,7 +5034,7 @@ components:
       type: object
       properties:
         value:
-          type: string
+          type: object
           description: the value of the input expression for the specified entity
         error:
           type: string

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -4548,7 +4548,7 @@ components:
           default: ""
         properties:
           type: object
-          description: A map of key-value pairs to associate with the snapshot.
+          description: A map of key-value pairs to associate with the snapshot. Optional, defaults to an empty map if not specified.
         cloningInstructions:
           type: string
           default: COPY_NOTHING


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TSPS-276

* update default value of `NamedDataRepoSnapshot` to be null so it is compatible with openapi generator for java code. otherwise you get something like Object = {} as the default and im not sure thats what it should be anyways.  Happy to chat about a better way of doing it, this just worked for us.
* update `SubmissionValidationValue` value field to be object instead of String because it can be a string or an array so this will just not parse correctly for array values.  realistically we should be using [oneOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) for this but again doesnt seem [supported yet](https://github.com/OpenAPITools/openapi-generator/issues?q=is%3Aissue+is%3Aopen+java+oneof) for java client generation.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
