### PR TITLE
CORE-133: add status column for billing account change synchronizer

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -126,4 +126,5 @@
     <include file="changesets/20240723_workspace_settings.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240820_submission_cost_cap_threshold.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20240830_workflow_cost.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20241121_billing_account_changes_status.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241121_billing_account_changes_status.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241121_billing_account_changes_status.xml
@@ -7,7 +7,7 @@
         <!-- add BILLING_ACCOUNT_CHANGES.STATUS column, defaulting to 'outstanding' -->
         <addColumn tableName="BILLING_ACCOUNT_CHANGES">
             <column name="STATUS"
-                    type="ENUM('ignored','outstanding','synchronized')"
+                    type="ENUM('failed', 'ignored','outstanding','synchronized')"
                     defaultValue="outstanding"
                     afterColumn="GOOGLE_SYNC_TIME">
                 <constraints nullable="false"/>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241121_billing_account_changes_status.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241121_billing_account_changes_status.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+    <changeSet id="add_billing_account_changes_status" author="davidan" logicalFilePath="dummy">
+        <!-- add BILLING_ACCOUNT_CHANGES.STATUS column, defaulting to 'outstanding' -->
+        <addColumn tableName="BILLING_ACCOUNT_CHANGES">
+            <column name="STATUS"
+                    type="ENUM('ignored','outstanding','synchronized')"
+                    defaultValue="outstanding"
+                    afterColumn="GOOGLE_SYNC_TIME">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <!-- add an index on the BILLING_ACCOUNT_CHANGES.STATUS column -->
+        <createIndex tableName="BILLING_ACCOUNT_CHANGES" indexName="BILLING_ACCOUNT_CHANGES_STATUS" unique="false">
+            <column name="STATUS"/>
+        </createIndex>
+        <!-- set STATUS='synchronized' for all previously-synchronized rows -->
+        <sql>update BILLING_ACCOUNT_CHANGES
+             set STATUS='synchronized'
+             where GOOGLE_SYNC_TIME is not null;</sql>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241121_billing_account_changes_status.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241121_billing_account_changes_status.xml
@@ -7,19 +7,20 @@
         <!-- add BILLING_ACCOUNT_CHANGES.STATUS column, defaulting to 'outstanding' -->
         <addColumn tableName="BILLING_ACCOUNT_CHANGES">
             <column name="STATUS"
-                    type="ENUM('failed', 'ignored','outstanding','synchronized')"
-                    defaultValue="outstanding"
+                    type="ENUM('Ignored','Outstanding','Synchronized')"
+                    defaultValue="Outstanding"
                     afterColumn="GOOGLE_SYNC_TIME">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
         <!-- add an index on the BILLING_ACCOUNT_CHANGES.STATUS column -->
         <createIndex tableName="BILLING_ACCOUNT_CHANGES" indexName="BILLING_ACCOUNT_CHANGES_STATUS" unique="false">
-            <column name="STATUS"/>
+            <column name="STATUS"
+            remarks="Has this change been synchronized with GCP?"/>
         </createIndex>
         <!-- set STATUS='synchronized' for all previously-synchronized rows -->
         <sql>update BILLING_ACCOUNT_CHANGES
-             set STATUS='synchronized'
+             set STATUS='Synchronized'
              where GOOGLE_SYNC_TIME is not null;</sql>
     </changeSet>
 </databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -469,7 +469,6 @@ trait RawlsBillingProjectComponent {
         // - to keep an audit log of billing account changes
         _ <- DBIO.sequence(billingProjects.map { project =>
           // ignore all currently-outstanding changes for this project
-          // TODO CORE-133: should this be built-in to this method, or called explicitly, e.g. from updateBillingAccount?
           BillingAccountChanges.ignoreAllOutstanding(project.projectName) andThen {
             // insert the most recent change for this project
             BillingAccountChanges.create(
@@ -607,6 +606,9 @@ trait RawlsBillingProjectComponent {
 
     def setGoogleSyncTime(syncTime: Option[Instant]): WriteAction[Int] =
       query.map(_.googleSyncTime).update(syncTime.map(Timestamp.from))
+
+    def setStatus(status: BillingAccountChangeStatus): WriteAction[Int] =
+      query.map(_.status).update(status.toString)
 
     def ignoreAllOutstanding(billingProjectName: RawlsBillingProjectName): WriteAction[Int] =
       query

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -101,6 +101,7 @@ final case class BillingAccountChange(id: Long,
                                       newBillingAccount: Option[RawlsBillingAccountName],
                                       created: Instant,
                                       googleSyncTime: Option[Instant],
+                                      status: String,
                                       outcome: Option[Outcome]
 )
 
@@ -168,6 +169,8 @@ trait RawlsBillingProjectComponent {
 
     def googleSyncTime = column[Option[Timestamp]]("GOOGLE_SYNC_TIME")
 
+    def status = column[String]("STATUS")
+
     def outcome = column[Option[String]]("OUTCOME")
 
     def message = column[Option[String]]("MESSAGE")
@@ -181,6 +184,7 @@ trait RawlsBillingProjectComponent {
         newBillingAccount,
         created,
         googleSyncTime,
+        status,
         outcome,
         message
       ) <> (
@@ -469,6 +473,7 @@ trait RawlsBillingProjectComponent {
       Option[String], // New billing account
       Timestamp, // Created
       Option[Timestamp], // Google sync time
+      String, // status
       Option[String], // Outcome
       Option[String] // Message
     )
@@ -481,6 +486,7 @@ trait RawlsBillingProjectComponent {
             newBillingAccount,
             created,
             googleSyncTime,
+            status,
             outcome,
             message
           ) =>
@@ -493,6 +499,7 @@ trait RawlsBillingProjectComponent {
             newBillingAccount.map(RawlsBillingAccountName),
             created.toInstant,
             googleSyncTime.map(_.toInstant),
+            status,
             outcome
           )
         }
@@ -508,6 +515,7 @@ trait RawlsBillingProjectComponent {
         billingAccountChange.newBillingAccount.map(_.value),
         Timestamp.from(billingAccountChange.created),
         billingAccountChange.googleSyncTime.map(Timestamp.from),
+        billingAccountChange.status,
         outcome,
         message
       )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -452,6 +452,7 @@ trait RawlsBillingProjectComponent {
         // - to keep an audit log of billing account changes
         _ <- DBIO.sequence(billingProjects.map { project =>
           // ignore all currently-outstanding changes for this project
+          // TODO CORE-133: should this be built-in to this method, or called explicitly, e.g. from updateBillingAccount?
           BillingAccountChanges.ignoreAllOutstanding(project.projectName) andThen {
             // insert the most recent change for this project
             BillingAccountChanges.create(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -4,6 +4,7 @@ import cats.implicits.catsSyntaxOptionId
 import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.dataaccess.GoogleApiTypes.GoogleApiType
 import org.broadinstitute.dsde.rawls.dataaccess.GoogleOperationNames.GoogleOperationName
+import org.broadinstitute.dsde.rawls.dataaccess.slick.BillingAccountChangeStatus.BillingAccountChangeStatus
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleApiTypes, GoogleOperationNames}
 import org.broadinstitute.dsde.rawls.model.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.rawls.model._
@@ -101,9 +102,25 @@ final case class BillingAccountChange(id: Long,
                                       newBillingAccount: Option[RawlsBillingAccountName],
                                       created: Instant,
                                       googleSyncTime: Option[Instant],
-                                      status: String,
+                                      status: BillingAccountChangeStatus,
                                       outcome: Option[Outcome]
 )
+
+object BillingAccountChangeStatus extends Enumeration {
+  type BillingAccountChangeStatus = Value
+  val Failed: BillingAccountChangeStatus = Value("failed")
+  val Ignored: BillingAccountChangeStatus = Value("ignored")
+  val Outstanding: BillingAccountChangeStatus = Value("outstanding")
+  val Synchronized: BillingAccountChangeStatus = Value("synchronized")
+
+  def apply(value: String): BillingAccountChangeStatus = value match {
+    case "failed"       => Failed
+    case "ignored"      => Ignored
+    case "outstanding"  => Outstanding
+    case "synchronized" => Synchronized
+    case _              => throw new NoSuchElementException()
+  }
+}
 
 trait RawlsBillingProjectComponent {
   this: DriverComponent =>
@@ -504,7 +521,7 @@ trait RawlsBillingProjectComponent {
             newBillingAccount.map(RawlsBillingAccountName),
             created.toInstant,
             googleSyncTime.map(_.toInstant),
-            status,
+            BillingAccountChangeStatus.apply(status),
             outcome
           )
         }
@@ -520,7 +537,7 @@ trait RawlsBillingProjectComponent {
         billingAccountChange.newBillingAccount.map(_.value),
         Timestamp.from(billingAccountChange.created),
         billingAccountChange.googleSyncTime.map(Timestamp.from),
-        billingAccountChange.status,
+        billingAccountChange.status.toString,
         outcome,
         message
       )
@@ -593,9 +610,11 @@ trait RawlsBillingProjectComponent {
 
     def ignoreAllOutstanding(billingProjectName: RawlsBillingProjectName): WriteAction[Int] =
       query
-        .filter(c => c.billingProjectName === billingProjectName.value && c.status === "outstanding")
+        .filter(c =>
+          c.billingProjectName === billingProjectName.value && c.status === BillingAccountChangeStatus.Outstanding.toString
+        )
         .map(_.status)
-        .update("ignored")
+        .update(BillingAccountChangeStatus.Ignored.toString)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -615,6 +615,9 @@ trait RawlsBillingProjectComponent {
         )
         .map(_.status)
         .update(BillingAccountChangeStatus.Ignored.toString)
+
+    def nextOutstanding(): BillingAccountChangeQuery =
+      query.filter(_.status === BillingAccountChangeStatus.Outstanding.toString).sortBy(_.id).take(1)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -108,16 +108,14 @@ final case class BillingAccountChange(id: Long,
 
 object BillingAccountChangeStatus extends Enumeration {
   type BillingAccountChangeStatus = Value
-  val Failed: BillingAccountChangeStatus = Value("failed")
-  val Ignored: BillingAccountChangeStatus = Value("ignored")
-  val Outstanding: BillingAccountChangeStatus = Value("outstanding")
-  val Synchronized: BillingAccountChangeStatus = Value("synchronized")
+  val Ignored: BillingAccountChangeStatus = Value("Ignored")
+  val Outstanding: BillingAccountChangeStatus = Value("Outstanding")
+  val Synchronized: BillingAccountChangeStatus = Value("Synchronized")
 
   def apply(value: String): BillingAccountChangeStatus = value match {
-    case "failed"       => Failed
-    case "ignored"      => Ignored
-    case "outstanding"  => Outstanding
-    case "synchronized" => Synchronized
+    case "Ignored"      => Ignored
+    case "Outstanding"  => Outstanding
+    case "Synchronized" => Synchronized
     case _              => throw new NoSuchElementException()
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -451,12 +451,16 @@ trait RawlsBillingProjectComponent {
         // - so the `WorkspaceBillingAccountActor` can synchronise the changes with google
         // - to keep an audit log of billing account changes
         _ <- DBIO.sequence(billingProjects.map { project =>
-          BillingAccountChanges.create(
-            project.projectName,
-            project.billingAccount,
-            billingAccount,
-            userSubjectId
-          )
+          // ignore all currently-outstanding changes for this project
+          BillingAccountChanges.ignoreAllOutstanding(project.projectName) andThen {
+            // insert the most recent change for this project
+            BillingAccountChanges.create(
+              project.projectName,
+              project.billingAccount,
+              billingAccount,
+              userSubjectId
+            )
+          }
         })
       } yield count
   }
@@ -585,5 +589,12 @@ trait RawlsBillingProjectComponent {
 
     def setGoogleSyncTime(syncTime: Option[Instant]): WriteAction[Int] =
       query.map(_.googleSyncTime).update(syncTime.map(Timestamp.from))
+
+    def ignoreAllOutstanding(billingProjectName: RawlsBillingProjectName): WriteAction[Int] =
+      query
+        .filter(c => c.billingProjectName === billingProjectName.value && c.status === "outstanding")
+        .map(_.status)
+        .update("ignored")
   }
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
@@ -279,20 +279,16 @@ final case class BillingAccountChangeSynchronizer(dataSource: SlickDataSource,
     outcome: Outcome
   )(implicit R: Ask[F, BillingAccountChange], M: Monad[F], L: LiftIO[F]): F[Unit] =
     for {
-      changeId <- R.reader(_.id)
-      newStatus = outcome match {
-        case Success =>
-          info("Successfully synchronized Billing Account change")
-          BillingAccountChangeStatus.Synchronized
-        case Failure(message) =>
-          warn("Failed to synchronize Billing Account change", "details" -> message)
-          BillingAccountChangeStatus.Failed
+      _ <- outcome match {
+        case Success          => info("Successfully synchronized Billing Account change")
+        case Failure(message) => warn("Failed to synchronize Billing Account change", "details" -> message)
       }
+      changeId <- R.reader(_.id)
       record = BillingAccountChanges.withId(changeId)
       _ <- inTransaction {
         record.setGoogleSyncTime(Instant.now().some) *>
           record.setOutcome(outcome.some) *>
-          record.setStatus(newStatus)
+          record.setStatus(BillingAccountChangeStatus.Synchronized)
       }
     } yield ()
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
@@ -17,7 +17,12 @@ import cats.implicits.{
 import cats.mtl.Ask
 import cats.{Applicative, Functor, Monad, MonadThrow}
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{BillingAccountChange, ReadWriteAction, WriteAction}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  BillingAccountChange,
+  BillingAccountChangeStatus,
+  ReadWriteAction,
+  WriteAction
+}
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
@@ -274,15 +279,20 @@ final case class BillingAccountChangeSynchronizer(dataSource: SlickDataSource,
     outcome: Outcome
   )(implicit R: Ask[F, BillingAccountChange], M: Monad[F], L: LiftIO[F]): F[Unit] =
     for {
-      _ <- outcome match {
-        case Success          => info("Successfully synchronized Billing Account change")
-        case Failure(message) => warn("Failed to synchronize Billing Account change", "details" -> message)
-      }
-
       changeId <- R.reader(_.id)
+      newStatus = outcome match {
+        case Success =>
+          info("Successfully synchronized Billing Account change")
+          BillingAccountChangeStatus.Synchronized
+        case Failure(message) =>
+          warn("Failed to synchronize Billing Account change", "details" -> message)
+          BillingAccountChangeStatus.Failed
+      }
       record = BillingAccountChanges.withId(changeId)
       _ <- inTransaction {
-        record.setGoogleSyncTime(Instant.now().some) *> record.setOutcome(outcome.some)
+        record.setGoogleSyncTime(Instant.now().some) *>
+          record.setOutcome(outcome.some) *>
+          record.setStatus(newStatus)
       }
     } yield ()
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizer.scala
@@ -101,6 +101,12 @@ final case class BillingAccountChangeSynchronizer(dataSource: SlickDataSource,
     for {
       billingProject <- loadBillingProject
 
+      // Try out the new query using the STATUS column and compare results. If validation fails, don't
+      // fail the entire process.
+      _ <- validateStatusColumn.recover { case e: Exception =>
+        logger.warn(s"BillingAccountChangeStatus logic failed with ${e.getMessage}", e)
+      }
+
       // v1 billing projects are backed by google projects and are used for v1 workspace billing
       updateBillingProjectOutcome <- M.ifM(isV1BillingProject(billingProject.projectName))(
         updateBillingProjectGoogleProject(billingProject, tracingContext),
@@ -110,6 +116,44 @@ final case class BillingAccountChangeSynchronizer(dataSource: SlickDataSource,
       updateWorkspacesOutcome <- updateWorkspacesBillingAccountInGoogle(billingProject, tracingContext)
       _ <- writeBillingAccountChangeOutcome(updateBillingProjectOutcome |+| updateWorkspacesOutcome)
     } yield ()
+
+  private def validateStatusColumn[F[_]](implicit
+    R: Ask[F, BillingAccountChange],
+    M: Monad[F],
+    L: LiftIO[F]
+  ): F[Unit] =
+    for {
+      (changeStatus, changeId) <- R.reader(x => (x.status, x.id))
+      byStatus <- inTransaction(BillingAccountChanges.nextOutstanding().result)
+    } yield
+    /* validation:
+          - byStatus should find exactly 1
+          - byStatus should have same id
+          - changeStatus should have status == Outstanding
+     */
+    if (
+      byStatus.length == 1 &&
+      byStatus.head.id == changeId &&
+      changeStatus == BillingAccountChangeStatus.Outstanding
+    ) {
+      logger.info(s"BillingAccountChangeStatus logic correct for change id $changeId")
+    } else {
+      // collect errors
+      val sb = new StringBuilder(s"BillingAccountChangeStatus logic error for change id $changeId!")
+      if (byStatus.isEmpty) {
+        sb.append(" By-status lookup was empty.")
+      }
+      if (byStatus.length > 1) {
+        sb.append(s" By-status lookup had length ${byStatus.length}.")
+      }
+      if (changeStatus != BillingAccountChangeStatus.Outstanding) {
+        sb.append(s" Legacy lookup had status $changeStatus.")
+      }
+      if (changeId != byStatus.head.id) {
+        sb.append(s" Legacy found id $changeId, but by-status head had id ${byStatus.head.id}")
+      }
+      logger.warn(sb.toString())
+    }
 
   private def loadBillingProject[F[_]](implicit
     R: Ask[F, BillingAccountChange],

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -320,6 +320,47 @@ class RawlsBillingProjectComponentSpec
 
   }
 
+  it should "find the next outstanding change via nextOutstanding" in withDefaultTestDatabase {
+    import driver.api._
+
+    // insert some records
+    val setupSql = sqlu"""
+      insert into BILLING_ACCOUNT_CHANGES
+        (BILLING_PROJECT_NAME, USER_ID, PREVIOUS_BILLING_ACCOUNT, NEW_BILLING_ACCOUNT, STATUS)
+        values
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding')
+        ;
+        """
+    runAndWait(setupSql)
+
+    val next = runAndWait(BillingAccountChanges.nextOutstanding().result)
+
+    next should have length 1
+    next.head.billingProjectName shouldBe testData.testProject1Name
+  }
+
+  it should "find no outstanding change via nextOutstanding if none exist" in withDefaultTestDatabase {
+    import driver.api._
+
+    // insert some records
+    val setupSql = sqlu"""
+      insert into BILLING_ACCOUNT_CHANGES
+        (BILLING_PROJECT_NAME, USER_ID, PREVIOUS_BILLING_ACCOUNT, NEW_BILLING_ACCOUNT, STATUS)
+        values
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Ignored'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized')
+        ;
+        """
+    runAndWait(setupSql)
+
+    val next = runAndWait(BillingAccountChanges.nextOutstanding().result)
+
+    next shouldBe empty
+  }
+
   "BillingAccountChange" should "be able to load records that need to be sync'd" in withDefaultTestDatabase {
     runAndWait {
       import driver.api._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -224,6 +224,11 @@ class RawlsBillingProjectComponentSpec
       }
     }
 
+  it should "ignoreAllOutstanding correctly" is pending
+  it should "latestChangeForProject correctly" is pending
+  it should "setOutcome/setGoogleSyncTime should also set status" is pending
+  it should "replacement for readABillingProjectChange should be correct" is pending
+
   "BillingAccountChange" should "be able to load records that need to be sync'd" in withDefaultTestDatabase {
     runAndWait {
       import driver.api._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -84,6 +84,7 @@ class RawlsBillingProjectComponentSpec
     billingAccountChange.value.previousBillingAccount shouldBe previousBillingAccount
     billingAccountChange.value.newBillingAccount shouldBe newBillingAccount
     billingAccountChange.value.userId shouldBe userId
+    billingAccountChange.value.status shouldBe "outstanding"
   }
 
   it should "create a BillingAccountChange record when the Billing Account is set to None" in withDefaultTestDatabase {
@@ -99,6 +100,53 @@ class RawlsBillingProjectComponentSpec
     billingAccountChange.value.previousBillingAccount shouldBe previousBillingAccount
     billingAccountChange.value.newBillingAccount shouldBe empty
     billingAccountChange.value.userId shouldBe userId
+    billingAccountChange.value.status shouldBe "outstanding"
+  }
+
+  List(Option(RawlsBillingAccountName("avalue")), None) foreach { newBillingAccount =>
+    it should s"set previous BillingAccountChange records to status=ignored when creating a subsequent change of value $newBillingAccount" in withDefaultTestDatabase {
+      import driver.api._
+
+      val billingProject = testData.testProject3
+      val previousBillingAccount = billingProject.billingAccount
+      val userId = testData.userOwner.userSubjectId
+
+      // perform the first update; this inserts a billing account change
+      runAndWait(
+        rawlsBillingProjectQuery.updateBillingAccount(billingProject.projectName,
+                                                      Option(RawlsBillingAccountName("first")),
+                                                      userId
+        )
+      )
+      // validate the first update
+      val firstChange: Option[BillingAccountChange] =
+        runAndWait(
+          BillingAccountChanges
+            .filter(r => r.billingProjectName === billingProject.projectName.value && r.newBillingAccount === "first")
+            .result
+            .map(_.headOption)
+        )
+      firstChange shouldBe defined
+      firstChange.value.status shouldBe "outstanding"
+
+      // perform the second update; this should set the first update to ignored
+      runAndWait(rawlsBillingProjectQuery.updateBillingAccount(billingProject.projectName, newBillingAccount, userId))
+      val billingAccountChange = runAndWait(BillingAccountChanges.getLastChange(billingProject.projectName))
+
+      billingAccountChange shouldBe defined
+      billingAccountChange.value.status shouldBe "outstanding"
+
+      // re-check the first update; it should now be ignored
+      val firstChangeAgain: Option[BillingAccountChange] =
+        runAndWait(
+          BillingAccountChanges
+            .filter(r => r.billingProjectName === billingProject.projectName.value && r.newBillingAccount === "first")
+            .result
+            .map(_.headOption)
+        )
+      firstChangeAgain shouldBe defined
+      firstChangeAgain.value.status shouldBe "ignored"
+    }
   }
 
   it should "fail when the Billing Account is updated with the same value" in

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -320,11 +320,6 @@ class RawlsBillingProjectComponentSpec
 
   }
 
-  it should "latestChangeForProject correctly" is pending
-  it should "replacement for readABillingProjectChange should be correct" is pending
-
-  it should "setOutcome/setGoogleSyncTime should also set status" is pending
-
   "BillingAccountChange" should "be able to load records that need to be sync'd" in withDefaultTestDatabase {
     runAndWait {
       import driver.api._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -232,55 +232,43 @@ class RawlsBillingProjectComponentSpec
       insert into BILLING_ACCOUNT_CHANGES
         (BILLING_PROJECT_NAME, USER_ID, PREVIOUS_BILLING_ACCOUNT, NEW_BILLING_ACCOUNT, STATUS)
         values
-          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'failed'),
-          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
-          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding'),
 
-          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
-          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
-          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
 
-          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'ignored'),
-          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
-          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding')
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Ignored'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding')
         ;
         """
     runAndWait(setupSql)
 
     // validate initial setup
-    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
-                                                                      ("outstanding", 1),
-                                                                      ("synchronized", 1)
-    )
-    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
-    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("Outstanding", 1), ("Synchronized", 2))
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("Synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("Ignored", 1), ("Outstanding", 2))
 
     // call ignoreAllOutstanding for testProject1Name and validate
     runAndWait(BillingAccountChanges.ignoreAllOutstanding(testData.testProject1Name))
-    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
-                                                                      ("ignored", 1),
-                                                                      ("synchronized", 1)
-    )
-    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
-    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("Ignored", 1), ("Synchronized", 2))
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("Synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("Ignored", 1), ("Outstanding", 2))
 
     // call ignoreAllOutstanding for testProject2Name and validate
     runAndWait(BillingAccountChanges.ignoreAllOutstanding(testData.testProject2Name))
-    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
-                                                                      ("ignored", 1),
-                                                                      ("synchronized", 1)
-    )
-    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
-    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("Ignored", 1), ("Synchronized", 2))
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("Synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("Ignored", 1), ("Outstanding", 2))
 
     // call ignoreAllOutstanding for testProject3Name and validate
     runAndWait(BillingAccountChanges.ignoreAllOutstanding(testData.testProject3Name))
-    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
-                                                                      ("ignored", 1),
-                                                                      ("synchronized", 1)
-    )
-    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
-    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 3))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("Ignored", 1), ("Synchronized", 2))
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("Synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("Ignored", 3))
 
   }
 
@@ -292,28 +280,25 @@ class RawlsBillingProjectComponentSpec
       insert into BILLING_ACCOUNT_CHANGES
         (BILLING_PROJECT_NAME, USER_ID, PREVIOUS_BILLING_ACCOUNT, NEW_BILLING_ACCOUNT, STATUS)
         values
-          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'failed'),
-          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
-          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding'),
 
-          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
-          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
-          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'Synchronized'),
 
-          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'ignored'),
-          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
-          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding')
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Ignored'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'Outstanding')
         ;
         """
     runAndWait(setupSql)
 
     // validate initial setup
-    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
-                                                                      ("outstanding", 1),
-                                                                      ("synchronized", 1)
-    )
-    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
-    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("Outstanding", 1), ("Synchronized", 2))
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("Synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("Ignored", 1), ("Outstanding", 2))
 
     // Update the account for testProject3Name. It should set the previous outstanding changes to ignored,
     // and the new one should be the only one outstanding
@@ -323,12 +308,9 @@ class RawlsBillingProjectComponentSpec
                                                     testData.userOwner.userSubjectId
       )
     )
-    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
-                                                                      ("outstanding", 1),
-                                                                      ("synchronized", 1)
-    )
-    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
-    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 3), ("outstanding", 1))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("Outstanding", 1), ("Synchronized", 2))
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("Synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("Ignored", 3), ("Outstanding", 1))
     // and, validate that the outstanding change for testProject3Name is the one we just inserted
     val lastChange = runAndWait(BillingAccountChanges.getLastChange(testData.testProject3Name))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -2,11 +2,10 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import cats.implicits.catsSyntaxOptionId
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingAccountName, RawlsBillingProjectName, RawlsUserSubjectId}
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingAccountName, RawlsBillingProjectName}
 import org.scalatest.OptionValues
 
 import java.sql.SQLException
-import java.time.Instant
 
 class RawlsBillingProjectComponentSpec
     extends TestDriverComponentWithFlatSpecAndMatchers
@@ -285,17 +284,58 @@ class RawlsBillingProjectComponentSpec
 
   }
 
-  private def getStatusCountsForProject(projectName: RawlsBillingProjectName): Seq[(String, Int)] = {
+  it should "ignore all previous outstanding changes when updating an account" in withDefaultTestDatabase {
     import driver.api._
-    val countSql =
-      sql"""
-           select STATUS, count(1)
-           from BILLING_ACCOUNT_CHANGES
-           where BILLING_PROJECT_NAME = ${projectName.value}
-           group by STATUS
-           order by STATUS
-           """.as[(String, Int)]
-    runAndWait(countSql)
+
+    // insert some records
+    val setupSql = sqlu"""
+      insert into BILLING_ACCOUNT_CHANGES
+        (BILLING_PROJECT_NAME, USER_ID, PREVIOUS_BILLING_ACCOUNT, NEW_BILLING_ACCOUNT, STATUS)
+        values
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'failed'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
+
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'ignored'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding')
+        ;
+        """
+    runAndWait(setupSql)
+
+    // validate initial setup
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
+                                                                      ("outstanding", 1),
+                                                                      ("synchronized", 1)
+    )
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+
+    // Update the account for testProject3Name. It should set the previous outstanding changes to ignored,
+    // and the new one should be the only one outstanding
+    runAndWait(
+      rawlsBillingProjectQuery.updateBillingAccount(testData.testProject3Name,
+                                                    RawlsBillingAccountName("bargle").some,
+                                                    testData.userOwner.userSubjectId
+      )
+    )
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
+                                                                      ("outstanding", 1),
+                                                                      ("synchronized", 1)
+    )
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 3), ("outstanding", 1))
+    // and, validate that the outstanding change for testProject3Name is the one we just inserted
+    val lastChange = runAndWait(BillingAccountChanges.getLastChange(testData.testProject3Name))
+
+    lastChange shouldBe defined
+    lastChange.value.status shouldBe BillingAccountChangeStatus.Outstanding
+    lastChange.value.newBillingAccount should contain(RawlsBillingAccountName("bargle"))
+
   }
 
   it should "latestChangeForProject correctly" is pending
@@ -331,4 +371,21 @@ class RawlsBillingProjectComponentSpec
       } yield changes shouldBe List(change1, change2).map(_.value)
     }
   }
+
+  // =========== test helpers
+
+  // for a given billing project, return the distinct statuses and their counts from the db
+  private def getStatusCountsForProject(projectName: RawlsBillingProjectName): Seq[(String, Int)] = {
+    import driver.api._
+    val countSql =
+      sql"""
+           select STATUS, count(1)
+           from BILLING_ACCOUNT_CHANGES
+           where BILLING_PROJECT_NAME = ${projectName.value}
+           group by STATUS
+           order by STATUS
+           """.as[(String, Int)]
+    runAndWait(countSql)
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -2,15 +2,17 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import cats.implicits.catsSyntaxOptionId
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingAccountName, RawlsBillingProjectName}
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingAccountName, RawlsBillingProjectName, RawlsUserSubjectId}
 import org.scalatest.OptionValues
 
 import java.sql.SQLException
+import java.time.Instant
 
 class RawlsBillingProjectComponentSpec
     extends TestDriverComponentWithFlatSpecAndMatchers
     with RawlsTestUtils
-    with OptionValues {
+    with OptionValues
+    with RawSqlQuery {
 
   "RawlsBillingProjectComponent" should "save, load and delete" in withDefaultTestDatabase {
     // note that create is called in test data save
@@ -84,7 +86,7 @@ class RawlsBillingProjectComponentSpec
     billingAccountChange.value.previousBillingAccount shouldBe previousBillingAccount
     billingAccountChange.value.newBillingAccount shouldBe newBillingAccount
     billingAccountChange.value.userId shouldBe userId
-    billingAccountChange.value.status shouldBe "outstanding"
+    billingAccountChange.value.status shouldBe BillingAccountChangeStatus.Outstanding
   }
 
   it should "create a BillingAccountChange record when the Billing Account is set to None" in withDefaultTestDatabase {
@@ -100,7 +102,7 @@ class RawlsBillingProjectComponentSpec
     billingAccountChange.value.previousBillingAccount shouldBe previousBillingAccount
     billingAccountChange.value.newBillingAccount shouldBe empty
     billingAccountChange.value.userId shouldBe userId
-    billingAccountChange.value.status shouldBe "outstanding"
+    billingAccountChange.value.status shouldBe BillingAccountChangeStatus.Outstanding
   }
 
   List(Option(RawlsBillingAccountName("avalue")), None) foreach { newBillingAccount =>
@@ -108,7 +110,6 @@ class RawlsBillingProjectComponentSpec
       import driver.api._
 
       val billingProject = testData.testProject3
-      val previousBillingAccount = billingProject.billingAccount
       val userId = testData.userOwner.userSubjectId
 
       // perform the first update; this inserts a billing account change
@@ -127,14 +128,14 @@ class RawlsBillingProjectComponentSpec
             .map(_.headOption)
         )
       firstChange shouldBe defined
-      firstChange.value.status shouldBe "outstanding"
+      firstChange.value.status shouldBe BillingAccountChangeStatus.Outstanding
 
       // perform the second update; this should set the first update to ignored
       runAndWait(rawlsBillingProjectQuery.updateBillingAccount(billingProject.projectName, newBillingAccount, userId))
       val billingAccountChange = runAndWait(BillingAccountChanges.getLastChange(billingProject.projectName))
 
       billingAccountChange shouldBe defined
-      billingAccountChange.value.status shouldBe "outstanding"
+      billingAccountChange.value.status shouldBe BillingAccountChangeStatus.Outstanding
 
       // re-check the first update; it should now be ignored
       val firstChangeAgain: Option[BillingAccountChange] =
@@ -145,7 +146,7 @@ class RawlsBillingProjectComponentSpec
             .map(_.headOption)
         )
       firstChangeAgain shouldBe defined
-      firstChangeAgain.value.status shouldBe "ignored"
+      firstChangeAgain.value.status shouldBe BillingAccountChangeStatus.Ignored
     }
   }
 
@@ -224,10 +225,83 @@ class RawlsBillingProjectComponentSpec
       }
     }
 
-  it should "ignoreAllOutstanding correctly" is pending
+  it should "set statuses properly in ignoreAllOutstanding" in withDefaultTestDatabase {
+    import driver.api._
+
+    // insert some records
+    val setupSql = sqlu"""
+      insert into BILLING_ACCOUNT_CHANGES
+        (BILLING_PROJECT_NAME, USER_ID, PREVIOUS_BILLING_ACCOUNT, NEW_BILLING_ACCOUNT, STATUS)
+        values
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'failed'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject1Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
+
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+          (${testData.testProject2Name.value}, 'user', 'oldaccount', 'newaccount', 'synchronized'),
+
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'ignored'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding'),
+          (${testData.testProject3Name.value}, 'user', 'oldaccount', 'newaccount', 'outstanding')
+        ;
+        """
+    runAndWait(setupSql)
+
+    // validate initial setup
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
+                                                                      ("outstanding", 1),
+                                                                      ("synchronized", 1)
+    )
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+
+    // call ignoreAllOutstanding for testProject1Name and validate
+    runAndWait(BillingAccountChanges.ignoreAllOutstanding(testData.testProject1Name))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
+                                                                      ("ignored", 1),
+                                                                      ("synchronized", 1)
+    )
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+
+    // call ignoreAllOutstanding for testProject2Name and validate
+    runAndWait(BillingAccountChanges.ignoreAllOutstanding(testData.testProject2Name))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
+                                                                      ("ignored", 1),
+                                                                      ("synchronized", 1)
+    )
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 1), ("outstanding", 2))
+
+    // call ignoreAllOutstanding for testProject3Name and validate
+    runAndWait(BillingAccountChanges.ignoreAllOutstanding(testData.testProject3Name))
+    getStatusCountsForProject(testData.testProject1Name) shouldBe Seq(("failed", 1),
+                                                                      ("ignored", 1),
+                                                                      ("synchronized", 1)
+    )
+    getStatusCountsForProject(testData.testProject2Name) shouldBe Seq(("synchronized", 3))
+    getStatusCountsForProject(testData.testProject3Name) shouldBe Seq(("ignored", 3))
+
+  }
+
+  private def getStatusCountsForProject(projectName: RawlsBillingProjectName): Seq[(String, Int)] = {
+    import driver.api._
+    val countSql =
+      sql"""
+           select STATUS, count(1)
+           from BILLING_ACCOUNT_CHANGES
+           where BILLING_PROJECT_NAME = ${projectName.value}
+           group by STATUS
+           order by STATUS
+           """.as[(String, Int)]
+    runAndWait(countSql)
+  }
+
   it should "latestChangeForProject correctly" is pending
-  it should "setOutcome/setGoogleSyncTime should also set status" is pending
   it should "replacement for readABillingProjectChange should be correct" is pending
+
+  it should "setOutcome/setGoogleSyncTime should also set status" is pending
 
   "BillingAccountChange" should "be able to load records that need to be sync'd" in withDefaultTestDatabase {
     runAndWait {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
@@ -625,7 +625,7 @@ class BillingAccountChangeSynchronizerSpec
             case Failure(msg) =>
               msg should include(testData.billingProject.googleProjectId.value)
           }
-          lastChange.value.status shouldBe BillingAccountChangeStatus.Failed
+          lastChange.value.status shouldBe BillingAccountChangeStatus.Synchronized
 
           billingProject.value.invalidBillingAccount shouldBe false
           billingProject.value.message shouldBe defined
@@ -688,7 +688,7 @@ class BillingAccountChangeSynchronizerSpec
                 msg should include(workspace.googleProjectId.value)
               }
           }
-          lastChange.value.status shouldBe BillingAccountChangeStatus.Failed
+          lastChange.value.status shouldBe BillingAccountChangeStatus.Synchronized
 
           billingProject.value.invalidBillingAccount shouldBe false
           billingProject.value.message shouldBe empty

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
@@ -6,7 +6,11 @@ import cats.implicits.{catsSyntaxApplyOps, catsSyntaxOptionId, toFoldableOps}
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
 import io.opencensus.trace.{Span => OpenCensusSpan}
 import org.broadinstitute.dsde.rawls.dataaccess._
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{ReadAction, TestDriverComponentWithFlatSpecAndMatchers}
+import org.broadinstitute.dsde.rawls.dataaccess.slick.{
+  BillingAccountChangeStatus,
+  ReadAction,
+  TestDriverComponentWithFlatSpecAndMatchers
+}
 import org.broadinstitute.dsde.rawls.mock.MockSamDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor.migration.MigrationUtils.Implicits._
@@ -495,6 +499,7 @@ class BillingAccountChangeSynchronizerSpec
 
         lastChange.googleSyncTime shouldBe defined
         lastChange.newBillingAccount shouldBe Some(finalBillingAccountName)
+        lastChange.status shouldBe BillingAccountChangeStatus.Synchronized
 
         // all previous changes should be ignored
         every(previousChanges.map(_.googleSyncTime)) shouldBe empty
@@ -620,6 +625,7 @@ class BillingAccountChangeSynchronizerSpec
             case Failure(msg) =>
               msg should include(testData.billingProject.googleProjectId.value)
           }
+          lastChange.value.status shouldBe BillingAccountChangeStatus.Failed
 
           billingProject.value.invalidBillingAccount shouldBe false
           billingProject.value.message shouldBe defined
@@ -682,6 +688,7 @@ class BillingAccountChangeSynchronizerSpec
                 msg should include(workspace.googleProjectId.value)
               }
           }
+          lastChange.value.status shouldBe BillingAccountChangeStatus.Failed
 
           billingProject.value.invalidBillingAccount shouldBe false
           billingProject.value.message shouldBe empty
@@ -754,6 +761,7 @@ class BillingAccountChangeSynchronizerSpec
             case Failure(_) =>
               fail("should not fail when updating workspaces succeed")
           }
+          lastChange.value.status shouldBe BillingAccountChangeStatus.Synchronized
 
           billingProject.value.invalidBillingAccount shouldBe false
           billingProject.value.message shouldBe empty


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-133

This is setup/pre-work for improving the SQL query used by the billing account change synchronizer.

In this PR:
* add a new STATUS column to the BILLING_ACCOUNT_CHANGES table. The column is an enum of `Ignored`, `Outstanding`, `Synchronized`. It reflects whether this change has been synchronized to Google.
* add a db index for the STATUS column
* as new rows are added to the table, they will have status=`Outstanding`
* as these rows are processed by the synchronizer, the synchronizer will update their status to `Synchronized`.
* any time a new `Outstanding` row is added, any pre-existing `Outstanding` rows _for the same billing project_ will be changed to `Ignored`.
* when the current implementation of the `BillingAccountChangeSynchronizer` finds a change it wants to process, also perform a "preview" lookup using the new STATUS column, to validate that the STATUS implementation is correct. This "preview" query is unused for anything other than validation/logging.

This status column works in conjunction with the pre-existing "Outcome" column. When STATUS='Synchronized`, OUTCOME will be 'Success' or 'Failure'; when STATUS is anything else, OUTCOME will be null. I considered changing the OUTCOME column for this PR to be non-null and include "Ignored" and "Outstanding" values, but I went with a separate column instead.

As of this PR, we are only writing the statuses. We never read them or rely on them. My intention is to let this run in production for a bit and manually validate that the status-tracking is correct before switching over the logic in the synchronizer to use this column. When that time comes, the synchronizer can query for the "Outstanding" status instead of its current logic.


---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [x] Inform other teams of any substantial changes via Slack and/or email
