### PR TITLE
CORE-69: remove joda-convert dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,6 @@ object Dependencies {
   val scalaLogging: ModuleID =    "com.typesafe.scala-logging"    %% "scala-logging"        % "3.9.5"
   val jacksonCore: ModuleID =     "com.fasterxml.jackson.core"    % "jackson-core"          % "2.18.1"
   val jodaTime: ModuleID =        "joda-time"                     % "joda-time"             % "2.13.0"
-  val jodaConvert: ModuleID =     "org.joda"                      % "joda-convert"          % "2.2.4"
   val typesafeConfig: ModuleID =  "com.typesafe"                  % "config"                % "1.4.3"
   val sentryLogback: ModuleID =   "io.sentry"                     % "sentry-logback"        % "7.16.0"
   val webjarsLocator: ModuleID =  "org.webjars"                   % "webjars-locator"       % "0.52"
@@ -218,7 +217,6 @@ object Dependencies {
     akkaHttp,
     akkaStream,
     jodaTime,
-    jodaConvert,
     scalaLogging,
     googleApiClient,
     scalaUri,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-69

The `joda-convert` dependency is unused; remove it. This obsoletes #3128.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
