### PR TITLE
[WOR-1829] Update Rawls model version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ Running the `publishRelease.sh` script publishes a release of rawls-model, workb
 You should do this manually from the base directory of the repo when you change something in `model/src`, `util/src` or `google/src`.
 
 Note: We have started just using the automatically generated `-SNAP` versions published by [`rawls-build` GitHub action](https://github.com/broadinstitute/terra-github-workflows/actions/workflows/rawls-build.yaml) on every dev build. Here are detailed instructions for finding the name of the jar file:
-* Navigate to the [`rawls-build-tag-publish-and-run-tests` workflow](https://github.com/broadinstitute/rawls/blob/develop/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml).
-  github action for your commit
+* Navigate to the [`rawls-build-tag-publish-and-run-tests` workflow](https://github.com/broadinstitute/rawls/blob/develop/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml) github action for your commit
 * Navigate to the rawls-build-publish-job job of that workflow
 * Open the "dispatch build" step, and click over to the run in terra-github-workflows
 * Expand the "Publish model library" step

--- a/README.md
+++ b/README.md
@@ -132,10 +132,13 @@ Supported Scala versions: 2.13
 Running the `publishRelease.sh` script publishes a release of rawls-model, workbench-util and workbench-google to Artifactory.
 You should do this manually from the base directory of the repo when you change something in `model/src`, `util/src` or `google/src`.
 
-- The [`rawls-build` GitHub action](https://github.com/broadinstitute/terra-github-workflows/actions/workflows/rawls-build.yaml)
-publishes these libraries, but it makes "unofficial" `-SNAP` versions. This action runs on every dev build as part of the
-[`rawls-build-tag-publish-and-run-tests` workflow](https://github.com/broadinstitute/rawls/blob/develop/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml).
-
+Note: We have started just using the automatically generated `-SNAP` versions published by [`rawls-build` GitHub action](https://github.com/broadinstitute/terra-github-workflows/actions/workflows/rawls-build.yaml) on every dev build. Here are detailed instructions for finding the name of the jar file:
+* Navigate to the [`rawls-build-tag-publish-and-run-tests` workflow](https://github.com/broadinstitute/rawls/blob/develop/.github/workflows/rawls-build-tag-publish-and-run-tests.yaml).
+  github action for your commit
+* Navigate to the rawls-build-publish-job job of that workflow
+* Open the "dispatch build" step, and click over to the run in terra-github-workflows
+* Expand the "Publish model library" step
+* Note that version published, e.g. "rawls-model_2.13-v0.0.180-SNAP.jar"
 
 To publish a temporary or test version, use `publishSnapshot.sh` like so:
 

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.180-SNAP"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.189-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("bio.terra", "workspace-manager-client"),

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -8,4 +8,4 @@ Added:
 - Support 2.13
 - ExecutionModel classes moved from core to model
 
-SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "v0.0.180-SNAP"`
+SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "v0.0.189-SNAP"`


### PR DESCRIPTION
Follow-up to https://github.com/broadinstitute/rawls/pull/3059

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
