### PR TITLE
CORE-79: update Bard client to update spring-web

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   // allowing for Rawls to upgrade its Scala version without requiring any changes to this artifact.
   val cromwellClient: ModuleID =    "org.broadinstitute.cromwell" % "cromwell-client_2.12" % "0.1-8b413b45f-SNAP"
 
-  val bardClient: ModuleID = "bio.terra" % "bard-client-resttemplate" % "1.0.8" exclude("org.springframework", "spring-aop") exclude("org.springframework", "spring-jcl")
+  val bardClient: ModuleID = "bio.terra" % "bard-client-resttemplate" % "1.0.9" exclude("org.springframework", "spring-aop") exclude("org.springframework", "spring-jcl")
   val httpComponents5: ModuleID = "org.apache.httpcomponents.client5" % "httpclient5" % "5.3.1" // Needed for connection pooling with the Bard client
 
   val googleApiClient: ModuleID =             excludeGuavaJDK5("com.google.api-client"  % "google-api-client"                         % googleV)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-79

`spring-web` is a transitive dependency via the Bard client. This PR updates the Bard client to update the version of `spring-web` in use.

We can't just exclude spring-web; we actually do use it: https://github.com/broadinstitute/rawls/blob/fbc3a8c57c5f685e9234e0b42584b5f81dae1608/core/src/main/scala/org/broadinstitute/dsde/rawls/metrics/BardService.scala#L51

See also https://github.com/DataBiosphere/bard/pull/92, in which I updated the dependencies for the Bard client.

`sbt dependencyBrowseTree` before this PR:
![Screenshot 2024-10-16 at 2 30 39 PM](https://github.com/user-attachments/assets/05dedd43-c3ab-42e6-924d-4a6a79cb37f7)

`sbt dependencyBrowseTree` after this PR:
![Screenshot 2024-10-16 at 4 30 53 PM](https://github.com/user-attachments/assets/a1923eb4-0e4e-4a11-8a80-b80a3e6d97e5)


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
