### PR TITLE
WX-1840 Pause intermediates/final separation

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -284,8 +284,9 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       // Intermediate/final output separation: location 2/2 (SU-166, WX-1702)
       // Final outputs are moved to the directory specified
       // Cromwell `/outputs` endpoint and Terra data table use this location
-      Option(s"gs://${workspace.bucketName}/submissions/final-outputs/${submission.id}"),
-      Option("move"),
+      // Temporarily paused as of 2024-09-05
+      None,
+      None,
       workspace.googleProjectId,
       userEmail.value,
       petSAEmail,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -163,7 +163,8 @@ object SubmissionsService {
     // Intermediate/final output separation: location 1/2 (SU-166, WX-1702)
     // All intermediate files including logs live here.
     // UI links to execution directory point here.
-    s"gs://${workspace.bucketName}/submissions/intermediates/$id"
+    // Temporarily paused as of 2024-09-05
+    s"gs://${workspace.bucketName}/submissions/$id"
 }
 
 class SubmissionsService(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -376,8 +376,8 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Some(
           ExecutionServiceWorkflowOptions(
             jes_gcs_root = s"gs://${testData.workspace.bucketName}/${testData.submission1.submissionId}",
-            Some(s"gs://${testData.workspace.bucketName}/submissions/final-outputs/${testData.submission1.submissionId}"),
-            Some("move"),
+            None,
+            None,
             google_project = testData.workspace.googleProjectId.value,
             account_name = testData.userOwner.userEmail.value,
             google_compute_service_account = "pet-110347448408766049948@broad-dsde-dev.iam.gserviceaccount.com",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/model/ExecutionModelSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/model/ExecutionModelSpec.scala
@@ -126,8 +126,8 @@ class ExecutionModelSpec extends AnyFlatSpec with Matchers {
   "ExecutionServiceWorkflowOptions" should "serialize/deserialize to/from JSON" in {
     val test = ExecutionServiceWorkflowOptions(
       jes_gcs_root = "jes_gcs_root",
-      final_workflow_outputs_dir = Option("example_final_workflow_outputs_dir"),
-      final_workflow_outputs_mode = Option("example_final_workflow_outputs_mode"),
+      final_workflow_outputs_dir = None,
+      final_workflow_outputs_mode = None,
       google_project = "google_project",
       account_name = "account_name",
       google_compute_service_account = "account@foo.com",
@@ -162,8 +162,6 @@ class ExecutionModelSpec extends AnyFlatSpec with Matchers {
       """
         |{
         |  "jes_gcs_root": "jes_gcs_root",
-        |  "final_workflow_outputs_dir": "example_final_workflow_outputs_dir",
-        |  "final_workflow_outputs_mode": "example_final_workflow_outputs_mode",
         |  "google_project": "google_project",
         |  "account_name": "account_name",
         |  "google_compute_service_account": "account@foo.com",
@@ -194,8 +192,6 @@ class ExecutionModelSpec extends AnyFlatSpec with Matchers {
       """
         |{
         |  "jes_gcs_root": "jes_gcs_root",
-        |  "final_workflow_outputs_dir": "example_final_workflow_outputs_dir",
-        |  "final_workflow_outputs_mode": "example_final_workflow_outputs_mode",
         |  "google_project": "google_project",
         |  "account_name": "account_name",
         |  "google_compute_service_account": "account@foo.com",

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -1413,7 +1413,7 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
                 status
               }
               val response = responseAs[Submission]
-              response.submissionRoot shouldBe s"gs://${testData.workspace.bucketName}/submissions/intermediates/${submission.submissionId}"
+              response.submissionRoot shouldBe s"gs://${testData.workspace.bucketName}/submissions/${submission.submissionId}"
             }
         }
     }


### PR DESCRIPTION
- Primarly due to breaking side effects on Theiagen, who pass strings to `File` final outputs to snapshot objects from public buckets into their workflow outputs
- Also was not great that we showed no-context links that people followed to soft-deleted files