### PR TITLE
[CORE-293] Remove Google Genomics from status checks

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -7095,8 +7095,6 @@ components:
                 - Google Billing is misbehaving!
             GoogleBuckets:
               ok: true
-            GoogleGenomics:
-              ok: true
             GoogleGroups:
               ok: true
             GooglePubSub:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -182,18 +182,6 @@ trait GoogleServicesDAO extends ErrorReportable {
 
   def getGenomicsOperation(jobId: String): Future[Option[JsObject]]
 
-  /**
-   * Checks that a query can be performed against the genomics api.
-   *
-   * Note: takes an implicit ExecutionContext to override the class-level ExecutionContext. This
-   * is because this method is used for health monitoring, and we want health checks to use a
-   * different execution context (thread pool) than user-facing operations.
-   *
-   * @param executionContext the execution context to use for aysnc operations
-   * @return sequence of Google operations
-   */
-  def checkGenomicsOperationsHealth(implicit executionContext: ExecutionContext): Future[Boolean]
-
   def getResourceBufferServiceAccountCredential: Credential
 
   def getServiceAccountUserInfo(): Future[UserInfo]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -909,19 +909,6 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
     handleByOperationIdType(opId, papiv1Handler, papiv2Alpha1Handler, lifeSciencesBetaHandler, noMatchHandler)
   }
 
-  override def checkGenomicsOperationsHealth(implicit executionContext: ExecutionContext): Future[Boolean] = {
-    implicit val service = GoogleInstrumentedService.Genomics
-    val opId = s"projects/$serviceProject/operations"
-    val genomicsApi = new Genomics.Builder(httpTransport, jsonFactory, getGenomicsServiceAccountCredential)
-      .setApplicationName(appName)
-      .build()
-    val operationRequest = genomicsApi.projects().operations().list(opId).setPageSize(1)
-    retryWhen500orGoogleError { () =>
-      executeGoogleRequest(operationRequest)
-      true
-    }
-  }
-
   override def getGoogleProject(googleProject: GoogleProjectId): Future[Project] = {
     implicit val service = GoogleInstrumentedService.Billing
     val cloudResManager = getCloudResourceManagerWithBillingServiceAccountCredential

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/HealthMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/HealthMonitor.scala
@@ -68,7 +68,6 @@ object HealthMonitor {
           (Database, checkDB(slickDataSource)),
           (GoogleBilling, checkGoogleBilling(googleServicesDAO)),
           (GoogleBuckets, checkGoogleBuckets(googleServicesDAO, bucketsToCheck)),
-          (GoogleGenomics, checkGoogleGenomics(googleServicesDAO)),
           (GooglePubSub, checkGooglePubsub(googlePubSubDAO, topicsToCheck)),
           (Sam, checkSam(samDAO)),
           (BillingProfileManager, checkBPM(billingProfileManagerDAO)),
@@ -318,20 +317,6 @@ object SystemChecks extends LazyLogging {
     googleServicesDAO.listBillingAccountsUsingServiceCredential.map { accts =>
       if (accts.isEmpty) failedStatus("Could not find any Rawls billing accounts")
       else OkStatus
-    }
-  }
-
-  /**
-   * Checks Google genomics status by doing a list() using the genomics service account.
-   * Does not validate the results; only that the API call succeeds.
-   */
-  def checkGoogleGenomics(
-    googleServicesDAO: GoogleServicesDAO
-  )(executionContext: ExecutionContext): Future[SubsystemStatus] = {
-    implicit val ec = executionContext
-    logger.debug("Checking Google Genomics...")
-    googleServicesDAO.checkGenomicsOperationsHealth.map { _ =>
-      OkStatus
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -228,9 +228,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
     }
   }
 
-  override def checkGenomicsOperationsHealth(implicit executionContext: ExecutionContext): Future[Boolean] =
-    Future.successful(true)
-
   override def getBucketDetails(bucket: String, project: GoogleProjectId): Future[WorkspaceBucketOptions] =
     Future.successful(WorkspaceBucketOptions(false, bucketLocation))
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/StatusModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/StatusModel.scala
@@ -24,7 +24,6 @@ object Subsystems {
         Database,
         GoogleBilling,
         GoogleBuckets,
-        GoogleGenomics,
         GooglePubSub,
         Sam,
         BillingProfileManager,
@@ -32,7 +31,7 @@ object Subsystems {
     )
   // CriticalSubsystems are those that will trigger rawls to report down
   val CriticalSubsystems = Set(Database, Sam)
-  val GoogleSubsystems = Set(GoogleBilling, GoogleBuckets, GoogleGenomics, GooglePubSub)
+  val GoogleSubsystems = Set(GoogleBilling, GoogleBuckets, GooglePubSub)
 
   sealed trait Subsystem extends RawlsEnumeration[Subsystem] {
     override def toString = getClass.getSimpleName.stripSuffix("$")
@@ -47,7 +46,6 @@ object Subsystems {
       case "Database"              => Database
       case "GoogleBilling"         => GoogleBilling
       case "GoogleBuckets"         => GoogleBuckets
-      case "GoogleGenomics"        => GoogleGenomics
       case "GooglePubSub"          => GooglePubSub
       case "Mongo"                 => Mongo
       case "Sam"                   => Sam
@@ -61,7 +59,6 @@ object Subsystems {
   case object Database extends Subsystem
   case object GoogleBilling extends Subsystem
   case object GoogleBuckets extends Subsystem
-  case object GoogleGenomics extends Subsystem
   case object GooglePubSub extends Subsystem
   case object Mongo extends Subsystem
   case object Sam extends Subsystem


### PR DESCRIPTION
Ticket: [CORE-293](https://broadworkbench.atlassian.net/browse/CORE-293)
* Google Genomics API (aka Life Sciences API) has been deprecated and is no longer responding as healthy to the Rawls subsystem status checks. This causes Rawls to report an unhealthy status and limits functionality in SCP. This PR removes the check from the Rawls status check.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-293]: https://broadworkbench.atlassian.net/browse/CORE-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ