### PR TITLE
Revert "[WOR-432] Add additional validation for updateAcl"

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1080,31 +1080,6 @@ class WorkspaceService(
                                  workspace: Workspace
   ): Unit = {
     val emailsBeingChanged = aclChanges.map(_.email.toLowerCase)
-    val currentUserAcl = existingAcls.find(_.email.equalsIgnoreCase(ctx.userInfo.userEmail.value))
-    if (currentUserAcl.exists(_.accessLevel == WorkspaceAccessLevels.NoAccess) || currentUserAcl.isEmpty) {
-      throw new InvalidWorkspaceAclUpdateException(
-        ErrorReport(StatusCodes.BadRequest, "you do not have access to change permissions for this workspace")
-      )
-    }
-    // Add the existingAcl entries that are being modified so we can check what we will
-    // be removing as well as what we are adding.
-    val allRolePermissionChanges =
-      aclChanges ++ existingAcls.filter(existingAcl => emailsBeingChanged.contains(existingAcl.email.toLowerCase))
-    if (currentUserAcl.exists(_.accessLevel < WorkspaceAccessLevels.Owner)) {
-      val invalidAclUpdates = allRolePermissionChanges.collect {
-        case aclChange if aclChange.accessLevel > currentUserAcl.get.accessLevel =>
-          "cannot change access levels higher than your own"
-        case WorkspaceACLUpdate(_, _, Some(true), _) =>
-          "cannot change canShare permission"
-        case WorkspaceACLUpdate(_, _, _, Some(true)) =>
-          "cannot change canCompute permission"
-      }.toSeq
-      if (invalidAclUpdates.nonEmpty) {
-        throw new InvalidWorkspaceAclUpdateException(
-          ErrorReport(StatusCodes.BadRequest, "you do not have sufficient permissions to make these changes")
-        )
-      }
-    }
     if (
       aclChanges.exists(_.accessLevel == WorkspaceAccessLevels.ProjectOwner) || existingAcls.exists(existingAcl =>
         existingAcl.accessLevel == ProjectOwner && emailsBeingChanged.contains(existingAcl.email.toLowerCase)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -369,25 +369,12 @@ class FastPassServiceSpec
     val newWorkspaceName = "space_for_workin"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)
     val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
-    // Mock the caller being an owner on the workspace.
-    when(services.samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any(), any()))
-      .thenReturn(
-        Future(
-          Set(
-            SamPolicyWithNameAndEmail(
-              SamWorkspacePolicyNames.owner,
-              SamPolicy(Set(WorkbenchEmail(services.ctx1.userInfo.userEmail.value)), Set.empty, Set.empty),
-              WorkbenchEmail("ownerPolicy@example.com")
-            )
-          )
-        )
-      )
 
     val aclAdd = Set(
       WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Write, canCompute = Option(true)),
       WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Read, canShare = Option(true))
     )
-    Await.result(services.workspaceService.updateACL(workspace.toWorkspaceName, aclAdd, false), Duration.Inf)
+    Await.ready(services.workspaceService.updateACL(workspace.toWorkspaceName, aclAdd, false), Duration.Inf)
 
     verify(services.mockFastPassService)
       .syncFastPassesForUserInWorkspace(
@@ -1047,19 +1034,6 @@ class FastPassServiceSpec
   }
 
   it should "not block workspace ACL modifications if FastPass fails" in withTestDataServices { services =>
-    // Mock the caller being an owner on the workspace.
-    when(services.samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any(), any()))
-      .thenReturn(
-        Future(
-          Set(
-            SamPolicyWithNameAndEmail(
-              SamWorkspacePolicyNames.owner,
-              SamPolicy(Set(WorkbenchEmail(services.ctx1.userInfo.userEmail.value)), Set.empty, Set.empty),
-              WorkbenchEmail("ownerPolicy@example.com")
-            )
-          )
-        )
-      )
     doThrow(new RuntimeException("foo"))
       .when(services.googleStorageDAO)
       .addIamRoles(
@@ -1079,7 +1053,7 @@ class FastPassServiceSpec
       WorkspaceACLUpdate(testData.userWriter.userEmail.value, WorkspaceAccessLevels.Write, canCompute = Option(true)),
       WorkspaceACLUpdate(testData.userReader.userEmail.value, WorkspaceAccessLevels.Read, canShare = Option(true))
     )
-    Await.result(services.workspaceService.updateACL(workspace.toWorkspaceName, aclAdd, false), Duration.Inf)
+    Await.ready(services.workspaceService.updateACL(workspace.toWorkspaceName, aclAdd, false), Duration.Inf)
   }
 
   it should "collect errors while removing FastPass grants" in withTestDataServices { services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -717,8 +717,6 @@ class WorkspaceServiceSpec
   }
 
   it should "invite a user to a workspace" in withTestDataServicesCustomSam { services =>
-    populateWorkspacePolicies(services)
-
     val aclUpdates2 = Set(WorkspaceACLUpdate("obama@whitehouse.gov", WorkspaceAccessLevels.Owner, None))
     val vComplete2 =
       Await.result(services.workspaceService.updateACL(testData.workspace.toWorkspaceName, aclUpdates2, true),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -1573,7 +1573,7 @@ class WorkspaceServiceUnitTests
   behavior of "updateAcl"
   it should "call Sam for Rawls workspaces" in {
     val projectOwnerEmail = "projectOwner@example.com"
-    val ownerEmail = ctx.userInfo.userEmail.value // user making the request is an owner
+    val ownerEmail = "owner@example.com"
     val writerEmail = "writer@example.com"
     val readerEmail = "reader@example.com"
 
@@ -1630,7 +1630,7 @@ class WorkspaceServiceUnitTests
   }
 
   it should "call WSM for McWorkspaces" in {
-    val ownerEmail = ctx.userInfo.userEmail.value // user making the request is an owner
+    val ownerEmail = "owner@example.com"
     val writerEmail = "writer@example.com"
     val readerEmail = "reader@example.com"
 
@@ -1682,6 +1682,7 @@ class WorkspaceServiceUnitTests
     val ownerEmail = "owner@example.com"
     val writerEmail = "writer@example.com"
     val readerEmail = "reader@example.com"
+    val workspaceId = UUID.randomUUID()
 
     val wsmDAO = mockWsmForAclTests(ownerEmail, writerEmail, readerEmail)
     val workspaceRepository = mockWorkspaceRepositoryForAclTests(WorkspaceType.McWorkspace)
@@ -1705,6 +1706,7 @@ class WorkspaceServiceUnitTests
     val ownerEmail = "owner@example.com"
     val writerEmail = "writer@example.com"
     val readerEmail = "reader@example.com"
+    val workspaceId = UUID.randomUUID()
 
     val wsmDAO = mockWsmForAclTests(ownerEmail, writerEmail, readerEmail)
     val workspaceRepository = mockWorkspaceRepositoryForAclTests(WorkspaceType.McWorkspace)
@@ -1751,7 +1753,7 @@ class WorkspaceServiceUnitTests
 
   it should "not allow readers to have compute access but should allow writers for Rawls workspaces" in {
     val projectOwnerEmail = "projectOwner@example.com"
-    val ownerEmail = ctx.userInfo.userEmail.value // user making the request is an owner
+    val ownerEmail = "owner@example.com"
     val writerEmail = "writer@example.com"
     val readerEmail = "reader@example.com"
 
@@ -1782,7 +1784,7 @@ class WorkspaceServiceUnitTests
 
   it should "allow readers with and without share access for Rawls workspaces" in {
     val projectOwnerEmail = "projectOwner@example.com"
-    val ownerEmail = ctx.userInfo.userEmail.value // user making the request is an owner
+    val ownerEmail = "owner@example.com"
     val writerEmail = "writer@example.com"
     val readerEmail = "reader@example.com"
 
@@ -1807,136 +1809,6 @@ class WorkspaceServiceUnitTests
     )
 
     Await.result(service.updateACL(WorkspaceName("fake_namespace", "fake_name"), aclUpdate, true), Duration.Inf)
-  }
-
-  it should "not allow users to change their own ACL" in {
-    val projectOwnerEmail = "projectOwner@example.com"
-    val writerEmail = "writer@example.com"
-    val readerEmail = "reader@example.com"
-
-    val callingUserEmail = ctx.userInfo.userEmail.value
-
-    val samDAO = mockSamForAclTests()
-    // Mock caller being an owner.
-    when(samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any(), any())).thenReturn(
-      Future(samWorkspacePoliciesForAclTests(projectOwnerEmail, callingUserEmail, writerEmail, readerEmail))
-    )
-
-    val workspaceRepository = mockWorkspaceRepositoryForAclTests(WorkspaceType.RawlsWorkspace)
-    val mockFastPassService = mock[FastPassService]
-    when(mockFastPassService.syncFastPassesForUserInWorkspace(any[Workspace], any[String])).thenReturn(Future())
-
-    val service = workspaceServiceConstructor(workspaceRepository = workspaceRepository,
-                                              samDAO = samDAO,
-                                              fastPassServiceConstructor = _ => mockFastPassService
-    )(ctx)
-
-    val aclUpdate = Set(
-      WorkspaceACLUpdate(callingUserEmail, WorkspaceAccessLevels.Read, Option(true), Option(false))
-    )
-
-    val thrown = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.updateACL(WorkspaceName("fake_namespace", "fake_name"), aclUpdate, true), Duration.Inf)
-    }
-    thrown.errorReport.message shouldBe "you may not change your own permissions"
-  }
-
-  it should "verify the calling user has sufficient permissions to modify canCompute and canShare" in {
-    val projectOwnerEmail = "projectOwner@example.com"
-    val ownerEmail = "owner@example.com"
-    val readerEmail = "reader@example.com"
-
-    val callingUserEmail = ctx.userInfo.userEmail.value
-
-    val samDAO = mockSamForAclTests()
-    // Mock caller being a writer.
-    when(samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any(), any())).thenReturn(
-      Future(samWorkspacePoliciesForAclTests(projectOwnerEmail, ownerEmail, callingUserEmail, readerEmail))
-    )
-
-    val workspaceRepository = mockWorkspaceRepositoryForAclTests(WorkspaceType.RawlsWorkspace)
-    val mockFastPassService = mock[FastPassService]
-    when(mockFastPassService.syncFastPassesForUserInWorkspace(any[Workspace], any[String])).thenReturn(Future())
-
-    val service = workspaceServiceConstructor(workspaceRepository = workspaceRepository,
-                                              samDAO = samDAO,
-                                              fastPassServiceConstructor = _ => mockFastPassService
-    )(ctx)
-
-    // Try to give the reader canShare privileges (did not have it previously)
-    val aclUpdate = Set(
-      WorkspaceACLUpdate(readerEmail, WorkspaceAccessLevels.Read, Option(true), Option(false))
-    )
-
-    val thrown = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.updateACL(WorkspaceName("fake_namespace", "fake_name"), aclUpdate, true), Duration.Inf)
-    }
-    thrown.errorReport.message shouldBe "you do not have sufficient permissions to make these changes"
-  }
-
-  it should "verify the calling user is not trying to change access levels higher than their own" in {
-    val projectOwnerEmail = "projectOwner@example.com"
-    val ownerEmail = "owner@example.com"
-    val readerEmail = "reader@example.com"
-
-    val callingUserEmail = ctx.userInfo.userEmail.value
-
-    val samDAO = mockSamForAclTests()
-    // Mock caller being a writer.
-    when(samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any(), any())).thenReturn(
-      Future(samWorkspacePoliciesForAclTests(projectOwnerEmail, ownerEmail, callingUserEmail, readerEmail))
-    )
-
-    val workspaceRepository = mockWorkspaceRepositoryForAclTests(WorkspaceType.RawlsWorkspace)
-    val mockFastPassService = mock[FastPassService]
-    when(mockFastPassService.syncFastPassesForUserInWorkspace(any[Workspace], any[String])).thenReturn(Future())
-
-    val service = workspaceServiceConstructor(workspaceRepository = workspaceRepository,
-                                              samDAO = samDAO,
-                                              fastPassServiceConstructor = _ => mockFastPassService
-    )(ctx)
-
-    // Try to change owner to be a reader.
-    val aclUpdate = Set(
-      WorkspaceACLUpdate(ownerEmail, WorkspaceAccessLevels.Read, Option(false), Option(false))
-    )
-
-    val thrown = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.updateACL(WorkspaceName("fake_namespace", "fake_name"), aclUpdate, true), Duration.Inf)
-    }
-    thrown.errorReport.message shouldBe "you do not have sufficient permissions to make these changes"
-  }
-
-  it should "verify the calling user has access on the workspace" in {
-    val projectOwnerEmail = "projectOwner@example.com"
-    val ownerEmail = "owner@example.com"
-    val writerEmail = "writer@example.com"
-    val readerEmail = "reader@example.com"
-
-    val samDAO = mockSamForAclTests()
-
-    when(samDAO.listPoliciesForResource(ArgumentMatchers.eq(SamResourceTypeNames.workspace), any(), any())).thenReturn(
-      // Note that calling user is not included
-      Future(samWorkspacePoliciesForAclTests(projectOwnerEmail, ownerEmail, writerEmail, readerEmail))
-    )
-
-    val workspaceRepository = mockWorkspaceRepositoryForAclTests(WorkspaceType.RawlsWorkspace)
-    val mockFastPassService = mock[FastPassService]
-    when(mockFastPassService.syncFastPassesForUserInWorkspace(any[Workspace], any[String])).thenReturn(Future())
-
-    val service = workspaceServiceConstructor(workspaceRepository = workspaceRepository,
-                                              samDAO = samDAO,
-                                              fastPassServiceConstructor = _ => mockFastPassService
-    )(ctx)
-
-    val aclUpdate = Set(
-      WorkspaceACLUpdate(writerEmail, WorkspaceAccessLevels.Read, Option(true), Option(false))
-    )
-
-    val thrown = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.updateACL(WorkspaceName("fake_namespace", "fake_name"), aclUpdate, true), Duration.Inf)
-    }
-    thrown.errorReport.message shouldBe "you do not have access to change permissions for this workspace"
   }
 
   behavior of "getBucketUsage"


### PR DESCRIPTION
Reverts broadinstitute/rawls#3064

It turns out that if you are PROJECT_OWNER on a workspace that was _created by someone else_ (ie., you are ONLY a PROJECT_OWNER on it), your access level on the workspace is not represented in the ACL response. Thus with my change, if you try to share the workspace with someone you will get the new error "you do not have access to change permissions for this workspace". This is a change in behavior, so I'm reverting this PR until I can change the validation to handle this case.

Also, for some reason the error message is duplicated… I guess that is just the display of the stack trace through orchestration.

![image](https://github.com/user-attachments/assets/01c292d3-4e16-4f65-bbc4-7bd7d08a1332)
