### PR TITLE
CORE-217: send failed notification if cost cap aborted some workflows

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -316,6 +316,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
         for {
           costBreakdown <- executionServiceCluster.getCost(workflowRec, petUser)
           updatedWorkflowRec <-
+            // TODO CORE-217: if workflow is already in Aborted or Aborting, don't try to re-abort it
             if (costBreakdown.cost > costCap) {
               executionServiceCluster.abort(workflowRec, petUser).map {
                 case Success(abortedWfRec) =>
@@ -330,6 +331,9 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
                   Option(workflowRec.copy(status = costBreakdown.status, cost = costBreakdown.cost.some))
               }
             } else {
+              // TODO CORE-217: don't update unless status or cost has actually changed?
+              //   Do we need to incrementally update cost?
+              //   If we track cost changes on every iteration, we're going to blow up the AUDIT_WORKFLOW_STATUS table
               Future.successful(Option(workflowRec.copy(status = costBreakdown.status, cost = costBreakdown.cost.some)))
             }
         } yield updatedWorkflowRec
@@ -510,7 +514,9 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
     val dataEntity = submission.submissionEntity.fold("N/A")(entity =>
       s"${entity.entityName} (${entity.entityType})"
     ) // Format: my_sample (sample)
-    val hasFailedWorkflows = submission.workflows.exists(_.status.equals(WorkflowStatuses.Failed))
+    val hasFailedOrAbortedWorkflows = submission.workflows.exists(wf =>
+      wf.status.equals(WorkflowStatuses.Failed) || wf.status.equals(WorkflowStatuses.Aborted)
+    )
     val notificationWorkspaceName = Notifications.WorkspaceName(workspaceName.namespace, workspaceName.name)
     val userComment = submission.userComment.getOrElse("N/A")
 
@@ -528,7 +534,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
             userComment
           )
         )
-      case SubmissionStatuses.Done if hasFailedWorkflows =>
+      case SubmissionStatuses.Done if hasFailedOrAbortedWorkflows =>
         Some(
           FailedSubmissionNotification(
             recipientUserId,
@@ -541,7 +547,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
             userComment
           )
         )
-      case SubmissionStatuses.Done if !hasFailedWorkflows =>
+      case SubmissionStatuses.Done if !hasFailedOrAbortedWorkflows =>
         Some(
           SuccessfulSubmissionNotification(
             recipientUserId,
@@ -556,7 +562,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
         )
       case _ =>
         logger.info(
-          s"Unable to send terminal submission notification for ${submissionId}. State was unexpected: status: ${finalStatus}, hasFailedWorkflows: ${hasFailedWorkflows}"
+          s"Unable to send terminal submission notification for ${submissionId}. State was unexpected: status: ${finalStatus}, hasFailedOrAbortedWorkflows: ${hasFailedOrAbortedWorkflows}"
         )
         None
     }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-217

When sending the email notification for a submission, send the "failed workflows" message instead of the "successful" email if the submission contains aborted workflows. The cost-cap feature can abort individual workflows in a submission.

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [x] **...and Orchestration's Swagger too!**
- [x] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [x] in the automation subdirectory
  - [x] in workbench-libs
  - [x] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
