### PR TITLE
CORE-189: streamline ENTITY_ATTRIBUTE_TEMP temp table

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -126,4 +126,5 @@
     <include file="changesets/20240723_workspace_settings.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240820_submission_cost_cap_threshold.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240830_workflow_cost.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20241106_streamline_entity_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -127,4 +127,5 @@
     <include file="changesets/20240820_submission_cost_cap_threshold.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240830_workflow_cost.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20241106_streamline_entity_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20241106_streamline_workspace_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="streamline_entity_attr_temp_table">
+        <createProcedure replaceIfExists="true" procedureName="createEntityAttributeTempTable">
+            CREATE PROCEDURE createEntityAttributeTempTable ()
+            BEGIN
+            create temporary table ENTITY_ATTRIBUTE_TEMP (
+                id bigint(20) unsigned NOT NULL AUTO_INCREMENT primary key,
+                namespace varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+                name varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
+                value_string text,
+                value_json longtext,
+                value_number double DEFAULT NULL,
+                value_boolean bit(1) DEFAULT NULL,
+                value_entity_ref bigint(20) unsigned DEFAULT NULL,
+                list_index int(11) DEFAULT NULL,
+                list_length int(11) DEFAULT NULL,
+                owner_id bigint(20) unsigned NOT NULL,
+                deleted bit(1) DEFAULT false,
+                deleted_date timestamp NULL DEFAULT NULL,
+                INDEX entity_tmp_owner_id_idx (owner_id),
+                INDEX UNQ_ENTITY_ATTRIBUTE(owner_id, namespace, name, list_index)
+            );
+            END
+        </createProcedure>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
@@ -22,9 +22,7 @@
                 list_length int(11) DEFAULT NULL,
                 owner_id bigint(20) unsigned NOT NULL,
                 deleted bit(1) DEFAULT false,
-                deleted_date timestamp NULL DEFAULT NULL,
-                INDEX entity_tmp_owner_id_idx (owner_id),
-                INDEX UNQ_ENTITY_ATTRIBUTE(owner_id, namespace, name, list_index)
+                deleted_date timestamp NULL DEFAULT NULL
             );
             END
         </createProcedure>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
@@ -3,7 +3,7 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
     <changeSet logicalFilePath="dummy" author="davidan" id="streamline_entity_attr_temp_table">
         <createProcedure replaceIfExists="true" procedureName="createEntityAttributeTempTable">

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
@@ -10,17 +10,17 @@
             CREATE PROCEDURE createEntityAttributeTempTable ()
             BEGIN
             create temporary table ENTITY_ATTRIBUTE_TEMP (
-                id bigint(20) unsigned NOT NULL AUTO_INCREMENT primary key,
+                id bigint unsigned NOT NULL AUTO_INCREMENT primary key,
                 namespace varchar(32) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
                 name varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,
                 value_string text,
                 value_json longtext,
                 value_number double DEFAULT NULL,
                 value_boolean bit(1) DEFAULT NULL,
-                value_entity_ref bigint(20) unsigned DEFAULT NULL,
+                value_entity_ref bigint unsigned DEFAULT NULL,
                 list_index int DEFAULT NULL,
                 list_length int DEFAULT NULL,
-                owner_id bigint(20) unsigned NOT NULL,
+                owner_id bigint unsigned NOT NULL,
                 deleted bit(1) DEFAULT false,
                 deleted_date timestamp NULL DEFAULT NULL
             );

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_entity_attr_temp_table_procedure.xml
@@ -18,8 +18,8 @@
                 value_number double DEFAULT NULL,
                 value_boolean bit(1) DEFAULT NULL,
                 value_entity_ref bigint(20) unsigned DEFAULT NULL,
-                list_index int(11) DEFAULT NULL,
-                list_length int(11) DEFAULT NULL,
+                list_index int DEFAULT NULL,
+                list_length int DEFAULT NULL,
                 owner_id bigint(20) unsigned NOT NULL,
                 deleted bit(1) DEFAULT false,
                 deleted_date timestamp NULL DEFAULT NULL

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_workspace_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_workspace_attr_temp_table_procedure.xml
@@ -22,9 +22,7 @@
                 list_length int DEFAULT NULL,
                 owner_id BINARY(16) NOT NULL,
                 deleted bit(1) DEFAULT false,
-                deleted_date timestamp NULL DEFAULT NULL,
-                INDEX entity_tmp_owner_id_idx (owner_id),
-                INDEX UNQ_WORKSPACE_ATTRIBUTE (owner_id,namespace,name,list_index)
+                deleted_date timestamp NULL DEFAULT NULL
             );
             END
         </createProcedure>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_workspace_attr_temp_table_procedure.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241106_streamline_workspace_attr_temp_table_procedure.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet logicalFilePath="dummy" author="davidan" id="streamline_workspace_attr_temp_table">
+        <createProcedure replaceIfExists="true" procedureName="createWorkspaceAttributeTempTable">
+            CREATE PROCEDURE createWorkspaceAttributeTempTable ()
+            BEGIN
+            create temporary table WORKSPACE_ATTRIBUTE_TEMP (
+                id bigint unsigned NOT NULL AUTO_INCREMENT primary key,
+                namespace varchar(32) NOT NULL,
+                name varchar(200) NOT NULL,
+                value_string text,
+                value_json longtext,
+                value_number double DEFAULT NULL,
+                value_boolean bit(1) DEFAULT NULL,
+                value_entity_ref bigint unsigned DEFAULT NULL,
+                list_index int DEFAULT NULL,
+                list_length int DEFAULT NULL,
+                owner_id BINARY(16) NOT NULL,
+                deleted bit(1) DEFAULT false,
+                deleted_date timestamp NULL DEFAULT NULL,
+                INDEX entity_tmp_owner_id_idx (owner_id),
+                INDEX UNQ_WORKSPACE_ATTRIBUTE (owner_id,namespace,name,list_index)
+            );
+            END
+        </createProcedure>
+    </changeSet>
+
+
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -802,19 +802,10 @@ trait AttributeComponent {
              """.as[Int]
       }
 
-      def clearAttributeScratchTableAction(transactionId: String = "") = {
-        val joinTableName = getTempOrScratchTableName(baseTableRow.tableName)
-
-        if (joinTableName.endsWith("SCRATCH"))
-          sqlu"""delete from #${joinTableName} where transaction_id = $transactionId"""
-        else DBIO.successful(0)
-      }
-
       def updateAction(insertIntoScratchFunction: () => WriteAction[Int], tracingContext: RawlsTracingContext) =
         traceDBIOWithParent("updateAction", tracingContext) { span =>
           traceDBIOWithParent("insertIntoScratchFunction", span)(_ => insertIntoScratchFunction()) andThen
-            traceDBIOWithParent("updateInMasterAction", span)(_ => updateInMasterAction()) andThen
-            traceDBIOWithParent("clearAttributeScratchTableAction", span)(_ => clearAttributeScratchTableAction())
+            traceDBIOWithParent("updateInMasterAction", span)(_ => updateInMasterAction())
         }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -310,7 +310,7 @@ trait AttributeComponent {
                    Option[Timestamp]
     ) => TEMP_RECORD
   ) extends TableQuery[T](cons) {
-    def insertScratchAttributes(attributeRecs: Seq[RECORD]): WriteAction[Int] =
+    def insertScratchAttributes(attributeRecs: Seq[RECORD])(): WriteAction[Int] =
       batchInsertAttributes(attributeRecs)
 
     def batchInsertAttributes(attributes: Seq[RECORD]) =
@@ -587,7 +587,7 @@ trait AttributeComponent {
     def patchAttributesAction(inserts: Traversable[RECORD],
                               updates: Traversable[RECORD],
                               deleteIds: Traversable[Long],
-                              insertFunction: Seq[RECORD] => String => WriteAction[Int],
+                              insertFunction: Seq[RECORD] => () => WriteAction[Int],
                               tracingContext: RawlsTracingContext
     ) =
       traceDBIOWithParent("patchAttributesAction", tracingContext) { span =>
@@ -695,7 +695,7 @@ trait AttributeComponent {
      */
     def rewriteAttrsAction(attributesToSave: Traversable[RECORD],
                            existingAttributes: Traversable[RECORD],
-                           insertFunction: Seq[RECORD] => String => WriteAction[Int]
+                           insertFunction: Seq[RECORD] => () => WriteAction[Int]
     ): ReadWriteAction[Set[OWNER_ID]] =
       traceDBIOWithParent("AttributeComponent.rewriteAttrsAction", RawlsTracingContext(Option.empty)) {
         tracingContext =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala
@@ -33,9 +33,7 @@ trait AttributeRecord[OWNER_ID] {
   val deletedDate: Option[Timestamp]
 }
 
-trait AttributeScratchRecord[OWNER_ID] extends AttributeRecord[OWNER_ID] {
-  val transactionId: String
-}
+trait AttributeScratchRecord[OWNER_ID] extends AttributeRecord[OWNER_ID]
 
 case class EntityAttributeRecord(id: Long,
                                  ownerId: Long, // entity id
@@ -64,8 +62,7 @@ case class EntityAttributeTempRecord(id: Long,
                                      listIndex: Option[Int],
                                      listLength: Option[Int],
                                      deleted: Boolean,
-                                     deletedDate: Option[Timestamp],
-                                     transactionId: String
+                                     deletedDate: Option[Timestamp]
 ) extends AttributeScratchRecord[Long]
 
 case class WorkspaceAttributeRecord(id: Long,
@@ -95,8 +92,7 @@ case class WorkspaceAttributeTempRecord(id: Long,
                                         listIndex: Option[Int],
                                         listLength: Option[Int],
                                         deleted: Boolean,
-                                        deletedDate: Option[Timestamp],
-                                        transactionId: String
+                                        deletedDate: Option[Timestamp]
 ) extends AttributeScratchRecord[UUID]
 
 case class SubmissionAttributeRecord(id: Long,
@@ -148,9 +144,7 @@ trait AttributeComponent {
   abstract class AttributeScratchTable[OWNER_ID: TypedType, RECORD <: AttributeScratchRecord[OWNER_ID]](
     tag: Tag,
     tableName: String
-  ) extends AttributeTable[OWNER_ID, RECORD](tag, tableName) {
-    def transactionId = column[String]("transaction_id")
-  }
+  ) extends AttributeTable[OWNER_ID, RECORD](tag, tableName)
 
   class EntityAttributeTable(shard: ShardId)(tag: Tag)
       extends AttributeTable[Long, EntityAttributeRecord](tag, s"ENTITY_ATTRIBUTE_$shard") {
@@ -236,8 +230,7 @@ trait AttributeComponent {
              listIndex,
              listLength,
              deleted,
-             deletedDate,
-             transactionId
+             deletedDate
     ) <> (EntityAttributeTempRecord.tupled, EntityAttributeTempRecord.unapply)
   }
 
@@ -255,8 +248,7 @@ trait AttributeComponent {
              listIndex,
              listLength,
              deleted,
-             deletedDate,
-             transactionId
+             deletedDate
     ) <> (WorkspaceAttributeTempRecord.tupled, WorkspaceAttributeTempRecord.unapply)
   }
 
@@ -315,14 +307,13 @@ trait AttributeComponent {
                    Option[Int],
                    Option[Int],
                    Boolean,
-                   Option[Timestamp],
-                   String
+                   Option[Timestamp]
     ) => TEMP_RECORD
   ) extends TableQuery[T](cons) {
-    def insertScratchAttributes(attributeRecs: Seq[RECORD])(transactionId: String): WriteAction[Int] =
-      batchInsertAttributes(attributeRecs, transactionId)
+    def insertScratchAttributes(attributeRecs: Seq[RECORD]): WriteAction[Int] =
+      batchInsertAttributes(attributeRecs)
 
-    def batchInsertAttributes(attributes: Seq[RECORD], transactionId: String) =
+    def batchInsertAttributes(attributes: Seq[RECORD]) =
       insertInBatches(
         this,
         attributes.map(rec =>
@@ -339,8 +330,7 @@ trait AttributeComponent {
             rec.listIndex,
             rec.listLength,
             rec.deleted,
-            rec.deletedDate,
-            transactionId
+            rec.deletedDate
           )
         )
       )
@@ -714,8 +704,6 @@ trait AttributeComponent {
 
           // note that currently-existing attributes will have a populated id e.g. "1234", but to-save will have an id of "0"
           // therefore, we use this ComparableRecord class which omits the id when checking equality between existing and to-save.
-          // note this does not include transactionId for AttributeScratchRecords. We do not expect AttributeScratchRecords
-          // here, and transactionId will eventually be going away, so don't bother
           object ComparableRecord {
             def fromRecord(rec: RECORD): ComparableRecord =
               new ComparableRecord(
@@ -795,7 +783,7 @@ trait AttributeComponent {
       // attributes.
 
       // updateInMasterAction: updates any row in *_ATTRIBUTE that also exists in *_ATTRIBUTE_SCRATCH
-      def updateInMasterAction(transactionId: String) = {
+      def updateInMasterAction() = {
         val joinTableName = getTempOrScratchTableName(baseTableRow.tableName)
 
         sql"""
@@ -803,7 +791,6 @@ trait AttributeComponent {
               join #${joinTableName} ta
               on (a.namespace, a.name, a.owner_id, ifnull(a.list_index, 0)) =
                  (ta.namespace, ta.name, ta.owner_id, ifnull(ta.list_index, 0))
-                  and ta.transaction_id = $transactionId
           set a.value_string=ta.value_string,
               a.value_number=ta.value_number,
               a.value_boolean=ta.value_boolean,
@@ -815,7 +802,7 @@ trait AttributeComponent {
              """.as[Int]
       }
 
-      def clearAttributeScratchTableAction(transactionId: String) = {
+      def clearAttributeScratchTableAction(transactionId: String = "") = {
         val joinTableName = getTempOrScratchTableName(baseTableRow.tableName)
 
         if (joinTableName.endsWith("SCRATCH"))
@@ -823,14 +810,11 @@ trait AttributeComponent {
         else DBIO.successful(0)
       }
 
-      def updateAction(insertIntoScratchFunction: String => WriteAction[Int], tracingContext: RawlsTracingContext) =
+      def updateAction(insertIntoScratchFunction: () => WriteAction[Int], tracingContext: RawlsTracingContext) =
         traceDBIOWithParent("updateAction", tracingContext) { span =>
-          val transactionId = UUID.randomUUID().toString
-          traceDBIOWithParent("insertIntoScratchFunction", span)(_ => insertIntoScratchFunction(transactionId)) andThen
-            traceDBIOWithParent("updateInMasterAction", span)(_ => updateInMasterAction(transactionId)) andThen
-            traceDBIOWithParent("clearAttributeScratchTableAction", span)(_ =>
-              clearAttributeScratchTableAction(transactionId)
-            )
+          traceDBIOWithParent("insertIntoScratchFunction", span)(_ => insertIntoScratchFunction()) andThen
+            traceDBIOWithParent("updateInMasterAction", span)(_ => updateInMasterAction()) andThen
+            traceDBIOWithParent("clearAttributeScratchTableAction", span)(_ => clearAttributeScratchTableAction())
         }
     }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-189

## Incremental performance improvements for batch-upsert operations

The `ENTITY_ATTRIBUTE_TEMP` temp table is used during batch upsert/batch update operations. These operations can include tens or hundreds of thousands of updates to entity attributes. `UPDATE` sql statements cannot be batched, and issuing individual update statements would incur lots and lots of overhead to process each individual statement.

Instead, each "update" is implemented as an `INSERT` statement into the `ENTITY_ATTRIBUTE_TEMP` temp table. The MySQL driver, via `rewriteBatchedStatements=true` [on the connection string](
https://github.com/broadinstitute/terra-helmfile/blob/d70c8da26bcdeb475da33972715f798fee64cb83/charts/rawls/templates/config/_conf.tpl#L201), batches multiple inserts to avoid overhead. Finally, after executing all the inserts into the temp table, we perform a single update of the persistent `ENTITY_ATTRIBUTE_xx_xx` table using values from the temp table. This final update is the [`updateInMaster` function](https://github.com/broadinstitute/rawls/blob/995cd5571ca87abe6a25e23b9148be725e71912b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/AttributeComponent.scala#L797-L816).

This PR attempts to optimize the `updateInMaster` function by optimizing its SQL and the schema of the temp table:
* remove `transaction_id` from the `ENTITY_ATTRIBUTE_TEMP` temp table. Since each connection gets its own temp table, this is extraneous and irrelevant and only adds to the complexity of the `where` clause used by this table.
* align the `namespace` and `name` columns of `ENTITY_ATTRIBUTE_TEMP` to what is actually in use by the persistent `ENTITY_ATTRIBUTE_*` shard tables. Specifically, change from `text` to `varchar` and set the same explicit character set and collation. The change from `text` to `varchar` should help with performance.
* remove the extraneous `entity_tmp_owner_id_idx` index from the temp table. This index doesn't get used for anything and therefore only adds overhead on inserts.

the visual explain-plan for the `updateInMaster` function:
![explain](https://github.com/user-attachments/assets/776154d8-d5af-464a-9851-6ddfea4e4489)
I interpret this as:
* for every row in the temp table (the full table scan on `ta`)
* find the matching row in the persistent table (the nested loop and lookup against the `UNQ_ENTITY_ATTRIBUTE` index on `a`)
* and update that row (`query block #1`)



---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
