### PR TITLE
[AN-225] Cromwell Google Batch API workspace setting

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5989,13 +5989,15 @@ components:
             - GcpBucketSoftDelete
             - GcpBucketRequesterPays
             - SeparateSubmissionFinalOutputs
+            - UseCromwellGcpBatchBackend
         config:
           description: The configuration of the workspace setting
           oneOf:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketLifecycleConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketSoftDeleteConfig'
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketRequesterPaysConfig'
-            - $ref: '#/components/schemas/WorkspaceSettingSeparateSubmissionFinalOutputs'
+            - $ref: '#/components/schemas/WorkspaceSettingSeparateSubmissionFinalOutputsConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingUseCromwellGcpBatchBackendConfig'
     WorkspaceSettingGcpBucketLifecycleConfig:
       required:
         - rules
@@ -6054,7 +6056,7 @@ components:
         enabled:
           type: boolean
           description: Enabled status to set for requester pays
-    WorkspaceSettingSeparateSubmissionFinalOutputs:
+    WorkspaceSettingSeparateSubmissionFinalOutputsConfig:
       required:
         - enabled
       type: object
@@ -6062,6 +6064,14 @@ components:
         enabled:
           type: boolean
           description: Whether submission final outputs should be separated from intermediate outputs
+    WorkspaceSettingUseCromwellGcpBatchBackendConfig:
+      required:
+        - enabled
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Whether workflows submitted to Cromwell should be run using Cromwell's GCP Batch backend
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -5,14 +5,14 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketRequesterPaysConfigFormat,
   GcpBucketSoftDeleteConfigFormat,
   SeparateSubmissionFinalOutputsConfigFormat,
-  UseCromwellGCPBatchBackendConfigFormat
+  UseCromwellGcpBatchBackendConfigFormat
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
   SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGCPBatchBackendConfig
+  UseCromwellGcpBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model._
@@ -73,9 +73,9 @@ object WorkspaceSettingRecord {
         SeparateSubmissionFinalOutputsSetting(
           workspaceSettingRecord.config.parseJson.convertTo[SeparateSubmissionFinalOutputsConfig]
         )
-      case WorkspaceSettingTypes.UseCromwellGCPBatchBackend =>
-        UseCromwellGCPBatchBackendSetting(
-          workspaceSettingRecord.config.parseJson.convertTo[UseCromwellGCPBatchBackendConfig]
+      case WorkspaceSettingTypes.UseCromwellGcpBatchBackend =>
+        UseCromwellGcpBatchBackendSetting(
+          workspaceSettingRecord.config.parseJson.convertTo[UseCromwellGcpBatchBackendConfig]
         )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -4,13 +4,15 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketLifecycleConfigFormat,
   GcpBucketRequesterPaysConfigFormat,
   GcpBucketSoftDeleteConfigFormat,
-  SeparateSubmissionFinalOutputsConfigFormat
+  SeparateSubmissionFinalOutputsConfigFormat,
+  UseCromwellGCPBatchBackendConfigFormat
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
-  SeparateSubmissionFinalOutputsConfig
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGCPBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.WorkspaceSettingType
 import org.broadinstitute.dsde.rawls.model._
@@ -70,6 +72,10 @@ object WorkspaceSettingRecord {
       case WorkspaceSettingTypes.SeparateSubmissionFinalOutputs =>
         SeparateSubmissionFinalOutputsSetting(
           workspaceSettingRecord.config.parseJson.convertTo[SeparateSubmissionFinalOutputsConfig]
+        )
+      case WorkspaceSettingTypes.UseCromwellGCPBatchBackend =>
+        UseCromwellGCPBatchBackendSetting(
+          workspaceSettingRecord.config.parseJson.convertTo[UseCromwellGCPBatchBackendConfig]
         )
     }
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   SamWorkspaceActions,
   SeparateSubmissionFinalOutputsSetting,
+  UseCromwellGCPBatchBackendSetting,
   Workspace,
   WorkspaceName,
   WorkspaceSetting,
@@ -94,6 +95,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
             }
           case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(_))                 => None
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
+          case UseCromwellGCPBatchBackendSetting(UseCromwellGCPBatchBackendConfig(_))         => None
         }
       }
 
@@ -158,8 +160,13 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(enabled)) =>
           gcsDAO.setRequesterPays(workspace.bucketName, enabled, workspace.googleProjectId)
 
+        // SeparateSubmissionFinalOutputsSetting and UseCromwellGCPBatchBackendSetting are not bucket settings,
+        // so we do not need to apply anything here
+
         case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) =>
-          // SeparateSubmissionFinalOutputsSetting is not a bucket setting, so we don't need to apply anything here
+          Future.successful(())
+
+        case UseCromwellGCPBatchBackendSetting(UseCromwellGCPBatchBackendConfig(_)) =>
           Future.successful(())
 
         case _ => throw new RawlsException("unsupported workspace setting")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -168,8 +168,6 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
 
         case UseCromwellGCPBatchBackendSetting(UseCromwellGCPBatchBackendConfig(_)) =>
           Future.successful(())
-
-        case _ => throw new RawlsException("unsupported workspace setting")
       }
 
     validateSettings(workspaceSettings)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.rawls.model.{
   RawlsRequestContext,
   SamWorkspaceActions,
   SeparateSubmissionFinalOutputsSetting,
-  UseCromwellGCPBatchBackendSetting,
+  UseCromwellGcpBatchBackendSetting,
   Workspace,
   WorkspaceName,
   WorkspaceSetting,
@@ -95,7 +95,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
             }
           case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(_))                 => None
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
-          case UseCromwellGCPBatchBackendSetting(UseCromwellGCPBatchBackendConfig(_))         => None
+          case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
         }
       }
 
@@ -160,13 +160,13 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(enabled)) =>
           gcsDAO.setRequesterPays(workspace.bucketName, enabled, workspace.googleProjectId)
 
-        // SeparateSubmissionFinalOutputsSetting and UseCromwellGCPBatchBackendSetting are not bucket settings,
+        // SeparateSubmissionFinalOutputsSetting and UseCromwellGcpBatchBackendSetting are not bucket settings,
         // so we do not need to apply anything here
 
         case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) =>
           Future.successful(())
 
-        case UseCromwellGCPBatchBackendSetting(UseCromwellGCPBatchBackendConfig(_)) =>
+        case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_)) =>
           Future.successful(())
       }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -102,16 +102,18 @@ class WorkspaceSettingRepositorySpec
     assertResult(result)(List(appliedSetting))
   }
 
-  it should "support all workspace setting types" in {
-    for {
-      workspaceSetting <- List(
-        GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List())),
-        GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(0)),
-        GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
-        SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
-        UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
-      )
-    } {
+  // Helps ensure that WorkspaceSettingRecord.toWorkspaceSetting in WorkspaceSettingComponent.scala
+  // is able to successfully create every type of workspace setting from a corresponding record
+  for {
+    workspaceSetting <- List(
+      GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List())),
+      GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(0)),
+      GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
+      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
+      UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
+    )
+  }
+    it should s"be able to get a ${workspaceSetting.getClass.getSimpleName}" in {
       val repo = new WorkspaceSettingRepository(slickDataSource)
       val workspaceRepo = new WorkspaceRepository(slickDataSource)
       val ws: Workspace = makeWorkspace()
@@ -139,7 +141,6 @@ class WorkspaceSettingRepositorySpec
 
       assertResult(result)(List(workspaceSetting))
     }
-  }
 
   behavior of "getWorkspacesSettingsOfType"
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingRepositorySpec.scala
@@ -9,15 +9,18 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
-  GcpBucketSoftDeleteConfig
+  GcpBucketSoftDeleteConfig,
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGcpBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.GcpBucketSoftDelete
 import org.broadinstitute.dsde.rawls.model.{
   GcpBucketLifecycleSetting,
   GcpBucketRequesterPaysSetting,
   GcpBucketSoftDeleteSetting,
+  SeparateSubmissionFinalOutputsSetting,
+  UseCromwellGcpBatchBackendSetting,
   Workspace,
-  WorkspaceSetting,
   WorkspaceSettingTypes
 }
 import org.joda.time.DateTime
@@ -97,6 +100,45 @@ class WorkspaceSettingRepositorySpec
     val result = Await.result(repo.getWorkspaceSettings(ws.workspaceIdAsUUID), Duration.Inf)
 
     assertResult(result)(List(appliedSetting))
+  }
+
+  it should "support all workspace setting types" in {
+    for {
+      workspaceSetting <- List(
+        GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List())),
+        GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(0)),
+        GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
+        SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
+        UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
+      )
+    } {
+      val repo = new WorkspaceSettingRepository(slickDataSource)
+      val workspaceRepo = new WorkspaceRepository(slickDataSource)
+      val ws: Workspace = makeWorkspace()
+      Await.result(workspaceRepo.createWorkspace(ws), Duration.Inf)
+
+      Await.result(
+        slickDataSource.inTransaction { dataAccess =>
+          for {
+            _ <- dataAccess.workspaceSettingQuery.saveAll(ws.workspaceIdAsUUID,
+                                                          List(workspaceSetting),
+                                                          userInfo.userSubjectId
+            )
+            _ <- dataAccess.workspaceSettingQuery.updateSettingStatus(
+              ws.workspaceIdAsUUID,
+              workspaceSetting.settingType,
+              WorkspaceSettingRecord.SettingStatus.Pending,
+              WorkspaceSettingRecord.SettingStatus.Applied
+            )
+          } yield ()
+        },
+        Duration.Inf
+      )
+
+      val result = Await.result(repo.getWorkspaceSettings(ws.workspaceIdAsUUID), Duration.Inf)
+
+      assertResult(result)(List(workspaceSetting))
+    }
   }
 
   behavior of "getWorkspacesSettingsOfType"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -13,7 +13,8 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
-  SeparateSubmissionFinalOutputsConfig
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGcpBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model.{
   ErrorReport,
@@ -27,6 +28,7 @@ import org.broadinstitute.dsde.rawls.model.{
   SamUserStatusResponse,
   SamWorkspaceActions,
   SeparateSubmissionFinalOutputsSetting,
+  UseCromwellGcpBatchBackendSetting,
   UserInfo,
   Workspace,
   WorkspaceSettingTypes
@@ -184,7 +186,8 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
       GcpBucketLifecycleSetting(GcpBucketLifecycleConfig(List.empty)),
       GcpBucketSoftDeleteSetting(GcpBucketSoftDeleteConfig(7.days.toSeconds)),
       GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(true)),
-      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true))
+      SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(true)),
+      UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(true))
     )
 
     val workspaceRepository = mock[WorkspaceRepository]

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -1318,7 +1318,6 @@ class WorkspaceJsonSupport extends JsonSupport {
           SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
         case UseCromwellGCPBatchBackend =>
           UseCromwellGCPBatchBackendSetting(fields("config").convertTo[UseCromwellGCPBatchBackendConfig])
-        case _ => throw DeserializationException(s"unexpected setting type $settingType")
       }
     }
   }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -18,13 +18,15 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
-  SeparateSubmissionFinalOutputsConfig
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGCPBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   GcpBucketLifecycle,
   GcpBucketRequesterPays,
   GcpBucketSoftDelete,
   SeparateSubmissionFinalOutputs,
+  UseCromwellGCPBatchBackend,
   WorkspaceSettingType
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
@@ -591,6 +593,9 @@ case class GcpBucketRequesterPaysSetting(override val config: GcpBucketRequester
 case class SeparateSubmissionFinalOutputsSetting(override val config: SeparateSubmissionFinalOutputsConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.SeparateSubmissionFinalOutputs, config)
 
+case class UseCromwellGCPBatchBackendSetting(override val config: UseCromwellGCPBatchBackendConfig)
+    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.UseCromwellGCPBatchBackend, config)
+
 object WorkspaceSettingTypes {
   sealed trait WorkspaceSettingType extends RawlsEnumeration[WorkspaceSettingType] {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
@@ -602,6 +607,7 @@ object WorkspaceSettingTypes {
     case "gcpbucketsoftdelete"            => GcpBucketSoftDelete
     case "gcpbucketrequesterpays"         => GcpBucketRequesterPays
     case "separatesubmissionfinaloutputs" => SeparateSubmissionFinalOutputs
+    case "usecromwellgcpbatchbackend"     => UseCromwellGCPBatchBackend
     case _                                => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
   }
 
@@ -612,6 +618,8 @@ object WorkspaceSettingTypes {
   case object GcpBucketRequesterPays extends WorkspaceSettingType
 
   case object SeparateSubmissionFinalOutputs extends WorkspaceSettingType
+
+  case object UseCromwellGCPBatchBackend extends WorkspaceSettingType
 }
 
 sealed trait WorkspaceSettingConfig
@@ -629,6 +637,8 @@ object WorkspaceSettingConfig {
   case class GcpBucketRequesterPaysConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
   case class SeparateSubmissionFinalOutputsConfig(enabled: Boolean) extends WorkspaceSettingConfig
+
+  case class UseCromwellGCPBatchBackendConfig(enabled: Boolean) extends WorkspaceSettingConfig
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])
@@ -1261,6 +1271,9 @@ class WorkspaceJsonSupport extends JsonSupport {
     jsonFormat1(
       SeparateSubmissionFinalOutputsConfig.apply
     )
+  implicit val UseCromwellGCPBatchBackendConfigFormat: RootJsonFormat[UseCromwellGCPBatchBackendConfig] = jsonFormat1(
+    UseCromwellGCPBatchBackendConfig.apply
+  )
 
   implicit object WorkspaceSettingTypeFormat extends RootJsonFormat[WorkspaceSettingType] {
     override def write(obj: WorkspaceSettingType): JsValue = JsString(obj.toString)
@@ -1277,6 +1290,7 @@ class WorkspaceJsonSupport extends JsonSupport {
       case config: GcpBucketSoftDeleteConfig            => config.toJson
       case config: GcpBucketRequesterPaysConfig         => config.toJson
       case config: SeparateSubmissionFinalOutputsConfig => config.toJson
+      case config: UseCromwellGCPBatchBackendConfig     => config.toJson
     }
 
     // We prevent reading WorkspaceSettingConfig directly because we need
@@ -1302,6 +1316,8 @@ class WorkspaceJsonSupport extends JsonSupport {
           GcpBucketRequesterPaysSetting(fields("config").convertTo[GcpBucketRequesterPaysConfig])
         case SeparateSubmissionFinalOutputs =>
           SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
+        case UseCromwellGCPBatchBackend =>
+          UseCromwellGCPBatchBackendSetting(fields("config").convertTo[UseCromwellGCPBatchBackendConfig])
         case _ => throw DeserializationException(s"unexpected setting type $settingType")
       }
     }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -19,14 +19,14 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
   SeparateSubmissionFinalOutputsConfig,
-  UseCromwellGCPBatchBackendConfig
+  UseCromwellGcpBatchBackendConfig
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   GcpBucketLifecycle,
   GcpBucketRequesterPays,
   GcpBucketSoftDelete,
   SeparateSubmissionFinalOutputs,
-  UseCromwellGCPBatchBackend,
+  UseCromwellGcpBatchBackend,
   WorkspaceSettingType
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceState.WorkspaceState
@@ -593,8 +593,8 @@ case class GcpBucketRequesterPaysSetting(override val config: GcpBucketRequester
 case class SeparateSubmissionFinalOutputsSetting(override val config: SeparateSubmissionFinalOutputsConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.SeparateSubmissionFinalOutputs, config)
 
-case class UseCromwellGCPBatchBackendSetting(override val config: UseCromwellGCPBatchBackendConfig)
-    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.UseCromwellGCPBatchBackend, config)
+case class UseCromwellGcpBatchBackendSetting(override val config: UseCromwellGcpBatchBackendConfig)
+    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.UseCromwellGcpBatchBackend, config)
 
 object WorkspaceSettingTypes {
   sealed trait WorkspaceSettingType extends RawlsEnumeration[WorkspaceSettingType] {
@@ -607,7 +607,7 @@ object WorkspaceSettingTypes {
     case "gcpbucketsoftdelete"            => GcpBucketSoftDelete
     case "gcpbucketrequesterpays"         => GcpBucketRequesterPays
     case "separatesubmissionfinaloutputs" => SeparateSubmissionFinalOutputs
-    case "usecromwellgcpbatchbackend"     => UseCromwellGCPBatchBackend
+    case "usecromwellgcpbatchbackend"     => UseCromwellGcpBatchBackend
     case _                                => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
   }
 
@@ -619,7 +619,7 @@ object WorkspaceSettingTypes {
 
   case object SeparateSubmissionFinalOutputs extends WorkspaceSettingType
 
-  case object UseCromwellGCPBatchBackend extends WorkspaceSettingType
+  case object UseCromwellGcpBatchBackend extends WorkspaceSettingType
 }
 
 sealed trait WorkspaceSettingConfig
@@ -638,7 +638,7 @@ object WorkspaceSettingConfig {
 
   case class SeparateSubmissionFinalOutputsConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
-  case class UseCromwellGCPBatchBackendConfig(enabled: Boolean) extends WorkspaceSettingConfig
+  case class UseCromwellGcpBatchBackendConfig(enabled: Boolean) extends WorkspaceSettingConfig
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])
@@ -1271,8 +1271,8 @@ class WorkspaceJsonSupport extends JsonSupport {
     jsonFormat1(
       SeparateSubmissionFinalOutputsConfig.apply
     )
-  implicit val UseCromwellGCPBatchBackendConfigFormat: RootJsonFormat[UseCromwellGCPBatchBackendConfig] = jsonFormat1(
-    UseCromwellGCPBatchBackendConfig.apply
+  implicit val UseCromwellGcpBatchBackendConfigFormat: RootJsonFormat[UseCromwellGcpBatchBackendConfig] = jsonFormat1(
+    UseCromwellGcpBatchBackendConfig.apply
   )
 
   implicit object WorkspaceSettingTypeFormat extends RootJsonFormat[WorkspaceSettingType] {
@@ -1290,7 +1290,7 @@ class WorkspaceJsonSupport extends JsonSupport {
       case config: GcpBucketSoftDeleteConfig            => config.toJson
       case config: GcpBucketRequesterPaysConfig         => config.toJson
       case config: SeparateSubmissionFinalOutputsConfig => config.toJson
-      case config: UseCromwellGCPBatchBackendConfig     => config.toJson
+      case config: UseCromwellGcpBatchBackendConfig     => config.toJson
     }
 
     // We prevent reading WorkspaceSettingConfig directly because we need
@@ -1316,8 +1316,8 @@ class WorkspaceJsonSupport extends JsonSupport {
           GcpBucketRequesterPaysSetting(fields("config").convertTo[GcpBucketRequesterPaysConfig])
         case SeparateSubmissionFinalOutputs =>
           SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
-        case UseCromwellGCPBatchBackend =>
-          UseCromwellGCPBatchBackendSetting(fields("config").convertTo[UseCromwellGCPBatchBackendConfig])
+        case UseCromwellGcpBatchBackend =>
+          UseCromwellGcpBatchBackendSetting(fields("config").convertTo[UseCromwellGcpBatchBackendConfig])
       }
     }
   }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -1008,57 +1008,57 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         }
       }
     }
-  }
 
-  "SeparateSubmissionFinalOutputsSetting" - {
-    "parses setting with enabled" in {
-      val setting =
-        """{
-          |    "settingType": "SeparateSubmissionFinalOutputs",
-          |    "config": {
-          |      "enabled": true
-          |    }
-          |  }""".stripMargin.parseJson
-      assertResult {
-        SeparateSubmissionFinalOutputsSetting(
-          SeparateSubmissionFinalOutputsConfig(true)
-        )
-      } {
-        WorkspaceSettingFormat.read(setting)
+    "SeparateSubmissionFinalOutputsSetting" - {
+      "parses setting with enabled" in {
+        val setting =
+          """{
+            |    "settingType": "SeparateSubmissionFinalOutputs",
+            |    "config": {
+            |      "enabled": true
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult {
+          SeparateSubmissionFinalOutputsSetting(
+            SeparateSubmissionFinalOutputsConfig(true)
+          )
+        } {
+          WorkspaceSettingFormat.read(setting)
+        }
       }
-    }
 
-    "throws an exception for missing enabled" in {
-      val settingNoEnabled =
-        """{
-          |    "settingType": "SeparateSubmissionFinalOutputs",
-          |    "config": {}
-          |  }""".stripMargin.parseJson
-      intercept[DeserializationException] {
-        WorkspaceSettingFormat.read(settingNoEnabled)
+      "throws an exception for missing enabled" in {
+        val settingNoEnabled =
+          """{
+            |    "settingType": "SeparateSubmissionFinalOutputs",
+            |    "config": {}
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(settingNoEnabled)
+        }
       }
-    }
 
-    "throws an exception for missing config" in {
-      val settingNoConfig =
-        """{
-          |    "settingType": "SeparateSubmissionFinalOutputs"
-          |  }""".stripMargin.parseJson
-      intercept[NoSuchElementException] {
-        WorkspaceSettingFormat.read(settingNoConfig)
+      "throws an exception for missing config" in {
+        val settingNoConfig =
+          """{
+            |    "settingType": "SeparateSubmissionFinalOutputs"
+            |  }""".stripMargin.parseJson
+        intercept[NoSuchElementException] {
+          WorkspaceSettingFormat.read(settingNoConfig)
+        }
       }
-    }
 
-    "throws an exception for incorrect format" in {
-      val settingBadConfig =
-        """{
-          |    "settingType": "SeparateSubmissionFinalOutputs",
-          |    "config": {
-          |      "enabled": 0
-          |    }
-          |  }""".stripMargin.parseJson
-      intercept[DeserializationException] {
-        WorkspaceSettingFormat.read(settingBadConfig)
+      "throws an exception for incorrect format" in {
+        val settingBadConfig =
+          """{
+            |    "settingType": "SeparateSubmissionFinalOutputs",
+            |    "config": {
+            |      "enabled": 0
+            |    }
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(settingBadConfig)
+        }
       }
     }
   }

--- a/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModelSpec.scala
@@ -11,7 +11,8 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
-  SeparateSubmissionFinalOutputsConfig
+  SeparateSubmissionFinalOutputsConfig,
+  UseCromwellGcpBatchBackendConfig
 }
 import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
@@ -693,7 +694,73 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
       }
     }
 
+    "Workspace Setting Type" - {
+      "should parse workspace setting type properly" in {
+        WorkspaceSettingTypes.withName("gcpbucketlifecycle") shouldBe WorkspaceSettingTypes.GcpBucketLifecycle
+        WorkspaceSettingTypes.withName("gcpbucketsoftdelete") shouldBe WorkspaceSettingTypes.GcpBucketSoftDelete
+        WorkspaceSettingTypes.withName("gcpbucketrequesterpays") shouldBe WorkspaceSettingTypes.GcpBucketRequesterPays
+        WorkspaceSettingTypes.withName(
+          "separatesubmissionfinaloutputs"
+        ) shouldBe WorkspaceSettingTypes.SeparateSubmissionFinalOutputs
+        WorkspaceSettingTypes.withName(
+          "usecromwellgcpbatchbackend"
+        ) shouldBe WorkspaceSettingTypes.UseCromwellGcpBatchBackend
+      }
+
+      "should fail trying to parse an invalid workspace setting type" in {
+        val thrown = intercept[RawlsException] {
+          WorkspaceSettingTypes.withName("incorrect")
+        }
+
+        thrown.getMessage.contains("invalid WorkspaceSetting [incorrect]")
+      }
+
+      "should output the string representation" in {
+        WorkspaceSettingTypes.GcpBucketLifecycle.toString shouldBe "GcpBucketLifecycle"
+        WorkspaceSettingTypes.GcpBucketSoftDelete.toString shouldBe "GcpBucketSoftDelete"
+        WorkspaceSettingTypes.GcpBucketRequesterPays.toString shouldBe "GcpBucketRequesterPays"
+        WorkspaceSettingTypes.SeparateSubmissionFinalOutputs.toString shouldBe "SeparateSubmissionFinalOutputs"
+        WorkspaceSettingTypes.UseCromwellGcpBatchBackend.toString shouldBe "UseCromwellGcpBatchBackend"
+      }
+    }
+
     "GoogleBucketLifecycleSettings" - {
+      "serializes properly" in {
+        val lifecycleSettingJson =
+          """{
+            |    "settingType": "GcpBucketLifecycle",
+            |    "config": {
+            |      "rules": [
+            |        {
+            |          "action": {
+            |            "actionType": "Delete"
+            |          },
+            |          "conditions": {
+            |            "age": 30,
+            |            "matchesPrefix": [
+            |              "prefix1",
+            |              "prefix2"
+            |            ]
+            |          }
+            |        }
+            |      ]
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult(lifecycleSettingJson) {
+          WorkspaceSettingFormat.write(
+            GcpBucketLifecycleSetting(
+              GcpBucketLifecycleConfig(
+                List(
+                  GcpBucketLifecycleRule(GcpBucketLifecycleAction("Delete"),
+                                         GcpBucketLifecycleCondition(Some(Set("prefix1", "prefix2")), Some(30))
+                  )
+                )
+              )
+            )
+          )
+        }
+      }
+
       "parses lifecycle settings with matchesPrefix and age" in {
         val lifecycleSetting =
           """{
@@ -891,6 +958,23 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
     }
 
     "GoogleBucketSoftDeleteSetting" - {
+      "serializes properly" in {
+        val softDeleteSettingJson =
+          """{
+            |    "settingType": "GcpBucketSoftDelete",
+            |    "config": {
+            |      "retentionDurationInSeconds": 500
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult(softDeleteSettingJson) {
+          WorkspaceSettingFormat.write(
+            GcpBucketSoftDeleteSetting(
+              GcpBucketSoftDeleteConfig(500)
+            )
+          )
+        }
+      }
+
       "parses soft delete setting with retentionDurationInSeconds" in {
         val softDeleteSetting =
           """{
@@ -957,6 +1041,23 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
     }
 
     "GoogleBucketRequesterPaysSettings" - {
+      "serializes properly" in {
+        val requesterPaysSettingJson =
+          """{
+            |    "settingType": "GcpBucketRequesterPays",
+            |    "config": {
+            |      "enabled": true
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult(requesterPaysSettingJson) {
+          WorkspaceSettingFormat.write(
+            GcpBucketRequesterPaysSetting(
+              GcpBucketRequesterPaysConfig(true)
+            )
+          )
+        }
+      }
+
       "parses requester pays setting with enabled" in {
         val requesterPaysSetting =
           """{
@@ -1010,6 +1111,23 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
     }
 
     "SeparateSubmissionFinalOutputsSetting" - {
+      "serializes properly" in {
+        val settingJson =
+          """{
+            |    "settingType": "SeparateSubmissionFinalOutputs",
+            |    "config": {
+            |      "enabled": true
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult(settingJson) {
+          WorkspaceSettingFormat.write(
+            SeparateSubmissionFinalOutputsSetting(
+              SeparateSubmissionFinalOutputsConfig(true)
+            )
+          )
+        }
+      }
+
       "parses setting with enabled" in {
         val setting =
           """{
@@ -1052,6 +1170,76 @@ class WorkspaceModelSpec extends AnyFreeSpec with Matchers {
         val settingBadConfig =
           """{
             |    "settingType": "SeparateSubmissionFinalOutputs",
+            |    "config": {
+            |      "enabled": 0
+            |    }
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(settingBadConfig)
+        }
+      }
+    }
+
+    "UseCromwellGcpBatchBackendSetting" - {
+      "serializes properly" in {
+        val settingJson =
+          """{
+            |    "settingType": "UseCromwellGcpBatchBackend",
+            |    "config": {
+            |      "enabled": true
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult(settingJson) {
+          WorkspaceSettingFormat.write(
+            UseCromwellGcpBatchBackendSetting(
+              UseCromwellGcpBatchBackendConfig(true)
+            )
+          )
+        }
+      }
+
+      "parses setting with enabled" in {
+        val setting =
+          """{
+            |    "settingType": "UseCromwellGcpBatchBackend",
+            |    "config": {
+            |      "enabled": true
+            |    }
+            |  }""".stripMargin.parseJson
+        assertResult {
+          UseCromwellGcpBatchBackendSetting(
+            UseCromwellGcpBatchBackendConfig(true)
+          )
+        } {
+          WorkspaceSettingFormat.read(setting)
+        }
+      }
+
+      "throws an exception for missing enabled" in {
+        val settingNoEnabled =
+          """{
+            |    "settingType": "UseCromwellGcpBatchBackend",
+            |    "config": {}
+            |  }""".stripMargin.parseJson
+        intercept[DeserializationException] {
+          WorkspaceSettingFormat.read(settingNoEnabled)
+        }
+      }
+
+      "throws an exception for missing config" in {
+        val settingNoConfig =
+          """{
+            |    "settingType": "UseCromwellGcpBatchBackend"
+            |  }""".stripMargin.parseJson
+        intercept[NoSuchElementException] {
+          WorkspaceSettingFormat.read(settingNoConfig)
+        }
+      }
+
+      "throws an exception for incorrect format" in {
+        val settingBadConfig =
+          """{
+            |    "settingType": "UseCromwellGcpBatchBackend",
             |    "config": {
             |      "enabled": 0
             |    }


### PR DESCRIPTION
Ticket: [AN-225](https://broadworkbench.atlassian.net/browse/AN-225)

Adds a new workspace setting, `UseCromwellGcpBatchBackendSetting`, that will eventually enable workflows submitted to Cromwell by Rawls to be run with Cromwell's GCP Batch backend. Additional PRs for this ticket will update the Rawls model version in Rawls automation, `firecloud-orchestration`, and `workbench-libs`. This ticket does not involve making the workspace setting value editable in Terra UI or using the setting value to alter workflow submission requests to Cromwell.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email


[AN-225]: https://broadworkbench.atlassian.net/browse/AN-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ