### PR TITLE
[CORE-50] Update workspace states after billing account change

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -659,6 +659,9 @@ trait WorkspaceComponent {
 
     def setIsLocked(isLocked: Boolean): WriteAction[Boolean] =
       query.map(_.isLocked).filter(_ =!= isLocked).update(isLocked).map(_ > 0)
+
+    def setState(state: WorkspaceState): WriteAction[Int] =
+      query.map(_.state).update(state.toString)
   }
 
   private def groupByWorkspaceId(runningSubmissions: Seq[(UUID, Int)]): Map[UUID, Int] =


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/CORE-50](https://broadworkbench.atlassian.net/browse/CORE-50)

This change accomplishes the AC of setting workspaces to the `Ready` state after their billing account is successfully updated. If a workspace is in the `UpdateFailed` state, a user can take its billing project through the billing account change process to attempt to fix this.

There are some things about the `BillingAccountChangeSynchronizer` that could be improved in service of readability and testing (for example, using `WorkspaceRepository` instead of `inTransaction` for database queries). I would like to do those things at some point, but I am not wrapping them up in this ticket.

Demo:

https://github.com/user-attachments/assets/6c7f714f-3618-4e85-88e7-d41b5d170332

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
