### PR TITLE
[CORE-319] Allow adding users upon workspace creation

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6216,6 +6216,11 @@ components:
           description: Optional, array of policies to attach to the workspace.
           items:
             $ref: '#/components/schemas/WorkspacePolicy'
+        addUsers:
+          type: array
+          description: Optional, array of users to add to the workspace
+          items:
+            $ref: '#/components/schemas/WorkspaceACLUpdate'
       description: ""
     WorkspaceRequestClone:
       required:

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1790,14 +1790,61 @@ class WorkspaceService(
     } else {
       Set(WorkbenchEmail(ctx.userInfo.userEmail.value))
     }
+    val groupedAclUpdates: Map[WorkspaceAccessLevel, List[WorkspaceACLUpdate]] = workspaceRequest.addUsers
+      .map { aclUpdates =>
+        aclUpdates.groupBy(_.accessLevel)
+      }
+      .getOrElse(Map.empty)
+
     val ownerPolicy =
-      SamWorkspacePolicyNames.owner -> SamPolicy(ownerPolicyMembership, Set.empty, Set(SamWorkspaceRoles.owner))
-    val writerPolicy = SamWorkspacePolicyNames.writer -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.writer))
-    val readerPolicy = SamWorkspacePolicyNames.reader -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.reader))
+      SamWorkspacePolicyNames.owner -> SamPolicy(
+        ownerPolicyMembership ++ groupedAclUpdates
+          .getOrElse(WorkspaceAccessLevels.Owner, Set.empty)
+          .map(update => WorkbenchEmail(update.email))
+          .toSet,
+        Set.empty,
+        Set(SamWorkspaceRoles.owner)
+      )
+    val writerPolicy =
+      SamWorkspacePolicyNames.writer -> SamPolicy(
+        groupedAclUpdates
+          .getOrElse(WorkspaceAccessLevels.Write, Set.empty)
+          .map(update => WorkbenchEmail(update.email))
+          .toSet,
+        Set.empty,
+        Set(SamWorkspaceRoles.writer)
+      )
+    val readerPolicy =
+      SamWorkspacePolicyNames.reader -> SamPolicy(
+        groupedAclUpdates
+          .getOrElse(WorkspaceAccessLevels.Read, Set.empty)
+          .map(update => WorkbenchEmail(update.email))
+          .toSet,
+        Set.empty,
+        Set(SamWorkspaceRoles.reader)
+      )
+
     val shareReaderPolicy =
-      SamWorkspacePolicyNames.shareReader -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.shareReader))
+      SamWorkspacePolicyNames.shareReader -> SamPolicy(
+        groupedAclUpdates
+          .getOrElse(WorkspaceAccessLevels.Read, Set.empty)
+          .filter(_.canShare.get)
+          .map(update => WorkbenchEmail(update.email))
+          .toSet,
+        Set.empty,
+        Set(SamWorkspaceRoles.shareReader)
+      )
     val shareWriterPolicy =
-      SamWorkspacePolicyNames.shareWriter -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.shareWriter))
+      SamWorkspacePolicyNames.shareWriter -> SamPolicy(
+        groupedAclUpdates
+          .getOrElse(WorkspaceAccessLevels.Write, Set.empty)
+          .filter(update => update.canShare.contains(true))
+          .map(update => WorkbenchEmail(update.email))
+          .toSet,
+        Set.empty,
+        Set(SamWorkspaceRoles.shareWriter)
+      )
+    // TODO what goes here
     val canComputePolicy =
       SamWorkspacePolicyNames.canCompute -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCompute))
     val canCatalogPolicy =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -62,7 +62,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
-import com.google.cloud.monitoring.v3.{MetricServiceClient, MetricServiceSettings}
 
 /**
  * Created by dvoet on 4/27/15.
@@ -1790,63 +1789,71 @@ class WorkspaceService(
     } else {
       Set(WorkbenchEmail(ctx.userInfo.userEmail.value))
     }
+
     val groupedAclUpdates: Map[WorkspaceAccessLevel, List[WorkspaceACLUpdate]] = workspaceRequest.addUsers
       .map { aclUpdates =>
         aclUpdates.groupBy(_.accessLevel)
       }
       .getOrElse(Map.empty)
 
+    def getEmailsByAccessLevel(access: WorkspaceAccessLevel): Set[WorkbenchEmail] =
+      groupedAclUpdates
+        .getOrElse(access, Set.empty)
+        .map(update => WorkbenchEmail(update.email))
+        .toSet
+
+    def getShareEmailsByAccessLevel(access: WorkspaceAccessLevel): Set[WorkbenchEmail] =
+      groupedAclUpdates
+        .getOrElse(access, Set.empty)
+        .filter(_.canShare.get)
+        .map(update => WorkbenchEmail(update.email))
+        .toSet
+
     val ownerPolicy =
       SamWorkspacePolicyNames.owner -> SamPolicy(
-        ownerPolicyMembership ++ groupedAclUpdates
-          .getOrElse(WorkspaceAccessLevels.Owner, Set.empty)
-          .map(update => WorkbenchEmail(update.email))
-          .toSet,
+        ownerPolicyMembership ++ getEmailsByAccessLevel(WorkspaceAccessLevels.Owner),
         Set.empty,
         Set(SamWorkspaceRoles.owner)
       )
     val writerPolicy =
       SamWorkspacePolicyNames.writer -> SamPolicy(
-        groupedAclUpdates
-          .getOrElse(WorkspaceAccessLevels.Write, Set.empty)
-          .map(update => WorkbenchEmail(update.email))
-          .toSet,
+        getEmailsByAccessLevel(WorkspaceAccessLevels.Write),
         Set.empty,
         Set(SamWorkspaceRoles.writer)
       )
     val readerPolicy =
       SamWorkspacePolicyNames.reader -> SamPolicy(
-        groupedAclUpdates
-          .getOrElse(WorkspaceAccessLevels.Read, Set.empty)
-          .map(update => WorkbenchEmail(update.email))
-          .toSet,
+        getEmailsByAccessLevel(WorkspaceAccessLevels.Read),
         Set.empty,
         Set(SamWorkspaceRoles.reader)
       )
 
     val shareReaderPolicy =
       SamWorkspacePolicyNames.shareReader -> SamPolicy(
-        groupedAclUpdates
-          .getOrElse(WorkspaceAccessLevels.Read, Set.empty)
-          .filter(_.canShare.get)
-          .map(update => WorkbenchEmail(update.email))
-          .toSet,
+        getShareEmailsByAccessLevel(WorkspaceAccessLevels.Read),
         Set.empty,
         Set(SamWorkspaceRoles.shareReader)
       )
     val shareWriterPolicy =
       SamWorkspacePolicyNames.shareWriter -> SamPolicy(
-        groupedAclUpdates
-          .getOrElse(WorkspaceAccessLevels.Write, Set.empty)
-          .filter(update => update.canShare.contains(true))
-          .map(update => WorkbenchEmail(update.email))
-          .toSet,
+        getShareEmailsByAccessLevel(WorkspaceAccessLevels.Write),
         Set.empty,
         Set(SamWorkspaceRoles.shareWriter)
       )
-    // TODO what goes here
+
     val canComputePolicy =
-      SamWorkspacePolicyNames.canCompute -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCompute))
+      SamWorkspacePolicyNames.canCompute -> SamPolicy(
+        workspaceRequest.addUsers
+          .map { aclUpdates =>
+            aclUpdates
+              .filter(_.canCompute.get)
+              .map(update => WorkbenchEmail(update.email))
+              .toSet
+          }
+          .getOrElse(Set.empty),
+        Set.empty,
+        Set(SamWorkspaceRoles.canCompute)
+      )
     val canCatalogPolicy =
       SamWorkspacePolicyNames.canCatalog -> SamPolicy(Set.empty, Set.empty, Set(SamWorkspaceRoles.canCatalog))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1409,6 +1409,71 @@ class WorkspaceServiceSpec
       .roles should contain theSameElementsAs Set(SamWorkspaceRoles.canCatalog)
   }
 
+  it should "add user policies if included" in withTestDataServices { services =>
+    val newWorkspaceName = "workspaceResourcePoliciesTest"
+    val readerOnly = WorkspaceACLUpdate("readerOnly@email.com", WorkspaceAccessLevels.Read, Some(false), Some(false))
+    val readerShare = WorkspaceACLUpdate("readerShare@email.com", WorkspaceAccessLevels.Read, Some(true), Some(false))
+    val writerOnly = WorkspaceACLUpdate("writerOnly@email.com", WorkspaceAccessLevels.Write, Some(false), Some(false))
+    val writerShare = WorkspaceACLUpdate("writerShare@email.com", WorkspaceAccessLevels.Write, Some(true), Some(false))
+    val writerCompute =
+      WorkspaceACLUpdate("writerCompute@email.com", WorkspaceAccessLevels.Write, Some(true), Some(true))
+    val owner = WorkspaceACLUpdate("owner@email.com", WorkspaceAccessLevels.Owner, Some(true), Some(true))
+    val workspaceRequest =
+      WorkspaceRequest(testData.testProject1Name.value,
+                       newWorkspaceName,
+                       Map.empty,
+                       addUsers = Some(List(readerOnly, readerShare, writerOnly, writerShare, writerCompute, owner))
+      )
+    val workspace = Await.result(services.workspaceService.createWorkspace(workspaceRequest), Duration.Inf)
+
+    val requestedPoliciesCaptor = captor[Map[SamResourcePolicyName, SamPolicy]]
+    verify(services.samDAO).createResourceFull(
+      ArgumentMatchers.eq(SamResourceTypeNames.workspace),
+      ArgumentMatchers.eq(workspace.workspaceId),
+      requestedPoliciesCaptor.capture,
+      any[Set[String]],
+      any[RawlsRequestContext],
+      ArgumentMatchers.eq(None)
+    )
+
+    val requestedPolicies = requestedPoliciesCaptor.getValue
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.projectOwner, fail("Missing project-owner policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("foo@bar.com"))
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.owner, fail("Missing owner policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("owner-access"),
+                                                         WorkbenchEmail("owner@email.com")
+    )
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.writer, fail("Missing writer policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("writerOnly@email.com"),
+                                                         WorkbenchEmail("writerShare@email.com"),
+                                                         WorkbenchEmail("writerCompute@email.com")
+    )
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.reader, fail("Missing reader policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("readerOnly@email.com"),
+                                                         WorkbenchEmail("readerShare@email.com")
+    )
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.shareWriter, fail("Missing share-writer policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("writerShare@email.com"),
+                                                         WorkbenchEmail("writerCompute@email.com")
+    )
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.shareReader, fail("Missing share-reader policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("readerShare@email.com"))
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.canCompute, fail("Missing can-compute policy"))
+      .memberEmails should contain theSameElementsAs Set(WorkbenchEmail("writerCompute@email.com"),
+                                                         WorkbenchEmail("owner@email.com")
+    )
+    requestedPolicies
+      .getOrElse(SamWorkspacePolicyNames.canCatalog, fail("Missing can-catalog policy"))
+      .memberEmails should contain theSameElementsAs Set.empty
+  }
+
   it should "create Sam resource for google project" in withTestDataServices { services =>
     val newWorkspaceName = "new-workspace"
     val workspaceRequest = WorkspaceRequest(testData.testProject1Name.value, newWorkspaceName, Map.empty)

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceModel.scala
@@ -191,7 +191,8 @@ case class WorkspaceRequest(
   bucketLocation: Option[String] = None,
   enhancedBucketLogging: Option[Boolean] = Option(false),
   protectedData: Option[Boolean] = Option(false),
-  policies: Option[List[WorkspacePolicy]] = None
+  policies: Option[List[WorkspacePolicy]] = None,
+  addUsers: Option[List[WorkspaceACLUpdate]] = None
 ) extends Attributable {
   def toWorkspaceName: WorkspaceName = WorkspaceName(namespace, name)
   def briefName: String = toWorkspaceName.toString
@@ -1227,6 +1228,7 @@ class WorkspaceJsonSupport extends JsonSupport {
   import DataReferenceModelJsonSupport.DataReferenceNameFormat
   import UserModelJsonSupport.RawlsBillingAccountNameFormat
   import WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
+  import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceACLUpdateFormat
   import spray.json.DefaultJsonProtocol._
 
   implicit object SortDirectionFormat extends JsonFormat[SortDirection] {
@@ -1361,7 +1363,7 @@ class WorkspaceJsonSupport extends JsonSupport {
 
   implicit val WorkspacePolicyFormat: RootJsonFormat[WorkspacePolicy] = jsonFormat3(WorkspacePolicy.apply)
 
-  implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat10(WorkspaceRequest)
+  implicit val WorkspaceRequestFormat: RootJsonFormat[WorkspaceRequest] = jsonFormat11(WorkspaceRequest)
 
   implicit val workspaceFieldSpecsFormat: RootJsonFormat[WorkspaceFieldSpecs] = jsonFormat1(WorkspaceFieldSpecs.apply)
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-319
This adds an `addUsers` parameter to a `WorkspaceRequest` that allows collaborators to be added to a workspace simultaneously with workspace creation.  I've used the same object, `WorkspaceACLUpdate` that is defined for adding users after workspace creation, as that seemed logical, but will listen to arguments that some new or different argument makes more sense.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
