### PR TITLE
WOR-1823: use original comparisons to resolve canShare

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -283,12 +283,11 @@ class WorkspaceService(
       }
       owners = ownersPolicy.map(policy => policy.memberEmails.map(_.value))
       canShare <- options.anyPresentFuture("canShare") {
-        accessLevel match {
-          case WorkspaceAccessLevels.Read  => Future.successful(false)
-          case WorkspaceAccessLevels.Owner => Future.successful(true)
-          case _ =>
-            val sharePolicy = SamWorkspaceActions.sharePolicy(accessLevel.toString.toLowerCase())
-            samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, sharePolicy, ctx)
+        if (accessLevel < WorkspaceAccessLevels.Read) Future.successful(false)
+        else if(accessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+        else {
+          val sharePolicy = SamWorkspaceActions.sharePolicy(accessLevel.toString.toLowerCase())
+          samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, sharePolicy, ctx)
         }
       }
       wsmService = new AggregatedWorkspaceService(workspaceManagerDAO)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -284,7 +284,7 @@ class WorkspaceService(
       owners = ownersPolicy.map(policy => policy.memberEmails.map(_.value))
       canShare <- options.anyPresentFuture("canShare") {
         if (accessLevel < WorkspaceAccessLevels.Read) Future.successful(false)
-        else if(accessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
+        else if (accessLevel >= WorkspaceAccessLevels.Owner) Future.successful(true)
         else {
           val sharePolicy = SamWorkspaceActions.sharePolicy(accessLevel.toString.toLowerCase())
           samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, sharePolicy, ctx)
@@ -2229,7 +2229,6 @@ class WorkspaceService(
         )
     }
 
-
   def failIfBucketRegionInvalid(bucketRegion: Option[String]): Future[Unit] =
     bucketRegion.traverse_ { region =>
       // if the user specifies a region for the workspace bucket, it must be in the proper format
@@ -2263,8 +2262,6 @@ class WorkspaceService(
         gcsDAO.getRegionForRegionalBucket(sourceBucketName, Option(googleProjectId))
       case (None, None) => Future(Some(config.defaultLocation))
     }
-
-
 
 }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1823

Fixes a bug introduced earlier, which matches accessLevel exactly, instead of using comparisons when resolving canShare on a workspace.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
