### PR TITLE
[WOR-1794] Enforce submission cost cap

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -125,4 +125,5 @@
     <include file="changesets/20240418_workspace_monitor_args.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240723_workspace_settings.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240820_submission_cost_cap_threshold.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20240830_workflow_cost.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20240830_workflow_cost.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20240830_workflow_cost.xml
@@ -2,9 +2,7 @@
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
     <changeSet id="add_workflow_cost" author="mtalbott" logicalFilePath="dummy">
         <addColumn tableName="WORKFLOW">
-            <column name="cost" type="NUMBER(10,2)" defaultValue="0.00">
-                <constraints nullable="false" />
-            </column>
+            <column name="cost" type="NUMBER(10,2)" />
         </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20240830_workflow_cost.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20240830_workflow_cost.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+    <changeSet id="add_workflow_cost" author="mtalbott" logicalFilePath="dummy">
+        <addColumn tableName="WORKFLOW">
+            <column name="cost" type="NUMBER(10,2)" defaultValue="0.00">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceCluster.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceCluster.scala
@@ -34,6 +34,8 @@ trait ExecutionServiceCluster extends ErrorReportable {
 
   def abort(workflowRec: WorkflowRecord, userInfo: UserInfo): Future[Try[ExecutionServiceStatus]]
 
+  def getCost(workflowRec: WorkflowRecord, workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams], userInfo: UserInfo): Future[WorkflowCostBreakdown]
+
   def version: Future[ExecutionServiceVersion]
 
   // ====================

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceCluster.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceCluster.scala
@@ -34,7 +34,7 @@ trait ExecutionServiceCluster extends ErrorReportable {
 
   def abort(workflowRec: WorkflowRecord, userInfo: UserInfo): Future[Try[ExecutionServiceStatus]]
 
-  def getCost(workflowRec: WorkflowRecord, workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams], userInfo: UserInfo): Future[WorkflowCostBreakdown]
+  def getCost(workflowRec: WorkflowRecord, userInfo: UserInfo): Future[WorkflowCostBreakdown]
 
   def version: Future[ExecutionServiceVersion]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
@@ -25,10 +25,7 @@ trait ExecutionServiceDAO extends ErrorReportable {
   def abort(id: String, userInfo: UserInfo): Future[Try[ExecutionServiceStatus]]
   def getLabels(id: String, userInfo: UserInfo): Future[ExecutionServiceLabelResponse]
   def patchLabels(id: String, userInfo: UserInfo, labels: Map[String, String]): Future[ExecutionServiceLabelResponse]
-  def getCost(id: String,
-              workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
-              userInfo: UserInfo
-  ): Future[WorkflowCostBreakdown]
+  def getCost(id: String, userInfo: UserInfo): Future[WorkflowCostBreakdown]
 
   // get the version of the execution service itself
   def version(): Future[ExecutionServiceVersion]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ExecutionServiceDAO.scala
@@ -25,6 +25,10 @@ trait ExecutionServiceDAO extends ErrorReportable {
   def abort(id: String, userInfo: UserInfo): Future[Try[ExecutionServiceStatus]]
   def getLabels(id: String, userInfo: UserInfo): Future[ExecutionServiceLabelResponse]
   def patchLabels(id: String, userInfo: UserInfo, labels: Map[String, String]): Future[ExecutionServiceLabelResponse]
+  def getCost(id: String,
+              workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
+              userInfo: UserInfo
+  ): Future[WorkflowCostBreakdown]
 
   // get the version of the execution service itself
   def version(): Future[ExecutionServiceVersion]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
@@ -131,20 +131,9 @@ class HttpExecutionServiceDAO(executionServiceURL: String, override val workbenc
     retry(when5xx)(() => pipeline[ExecutionServiceLabelResponse](userInfo) apply Patch(url, labels))
   }
 
-  override def getCost(id: String,
-                       workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
-                       userInfo: UserInfo
-  ): Future[WorkflowCostBreakdown] = {
-    val uri = Uri(executionServiceURL + s"/api/workflows/v1/$id/cost")
-    workflowCostBreakdownParams
-      .map(p =>
-        Map("includeSubworkflowBreakdown" -> p.includeSubworkflowBreakdown.toString,
-            "includeTaskBreakdown" -> p.includeTaskBreakdown.toString
-        )
-      )
-      .map(p => uri.withQuery(Query(p)))
-
-    retry(when5xx)(() => pipeline[WorkflowCostBreakdown](userInfo) apply Get(uri))
+  override def getCost(id: String, userInfo: UserInfo): Future[WorkflowCostBreakdown] = {
+    val url = executionServiceURL + s"/api/workflows/v1/$id/cost"
+    retry(when5xx)(() => pipeline[WorkflowCostBreakdown](userInfo) apply Get(url))
   }
 
   override def version(): Future[ExecutionServiceVersion] = {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpExecutionServiceDAO.scala
@@ -131,6 +131,22 @@ class HttpExecutionServiceDAO(executionServiceURL: String, override val workbenc
     retry(when5xx)(() => pipeline[ExecutionServiceLabelResponse](userInfo) apply Patch(url, labels))
   }
 
+  override def getCost(id: String,
+                       workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
+                       userInfo: UserInfo
+  ): Future[WorkflowCostBreakdown] = {
+    val uri = Uri(executionServiceURL + s"/api/workflows/v1/$id/cost")
+    workflowCostBreakdownParams
+      .map(p =>
+        Map("includeSubworkflowBreakdown" -> p.includeSubworkflowBreakdown.toString,
+            "includeTaskBreakdown" -> p.includeTaskBreakdown.toString
+        )
+      )
+      .map(p => uri.withQuery(Query(p)))
+
+    retry(when5xx)(() => pipeline[WorkflowCostBreakdown](userInfo) apply Get(uri))
+  }
+
   override def version(): Future[ExecutionServiceVersion] = {
     val url = executionServiceURL + s"/engine/v1/version"
     retry(when5xx)(() => httpClientUtils.executeRequestUnmarshalResponse[ExecutionServiceVersion](http, Get(url)))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ShardedHttpExecutionServiceCluster.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ShardedHttpExecutionServiceCluster.scala
@@ -68,6 +68,9 @@ class ShardedHttpExecutionServiceCluster(readMembers: Set[ClusterMember],
     // the abort operation is special, it needs to go to a specific cromwell
     getMember(workflowRec).dao.abort(workflowRec.externalId.get, userInfo)
 
+  def getCost(workflowRec: WorkflowRecord, workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams], userInfo: UserInfo): Future[WorkflowCostBreakdown] =
+    getMember(workflowRec).dao.getCost(workflowRec.externalId.get, workflowCostBreakdownParams, userInfo)
+
   def version: Future[ExecutionServiceVersion] =
     getRandomReadMember.dao.version
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ShardedHttpExecutionServiceCluster.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/ShardedHttpExecutionServiceCluster.scala
@@ -68,8 +68,8 @@ class ShardedHttpExecutionServiceCluster(readMembers: Set[ClusterMember],
     // the abort operation is special, it needs to go to a specific cromwell
     getMember(workflowRec).dao.abort(workflowRec.externalId.get, userInfo)
 
-  def getCost(workflowRec: WorkflowRecord, workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams], userInfo: UserInfo): Future[WorkflowCostBreakdown] =
-    getMember(workflowRec).dao.getCost(workflowRec.externalId.get, workflowCostBreakdownParams, userInfo)
+  def getCost(workflowRec: WorkflowRecord, userInfo: UserInfo): Future[WorkflowCostBreakdown] =
+    getMember(workflowRec).dao.getCost(workflowRec.externalId.get, userInfo)
 
   def version: Future[ExecutionServiceVersion] =
     getRandomReadMember.dao.version

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -299,12 +299,12 @@ trait SubmissionComponent {
         })
       )
 
-    def listActiveSubmissionIdsWithWorkspace(limit: FiniteDuration): ReadAction[Seq[(UUID, WorkspaceName)]] = {
+    def listActiveSubmissionIdsWithWorkspace(limit: FiniteDuration): ReadAction[Seq[(UUID, WorkspaceName, Option[BigDecimal])]] = {
       // Exclude submissions from monitoring if they are ancient/stuck [WX-820]
       val cutoffTime = new Timestamp(DateTime.now().minusDays(limit.toDays.toInt).getMillis)
       val query = findActiveSubmissionsAfterTime(cutoffTime) join workspaceQuery on (_.workspaceId === _.id)
-      val result = query.map { case (sub, ws) => (sub.id, ws.namespace, ws.name) }.result
-      result.map(rows => rows.map { case (subId, wsNs, wsName) => (subId, WorkspaceName(wsNs, wsName)) })
+      val result = query.map { case (sub, ws) => (sub.id, ws.namespace, ws.name, sub.costCapThreshold) }.result
+      result.map(rows => rows.map { case (subId, wsNs, wsName, costCapThreshold) => (subId, WorkspaceName(wsNs, wsName), costCapThreshold) })
     }
 
     def getSubmissionMethodConfigId(workspaceContext: Workspace, submissionId: UUID): ReadAction[Option[Long]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -568,7 +568,7 @@ trait SubmissionComponent {
       )
 
       implicit val getWorkflowMessagesListResult: GetResult[WorkflowMessagesListResult] = GetResult { r =>
-        val workflowRec = WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
+        val workflowRec = WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
         val rootEntityTypeOption: Option[String] = r.<<
 
         val messageOption: Option[String] = r.<<
@@ -607,7 +607,7 @@ trait SubmissionComponent {
       )
 
       implicit val getWorkflowInputResolutionListResult: GetResult[WorkflowInputResolutionListResult] = GetResult { r =>
-        val workflowRec = WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
+        val workflowRec = WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
         val (submissionValidation, attribute) = r.nextLongOption() match {
           case Some(submissionValidationId) =>
             (Option(SubmissionValidationRecord(submissionValidationId, workflowRec.id, r.<<, r.<<)),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -299,12 +299,18 @@ trait SubmissionComponent {
         })
       )
 
-    def listActiveSubmissionIdsWithWorkspace(limit: FiniteDuration): ReadAction[Seq[(UUID, WorkspaceName, Option[BigDecimal])]] = {
+    def listActiveSubmissionIdsWithWorkspace(
+      limit: FiniteDuration
+    ): ReadAction[Seq[(UUID, WorkspaceName, Option[BigDecimal])]] = {
       // Exclude submissions from monitoring if they are ancient/stuck [WX-820]
       val cutoffTime = new Timestamp(DateTime.now().minusDays(limit.toDays.toInt).getMillis)
       val query = findActiveSubmissionsAfterTime(cutoffTime) join workspaceQuery on (_.workspaceId === _.id)
       val result = query.map { case (sub, ws) => (sub.id, ws.namespace, ws.name, sub.costCapThreshold) }.result
-      result.map(rows => rows.map { case (subId, wsNs, wsName, costCapThreshold) => (subId, WorkspaceName(wsNs, wsName), costCapThreshold) })
+      result.map(rows =>
+        rows.map { case (subId, wsNs, wsName, costCapThreshold) =>
+          (subId, WorkspaceName(wsNs, wsName), costCapThreshold)
+        }
+      )
     }
 
     def getSubmissionMethodConfigId(workspaceContext: Workspace, submissionId: UUID): ReadAction[Option[Long]] =
@@ -588,7 +594,7 @@ trait SubmissionComponent {
       }
 
       def action(submissionId: UUID) =
-        sql"""select w.ID, w.EXTERNAL_ID, w.SUBMISSION_ID, w.STATUS, w.STATUS_LAST_CHANGED, w.ENTITY_ID, w.record_version, w.EXEC_SERVICE_KEY, w.EXTERNAL_ENTITY_ID,
+        sql"""select w.ID, w.EXTERNAL_ID, w.SUBMISSION_ID, w.STATUS, w.STATUS_LAST_CHANGED, w.ENTITY_ID, w.record_version, w.EXEC_SERVICE_KEY, w.EXTERNAL_ENTITY_ID, w.COST,
         s.ROOT_ENTITY_TYPE,
         m.MESSAGE,
         e.name, e.entity_type, e.workspace_id, e.record_version, e.deleted, e.deleted_date
@@ -635,7 +641,7 @@ trait SubmissionComponent {
       }
 
       def action(submissionId: UUID) =
-        sql"""select w.ID, w.EXTERNAL_ID, w.SUBMISSION_ID, w.STATUS, w.STATUS_LAST_CHANGED, w.ENTITY_ID, w.record_version, w.EXEC_SERVICE_KEY, w.EXTERNAL_ENTITY_ID,
+        sql"""select w.ID, w.EXTERNAL_ID, w.SUBMISSION_ID, w.STATUS, w.STATUS_LAST_CHANGED, w.ENTITY_ID, w.record_version, w.EXEC_SERVICE_KEY, w.EXTERNAL_ENTITY_ID, w.COST,
               sv.id, sv.ERROR_TEXT, sv.INPUT_NAME,
               sa.id, sa.namespace, sa.name, sa.value_string, sa.value_number, sa.value_boolean, sa.value_json, sa.value_entity_ref, sa.list_index, sa.list_length, sa.deleted, sa.deleted_date
         from WORKFLOW w

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -299,7 +299,7 @@ trait SubmissionComponent {
         })
       )
 
-    def listActiveSubmissionIdsWithWorkspace(
+    def listActiveSubmissionIdsWithWorkspaceAndCostCapThreshold(
       limit: FiniteDuration
     ): ReadAction[Seq[(UUID, WorkspaceName, Option[BigDecimal])]] = {
       // Exclude submissions from monitoring if they are ancient/stuck [WX-820]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -633,7 +633,7 @@ trait WorkflowComponent {
         0,
         None,
         externalEntityId,
-        Some(BigDecimal(0)) // workflow.cost.map(BigDecimal(_))
+        workflow.cost.map(BigDecimal(_))
       )
 
     private def unmarshalWorkflow(workflowRec: WorkflowRecord,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkflowComponent.scala
@@ -66,7 +66,7 @@ trait WorkflowComponent {
              version,
              executionServiceKey,
              externalEntityId,
-      cost
+             cost
     ) <> (WorkflowRecord.tupled, WorkflowRecord.unapply)
 
     def submission = foreignKey("FK_WF_SUB", submissionId, submissionQuery)(_.id)
@@ -633,7 +633,7 @@ trait WorkflowComponent {
         0,
         None,
         externalEntityId,
-        None
+        Some(BigDecimal(0)) // workflow.cost.map(BigDecimal(_))
       )
 
     private def unmarshalWorkflow(workflowRec: WorkflowRecord,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -607,7 +607,9 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
           dataAccess.submissionQuery.updateStatus(submissionId, newStatus)
         } map (_ => true)
       } else if (costCapThreshold.isDefined && costCapThreshold.get <= workflowRecs.flatMap(_.cost).sum) {
-        logger.info(s"Submission $submissionId exceeded its cost cap and will be aborted. [costCap=${costCapThreshold.get},currentSubmissionCost=${workflowRecs.flatMap(_.cost).sum}]")
+        logger.info(
+          s"Submission $submissionId exceeded its cost cap and will be aborted. [costCap=${costCapThreshold.get},currentSubmissionCost=${workflowRecs.flatMap(_.cost).sum}]"
+        )
         dataAccess.submissionQuery.updateStatus(submissionId, SubmissionStatuses.Aborting).map(_ => false)
       } else {
         DBIO.successful(false)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -307,7 +307,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     workflowRec.externalId match {
       // fetch cost information for the workflow if submission has a cost cap threshold defined
       case Some(externalId) if costCapThreshold.isDefined =>
-        executionServiceCluster.getCost(workflowRec, None, petUser).map { costBreakdown =>
+        executionServiceCluster.getCost(workflowRec, petUser).map { costBreakdown =>
           Option(workflowRec.copy(status = costBreakdown.status, cost = costBreakdown.cost.some))
         }
       // fetch workflow status only if cost cap threshold is not defined
@@ -607,7 +607,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
           dataAccess.submissionQuery.updateStatus(submissionId, newStatus)
         } map (_ => true)
       } else if (costCapThreshold.isDefined && costCapThreshold.get <= workflowRecs.flatMap(_.cost).sum) {
-        logger.info(s"Submission $submissionId exceeded its cost cap and will be aborted.")
+        logger.info(s"Submission $submissionId exceeded its cost cap and will be aborted. [costCap=${costCapThreshold.get},currentSubmissionCost=${workflowRecs.flatMap(_.cost).sum}]")
         dataAccess.submissionQuery.updateStatus(submissionId, SubmissionStatuses.Aborting).map(_ => false)
       } else {
         DBIO.successful(false)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -313,6 +313,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     workflowRec.externalId match {
       case Some(externalId) if costCapThreshold.isDefined => // only fetch cost information if threshold is defined
         executionServiceCluster.getCost(workflowRec, None, petUser).map { costBreakdown =>
+          logger.info(s"costBreakdown = $costBreakdown")
           Option(workflowRec.copy(status = costBreakdown.status, cost = costBreakdown.cost.some))
         }
       case Some(externalId) =>
@@ -590,6 +591,8 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
       )
     }
 
+    logger.info(s"costCapThreshold: $costCapThreshold")
+
     workflowRecsAction.flatMap { workflowRecs =>
       if (workflowRecs.isEmpty || costCapThreshold.isDefined) {
         dataAccess.submissionQuery.findById(submissionId).map(_.status).result.head.flatMap { status =>
@@ -612,9 +615,14 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
               logger.debug(s"submission $submissionId terminating to status $newStatus")
               dataAccess.submissionQuery.updateStatus(submissionId, newStatus)
             } map (_ => true)
-          } else if (costCapThreshold.isDefined && costCapThreshold.get <= workflowRecs.flatMap(_.cost).sum) {
-            logger.info(s"cost cap exceeded, aborting $submissionId")
-            dataAccess.submissionQuery.updateStatus(submissionId, SubmissionStatuses.Aborting).map(_ => false)
+          } else if (costCapThreshold.isDefined) { // && costCapThreshold.get <= workflowRecs.flatMap(_.cost).sum) {
+            logger.info(s"costCap: ${costCapThreshold.get}")
+            logger.info(s"workflowRecs: $workflowRecs")
+            logger.info(s"workflowRecsSum: ${workflowRecs.flatMap(_.cost).sum}")
+            if (costCapThreshold.get <= workflowRecs.flatMap(_.cost).sum) {
+              logger.info(s"cost cap exceeded, aborting $submissionId")
+              dataAccess.submissionQuery.updateStatus(submissionId, SubmissionStatuses.Aborting).map(_ => false)
+            } else DBIO.successful(false)
           } else {
             DBIO.successful(false)
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -464,7 +464,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
                     if (costCapThreshold.isDefined) {
                       dataAccess.workflowQuery.updateStatusAndCost(currentRec,
                                                                    WorkflowStatuses.withName(workflowRec.status),
-                                                                   currentRec.cost.getOrElse(BigDecimal(0))
+                                                                   workflowRec.cost.getOrElse(BigDecimal(0))
                       )
                     } else {
                       dataAccess.workflowQuery.updateStatus(currentRec, WorkflowStatuses.withName(workflowRec.status))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -254,10 +254,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
         } yield abortResults
       }
 
-    // external workflow ids for running workflows
-    def gatherWorkflowOutputs(externalWorkflowIds: Seq[WorkflowRecord],
-                              petUser: UserInfo
-    ): Future[Seq[Try[Option[(WorkflowRecord, Option[ExecutionServiceOutputs])]]]] =
+    def gatherWorkflowOutputs(externalWorkflowIds: Seq[WorkflowRecord], petUser: UserInfo) =
       Future.traverse(externalWorkflowIds) { workflowRec =>
         // for each workflow query the exec service for status and if has Succeeded query again for outputs
         toFutureTry(execServiceStatus(workflowRec, petUser) flatMap {
@@ -342,7 +339,6 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     * @return
     */
 
-  // okay so this is now going to be dealing with non-terminal workflows. but it must have before since I think this is how workflows go from submitted -> running -> aborting as well. it's not just for terminal statuses.
   def handleStatusResponses(
     response: ExecutionServiceStatusResponse
   )(implicit executionContext: ExecutionContext): Future[StatusCheckComplete] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -179,7 +179,10 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     // we want to track them over a longer time frame.
     workspaceSubmissionMetricBuilder(workspaceName, submissionId).expand("cause", cause).asCounter("monitorRestarted")
 
-  private def startSubmissionMonitor(workspaceName: WorkspaceName, submissionId: UUID, costCapThreshold: Option[BigDecimal]) =
+  private def startSubmissionMonitor(workspaceName: WorkspaceName,
+                                     submissionId: UUID,
+                                     costCapThreshold: Option[BigDecimal]
+  ) =
     actorOf(
       SubmissionMonitorActor
         .props(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -134,7 +134,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     case StartMonitorPass =>
       startMonitoringNewSubmissions pipeTo self
     case SubmissionStarted(workspaceName, submissionId, costCapThreshold) =>
-      val child = startSubmissionMonitor(workspaceName, submissionId)
+      val child = startSubmissionMonitor(workspaceName, submissionId, costCapThreshold)
       scheduleNextCheckCurrentWorkflowStatus(child)
       registerDetailedJobExecGauges(workspaceName, submissionId)
 
@@ -192,7 +192,8 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
           executionServiceCluster,
           submissionMonitorConfig,
           entityQueryTimeout,
-          workbenchMetricBaseName
+          workbenchMetricBaseName,
+          costCapThreshold
         )
         .withDispatcher("submission-monitor-dispatcher"),
       submissionId.toString

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisor.scala
@@ -222,7 +222,7 @@ class SubmissionSupervisor(executionServiceCluster: ExecutionServiceCluster,
     val monitoredSubmissions = context.children.map(_.path.name).toSet
 
     datasource.inTransaction { dataAccess =>
-      dataAccess.submissionQuery.listActiveSubmissionIdsWithWorkspace(limit =
+      dataAccess.submissionQuery.listActiveSubmissionIdsWithWorkspaceAndCostCapThreshold(limit =
         submissionMonitorConfig.submissionPollExpiration
       ) map { activeSubs =>
         val unmonitoredSubmissions = activeSubs.filterNot { case (subId, _, _) =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -459,7 +459,7 @@ class SubmissionsService(
             case Success(costMap) =>
               val costedWorkflows = submission.workflows.map { workflow =>
                 workflow.workflowId match {
-                  case Some(wfId) => workflow.copy(cost = costMap.get(wfId)) // use the workflow cost from the BigQuery cost report instead of the Cromwell estimated workflow cost where possible.
+                  case Some(wfId) => workflow.copy(cost = costMap.get(wfId))
                   case None       => workflow
                 }
               }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -459,7 +459,7 @@ class SubmissionsService(
             case Success(costMap) =>
               val costedWorkflows = submission.workflows.map { workflow =>
                 workflow.workflowId match {
-                  case Some(wfId) => workflow.copy(cost = costMap.get(wfId))
+                  case Some(wfId) => workflow.copy(cost = costMap.get(wfId)) // use the workflow cost from the BigQuery cost report instead of the Cromwell estimated workflow cost where possible.
                   case None       => workflow
                 }
               }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockExecutionServiceDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockExecutionServiceDAO.scala
@@ -84,6 +84,11 @@ class MockExecutionServiceDAO(timeout: Boolean = false, val identifier: String =
     Future.successful(ExecutionServiceLabelResponse(id, labels))
   }
 
+  override def getCost(id: String,
+                       workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
+                       userInfo: UserInfo
+  ): Future[WorkflowCostBreakdown] = ???
+
   override def version() = Future.successful(ExecutionServiceVersion("25"))
 
   override def getStatus() = {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockExecutionServiceDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockExecutionServiceDAO.scala
@@ -84,10 +84,7 @@ class MockExecutionServiceDAO(timeout: Boolean = false, val identifier: String =
     Future.successful(ExecutionServiceLabelResponse(id, labels))
   }
 
-  override def getCost(id: String,
-                       workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
-                       userInfo: UserInfo
-  ): Future[WorkflowCostBreakdown] = ???
+  override def getCost(id: String, userInfo: UserInfo): Future[WorkflowCostBreakdown] = ???
 
   override def version() = Future.successful(ExecutionServiceVersion("25"))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
@@ -15,7 +15,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   //   createBatches
 
   implicit val getWorkflowRecord: GetResult[WorkflowRecord] = GetResult { r =>
-    WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
+    WorkflowRecord(r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<, r.<<)
   }
 
   val selectAllFromWorkflow =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DriverComponentSpec.scala
@@ -19,7 +19,7 @@ class DriverComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers wit
   }
 
   val selectAllFromWorkflow =
-    "SELECT ID, EXTERNAL_ID, SUBMISSION_ID, STATUS, STATUS_LAST_CHANGED, ENTITY_ID, record_version, EXEC_SERVICE_KEY, EXTERNAL_ENTITY_ID FROM WORKFLOW"
+    "SELECT ID, EXTERNAL_ID, SUBMISSION_ID, STATUS, STATUS_LAST_CHANGED, ENTITY_ID, record_version, EXEC_SERVICE_KEY, EXTERNAL_ENTITY_ID, COST FROM WORKFLOW"
 
   "DriverComponent" should "test concatSqlActions" in withDefaultTestDatabase {
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -353,6 +353,7 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
                        None,
                        1,
                        Option("unittestdefault"),
+                       None,
                        None
         ),
         WorkflowRecord(22222,
@@ -363,6 +364,7 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
                        None,
                        1,
                        Option("unittestdefault"),
+                       None,
                        None
         )
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/ShardedHttpExecutionServiceClusterTest.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/ShardedHttpExecutionServiceClusterTest.scala
@@ -57,6 +57,7 @@ class ShardedHttpExecutionServiceClusterTest(_system: ActorSystem)
                                           Some(1),
                                           1,
                                           Some("default"),
+                                          None,
                                           None
   )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -423,6 +423,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                       Some(entityId),
                       0,
                       None,
+                      None,
                       None
        ),
        outputs
@@ -478,6 +479,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                       Some(entityId),
                       0,
                       None,
+                      None,
                       None
        ),
        outputs
@@ -532,6 +534,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                       Some(entityId),
                       0,
                       None,
+                      None,
                       None
        ),
        outputs
@@ -580,6 +583,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                       Some(entityId),
                       0,
                       None,
+                      None,
                       None
        ),
        emptyOutputs
@@ -616,6 +620,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           null,
           Some(entityId),
           0,
+          None,
           None,
           None
         ),
@@ -661,6 +666,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                       Some(entityId),
                       0,
                       None,
+                      None,
                       None
        ),
        outputs
@@ -693,6 +699,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                       None,
                       0,
                       None,
+                      None,
                       None
        ),
        outputs
@@ -724,6 +731,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
                                         null,
                                         Some(entityId),
                                         0,
+                                        None,
                                         None,
                                         None
     )
@@ -1927,7 +1935,8 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       new Builder().build(),
       config,
       ConfigFactory.load().getDuration("entities.queryTimeout").toScala,
-      "test"
+      "test",
+      None
     )
   }
 
@@ -1983,6 +1992,11 @@ class SubmissionTestExecutionServiceDAO(workflowStatus: => String) extends Execu
     Future.successful(ExecutionServiceLabelResponse(id, labels))
   }
 
+  override def getCost(id: String,
+                       workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
+                       userInfo: UserInfo
+  ): Future[WorkflowCostBreakdown] = ???
+
   override def version() = Future.successful(ExecutionServiceVersion("25"))
 
   override def getStatus() = {
@@ -2005,5 +2019,6 @@ class TestSubmissionMonitor(val workspaceName: WorkspaceName,
                             val credential: Credential,
                             val config: SubmissionMonitorConfig,
                             val queryTimeout: Duration,
-                            override val workbenchMetricBaseName: String
+                            override val workbenchMetricBaseName: String,
+                            val costCapThreshold: Option[BigDecimal]
 ) extends SubmissionMonitor {}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -2093,11 +2093,8 @@ class SubmissionTestExecutionServiceDAO(workflowStatus: => String, workflowCost:
     Future.successful(ExecutionServiceLabelResponse(id, labels))
   }
 
-  override def getCost(id: String,
-                       workflowCostBreakdownParams: Option[WorkflowCostBreakdownParams],
-                       userInfo: UserInfo
-  ): Future[WorkflowCostBreakdown] =
-    Future.successful(WorkflowCostBreakdown(id, workflowCost, "USD", workflowStatus, None, None))
+  override def getCost(id: String, userInfo: UserInfo): Future[WorkflowCostBreakdown] =
+    Future.successful(WorkflowCostBreakdown(id, workflowCost, "USD", workflowStatus, Seq.empty))
 
   override def version() = Future.successful(ExecutionServiceVersion("25"))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -101,7 +101,8 @@ class SubmissionSupervisorSpec
     withStatsD {
       withSupervisor() { supervisor =>
         supervisor ! SubmissionStarted(testData.workspace.toWorkspaceName,
-                                       UUID.fromString(testData.submission1.submissionId)
+                                       UUID.fromString(testData.submission1.submissionId),
+                                       None
         )
         supervisor ! SaveCurrentWorkflowStatusCounts(
           testData.workspace.toWorkspaceName,
@@ -112,7 +113,8 @@ class SubmissionSupervisorSpec
         )
 
         supervisor ! SubmissionStarted(testData.workspaceSuccessfulSubmission.toWorkspaceName,
-                                       UUID.fromString(testData.submissionSuccessful1.submissionId)
+                                       UUID.fromString(testData.submissionSuccessful1.submissionId),
+                                       None
         )
         supervisor ! SaveCurrentWorkflowStatusCounts(
           testData.workspaceSuccessfulSubmission.toWorkspaceName,
@@ -162,10 +164,12 @@ class SubmissionSupervisorSpec
       withSupervisor() { supervisor =>
         // start the submission
         supervisor ! SubmissionStarted(testData.workspace.toWorkspaceName,
-                                       UUID.fromString(testData.submission1.submissionId)
+                                       UUID.fromString(testData.submission1.submissionId),
+                                       None
         )
         supervisor ! SubmissionStarted(testData.workspace.toWorkspaceName,
-                                       UUID.fromString(testData.submission2.submissionId)
+                                       UUID.fromString(testData.submission2.submissionId),
+                                       None
         )
 
         // the first submission updates once and then completes
@@ -234,10 +238,12 @@ class SubmissionSupervisorSpec
       withSupervisor() { supervisor =>
         // start the submission
         supervisor ! SubmissionStarted(testData.workspace.toWorkspaceName,
-                                       UUID.fromString(testData.submission1.submissionId)
+                                       UUID.fromString(testData.submission1.submissionId),
+                                       None
         )
         supervisor ! SubmissionStarted(testData.workspace.toWorkspaceName,
-                                       UUID.fromString(testData.submission2.submissionId)
+                                       UUID.fromString(testData.submission2.submissionId),
+                                       None
         )
 
         // both submissions immediately complete
@@ -303,7 +309,8 @@ class SubmissionSupervisorSpec
     withStatsD {
       withSupervisor(trackDetailedMetrics = false) { supervisor =>
         supervisor ! SubmissionStarted(testData.workspace.toWorkspaceName,
-                                       UUID.fromString(testData.submission1.submissionId)
+                                       UUID.fromString(testData.submission1.submissionId),
+                                       None
         )
         supervisor ! SaveCurrentWorkflowStatusCounts(
           testData.workspace.toWorkspaceName,
@@ -314,7 +321,8 @@ class SubmissionSupervisorSpec
         )
 
         supervisor ! SubmissionStarted(testData.workspaceSuccessfulSubmission.toWorkspaceName,
-                                       UUID.fromString(testData.submissionSuccessful1.submissionId)
+                                       UUID.fromString(testData.submissionSuccessful1.submissionId),
+                                       None
         )
         supervisor ! SaveCurrentWorkflowStatusCounts(
           testData.workspaceSuccessfulSubmission.toWorkspaceName,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -144,12 +144,7 @@ case class WorkflowCost(
   cost: Option[Float]
 )
 
-case class WorkflowCostBreakdown(id: String,
-                                 cost: BigDecimal,
-                                 currency: String,
-                                 status: String,
-                                 errors: Seq[String]
-)
+case class WorkflowCostBreakdown(id: String, cost: BigDecimal, currency: String, status: String, errors: Seq[String])
 
 case class ExternalEntityInfo(dataStoreId: String, rootEntityType: String)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -144,14 +144,11 @@ case class WorkflowCost(
   cost: Option[Float]
 )
 
-case class WorkflowCostBreakdownParams(includeTaskBreakdown: Boolean, includeSubworkflowBreakdown: Boolean)
-
 case class WorkflowCostBreakdown(id: String,
                                  cost: BigDecimal,
                                  currency: String,
                                  status: String,
-                                 subworkflowBreakdown: Option[Map[String, BigDecimal]],
-                                 taskBreakdown: Option[Map[String, BigDecimal]]
+                                 errors: Seq[String]
 )
 
 case class ExternalEntityInfo(dataStoreId: String, rootEntityType: String)
@@ -491,7 +488,7 @@ trait ExecutionJsonSupport extends JsonSupport {
 
   implicit val WorkflowCostFormat: RootJsonFormat[WorkflowCost] = jsonFormat2(WorkflowCost)
 
-  implicit val WorkflowCostBreakdownFormat: RootJsonFormat[WorkflowCostBreakdown] = jsonFormat6(WorkflowCostBreakdown)
+  implicit val WorkflowCostBreakdownFormat: RootJsonFormat[WorkflowCostBreakdown] = jsonFormat5(WorkflowCostBreakdown)
 
   implicit val SubmissionValidationInputFormat: RootJsonFormat[SubmissionValidationInput] = jsonFormat2(
     SubmissionValidationInput

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/ExecutionModel.scala
@@ -144,6 +144,16 @@ case class WorkflowCost(
   cost: Option[Float]
 )
 
+case class WorkflowCostBreakdownParams(includeTaskBreakdown: Boolean, includeSubworkflowBreakdown: Boolean)
+
+case class WorkflowCostBreakdown(id: String,
+                                 cost: BigDecimal,
+                                 currency: String,
+                                 status: String,
+                                 subworkflowBreakdown: Option[Map[String, BigDecimal]],
+                                 taskBreakdown: Option[Map[String, BigDecimal]]
+)
+
 case class ExternalEntityInfo(dataStoreId: String, rootEntityType: String)
 
 // Status of a submission
@@ -480,6 +490,8 @@ trait ExecutionJsonSupport extends JsonSupport {
   implicit val WorkflowOutputsFormat: RootJsonFormat[WorkflowOutputs] = jsonFormat2(WorkflowOutputs)
 
   implicit val WorkflowCostFormat: RootJsonFormat[WorkflowCost] = jsonFormat2(WorkflowCost)
+
+  implicit val WorkflowCostBreakdownFormat: RootJsonFormat[WorkflowCostBreakdown] = jsonFormat6(WorkflowCostBreakdown)
 
   implicit val SubmissionValidationInputFormat: RootJsonFormat[SubmissionValidationInput] = jsonFormat2(
     SubmissionValidationInput


### PR DESCRIPTION
Ticket: [WOR-1794](https://broadworkbench.atlassian.net/browse/WOR-1794)
* Add column to `WORKFLOW` table that stores the last fetched cost for the workflow if the workflow's submission has a cost cap set.
* When updating submission status, check that the current cost of all workflows is under the cost cap. Abort the submission if the cost cap has been exceeded.
* Submission monitor is functionally unchanged if a cost cap has not been set.
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[WOR-1794]: https://broadworkbench.atlassian.net/browse/WOR-1794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ