### PR TITLE
[CORE-227] Only insert into AUDIT_WORKFLOW_STATUS when the workflow status changes

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -130,4 +130,5 @@
     <include file="changesets/20241106_streamline_workspace_attr_temp_table_procedure.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20241120_rename_submission_cost_cap_threshold.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20241121_billing_account_changes_status.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20241218_alter_audit_workflow_status_trigger_frequency.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241218_alter_audit_workflow_status_trigger_frequency.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20241218_alter_audit_workflow_status_trigger_frequency.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+    <changeSet id="alter_audit_workflow_status_trigger_frequency" author="mtalbott" logicalFilePath="dummy">
+        <sql>
+            DROP TRIGGER IF EXISTS after_workflow_update;
+        </sql>
+        <sql splitStatements="false">
+            CREATE TRIGGER after_workflow_update
+                AFTER UPDATE ON WORKFLOW
+                FOR EACH ROW
+            BEGIN
+                IF NEW.STATUS != OLD.STATUS THEN
+                    INSERT INTO AUDIT_WORKFLOW_STATUS
+                        (workflow_id, status, timestamp)
+                    VALUES
+                        (NEW.ID, NEW.STATUS, NEW.STATUS_LAST_CHANGED);
+                END IF;
+            END
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Ticket: [CORE-227](https://broadworkbench.atlassian.net/browse/CORE-227)
* Change trigger on `AUDIT_WORKFLOW_STATUS` table to only insert new records when a workflow status changes as opposed to on every update to the `WORKFLOW` table

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-227]: https://broadworkbench.atlassian.net/browse/CORE-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ