### PR TITLE
CORE-237: Show cost limit on submission history detail page

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponent.scala
@@ -544,7 +544,8 @@ trait SubmissionComponent {
         ignoreEmptyOutputs = submissionRec.ignoreEmptyOutputs,
         monitoringScript = submissionRec.monitoringScript,
         monitoringImage = submissionRec.monitoringImage,
-        monitoringImageScript = submissionRec.monitoringImageScript
+        monitoringImageScript = submissionRec.monitoringImageScript,
+        perWorkflowCostCap = submissionRec.perWorkflowCostCap
       )
 
     private def unmarshalActiveSubmission(submissionRec: SubmissionRecord,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -463,8 +463,7 @@ class SubmissionsService(
               }
               val costedSubmission = submission.copy(
                 cost = Some(costMap.values.sum), 
-                workflows = costedWorkflows,
-                perWorkflowCostCap = submission.perWorkflowCostCap // Include the cost cap data
+                workflows = costedWorkflows
               )
               costedSubmission
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -461,10 +461,7 @@ class SubmissionsService(
                   case None       => workflow
                 }
               }
-              val costedSubmission = submission.copy(
-                cost = Some(costMap.values.sum), 
-                workflows = costedWorkflows
-              )
+              val costedSubmission = submission.copy(cost = Some(costMap.values.sum), workflows = costedWorkflows)
               costedSubmission
           }
         }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -461,7 +461,11 @@ class SubmissionsService(
                   case None       => workflow
                 }
               }
-              val costedSubmission = submission.copy(cost = Some(costMap.values.sum), workflows = costedWorkflows)
+              val costedSubmission = submission.copy(
+                cost = Some(costMap.values.sum), 
+                workflows = costedWorkflows,
+                perWorkflowCostCap = submission.perWorkflowCostCap // Include the cost cap data
+              )
               costedSubmission
           }
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/SubmissionComponentSpec.scala
@@ -176,6 +176,24 @@ class SubmissionComponentSpec extends TestDriverComponentWithFlatSpecAndMatchers
     assert(runAndWait(submissionQuery.list(workspaceContext)).toSet.contains(submissionExternalEntities))
   }
 
+  it should "save, get and list a submission with a cost threshold (aka cost cap)" in withDefaultTestDatabase {
+    val workspaceContext = testData.workspace
+    val costThreshold = BigDecimal.valueOf(12.34)
+    val testSubmission = submission3.copy(perWorkflowCostCap = Option(costThreshold))
+    // create submission with cost threshold
+    runAndWait(submissionQuery.create(workspaceContext, testSubmission))
+    // validate the .get method
+    val actualGet = runAndWait(submissionQuery.get(workspaceContext, testSubmission.submissionId))
+    actualGet should contain(testSubmission)
+    actualGet.get.perWorkflowCostCap should contain(costThreshold)
+    // validate the .list method
+    val actualList = runAndWait(submissionQuery.list(workspaceContext))
+    actualList should contain(testSubmission)
+    actualList.filter(_.submissionId == testSubmission.submissionId).head.perWorkflowCostCap should contain(
+      costThreshold
+    )
+  }
+
   it should "save, get, list, and delete two submission statuses" in withDefaultTestDatabase {
     val workspaceContext = testData.workspace
 


### PR DESCRIPTION
Ticket: [<Link to Jira ticket>](https://broadworkbench.atlassian.net/browse/CORE-237)

We should show what the cost limit was set to on the submission history page so that a user knows what the cost limit was set to when reviewing the submission.
---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
