### PR TITLE
CORE-229: reword cost-overrun message

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -328,7 +328,7 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
                   datasource
                     .inTransaction { dataAccess =>
                       dataAccess.workflowQuery.saveMessages(
-                        Seq(AttributeString("Cost limit reached. Workflow was aborted to prevent cost overrun.")),
+                        Seq(AttributeString("Cost limit reached. Workflow was aborted to stay on budget.")),
                         workflowRec.id
                       )
                     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -1560,7 +1560,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
           .getOrElse(fail())
           .messages
       actualMessages should have size 1
-      actualMessages.head.value shouldBe "Cost limit reached. Workflow was aborted to prevent cost overrun."
+      actualMessages.head.value shouldBe "Cost limit reached. Workflow was aborted to stay on budget."
   }
 
   it should "handleOutputs which are unbound by ignoring them" in withDefaultTestDatabase {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-229

Reword the message when aborting a workflow due to hitting its cost limit:

new:
```
Workflow was aborted to stay on budget.
```
old:
```
Workflow was aborted to prevent cost overrun.
```


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
