### PR TITLE
CORE-69: tweak scala steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,6 +25,10 @@
 #
 pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 
+# pullRequests.customLabels allows to add custom labels to PRs.
+# This is useful if you want to use the labels for automation (project board for example).
+# Defaults to no labels (no labels are added).
+pullRequests.customLabels = [ "Scala_Steward" ]
 
 # Only these dependencies which match the given patterns are updated.
 #
@@ -49,7 +53,7 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 # Default: None
-updates.limit = 5
+updates.limit = 10
 
 # The extensions of files that should be updated.
 # Default: [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml"]
@@ -61,12 +65,12 @@ updates.limit = 5
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
-updatePullRequests = "on-conflicts"
+updatePullRequests = "always"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
 # Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
-commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+commits.message = "CORE-69: Update ${artifactName} from ${currentVersion} to ${nextVersion}"
 
 # If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt
 # and add a separate commit when format changed. So you don't need reformat manually and can merge PR.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-69

Ergonomics for Scala Steward:
* add "CORE-69: " to PR titles
* change max PRs from 5 to 10
* allow Scala Steward to update PRs
* add the `Scala_Steward` label to PRs

Note that we are currently adding the `Scala_Steward` label to PRs via the [`pr-labeler-action`](https://github.com/broadinstitute/rawls/actions/workflows/pr-labeler.yml), so there's duplication here. This tweak to Scala Steward config would allow us to disable/remove the pr-labeler-action.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
