### PR TITLE
[CORE-267] Query BQ once per BP for spend report, handle errors

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala
@@ -23,7 +23,21 @@ case class SpendReportingAggregationKeyWithSub(key: SpendReportingAggregationKey
                                                subAggregationKey: Option[SpendReportingAggregationKey] = None
 )
 
-case class SpendReportingResults(spendDetails: Seq[SpendReportingAggregation], spendSummary: SpendReportingForDateRange)
+case class SpendReportingResults(spendDetails: Seq[SpendReportingAggregation],
+                                 spendSummary: SpendReportingForDateRange
+) {
+  def +(other: SpendReportingResults): SpendReportingResults =
+    new SpendReportingResults(
+      spendDetails ++ other.spendDetails,
+      SpendReportingForDateRange(
+        (BigDecimal(this.spendSummary.cost) + BigDecimal(other.spendSummary.cost)).toString,
+        (BigDecimal(this.spendSummary.credits) + BigDecimal(other.spendSummary.credits)).toString,
+        this.spendSummary.currency,
+        this.spendSummary.startTime,
+        this.spendSummary.endTime
+      )
+    )
+}
 object SpendReportingResults {
   def apply(spendReport: bio.terra.profile.model.SpendReport): SpendReportingResults = {
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -359,7 +359,7 @@ class SpendReportingService(
 
   def getAllUserWorkspaceQuery(
     spendExportTable: String,
-    workspaces: Seq[(GoogleProjectId, WorkspaceName)],
+    workspaces: Seq[GoogleProjectId],
     pageSize: Int,
     offset: Int
   ): String = {
@@ -389,7 +389,11 @@ class SpendReportingService(
       baseQuery
         .replace("_PARTITIONTIME", timePartitionColumn)
         .replace("_BILLING_ACCOUNT_TABLE", spendExportTable)
-        .replace("_PROJECT_ID_LIST", "(" + workspaces.map(tuple => s""""${tuple._1.value}"""").mkString(", ") + ")")
+        .replace("_PROJECT_ID_LIST",
+                 workspaces
+                   .map(projectId => s""""${projectId}"""")
+                   .mkString("(", ", ", ")")
+        )
 
     s"""WITH spend_categories AS (
        |$bpSubQuery
@@ -565,8 +569,11 @@ class SpendReportingService(
           return Future.successful(None)
         }
         projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
-        results <- Future.sequence(billingMap.map { case (spendExportTable, workspaces) =>
-          val query = getAllUserWorkspaceQuery(spendExportTable, workspaces, pageSize, offset)
+        tableToProjectIdsMap: Map[String, Seq[GoogleProjectId]] = billingMap.map { case (table, workspaces) =>
+          table -> workspaces.map(_._1)
+        }
+        results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
+          val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
           val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
           runBigQueryJob(queryJob, childContext)
             .map { result =>
@@ -575,7 +582,8 @@ class SpendReportingService(
                 case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
               }
             }
-            .recoverWith { case ex =>
+            .recoverWith { case ex: Throwable =>
+              logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
               Future.successful(None)
             }
         })

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -358,7 +358,8 @@ class SpendReportingService(
   }
 
   def getAllUserWorkspaceQuery(
-    billingProjects: Map[BillingProjectSpendExport, Seq[(GoogleProjectId, WorkspaceName)]],
+    billingProject: BillingProjectSpendExport,
+    workspaces: Seq[(GoogleProjectId, WorkspaceName)],
     pageSize: Int,
     offset: Int
   ): String = {
@@ -383,16 +384,17 @@ class SpendReportingService(
                        |    spend_category,
                        |    currency""".stripMargin.trim
 
-    val bpSubQuery = billingProjects
-      .map { bp =>
-        val tableName = bp._1.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
-        val timePartitionColumn: String = getTimePartitionColumn(tableName)
-        baseQuery
-          .replace("_PARTITIONTIME", timePartitionColumn)
-          .replace("_BILLING_ACCOUNT_TABLE", tableName)
-          .replace("_PROJECT_ID_LIST", "(" + bp._2.map(tuple => s""""${tuple._1.value}"""").mkString(", ") + ")")
-      }
-      .mkString("\nUNION ALL\n")
+//    val bpSubQuery = billingProjects
+//      .map { bp =>
+    val tableName = billingProject.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
+    val timePartitionColumn: String = getTimePartitionColumn(tableName)
+    val bpSubQuery =
+      baseQuery
+        .replace("_PARTITIONTIME", timePartitionColumn)
+        .replace("_BILLING_ACCOUNT_TABLE", tableName)
+        .replace("_PROJECT_ID_LIST", "(" + workspaces.map(tuple => s""""${tuple._1.value}"""").mkString(", ") + ")")
+//      }
+//      .mkString("\nUNION ALL\n")
 
     s"""WITH spend_categories AS (
        |$bpSubQuery
@@ -417,6 +419,67 @@ class SpendReportingService(
        |limit $pageSize offset $offset
        |""".stripMargin.trim
   }
+
+//  def getAllUserWorkspaceQuery(
+//                                billingProjects: Map[BillingProjectSpendExport, Seq[(GoogleProjectId, WorkspaceName)]],
+//                                pageSize: Int,
+//                                offset: Int
+//                              ): String = {
+//    val baseQuery = s"""
+//                       |  SELECT
+//                       |    project.id AS project_id,
+//                       |    currency,
+//                       |    SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
+//                       |    CASE
+//                       |      WHEN service.description IN ('Cloud Storage') THEN 'Storage'
+//                       |      WHEN service.description IN ('Compute Engine', 'Google Kubernetes Engine') THEN 'Compute'
+//                       |      ELSE 'Other'
+//                       |    END AS spend_category,
+//                       |    SUM(CAST(cost AS FLOAT64)) AS category_cost
+//                       |  FROM
+//                       |    _BILLING_ACCOUNT_TABLE
+//                       |  where
+//                       |    project.id in _PROJECT_ID_LIST AND
+//                       |    _PARTITIONTIME BETWEEN @startDate AND @endDate
+//                       |  GROUP BY
+//                       |    project_id,
+//                       |    spend_category,
+//                       |    currency""".stripMargin.trim
+//
+//    val bpSubQuery = billingProjects
+//      .map { bp =>
+//        val tableName = bp._1.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
+//        val timePartitionColumn: String = getTimePartitionColumn(tableName)
+//        baseQuery
+//          .replace("_PARTITIONTIME", timePartitionColumn)
+//          .replace("_BILLING_ACCOUNT_TABLE", tableName)
+//          .replace("_PROJECT_ID_LIST", "(" + bp._2.map(tuple => s""""${tuple._1.value}"""").mkString(", ") + ")")
+//      }
+//      .mkString("\nUNION ALL\n")
+//
+//    s"""WITH spend_categories AS (
+//       |$bpSubQuery
+//       |)
+//       |SELECT
+//       |  project_id,
+//       |  SUM(category_cost) AS total_cost,
+//       |  SUM(CASE WHEN spend_category = 'Storage' THEN category_cost ELSE 0 END) AS storage_cost,
+//       |  SUM(CASE WHEN spend_category = 'Compute' THEN category_cost ELSE 0 END) AS compute_cost,
+//       |  SUM(CASE WHEN spend_category = 'Other' THEN category_cost ELSE 0 END) AS other_cost,
+//       |  currency,
+//       |  SUM(CASE WHEN spend_category = 'Storage' THEN credits ELSE 0 END) AS storage_credits,
+//       |  SUM(CASE WHEN spend_category = 'Compute' THEN credits ELSE 0 END) AS compute_credits,
+//       |  SUM(CASE WHEN spend_category = 'Other' THEN credits ELSE 0 END) AS other_credits,
+//       |FROM
+//       |  spend_categories
+//       |GROUP BY
+//       |  project_id,
+//       |  currency
+//       |ORDER BY
+//       |  total_cost DESC
+//       |limit $pageSize offset $offset
+//       |""".stripMargin.trim
+//  }
 
   def setUpQuery(
     query: String,
@@ -568,15 +631,35 @@ class SpendReportingService(
           return Future.successful(None)
         }
         projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
-        query = getAllUserWorkspaceQuery(billingMap, pageSize, offset)
-        queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+        results <- Future.sequence(billingMap.map { case (billingProject, workspaces) =>
+          val query = getAllUserWorkspaceQuery(billingProject, workspaces, pageSize, offset)
+          val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+          runBigQueryJob(queryJob, childContext).map { result =>
+            result.getValues.asScala.toList match {
+              case Nil  => None
+              case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
+            }
+          }
+        })
+        combinedResults = results.flatten.reduceOption((acc, res) =>
+          SpendReportingResults(
+            acc.spendDetails ++ res.spendDetails,
+            SpendReportingForDateRange(
+              (BigDecimal(acc.spendSummary.cost) + BigDecimal(res.spendSummary.cost)).toString,
+              (BigDecimal(acc.spendSummary.credits) + BigDecimal(res.spendSummary.credits)).toString,
+              acc.spendSummary.currency,
+              acc.spendSummary.startTime,
+              acc.spendSummary.endTime
+            )
+          )
+        )
+      } yield combinedResults
 
-        result <- runBigQueryJob(queryJob, childContext)
-      } yield result.getValues.asScala.toList match {
-        case Nil =>
-          None
-        case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
-      }
+//      } yield result.getValues.asScala.toList match {
+//        case Nil =>
+//          None
+//        case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
+//      }
     }
 
   def runBigQueryJob(queryJob: JobInfo, ctx: RawlsRequestContext): Future[TableResult] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -634,12 +634,16 @@ class SpendReportingService(
         results <- Future.sequence(billingMap.map { case (billingProject, workspaces) =>
           val query = getAllUserWorkspaceQuery(billingProject, workspaces, pageSize, offset)
           val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
-          runBigQueryJob(queryJob, childContext).map { result =>
-            result.getValues.asScala.toList match {
-              case Nil  => None
-              case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
+          runBigQueryJob(queryJob, childContext)
+            .map { result =>
+              result.getValues.asScala.toList match {
+                case Nil  => None
+                case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
+              }
             }
-          }
+            .recoverWith { case ex =>
+              Future.successful(None)
+            }
         })
         combinedResults = results.flatten.reduceOption((acc, res) =>
           SpendReportingResults(
@@ -655,11 +659,6 @@ class SpendReportingService(
         )
       } yield combinedResults
 
-//      } yield result.getValues.asScala.toList match {
-//        case Nil =>
-//          None
-//        case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
-//      }
     }
 
   def runBigQueryJob(queryJob: JobInfo, ctx: RawlsRequestContext): Future[TableResult] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -587,18 +587,7 @@ class SpendReportingService(
               Future.successful(None)
             }
         })
-        combinedResults = results.flatten.reduceOption((acc, res) =>
-          SpendReportingResults(
-            acc.spendDetails ++ res.spendDetails,
-            SpendReportingForDateRange(
-              (BigDecimal(acc.spendSummary.cost) + BigDecimal(res.spendSummary.cost)).toString,
-              (BigDecimal(acc.spendSummary.credits) + BigDecimal(res.spendSummary.credits)).toString,
-              acc.spendSummary.currency,
-              acc.spendSummary.startTime,
-              acc.spendSummary.endTime
-            )
-          )
-        )
+        combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
       } yield combinedResults
 
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -358,7 +358,7 @@ class SpendReportingService(
   }
 
   def getAllUserWorkspaceQuery(
-    billingProject: BillingProjectSpendExport,
+    spendExportTable: String,
     workspaces: Seq[(GoogleProjectId, WorkspaceName)],
     pageSize: Int,
     offset: Int
@@ -384,17 +384,12 @@ class SpendReportingService(
                        |    spend_category,
                        |    currency""".stripMargin.trim
 
-//    val bpSubQuery = billingProjects
-//      .map { bp =>
-    val tableName = billingProject.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
-    val timePartitionColumn: String = getTimePartitionColumn(tableName)
+    val timePartitionColumn: String = getTimePartitionColumn(spendExportTable)
     val bpSubQuery =
       baseQuery
         .replace("_PARTITIONTIME", timePartitionColumn)
-        .replace("_BILLING_ACCOUNT_TABLE", tableName)
+        .replace("_BILLING_ACCOUNT_TABLE", spendExportTable)
         .replace("_PROJECT_ID_LIST", "(" + workspaces.map(tuple => s""""${tuple._1.value}"""").mkString(", ") + ")")
-//      }
-//      .mkString("\nUNION ALL\n")
 
     s"""WITH spend_categories AS (
        |$bpSubQuery
@@ -419,67 +414,6 @@ class SpendReportingService(
        |limit $pageSize offset $offset
        |""".stripMargin.trim
   }
-
-//  def getAllUserWorkspaceQuery(
-//                                billingProjects: Map[BillingProjectSpendExport, Seq[(GoogleProjectId, WorkspaceName)]],
-//                                pageSize: Int,
-//                                offset: Int
-//                              ): String = {
-//    val baseQuery = s"""
-//                       |  SELECT
-//                       |    project.id AS project_id,
-//                       |    currency,
-//                       |    SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
-//                       |    CASE
-//                       |      WHEN service.description IN ('Cloud Storage') THEN 'Storage'
-//                       |      WHEN service.description IN ('Compute Engine', 'Google Kubernetes Engine') THEN 'Compute'
-//                       |      ELSE 'Other'
-//                       |    END AS spend_category,
-//                       |    SUM(CAST(cost AS FLOAT64)) AS category_cost
-//                       |  FROM
-//                       |    _BILLING_ACCOUNT_TABLE
-//                       |  where
-//                       |    project.id in _PROJECT_ID_LIST AND
-//                       |    _PARTITIONTIME BETWEEN @startDate AND @endDate
-//                       |  GROUP BY
-//                       |    project_id,
-//                       |    spend_category,
-//                       |    currency""".stripMargin.trim
-//
-//    val bpSubQuery = billingProjects
-//      .map { bp =>
-//        val tableName = bp._1.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
-//        val timePartitionColumn: String = getTimePartitionColumn(tableName)
-//        baseQuery
-//          .replace("_PARTITIONTIME", timePartitionColumn)
-//          .replace("_BILLING_ACCOUNT_TABLE", tableName)
-//          .replace("_PROJECT_ID_LIST", "(" + bp._2.map(tuple => s""""${tuple._1.value}"""").mkString(", ") + ")")
-//      }
-//      .mkString("\nUNION ALL\n")
-//
-//    s"""WITH spend_categories AS (
-//       |$bpSubQuery
-//       |)
-//       |SELECT
-//       |  project_id,
-//       |  SUM(category_cost) AS total_cost,
-//       |  SUM(CASE WHEN spend_category = 'Storage' THEN category_cost ELSE 0 END) AS storage_cost,
-//       |  SUM(CASE WHEN spend_category = 'Compute' THEN category_cost ELSE 0 END) AS compute_cost,
-//       |  SUM(CASE WHEN spend_category = 'Other' THEN category_cost ELSE 0 END) AS other_cost,
-//       |  currency,
-//       |  SUM(CASE WHEN spend_category = 'Storage' THEN credits ELSE 0 END) AS storage_credits,
-//       |  SUM(CASE WHEN spend_category = 'Compute' THEN credits ELSE 0 END) AS compute_credits,
-//       |  SUM(CASE WHEN spend_category = 'Other' THEN credits ELSE 0 END) AS other_credits,
-//       |FROM
-//       |  spend_categories
-//       |GROUP BY
-//       |  project_id,
-//       |  currency
-//       |ORDER BY
-//       |  total_cost DESC
-//       |limit $pageSize offset $offset
-//       |""".stripMargin.trim
-//  }
 
   def setUpQuery(
     query: String,
@@ -631,8 +565,8 @@ class SpendReportingService(
           return Future.successful(None)
         }
         projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
-        results <- Future.sequence(billingMap.map { case (billingProject, workspaces) =>
-          val query = getAllUserWorkspaceQuery(billingProject, workspaces, pageSize, offset)
+        results <- Future.sequence(billingMap.map { case (spendExportTable, workspaces) =>
+          val query = getAllUserWorkspaceQuery(spendExportTable, workspaces, pageSize, offset)
           val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
           runBigQueryJob(queryJob, childContext)
             .map { result =>
@@ -672,7 +606,7 @@ class SpendReportingService(
 
   def getBillingWithSpendPermission(
     parentContext: RawlsRequestContext
-  ): Future[Map[BillingProjectSpendExport, Seq[(GoogleProjectId, WorkspaceName)]]] =
+  ): Future[Map[String, Seq[(GoogleProjectId, WorkspaceName)]]] =
     traceFutureWithParent("getBillingWithSpendPermission", parentContext) { childContext =>
       for {
         ownerWorkspaces <- samDAO.listResourcesWithActions(
@@ -699,10 +633,17 @@ class SpendReportingService(
           } else {
             getSpendExportConfigurations(groupedWorkspaces.keys.toList)
           }
-      } yield spendConfigs.map { config =>
-        config -> groupedWorkspaces
-          .getOrElse(RawlsBillingProjectName(config.billingProjectName.value), Seq.empty)
-          .map(ws => (ws.googleProjectId, ws.toWorkspaceName))
-      }.toMap
+        groupedByTable = spendConfigs.groupBy(
+          _.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
+        )
+        combinedResults = groupedByTable.map { case (table, configs) =>
+          val combinedWorkspaces = configs.flatMap { config =>
+            groupedWorkspaces
+              .getOrElse(RawlsBillingProjectName(config.billingProjectName.value), Seq.empty)
+              .map(ws => (ws.googleProjectId, ws.toWorkspaceName))
+          }
+          table -> combinedWorkspaces
+        }
+      } yield combinedResults
     }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1647,4 +1647,155 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
+  "getSpendForAllWorkspaces" should "handle errors from bigquery gracefully" in {
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
+    // Billing projects
+    val billingProfileId1 = UUID.randomUUID()
+    val projectName1 = RawlsBillingProjectName("billingProject1")
+    val billingAccount1 = RawlsBillingAccountName("billingAcct1")
+    val billingProject1 = RawlsBillingProject(
+      projectName1,
+      CreationStatuses.Ready,
+      Option(billingAccount1),
+      None,
+      billingProfileId = Option.apply(billingProfileId1.toString)
+    )
+    val billingProfileId2 = UUID.randomUUID()
+    val projectName2 = RawlsBillingProjectName("billingProject2")
+    val billingAccount2 = RawlsBillingAccountName("billingAcct2")
+    val billingProject2 = RawlsBillingProject(
+      projectName2,
+      CreationStatuses.Ready,
+      Option(billingAccount2),
+      None,
+      billingProfileId = Option.apply(billingProfileId2.toString)
+    )
+
+    // Billing project spend exports
+    val billingProject1SpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
+                                RawlsBillingAccountName("billingAccount1"),
+                                Some("billing1_bq_project.billing1_dataset.billing1_table")
+      )
+
+    val billingProject2SpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
+                                RawlsBillingAccountName("billingAccount2"),
+                                None
+      )
+
+    // Workspaces
+    val workspace1Billing1 =
+      TestData.workspace("workspace1Billing1",
+                         GoogleProjectId("workspace1ProjectId"),
+                         WorkspaceVersions.V1,
+                         "billingProject1"
+      )
+    val workspace2Billing2 =
+      TestData.workspace("workspace2Billing2",
+                         GoogleProjectId("workspace2ProjectId"),
+                         WorkspaceVersions.V2,
+                         "billingProject2"
+      )
+
+    val mockWorkspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
+    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(
+        Future.successful(
+          Map(billingProject1.projectName -> List(workspace1Billing1),
+              billingProject2.projectName -> List(workspace2Billing2)
+          )
+        )
+      )
+
+    val mockWorkspaceServiceConstructor: RawlsRequestContext => WorkspaceService = { _ =>
+      mockWorkspaceService
+    }
+
+    when(billingRepository.getBillingProject(mockitoEq(projectName1)))
+      .thenReturn(Future.successful(Option.apply(billingProject1)))
+    when(billingRepository.getBillingProject(mockitoEq(projectName2)))
+      .thenReturn(Future.successful(Option.apply(billingProject2)))
+
+    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(
+      Future.successful(
+        List(
+          new FilteredFlatResource().resourceId(UUID.randomUUID().toString),
+          new FilteredFlatResource().resourceId(UUID.randomUUID().toString)
+        )
+      )
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val price1 = BigDecimal("10.22")
+    val price2 = BigDecimal("50.74")
+    val zero = BigDecimal("0.00")
+    val total = price1 + price2
+
+    val table: List[Map[String, String]] = List(
+      Map(
+        "storage_cost" -> s"$price1",
+        "compute_cost" -> s"$zero",
+        "other_cost" -> s"$price2",
+        "total_cost" -> s"$total",
+        "currency" -> "USD",
+        "project_id" -> "workspace1ProjectId",
+        "project_name" -> "terra-billing-project1",
+        "storage_credits" -> s"$zero",
+        "compute_credits" -> s"$zero",
+        "other_credits" -> s"$zero"
+      )
+    )
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val job = mock[Job]
+    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job.waitFor()).thenReturn(job)
+    when(bigQueryService.runJob(any(), any()))
+      .thenReturn(IO(job))
+      .thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor
+      )
+    )
+    doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
+      .when(service)
+      .getSpendExportConfigurations(
+        any()
+      )
+
+    val result = Await.result(
+      service.getSpendForAllWorkspaces(from, to, 100, 0),
+      Duration.Inf
+    )
+
+    result.get.spendDetails.length shouldBe 1
+
+    val spendSummary = result.get.spendSummary
+
+    spendSummary.credits shouldBe zero.toString()
+    spendSummary.cost shouldBe total.toString()
+    spendSummary.currency shouldBe "USD"
+    spendSummary.startTime.get.toString(ISODateTimeFormat.date()) shouldBe from.toString(
+      ISODateTimeFormat.date()
+    )
+    spendSummary.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
+
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1305,7 +1305,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mockWorkspaceServiceConstructor
     )
     val result = service.getAllUserWorkspaceQuery(
-      billingProjectSpendExport,
+      billingProjectSpendExport.spendExportTable.get,
       workspaces,
       5,
       5
@@ -1317,20 +1317,20 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
-  "getBillingWithSpendPermission" should "return spendConfigurations for workspaces" in {
+  "getBillingWithSpendPermission" should "return spendExportTables for workspaces" in {
 
     val dataSource = mock[SlickDataSource]
 
     val billingProject1SpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
                                 RawlsBillingAccountName("billingAccount1"),
-                                Some("billing1_bq_project.billing1_dataset.billing1_table")
+                                Some("billing_bq_project.billing_dataset.billing_table")
       )
 
     val billingProject2SpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
                                 RawlsBillingAccountName("billingAccount2"),
-                                Some("billing2_bq_project.billing2_dataset.billing2_table")
+                                Some("billing_bq_project.billing_dataset.billing_table")
       )
 
     val billingProject3SpendExport =
@@ -1428,12 +1428,12 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     )
 
     result shouldBe Map(
-      billingProject1SpendExport -> Seq(
+      "billing_bq_project.billing_dataset.billing_table" -> Seq(
         (workspace1Billing1.googleProjectId, workspace1Billing1.toWorkspaceName),
-        (workspace2Billing1.googleProjectId, workspace2Billing1.toWorkspaceName)
+        (workspace2Billing1.googleProjectId, workspace2Billing1.toWorkspaceName),
+        (workspace1Billing2.googleProjectId, workspace1Billing2.toWorkspaceName)
       ),
-      billingProject2SpendExport -> Seq((workspace1Billing2.googleProjectId, workspace1Billing2.toWorkspaceName)),
-      billingProject3SpendExport -> Seq((workspace1Billing3.googleProjectId, workspace1Billing3.toWorkspaceName))
+      "fakeTable" -> Seq((workspace1Billing3.googleProjectId, workspace1Billing3.toWorkspaceName))
     )
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1239,37 +1239,17 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     result shouldBe Map(GoogleProjectId("v2ProjectId") -> v2Workspace.toWorkspaceName)
   }
 
-  "getAllUserWorkspaceQuery" should "union all billingProjects with their workspace projects" in {
+  "getAllUserWorkspaceQuery" should "generate a query for a billingProject with its workspace projects" in {
 
-    val billingProject1SpendExport =
+    val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
                                 RawlsBillingAccountName("billingAccount1"),
                                 Some("billing1_bq_project.billing1_dataset.billing1_table")
       )
 
-    val billingProject2SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
-                                RawlsBillingAccountName("billingAccount2"),
-                                Some("billing2_bq_project.billing2_dataset.billing2_table")
-      )
-
-    val billingProject3SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject3"),
-                                RawlsBillingAccountName("billingAccount3"),
-                                None
-      )
-
-    val inputMap = Map(
-      billingProject1SpendExport -> Seq(
-        (GoogleProjectId("workspace2ProjectId"), WorkspaceName("billingProject1", "workspace2")),
-        (GoogleProjectId("workspace1ProjectId"), WorkspaceName("billingProject1", "workspace1"))
-      ),
-      billingProject2SpendExport -> Seq(
-        (GoogleProjectId("workspace3ProjectId"), WorkspaceName("billingProject2", "workspace3"))
-      ),
-      billingProject3SpendExport -> Seq(
-        (GoogleProjectId("workspace4ProjectId"), WorkspaceName("billingProject3", "workspace4"))
-      )
+    val workspaces = Seq(
+      (GoogleProjectId("workspace2ProjectId"), WorkspaceName("billingProject1", "workspace2")),
+      (GoogleProjectId("workspace1ProjectId"), WorkspaceName("billingProject1", "workspace1"))
     )
 
     val expectedQuery =
@@ -1293,46 +1273,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |    project_id,
           |    spend_category,
           |    currency
-          | UNION ALL
-          |    SELECT
-          |      project.id AS project_id,
-          |      currency,
-          |      SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
-          |      CASE
-          |        WHEN service.description IN ('Cloud Storage') THEN 'Storage'
-          |        WHEN service.description IN ('Compute Engine', 'Google Kubernetes Engine') THEN 'Compute'
-          |        ELSE 'Other'
-          |      END AS spend_category,
-          |      SUM(CAST(cost AS FLOAT64)) AS category_cost
-          |    FROM
-          |      billing2_bq_project.billing2_dataset.billing2_table
-          |    where
-          |      project.id in ("workspace3ProjectId") AND
-          |      _PARTITIONTIME BETWEEN @startDate AND @endDate
-          |    GROUP BY
-          |      project_id,
-          |      spend_category,
-          |      currency
-          | UNION ALL
-          |    SELECT
-          |      project.id AS project_id,
-          |      currency,
-          |      SUM(IFNULL((SELECT SUM(c.amount) FROM UNNEST(credits) c), 0)) as credits,
-          |      CASE
-          |        WHEN service.description IN ('Cloud Storage') THEN 'Storage'
-          |        WHEN service.description IN ('Compute Engine', 'Google Kubernetes Engine') THEN 'Compute'
-          |        ELSE 'Other'
-          |      END AS spend_category,
-          |      SUM(CAST(cost AS FLOAT64)) AS category_cost
-          |    FROM
-          |      fakeTable
-          |    where
-          |      project.id in ("workspace4ProjectId") AND
-          |      fakeTimePartitionColumn BETWEEN @startDate AND @endDate
-          |    GROUP BY
-          |      project_id,
-          |      spend_category,
-          |      currency
           |)
           |SELECT
           |  project_id,
@@ -1365,7 +1305,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mockWorkspaceServiceConstructor
     )
     val result = service.getAllUserWorkspaceQuery(
-      inputMap,
+      billingProjectSpendExport,
+      workspaces,
       5,
       5
     )
@@ -1629,7 +1570,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val zero = BigDecimal("0.00")
     val total = price1 + price2
 
-    val table: List[Map[String, String]] = List(
+    val table1: List[Map[String, String]] = List(
       Map(
         "storage_cost" -> s"$price1",
         "compute_cost" -> s"$zero",
@@ -1641,7 +1582,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         "storage_credits" -> s"$zero",
         "compute_credits" -> s"$zero",
         "other_credits" -> s"$zero"
-      ),
+      )
+    )
+    val table2: List[Map[String, String]] = List(
       Map(
         "storage_cost" -> s"$price2",
         "compute_cost" -> s"$zero",
@@ -1656,13 +1599,22 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       )
     )
 
-    val bigQueryService = mockBigQuery(table)
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val job1 = mock[Job]
+    when(job1.getQueryResults(any())).thenReturn(createTableResult(table1))
+    when(job1.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job1.waitFor()).thenReturn(job1)
+    val job2 = mock[Job]
+    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
+    when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job2.waitFor()).thenReturn(job2)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job1), IO(job2))
 
     val service = spy(
       new SpendReportingService(
         testContext,
         mock[SlickDataSource],
-        bigQueryService,
+        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
         billingRepository,
         bpmDAO,
         samDAO,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1248,8 +1248,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       )
 
     val workspaces = Seq(
-      (GoogleProjectId("workspace2ProjectId"), WorkspaceName("billingProject1", "workspace2")),
-      (GoogleProjectId("workspace1ProjectId"), WorkspaceName("billingProject1", "workspace1"))
+      GoogleProjectId("workspace2ProjectId"),
+      GoogleProjectId("workspace1ProjectId")
     )
 
     val expectedQuery =


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-267
For the consolidated spend report, instead of unioning all billing projects together into one BQ query, this PR does a separate query for each billing project.  If BQ returns an error for any one of them, it is left out of the results.

As currently implemented, BPs that generate errors are essentially ignored, resulting in all these workspaces simply not showing up in the UI.  Since the form of the result returned from the Rawls API has a list of [SpendReportingForDateRange](https://github.com/broadinstitute/rawls/blob/9c4e0f908012989fafa7dc670dd9830198d48940/core/src/main/scala/org/broadinstitute/dsde/rawls/model/SpendReportingModel.scala#L88), it might not be very straightforward to return a result for all the workspaces in a problematic BP that indicates that there was a problem.  So that would suggest that the UI would have to figure out which, if any, workspaces are missing and display an 'N/A' for them, but that leaves out some information that we do have.  Reviewers, is it worth it to try to shove some indication of the problem into a `SpendReportingResult` or is it ok just to leave it to the UI?

Testing:
I compared my results from the consolidated spend report API both before and after I split the query up and I believe the substance did not change.  I then created a BP and gave it a false BQ dataset in its spend report configuration.  After checking that this resulted in errors on the main branch, I verified that I was able to successfully get the report on this branch.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
