### PR TITLE
[AN-226] Update Rawls model version in automation

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.189-SNAP"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.251-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("bio.terra", "workspace-manager-client"),

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
     "org.scalatest"       %%  "scalatest"     % "3.2.2"   % Test,
     "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.251-SNAP"
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.258-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("bio.terra", "workspace-manager-client"),

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -295,7 +295,7 @@ class WorkspaceApiSpec
               eventually {
                 workspaceResponse(
                   Rawls.workspaces.getWorkspaceDetails(sourceProjectName, workspaceName)(userToken)
-                ).bucketOptions should contain(WorkspaceBucketOptions(true))
+                ).bucketOptions.get should matchPattern { case WorkspaceBucketOptions(true, _) => }
               }
 
               // The user clones the workspace into their project

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -8,4 +8,4 @@ Added:
 - Support 2.13
 - ExecutionModel classes moved from core to model
 
-SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "v0.0.189-SNAP"`
+SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "v0.0.251-SNAP"`

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -8,4 +8,4 @@ Added:
 - Support 2.13
 - ExecutionModel classes moved from core to model
 
-SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "v0.0.251-SNAP"`
+SBT dependency: `"org.broadinstitute.dsde" %% "rawls-model" % "v0.0.258-SNAP"`


### PR DESCRIPTION
Ticket: [AN-226](https://broadworkbench.atlassian.net/browse/AN-226)

Follow-up to https://github.com/broadinstitute/rawls/pull/3141. Required updating an integration test that was broken by other changes to the Rawls model that were made after the last time the version was updated here.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email

[AN-226]: https://broadworkbench.atlassian.net/browse/AN-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ