### PR TITLE
[WOR-1456] Add requester pays setting

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5925,11 +5925,13 @@ components:
           enum:
             - GcpBucketLifecycle
             - GcpBucketSoftDelete
+            - GcpBucketRequesterPays
         config:
           description: The configuration of the workspace setting
           oneOf:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketLifecycleConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketSoftDeleteConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingGcpBucketRequesterPaysConfig'
     WorkspaceSettingGcpBucketLifecycleConfig:
       required:
         - rules
@@ -5980,6 +5982,14 @@ components:
         retentionDurationInSeconds:
           type: integer
           description: The length of time to retain soft-deleted objects for, in seconds
+    WorkspaceSettingGcpBucketRequesterPaysConfig:
+      required:
+        - enabled
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Enabled status to set for requester pays
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -65,9 +65,14 @@ trait GoogleServicesDAO extends ErrorReportable {
    */
   def deleteBucket(bucketName: String): Future[Boolean]
 
-  def setBucketLifecycle(bucketName: String, lifecycle: List[LifecycleRule]): Future[Unit]
+  def setBucketLifecycle(bucketName: String, lifecycle: List[LifecycleRule], userProject: GoogleProjectId): Future[Unit]
 
-  def setSoftDeletePolicy(bucketName: String, softDeletePolicy: SoftDeletePolicy): Future[Unit]
+  def setSoftDeletePolicy(bucketName: String,
+                          softDeletePolicy: SoftDeletePolicy,
+                          userProject: GoogleProjectId
+  ): Future[Unit]
+
+  def setRequesterPays(bucketName: String, requesterPaysEnabled: Boolean, userProject: GoogleProjectId): Future[Unit]
 
   def isAdmin(userEmail: String): Future[Boolean]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -40,7 +40,7 @@ import com.google.api.services.storage.model._
 import com.google.api.services.storage.{Storage, StorageScopes}
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.Identity
-import com.google.cloud.storage.Storage.BucketSourceOption
+import com.google.cloud.storage.Storage.{BucketSourceOption, BucketTargetOption}
 import com.google.cloud.storage.{BucketInfo, Cors, HttpMethod, StorageClass, StorageException}
 import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.StringUtils
@@ -307,16 +307,44 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
     }
   }
 
-  override def setBucketLifecycle(bucketName: String, lifecycle: List[BucketInfo.LifecycleRule]): Future[Unit] =
+  override def setBucketLifecycle(bucketName: String,
+                                  lifecycle: List[BucketInfo.LifecycleRule],
+                                  userProject: GoogleProjectId
+  ): Future[Unit] =
     googleStorageService
-      .setBucketLifecycle(GcsBucketName(bucketName), lifecycle)
+      .setBucketLifecycle(
+        GcsBucketName(bucketName),
+        lifecycle,
+        bucketTargetOptions = List(BucketTargetOption.userProject(userProject.value))
+      )
       .compile
       .drain
       .unsafeToFuture()
 
-  override def setSoftDeletePolicy(bucketName: String, softDeletePolicy: BucketInfo.SoftDeletePolicy): Future[Unit] =
+  override def setSoftDeletePolicy(bucketName: String,
+                                   softDeletePolicy: BucketInfo.SoftDeletePolicy,
+                                   userProject: GoogleProjectId
+  ): Future[Unit] =
     googleStorageService
-      .setSoftDeletePolicy(GcsBucketName(bucketName), softDeletePolicy)
+      .setSoftDeletePolicy(
+        GcsBucketName(bucketName),
+        softDeletePolicy,
+        bucketTargetOptions = List(BucketTargetOption.userProject(userProject.value))
+      )
+      .compile
+      .drain
+      .unsafeToFuture()
+
+  override def setRequesterPays(bucketName: String,
+                                requesterPaysEnabled: Boolean,
+                                userProject: GoogleProjectId
+  ): Future[Unit] =
+    googleStorageService
+      .setRequesterPays(
+        GcsBucketName(bucketName),
+        requesterPaysEnabled,
+        bucketTargetOptions = List(BucketTargetOption.userProject(userProject.value))
+      )
       .compile
       .drain
       .unsafeToFuture()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -2,9 +2,14 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketLifecycleConfigFormat,
+  GcpBucketRequesterPaysConfigFormat,
   GcpBucketSoftDeleteConfigFormat
 }
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{GcpBucketLifecycleConfig, GcpBucketSoftDeleteConfig}
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
+  GcpBucketLifecycleConfig,
+  GcpBucketRequesterPaysConfig,
+  GcpBucketSoftDeleteConfig
+}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model._
 
@@ -58,6 +63,8 @@ object WorkspaceSettingRecord {
         GcpBucketLifecycleSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketLifecycleConfig])
       case WorkspaceSettingTypes.GcpBucketSoftDelete =>
         GcpBucketSoftDeleteSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketSoftDeleteConfig])
+      case WorkspaceSettingTypes.GcpBucketRequesterPays =>
+        GcpBucketRequesterPaysSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketRequesterPaysConfig])
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -123,10 +123,21 @@ class MockGoogleServicesDAO(groupsPrefix: String,
 
   override def deleteBucket(bucketName: String) = Future.successful(true)
 
-  override def setBucketLifecycle(bucketName: String, lifecycle: List[BucketInfo.LifecycleRule]): Future[Unit] = ???
+  override def setBucketLifecycle(bucketName: String,
+                                  lifecycle: List[BucketInfo.LifecycleRule],
+                                  userProject: GoogleProjectId
+  ): Future[Unit] = ???
 
-  override def setSoftDeletePolicy(bucketName: String, softDeletePolicy: BucketInfo.SoftDeletePolicy): Future[Unit] =
+  override def setSoftDeletePolicy(bucketName: String,
+                                   softDeletePolicy: BucketInfo.SoftDeletePolicy,
+                                   userProject: GoogleProjectId
+  ): Future[Unit] =
     ???
+
+  override def setRequesterPays(bucketName: String,
+                                requesterPaysEnabled: Boolean,
+                                userProject: GoogleProjectId
+  ): Future[Unit] = ???
 
   override def getBucket(bucketName: String, userProject: Option[GoogleProjectId])(implicit
     executionContext: ExecutionContext

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -114,7 +114,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     )
   }
 
-  it should "handle adding a setting to a workspace with no settings" in {
+  it should "handle a workspace with no settings" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -17,7 +17,6 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   GcpBucketLifecycleSetting,
   GcpBucketSoftDeleteSetting,
-  GoogleProjectId,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -31,7 +30,7 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.{contain, include}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
   GcpBucketLifecycleSetting,
   GcpBucketSoftDeleteSetting,
+  GoogleProjectId,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
@@ -25,13 +26,12 @@ import org.broadinstitute.dsde.rawls.model.{
   SamWorkspaceActions,
   UserInfo,
   Workspace,
-  WorkspaceSetting,
   WorkspaceSettingTypes
 }
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{verify, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers.{contain, include}
@@ -206,7 +206,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     ).thenReturn(Future.successful(true))
 
     val gcsDAO = mock[GoogleServicesDAO]
-    when(gcsDAO.setBucketLifecycle(workspace.bucketName, List())).thenReturn(Future.successful())
+    when(gcsDAO.setBucketLifecycle(ArgumentMatchers.eq(workspace.bucketName), ArgumentMatchers.eq(List()), any()))
+      .thenReturn(Future.successful())
 
     val service =
       workspaceSettingServiceConstructor(samDAO = samDAO,
@@ -275,7 +276,12 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       LifecycleAction.newDeleteAction(),
       LifecycleCondition.newBuilder().setMatchesPrefix(List("muchBetterPrefix").asJava).setAge(31).build()
     )
-    when(gcsDAO.setBucketLifecycle(workspace.bucketName, List(newSettingGoogleRule))).thenReturn(Future.successful())
+    when(
+      gcsDAO.setBucketLifecycle(ArgumentMatchers.eq(workspace.bucketName),
+                                ArgumentMatchers.eq(List(newSettingGoogleRule)),
+                                any()
+      )
+    ).thenReturn(Future.successful())
 
     val service =
       workspaceSettingServiceConstructor(samDAO = samDAO,
@@ -434,8 +440,12 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       LifecycleAction.newDeleteAction(),
       LifecycleCondition.newBuilder().setMatchesPrefix(List("muchBetterPrefix").asJava).setAge(31).build()
     )
-    when(gcsDAO.setBucketLifecycle(workspace.bucketName, List(newSettingGoogleRule)))
-      .thenReturn(Future.failed(new Exception("failed to apply settings")))
+    when(
+      gcsDAO.setBucketLifecycle(ArgumentMatchers.eq(workspace.bucketName),
+                                ArgumentMatchers.eq(List(newSettingGoogleRule)),
+                                any()
+      )
+    ).thenReturn(Future.failed(new Exception("failed to apply settings")))
 
     val service =
       workspaceSettingServiceConstructor(samDAO = samDAO,

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleCondition,
   GcpBucketLifecycleConfig,
   GcpBucketLifecycleRule,
+  GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig
 }
 import org.joda.time.DateTime
@@ -950,6 +951,59 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
             |  }""".stripMargin.parseJson
         intercept[DeserializationException] {
           WorkspaceSettingFormat.read(lifecycleSettingSoftDeleteConfig)
+        }
+      }
+    }
+
+    "GoogleBucketRequesterPaysSettings" - {
+      "parses requester pays setting with enabled" in {
+        val requesterPaysSetting =
+          """{
+            |    "settingType": "GcpBucketRequesterPays",
+            |    "config": {
+            |      "enabled": true
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult {
+          GcpBucketRequesterPaysSetting(
+            GcpBucketRequesterPaysConfig(true)
+          )
+        } {
+          WorkspaceSettingFormat.read(requesterPaysSetting)
+        }
+      }
+
+      "throws an exception for missing enabled" in {
+        val requesterPaysSettingNoEnabled =
+          """{
+            |    "settingType": "GcpBucketRequesterPays",
+            |    "config": {}
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(requesterPaysSettingNoEnabled)
+        }
+      }
+
+      "throws an exception for missing config" in {
+        val requesterPaysSettingNoConfig =
+          """{
+            |    "settingType": "GcpBucketRequesterPays"
+            |  }""".stripMargin.parseJson
+        intercept[NoSuchElementException] {
+          WorkspaceSettingFormat.read(requesterPaysSettingNoConfig)
+        }
+      }
+
+      "throws an exception for incorrect format" in {
+        val requesterPaysSettingBadConfig =
+          """{
+            |    "settingType": "GcpBucketRequesterPays",
+            |    "config": {
+            |      "enabled": 0
+            |    }
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(requesterPaysSettingBadConfig)
         }
       }
     }


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/WOR-1456](https://broadworkbench.atlassian.net/browse/WOR-1456)

Adds requester pays as a workspace setting.

Workspace settings previously didn't play nice with requester pays workspaces, so this PR also fixes that behavior. Workspace settings requests now always pass a user project (the workspace's google project), which works when requester pays is off as well as on.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
