### PR TITLE
[CORE-175] Add aggregation to bucket usage metric query

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -39,7 +39,7 @@ import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Cond
 import com.google.api.services.storage.model._
 import com.google.api.services.storage.{Storage, StorageScopes}
 import com.google.cloud.monitoring.v3.{MetricServiceClient, MetricServiceSettings}
-import com.google.monitoring.v3.{ListTimeSeriesRequest, TimeInterval}
+import com.google.monitoring.v3.{Aggregation, ListTimeSeriesRequest, TimeInterval}
 import com.google.api.services.monitoring.v3.MonitoringScopes
 import com.google.protobuf.util.Timestamps
 import com.google.auth.oauth2.ServiceAccountCredentials
@@ -47,6 +47,8 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.Identity
 import com.google.cloud.storage.Storage.{BucketSourceOption, BucketTargetOption}
 import com.google.cloud.storage.{BucketInfo, Cors, HttpMethod, StorageClass, StorageException}
+import com.google.monitoring.v3.Aggregation.Aligner
+import com.google.protobuf.Duration
 import io.opentelemetry.api.common.AttributeKey
 import org.apache.commons.lang3.StringUtils
 import org.broadinstitute.dsde.rawls.dataaccess.CloudResourceManagerV2Model.{Folder, FolderSearchResponse}
@@ -1155,6 +1157,14 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
       .setName("projects/" + projectName)
       .setFilter("metric.type=\"storage.googleapis.com/storage/v2/total_bytes\"")
       .setInterval(interval)
+      .setAggregation(
+        Aggregation
+          .newBuilder()
+          .setAlignmentPeriod(Duration.newBuilder().setSeconds(86400).build())
+          .setCrossSeriesReducer(Aggregation.Reducer.REDUCE_NONE)
+          .setPerSeriesAligner(Aligner.ALIGN_MEAN)
+          .build()
+      )
       .build()
     val response = metricServiceClient.listTimeSeries(request)
     metricServiceClient.close()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-175
While working on core-175, I occasionally noticed that a call to the new `getBucketUsageV2` API would return nothing.  At first I thought it was a fluke, then maybe an artifact of development, but as I saw it again and again, it became more alarming.   I eventually managed to reproduce it directly in the [google api explorer](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list).  I think it might be that since the time interval of 5 minutes is exactly the sampling rate, there may be a certain period of time every N minutes where 5 minutes back doesn't catch anything; the [description](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-storage) of the metric says "After sampling, data is not visible for up to 690 seconds."  So this probably means we need to go back 11.5 minutes, but then we might get duplicate data points, so instead I went with @davidangb 's suggestion from a slack [discussion](https://broadinstitute.slack.com/archives/C07QQ3L0AHX/p1739285251911529?thread_ts=1739213985.429469&cid=C07QQ3L0AHX) to use aggregation.  In practice, this never produced the empty metrics response while the [current implementation](https://rawls.dsde-dev.broadinstitute.org/#/workspaces_v2/getBucketUsageV2) did.
 
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
