### PR TITLE
[WOR-1829] Add setting for separating submission outputs

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5955,12 +5955,14 @@ components:
             - GcpBucketLifecycle
             - GcpBucketSoftDelete
             - GcpBucketRequesterPays
+            - SeparateSubmissionFinalOutputs
         config:
           description: The configuration of the workspace setting
           oneOf:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketLifecycleConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketSoftDeleteConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketRequesterPaysConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingSeparateSubmissionFinalOutputs'
     WorkspaceSettingGcpBucketLifecycleConfig:
       required:
         - rules
@@ -6019,6 +6021,14 @@ components:
         enabled:
           type: boolean
           description: Enabled status to set for requester pays
+    WorkspaceSettingSeparateSubmissionFinalOutputs:
+      required:
+        - enabled
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Whether submission final outputs should be separated from intermediate outputs
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -3,12 +3,14 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketLifecycleConfigFormat,
   GcpBucketRequesterPaysConfigFormat,
-  GcpBucketSoftDeleteConfigFormat
+  GcpBucketSoftDeleteConfigFormat,
+  SeparateSubmissionFinalOutputsConfigFormat
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig
+  GcpBucketSoftDeleteConfig,
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model._
@@ -65,6 +67,10 @@ object WorkspaceSettingRecord {
         GcpBucketSoftDeleteSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketSoftDeleteConfig])
       case WorkspaceSettingTypes.GcpBucketRequesterPays =>
         GcpBucketRequesterPaysSetting(workspaceSettingRecord.config.parseJson.convertTo[GcpBucketRequesterPaysConfig])
+      case WorkspaceSettingTypes.SeparateSubmissionFinalOutputs =>
+        SeparateSubmissionFinalOutputsSetting(
+          workspaceSettingRecord.config.parseJson.convertTo[SeparateSubmissionFinalOutputsConfig]
+        )
     }
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -12,7 +12,8 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig
+  GcpBucketSoftDeleteConfig,
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
@@ -25,6 +26,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SamResourceTypeNames,
   SamUserStatusResponse,
   SamWorkspaceActions,
+  SeparateSubmissionFinalOutputsSetting,
   UserInfo,
   Workspace,
   WorkspaceSettingTypes
@@ -181,7 +183,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     val workspaceSettings = List(
       GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty)),
       GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(7.days.toSeconds)),
-      GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))
+      GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
+      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true))
     )
 
     val workspaceRepository = mock[WorkspaceRepository]

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -17,12 +17,14 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig
+  GcpBucketSoftDeleteConfig,
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   GcpBucketLifecycle,
   GcpBucketRequesterPays,
   GcpBucketSoftDelete,
+  SeparateSubmissionFinalOutputs,
   WorkspaceSettingType
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
@@ -586,6 +588,9 @@ case class GcpBucketSoftDeleteSetting(override val config: GcpBucketSoftDeleteCo
 case class GcpBucketRequesterPaysSetting(override val config: GcpBucketRequesterPaysConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.GcpBucketRequesterPays, config)
 
+case class SeparateSubmissionFinalOutputsSetting(override val config: SeparateSubmissionFinalOutputsConfig)
+    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.SeparateSubmissionFinalOutputs, config)
+
 object WorkspaceSettingTypes {
   sealed trait WorkspaceSettingType extends RawlsEnumeration[WorkspaceSettingType] {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
@@ -593,10 +598,11 @@ object WorkspaceSettingTypes {
   }
 
   def withName(name: String): WorkspaceSettingType = name.toLowerCase match {
-    case "gcpbucketlifecycle"     => GcpBucketLifecycle
-    case "gcpbucketsoftdelete"    => GcpBucketSoftDelete
-    case "gcpbucketrequesterpays" => GcpBucketRequesterPays
-    case _                        => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
+    case "gcpbucketlifecycle"             => GcpBucketLifecycle
+    case "gcpbucketsoftdelete"            => GcpBucketSoftDelete
+    case "gcpbucketrequesterpays"         => GcpBucketRequesterPays
+    case "separatesubmissionfinaloutputs" => SeparateSubmissionFinalOutputs
+    case _                                => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
   }
 
   case object GcpBucketLifecycle extends WorkspaceSettingType
@@ -604,6 +610,8 @@ object WorkspaceSettingTypes {
   case object GcpBucketSoftDelete extends WorkspaceSettingType
 
   case object GcpBucketRequesterPays extends WorkspaceSettingType
+
+  case object SeparateSubmissionFinalOutputs extends WorkspaceSettingType
 }
 
 sealed trait WorkspaceSettingConfig
@@ -619,6 +627,8 @@ object WorkspaceSettingConfig {
   case class GcpBucketSoftDeleteConfig(retentionDurationInSeconds: Seconds) extends WorkspaceSettingConfig
 
   case class GcpBucketRequesterPaysConfig(enabled: Boolean) extends WorkspaceSettingConfig
+
+  case class SeparateSubmissionFinalOutputsConfig(enabled: Boolean) extends WorkspaceSettingConfig
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])
@@ -1247,6 +1257,10 @@ class WorkspaceJsonSupport extends JsonSupport {
   implicit val GcpBucketRequesterPaysConfigFormat: RootJsonFormat[GcpBucketRequesterPaysConfig] = jsonFormat1(
     GcpBucketRequesterPaysConfig.apply
   )
+  implicit val SeparateSubmissionFinalOutputsConfigFormat: RootJsonFormat[SeparateSubmissionFinalOutputsConfig] =
+    jsonFormat1(
+      SeparateSubmissionFinalOutputsConfig.apply
+    )
 
   implicit object WorkspaceSettingTypeFormat extends RootJsonFormat[WorkspaceSettingType] {
     override def write(obj: WorkspaceSettingType): JsValue = JsString(obj.toString)
@@ -1259,9 +1273,10 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit object WorkspaceSettingConfigFormat extends RootJsonFormat[WorkspaceSettingConfig] {
     def write(obj: WorkspaceSettingConfig): JsValue = obj match {
-      case config: GcpBucketLifecycleConfig     => config.toJson
-      case config: GcpBucketSoftDeleteConfig    => config.toJson
-      case config: GcpBucketRequesterPaysConfig => config.toJson
+      case config: GcpBucketLifecycleConfig             => config.toJson
+      case config: GcpBucketSoftDeleteConfig            => config.toJson
+      case config: GcpBucketRequesterPaysConfig         => config.toJson
+      case config: SeparateSubmissionFinalOutputsConfig => config.toJson
     }
 
     // We prevent reading WorkspaceSettingConfig directly because we need
@@ -1285,6 +1300,8 @@ class WorkspaceJsonSupport extends JsonSupport {
         case GcpBucketSoftDelete => GcpBucketSoftDeleteSetting(fields("config").convertTo[GcpBucketSoftDeleteConfig])
         case GcpBucketRequesterPays =>
           GcpBucketRequesterPaysSetting(fields("config").convertTo[GcpBucketRequesterPaysConfig])
+        case SeparateSubmissionFinalOutputs =>
+          SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
         case _ => throw DeserializationException(s"unexpected setting type $settingType")
       }
     }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -10,7 +10,8 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig
+  GcpBucketSoftDeleteConfig,
+  SeparateSubmissionFinalOutputsConfig
 }
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
@@ -889,7 +890,7 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
       }
     }
 
-    "GoogleBucketSoftDeleteSettings" - {
+    "GoogleBucketSoftDeleteSetting" - {
       "parses soft delete setting with retentionDurationInSeconds" in {
         val softDeleteSetting =
           """{
@@ -1005,6 +1006,59 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         intercept[DeserializationException] {
           WorkspaceSettingFormat.read(requesterPaysSettingBadConfig)
         }
+      }
+    }
+  }
+
+  "SeparateSubmissionFinalOutputsSetting" - {
+    "parses setting with enabled" in {
+      val setting =
+        """{
+          |    "settingType": "SeparateSubmissionFinalOutputs",
+          |    "config": {
+          |      "enabled": true
+          |    }
+          |  }""".stripMargin.parseJson
+      assertResult {
+        SeparateSubmissionFinalOutputsSetting(
+          SeparateSubmissionFinalOutputsConfig(true)
+        )
+      } {
+        WorkspaceSettingFormat.read(setting)
+      }
+    }
+
+    "throws an exception for missing enabled" in {
+      val settingNoEnabled =
+        """{
+          |    "settingType": "SeparateSubmissionFinalOutputs",
+          |    "config": {}
+          |  }""".stripMargin.parseJson
+      intercept[DeserializationException] {
+        WorkspaceSettingFormat.read(settingNoEnabled)
+      }
+    }
+
+    "throws an exception for missing config" in {
+      val settingNoConfig =
+        """{
+          |    "settingType": "SeparateSubmissionFinalOutputs"
+          |  }""".stripMargin.parseJson
+      intercept[NoSuchElementException] {
+        WorkspaceSettingFormat.read(settingNoConfig)
+      }
+    }
+
+    "throws an exception for incorrect format" in {
+      val settingBadConfig =
+        """{
+          |    "settingType": "SeparateSubmissionFinalOutputs",
+          |    "config": {
+          |      "enabled": 0
+          |    }
+          |  }""".stripMargin.parseJson
+      intercept[DeserializationException] {
+        WorkspaceSettingFormat.read(settingBadConfig)
       }
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1829

This adds a new setting that will be used with a submission is launched to opt-in to the new directory (and copy) structure.

I will need to publish a new Rawls model version and update orchestration.

I tested this by running local Rawls swagger and enabling the new setting on a workspace:

![image](https://github.com/user-attachments/assets/7a576a8f-cb67-4f38-b054-0cff785c88ea)


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
