### PR TITLE
[CORE-53] Fix storage request errors on requester pays workspaces

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3194,6 +3194,13 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
+        - name: userProject
+          in: query
+          description: |
+            When specified, bill google storage requests to this project
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Successful Request
@@ -3386,6 +3393,13 @@ paths:
             type: array
             items:
               type: string
+        - name: userProject
+          in: query
+          description: |
+            When specified, bill google storage requests to this project
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Successful Request
@@ -3428,6 +3442,13 @@ paths:
             type: array
             items:
               type: string
+        - name: userProject
+          in: query
+          description: |
+            When specified, bill google storage requests to this project
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Successful Request
@@ -6325,11 +6346,15 @@ components:
     WorkspaceBucketOptions:
       required:
         - requesterPays
+        - location
       type: object
       properties:
         requesterPays:
           type: boolean
           description: Whether the bucket is requester pays
+        location:
+          type: string
+          description: The region the bucket is in
       description: Extra information about a GCS bucket attached to a workspace
     WorkspaceAccessLevel:
       type: string

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3194,13 +3194,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'
         - $ref: '#/components/parameters/workspaceNamePathParam'
-        - name: userProject
-          in: query
-          description: |
-            When specified, bill google storage requests to this project
-          required: false
-          schema:
-            type: string
+        - $ref: '#/components/parameters/userProjectQueryParam'
       responses:
         200:
           description: Successful Request
@@ -3393,13 +3387,7 @@ paths:
             type: array
             items:
               type: string
-        - name: userProject
-          in: query
-          description: |
-            When specified, bill google storage requests to this project
-          required: false
-          schema:
-            type: string
+        - $ref: '#/components/parameters/userProjectQueryParam'
       responses:
         200:
           description: Successful Request
@@ -3442,13 +3430,7 @@ paths:
             type: array
             items:
               type: string
-        - name: userProject
-          in: query
-          description: |
-            When specified, bill google storage requests to this project
-          required: false
-          schema:
-            type: string
+        - $ref: '#/components/parameters/userProjectQueryParam'
       responses:
         200:
           description: Successful Request
@@ -7236,6 +7218,14 @@ components:
       in: path
       description: Submission Id
       required: true
+      schema:
+        type: string
+    userProjectQueryParam:
+      name: userProject
+      in: query
+      description: |
+        When specified, bill google storage requests to this project
+      required: false
       schema:
         type: string
     workbenchRolePathParam:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1100,11 +1100,11 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
         billing <- Option(bucketDetails.getBilling)
         rp <- Option(billing.getRequesterPays)
       } yield rp.booleanValue()
-      val location = bucketDetails.getLocation
+      val location = Option(bucketDetails.getLocation)
 
       WorkspaceBucketOptions(
         requesterPays = requesterPays.getOrElse(false),
-        location = location
+        location = location.getOrElse("")
       )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1100,9 +1100,11 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
         billing <- Option(bucketDetails.getBilling)
         rp <- Option(billing.getRequesterPays)
       } yield rp.booleanValue()
+      val location = bucketDetails.getLocation
 
       WorkspaceBucketOptions(
-        requesterPays = requesterPays.getOrElse(false)
+        requesterPays = requesterPays.getOrElse(false),
+        location = location
       )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponent.scala
@@ -365,6 +365,9 @@ trait WorkspaceComponent {
       _.getOrElse(throw new RawlsException(s"""No workspace found matching id "$workspaceId"."""))
     }
 
+    def findByGoogleProjectId(googleProjectId: GoogleProjectId): ReadAction[Option[Workspace]] =
+      loadWorkspace(findByGoogleProjectIdQuery(googleProjectId))
+
     def listByIds(workspaceIds: Seq[UUID],
                   attributeSpecs: Option[WorkspaceAttributeSpecs] = None
     ): ReadAction[Seq[Workspace]] =
@@ -595,6 +598,9 @@ trait WorkspaceComponent {
 
     def findByGoogleProjectNumbersQuery(googleProjectNumbers: Seq[String]): WorkspaceQueryType =
       filter(w => w.googleProjectNumber.map(_.inSetBind(googleProjectNumbers)))
+
+    def findByGoogleProjectIdQuery(googleProjectId: GoogleProjectId): WorkspaceQueryType =
+      workspaceQuery.withGoogleProjectId(googleProjectId)
 
     private def loadWorkspace(lookup: WorkspaceQueryType,
                               attributeSpecs: Option[WorkspaceAttributeSpecs] = None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -128,5 +128,16 @@ trait WorkspaceSettingComponent {
     ): ReadAction[List[WorkspaceSetting]] =
       filter(rec => rec.workspaceId === workspaceId && rec.status === status.toString).result
         .map(_.map(WorkspaceSettingRecord.toWorkspaceSetting).toList)
+
+    def getAppliedSettingForWorkspaceByType(workspaceId: UUID,
+                                            settingType: WorkspaceSettingType
+    ): ReadAction[Option[WorkspaceSetting]] =
+      uniqueResult(
+        filter(rec =>
+          rec.workspaceId === workspaceId
+            && rec.status === WorkspaceSettingRecord.SettingStatus.Applied.toString
+            && rec.settingType === settingType.toString
+        ).take(1).result.map(_.map(WorkspaceSettingRecord.toWorkspaceSetting).toList)
+      )
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiService.scala
@@ -67,13 +67,16 @@ trait WorkspaceApiService extends UserInfoDirectives {
         } ~
         path("workspaces" / "id" / Segment) { workspaceId =>
           get {
-            parameterSeq { allParams =>
-              complete {
-                workspaceServiceConstructor(ctx).getWorkspaceById(workspaceId,
-                                                                  WorkspaceFieldSpecs.fromQueryParams(allParams,
-                                                                                                      "fields"
-                                                                  )
-                )
+            parameters("userProject".optional) { userProject =>
+              parameterSeq { allParams =>
+                complete {
+                  workspaceServiceConstructor(ctx).getWorkspaceById(workspaceId,
+                                                                    WorkspaceFieldSpecs.fromQueryParams(allParams,
+                                                                                                        "fields"
+                                                                    ),
+                                                                    userProject.map(GoogleProjectId)
+                  )
+                }
               }
             }
           }
@@ -89,11 +92,16 @@ trait WorkspaceApiService extends UserInfoDirectives {
             }
           } ~
             get {
-              parameterSeq { allParams =>
-                complete {
-                  workspaceServiceConstructor(ctx).getWorkspace(WorkspaceName(workspaceNamespace, workspaceName),
-                                                                WorkspaceFieldSpecs.fromQueryParams(allParams, "fields")
-                  )
+              parameters("userProject".optional) { userProject =>
+                parameterSeq { allParams =>
+                  complete {
+                    workspaceServiceConstructor(ctx).getWorkspace(WorkspaceName(workspaceNamespace, workspaceName),
+                                                                  WorkspaceFieldSpecs.fromQueryParams(allParams,
+                                                                                                      "fields"
+                                                                  ),
+                                                                  userProject.map(GoogleProjectId)
+                    )
+                  }
                 }
               }
             } ~
@@ -116,8 +124,13 @@ trait WorkspaceApiService extends UserInfoDirectives {
         } ~
         path("workspaces" / Segment / Segment / "bucketOptions") { (workspaceNamespace, workspaceName) =>
           get {
-            complete {
-              workspaceServiceConstructor(ctx).getBucketOptions(WorkspaceName(workspaceNamespace, workspaceName))
+            parameters("userProject".optional) { userProject =>
+              complete {
+                workspaceServiceConstructor(ctx).getBucketOptions(
+                  WorkspaceName(workspaceNamespace, workspaceName),
+                  userProject.map(GoogleProjectId)
+                )
+              }
             }
           }
         } ~

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceRepository.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.PendingBucketDeletionRecor
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
+  GoogleProjectId,
   PendingCloneWorkspaceFileTransfer,
   RawlsBillingProjectName,
   RawlsRequestContext,
@@ -51,6 +52,11 @@ class WorkspaceRepository(dataSource: SlickDataSource) {
   def getWorkspaceId(workspaceName: WorkspaceName): Future[Option[UUID]] = dataSource.inTransaction {
     _.workspaceQuery.getV2WorkspaceId(workspaceName)
   }
+
+  def getWorkspaceByGoogleProject(googleProjectId: GoogleProjectId): Future[Option[Workspace]] =
+    dataSource.inTransaction { access =>
+      access.workspaceQuery.findByGoogleProjectId(googleProjectId)
+    }
 
   def listWorkspacesByIds(workspaceIds: Seq[UUID],
                           attributeSpecs: Option[WorkspaceAttributeSpecs] = None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -24,6 +24,7 @@ import org.broadinstitute.dsde.rawls.metrics.{MetricsHelper, RawlsInstrumented}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketRequesterPays
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model._
@@ -1455,11 +1456,11 @@ class WorkspaceService(
                                      ctx
     )
     requesterPays <- workspaceSettingsRepository
-      .getWorkspaceSettings(workspaceContext.workspaceIdAsUUID)
-      .map(_.exists {
-        case GcpBucketRequesterPaysSetting(config) => config.enabled
-        case _                                     => false
-      })
+      .getWorkspaceSettingOfType(workspaceContext.workspaceIdAsUUID, GcpBucketRequesterPays)
+      .map {
+        case Some(GcpBucketRequesterPaysSetting(config)) => config.enabled
+        case _                                           => false
+      }
     userProjectWorkspace <- userProject.flatTraverse(workspaceRepository.getWorkspaceByGoogleProject)
     isUserProjectWriter <- userProjectWorkspace.traverse(ws =>
       samDAO.userHasAction(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -54,9 +54,6 @@ import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, W
 import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol._
 import spray.json._
-import org.broadinstitute.dsde.rawls.metrics.MetricsHelper
-import org.broadinstitute.dsde.rawls.billing.BillingRepository
-import org.broadinstitute.dsde.rawls.submissions.SubmissionsRepository
 
 import java.io.IOException
 import java.util.UUID

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1463,9 +1463,23 @@ class WorkspaceService(
         case GcpBucketRequesterPaysSetting(config) => config.enabled
         case _                                     => false
       })
-    _ = if (requesterPays && !isWriter && userProject.isEmpty) {
+    userProjectWorkspace <- userProject.flatTraverse(workspaceRepository.getWorkspaceByGoogleProject)
+    isUserProjectWriter <- userProjectWorkspace.traverse(ws =>
+      samDAO.userHasAction(
+        SamResourceTypeNames.workspace,
+        ws.workspaceId,
+        SamWorkspaceActions.write,
+        ctx
+      )
+    )
+    _ = if (!isUserProjectWriter.getOrElse(true)) {
       throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.BadRequest, "Reader should provide a user project to bill on requester pays workspace")
+        ErrorReport(StatusCodes.BadRequest, "User must have write access to user project")
+      )
+    }
+    _ = if (requesterPays && !isWriter && userProjectWorkspace.isEmpty) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "Readers must provide a user project to bill on requester pays workspaces")
       )
     }
     options <- gcsDAO.getBucketDetails(workspaceContext.bucketName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -54,6 +54,10 @@ import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, W
 import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol._
 import spray.json._
+import org.broadinstitute.dsde.rawls.metrics.MetricsHelper
+import org.broadinstitute.dsde.rawls.billing.BillingRepository
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketRequesterPays
+import org.broadinstitute.dsde.rawls.submissions.SubmissionsRepository
 
 import java.io.IOException
 import java.util.UUID
@@ -118,7 +122,8 @@ object WorkspaceService {
       (context: RawlsRequestContext) => fastPassServiceConstructor(context, dataSource),
       new WorkspaceRepository(dataSource),
       new BillingRepository(dataSource),
-      new SubmissionsRepository(dataSource, config.trackDetailedSubmissionMetrics, workbenchMetricBaseName)
+      new SubmissionsRepository(dataSource, config.trackDetailedSubmissionMetrics, workbenchMetricBaseName),
+      new WorkspaceSettingRepository(dataSource)
     )
 
   val SECURITY_LABEL_KEY: String = "security"
@@ -166,7 +171,8 @@ class WorkspaceService(
   val fastPassServiceConstructor: RawlsRequestContext => FastPassService,
   val workspaceRepository: WorkspaceRepository,
   val billingRepository: BillingRepository,
-  val submissionsRepository: SubmissionsRepository
+  val submissionsRepository: SubmissionsRepository,
+  val workspaceSettingsRepository: WorkspaceSettingRepository
 )(implicit protected val executionContext: ExecutionContext)
     extends LazyLogging
     with LibraryPermissionsSupport
@@ -229,33 +235,42 @@ class WorkspaceService(
     } yield workspace
   }
 
-  def getWorkspace(workspaceName: WorkspaceName, params: WorkspaceFieldSpecs): Future[JsObject] = {
+  def getWorkspace(workspaceName: WorkspaceName,
+                   params: WorkspaceFieldSpecs,
+                   userProject: Option[GoogleProjectId] = None
+  ): Future[JsObject] = {
     val options = processOptions(params)
     traceFutureWithParent("getV2WorkspaceContextAndPermissions", ctx)(_ =>
       for {
         workspace <-
           getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read, Option(options.attrSpecs))
-        workspaceResponse <- getWorkspaceDetails(workspace, options)
+        workspaceResponse <- getWorkspaceDetails(workspace, options, userProject)
       } yield
       // post-process JSON to remove calculated-but-undesired keys
       deepFilterJsObject(workspaceResponse.toJson.asJsObject, options.options)
     )
   }
 
-  def getWorkspaceById(workspaceId: String, params: WorkspaceFieldSpecs): Future[JsObject] = {
+  def getWorkspaceById(workspaceId: String,
+                       params: WorkspaceFieldSpecs,
+                       userProject: Option[GoogleProjectId] = None
+  ): Future[JsObject] = {
     val options = processOptions(params)
     traceFutureWithParent("getV2WorkspaceContextAndPermissions", ctx)(_ =>
       for {
         workspace <-
           getV2WorkspaceContextAndPermissionsById(workspaceId, SamWorkspaceActions.read, Option(options.attrSpecs))
-        workspaceResponse <- getWorkspaceDetails(workspace, options)
+        workspaceResponse <- getWorkspaceDetails(workspace, options, userProject)
       } yield
       // post-process JSON to remove calculated-but-undesired keys
       deepFilterJsObject(workspaceResponse.toJson.asJsObject, options.options)
     )
   }
 
-  def getWorkspaceDetails(workspace: Workspace, options: QueryOptions): Future[WorkspaceResponse] = {
+  def getWorkspaceDetails(workspace: Workspace,
+                          options: QueryOptions,
+                          userProject: Option[GoogleProjectId] = None
+  ): Future[WorkspaceResponse] = {
     val workspaceId = workspace.workspaceId
     /*
     If we're looking to improve performance, we could potentially use this, instead trying to run futures in parallel:
@@ -311,9 +326,13 @@ class WorkspaceService(
           case _ => samDAO.userHasAction(SamResourceTypeNames.workspace, workspaceId, SamWorkspaceActions.compute, ctx)
         }
       }
+
       bucketDetails: Option[WorkspaceBucketOptions] <- wsmContext.googleProjectId match {
-        case None     => Future.successful(None)
-        case Some(id) => options.anyPresentFuture("bucketOptions")(gcsDAO.getBucketDetails(workspace.bucketName, id))
+        case None => Future.successful(None)
+        case Some(_) =>
+          options.anyPresentFuture("bucketOptions")(
+            getBucketOptions(WorkspaceName(workspace.namespace, workspace.name), userProject)
+          )
       }
     } yield WorkspaceResponse(
       options.anyPresent("accessLevel")(accessLevel),
@@ -972,7 +991,9 @@ class WorkspaceService(
         (aclChanges ++ existingAcls.filter(existingAcl => emailsBeingChanged.contains(existingAcl.email.toLowerCase)))
           .flatMap(aclUpdateToPolicies)
 
-      if (changingPolicies.exists(policy => !callingUserActions.contains(SamWorkspaceActions.sharePolicy(policy.value)))) {
+      if (
+        changingPolicies.exists(policy => !callingUserActions.contains(SamWorkspaceActions.sharePolicy(policy.value)))
+      ) {
         throw new InvalidWorkspaceAclUpdateException(
           ErrorReport(StatusCodes.BadRequest, "you do not have sufficient permissions to make these changes")
         )
@@ -1428,9 +1449,29 @@ class WorkspaceService(
       case Some(workspace) => op(workspace)
     }
 
-  def getBucketOptions(workspaceName: WorkspaceName): Future[WorkspaceBucketOptions] = for {
+  def getBucketOptions(workspaceName: WorkspaceName,
+                       userProject: Option[GoogleProjectId] = None
+  ): Future[WorkspaceBucketOptions] = for {
     workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName, SamWorkspaceActions.read)
-    options <- gcsDAO.getBucketDetails(workspaceContext.bucketName, workspaceContext.googleProjectId)
+    isWriter <- samDAO.userHasAction(SamResourceTypeNames.workspace,
+                                     workspaceContext.workspaceId,
+                                     SamWorkspaceActions.write,
+                                     ctx
+    )
+    requesterPays <- workspaceSettingsRepository
+      .getWorkspaceSettings(workspaceContext.workspaceIdAsUUID)
+      .map(_.exists {
+        case GcpBucketRequesterPaysSetting(config) => config.enabled
+        case _                                     => false
+      })
+    _ = if (requesterPays && !isWriter && userProject.isEmpty) {
+      throw new RawlsExceptionWithErrorReport(
+        ErrorReport(StatusCodes.BadRequest, "Reader should provide a user project to bill on requester pays workspace")
+      )
+    }
+    options <- gcsDAO.getBucketDetails(workspaceContext.bucketName,
+                                       userProject.getOrElse(workspaceContext.googleProjectId)
+    )
   } yield options
 
   def getBucketUsage(workspaceName: WorkspaceName): Future[BucketUsageResponse] = (for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -56,7 +56,6 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import org.broadinstitute.dsde.rawls.metrics.MetricsHelper
 import org.broadinstitute.dsde.rawls.billing.BillingRepository
-import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketRequesterPays
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsRepository
 
 import java.io.IOException

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepository.scala
@@ -27,6 +27,14 @@ class WorkspaceSettingRepository(dataSource: SlickDataSource) {
       )
     }
 
+  // Return applied setting for a workspace of a certain setting type. Deleted and pending settings are not returned.
+  def getWorkspaceSettingOfType(workspaceId: UUID,
+                                settingType: WorkspaceSettingType
+  ): Future[Option[WorkspaceSetting]] =
+    dataSource.inTransaction { access =>
+      access.workspaceSettingQuery.getAppliedSettingForWorkspaceByType(workspaceId, settingType)
+    }
+
   // Create new settings for a workspace as pending. If there are any existing pending settings, throw an exception.
   def createWorkspaceSettingsRecords(workspaceId: UUID,
                                      workspaceSettings: List[WorkspaceSetting],

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -10,6 +10,7 @@ import com.google.api.services.storage.model.{Bucket, BucketAccessControl, Stora
 import com.google.cloud.storage.BucketInfo
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.RawlsBillingProjectOperationRecord
 import org.broadinstitute.dsde.rawls.google.{AccessContextManagerDAO, MockGoogleAccessContextManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._
@@ -42,6 +43,8 @@ class MockGoogleServicesDAO(groupsPrefix: String,
   val inaccessibleBillingAccountName = RawlsBillingAccountName("billingAccounts/badbad-badbad-badbad")
 
   val mockJobIds = Seq("operations/dummy-job-id", "projects/dummy-project/operations/dummy-job-id")
+
+  val bucketLocation = "us-central1"
 
   override def listBillingAccounts(userInfo: UserInfo,
                                    firecloudHasAccess: Option[Boolean] = None
@@ -230,7 +233,7 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     Future.successful(true)
 
   override def getBucketDetails(bucket: String, project: GoogleProjectId): Future[WorkspaceBucketOptions] =
-    Future.successful(WorkspaceBucketOptions(false))
+    Future.successful(WorkspaceBucketOptions(false, bucketLocation))
 
   protected def updatePolicyBindings(
     googleProject: GoogleProjectId

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -10,7 +10,6 @@ import com.google.api.services.storage.model.{Bucket, BucketAccessControl, Stora
 import com.google.cloud.storage.BucketInfo
 import io.opencensus.trace.Span
 import org.broadinstitute.dsde.rawls.RawlsException
-import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.RawlsBillingProjectOperationRecord
 import org.broadinstitute.dsde.rawls.google.{AccessContextManagerDAO, MockGoogleAccessContextManagerDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -106,7 +106,7 @@ class PetSASpec extends ApiServiceSpec {
                                                      Some(WorkspaceCloudPlatform.Gcp)
             ),
             Option(WorkspaceSubmissionStats(None, None, 0)),
-            Option(WorkspaceBucketOptions(false)),
+            Option(WorkspaceBucketOptions(false, services.gcsDAO.bucketLocation)),
             Option(Set.empty),
             None,
             None
@@ -155,7 +155,7 @@ class PetSASpec extends ApiServiceSpec {
                                                      Some(WorkspaceCloudPlatform.Gcp)
             ),
             Option(WorkspaceSubmissionStats(None, None, 0)),
-            Option(WorkspaceBucketOptions(false)),
+            Option(WorkspaceBucketOptions(false, services.gcsDAO.bucketLocation)),
             Option(Set.empty),
             None,
             None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -256,7 +256,7 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
                                              Some(WorkspaceCloudPlatform.Gcp)
     ),
     Option(WorkspaceSubmissionStats(Option(testDate), Option(testDate), 2)),
-    Option(WorkspaceBucketOptions(false)),
+    Option(WorkspaceBucketOptions(false, "us-central1")),
     Option(Set.empty),
     None,
     Some(List.empty)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.{StatusCodes, _}
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import bio.terra.workspace.model.{ErrorReport => _}
+import cats.implicits.catsSyntaxOptionId
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
@@ -182,6 +183,31 @@ class WorkspaceApiServiceSpec
     verify(workspaceService).getWorkspaceById(workspace.workspaceId, params, None)
   }
 
+  it should "get a workspace by id from the workspace service with user project" in {
+    val mcWorkspaceService = mock[MultiCloudWorkspaceService]
+    val workspace = testData.workspace
+    val userProject = testData.workspace.googleProjectId
+    val details = WorkspaceDetails(workspace, Set())
+    val responseWorkspace = WorkspaceResponse(None, None, None, None, details, None, None, None, None, None)
+    val response: JsObject = responseWorkspace.toJson.asJsObject
+    val workspaceService = mock[WorkspaceService]
+    val params = WorkspaceFieldSpecs(Some(Set("a", "b", "c")))
+    when(workspaceService.getWorkspaceById(workspace.workspaceId, params, userProject.some))
+      .thenReturn(Future.successful(response))
+    val service = new MockApiService(
+      workspaceServiceConstructor = _ => workspaceService,
+      multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
+    )
+    Get(s"/workspaces/id/${workspace.workspaceId}?fields=a,b,c&userProject=${userProject.value}") ~>
+      service.testRoutes ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[WorkspaceResponse]
+        resp shouldBe responseWorkspace
+      }
+    verify(workspaceService).getWorkspaceById(workspace.workspaceId, params, userProject.some)
+  }
+
   it should "get a workspace by name and namespace from the workspace service" in {
     val mcWorkspaceService = mock[MultiCloudWorkspaceService]
     val workspace = testData.workspace
@@ -203,6 +229,30 @@ class WorkspaceApiServiceSpec
         resp shouldBe responseWorkspace
       }
     verify(workspaceService).getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None), None)
+  }
+
+  it should "get a workspace by name and namespace from the workspace service with user project" in {
+    val mcWorkspaceService = mock[MultiCloudWorkspaceService]
+    val workspace = testData.workspace
+    val userProject = testData.workspace.googleProjectId
+    val details = WorkspaceDetails(workspace, Set())
+    val responseWorkspace = WorkspaceResponse(None, None, None, None, details, None, None, None, None, None)
+    val response: JsObject = responseWorkspace.toJson.asJsObject
+    val workspaceService = mock[WorkspaceService]
+    when(workspaceService.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None), userProject.some))
+      .thenReturn(Future.successful(response))
+    val service = new MockApiService(
+      workspaceServiceConstructor = _ => workspaceService,
+      multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
+    )
+    Get(s"/workspaces/${workspace.namespace}/${workspace.name}?userProject=${userProject.value}") ~>
+      service.testRoutes ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[WorkspaceResponse]
+        resp shouldBe responseWorkspace
+      }
+    verify(workspaceService).getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None), userProject.some)
   }
 
   it should "pass the fields parameter when getting a workspace by name and namespace" in {
@@ -318,6 +368,31 @@ class WorkspaceApiServiceSpec
       }
 
     verify(workspaceService).getBucketOptions(workspaceName, None)
+  }
+
+  it should "get bucketOptions by name and namespace with user project" in {
+    val mcWorkspaceService = mock[MultiCloudWorkspaceService]
+    val workspaceName = WorkspaceName("ns", "n")
+    val userProject = GoogleProjectId("123")
+    val workspaceService = mock[WorkspaceService]
+    val serviceResponse = WorkspaceBucketOptions(requesterPays = true, "")
+    when(workspaceService.getBucketOptions(workspaceName, userProject.some))
+      .thenReturn(Future.successful(serviceResponse))
+    val service = new MockApiService(
+      workspaceServiceConstructor = _ => workspaceService,
+      multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
+    )
+    Get(
+      s"/workspaces/${workspaceName.namespace}/${workspaceName.name}/bucketOptions?userProject=${userProject.value}"
+    ) ~>
+      service.testRoutes ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[WorkspaceBucketOptions]
+        resp shouldBe serviceResponse
+      }
+
+    verify(workspaceService).getBucketOptions(workspaceName, userProject.some)
   }
 
   it should "clone a workspace using the multicloud workspace service" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiServiceSpec.scala
@@ -167,7 +167,7 @@ class WorkspaceApiServiceSpec
     val response: JsObject = responseWorkspace.toJson.asJsObject
     val workspaceService = mock[WorkspaceService]
     val params = WorkspaceFieldSpecs(Some(Set("a", "b", "c")))
-    when(workspaceService.getWorkspaceById(workspace.workspaceId, params)).thenReturn(Future.successful(response))
+    when(workspaceService.getWorkspaceById(workspace.workspaceId, params, None)).thenReturn(Future.successful(response))
     val service = new MockApiService(
       workspaceServiceConstructor = _ => workspaceService,
       multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
@@ -179,7 +179,7 @@ class WorkspaceApiServiceSpec
         val resp = responseAs[WorkspaceResponse]
         resp shouldBe responseWorkspace
       }
-    verify(workspaceService).getWorkspaceById(workspace.workspaceId, params)
+    verify(workspaceService).getWorkspaceById(workspace.workspaceId, params, None)
   }
 
   it should "get a workspace by name and namespace from the workspace service" in {
@@ -189,7 +189,7 @@ class WorkspaceApiServiceSpec
     val responseWorkspace = WorkspaceResponse(None, None, None, None, details, None, None, None, None, None)
     val response: JsObject = responseWorkspace.toJson.asJsObject
     val workspaceService = mock[WorkspaceService]
-    when(workspaceService.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None)))
+    when(workspaceService.getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None), None))
       .thenReturn(Future.successful(response))
     val service = new MockApiService(
       workspaceServiceConstructor = _ => workspaceService,
@@ -202,7 +202,7 @@ class WorkspaceApiServiceSpec
         val resp = responseAs[WorkspaceResponse]
         resp shouldBe responseWorkspace
       }
-    verify(workspaceService).getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None))
+    verify(workspaceService).getWorkspace(workspace.toWorkspaceName, WorkspaceFieldSpecs(None), None)
   }
 
   it should "pass the fields parameter when getting a workspace by name and namespace" in {
@@ -213,7 +213,7 @@ class WorkspaceApiServiceSpec
     val response: JsObject = responseWorkspace.toJson.asJsObject
     val workspaceService = mock[WorkspaceService]
     val params = WorkspaceFieldSpecs(Some(Set("a", "b", "c")))
-    when(workspaceService.getWorkspace(workspace.toWorkspaceName, params)).thenReturn(Future.successful(response))
+    when(workspaceService.getWorkspace(workspace.toWorkspaceName, params, None)).thenReturn(Future.successful(response))
     val service = new MockApiService(
       workspaceServiceConstructor = _ => workspaceService,
       multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
@@ -225,7 +225,7 @@ class WorkspaceApiServiceSpec
         val resp = responseAs[WorkspaceResponse]
         resp shouldBe responseWorkspace
       }
-    verify(workspaceService).getWorkspace(workspace.toWorkspaceName, params)
+    verify(workspaceService).getWorkspace(workspace.toWorkspaceName, params, None)
   }
 
   it should "update the workspace by name and namespace" in {
@@ -303,8 +303,8 @@ class WorkspaceApiServiceSpec
     val mcWorkspaceService = mock[MultiCloudWorkspaceService]
     val workspaceName = WorkspaceName("ns", "n")
     val workspaceService = mock[WorkspaceService]
-    val serviceResponse = WorkspaceBucketOptions(requesterPays = true)
-    when(workspaceService.getBucketOptions(workspaceName)).thenReturn(Future.successful(serviceResponse))
+    val serviceResponse = WorkspaceBucketOptions(requesterPays = true, "")
+    when(workspaceService.getBucketOptions(workspaceName, None)).thenReturn(Future.successful(serviceResponse))
     val service = new MockApiService(
       workspaceServiceConstructor = _ => workspaceService,
       multiCloudWorkspaceServiceConstructor = _ => mcWorkspaceService
@@ -317,7 +317,7 @@ class WorkspaceApiServiceSpec
         resp shouldBe serviceResponse
       }
 
-    verify(workspaceService).getBucketOptions(workspaceName)
+    verify(workspaceService).getBucketOptions(workspaceName, None)
   }
 
   it should "clone a workspace using the multicloud workspace service" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -2426,7 +2426,7 @@ class WorkspaceServiceSpec
 
     response.workspace.name shouldBe workspaceName
     response.workspace.namespace shouldBe testData.testProject1Name.value
-    response.bucketOptions shouldBe Some(WorkspaceBucketOptions(false))
+    response.bucketOptions shouldBe Some(WorkspaceBucketOptions(false, services.gcsDAO.bucketLocation))
     response.azureContext shouldEqual None
     response.workspace.cloudPlatform shouldBe Some(WorkspaceCloudPlatform.Gcp)
     response.workspace.state shouldBe WorkspaceState.Ready

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -12,7 +12,6 @@ import bio.terra.workspace.model.{
   WorkspaceDescription,
   WorkspaceStageModel
 }
-import cats.implicits.catsSyntaxOptionId
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
@@ -487,96 +486,6 @@ class WorkspaceServiceUnitTests
 
     result.bucketOptions shouldBe Some(bucketDetails)
     verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
-  }
-
-  it should "get the bucket options for a reader on a non requester pays workspace" in {
-    val options = WorkspaceService.QueryOptions(Set("bucketOptions"), WorkspaceAttributeSpecs(false))
-    val wsm = mock[WorkspaceManagerDAO]
-    when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
-    val gcs = mock[GoogleServicesDAO]
-    val bucketDetails = WorkspaceBucketOptions(false, "")
-    when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
-    val repository = mock[WorkspaceRepository]
-    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
-    val sam = mock[SamDAO]
-    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
-      .thenReturn(Future(true))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
-      .thenReturn(Future(false))
-    val settings = mock[WorkspaceSettingRepository]
-    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(Future(List.empty))
-    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
-                                              workspaceRepository = repository,
-                                              workspaceSettingRepository = settings,
-                                              samDAO = sam,
-                                              gcsDAO = gcs
-    )(ctx)
-
-    val result = Await.result(service.getWorkspaceDetails(workspace, options), Duration.Inf)
-
-    result.bucketOptions shouldBe Some(bucketDetails)
-    verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
-  }
-
-  it should "fail to get the bucket options for a reader on a requester pays workspace" in {
-    val options = WorkspaceService.QueryOptions(Set("bucketOptions"), WorkspaceAttributeSpecs(false))
-    val wsm = mock[WorkspaceManagerDAO]
-    when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
-    val gcs = mock[GoogleServicesDAO]
-    val repository = mock[WorkspaceRepository]
-    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
-    val sam = mock[SamDAO]
-    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
-      .thenReturn(Future(true))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
-      .thenReturn(Future(false))
-    val settings = mock[WorkspaceSettingRepository]
-    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID))
-      .thenReturn(Future(List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))))
-    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
-                                              workspaceRepository = repository,
-                                              workspaceSettingRepository = settings,
-                                              samDAO = sam,
-                                              gcsDAO = gcs
-    )(ctx)
-
-    intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getWorkspaceDetails(workspace, options), Duration.Inf)
-    }
-  }
-
-  it should "get the bucket options for a reader on a requester pays workspace if a user project is provided" in {
-    val options = WorkspaceService.QueryOptions(Set("bucketOptions"), WorkspaceAttributeSpecs(false))
-    val wsm = mock[WorkspaceManagerDAO]
-    when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
-    val gcs = mock[GoogleServicesDAO]
-    val userProject = GoogleProjectId("123")
-    val bucketDetails = WorkspaceBucketOptions(true, "")
-    when(gcs.getBucketDetails(workspace.bucketName, userProject)).thenReturn(Future(bucketDetails))
-    val repository = mock[WorkspaceRepository]
-    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
-    val sam = mock[SamDAO]
-    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
-      .thenReturn(Future(true))
-    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
-      .thenReturn(Future(false))
-    val settings = mock[WorkspaceSettingRepository]
-    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID))
-      .thenReturn(Future(List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))))
-    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
-                                              workspaceRepository = repository,
-                                              workspaceSettingRepository = settings,
-                                              samDAO = sam,
-                                              gcsDAO = gcs
-    )(ctx)
-
-    val result = Await.result(service.getWorkspaceDetails(workspace, options, userProject.some), Duration.Inf)
-
-    result.bucketOptions shouldBe Some(bucketDetails)
-    verify(gcs).getBucketDetails(workspace.bucketName, userProject)
   }
 
   it should "get the owner emails using the policy from sam when requested" in {
@@ -1753,6 +1662,7 @@ class WorkspaceServiceUnitTests
   }
 
   behavior of "getBucketOptions"
+
   it should "get the bucket options for a gcp workspace" in {
     val repository = mock[WorkspaceRepository]
     when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
@@ -1775,5 +1685,160 @@ class WorkspaceServiceUnitTests
 
     Await.result(service.getBucketOptions(workspace.toWorkspaceName), Duration.Inf) shouldBe bucketDetails
     verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
+  }
+
+  List((false, false), (false, true), (true, true)) foreach { case (isRequesterPays, hasWriteAccess) =>
+    it should s"get bucket options and bill the workspace project if a user has " +
+      s"${if (hasWriteAccess) "write" else "read"} access and the workspace" +
+      s"${if (isRequesterPays) "is" else "is non"} requester pays" in {
+        val repository = mock[WorkspaceRepository]
+        when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+        val sam = mock[SamDAO]
+        when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+        when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+          .thenReturn(Future(true))
+        when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+          .thenReturn(Future(hasWriteAccess))
+        val settings = mock[WorkspaceSettingRepository]
+        when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
+          Future(
+            List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))).filter(_ => isRequesterPays)
+          )
+        )
+        val bucketDetails = mock[WorkspaceBucketOptions]
+        val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+        when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
+        val service = workspaceServiceConstructor(samDAO = sam,
+                                                  workspaceRepository = repository,
+                                                  gcsDAO = gcs,
+                                                  workspaceSettingRepository = settings
+        )(ctx)
+
+        Await.result(service.getBucketOptions(workspace.toWorkspaceName), Duration.Inf) shouldBe bucketDetails
+        verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
+      }
+  }
+
+  it should "get bucket options and bill a user project if a user provides one to which they have write access" in {
+    List((false, false), (false, true), (true, false), (true, true)) foreach { case (isRequesterPays, hasWriteAccess) =>
+      val userProjectWs: Workspace = Workspace(
+        "test-namespace",
+        "user-project-ws",
+        UUID.randomUUID().toString,
+        "userBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "test",
+        Map.empty
+      )
+      val userProjectId: GoogleProjectId = GoogleProjectId("123")
+
+      val repository = mock[WorkspaceRepository]
+      when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+      when(repository.getWorkspaceByGoogleProject(userProjectId)).thenReturn(Future(Some(userProjectWs)))
+      val sam = mock[SamDAO]
+      when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+      when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+        .thenReturn(Future(true))
+      when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+        .thenReturn(Future(hasWriteAccess))
+      when(sam.userHasAction(SamResourceTypeNames.workspace, userProjectWs.workspaceId, SamWorkspaceActions.write, ctx))
+        .thenReturn(Future(true))
+      val settings = mock[WorkspaceSettingRepository]
+      when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
+        Future(
+          List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))).filter(_ => isRequesterPays)
+        )
+      )
+      val bucketDetails = mock[WorkspaceBucketOptions]
+      val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      when(gcs.getBucketDetails(workspace.bucketName, userProjectId)).thenReturn(Future(bucketDetails))
+      val service = workspaceServiceConstructor(samDAO = sam,
+                                                workspaceRepository = repository,
+                                                gcsDAO = gcs,
+                                                workspaceSettingRepository = settings
+      )(ctx)
+
+      Await.result(service.getBucketOptions(workspace.toWorkspaceName, Some(userProjectId)),
+                   Duration.Inf
+      ) shouldBe bucketDetails
+      verify(gcs).getBucketDetails(workspace.bucketName, userProjectId)
+    }
+  }
+
+  it should "fail if a user provides a user project to which they do not have write access" in {
+    List((false, false), (false, true), (true, false), (true, true)) foreach { case (isRequesterPays, hasWriteAccess) =>
+      val userProjectWs: Workspace = Workspace(
+        "test-namespace",
+        "user-project-ws",
+        UUID.randomUUID().toString,
+        "userBucket",
+        Some("workflow-collection"),
+        new DateTime(),
+        new DateTime(),
+        "test",
+        Map.empty
+      )
+      val userProjectId: GoogleProjectId = GoogleProjectId("123")
+
+      val repository = mock[WorkspaceRepository]
+      when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+      when(repository.getWorkspaceByGoogleProject(userProjectId)).thenReturn(Future(Some(userProjectWs)))
+      val sam = mock[SamDAO]
+      when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+      when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+        .thenReturn(Future(true))
+      when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+        .thenReturn(Future(hasWriteAccess))
+      when(sam.userHasAction(SamResourceTypeNames.workspace, userProjectWs.workspaceId, SamWorkspaceActions.write, ctx))
+        .thenReturn(Future(false))
+      val settings = mock[WorkspaceSettingRepository]
+      when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
+        Future(
+          List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))).filter(_ => isRequesterPays)
+        )
+      )
+      val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+      val service = workspaceServiceConstructor(samDAO = sam,
+                                                workspaceRepository = repository,
+                                                gcsDAO = gcs,
+                                                workspaceSettingRepository = settings
+      )(ctx)
+
+      intercept[RawlsExceptionWithErrorReport] {
+        Await.result(service.getBucketOptions(workspace.toWorkspaceName, Some(userProjectId)), Duration.Inf)
+      }
+      verify(gcs, never).getBucketDetails(workspace.bucketName, userProjectId)
+    }
+  }
+
+  it should "fail on a requester pays workspace for a user who does not provide a user project" in {
+    val repository = mock[WorkspaceRepository]
+    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+    val sam = mock[SamDAO]
+    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+      .thenReturn(Future(true))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+      .thenReturn(Future(false))
+    val settings = mock[WorkspaceSettingRepository]
+    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
+      Future(
+        List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))
+      )
+    )
+    val bucketDetails = mock[WorkspaceBucketOptions]
+    val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+    val service = workspaceServiceConstructor(samDAO = sam,
+                                              workspaceRepository = repository,
+                                              gcsDAO = gcs,
+                                              workspaceSettingRepository = settings
+    )(ctx)
+
+    intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.getBucketOptions(workspace.toWorkspaceName), Duration.Inf) shouldBe bucketDetails
+    }
+    verify(gcs, never).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -22,6 +22,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManage
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.GcpBucketRequesterPaysConfig
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketRequesterPays
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
@@ -474,7 +475,8 @@ class WorkspaceServiceUnitTests
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
       .thenReturn(Future(true))
     val settings = mock[WorkspaceSettingRepository]
-    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(Future(List.empty))
+    when(settings.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, GcpBucketRequesterPays))
+      .thenReturn(Future(None))
     val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
                                               workspaceRepository = repository,
                                               workspaceSettingRepository = settings,
@@ -1673,7 +1675,8 @@ class WorkspaceServiceUnitTests
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
       .thenReturn(Future(true))
     val settings = mock[WorkspaceSettingRepository]
-    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(Future(List.empty))
+    when(settings.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, GcpBucketRequesterPays))
+      .thenReturn(Future(None))
     val bucketDetails = mock[WorkspaceBucketOptions]
     val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
     when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
@@ -1700,11 +1703,8 @@ class WorkspaceServiceUnitTests
         when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
           .thenReturn(Future(hasWriteAccess))
         val settings = mock[WorkspaceSettingRepository]
-        when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
-          Future(
-            List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))).filter(_ => isRequesterPays)
-          )
-        )
+        when(settings.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, GcpBucketRequesterPays))
+          .thenReturn(Future(Some(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(isRequesterPays)))))
         val bucketDetails = mock[WorkspaceBucketOptions]
         val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
         when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
@@ -1746,11 +1746,8 @@ class WorkspaceServiceUnitTests
       when(sam.userHasAction(SamResourceTypeNames.workspace, userProjectWs.workspaceId, SamWorkspaceActions.write, ctx))
         .thenReturn(Future(true))
       val settings = mock[WorkspaceSettingRepository]
-      when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
-        Future(
-          List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))).filter(_ => isRequesterPays)
-        )
-      )
+      when(settings.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, GcpBucketRequesterPays))
+        .thenReturn(Future(Some(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(isRequesterPays)))))
       val bucketDetails = mock[WorkspaceBucketOptions]
       val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       when(gcs.getBucketDetails(workspace.bucketName, userProjectId)).thenReturn(Future(bucketDetails))
@@ -1794,11 +1791,8 @@ class WorkspaceServiceUnitTests
       when(sam.userHasAction(SamResourceTypeNames.workspace, userProjectWs.workspaceId, SamWorkspaceActions.write, ctx))
         .thenReturn(Future(false))
       val settings = mock[WorkspaceSettingRepository]
-      when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
-        Future(
-          List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))).filter(_ => isRequesterPays)
-        )
-      )
+      when(settings.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, GcpBucketRequesterPays))
+        .thenReturn(Future(Some(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(isRequesterPays)))))
       val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
       val service = workspaceServiceConstructor(samDAO = sam,
                                                 workspaceRepository = repository,
@@ -1823,11 +1817,8 @@ class WorkspaceServiceUnitTests
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
       .thenReturn(Future(false))
     val settings = mock[WorkspaceSettingRepository]
-    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(
-      Future(
-        List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))
-      )
-    )
+    when(settings.getWorkspaceSettingOfType(workspace.workspaceIdAsUUID, GcpBucketRequesterPays))
+      .thenReturn(Future(Some(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))))
     val bucketDetails = mock[WorkspaceBucketOptions]
     val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
     val service = workspaceServiceConstructor(samDAO = sam,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -12,6 +12,7 @@ import bio.terra.workspace.model.{
   WorkspaceDescription,
   WorkspaceStageModel
 }
+import cats.implicits.catsSyntaxOptionId
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository}
@@ -21,6 +22,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.leonardo.LeonardoService
 import org.broadinstitute.dsde.rawls.dataaccess.workspacemanager.WorkspaceManagerDAO
 import org.broadinstitute.dsde.rawls.fastpass.FastPassService
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.GcpBucketRequesterPaysConfig
 import org.broadinstitute.dsde.rawls.model.WorkspaceType.WorkspaceType
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferService
@@ -485,6 +487,96 @@ class WorkspaceServiceUnitTests
 
     result.bucketOptions shouldBe Some(bucketDetails)
     verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
+  }
+
+  it should "get the bucket options for a reader on a non requester pays workspace" in {
+    val options = WorkspaceService.QueryOptions(Set("bucketOptions"), WorkspaceAttributeSpecs(false))
+    val wsm = mock[WorkspaceManagerDAO]
+    when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
+    val gcs = mock[GoogleServicesDAO]
+    val bucketDetails = WorkspaceBucketOptions(false, "")
+    when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
+    val repository = mock[WorkspaceRepository]
+    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+    val sam = mock[SamDAO]
+    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+      .thenReturn(Future(true))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+      .thenReturn(Future(false))
+    val settings = mock[WorkspaceSettingRepository]
+    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(Future(List.empty))
+    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
+                                              workspaceRepository = repository,
+                                              workspaceSettingRepository = settings,
+                                              samDAO = sam,
+                                              gcsDAO = gcs
+    )(ctx)
+
+    val result = Await.result(service.getWorkspaceDetails(workspace, options), Duration.Inf)
+
+    result.bucketOptions shouldBe Some(bucketDetails)
+    verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)
+  }
+
+  it should "fail to get the bucket options for a reader on a requester pays workspace" in {
+    val options = WorkspaceService.QueryOptions(Set("bucketOptions"), WorkspaceAttributeSpecs(false))
+    val wsm = mock[WorkspaceManagerDAO]
+    when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
+    val gcs = mock[GoogleServicesDAO]
+    val repository = mock[WorkspaceRepository]
+    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+    val sam = mock[SamDAO]
+    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+      .thenReturn(Future(true))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+      .thenReturn(Future(false))
+    val settings = mock[WorkspaceSettingRepository]
+    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID))
+      .thenReturn(Future(List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))))
+    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
+                                              workspaceRepository = repository,
+                                              workspaceSettingRepository = settings,
+                                              samDAO = sam,
+                                              gcsDAO = gcs
+    )(ctx)
+
+    intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.getWorkspaceDetails(workspace, options), Duration.Inf)
+    }
+  }
+
+  it should "get the bucket options for a reader on a requester pays workspace if a user project is provided" in {
+    val options = WorkspaceService.QueryOptions(Set("bucketOptions"), WorkspaceAttributeSpecs(false))
+    val wsm = mock[WorkspaceManagerDAO]
+    when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
+    val gcs = mock[GoogleServicesDAO]
+    val userProject = GoogleProjectId("123")
+    val bucketDetails = WorkspaceBucketOptions(true, "")
+    when(gcs.getBucketDetails(workspace.bucketName, userProject)).thenReturn(Future(bucketDetails))
+    val repository = mock[WorkspaceRepository]
+    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+    val sam = mock[SamDAO]
+    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+      .thenReturn(Future(true))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+      .thenReturn(Future(false))
+    val settings = mock[WorkspaceSettingRepository]
+    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID))
+      .thenReturn(Future(List(GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)))))
+    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
+                                              workspaceRepository = repository,
+                                              workspaceSettingRepository = settings,
+                                              samDAO = sam,
+                                              gcsDAO = gcs
+    )(ctx)
+
+    val result = Await.result(service.getWorkspaceDetails(workspace, options, userProject.some), Duration.Inf)
+
+    result.bucketOptions shouldBe Some(bucketDetails)
+    verify(gcs).getBucketDetails(workspace.bucketName, userProject)
   }
 
   it should "get the owner emails using the policy from sam when requested" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUnitTests.scala
@@ -115,7 +115,8 @@ class WorkspaceServiceUnitTests
       mock[FastPassService](RETURNS_SMART_NULLS),
     workspaceRepository: WorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS),
     billingRepository: BillingRepository = mock[BillingRepository](RETURNS_SMART_NULLS),
-    submissionsRepository: SubmissionsRepository = mock[SubmissionsRepository](RETURNS_SMART_NULLS)
+    submissionsRepository: SubmissionsRepository = mock[SubmissionsRepository](RETURNS_SMART_NULLS),
+    workspaceSettingRepository: WorkspaceSettingRepository = mock[WorkspaceSettingRepository](RETURNS_SMART_NULLS)
   ): RawlsRequestContext => WorkspaceService = info =>
     new WorkspaceService(
       info,
@@ -143,7 +144,8 @@ class WorkspaceServiceUnitTests
       fastPassServiceConstructor,
       workspaceRepository,
       billingRepository,
-      submissionsRepository
+      submissionsRepository,
+      workspaceSettingRepository
     )(scala.concurrent.ExecutionContext.global)
 
   behavior of "getWorkspaceById"
@@ -460,9 +462,24 @@ class WorkspaceServiceUnitTests
     val wsm = mock[WorkspaceManagerDAO]
     when(wsm.getWorkspace(any, any)).thenAnswer(_ => throw new AggregateWorkspaceNotFoundException(ErrorReport("")))
     val gcs = mock[GoogleServicesDAO]
-    val bucketDetails = WorkspaceBucketOptions(true)
+    val bucketDetails = WorkspaceBucketOptions(true, "")
     when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
-    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm, gcsDAO = gcs)(ctx)
+    val repository = mock[WorkspaceRepository]
+    when(repository.getWorkspace(workspace.toWorkspaceName, None)).thenReturn(Future(Some(workspace)))
+    val sam = mock[SamDAO]
+    when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
+      .thenReturn(Future(true))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+      .thenReturn(Future(true))
+    val settings = mock[WorkspaceSettingRepository]
+    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(Future(List.empty))
+    val service = workspaceServiceConstructor(workspaceManagerDAO = wsm,
+                                              workspaceRepository = repository,
+                                              workspaceSettingRepository = settings,
+                                              samDAO = sam,
+                                              gcsDAO = gcs
+    )(ctx)
 
     val result = Await.result(service.getWorkspaceDetails(workspace, options), Duration.Inf)
 
@@ -1651,10 +1668,18 @@ class WorkspaceServiceUnitTests
     when(sam.getUserStatus(ctx)).thenReturn(Future(Some(enabledUser)))
     when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.read, ctx))
       .thenReturn(Future(true))
+    when(sam.userHasAction(SamResourceTypeNames.workspace, workspace.workspaceId, SamWorkspaceActions.write, ctx))
+      .thenReturn(Future(true))
+    val settings = mock[WorkspaceSettingRepository]
+    when(settings.getWorkspaceSettings(workspace.workspaceIdAsUUID)).thenReturn(Future(List.empty))
     val bucketDetails = mock[WorkspaceBucketOptions]
     val gcs = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
     when(gcs.getBucketDetails(workspace.bucketName, workspace.googleProjectId)).thenReturn(Future(bucketDetails))
-    val service = workspaceServiceConstructor(samDAO = sam, workspaceRepository = repository, gcsDAO = gcs)(ctx)
+    val service = workspaceServiceConstructor(samDAO = sam,
+                                              workspaceRepository = repository,
+                                              gcsDAO = gcs,
+                                              workspaceSettingRepository = settings
+    )(ctx)
 
     Await.result(service.getBucketOptions(workspace.toWorkspaceName), Duration.Inf) shouldBe bucketDetails
     verify(gcs).getBucketDetails(workspace.bucketName, workspace.googleProjectId)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUpdateAclSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceUpdateAclSpec.scala
@@ -101,7 +101,8 @@ class WorkspaceServiceUpdateAclSpec extends AnyFlatSpecLike with MockitoSugar wi
       mock[FastPassService](RETURNS_SMART_NULLS),
     workspaceRepository: WorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS),
     billingRepository: BillingRepository = mock[BillingRepository](RETURNS_SMART_NULLS),
-    submissionsRepository: SubmissionsRepository = mock[SubmissionsRepository](RETURNS_SMART_NULLS)
+    submissionsRepository: SubmissionsRepository = mock[SubmissionsRepository](RETURNS_SMART_NULLS),
+    workspaceSettingRepository: WorkspaceSettingRepository = mock[WorkspaceSettingRepository](RETURNS_SMART_NULLS)
   ): RawlsRequestContext => WorkspaceService = info =>
     new WorkspaceService(
       info,
@@ -129,7 +130,8 @@ class WorkspaceServiceUpdateAclSpec extends AnyFlatSpecLike with MockitoSugar wi
       fastPassServiceConstructor,
       workspaceRepository,
       billingRepository,
-      submissionsRepository
+      submissionsRepository,
+      workspaceSettingRepository
     )(scala.concurrent.ExecutionContext.global)
 
   // Return mocks with reasonable defaults for basic usage. Override mocked behavior as needed.

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -7,10 +7,15 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleAction,
   GcpBucketLifecycleCondition,
   GcpBucketLifecycleConfig,
-  GcpBucketLifecycleRule
+  GcpBucketLifecycleRule,
+  GcpBucketRequesterPaysConfig,
+  GcpBucketSoftDeleteConfig
 }
+import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketSoftDelete
 import org.broadinstitute.dsde.rawls.model.{
   GcpBucketLifecycleSetting,
+  GcpBucketRequesterPaysSetting,
+  GcpBucketSoftDeleteSetting,
   Workspace,
   WorkspaceSetting,
   WorkspaceSettingTypes
@@ -92,6 +97,85 @@ class WorkspaceSettingRepositorySpec
     val result = Await.result(repo.getWorkspaceSettings(ws.workspaceIdAsUUID), Duration.Inf)
 
     assertResult(result)(List(appliedSetting))
+  }
+
+  behavior of "getWorkspacesSettingsOfType"
+
+  it should "return applied soft delete setting when soft delete type is requested" in {
+    val repo = new WorkspaceSettingRepository(slickDataSource)
+    val workspaceRepo = new WorkspaceRepository(slickDataSource)
+    val ws: Workspace = makeWorkspace()
+    Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
+    val appliedSoftDeleteSetting = GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(0))
+    val appliedRequesterPaysSetting = GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))
+    val pendingSetting = GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(2_000_000))
+
+    Await.result(
+      slickDataSource.inTransaction { dataAccess =>
+        for {
+          _ <- dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID,
+                                                        List(appliedSoftDeleteSetting, appliedRequesterPaysSetting),
+                                                        userInfo.userSubjectId
+          )
+          _ <- dataAccess.workspaceSettingQuery.updateSettingStatus(
+            ws.workspaceIdAsUUID,
+            WorkspaceSettingTypes.GcpBucketSoftDelete,
+            WorkspaceSettingRecord.SettingStatus.Pending,
+            WorkspaceSettingRecord.SettingStatus.Applied
+          )
+          _ <- dataAccess.workspaceSettingQuery.updateSettingStatus(
+            ws.workspaceIdAsUUID,
+            WorkspaceSettingTypes.GcpBucketRequesterPays,
+            WorkspaceSettingRecord.SettingStatus.Pending,
+            WorkspaceSettingRecord.SettingStatus.Applied
+          )
+          _ <- dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID,
+                                                        List(pendingSetting),
+                                                        userInfo.userSubjectId
+          )
+        } yield ()
+      },
+      Duration.Inf
+    )
+
+    val result = Await.result(repo.getWorkspaceSettingOfType(ws.workspaceIdAsUUID, GcpBucketSoftDelete), Duration.Inf)
+
+    assertResult(result)(Some(appliedSoftDeleteSetting))
+  }
+
+  it should "return none if no setting of requested type is applied" in {
+    val repo = new WorkspaceSettingRepository(slickDataSource)
+    val workspaceRepo = new WorkspaceRepository(slickDataSource)
+    val ws: Workspace = makeWorkspace()
+    Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
+    val appliedRequesterPaysSetting = GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true))
+    val pendingSetting = GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(2_000_000))
+
+    Await.result(
+      slickDataSource.inTransaction { dataAccess =>
+        for {
+          _ <- dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID,
+                                                        List(appliedRequesterPaysSetting),
+                                                        userInfo.userSubjectId
+          )
+          _ <- dataAccess.workspaceSettingQuery.updateSettingStatus(
+            ws.workspaceIdAsUUID,
+            WorkspaceSettingTypes.GcpBucketRequesterPays,
+            WorkspaceSettingRecord.SettingStatus.Pending,
+            WorkspaceSettingRecord.SettingStatus.Applied
+          )
+          _ <- dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID,
+                                                        List(pendingSetting),
+                                                        userInfo.userSubjectId
+          )
+        } yield ()
+      },
+      Duration.Inf
+    )
+
+    val result = Await.result(repo.getWorkspaceSettingOfType(ws.workspaceIdAsUUID, GcpBucketSoftDelete), Duration.Inf)
+
+    assertResult(result)(None)
   }
 
   behavior of "createWorkspaceSettingsRecords"

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -345,7 +345,7 @@ case class WorkspaceSubmissionStats(lastSuccessDate: Option[DateTime],
                                     runningSubmissionsCount: Int
 )
 
-case class WorkspaceBucketOptions(requesterPays: Boolean)
+case class WorkspaceBucketOptions(requesterPays: Boolean, location: String)
 
 case class EntityTypeRename(newName: String)
 
@@ -1438,7 +1438,7 @@ class WorkspaceJsonSupport extends JsonSupport {
     WorkspaceSubmissionStats
   )
 
-  implicit val WorkspaceBucketOptionsFormat: RootJsonFormat[WorkspaceBucketOptions] = jsonFormat1(
+  implicit val WorkspaceBucketOptionsFormat: RootJsonFormat[WorkspaceBucketOptions] = jsonFormat2(
     WorkspaceBucketOptions
   )
 


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/CORE-53](https://broadworkbench.atlassian.net/browse/CORE-53)

While working through this ticket, Adam and I found that the current requester pays behavior for storage cost + region are inconsistent in the UI. For both features, the only information needed from Google storage service is the bucket location (which is used in the cost calculation to identify rates). However, the current implementation has the logic for estimated cost in Orchestration, and the logic for displaying bucket region in Terra UI. Both do the Google storage service request and error handling independently.

This change adds bucket location info to the `bucketOptions` returned by the workspace details API. It also adds an optional `userProject` parameter which can be used when getting `bucketOptions`. There is some new validation, too: if a reader is trying to get `bucketOptions` on a requester pays workspace without providing a project to bill, this is considered to be a bad request. In all other cases, a `userProject` is not required (the request will be billed to the workspace's google project, as it was previously).

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
