### PR TITLE
[WOR-432] Add additional validation for updateAcl

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1083,7 +1083,7 @@ class WorkspaceService(
     val currentUserAcl = existingAcls.find(_.email.equalsIgnoreCase(ctx.userInfo.userEmail.value))
     if (currentUserAcl.exists(_.accessLevel == WorkspaceAccessLevels.NoAccess) || currentUserAcl.isEmpty) {
       throw new InvalidWorkspaceAclUpdateException(
-        ErrorReport(StatusCodes.BadRequest, "do not have access to change permissions for this workspace")
+        ErrorReport(StatusCodes.BadRequest, "you do not have access to change permissions for this workspace")
       )
     }
     // Add the existingAcl entries that are being modified so we can check what we will
@@ -1093,13 +1093,11 @@ class WorkspaceService(
     if (currentUserAcl.exists(_.accessLevel < WorkspaceAccessLevels.Owner)) {
       val invalidAclUpdates = allRolePermissionChanges.collect {
         case aclChange if aclChange.accessLevel > currentUserAcl.get.accessLevel =>
-          "cannot change roles higher than your own"
-        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, Some(true), _) =>
-          "cannot change reader share access"
-        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, Some(true), _) =>
-          "cannot change writer share access"
-        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, _, Some(true)) =>
-          "cannot change writer can compute access"
+          "cannot change access levels higher than your own"
+        case WorkspaceACLUpdate(_, _, Some(true), _) =>
+          "cannot change canShare permission"
+        case WorkspaceACLUpdate(_, _, _, Some(true)) =>
+          "cannot change canCompute permission"
       }.toSeq
       if (invalidAclUpdates.nonEmpty) {
         throw new InvalidWorkspaceAclUpdateException(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1080,6 +1080,33 @@ class WorkspaceService(
                                  workspace: Workspace
   ): Unit = {
     val emailsBeingChanged = aclChanges.map(_.email.toLowerCase)
+    val currentUserAcl = existingAcls.find(_.email.equalsIgnoreCase(ctx.userInfo.userEmail.value))
+    if (currentUserAcl.exists(_.accessLevel == WorkspaceAccessLevels.NoAccess) || currentUserAcl.isEmpty) {
+      throw new InvalidWorkspaceAclUpdateException(
+        ErrorReport(StatusCodes.BadRequest, "do not have access to change permissions for this workspace")
+      )
+    }
+    // Add the existingAcl entries that are being modified so we can check what we will
+    // be removing as well as what we are adding.
+    val allRolePermissionChanges =
+      aclChanges ++ existingAcls.filter(existingAcl => emailsBeingChanged.contains(existingAcl.email.toLowerCase))
+    if (currentUserAcl.exists(_.accessLevel < WorkspaceAccessLevels.Owner)) {
+      val invalidAclUpdates = allRolePermissionChanges.collect {
+        case aclChange if aclChange.accessLevel > currentUserAcl.get.accessLevel =>
+          "cannot change roles higher than your own"
+        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Read, Some(true), _) =>
+          "cannot change reader share access"
+        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, Some(true), _) =>
+          "cannot change writer share access"
+        case WorkspaceACLUpdate(_, WorkspaceAccessLevels.Write, _, Some(true)) =>
+          "cannot change writer can compute access"
+      }.toSeq
+      if (invalidAclUpdates.nonEmpty) {
+        throw new InvalidWorkspaceAclUpdateException(
+          ErrorReport(StatusCodes.BadRequest, "you do not have sufficient permissions to make these changes")
+        )
+      }
+    }
     if (
       aclChanges.exists(_.accessLevel == WorkspaceAccessLevels.ProjectOwner) || existingAcls.exists(existingAcl =>
         existingAcl.accessLevel == ProjectOwner && emailsBeingChanged.contains(existingAcl.email.toLowerCase)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -717,6 +717,8 @@ class WorkspaceServiceSpec
   }
 
   it should "invite a user to a workspace" in withTestDataServicesCustomSam { services =>
+    populateWorkspacePolicies(services)
+
     val aclUpdates2 = Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, None))
     val vComplete2 =
       Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates2, true),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -1874,7 +1874,7 @@ class WorkspaceServiceUnitTests
     thrown.errorReport.message shouldBe "you do not have sufficient permissions to make these changes"
   }
 
-  it should "verify the calling user is not trying to change roles higher than their own" in {
+  it should "verify the calling user is not trying to change access levels higher than their own" in {
     val projectOwnerEmail = "projectOwner@example.com"
     val ownerEmail = "owner@example.com"
     val readerEmail = "reader@example.com"
@@ -1936,7 +1936,7 @@ class WorkspaceServiceUnitTests
     val thrown = intercept[RawlsExceptionWithErrorReport] {
       Await.result(service.updateACL(WorkspaceName("fake_namespace", "fake_name"), aclUpdate, true), Duration.Inf)
     }
-    thrown.errorReport.message shouldBe "do not have access to change permissions for this workspace"
+    thrown.errorReport.message shouldBe "you do not have access to change permissions for this workspace"
   }
 
   behavior of "getBucketUsage"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-432

The terra-ui portion of this ticket has already been completed, so we don't present options in the Share Workspace modal that will fail. This PR adds additional validation logic to the Rawls `updateAcl` method so that we don't end up in a confusing "partially updated" state (if called via the Rawls Swagger).

Previously, the Rawls method did not check the permissions that the caller has on the workspace, and instead relied on Sam to throw exceptions. That was problematic because changing the workspace access level or permissions of a user is a 2-step process: we first add the new access levels/permissions, and then remove the old ones.

So, for instance, if a Writer attempted to change a Writer w/canShare -> Reader wout/canShare, the following would occur:

1. Add the user as Reader without canShare (would succeed)
2. Attempt to remove the user as Writer with canShare (would fail because a Writer can't modify the canShare permission)

Now we do validation before calling Sam.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
