### PR TITLE
[CORE-227] Deprecate queueStatus API

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -1784,6 +1784,7 @@ paths:
       summary: workflow queue status
       description: List workflow counts by queueing state
       operationId: workflowQueueStatus
+      deprecated: true
       responses:
         200:
           description: Successful Request


### PR DESCRIPTION
Ticket: [CORE-227](https://broadworkbench.atlassian.net/browse/CORE-227)
* Deprecates this API as it is not used and no longer returns valuable information as Rawls submits workflows to Cromwell much faster than it did when the API was introduced. The API will be removed as part of [CORE-255](https://broadworkbench.atlassian.net/browse/CORE-255)

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-227]: https://broadworkbench.atlassian.net/browse/CORE-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-255]: https://broadworkbench.atlassian.net/browse/CORE-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ