### PR TITLE
CORE-95: update to BPM client 0.1.584 and adjust syntax

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAO.scala
@@ -208,7 +208,7 @@ class BillingProfileManagerDAOImpl(
     }
 
   override def deleteBillingProfile(billingProfileId: UUID, ctx: RawlsRequestContext): Unit =
-    Try(apiClientProvider.getProfileApi(ctx).deleteProfile(billingProfileId)) match {
+    Try(apiClientProvider.getProfileApi(ctx).deleteProfile(billingProfileId, null)) match {
       case Failure(exception: ApiException) if exception.getCode == HttpStatus.SC_NOT_FOUND =>
         logger.info(s"No billing profile record found for $billingProfileId when deleting BPM-backed billing project")
       case Failure(t) => throw t
@@ -252,7 +252,7 @@ class BillingProfileManagerDAOImpl(
       Future {
         apiClientProvider
           .getProfileApi(ctx)
-          .removeBillingAccount(billingProfileId)
+          .removeBillingAccount(billingProfileId, null)
       }
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProfileManagerDAOSpec.scala
@@ -236,7 +236,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
 
     billingProfileManagerDAO.deleteBillingProfile(profileId, testContext)
-    verify(profileApi).deleteProfile(profileId)
+    verify(profileApi).deleteProfile(profileId, null)
   }
 
   it should "not fail if BPM returns a 404" in {
@@ -248,11 +248,12 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
       provider,
       multiCloudWorkspaceConfig
     )
-    when(profileApi.deleteProfile(profileId)).thenThrow(new ApiException(StatusCodes.NotFound.intValue, "not found"))
+    when(profileApi.deleteProfile(profileId, null))
+      .thenThrow(new ApiException(StatusCodes.NotFound.intValue, "not found"))
     when(provider.getProfileApi(ArgumentMatchers.eq(testContext))).thenReturn(profileApi)
 
     billingProfileManagerDAO.deleteBillingProfile(profileId, testContext)
-    verify(profileApi).deleteProfile(profileId)
+    verify(profileApi).deleteProfile(profileId, null)
   }
 
   behavior of "listManagedApps"
@@ -352,7 +353,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     doThrow(new ApiException(StatusCodes.InternalServerError.intValue, "internal server error"))
       .doNothing()
       .when(profileApi)
-      .removeBillingAccount(any())
+      .removeBillingAccount(any(), any())
 
     val apiProvider = mock[BillingProfileManagerClientProvider]
     when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
@@ -361,7 +362,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
 
     Await.result(bpmDAO.removeBillingAccountFromBillingProfile(UUID.randomUUID(), testContext), Duration.Inf)
 
-    verify(profileApi, times(2)).removeBillingAccount(any())
+    verify(profileApi, times(2)).removeBillingAccount(any(), any())
   }
 
   it should "throw 4xx errors" in {
@@ -369,7 +370,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
     doThrow(new ApiException(StatusCodes.Forbidden.intValue, "internal server error"))
       .doNothing()
       .when(profileApi)
-      .removeBillingAccount(any())
+      .removeBillingAccount(any(), any())
 
     val apiProvider = mock[BillingProfileManagerClientProvider]
     when(apiProvider.getProfileApi(any())).thenReturn(profileApi)
@@ -380,7 +381,7 @@ class BillingProfileManagerDAOSpec extends AnyFlatSpec with MockitoTestUtils {
       Await.result(bpmDAO.removeBillingAccountFromBillingProfile(UUID.randomUUID(), testContext), Duration.Inf)
     }
 
-    verify(profileApi, times(1)).removeBillingAccount(any())
+    verify(profileApi, times(1)).removeBillingAccount(any(), any())
   }
 
   behavior of "addProfilePolicyMember"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -131,7 +131,7 @@ object Dependencies {
   val workspaceManager = clientLibExclusions("bio.terra" % "workspace-manager-client" % "0.254.1152-SNAPSHOT")
   val dataRepo = clientLibExclusions("bio.terra" % "datarepo-jakarta-client" % "1.593.0-SNAPSHOT")
   val resourceBufferService = clientLibExclusions("bio.terra" % "terra-resource-buffer-client" % "0.198.42-SNAPSHOT")
-  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.568-SNAPSHOT")
+  val billingProfileManager = clientLibExclusions("bio.terra" % "billing-profile-manager-client" % "0.1.584-SNAPSHOT")
   val terraCommonLib = tclExclusions(clientLibExclusions("bio.terra" % "terra-common-lib" % "0.1.23-SNAPSHOT" classifier "plain"))
   val sam: ModuleID = clientLibExclusions("org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.289")
   val leonardo: ModuleID = "org.broadinstitute.dsde.workbench" % "leonardo-client_2.13" % "1.3.6-2e87300"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-95

BPM client >= 0.1.569-SNAPSHOT introduces some minor syntax changes in its client. This PR updates Rawls past the breaking changes, and makes the necessary changes to syntax to handle the update. 

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
