### PR TITLE
CORE-313: round Cromwell cost estimates to 2 decimal places before saving to db

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala
@@ -54,6 +54,8 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import spray.json._
 
+import scala.math.BigDecimal.RoundingMode
+
 /**
  * Created by dvoet on 6/26/15.
  */
@@ -348,7 +350,10 @@ trait SubmissionMonitor extends FutureSupport with LazyLogging with RawlsInstrum
               }
             } else {
               // don't update unless status or cost has actually changed
-              if (costBreakdown.status != workflowRec.status || Option(costBreakdown.cost) != workflowRec.cost) {
+              // round the Cromwell cost estimate to 2 decimal places before comparing.
+              // the existing workflow cost will already be 2 decimal places due to Rawls db precision.
+              val roundedEstimate = costBreakdown.cost.setScale(2, RoundingMode.HALF_UP)
+              if (costBreakdown.status != workflowRec.status || Option(roundedEstimate) != workflowRec.cost) {
                 Future.successful(
                   Option(workflowRec.copy(status = costBreakdown.status, cost = costBreakdown.cost.some))
                 )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorSpec.scala
@@ -1401,6 +1401,67 @@ class SubmissionMonitorSpec(_system: ActorSystem)
       workflowsSecondPass should have size 0
   }
 
+  it should "skip updates to workflow costs if the cost has only changed by fractions of a penny" in withDefaultTestDatabase {
+    dataSource: SlickDataSource =>
+      val expensiveWorkflowId = UUID.randomUUID().toString
+      val expensiveWorkflow = Workflow(Some(expensiveWorkflowId),
+                                       WorkflowStatuses.Submitted,
+                                       new DateTime(),
+                                       Some(testData.sample2.toReference),
+                                       Seq.empty
+      )
+      val submission =
+        testData.submission1.copy(submissionId = UUID.randomUUID().toString, workflows = Seq(expensiveWorkflow))
+      runAndWait(submissionQuery.create(testData.workspace, submission))
+      runAndWait(updateWorkflowExecutionServiceKey("unittestdefault"))
+
+      class CostCapTestExecutionServiceDAO(status: String) extends SubmissionTestExecutionServiceDAO(status) {
+        // this mock DAO uses a var. The first time the test calls getCost it will return $0.09;
+        // the second time it is called it will return $0.0901.
+        var statefulCost = BigDecimal(0.09)
+        val increment = BigDecimal(0.0001)
+
+        override def getCost(id: String, userInfo: UserInfo): Future[WorkflowCostBreakdown] =
+          if (id.equals(expensiveWorkflowId)) {
+            val resp = Future.successful(WorkflowCostBreakdown(id, statefulCost, "USD", status, Seq.empty))
+            statefulCost += increment
+            resp
+          } else {
+            Future.failed(new Exception("Unexpected workflow ID"))
+          }
+      }
+
+      val monitor = createSubmissionMonitor(
+        dataSource,
+        mockSamDAO,
+        mockGoogleServicesDAO,
+        submission,
+        testData.wsName,
+        new CostCapTestExecutionServiceDAO(WorkflowStatuses.Running.toString),
+        perWorkflowCostCap = Option(BigDecimal(99))
+      )
+
+      // Trigger a monitor pass. This first pass will update the workflow to Running/cost=$0.09
+      // due to our CostCapTestExecutionServiceDAO.getCost override
+      val executionServiceStatusResponse = await(monitor.queryExecutionServiceForStatus())
+      val workflowsFirstPass = executionServiceStatusResponse.statusResponse.collect {
+        case Success(Some(recordWithOutputs)) => recordWithOutputs._1
+      }
+      workflowsFirstPass should have size 1
+      workflowsFirstPass.head.status shouldBe "Running"
+      workflowsFirstPass.head.cost should contain(BigDecimal(0.09))
+
+      // make sure the monitor processes the response of the first pass
+      await(monitor.handleStatusResponses(executionServiceStatusResponse))
+
+      // Trigger another monitor pass. This second pass will receive a Cromwell cost of $0.0901,
+      // which it should round, notice that the rounded value hasn't changed, and not return the workflow.
+      val workflowsSecondPass = await(monitor.queryExecutionServiceForStatus()).statusResponse.collect {
+        case Success(Some(recordWithOutputs)) => recordWithOutputs._1
+      }
+      workflowsSecondPass should have size 0
+  }
+
   it should "abort a workflow that has exceeded the per-workflow cost cap but not abort the entire submission" in withDefaultTestDatabase {
     dataSource: SlickDataSource =>
       val cheapWorkflowId = UUID.randomUUID().toString


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-313

From the Jira ticket:
When Cromwell returns a cost estimate for a workflow, that estimate can have “up to 6 decimal places” ([source](https://broadinstitute.slack.com/archives/C07RK8KNWMV/p1739306907763299)).

When Rawls monitors a running workflow, it checks to see if Cromwell’s estimate has changed. If it has, Rawls persists the new estimate to the Rawls db. ([source](https://github.com/broadinstitute/rawls/blob/f246f1f651231c873329b1b7d15c68192acd13e0/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionMonitorActor.scala#L350-L357))

The Rawls db only supports two decimal places ([source](https://github.com/broadinstitute/rawls/blob/f246f1f651231c873329b1b7d15c68192acd13e0/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20240830_workflow_cost.xml#L5)).

This PR rounds the Cromwell cost estimate to 2 decimal places before comparing it to the existing cost estimate and thus skips db writes for fractional changes.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
