### PR TITLE
CORE-216: validate per-workflow cost cap values

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -533,35 +533,26 @@ class SubmissionsService(
     )
 
   @VisibleForTesting
-  def validateCostCap(costCap: Option[BigDecimal]) =
-    // must be a positive number
-    costCap.foreach { cap =>
-      if (cap.sign != 1) {
-        throw new RawlsExceptionWithErrorReport(
-          errorReport = ErrorReport(
-            StatusCodes.BadRequest,
-            s"per-workflow cost cap must be positive"
-          )
-        )
-      }
-      // backend supports decimal(10,2)
-      if (!(cap * 100).isWhole) {
-        throw new RawlsExceptionWithErrorReport(
-          errorReport = ErrorReport(
-            StatusCodes.BadRequest,
-            s"per-workflow cost cap must have a max of two decimal places"
-          )
-        )
-      }
-      if (cap.compare(BigDecimal.valueOf(10000000000L)) >= 0) {
-        throw new RawlsExceptionWithErrorReport(
-          errorReport = ErrorReport(
-            StatusCodes.BadRequest,
-            s"per-workflow cost cap must be less than 10,000,000,000"
-          )
-        )
-      }
+  def validateCostCap(costCap: Option[BigDecimal]): Unit = {
+    // must be a positive number, no more than two decimal places, and a max of ... 10 billion?
+    val maybeErrorMessage = costCap.map {
+      case cap if cap.sign != 1 => "per-workflow cost cap must be positive"
+      case cap if cap.compare(BigDecimal.valueOf(10000000000L)) >= 0 =>
+        "per-workflow cost cap must be less than 10,000,000,000"
+      case cap if !(cap * 100).isWhole =>
+        "per-workflow cost cap must have a max of two decimal places"
     }
+
+    maybeErrorMessage.foreach { msg =>
+      throw new RawlsExceptionWithErrorReport(
+        errorReport = ErrorReport(
+          StatusCodes.BadRequest,
+          msg
+        )
+      )
+    }
+
+  }
 
   private def prepareSubmission(workspaceName: WorkspaceName,
                                 submissionRequest: SubmissionRequest

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -535,7 +535,7 @@ class SubmissionsService(
   @VisibleForTesting
   def validateCostCap(costCap: Option[BigDecimal]): Unit = {
     // must be a positive number, no more than two decimal places, and a max of ... 10 billion?
-    val maybeErrorMessage = costCap.map {
+    val maybeErrorMessage = costCap.collectFirst {
       case cap if cap.sign != 1 => "per-workflow cost cap must be positive"
       case cap if cap.compare(BigDecimal.valueOf(10000000000L)) >= 0 =>
         "per-workflow cost cap must be less than 10,000,000,000"

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.rawls.submissions
 
 import akka.http.scaladsl.model.StatusCodes
+import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.config.WorkspaceServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadWriteAction, WorkflowRecord}
@@ -531,9 +532,42 @@ class SubmissionsService(
       ps.inputs.filter(_.inputResolutions.forall(_.error.isEmpty))
     )
 
+  @VisibleForTesting
+  def validateCostCap(costCap: Option[BigDecimal]) =
+    // must be a positive number
+    costCap.foreach { cap =>
+      if (cap.sign != 1) {
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            StatusCodes.BadRequest,
+            s"per-workflow cost cap must be positive"
+          )
+        )
+      }
+      // backend supports decimal(10,2)
+      if (!(cap * 100).isWhole) {
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            StatusCodes.BadRequest,
+            s"per-workflow cost cap must have a max of two decimal places"
+          )
+        )
+      }
+      if (cap.compare(BigDecimal.valueOf(10000000000L)) >= 0) {
+        throw new RawlsExceptionWithErrorReport(
+          errorReport = ErrorReport(
+            StatusCodes.BadRequest,
+            s"per-workflow cost cap must be less than 10,000,000,000"
+          )
+        )
+      }
+    }
+
   private def prepareSubmission(workspaceName: WorkspaceName,
                                 submissionRequest: SubmissionRequest
   ): Future[PreparedSubmission] = {
+
+    validateCostCap(submissionRequest.perWorkflowCostCap)
 
     val submissionId: UUID = UUID.randomUUID()
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -30,7 +30,14 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.webservice._
-import org.broadinstitute.dsde.rawls.workspace.{MultiCloudWorkspaceAclManager, MultiCloudWorkspaceService, RawlsWorkspaceAclManager, WorkspaceRepository, WorkspaceService, WorkspaceSettingRepository}
+import org.broadinstitute.dsde.rawls.workspace.{
+  MultiCloudWorkspaceAclManager,
+  MultiCloudWorkspaceService,
+  RawlsWorkspaceAclManager,
+  WorkspaceRepository,
+  WorkspaceService,
+  WorkspaceSettingRepository
+}
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, RawlsTestUtils}
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
@@ -579,6 +586,51 @@ class SubmissionsServiceSpec
       ) // a random suffix is added in this case, should be something like "testConfig1_HoQyHjLZ"
       assert(result.deleted)
       assert(result.deletedDate.isDefined)
+  }
+
+  behavior of "per-workflow cost cap validation"
+  // all tests can use the same db and services; none of these tests perform writes
+  withTestDataServices { services =>
+    it should "pass when no cap is specified" in {
+      val input = Option.empty
+      services.submissionsService.validateCostCap(input)
+    }
+    it should "pass for a reasonable number" in {
+      val input = Option(BigDecimal(25.99))
+      services.submissionsService.validateCostCap(input)
+    }
+    it should "fail for zero" in {
+      val input = Option(BigDecimal(0))
+      val actual = intercept[RawlsExceptionWithErrorReport] {
+        services.submissionsService.validateCostCap(input)
+      }
+      actual.errorReport.statusCode should contain(StatusCodes.BadRequest)
+      actual.errorReport.message shouldBe "per-workflow cost cap must be positive"
+    }
+    it should "fail for a negative number" in {
+      val input = Option(BigDecimal(-1))
+      val actual = intercept[RawlsExceptionWithErrorReport] {
+        services.submissionsService.validateCostCap(input)
+      }
+      actual.errorReport.statusCode should contain(StatusCodes.BadRequest)
+      actual.errorReport.message shouldBe "per-workflow cost cap must be positive"
+    }
+    it should "fail for too many decimal places" in {
+      val input = Option(BigDecimal(12.345))
+      val actual = intercept[RawlsExceptionWithErrorReport] {
+        services.submissionsService.validateCostCap(input)
+      }
+      actual.errorReport.statusCode should contain(StatusCodes.BadRequest)
+      actual.errorReport.message shouldBe "per-workflow cost cap must have a max of two decimal places"
+    }
+    it should "fail when too large too many decimal places" in {
+      val input = Option(BigDecimal.valueOf(10000000000L))
+      val actual = intercept[RawlsExceptionWithErrorReport] {
+        services.submissionsService.validateCostCap(input)
+      }
+      actual.errorReport.statusCode should contain(StatusCodes.BadRequest)
+      actual.errorReport.message shouldBe "per-workflow cost cap must be less than 10,000,000,000"
+    }
   }
 
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-216

Add backend validation of the per-workflow cost cap. The UI still allows you to enter invalid cost-cap values (we'll need a separate PR for UI validation). However, as of this PR, we'll throw an error immediately upon submission, instead of allowing the submission to launch and then fail.

Screenshots from my BEE:
![Screenshot 09-12-2024 at 10 22](https://github.com/user-attachments/assets/6d69b602-4199-410b-812c-dc4c18a192fe)
![Screenshot 09-12-2024 at 10 21](https://github.com/user-attachments/assets/e0e00fd7-a438-48b9-8d35-47db6647c415)

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should [publish a new official `rawls-model`](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model) and update `rawls-model` in [Orchestration's dependencies](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/project/Dependencies.scala).
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
