### PR TITLE
[CORE-80] Add CSP Header to Swagger Page

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
   val akkaHttpV     = "10.2.0"
   val jacksonV      = "2.17.2"
 
-  val workbenchLibsHash = "d47b6d4"
+  val workbenchLibsHash = "80e4b8d"
   val serviceTestV = s"5.0-${workbenchLibsHash}"
-  val workbenchGoogleV = s"0.32-${workbenchLibsHash}"
+  val workbenchGoogleV = s"0.33-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
   val workbenchModelV  = s"0.20-${workbenchLibsHash}"
   val workbenchMetricsV  = s"0.8-${workbenchLibsHash}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,13 +84,13 @@ object Dependencies {
   val jakartaWsRs: ModuleID =     "jakarta.ws.rs"                 % "jakarta.ws.rs-api"     % "4.0.0"
   val jerseyJnhConnector: ModuleID = "org.glassfish.jersey.connectors" % "jersey-jnh-connector" % "3.1.8"
 
-  val workbenchLibsHash = "157f079"
+  val workbenchLibsHash = "80e4b8d"
 
   val workbenchModelV  = s"0.20-${workbenchLibsHash}"
   val workbenchGoogleV = s"0.33-${workbenchLibsHash}"
-  val workbenchNotificationsV = s"0.7-${workbenchLibsHash}"
+  val workbenchNotificationsV = s"0.8-${workbenchLibsHash}"
   val workbenchGoogle2V = s"0.36-${workbenchLibsHash}"
-  val workbenchOauth2V = s"0.7-${workbenchLibsHash}"
+  val workbenchOauth2V = s"0.8-${workbenchLibsHash}"
   val workbenchOpenTelemetryV = s"0.8-$workbenchLibsHash"
 
   def excludeWorkbenchGoogle = ExclusionRule("org.broadinstitute.dsde.workbench", "workbench-google_2.13")


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/CORE-80

**Description:**

This PR adds a Content Security Policy (CSP) header to the DRS Resolution Service (DRSHub) Swagger page to enhance security by reducing the risk of cross-site scripting (XSS) and data injection attacks.

**Testing:**

- Verified the Swagger page displays correctly with the CSP header.
- Checked for any security warnings or content issues.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
