### PR TITLE
[WOR-1197] Remove dupes and upgrade liquibase

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -88,10 +88,6 @@
     <include file="changesets/20201106_workspace_google_project_columns.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20201113_add_billing_account_workspace.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210430_add_workspace_billing_account_error_message.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20210524_add_memory_retry_multiplier.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20210609_add_workspace_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20210609_change_workspace_attr_temp_owner_id.xml" relativeToChangelogFile="true"/>
-    <include file="changesets/20210510_add_billing_project_export_columns.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210915_create_entity_cache_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210916_clone_workspace_file_transfer.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20210924_sharded_entity_tables.xml" relativeToChangelogFile="true"/>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20160318.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20160318.xml
@@ -10,7 +10,10 @@
             <column name="is_realm_acl" type="BIT"/>
         </addColumn>
     </changeSet>
-    <changeSet logicalFilePath="dummy" id="dvoet" author="fix_workspace_access_pk">
+    <changeSet logicalFilePath="dummy" id="dvoet" author="fix_workspace_access_pk" >
+        <!-- The id of this changeset is transposed with the author and thus collides with other similarly id'ed
+             changesets. Setting validCheckSum to 1:any to avoid checksum computation issues on liquibase upgrades -->
+        <validCheckSum>1:any</validCheckSum>
         <dropAllForeignKeyConstraints baseTableName="WORKSPACE_ACCESS"/>
         <dropPrimaryKey tableName="WORKSPACE_ACCESS" constraintName="PRIMARY"/>
         <addPrimaryKey columnNames="workspace_id, access_level, is_realm_acl" constraintName="PRIMARY" tableName="WORKSPACE_ACCESS"/>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161005_refactor_project_users.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161005_refactor_project_users.xml
@@ -27,6 +27,9 @@
     </changeSet>
 
     <changeSet logicalFilePath="dummy" author="mbemis" id="refactor-project-users-4">
+        <!-- Setting validCheckSum to 1:any to avoid checksum validation errors during liquibase upgrades due to string
+             interpolation in this changeset (i.e., ${gcs:appsDomain}) -->
+        <validCheckSum>1:any</validCheckSum>
         <sql stripComments="true">
             insert into `GROUP` select concat("PROJECT_",b.NAME,"-",r.role), concat("GROUP_PROJECT_",b.NAME,"-",r.role,"@","${gcs:appsDomain}") from BILLING_PROJECT b join temp_roles r
         </sql>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161026_superowner_workspace_acls.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20161026_superowner_workspace_acls.xml
@@ -8,6 +8,9 @@
     </changeSet>
 
     <changeSet logicalFilePath="dummy" author="mbemis" id="migrate-superowners-2">
+        <!-- Setting validCheckSum to 1:any to avoid checksum validation errors during liquibase upgrades due to string
+             interpolation in this changeset (i.e., ${gcs:appsDomain}) -->
+        <validCheckSum>1:any</validCheckSum>
         <sql stripComments="true">
             insert into super_owners_temp_no_realm select ws.id, ws.namespace,
                 concat("GROUP_", LOWER(CONCAT(
@@ -66,6 +69,9 @@
     </changeSet>
 
     <changeSet logicalFilePath="dummy" author="mbemis" id="migrate-superowners-9">
+        <!-- Setting validCheckSum to 1:any to avoid checksum validation errors during liquibase upgrades due to string
+             interpolation in this changeset (i.e., ${gcs:appsDomain}) -->
+        <validCheckSum>1:any</validCheckSum>
         <sql stripComments="true">
             insert into super_owners_temp_realm_intersection select ws.id, ws.namespace,
                 concat("GROUP_I_", LOWER(CONCAT(
@@ -87,6 +93,9 @@
     </changeSet>
 
     <changeSet logicalFilePath="dummy" author="mbemis" id="migrate-superowners-10">
+        <!-- Setting validCheckSum to 1:any to avoid checksum validation errors during liquibase upgrades due to string
+             interpolation in this changeset (i.e., ${gcs:appsDomain}) -->
+        <validCheckSum>1:any</validCheckSum>
         <sql stripComments="true">
             insert into super_owners_temp_realm select ws.id, ws.namespace,
                 concat("GROUP_", LOWER(CONCAT(

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170310_managed_groups.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170310_managed_groups.xml
@@ -27,6 +27,9 @@
     </changeSet>
 
     <changeSet id="insert-owner-groups" author="dvoet" logicalFilePath="dummy">
+        <!-- Setting validCheckSum to 1:any to avoid checksum validation errors during liquibase upgrades due to string
+             interpolation in this changeset (i.e., ${gcs:appsDomain}) -->
+        <validCheckSum>1:any</validCheckSum>
         <sql>
             insert into `GROUP` select concat(mg.USERS_GROUP_NAME,"-owners"), concat("GROUP_",mg.USERS_GROUP_NAME,"-owners","@","${gcs:appsDomain}"), now(), null from MANAGED_GROUP mg
         </sql>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170517_rename_tcga_group.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20170517_rename_tcga_group.xml
@@ -2,6 +2,9 @@
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
     <changeSet logicalFilePath="dummy" author="mbemis" id="rename-tcga-group-1">
+        <!-- Setting validCheckSum to 1:any to avoid checksum validation errors during liquibase upgrades due to string
+             interpolation in this changeset (i.e., ${gcs:appsDomain}) -->
+        <validCheckSum>1:any</validCheckSum>
         <sql stripComments="true">
             insert into `GROUP`(NAME, EMAIL) values ("TCGA-dbGaP-Authorized", concat("GROUP_TCGA-dbGaP-Authorized@", "${gcs:appsDomain}")), ("TCGA-dbGaP-Authorized-owners", concat("GROUP_TCGA-dbGaP-Authorized-owners@", "${gcs:appsDomain}"));
 

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220505_alter_fk_billing_account_changes.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20220505_alter_fk_billing_account_changes.xml
@@ -3,6 +3,9 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet logicalFilePath="dummy" author="ehigham" id="ALTER_BILLING_ACCOUNT_CHANGE_FK">
+        <!-- This file collides with 20220513_alter_entity_type_collation.xml, setting validCheckSum to 1:any here
+             as liquibase balks when it recomputes checksums in the event of an upgrade -->
+        <validCheckSum>1:any</validCheckSum>
         <comment>
             [CA-1875] The `FK_BILLING_ACCOUNT_CHANGES_PROJECT_NAME` foreign key constraint prevents
             users from deleting their billing projects if they changed the billing account.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,8 +80,7 @@ object Dependencies {
   val antlrParser: ModuleID =     "org.antlr"                     % "antlr4-runtime"        % "4.13.2"
   // protobuf is only need to use the MySQL X DevAPI which we don't. exclude it to avoid interference with Google client libraries
   val mysqlConnector: ModuleID =  "com.mysql"                         % "mysql-connector-j"  % "9.0.0" exclude("com.google.protobuf", "protobuf-java")
-  // Update warning for liquibase-core: Here be dragons! See https://broadworkbench.atlassian.net/browse/WOR-1197
-  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.17.2" // scala-steward:off
+  val liquibaseCore: ModuleID =   "org.liquibase"                 % "liquibase-core"        % "4.29.1"
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.7"
 


### PR DESCRIPTION
This upgrades liquibase to latest. A previous attempt failed out due to checksum validation failures at runtime. I pulled the changeset checksums from the `DATABASECHANGELOG` table in dev to a Bee. Running an upgraded liquibase reproduced the checksum errors. There are two issues:
  a) string interpolation within the changeset causing the checksum to be different than when the changeset originally ran or
  b) re-used id values between changesets

I've added a 'validCheckSum' element of '1:any' to the failing changesets, assuming they will not be changed in the future--all of the offending changesets are quite old and unlikely to change. This will prevent us from having to re-compute checksums any time there is a new algorithm version. 