### PR TITLE
CORE-69: update transitive dependency overrides

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -155,10 +155,8 @@ object Dependencies {
   // in Rawls by being listed here.
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides = Seq(
-    //Override for reactor-netty to address CVE-2023-34054 and CVE-2023-34062
-    "io.projectreactor.netty"       % "reactor-netty-http"    % "1.0.39",
     // override commons-codec to address a non-CVE warning from DefectDojo
-    "commons-codec"                 % "commons-codec"         % "1.16.1"
+    "commons-codec"                 % "commons-codec"         % "1.17.1"
   )
 
   val extraOpenTelemetryDependencies = Seq(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-69

* remove `reactor-netty-http` from transitive dependency overrides. Our override version is lower than the version currently being pulled in.
* bump `commons-codec` in transitive dependency overrides to latest version.

This PR will supersede #3126 and #3125.

`reactor-netty-http`, without the transitive dependency override:
![Screenshot 2024-11-12 at 11 57 47 AM](https://github.com/user-attachments/assets/e3f64ce8-75b8-4799-a88d-2968405f04a9)





---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
