### PR TITLE
CORE-158: optimize submission monitor for no-running-workflows case

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -275,10 +275,16 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
           workspaceRec <- getWorkspace(dataAccess, submissionRec.workspaceId)
         } yield (wfRecs, submitter, workspaceRec)
       } flatMap { case (externalWorkflowIds, submitter, workspaceRec) =>
-        for {
-          petUserInfo <- getPetServiceAccountUserInfo(GoogleProjectId(workspaceRec.googleProjectId), submitter)
-          workflowOutputs <- gatherWorkflowOutputs(externalWorkflowIds, petUserInfo)
-        } yield workflowOutputs
+        // if no running workflows, just return
+        if (externalWorkflowIds.isEmpty) {
+          Future.successful(Seq())
+        } else {
+          // else, check Cromwell's status for each running workflow and get outputs for workflows completed in Cromwell
+          for {
+            petUserInfo <- getPetServiceAccountUserInfo(GoogleProjectId(workspaceRec.googleProjectId), submitter)
+            workflowOutputs <- gatherWorkflowOutputs(externalWorkflowIds, petUserInfo)
+          } yield workflowOutputs
+        }
 
       } map ExecutionServiceStatusResponse
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-158

The `SubmissionMonitorActor`, when monitoring a submission, gets the list of running workflows (status in Submitted, Running, Aborting) from the Rawls db, then asks Cromwell for Cromwell's most up-to-date status of each of these workflows. The requests to Cromwell execute via a pet token.

In cases where Rawls has no running workflows - such as immediately after workflows have been aborted - the `SubmissionMonitorActor` would still retrieve the pet token from Sam. This introduces a failure case: if there is a problem retrieving the pet token, the `SubmissionMonitorActor` will error out. If the problem is persistent, the submission may appear hung trying to abort.

Even in the case where there is no problem getting the pet token, it is an extraneous API call because the pet token is not used.

This PR optimizes for this case.



---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
