### PR TITLE
[CORE-41] Update BQ spending report query to remove duplicates

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -365,7 +365,6 @@ class SpendReportingService(
     val baseQuery = s"""
                        |  SELECT
                        |    project.id AS project_id,
-                       |    COALESCE(project.name, '') AS project_name,
                        |    currency,
                        |    SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
                        |    CASE
@@ -381,7 +380,6 @@ class SpendReportingService(
                        |    _PARTITIONTIME BETWEEN @startDate AND @endDate
                        |  GROUP BY
                        |    project_id,
-                       |    COALESCE(project.name, ''),
                        |    spend_category,
                        |    currency""".stripMargin.trim
 
@@ -401,7 +399,6 @@ class SpendReportingService(
        |)
        |SELECT
        |  project_id,
-       |  MAX(project_name) AS project_name,
        |  SUM(category_cost) AS total_cost,
        |  SUM(CASE WHEN spend_category = 'Storage' THEN category_cost ELSE 0 END) AS storage_cost,
        |  SUM(CASE WHEN spend_category = 'Compute' THEN category_cost ELSE 0 END) AS compute_cost,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -4,8 +4,7 @@ import java.util.{Currency, UUID}
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import com.google.cloud.bigquery.{JobStatistics, Option => _, _}
-import com.google.cloud.bigquery.FieldValueList
+import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, JobStatistics, Option => _, _}
 import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, Histogram}
 import org.broadinstitute.dsde.rawls.billing.{
@@ -366,7 +365,7 @@ class SpendReportingService(
     val baseQuery = s"""
                        |  SELECT
                        |    project.id AS project_id,
-                       |    project.name AS project_name,
+                       |    COALESCE(project.name, '') AS project_name,
                        |    currency,
                        |    SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
                        |    CASE
@@ -382,7 +381,7 @@ class SpendReportingService(
                        |    _PARTITIONTIME BETWEEN @startDate AND @endDate
                        |  GROUP BY
                        |    project_id,
-                       |    project_name,
+                       |    COALESCE(project.name, ''),
                        |    spend_category,
                        |    currency""".stripMargin.trim
 
@@ -402,7 +401,7 @@ class SpendReportingService(
        |)
        |SELECT
        |  project_id,
-       |  project_name,
+       |  MAX(project_name) AS project_name,
        |  SUM(category_cost) AS total_cost,
        |  SUM(CASE WHEN spend_category = 'Storage' THEN category_cost ELSE 0 END) AS storage_cost,
        |  SUM(CASE WHEN spend_category = 'Compute' THEN category_cost ELSE 0 END) AS compute_cost,
@@ -415,7 +414,6 @@ class SpendReportingService(
        |  spend_categories
        |GROUP BY
        |  project_id,
-       |  project_name,
        |  currency
        |ORDER BY
        |  total_cost DESC

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1276,7 +1276,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       s"""|WITH spend_categories AS (
           |  SELECT
           |    project.id AS project_id,
-          |    project.name AS project_name,
+          |    COALESCE(project.name, '') AS project_name,
           |    currency,
           |    SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
           |    CASE
@@ -1292,13 +1292,13 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |    _PARTITIONTIME BETWEEN @startDate AND @endDate
           |  GROUP BY
           |    project_id,
-          |    project_name,
+          |    COALESCE(project.name, ''),
           |    spend_category,
           |    currency
           | UNION ALL
           |    SELECT
           |      project.id AS project_id,
-          |      project.name AS project_name,
+          |      COALESCE(project.name, '') AS project_name,
           |      currency,
           |      SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
           |      CASE
@@ -1314,13 +1314,13 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |      _PARTITIONTIME BETWEEN @startDate AND @endDate
           |    GROUP BY
           |      project_id,
-          |      project_name,
+          |      COALESCE(project.name, ''),
           |      spend_category,
           |      currency
           | UNION ALL
           |    SELECT
           |      project.id AS project_id,
-          |      project.name AS project_name,
+          |      COALESCE(project.name, '') AS project_name,
           |      currency,
           |      SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
           |      CASE
@@ -1336,13 +1336,13 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |      fakeTimePartitionColumn BETWEEN @startDate AND @endDate
           |    GROUP BY
           |      project_id,
-          |      project_name,
+          |      COALESCE(project.name, ''),
           |      spend_category,
           |      currency
           |)
           |SELECT
           |  project_id,
-          |  project_name,
+          |  MAX(project_name) AS project_name,
           |  SUM(category_cost) AS total_cost,
           |  SUM(CASE WHEN spend_category = 'Storage' THEN category_cost ELSE 0 END) AS storage_cost,
           |  SUM(CASE WHEN spend_category = 'Compute' THEN category_cost ELSE 0 END) AS compute_cost,
@@ -1355,7 +1355,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |  spend_categories
           |GROUP BY
           |  project_id,
-          |  project_name,
           |  currency
           |ORDER BY
           |  total_cost DESC

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1276,7 +1276,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       s"""|WITH spend_categories AS (
           |  SELECT
           |    project.id AS project_id,
-          |    COALESCE(project.name, '') AS project_name,
           |    currency,
           |    SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
           |    CASE
@@ -1292,13 +1291,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |    _PARTITIONTIME BETWEEN @startDate AND @endDate
           |  GROUP BY
           |    project_id,
-          |    COALESCE(project.name, ''),
           |    spend_category,
           |    currency
           | UNION ALL
           |    SELECT
           |      project.id AS project_id,
-          |      COALESCE(project.name, '') AS project_name,
           |      currency,
           |      SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
           |      CASE
@@ -1314,13 +1311,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |      _PARTITIONTIME BETWEEN @startDate AND @endDate
           |    GROUP BY
           |      project_id,
-          |      COALESCE(project.name, ''),
           |      spend_category,
           |      currency
           | UNION ALL
           |    SELECT
           |      project.id AS project_id,
-          |      COALESCE(project.name, '') AS project_name,
           |      currency,
           |      SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
           |      CASE
@@ -1336,13 +1331,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |      fakeTimePartitionColumn BETWEEN @startDate AND @endDate
           |    GROUP BY
           |      project_id,
-          |      COALESCE(project.name, ''),
           |      spend_category,
           |      currency
           |)
           |SELECT
           |  project_id,
-          |  MAX(project_name) AS project_name,
           |  SUM(category_cost) AS total_cost,
           |  SUM(CASE WHEN spend_category = 'Storage' THEN category_cost ELSE 0 END) AS storage_cost,
           |  SUM(CASE WHEN spend_category = 'Compute' THEN category_cost ELSE 0 END) AS compute_cost,


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/jira/software/c/projects/CORE/boards/214
For unknown reasons, BigQuery sometimes has rows in the spending table with null project names, resulting in a single project ID receiving two results: one with and one without the project name.  This causes weirdness in the UI as well as inaccurate results.  This PR updates the query to ignore project name altogether when consolidating rows, since it's not used in the result.


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
