### PR TITLE
[WOR-1808] Add soft delete policy to workspace settings

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5924,10 +5924,12 @@ components:
           description: The type of the workspace setting
           enum:
             - GcpBucketLifecycle
+            - GcpBucketSoftDelete
         config:
           description: The configuration of the workspace setting
           oneOf:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketLifecycleConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingGcpBucketSoftDeleteConfig'
     WorkspaceSettingGcpBucketLifecycleConfig:
       required:
         - rules
@@ -5970,6 +5972,14 @@ components:
           description: Object name prefixes that this rule applies to
           items:
             type: string
+    WorkspaceSettingGcpBucketSoftDeleteConfig:
+      required:
+        - retentionDuration
+      type: object
+      properties:
+        retentionDuration:
+          type: integer
+          description: The length of time to retain soft-deleted objects for, in seconds
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5974,10 +5974,10 @@ components:
             type: string
     WorkspaceSettingGcpBucketSoftDeleteConfig:
       required:
-        - retentionDuration
+        - retentionDurationInSeconds
       type: object
       properties:
-        retentionDuration:
+        retentionDurationInSeconds:
           type: integer
           description: The length of time to retain soft-deleted objects for, in seconds
     WorkspaceSubmissionStats:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -7,6 +7,7 @@ import com.google.api.services.cloudresourcemanager.model.Project
 import com.google.api.services.directory.model.Group
 import com.google.api.services.storage.model.{Bucket, BucketAccessControl, StorageObject}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
+import com.google.cloud.storage.BucketInfo.SoftDeletePolicy
 import org.broadinstitute.dsde.rawls.google.AccessContextManagerDAO
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model._
@@ -65,6 +66,8 @@ trait GoogleServicesDAO extends ErrorReportable {
   def deleteBucket(bucketName: String): Future[Boolean]
 
   def setBucketLifecycle(bucketName: String, lifecycle: List[LifecycleRule]): Future[Unit]
+
+  def setSoftDeletePolicy(bucketName: String, softDeletePolicy: SoftDeletePolicy): Future[Unit]
 
   def isAdmin(userEmail: String): Future[Boolean]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -338,6 +338,13 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       .drain
       .unsafeToFuture()
 
+  override def setSoftDeletePolicy(bucketName: String, softDeletePolicy: BucketInfo.SoftDeletePolicy): Future[Unit] =
+    googleStorageService
+      .setSoftDeletePolicy(GcsBucketName(bucketName), softDeletePolicy)
+      .compile
+      .drain
+      .unsafeToFuture()
+
   override def isAdmin(userEmail: String): Future[Boolean] =
     hasGoogleRole(adminGroupName, userEmail)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.GcpBucketLifecycleConfigFormat
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.GcpBucketLifecycleConfig
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
+  GcpBucketLifecycleConfigFormat,
+  GcpBucketSoftDeleteConfigFormat
+}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{GcpBucketLifecycleConfig, GcpBucketSoftDeleteConfig}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model._
 
@@ -53,6 +56,8 @@ object WorkspaceSettingRecord {
     val settingConfig = settingType match {
       case WorkspaceSettingTypes.GcpBucketLifecycle =>
         workspaceSettingRecord.config.parseJson.convertTo[GcpBucketLifecycleConfig]
+      case WorkspaceSettingTypes.GcpBucketSoftDelete =>
+        workspaceSettingRecord.config.parseJson.convertTo[GcpBucketSoftDeleteConfig]
     }
 
     WorkspaceSetting(settingType, settingConfig)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -53,14 +53,12 @@ object WorkspaceSettingRecord {
     import spray.json._
 
     val settingType = WorkspaceSettingTypes.withName(workspaceSettingRecord.settingType)
-    val settingConfig = settingType match {
+    settingType match {
       case WorkspaceSettingTypes.GcpBucketLifecycle =>
-        workspaceSettingRecord.config.parseJson.convertTo[GcpBucketLifecycleConfig]
+        GcpBucketLifecycleSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketLifecycleConfig])
       case WorkspaceSettingTypes.GcpBucketSoftDelete =>
-        workspaceSettingRecord.config.parseJson.convertTo[GcpBucketSoftDeleteConfig]
+        GcpBucketSoftDeleteSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketSoftDeleteConfig])
     }
-
-    WorkspaceSetting(settingType, settingConfig)
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -85,8 +85,8 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
             }
           case GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(retentionDuration)) =>
             val retentionDurationValidation = retentionDuration match {
-              case retentionDuration if retentionDuration < 0 || retentionDuration > 7776000 =>
-                Some(validationErrorReport(setting.settingType, "retention duration must be between 0 and 90 days"))
+              case retentionDuration if retentionDuration < 0 || retentionDuration > 7_776_000 =>
+                Some(validationErrorReport(setting.settingType, "retention duration must be from 0 to 90 days"))
               case _ => None
             }
             retentionDurationValidation

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -126,6 +126,9 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
   override def setBucketLifecycle(bucketName: String, lifecycle: List[BucketInfo.LifecycleRule]): Future[Unit] = ???
 
+  override def setSoftDeletePolicy(bucketName: String, softDeletePolicy: BucketInfo.SoftDeletePolicy): Future[Unit] =
+    ???
+
   override def getBucket(bucketName: String, userProject: Option[GoogleProjectId])(implicit
     executionContext: ExecutionContext
   ): Future[Either[String, Bucket]] = Future.successful(Right(new Bucket))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -9,7 +9,12 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketLifecycleRule
 }
-import org.broadinstitute.dsde.rawls.model.{Workspace, WorkspaceSetting, WorkspaceSettingTypes}
+import org.broadinstitute.dsde.rawls.model.{
+  GcpBucketLifecycleSetting,
+  Workspace,
+  WorkspaceSetting,
+  WorkspaceSettingTypes
+}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
@@ -43,8 +48,7 @@ class WorkspaceSettingRepositorySpec
     val workspaceRepo = new WorkspaceRepository(slickDataSource)
     val ws: Workspace = makeWorkspace()
     Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
-    val appliedSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val appliedSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -53,8 +57,7 @@ class WorkspaceSettingRepositorySpec
         )
       )
     )
-    val pendingSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val pendingSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -98,8 +101,7 @@ class WorkspaceSettingRepositorySpec
     val workspaceRepo = new WorkspaceRepository(slickDataSource)
     val ws: Workspace = makeWorkspace()
     Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
-    val setting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val setting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -129,8 +131,7 @@ class WorkspaceSettingRepositorySpec
     val workspaceRepo = new WorkspaceRepository(slickDataSource)
     val ws: Workspace = makeWorkspace()
     Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
-    val setting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val setting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -161,8 +162,7 @@ class WorkspaceSettingRepositorySpec
     val workspaceRepo = new WorkspaceRepository(slickDataSource)
     val ws: Workspace = makeWorkspace()
     Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
-    val existingSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val existingSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -171,8 +171,7 @@ class WorkspaceSettingRepositorySpec
         )
       )
     )
-    val newSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val newSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -235,8 +234,7 @@ class WorkspaceSettingRepositorySpec
     val workspaceRepo = new WorkspaceRepository(slickDataSource)
     val ws: Workspace = makeWorkspace()
     Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
-    val setting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val setting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -15,6 +15,8 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
 }
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
+  GcpBucketLifecycleSetting,
+  GcpBucketSoftDeleteSetting,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -76,8 +78,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
     val workspaceSettings = List(
-      WorkspaceSetting(WorkspaceSettingTypes.GcpBucketLifecycle,
-                       WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
+      GcpBucketLifecycleSetting(
+        WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
       )
     )
 
@@ -177,8 +179,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   "setWorkspaceSettings" should "set the workspace settings if there aren't any set" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val workspaceSetting = WorkspaceSetting(WorkspaceSettingTypes.GcpBucketLifecycle,
-                                            WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
+    val workspaceSetting = GcpBucketLifecycleSetting(
+      WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
     )
 
     val workspaceRepository = mock[WorkspaceRepository]
@@ -225,8 +227,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   it should "overwrite existing settings" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val existingSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val existingSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -235,8 +236,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         )
       )
     )
-    val newSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val newSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -295,8 +295,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   it should "not remove existing settings if no settings are specified" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val existingSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val existingSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -344,8 +343,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   it should "report errors while applying settings and remove pending settings" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val existingSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val existingSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -354,8 +352,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         )
       )
     )
-    val newSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val newSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -418,8 +415,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   it should "be limited to owners" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val newSetting = WorkspaceSetting(WorkspaceSettingTypes.GcpBucketLifecycle,
-                                      WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
+    val newSetting = GcpBucketLifecycleSetting(
+      WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
     )
 
     val workspaceRepository = mock[WorkspaceRepository]
@@ -455,8 +452,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   }
 
   "validateSettings" should "require a non-negative age for GcpBucketLifecycle settings" in {
-    val negativeAgeSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val negativeAgeSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -479,8 +475,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   }
 
   it should "not allow unsupported lifecycle actions for GcpBucketLifecycle settings" in {
-    val unsupportedActionSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val unsupportedActionSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("SetStorageClass"),
@@ -505,8 +500,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   }
 
   it should "require at least one condition for GcpBucketLifecycle settings" in {
-    val noConditionsSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val noConditionsSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"), GcpBucketLifecycleCondition(None, None))
@@ -527,8 +521,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   }
 
   it should "require at least one prefix if matchesPrefix is the only condition for GcpBucketLifecycle settings" in {
-    val noPrefixSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle,
+    val noPrefixSetting = GcpBucketLifecycleSetting(
       GcpBucketLifecycleConfig(
         List(
           GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"), GcpBucketLifecycleCondition(Some(Set.empty), None))
@@ -551,8 +544,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   }
 
   it should "require a non-negative retention duration for GcpBucketSoftDelete settings" in {
-    val negativeDurationSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketSoftDelete,
+    val negativeDurationSetting = GcpBucketSoftDeleteSetting(
       GcpBucketSoftDeleteConfig(-1)
     )
 
@@ -569,8 +561,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   }
 
   it should "require a retention duration no more than 90 days for GcpBucketSoftDelete settings" in {
-    val longDurationSetting = WorkspaceSetting(
-      WorkspaceSettingTypes.GcpBucketSoftDelete,
+    val longDurationSetting = GcpBucketSoftDeleteSetting(
       GcpBucketSoftDeleteConfig(999111999)
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -78,9 +78,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
     val workspaceSettings = List(
-      GcpBucketLifecycleSetting(
-        WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
-      )
+      GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty))
     )
 
     val workspaceRepository = mock[WorkspaceRepository]
@@ -179,9 +177,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   "setWorkspaceSettings" should "set the workspace settings if there aren't any set" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val workspaceSetting = GcpBucketLifecycleSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
-    )
+    val workspaceSetting = GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty))
 
     val workspaceRepository = mock[WorkspaceRepository]
     when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
@@ -416,9 +412,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
   it should "be limited to owners" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
-    val newSetting = GcpBucketLifecycleSetting(
-      WorkspaceSettingTypes.GcpBucketLifecycle.defaultConfig()
-    )
+    val newSetting = GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty))
 
     val workspaceRepository = mock[WorkspaceRepository]
     when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -613,7 +613,7 @@ object WorkspaceSettingConfig {
   case class GcpBucketLifecycleCondition(matchesPrefix: Option[Set[String]], age: Option[Days])
 
   type Seconds = Long
-  case class GcpBucketSoftDeleteConfig(retentionDuration: Seconds) extends WorkspaceSettingConfig
+  case class GcpBucketSoftDeleteConfig(retentionDurationInSeconds: Seconds) extends WorkspaceSettingConfig
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -585,7 +585,6 @@ object WorkspaceSettingTypes {
   sealed trait WorkspaceSettingType extends RawlsEnumeration[WorkspaceSettingType] {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
     override def withName(name: String): WorkspaceSettingType = WorkspaceSettingTypes.withName(name)
-    def defaultConfig(): WorkspaceSettingConfig
   }
 
   def withName(name: String): WorkspaceSettingType = name.toLowerCase match {
@@ -594,13 +593,9 @@ object WorkspaceSettingTypes {
     case _                     => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
   }
 
-  case object GcpBucketLifecycle extends WorkspaceSettingType {
-    override def defaultConfig(): GcpBucketLifecycleConfig = GcpBucketLifecycleConfig(List.empty)
-  }
+  case object GcpBucketLifecycle extends WorkspaceSettingType
 
-  case object GcpBucketSoftDelete extends WorkspaceSettingType {
-    override def defaultConfig(): GcpBucketSoftDeleteConfig = GcpBucketSoftDeleteConfig(0)
-  }
+  case object GcpBucketSoftDelete extends WorkspaceSettingType
 }
 
 sealed trait WorkspaceSettingConfig

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -714,8 +714,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |    }
             |  }""".stripMargin.parseJson
         assertResult {
-          WorkspaceSetting(
-            WorkspaceSettingTypes.GcpBucketLifecycle,
+          GcpBucketLifecycleSetting(
             GcpBucketLifecycleConfig(
               List(
                 GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -748,8 +747,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |    }
             |  }""".stripMargin.parseJson
         assertResult {
-          WorkspaceSetting(
-            WorkspaceSettingTypes.GcpBucketLifecycle,
+          GcpBucketLifecycleSetting(
             GcpBucketLifecycleConfig(
               List(
                 GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -784,8 +782,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |    }
             |  }""".stripMargin.parseJson
         assertResult {
-          WorkspaceSetting(
-            WorkspaceSettingTypes.GcpBucketLifecycle,
+          GcpBucketLifecycleSetting(
             GcpBucketLifecycleConfig(
               List(
                 GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
@@ -808,7 +805,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |    }
             |  }""".stripMargin.parseJson
         assertResult {
-          WorkspaceSetting(WorkspaceSettingTypes.GcpBucketLifecycle, GcpBucketLifecycleConfig(List.empty))
+          GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty))
         } {
           WorkspaceSettingFormat.read(lifecycleSettingNoRules)
         }
@@ -901,8 +898,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |    }
             |  }""".stripMargin.parseJson
         assertResult {
-          WorkspaceSetting(
-            WorkspaceSettingTypes.GcpBucketSoftDelete,
+          GcpBucketSoftDeleteSetting(
             GcpBucketSoftDeleteConfig(500)
           )
         } {

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -8,7 +8,8 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleAction,
   GcpBucketLifecycleCondition,
   GcpBucketLifecycleConfig,
-  GcpBucketLifecycleRule
+  GcpBucketLifecycleRule,
+  GcpBucketSoftDeleteConfig
 }
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
@@ -886,6 +887,73 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |  }""".stripMargin.parseJson
         intercept[DeserializationException] {
           WorkspaceSettingFormat.read(lifecycleSettingNoConditions)
+        }
+      }
+    }
+
+    "GoogleBucketSoftDeleteSettings" - {
+      "parses soft delete setting with retentionDuration" in {
+        val softDeleteSetting =
+          """{
+            |    "settingType": "GcpBucketSoftDelete",
+            |    "config": {
+            |      "retentionDuration": 500
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult {
+          WorkspaceSetting(
+            WorkspaceSettingTypes.GcpBucketSoftDelete,
+            GcpBucketSoftDeleteConfig(500)
+          )
+        } {
+          WorkspaceSettingFormat.read(softDeleteSetting)
+        }
+      }
+
+      "throws an exception for missing retentionDuration" in {
+        val softDeleteSettingNoDuration =
+          """{
+            |    "settingType": "GcpBucketSoftDelete",
+            |    "config": {}
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(softDeleteSettingNoDuration)
+        }
+      }
+
+      "throws an exception for missing config" in {
+        val softDeleteSettingNoConfig =
+          """{
+            |    "settingType": "GcpBucketSoftDelete"
+            |  }""".stripMargin.parseJson
+        intercept[NoSuchElementException] {
+          WorkspaceSettingFormat.read(softDeleteSettingNoConfig)
+        }
+      }
+
+      "throws an exception for incorrect format" in {
+        val softDeleteSettingBadConfig =
+          """{
+            |    "settingType": "GcpBucketSoftDelete",
+            |    "config": {
+            |      "retentionDuration": "not a number"
+            |    }
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(softDeleteSettingBadConfig)
+        }
+      }
+
+      "throws an exception for lifecycle setting with soft delete config" in {
+        val lifecycleSettingSoftDeleteConfig =
+          """{
+            |    "settingType": "GcpBucketLifecycle",
+            |    "config": {
+            |      "retentionDuration": 5
+            |    }
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(lifecycleSettingSoftDeleteConfig)
         }
       }
     }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -889,12 +889,12 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
     }
 
     "GoogleBucketSoftDeleteSettings" - {
-      "parses soft delete setting with retentionDuration" in {
+      "parses soft delete setting with retentionDurationInSeconds" in {
         val softDeleteSetting =
           """{
             |    "settingType": "GcpBucketSoftDelete",
             |    "config": {
-            |      "retentionDuration": 500
+            |      "retentionDurationInSeconds": 500
             |    }
             |  }""".stripMargin.parseJson
         assertResult {
@@ -906,7 +906,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         }
       }
 
-      "throws an exception for missing retentionDuration" in {
+      "throws an exception for missing retentionDurationInSeconds" in {
         val softDeleteSettingNoDuration =
           """{
             |    "settingType": "GcpBucketSoftDelete",
@@ -932,7 +932,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
           """{
             |    "settingType": "GcpBucketSoftDelete",
             |    "config": {
-            |      "retentionDuration": "not a number"
+            |      "retentionDurationInSeconds": "not a number"
             |    }
             |  }""".stripMargin.parseJson
         intercept[DeserializationException] {
@@ -945,7 +945,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
           """{
             |    "settingType": "GcpBucketLifecycle",
             |    "config": {
-            |      "retentionDuration": 5
+            |      "retentionDurationInSeconds": 5
             |    }
             |  }""".stripMargin.parseJson
         intercept[DeserializationException] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,11 +84,11 @@ object Dependencies {
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.7"
 
-  val workbenchLibsHash = "9138393"
+  val workbenchLibsHash = "097d95f5-SNAP"
 
   val workbenchModelV  = s"0.20-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
-  val workbenchNotificationsV = s"0.6-${workbenchLibsHash}"
+  val workbenchNotificationsV = s"0.7-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.7-${workbenchLibsHash}"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,10 +84,10 @@ object Dependencies {
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.7"
 
-  val workbenchLibsHash = "097d95f5-SNAP"
+  val workbenchLibsHash = "157f079"
 
   val workbenchModelV  = s"0.20-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.33-${workbenchLibsHash}"
   val workbenchNotificationsV = s"0.7-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
   val workbenchOauth2V = s"0.7-${workbenchLibsHash}"


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/WOR-1808](https://broadworkbench.atlassian.net/browse/WOR-1808)

Would recommend looking through this by commit--the first commit essentially accomplishes soft delete policy setting, following the template of the lifecycle rules implementation. See comments for additional info about the changes in subsequent commits.

- Added support for setting soft delete policy in workspace settings
- Changed some types around workspace settings to reflect the correspondence between setting type and config type
- Removed the `defaultConfig`s specified in `WorkspaceModel`

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
