### PR TITLE
[CORE-175] Deprecate bucket usage v1

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -3647,7 +3647,8 @@ paths:
       tags:
         - workspaces
       summary: Get bucket usage
-      description: Get the storage bucket usage
+      deprecated: true
+      description: Deprecated in favor of /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/bucketUsage
       operationId: getBucketUsage
       parameters:
         - $ref: '#/components/parameters/workspaceNamespacePathParam'


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-175
Since https://github.com/broadinstitute/rawls/pull/3179 added `getBucketUsageV2`, we can deprecate V1.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
