### PR TITLE
AJ-2001: add logging to delete-entity queries

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -33,6 +33,7 @@ import org.broadinstitute.dsde.rawls.workspace.{AttributeUpdateOperationExceptio
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
 
+import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -163,6 +164,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
           .recover { case delEx: DeleteEntitiesConflictException =>
             delEx.referringEntities
           }
+          .recover(sqlLoggingRecover(s"deleteEntities: $workspaceName ${entRefs.size} entities"))
           .recover(bigQueryRecover)
       }
     }
@@ -193,6 +195,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
             )
           )
         }
+        .recover(sqlLoggingRecover(s"deleteEntitiesOfType: $workspaceName $entityType"))
         .recover(bigQueryRecover)
     }
 
@@ -528,6 +531,16 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
       }
     }
+
+  private def sqlLoggingRecover[U](logHint: String): PartialFunction[Throwable, U] = {
+    case sqlException: SQLException =>
+      // don't log a stack trace, and don't log at ERROR level;
+      // these exceptions and their stack traces are already logged elsewhere. We just want to add logging
+      // so we understand which method generated the exception.
+      logger.warn(s"SQLException in $logHint: ${sqlException.getClass.getName} - ${sqlException.getMessage}")
+      // rethrow as-is; RawlsApiService.exceptionHandler has handling we don't want to break
+      throw sqlException;
+  }
 
   private def bigQueryRecover[U]: PartialFunction[Throwable, U] = {
     case dee: DataEntityException =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -537,7 +537,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
       // don't log a stack trace, and don't log at ERROR level;
       // these exceptions and their stack traces are already logged elsewhere. We just want to add logging
       // so we understand which method generated the exception.
-      logger.warn(s"SQLException in $logHint: ${sqlException.getClass.getName} - ${sqlException.getMessage}")
+      logger.warn(
+        s"SQLException in EntityService ($logHint): ${sqlException.getClass.getName} - ${sqlException.getMessage}"
+      )
       // rethrow as-is; RawlsApiService.exceptionHandler has handling we don't want to break
       throw sqlException;
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-2001

As we continue to struggle with tracking down sql exceptions, specifially lock wait timeouts, we thought it would be useful to add logging at the source. Scala stack traces have been unhelpful so far.

This PR adds such logging to two methods in `EntityService` as an example so future PRs have something to base themselves on.

No unit tests because trying to read log messages is fragile and complicated. I tested this manually and see the appropriate log messages.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
