### PR TITLE
CORE-269 publicly readable workspace setting

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6044,6 +6044,7 @@ components:
             - GcpBucketRequesterPays
             - SeparateSubmissionFinalOutputs
             - UseCromwellGcpBatchBackend
+            - PubliclyReadable
         config:
           description: The configuration of the workspace setting
           oneOf:
@@ -6052,6 +6053,7 @@ components:
             - $ref: '#/components/schemas/WorkspaceSettingGcpBucketRequesterPaysConfig'
             - $ref: '#/components/schemas/WorkspaceSettingSeparateSubmissionFinalOutputsConfig'
             - $ref: '#/components/schemas/WorkspaceSettingUseCromwellGcpBatchBackendConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingPubliclyReadableConfig'
     WorkspaceSettingGcpBucketLifecycleConfig:
       required:
         - rules
@@ -6126,6 +6128,14 @@ components:
         enabled:
           type: boolean
           description: Whether workflows submitted to Cromwell should be run using Cromwell's GCP Batch backend
+    WorkspaceSettingPubliclyReadableConfig:
+      required:
+        - enabled
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Whether or not the workspace should be publicly readable
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import cats.effect._
+import cats.effect.unsafe.IORuntime
 import cats.implicits._
 import com.codahale.metrics.SharedMetricRegistries
 import com.google.cloud.opentelemetry.trace.{TraceConfiguration, TraceExporter}
@@ -530,7 +531,13 @@ object Boot extends IOApp with LazyLogging {
 
       val workspaceSettingRepository = new WorkspaceSettingRepository(slickDataSource)
       val workspaceSettingServiceConstructor: RawlsRequestContext => WorkspaceSettingService =
-        new WorkspaceSettingService(_, workspaceSettingRepository, workspaceRepository, gcsDAO, samDAO)
+        new WorkspaceSettingService(_,
+                                    workspaceSettingRepository,
+                                    workspaceRepository,
+                                    gcsDAO,
+                                    samDAO,
+                                    appDependencies.googleStorageService
+        )(implicitly, IORuntime.global)
 
       val service = new RawlsApiServiceImpl(
         multiCloudWorkspaceServiceConstructor,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/GoogleServicesDAO.scala
@@ -25,6 +25,7 @@ object GoogleServicesDAO {
 
 trait GoogleServicesDAO extends ErrorReportable {
   val errorReportSource = ErrorReportSource("google")
+  val terraBucketReaderRole: String
 
   val accessContextManagerDAO: AccessContextManagerDAO
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -92,7 +92,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
                             googleStorageService: GoogleStorageService[IO],
                             override val workbenchMetricBaseName: String,
                             proxyNamePrefix: String,
-                            terraBucketReaderRole: String,
+                            override val terraBucketReaderRole: String,
                             terraBucketWriterRole: String,
                             override val accessContextManagerDAO: AccessContextManagerDAO,
                             resourceBufferJsonFile: String

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -23,7 +23,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.{
   ListResourcesV2200Response
 }
 import org.broadinstitute.dsde.workbench.client.sam.{ApiCallback, ApiClient, ApiException}
-import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroup, WorkbenchGroupName}
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -749,6 +749,28 @@ class HttpSamDAO(baseSamServiceURL: String, rawlsCredential: RawlsCredential, ti
         }
       )
     }
+  }
+
+  override def setPolicyPublic(resourceTypeName: SamResourceTypeName,
+                               resourceId: String,
+                               policyName: SamResourcePolicyName,
+                               public: Boolean,
+                               ctx: RawlsRequestContext
+  ): Future[Unit] =
+    retry(when401or5xx) { () =>
+      val callback = new SamApiCallback[Void]("setPolicyPublic")
+
+      resourcesApi(ctx).setPolicyPublicV2Async(resourceTypeName.value, resourceId, policyName.value, public, callback)
+
+      callback.future.map(_ => ())
+    }
+
+  override def getAllUsersGroup(ctx: RawlsRequestContext): Future[WorkbenchEmail] = {
+    val callback = new SamApiCallback[String]("getAllUsersGroup")
+
+    groupApi(ctx).getGroupAsync(allUsersGroupName.value, callback)
+
+    callback.future.map(WorkbenchEmail)
   }
 }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/SamDAO.scala
@@ -36,6 +36,7 @@ import scala.concurrent.Future
   */
 trait SamDAO {
   val errorReportSource = ErrorReportSource("sam")
+  val allUsersGroupName = WorkbenchGroupName("All_Users")
 
   def registerUser(ctx: RawlsRequestContext): Future[Option[RawlsUser]]
 
@@ -164,11 +165,20 @@ trait SamDAO {
                            ctx: RawlsRequestContext
   ): Future[Seq[SamFullyQualifiedResourceId]]
 
+  def setPolicyPublic(resourceTypeName: SamResourceTypeName,
+                      resourceId: String,
+                      policyName: SamResourcePolicyName,
+                      public: Boolean,
+                      ctx: RawlsRequestContext
+  ): Future[Unit]
+
   def admin: SamAdminDAO
 
   def rawlsSAContext: RawlsRequestContext = RawlsRequestContext(
     UserInfo(RawlsUserEmail(""), OAuth2BearerToken(""), 0, RawlsUserSubjectId(""), None)
   )
+
+  def getAllUsersGroup(ctx: RawlsRequestContext): Future[WorkbenchEmail]
 }
 
 trait SamAdminDAO {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSettingComponent.scala
@@ -4,6 +4,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.{
   GcpBucketLifecycleConfigFormat,
   GcpBucketRequesterPaysConfigFormat,
   GcpBucketSoftDeleteConfigFormat,
+  PubliclyReadableConfigFormat,
   SeparateSubmissionFinalOutputsConfigFormat,
   UseCromwellGcpBatchBackendConfigFormat
 }
@@ -11,6 +12,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleConfig,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
+  PubliclyReadableConfig,
   SeparateSubmissionFinalOutputsConfig,
   UseCromwellGcpBatchBackendConfig
 }
@@ -77,6 +79,8 @@ object WorkspaceSettingRecord {
         UseCromwellGcpBatchBackendSetting(
           workspaceSettingRecord.config.parseJson.convertTo[UseCromwellGcpBatchBackendConfig]
         )
+      case WorkspaceSettingTypes.PubliclyReadable =>
+        PubliclyReadableSetting(workspaceSettingRecord.config.parseJson.convertTo[PubliclyReadableConfig])
     }
   }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -1,7 +1,11 @@
 package org.broadinstitute.dsde.rawls.workspace
 
 import akka.http.scaladsl.model.StatusCodes
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import cats.implicits._
+import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.typesafe.scalalogging.LazyLogging
@@ -13,8 +17,11 @@ import org.broadinstitute.dsde.rawls.model.{
   GcpBucketLifecycleSetting,
   GcpBucketRequesterPaysSetting,
   GcpBucketSoftDeleteSetting,
+  PubliclyReadableSetting,
   RawlsRequestContext,
+  SamResourceTypeNames,
   SamWorkspaceActions,
+  SamWorkspacePolicyNames,
   SeparateSubmissionFinalOutputsSetting,
   UseCromwellGcpBatchBackendSetting,
   Workspace,
@@ -24,6 +31,9 @@ import org.broadinstitute.dsde.rawls.model.{
 }
 import org.broadinstitute.dsde.rawls.util.WorkspaceSupport
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, StorageRole}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 
 import java.time.Duration
 import scala.concurrent.duration.DurationInt
@@ -34,10 +44,20 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
                               workspaceSettingRepository: WorkspaceSettingRepository,
                               val workspaceRepository: WorkspaceRepository,
                               gcsDAO: GoogleServicesDAO,
-                              val samDAO: SamDAO
-)(implicit protected val executionContext: ExecutionContext)
+                              val samDAO: SamDAO,
+                              googleStorageService: GoogleStorageService[IO]
+)(implicit protected val executionContext: ExecutionContext, ioRuntime: IORuntime)
     extends WorkspaceSupport
     with LazyLogging {
+
+  private def getAllUsersRoleMapping(ctx: RawlsRequestContext) =
+    samDAO.getAllUsersGroup(ctx).map { allUsersGroup =>
+      Map[StorageRole, NonEmptyList[Identity]](
+        StorageRole.CustomStorageRole(gcsDAO.terraBucketReaderRole) -> NonEmptyList.one(
+          Identity.group(allUsersGroup.value)
+        )
+      )
+    }
 
   // Returns applied settings on a workspace.
   def getWorkspaceSettings(workspaceName: WorkspaceName): Future[List[WorkspaceSetting]] =
@@ -96,6 +116,7 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
           case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(_))                 => None
           case SeparateSubmissionFinalOutputsSetting(SeparateSubmissionFinalOutputsConfig(_)) => None
           case UseCromwellGcpBatchBackendSetting(UseCromwellGcpBatchBackendConfig(_))         => None
+          case PubliclyReadableSetting(PubliclyReadableConfig(_))                             => None
         }
       }
 
@@ -124,9 +145,13 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
           s"Failed to apply settings. [workspaceId=${workspace.workspaceIdAsUUID},settingType=${setting.settingType}]",
           e
         )
+        val statusCode = e match {
+          case re: RawlsExceptionWithErrorReport => re.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError)
+          case _                                 => StatusCodes.InternalServerError
+        }
         workspaceSettingRepository
           .removePendingSetting(workspace.workspaceIdAsUUID, setting.settingType)
-          .map(_ => Some((setting.settingType, ErrorReport(StatusCodes.InternalServerError, e.getMessage))))
+          .map(_ => Some((setting.settingType, ErrorReport(statusCode, e.getMessage))))
       }
 
     def applySettingToBucket(workspace: Workspace, workspaceSetting: WorkspaceSetting): Future[Unit] =
@@ -160,6 +185,9 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
         case GcpBucketRequesterPaysSetting(GcpBucketRequesterPaysConfig(enabled)) =>
           gcsDAO.setRequesterPays(workspace.bucketName, enabled, workspace.googleProjectId)
 
+        case PubliclyReadableSetting(PubliclyReadableConfig(enabled)) =>
+          applyPublicReadableSetting(workspace, enabled)
+
         // SeparateSubmissionFinalOutputsSetting and UseCromwellGcpBatchBackendSetting are not bucket settings,
         // so we do not need to apply anything here
 
@@ -189,4 +217,35 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
       WorkspaceSettingResponse(successes, applyFailures.flatten.toMap)
     }
   }
+
+  /**
+   * Calls sam to update the reader policy then update the buckets IAM to add or remove the allUsers group
+   */
+  private def applyPublicReadableSetting(workspace: Workspace, enabled: Boolean): Future[Unit] =
+    for {
+      // setPolicyPublic will only work if the caller has the appropriate permissions in Sam
+      _ <- samDAO
+        .setPolicyPublic(SamResourceTypeNames.workspace,
+                         workspace.workspaceId,
+                         SamWorkspacePolicyNames.reader,
+                         enabled,
+                         ctx
+        )
+        .recover {
+          case e: RawlsExceptionWithErrorReport
+              if e.errorReport.statusCode
+                .contains(StatusCodes.NotFound) || e.errorReport.statusCode.contains(StatusCodes.Forbidden) =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.Forbidden, "User does not have permission to update publicly readable setting")
+            )
+        }
+      allUsersRoleMapping <- getAllUsersRoleMapping(ctx)
+      iamPolicyAction =
+        if (enabled) {
+          googleStorageService.setIamPolicy(GcsBucketName(workspace.bucketName), allUsersRoleMapping)
+        } else {
+          googleStorageService.removeIamPolicy(GcsBucketName(workspace.bucketName), allUsersRoleMapping)
+        }
+      _ <- iamPolicyAction.compile.drain.unsafeToFuture()
+    } yield ()
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/MockGoogleServicesDAO.scala
@@ -315,4 +315,6 @@ class MockGoogleServicesDAO(groupsPrefix: String,
   override def testSAGoogleProjectIam(project: GoogleProject, saKey: String, permissions: Set[IamPermission])(implicit
     executionContext: ExecutionContext
   ): Future[Set[IamPermission]] = Future.successful(permissions)
+
+  override val terraBucketReaderRole: String = "terraBucketReaderRole"
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -814,9 +814,7 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       assert(submission.workflows.forall(_.status == WorkflowStatuses.Failed))
 
       submission.workflows.foreach { workflow =>
-        assertResult(Seq(AttributeString("a"), AttributeString("b"))) {
-          workflow.messages
-        }
+        workflow.messages should contain theSameElementsAs Seq(AttributeString("a"), AttributeString("b"))
       }
     } { capturedMetrics =>
       capturedMetrics should contain(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -289,6 +289,15 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
                                                     ctx: RawlsRequestContext
     ): Future[Boolean] = ???
   }
+
+  override def setPolicyPublic(resourceTypeName: SamResourceTypeName,
+                               resourceId: String,
+                               policyName: SamResourcePolicyName,
+                               public: Boolean,
+                               ctx: RawlsRequestContext
+  ): Future[Unit] = ???
+
+  override def getAllUsersGroup(ctx: RawlsRequestContext): Future[WorkbenchEmail] = ???
 }
 
 class CustomizableMockSamDAO(dataSource: SlickDataSource)(implicit executionContext: ExecutionContext)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -9,6 +9,8 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestActors, TestKitBase}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.RawlsTestUtils
@@ -61,6 +63,7 @@ import org.broadinstitute.dsde.rawls.workspace.{
 }
 import org.broadinstitute.dsde.workbench.dataaccess.{NotificationDAO, PubSubNotificationDAO}
 import org.broadinstitute.dsde.workbench.google.mock.{MockGoogleBigQueryDAO, MockGoogleIamDAO, MockGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.oauth2.mock.FakeOpenIDConnectConfiguration
 import org.mockito.ArgumentMatcher
@@ -402,7 +405,8 @@ trait ApiServiceSpec
                                   new WorkspaceSettingRepository(slickDataSource),
                                   new WorkspaceRepository(slickDataSource),
                                   gcsDAO,
-                                  samDAO
+                                  samDAO,
+                                  mock[GoogleStorageService[IO]]
       )
 
     val spendReportingBigQueryService = bigQueryServiceFactory.getServiceFromJson("json", GoogleProject("test-project"))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -670,7 +670,7 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
 
-    val workspaceRepository = mock[WorkspaceRepository]
+    val workspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
     when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
 
     val workspaceSettings = List(PubliclyReadableSetting(PubliclyReadableConfig(true)))
@@ -735,14 +735,34 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         googleStorageService = googleStorageService
       )
 
-    Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
+    val result = Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
+    result.successes should contain theSameElementsAs workspaceSettings
+    result.failures shouldEqual Map.empty
+    verify(samDAO).setPolicyPublic(
+      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+      ArgumentMatchers.eq(workspaceId.toString),
+      ArgumentMatchers.eq(SamWorkspacePolicyNames.reader),
+      ArgumentMatchers.eq(true),
+      any()
+    )
+    verify(googleStorageService).setIamPolicy(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(
+        Map[StorageRole, NonEmptyList[Identity]](
+          StorageRole.CustomStorageRole("terra-bucket-reader") -> NonEmptyList.one(Identity.group("allUsers@fc.org"))
+        )
+      ),
+      any(),
+      any(),
+      any()
+    )
   }
 
   it should "unset public in sam and remove all users from bucket" in {
     val workspaceId = workspace.workspaceIdAsUUID
     val workspaceName = workspace.toWorkspaceName
 
-    val workspaceRepository = mock[WorkspaceRepository]
+    val workspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
     when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
 
     val workspaceSettings = List(PubliclyReadableSetting(PubliclyReadableConfig(false)))
@@ -807,6 +827,82 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
         googleStorageService = googleStorageService
       )
 
-    Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
+    val result = Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
+    result.successes should contain theSameElementsAs workspaceSettings
+    result.failures shouldEqual Map.empty
+    verify(samDAO).setPolicyPublic(
+      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+      ArgumentMatchers.eq(workspaceId.toString),
+      ArgumentMatchers.eq(SamWorkspacePolicyNames.reader),
+      ArgumentMatchers.eq(false),
+      any()
+    )
+    verify(googleStorageService).removeIamPolicy(
+      ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+      ArgumentMatchers.eq(
+        Map[StorageRole, NonEmptyList[Identity]](
+          StorageRole.CustomStorageRole("terra-bucket-reader") -> NonEmptyList.one(Identity.group("allUsers@fc.org"))
+        )
+      ),
+      any(),
+      any(),
+      any()
+    )
+  }
+
+  it should "fail when sam returns error" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+
+    val workspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS)
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettings = List(PubliclyReadableSetting(PubliclyReadableConfig(true)))
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                workspaceSettings,
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(workspaceSettings))
+    workspaceSettings.foreach(workspaceSetting =>
+      when(workspaceSettingRepository.removePendingSetting(workspaceId, workspaceSetting.settingType))
+        .thenReturn(Future.successful(1))
+    )
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                           ArgumentMatchers.eq(workspaceId.toString),
+                           ArgumentMatchers.eq(SamWorkspaceActions.own),
+                           any()
+      )
+    ).thenReturn(Future.successful(true))
+    when(
+      samDAO.setPolicyPublic(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspacePolicyNames.reader),
+        ArgumentMatchers.eq(true),
+        any()
+      )
+    ).thenReturn(Future.failed(new RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.NotFound, "no permissions"))))
+
+    val service =
+      workspaceSettingServiceConstructor(
+        samDAO = samDAO,
+        workspaceRepository = workspaceRepository,
+        workspaceSettingRepository = workspaceSettingRepository,
+        gcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
+        googleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+      )
+
+    val result = Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
+    result.successes shouldEqual List.empty
+    result.failures.keys should contain theSameElementsAs List(WorkspaceSettingTypes.PubliclyReadable)
+    result.failures(WorkspaceSettingTypes.PubliclyReadable).statusCode shouldBe Some(StatusCodes.Forbidden)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingServiceUnitTests.scala
@@ -2,6 +2,10 @@ package org.broadinstitute.dsde.rawls.workspace
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
 import org.broadinstitute.dsde.rawls.{NoSuchWorkspaceException, RawlsExceptionWithErrorReport}
@@ -13,6 +17,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
+  PubliclyReadableConfig,
   SeparateSubmissionFinalOutputsConfig,
   UseCromwellGcpBatchBackendConfig
 }
@@ -21,12 +26,14 @@ import org.broadinstitute.dsde.rawls.model.{
   GcpBucketLifecycleSetting,
   GcpBucketRequesterPaysSetting,
   GcpBucketSoftDeleteSetting,
+  PubliclyReadableSetting,
   RawlsRequestContext,
   RawlsUserEmail,
   RawlsUserSubjectId,
   SamResourceTypeNames,
   SamUserStatusResponse,
   SamWorkspaceActions,
+  SamWorkspacePolicyNames,
   SeparateSubmissionFinalOutputsSetting,
   UseCromwellGcpBatchBackendSetting,
   UserInfo,
@@ -34,6 +41,9 @@ import org.broadinstitute.dsde.rawls.model.{
   WorkspaceSettingTypes
 }
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
+import org.broadinstitute.dsde.workbench.google2.{GoogleStorageService, StorageRole}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -63,9 +73,16 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     ),
     workspaceRepository: WorkspaceRepository = mock[WorkspaceRepository](RETURNS_SMART_NULLS),
     gcsDAO: GoogleServicesDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS),
-    samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    samDAO: SamDAO = mock[SamDAO](RETURNS_SMART_NULLS),
+    googleStorageService: GoogleStorageService[IO] = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
   ): WorkspaceSettingService =
-    new WorkspaceSettingService(ctx, workspaceSettingRepository, workspaceRepository, gcsDAO, samDAO)
+    new WorkspaceSettingService(ctx,
+                                workspaceSettingRepository,
+                                workspaceRepository,
+                                gcsDAO,
+                                samDAO,
+                                googleStorageService
+    )
 
   val workspace: Workspace = Workspace(
     "settingsTestWorkspace",
@@ -647,5 +664,149 @@ class WorkspaceSettingServiceUnitTests extends AnyFlatSpec with MockitoTestUtils
     exception.errorReport.statusCode shouldBe Some(StatusCodes.BadRequest)
     exception.errorReport.message should include("Invalid settings requested.")
     assert(exception.errorReport.causes.exists(_.message.matches("Invalid GcpBucketSoftDelete.*retention duration.*")))
+  }
+
+  "publicly readable setting" should "set public in sam and add all users to bucket" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettings = List(PubliclyReadableSetting(PubliclyReadableConfig(true)))
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                workspaceSettings,
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(workspaceSettings))
+    workspaceSettings.foreach(workspaceSetting =>
+      when(workspaceSettingRepository.markWorkspaceSettingApplied(workspaceId, workspaceSetting.settingType))
+        .thenReturn(Future.successful(1))
+    )
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                           ArgumentMatchers.eq(workspaceId.toString),
+                           ArgumentMatchers.eq(SamWorkspaceActions.own),
+                           any()
+      )
+    ).thenReturn(Future.successful(true))
+    when(
+      samDAO.setPolicyPublic(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspacePolicyNames.reader),
+        ArgumentMatchers.eq(true),
+        any()
+      )
+    ).thenReturn(Future.successful(()))
+    when(samDAO.getAllUsersGroup(any())).thenReturn(Future.successful(WorkbenchEmail("allUsers@fc.org")))
+
+    val gcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+    when(gcsDAO.terraBucketReaderRole).thenReturn("terra-bucket-reader")
+
+    val googleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+    when(
+      googleStorageService.setIamPolicy(
+        ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+        ArgumentMatchers.eq(
+          Map[StorageRole, NonEmptyList[Identity]](
+            StorageRole.CustomStorageRole("terra-bucket-reader") -> NonEmptyList.one(Identity.group("allUsers@fc.org"))
+          )
+        ),
+        any(),
+        any(),
+        any()
+      )
+    ).thenReturn(fs2.Stream.empty)
+
+    val service =
+      workspaceSettingServiceConstructor(
+        samDAO = samDAO,
+        workspaceRepository = workspaceRepository,
+        workspaceSettingRepository = workspaceSettingRepository,
+        gcsDAO = gcsDAO,
+        googleStorageService = googleStorageService
+      )
+
+    Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
+  }
+
+  it should "unset public in sam and remove all users from bucket" in {
+    val workspaceId = workspace.workspaceIdAsUUID
+    val workspaceName = workspace.toWorkspaceName
+
+    val workspaceRepository = mock[WorkspaceRepository]
+    when(workspaceRepository.getWorkspace(workspaceName, None)).thenReturn(Future.successful(Option(workspace)))
+
+    val workspaceSettings = List(PubliclyReadableSetting(PubliclyReadableConfig(false)))
+    val workspaceSettingRepository = mock[WorkspaceSettingRepository]
+    when(workspaceSettingRepository.getWorkspaceSettings(workspaceId)).thenReturn(Future.successful(List.empty))
+    when(
+      workspaceSettingRepository.createWorkspaceSettingsRecords(workspaceId,
+                                                                workspaceSettings,
+                                                                defaultRequestContext.userInfo.userSubjectId
+      )
+    ).thenReturn(Future.successful(workspaceSettings))
+    workspaceSettings.foreach(workspaceSetting =>
+      when(workspaceSettingRepository.markWorkspaceSettingApplied(workspaceId, workspaceSetting.settingType))
+        .thenReturn(Future.successful(1))
+    )
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.getUserStatus(any()))
+      .thenReturn(Future.successful(Option(SamUserStatusResponse("fake_user_id", "user@example.com", true))))
+    when(
+      samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+                           ArgumentMatchers.eq(workspaceId.toString),
+                           ArgumentMatchers.eq(SamWorkspaceActions.own),
+                           any()
+      )
+    ).thenReturn(Future.successful(true))
+    when(
+      samDAO.setPolicyPublic(
+        ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+        ArgumentMatchers.eq(workspaceId.toString),
+        ArgumentMatchers.eq(SamWorkspacePolicyNames.reader),
+        ArgumentMatchers.eq(false),
+        any()
+      )
+    ).thenReturn(Future.successful(()))
+    when(samDAO.getAllUsersGroup(any())).thenReturn(Future.successful(WorkbenchEmail("allUsers@fc.org")))
+
+    val gcsDAO = mock[GoogleServicesDAO](RETURNS_SMART_NULLS)
+    when(gcsDAO.terraBucketReaderRole).thenReturn("terra-bucket-reader")
+
+    val googleStorageService = mock[GoogleStorageService[IO]](RETURNS_SMART_NULLS)
+    when(
+      googleStorageService.removeIamPolicy(
+        ArgumentMatchers.eq(GcsBucketName(workspace.bucketName)),
+        ArgumentMatchers.eq(
+          Map[StorageRole, NonEmptyList[Identity]](
+            StorageRole.CustomStorageRole("terra-bucket-reader") -> NonEmptyList.one(Identity.group("allUsers@fc.org"))
+          )
+        ),
+        any(),
+        any(),
+        any()
+      )
+    ).thenReturn(fs2.Stream.empty)
+
+    val service =
+      workspaceSettingServiceConstructor(
+        samDAO = samDAO,
+        workspaceRepository = workspaceRepository,
+        workspaceSettingRepository = workspaceSettingRepository,
+        gcsDAO = gcsDAO,
+        googleStorageService = googleStorageService
+      )
+
+    Await.result(service.setWorkspaceSettings(workspaceName, workspaceSettings), Duration.Inf)
   }
 }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig.{
   GcpBucketLifecycleRule,
   GcpBucketRequesterPaysConfig,
   GcpBucketSoftDeleteConfig,
+  PubliclyReadableConfig,
   SeparateSubmissionFinalOutputsConfig,
   UseCromwellGcpBatchBackendConfig
 }
@@ -25,6 +26,7 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceSettingTypes.{
   GcpBucketLifecycle,
   GcpBucketRequesterPays,
   GcpBucketSoftDelete,
+  PubliclyReadable,
   SeparateSubmissionFinalOutputs,
   UseCromwellGcpBatchBackend,
   WorkspaceSettingType
@@ -596,6 +598,9 @@ case class SeparateSubmissionFinalOutputsSetting(override val config: SeparateSu
 case class UseCromwellGcpBatchBackendSetting(override val config: UseCromwellGcpBatchBackendConfig)
     extends WorkspaceSetting(settingType = WorkspaceSettingTypes.UseCromwellGcpBatchBackend, config)
 
+case class PubliclyReadableSetting(override val config: PubliclyReadableConfig)
+    extends WorkspaceSetting(settingType = WorkspaceSettingTypes.PubliclyReadable, config)
+
 object WorkspaceSettingTypes {
   sealed trait WorkspaceSettingType extends RawlsEnumeration[WorkspaceSettingType] {
     override def toString: String = getClass.getSimpleName.stripSuffix("$")
@@ -608,6 +613,7 @@ object WorkspaceSettingTypes {
     case "gcpbucketrequesterpays"         => GcpBucketRequesterPays
     case "separatesubmissionfinaloutputs" => SeparateSubmissionFinalOutputs
     case "usecromwellgcpbatchbackend"     => UseCromwellGcpBatchBackend
+    case "publiclyreadable"               => PubliclyReadable
     case _                                => throw new RawlsException(s"invalid WorkspaceSetting [$name]")
   }
 
@@ -620,6 +626,8 @@ object WorkspaceSettingTypes {
   case object SeparateSubmissionFinalOutputs extends WorkspaceSettingType
 
   case object UseCromwellGcpBatchBackend extends WorkspaceSettingType
+
+  case object PubliclyReadable extends WorkspaceSettingType
 }
 
 sealed trait WorkspaceSettingConfig
@@ -639,6 +647,8 @@ object WorkspaceSettingConfig {
   case class SeparateSubmissionFinalOutputsConfig(enabled: Boolean) extends WorkspaceSettingConfig
 
   case class UseCromwellGcpBatchBackendConfig(enabled: Boolean) extends WorkspaceSettingConfig
+
+  case class PubliclyReadableConfig(enabled: Boolean) extends WorkspaceSettingConfig
 }
 
 case class WorkspaceSettingResponse(successes: List[WorkspaceSetting], failures: Map[WorkspaceSettingType, ErrorReport])
@@ -1275,6 +1285,10 @@ class WorkspaceJsonSupport extends JsonSupport {
     UseCromwellGcpBatchBackendConfig.apply
   )
 
+  implicit val PubliclyReadableConfigFormat: RootJsonFormat[PubliclyReadableConfig] = jsonFormat1(
+    PubliclyReadableConfig.apply
+  )
+
   implicit object WorkspaceSettingTypeFormat extends RootJsonFormat[WorkspaceSettingType] {
     override def write(obj: WorkspaceSettingType): JsValue = JsString(obj.toString)
 
@@ -1291,6 +1305,7 @@ class WorkspaceJsonSupport extends JsonSupport {
       case config: GcpBucketRequesterPaysConfig         => config.toJson
       case config: SeparateSubmissionFinalOutputsConfig => config.toJson
       case config: UseCromwellGcpBatchBackendConfig     => config.toJson
+      case config: PubliclyReadableConfig               => config.toJson
     }
 
     // We prevent reading WorkspaceSettingConfig directly because we need
@@ -1318,6 +1333,8 @@ class WorkspaceJsonSupport extends JsonSupport {
           SeparateSubmissionFinalOutputsSetting(fields("config").convertTo[SeparateSubmissionFinalOutputsConfig])
         case UseCromwellGcpBatchBackend =>
           UseCromwellGcpBatchBackendSetting(fields("config").convertTo[UseCromwellGcpBatchBackendConfig])
+        case PubliclyReadable =>
+          PubliclyReadableSetting(fields("config").convertTo[PubliclyReadableConfig])
       }
     }
   }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-269

when a workspace publicly readable setting is true, the reader policy public flag must be set to true and the all users group must be granted reader on the workspace's bucket

when a workspace publicly readable setting is false, the reader policy public flag must be set to false and the all users group must be revoked reader on the workspace's bucket

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
