### PR TITLE
CORE-149 use default pet SA for read-only workspaces

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceImpl.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceImpl.scala
@@ -315,22 +315,32 @@ class FastPassServiceImpl(protected val ctx: RawlsRequestContext,
 
           _ <- removeFastPassesForUserInWorkspace(workspace, samUserInfo)
 
-          petSAJson <- DBIO.from(
-            samDAO.getPetServiceAccountKeyForUser(workspace.googleProjectId,
-                                                  RawlsUserEmail(samUserInfo.userEmail.value)
-            )
+          defaultPetSAJson <- DBIO.from(
+            samDAO.getUserArbitraryPetServiceAccountKey(samUserInfo.userEmail.value)
           )
-          petUserInfo <- DBIO.from(googleServicesDAO.getUserInfoUsingJson(petSAJson))
-          petCtx = ctx.copy(userInfo = petUserInfo)
-          samPetUserInfo <- DBIO.from(samDAO.getUserStatus(petCtx))
-          _ = if (!samPetUserInfo.exists(_.enabled)) throw new FastPassUserNotEnabledException(email)
+          defaultPetUserInfo <- DBIO.from(googleServicesDAO.getUserInfoUsingJson(defaultPetSAJson))
+          defaultPetCtx = ctx.copy(userInfo = defaultPetUserInfo)
+          userInfo <- DBIO.from(samDAO.getUserStatus(defaultPetCtx))
+          _ = if (!userInfo.exists(_.enabled)) throw new FastPassUserNotEnabledException(email)
           userType = getUserType(samUserInfo.userEmail)
-          petEmail = FastPassServiceImpl.getEmailFromPetSaKey(petSAJson)
+          workspaceRoles <- DBIO
+            .from(samDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, defaultPetCtx))
+          useDefaultPet = workspaceRoles.intersect(SamWorkspaceRoles.rolesContainingWritePermissions).isEmpty
+          petEmail <-
+            if (useDefaultPet) {
+              DBIO.successful(FastPassServiceImpl.getEmailFromPetSaKey(defaultPetSAJson))
+            } else {
+              DBIO.from(
+                samDAO
+                  .getPetServiceAccountKeyForUser(workspace.googleProjectId,
+                                                  RawlsUserEmail(samUserInfo.userEmail.value)
+                  )
+                  .map(FastPassServiceImpl.getEmailFromPetSaKey)
+              )
+            }
           userAndPet = UserAndPetEmails(samUserInfo.userEmail, userType, petEmail)
-          roles <- DBIO
-            .from(samDAO.listUserRolesForResource(SamResourceTypeNames.workspace, workspace.workspaceId, petCtx))
 
-          _ <- addFastPassGrantsForRoles(samUserInfo, userAndPet, workspace, roles, petCtx)
+          _ <- addFastPassGrantsForRoles(samUserInfo, userAndPet, workspace, workspaceRoles, defaultPetCtx)
         } yield ()
       }
       .transform {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/FastPassServiceSpec.scala
@@ -749,7 +749,15 @@ class FastPassServiceSpec
     val readerRoles = Vector(services.terraBucketReaderRole)
 
     userWriterGrants.map(_.organizationRole) should contain only (writerCanComputeRoles: _*)
+    userWriterGrants.map(_.accountEmail.value).toSet should contain only (
+      testData.userWriter.userEmail.value,
+      MockFastPassService.buildPetEmail(testData.userWriter, testData.workspace.googleProjectId.value).value
+    )
     userReaderGrants.map(_.organizationRole) should contain only (readerRoles: _*)
+    userReaderGrants.map(_.accountEmail.value).toSet should contain only (
+      testData.userReader.userEmail.value,
+      MockFastPassService.buildPetEmail(testData.userReader, MockFastPassService.defaultPetGoogleProject).value
+    )
 
     // share-reader added as bucket reader
     verify(services.googleStorageDAO).addIamRoles(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/MockFastPassService.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/fastpass/MockFastPassService.scala
@@ -106,7 +106,7 @@ object MockFastPassService {
       val petUserSubjectId = RawlsUserSubjectId(s"${testUser.userSubjectId.value}-pet")
 
       def projectPetInfo(googleProject: String): (WorkbenchEmail, String) = {
-        val petEmail = WorkbenchEmail(s"${testUser.userEmail.value}-pet@$googleProject.iam.gserviceaccount.com")
+        val petEmail = buildPetEmail(testUser, googleProject)
         val petKey =
           s"""{"private_key_id": "${testUser.userEmail.value}-$googleProject-pet-key", "client_id": "${petUserSubjectId.value}", "client_email": "${petEmail.value}" }"""
         (petEmail, petKey)
@@ -118,6 +118,14 @@ object MockFastPassService {
           ArgumentMatchers.argThat((ctx: RawlsRequestContext) =>
             ctx.userInfo.userEmail.value.startsWith(s"${testUser.userEmail.value}-pet")
           )
+        )
+
+      doAnswer { _ =>
+        Future.successful(projectPetInfo(defaultPetGoogleProject)._2)
+      }
+        .when(samDAO)
+        .getUserArbitraryPetServiceAccountKey(
+          ArgumentMatchers.eq(testUser.userEmail.value)
         )
 
       doAnswer { invocation =>
@@ -164,4 +172,8 @@ object MockFastPassService {
           ArgumentMatchers.argThat((arg: RawlsRequestContext) => arg.userInfo.userSubjectId.equals(petUserSubjectId))
         )
     }
+
+  val defaultPetGoogleProject = "default"
+  def buildPetEmail(testUser: RawlsUser, googleProject: String) =
+    WorkbenchEmail(s"${testUser.userEmail.value}-pet@$googleProject.iam.gserviceaccount.com")
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-149
<Put notes here to help reviewer understand this PR>

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
