### PR TITLE
AJ-2001: sql exception logging for more entity methods

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -76,7 +76,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         entityManager <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
         result <- entityManager.createEntity(entity)
       } yield result
-    }
+    }.recover(sqlLoggingRecover(s"createEntity: $workspaceName"))
 
   def getEntity(workspaceName: WorkspaceName,
                 entityType: String,
@@ -102,6 +102,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
             ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in $workspaceName")
           )
         }
+        .recover(sqlLoggingRecover(s"getEntity: $workspaceName $entityType/$entityName"))
         .recover(bigQueryRecover)
     }
 
@@ -138,7 +139,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
           }
         }
       }
-    }
+    }.recover(sqlLoggingRecover(s"updateEntity: $workspaceName $entityType/$entityName ${operations.size} operations"))
 
   def deleteEntities(workspaceName: WorkspaceName,
                      entRefs: Seq[AttributeEntityReference],
@@ -203,9 +204,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                              entityType: String,
                              attributeNames: Set[AttributeName]
   ): Future[Unit] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+    (getV2WorkspaceContextAndPermissions(workspaceName,
+                                         SamWorkspaceActions.write,
+                                         Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         dataAccess
@@ -218,12 +219,14 @@ class EntityService(protected val ctx: RawlsRequestContext,
           case _ => DBIO.successful(())
         }
       }
-    }
+    }).recover(
+      sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
+    )
 
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+    (getV2WorkspaceContextAndPermissions(workspaceName,
+                                         SamWorkspaceActions.write,
+                                         Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
@@ -237,7 +240,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
           }
         }
       }
-    }
+    }).recover(
+      sqlLoggingRecover(s"renameEntity: $workspaceName $entityType $entityName")
+    )
 
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
     import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
@@ -275,9 +280,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
           )
       }
 
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+    (getV2WorkspaceContextAndPermissions(workspaceName,
+                                         SamWorkspaceActions.write,
+                                         Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction { dataAccess =>
         for {
@@ -286,7 +291,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
           renameResult <- dataAccess.entityQuery.changeEntityTypeName(workspaceContext, oldName, renameInfo.newName)
         } yield renameResult
       }
-    }
+    }).recover(
+      sqlLoggingRecover(s"renameEntityType: $workspaceName $oldName")
+    )
   }
 
   def evaluateExpression(workspaceName: WorkspaceName,
@@ -294,9 +301,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                          entityName: String,
                          expression: String
   ): Future[Seq[AttributeValue]] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.read,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+    (getV2WorkspaceContextAndPermissions(workspaceName,
+                                         SamWorkspaceActions.read,
+                                         Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       dataSource.inTransaction(
         dataAccess =>
@@ -333,16 +340,18 @@ class EntityService(protected val ctx: RawlsRequestContext,
           },
         TransactionIsolation.ReadCommitted
       )
-    }
+    }).recover(
+      sqlLoggingRecover(s"evaluateExpression: $workspaceName $entityType $entityName $expression")
+    )
 
   def entityTypeMetadata(workspaceName: WorkspaceName,
                          dataReference: Option[DataReferenceName],
                          billingProject: Option[GoogleProjectId],
                          useCache: Boolean
   ): Future[Map[String, EntityTypeMetadata]] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.read,
-                                        Some(WorkspaceAttributeSpecs(all = false))
+    (getV2WorkspaceContextAndPermissions(workspaceName,
+                                         SamWorkspaceActions.read,
+                                         Some(WorkspaceAttributeSpecs(all = false))
     ) flatMap { workspaceContext =>
       val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
 
@@ -352,7 +361,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
       } yield metadata
 
       metadataFuture.recover(bigQueryRecover)
-    }
+    }).recover(
+      sqlLoggingRecover(s"entityTypeMetadata: $workspaceName")
+    )
 
   /*
    * Queries the db for a stream of entity attributes.
@@ -375,13 +386,15 @@ class EntityService(protected val ctx: RawlsRequestContext,
   }
 
   def listEntities(workspaceName: WorkspaceName, entityType: String) =
-    getWorkspaceContextAndPermissions(workspaceName,
-                                      SamWorkspaceActions.read,
-                                      Some(WorkspaceAttributeSpecs(all = false))
+    (getWorkspaceContextAndPermissions(workspaceName,
+                                       SamWorkspaceActions.read,
+                                       Some(WorkspaceAttributeSpecs(all = false))
     ) map { workspaceContext =>
       val dbSource = listEntitiesDbSource(workspaceContext, entityType)
       EntityStreamingUtils.gatherEntities(dataSource, dbSource)
-    }
+    }).recover(
+      sqlLoggingRecover(s"listEntities: $workspaceName $entityType")
+    )
 
   def queryEntitiesSource(workspaceName: WorkspaceName,
                           dataReference: Option[DataReferenceName],
@@ -411,7 +424,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
   }
 
   def copyEntities(entityCopyDef: EntityCopyDefinition, linkExistingEntities: Boolean): Future[EntityCopyResponse] =
-    for {
+    (for {
       destWsCtx <- getV2WorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
                                                        SamWorkspaceActions.write,
                                                        Some(WorkspaceAttributeSpecs(all = false))
@@ -434,7 +447,10 @@ class EntityService(protected val ctx: RawlsRequestContext,
                       ctx
         )
         .recover(bigQueryRecover)
-    } yield entityCopyResponse
+    } yield entityCopyResponse)
+      .recover(
+        sqlLoggingRecover(s"copyEntities: $entityCopyDef $linkExistingEntities")
+      )
 
   def batchUpdateEntitiesInternal(workspaceName: WorkspaceName,
                                   entityUpdates: Seq[EntityUpdateDefinition],
@@ -464,6 +480,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject)
+      .recover(
+        sqlLoggingRecover(s"batchUpdateEntities: $workspaceName ${entityUpdates.size} updates")
+      )
 
   def batchUpsertEntities(workspaceName: WorkspaceName,
                           entityUpdates: Seq[EntityUpdateDefinition],
@@ -471,6 +490,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
     batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject)
+      .recover(
+        sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
+      )
 
   def renameAttribute(workspaceName: WorkspaceName,
                       entityType: String,
@@ -530,7 +552,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
           } yield rowsUpdated
         }
       }
-    }
+    }.recover(
+      sqlLoggingRecover(s"renameAttribute: $workspaceName $oldAttributeName $attributeRenameRequest")
+    )
 
   private def sqlLoggingRecover[U](logHint: String): PartialFunction[Throwable, U] = {
     case sqlException: SQLException =>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AJ-2001

Followup to #3016, which has proven to be very helpful. This PR adds the same logging to the remainder of methods in `EntityService`.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
