### PR TITLE
WX-1839 Dead code removal

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -117,10 +117,6 @@ trait GoogleServicesDAO extends ErrorReportable {
     executionContext: ExecutionContext
   ): Future[Either[String, Bucket]]
 
-  def getBucketACL(bucketName: String): Future[Option[List[BucketAccessControl]]]
-
-  def diagnosticBucketRead(userInfo: UserInfo, bucketName: String): Future[Option[ErrorReport]]
-
   def listObjectsWithPrefix(bucketName: String,
                             objectNamePrefix: String,
                             userProject: Option[GoogleProjectId]
@@ -179,10 +175,6 @@ trait GoogleServicesDAO extends ErrorReportable {
     executionContext: ExecutionContext
   ): Future[ProjectBillingInfo]
 
-  def getBillingAccountIdForGoogleProject(googleProject: GoogleProject, userInfo: UserInfo)(implicit
-    executionContext: ExecutionContext
-  ): Future[Option[String]]
-
   def getGenomicsOperation(jobId: String): Future[Option[JsObject]]
 
   /**
@@ -196,8 +188,6 @@ trait GoogleServicesDAO extends ErrorReportable {
    * @return sequence of Google operations
    */
   def checkGenomicsOperationsHealth(implicit executionContext: ExecutionContext): Future[Boolean]
-
-  def toGoogleGroupName(groupName: RawlsGroupName): String
 
   def getResourceBufferServiceAccountCredential: Credential
 
@@ -247,14 +237,6 @@ trait GoogleServicesDAO extends ErrorReportable {
     updatePolicies: Map[String, Set[String]] => Map[String, Set[String]]
   ): Future[Boolean]
 
-  /**
-   *
-   * @param bucketName
-   * @param readers emails of users to be granted read access
-   * @return bucket name
-   */
-  def grantReadAccess(bucketName: String, readers: Set[WorkbenchEmail]): Future[String]
-
   def pollOperation(operationId: OperationId): Future[OperationStatus]
 
   def deleteV1Project(googleProject: GoogleProjectId): Future[Unit]
@@ -262,8 +244,6 @@ trait GoogleServicesDAO extends ErrorReportable {
   def updateGoogleProject(googleProjectId: GoogleProjectId, googleProjectWithUpdates: Project): Future[Project]
 
   def deleteGoogleProject(googleProject: GoogleProjectId): Future[Unit]
-
-  def getAccessTokenUsingJson(saKey: String): Future[String]
 
   def getUserInfoUsingJson(saKey: String): Future[UserInfo]
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -109,7 +109,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(googleWorkspaceInfo)
   }
 
-  override def getAccessTokenUsingJson(saKey: String): Future[String] = Future.successful("token")
   override def getUserInfoUsingJson(saKey: String): Future[UserInfo] = Future.successful(
     UserInfo(RawlsUserEmail("foo@bar.com"), OAuth2BearerToken("test_token"), 0, RawlsUserSubjectId("12345678000"))
   )
@@ -132,11 +131,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
   override def getBucket(bucketName: String, userProject: Option[GoogleProjectId])(implicit
     executionContext: ExecutionContext
   ): Future[Either[String, Bucket]] = Future.successful(Right(new Bucket))
-
-  override def getBucketACL(bucketName: String): Future[Option[List[BucketAccessControl]]] =
-    Future.successful(Some(List.fill(5)(new BucketAccessControl)))
-
-  override def diagnosticBucketRead(userInfo: UserInfo, bucketName: String) = Future.successful(None)
 
   override def listObjectsWithPrefix(bucketName: String,
                                      objectNamePrefix: String,
@@ -240,8 +234,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     }
   }
 
-  override def grantReadAccess(bucketName: String, readers: Set[WorkbenchEmail]): Future[String] = Future(bucketName)
-
   override def pollOperation(operationId: OperationId): Future[OperationStatus] =
     Future.successful(OperationStatus(true, None))
 
@@ -298,18 +290,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
         case _               => List("us-central1-b", "us-central1-c", "us-central1-f")
       }
     }
-
-  override def getBillingAccountIdForGoogleProject(googleProject: GoogleProject, userInfo: UserInfo)(implicit
-    executionContext: ExecutionContext
-  ): Future[Option[String]] = {
-    val billingAccount = googleProject.value match {
-      case "project_without_table"           => Some("billing_account_for_google_project_without_table")
-      case "project_without_billing_account" => None
-      case _                                 => Some("some-billing-account")
-    }
-
-    Future.successful(billingAccount)
-  }
 
   override def testSAGoogleBucketIam(bucketName: GcsBucketName, saKey: String, permissions: Set[IamPermission])(implicit
     executionContext: ExecutionContext


### PR DESCRIPTION
Ticket: [WX-1839](https://broadworkbench.atlassian.net/browse/WX-1839)

For the audit, I needed to understand the purpose of the `cromwell-auth-*` buckets. This old PR https://github.com/broadinstitute/rawls/pull/1291 helped me confirm they're obsolete; and I incidentally ran into dead code from the same era/area.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WX-1839]: https://broadworkbench.atlassian.net/browse/WX-1839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ