### PR TITLE
[CORE-153] Change Scala Steward settings for fewer PRs

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -30,6 +30,39 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 # Defaults to no labels (no labels are added).
 pullRequests.customLabels = [ "Scala_Steward" ]
 
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update together a filter like {group = "*"} can be # provided.
+#
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+#
+# Default: []
+pullRequests.grouping = [ { name = "Minor/patch updates", filter = [ { version = "minor" }, { version = "patch" } ] } ]
+
 # Only these dependencies which match the given patterns are updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.
@@ -53,7 +86,7 @@ pullRequests.customLabels = [ "Scala_Steward" ]
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 # Default: None
-updates.limit = 10
+updates.limit = 5
 
 # The extensions of files that should be updated.
 # Default: [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml"]
@@ -65,7 +98,7 @@ updates.limit = 10
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
-updatePullRequests = "always"
+updatePullRequests = "on-conflicts"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -61,7 +61,7 @@ pullRequests.customLabels = [ "Scala_Steward" ]
 # To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
 #
 # Default: []
-pullRequests.grouping = [ { name = "Minor/patch updates", filter = [ { version = "minor" }, { version = "patch" } ] } ]
+pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and patch updates - ${artifactVersions}", filter = [ { version = "minor" }, { version = "patch" } ] } ]
 
 # Only these dependencies which match the given patterns are updated.
 #


### PR DESCRIPTION
Ticket: [CORE-153](https://broadworkbench.atlassian.net/browse/CORE-153)
* Group minor and patch upgrades together
* Reduce new PR limit from 10 -> 5
* Only update PRs when there is a conflict 
    * I'm less certain about what changing this setting does, but I'm hoping it will prevent Scala Steward from rebasing and force pushing every update PR every morning at the same time across all our repos
    
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-153]: https://broadworkbench.atlassian.net/browse/CORE-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ