### PR TITLE
[CORE-307] Fix Spend Report Visibility for Billing Project Users (Workspace Owners)

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -467,41 +467,6 @@ class SpendReportingService(
         workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
-  def getSpendReportableWorkspaceGoogleProjectsInBillingProject(
-    projectName: RawlsBillingProjectName,
-    childContext: RawlsRequestContext
-  ): Future[Map[GoogleProjectId, WorkspaceName]] = {
-
-    def filterProjects(projects: Map[RawlsBillingProjectName, Seq[Workspace]]): Map[GoogleProjectId, WorkspaceName] =
-      projects.flatMap { case (_, value) =>
-        value.collect {
-          case workspace if workspace.namespace == projectName.value =>
-            workspace.googleProjectId -> workspace.toWorkspaceName
-        }
-      }
-
-    for {
-      projects <- getSpendReportableWorkspaceGoogleProjects(childContext)
-      filteredProjects = filterProjects(projects)
-      hasAction <- samDAO.userHasAction(SamResourceTypeNames.billingProject,
-                                        projectName.value,
-                                        SamBillingProjectActions.readSpendReport,
-                                        childContext
-      )
-      result <-
-        if (hasAction || filteredProjects.nonEmpty) {
-          Future.successful(filteredProjects)
-        } else {
-          Future.failed(
-            RawlsExceptionWithErrorReport(
-              StatusCodes.Forbidden,
-              s"${childContext.userInfo.userEmail.value} cannot perform ${SamBillingProjectActions.readSpendReport.value} on project ${projectName.value}"
-            )
-          )
-        }
-    } yield result
-  }
-
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
     start: DateTime,
@@ -511,7 +476,14 @@ class SpendReportingService(
     validateReportParameters(start, end)
     for {
       spendExportConf <- getSpendExportConfiguration(project)
-      projectNames <- getSpendReportableWorkspaceGoogleProjectsInBillingProject(project, childContext)
+      projectNames <- getSpendReportableWorkspaceGoogleProjects(ctx).map { workspacesByProject =>
+        workspacesByProject
+          .getOrElse(project, Seq.empty)
+          .map { workspace =>
+            workspace.googleProjectId -> workspace.toWorkspaceName
+          }
+          .toMap
+      }
 
       query = getQuery(aggregations, spendExportConf)
       queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -311,13 +311,6 @@ class SpendReportingService(
 
       }
 
-  def getWorkspaceGoogleProjects(projectName: RawlsBillingProjectName): Future[Map[GoogleProjectId, WorkspaceName]] =
-    dataSource.inTransaction(_.workspaceQuery.listWithBillingProject(projectName)).map {
-      _.collect {
-        case w if w.workspaceVersion == WorkspaceVersions.V2 => w.googleProjectId -> w.toWorkspaceName
-      }.toMap
-    }
-
   def validateReportParameters(startDate: DateTime, endDate: DateTime): Unit = if (startDate.isAfter(endDate)) {
     throw RawlsExceptionWithErrorReport(
       StatusCodes.BadRequest,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -269,18 +269,6 @@ class SpendReportingService(
   def bytesProcessedCounter: Histogram =
     spendReportingMetrics.expand(BigQueryKey, BigQueryBytesProcessedMetric).asHistogram("bytes")
 
-  private def requireProjectAction[T](projectName: RawlsBillingProjectName, action: SamResourceAction)(
-    op: => Future[T]
-  ): Future[T] =
-    samDAO.userHasAction(SamResourceTypeNames.billingProject, projectName.value, action, ctx).flatMap {
-      case true => op
-      case false =>
-        throw RawlsExceptionWithErrorReport(
-          StatusCodes.Forbidden,
-          s"${ctx.userInfo.userEmail.value} cannot perform ${action.value} on project ${projectName.value}"
-        )
-    }
-
   private def toISODateString(dt: DateTime): String = dt.toString(ISODateTimeFormat.date())
 
   def getSpendExportConfiguration(project: RawlsBillingProjectName): Future[BillingProjectSpendExport] = dataSource
@@ -462,7 +450,7 @@ class SpendReportingService(
     bytesProcessedCounter += stats.getEstimatedBytesProcessed
   }
 
-  def getOwnedWorkspaceGoogleProjects(
+  def getSpendReportableWorkspaceGoogleProjects(
     childContext: RawlsRequestContext
   ): Future[Map[RawlsBillingProjectName, Seq[Workspace]]] =
     samDAO
@@ -482,23 +470,40 @@ class SpendReportingService(
           workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
-  def getOwnedWorkspaceGoogleProjectsInProject(
+  def getSpendReportableWorkspaceGoogleProjectsInBillingProject(
     projectName: RawlsBillingProjectName,
     childContext: RawlsRequestContext
-  ): Future[Map[GoogleProjectId, WorkspaceName]] =
-    requireProjectAction(projectName, SamBillingProjectActions.createWorkspace) {
-      for {
-        // Get user owned workspaces in the project
-        projectNames <- getOwnedWorkspaceGoogleProjects(childContext).map {
-          _.flatMap { case (_, value) =>
-            value.collect {
-              case workspace if workspace.namespace == projectName.value =>
-                workspace.googleProjectId -> workspace.toWorkspaceName
-            }
-          }.toMap
+  ): Future[Map[GoogleProjectId, WorkspaceName]] = {
+
+    def filterProjects(projects: Map[RawlsBillingProjectName, Seq[Workspace]]): Map[GoogleProjectId, WorkspaceName] =
+      projects.flatMap { case (_, value) =>
+        value.collect {
+          case workspace if workspace.namespace == projectName.value =>
+            workspace.googleProjectId -> workspace.toWorkspaceName
         }
-      } yield projectNames
-    }
+      }
+
+    for {
+      projects <- getSpendReportableWorkspaceGoogleProjects(childContext)
+      filteredProjects = filterProjects(projects)
+      hasAction <- samDAO.userHasAction(SamResourceTypeNames.billingProject,
+                                        projectName.value,
+                                        SamBillingProjectActions.readSpendReport,
+                                        childContext
+      )
+      result <-
+        if (hasAction || filteredProjects.nonEmpty) {
+          Future.successful(filteredProjects)
+        } else {
+          Future.failed(
+            RawlsExceptionWithErrorReport(
+              StatusCodes.Forbidden,
+              s"${childContext.userInfo.userEmail.value} cannot perform ${SamBillingProjectActions.readSpendReport.value} on project ${projectName.value}"
+            )
+          )
+        }
+    } yield result
+  }
 
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
@@ -509,7 +514,7 @@ class SpendReportingService(
     validateReportParameters(start, end)
     for {
       spendExportConf <- getSpendExportConfiguration(project)
-      projectNames <- getOwnedWorkspaceGoogleProjectsInProject(project, childContext)
+      projectNames <- getSpendReportableWorkspaceGoogleProjectsInBillingProject(project, childContext)
 
       query = getQuery(aggregations, spendExportConf)
       queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
@@ -634,7 +639,7 @@ class SpendReportingService(
   ): Future[Map[String, Seq[(GoogleProjectId, WorkspaceName)]]] =
     traceFutureWithParent("getBillingWithSpendPermission", parentContext) { childContext =>
       for {
-        groupedWorkspaces <- getOwnedWorkspaceGoogleProjects(childContext)
+        groupedWorkspaces <- getSpendReportableWorkspaceGoogleProjects(childContext)
         // Only use the BPs we know exist in the DB and are GCP
         spendConfigs <-
           if (groupedWorkspaces.isEmpty) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -477,7 +477,9 @@ class SpendReportingService(
     aggregations: Set[SpendReportingAggregationKeyWithSub]
   ): Future[SpendReportingResults] = {
     validateReportParameters(start, end)
-    requireProjectAction(project, SamBillingProjectActions.readSpendReport) {
+    requireProjectAction(project,
+                         SamBillingProjectActions.createWorkspace
+    ) { // read_spend_report is a subset of create_workspace and allows workspace owners to see spend data
       for {
         spendExportConf <- getSpendExportConfiguration(project)
         projectNames <- getWorkspaceGoogleProjects(project)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -459,15 +459,12 @@ class SpendReportingService(
         SamWorkspaceActions.readSpendReport,
         childContext
       )
-      .flatMap {
-        case ownerWorkspaces if ownerWorkspaces.isEmpty =>
-          Future.successful(Map.empty[RawlsBillingProjectName, Seq[Workspace]])
-        case ownerWorkspaces =>
-          val validWorkspaceIds = ownerWorkspaces
-            .map(_.getResourceId)
-            .filter(resourceId => Try(UUID.fromString(resourceId)).isSuccess) // filter out non-UUIDs
-            .toList
-          workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
+      .flatMap { ownerWorkspaces =>
+        val validWorkspaceIds = ownerWorkspaces
+          .map(_.getResourceId)
+          .filter(resourceId => Try(UUID.fromString(resourceId)).isSuccess) // filter out non-UUIDs
+          .toList
+        workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
   def getSpendReportableWorkspaceGoogleProjectsInBillingProject(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -1,10 +1,9 @@
 package org.broadinstitute.dsde.rawls.spendreporting
 
-import java.util.{Currency, UUID}
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, JobStatistics, Option => _, _}
+import com.google.cloud.bigquery.{FieldValueList, JobStatistics, Option => _, _}
 import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, Histogram}
 import org.broadinstitute.dsde.rawls.billing.{
@@ -17,18 +16,18 @@ import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.metrics.{GoogleInstrumented, HitRatioGauge, RawlsInstrumented}
 import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeyWithSub, _}
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService._
+import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
-import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days}
 
+import java.util.{Currency, UUID}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
-import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
-
 import scala.util.Try
 
 object SpendReportingService {
@@ -470,34 +469,68 @@ class SpendReportingService(
     bytesProcessedCounter += stats.getEstimatedBytesProcessed
   }
 
+  def getOwnedWorkspaceGoogleProjects(
+    childContext: RawlsRequestContext
+  ): Future[Map[RawlsBillingProjectName, Seq[Workspace]]] =
+    samDAO
+      .listResourcesWithActions(
+        SamResourceTypeNames.workspace,
+        SamWorkspaceActions.readSpendReport,
+        childContext
+      )
+      .flatMap {
+        case ownerWorkspaces if ownerWorkspaces.isEmpty =>
+          Future.successful(Map.empty[RawlsBillingProjectName, Seq[Workspace]])
+        case ownerWorkspaces =>
+          val validWorkspaceIds = ownerWorkspaces
+            .map(_.getResourceId)
+            .filter(resourceId => Try(UUID.fromString(resourceId)).isSuccess) // filter out non-UUIDs
+            .toList
+          workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
+      }
+
+  def getOwnedWorkspaceGoogleProjectsInProject(
+    projectName: RawlsBillingProjectName,
+    childContext: RawlsRequestContext
+  ): Future[Map[GoogleProjectId, WorkspaceName]] =
+    requireProjectAction(projectName, SamBillingProjectActions.createWorkspace) {
+      for {
+        // Get user owned workspaces in the project
+        projectNames <- getOwnedWorkspaceGoogleProjects(childContext).map {
+          _.flatMap { case (_, value) =>
+            value.collect {
+              case workspace if workspace.namespace == projectName.value =>
+                workspace.googleProjectId -> workspace.toWorkspaceName
+            }
+          }.toMap
+        }
+      } yield projectNames
+    }
+
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
     start: DateTime,
     end: DateTime,
     aggregations: Set[SpendReportingAggregationKeyWithSub]
-  ): Future[SpendReportingResults] = {
+  ): Future[SpendReportingResults] = traceFutureWithParent("getSpendForGCPBillingProject", ctx) { childContext =>
     validateReportParameters(start, end)
-    requireProjectAction(project,
-                         SamBillingProjectActions.createWorkspace
-    ) { // read_spend_report is a subset of create_workspace and allows workspace owners to see spend data
-      for {
-        spendExportConf <- getSpendExportConfiguration(project)
-        projectNames <- getWorkspaceGoogleProjects(project)
+    for {
+      spendExportConf <- getSpendExportConfiguration(project)
+      projectNames <- getOwnedWorkspaceGoogleProjectsInProject(project, childContext)
 
-        query = getQuery(aggregations, spendExportConf)
-        queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
+      query = getQuery(aggregations, spendExportConf)
+      queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
 
-        job: Job <- bigQueryService.use(_.runJob(queryJob)).unsafeToFuture().map(_.waitFor())
-        _ = logSpendQueryStats(job.getStatistics[JobStatistics.QueryStatistics])
-        result = job.getQueryResults()
-      } yield result.getValues.asScala.toList match {
-        case Nil =>
-          throw RawlsExceptionWithErrorReport(
-            StatusCodes.NotFound,
-            s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
-          )
-        case rows => extractSpendReportingResults(rows, start, end, projectNames, aggregations)
-      }
+      job: Job <- bigQueryService.use(_.runJob(queryJob)).unsafeToFuture().map(_.waitFor())
+      _ = logSpendQueryStats(job.getStatistics[JobStatistics.QueryStatistics])
+      result = job.getQueryResults()
+    } yield result.getValues.asScala.toList match {
+      case Nil =>
+        throw RawlsExceptionWithErrorReport(
+          StatusCodes.NotFound,
+          s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+        )
+      case rows => extractSpendReportingResults(rows, start, end, projectNames, aggregations)
     }
   }
 
@@ -608,23 +641,7 @@ class SpendReportingService(
   ): Future[Map[String, Seq[(GoogleProjectId, WorkspaceName)]]] =
     traceFutureWithParent("getBillingWithSpendPermission", parentContext) { childContext =>
       for {
-        ownerWorkspaces <- samDAO.listResourcesWithActions(
-          SamResourceTypeNames.workspace,
-          SamWorkspaceActions.readSpendReport,
-          childContext
-        )
-        groupedWorkspaces <-
-          if (ownerWorkspaces.isEmpty) {
-            Future.successful(Map.empty[RawlsBillingProjectName, Seq[Workspace]])
-          } else {
-            // Ignore non-UUID workspaceIds; these shouldn't happen but if they do, we don't want them
-            workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(
-              ownerWorkspaces
-                .map(_.getResourceId)
-                .filter(resourceId => Try(UUID.fromString(resourceId)).isSuccess)
-                .toList
-            )
-          }
+        groupedWorkspaces <- getOwnedWorkspaceGoogleProjects(childContext)
         // Only use the BPs we know exist in the DB and are GCP
         spendConfigs <-
           if (groupedWorkspaces.isEmpty) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -735,7 +735,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
   }
 
-  it should "throw an exception when user does not have read_spend_report" in {
+  it should "throw an exception when user does not have create_workspace" in {
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     val billingRepository = mock[BillingRepository]
     val bpmDAO = mock[BillingProfileManagerDAO]
@@ -743,7 +743,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(
       samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
                            any(),
-                           mockitoEq(SamBillingProjectActions.readSpendReport),
+                           mockitoEq(SamBillingProjectActions.createWorkspace),
                            mockitoEq(testContext)
       )
     ).thenReturn(Future.successful(false))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -721,7 +721,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
-      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
@@ -737,7 +737,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
   }
 
-  it should "throw an exception when user does not have create_workspace" in {
+  it should "throw an exception when user does not have read_spend_report" in {
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     val billingRepository = mock[BillingRepository]
     val bpmDAO = mock[BillingProfileManagerDAO]
@@ -755,10 +755,12 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(
       samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
                            any(),
-                           mockitoEq(SamBillingProjectActions.createWorkspace),
+                           mockitoEq(SamBillingProjectActions.readSpendReport),
                            mockitoEq(testContext)
       )
     ).thenReturn(Future.successful(false))
+    when(samDAO.listResourcesWithActions(any(), any(), any()))
+      .thenReturn(Future.successful(List.empty[FilteredFlatResource]))
 
     val service = new SpendReportingService(
       testContext,
@@ -773,7 +775,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
-        service.getOwnedWorkspaceGoogleProjectsInProject(
+        service.getSpendReportableWorkspaceGoogleProjectsInBillingProject(
           billingProject.projectName,
           testContext
         ),
@@ -782,7 +784,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     }
 
     e.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
-    e.errorReport.message should include("cannot perform create_workspace on project")
+    e.errorReport.message should include("cannot perform read_spend_report on project")
   }
 
   it should "throw an exception if the billing project cannot be found" in {
@@ -874,7 +876,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
-      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
@@ -993,7 +995,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
-      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1044,7 +1046,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
-      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1792,7 +1794,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
-  "getOwnedWorkspaceGoogleProjects" should "return an empty map when no workspaces are owned" in {
+  "getSpendReportableWorkspaceGoogleProjects" should "return an empty map when no workspaces are owned" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
     val service = new SpendReportingService(
@@ -1808,7 +1810,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List()))
 
-    val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
+    val result = Await.result(service.getSpendReportableWorkspaceGoogleProjects(testContext), Duration.Inf)
     result shouldBe empty
   }
 
@@ -1833,12 +1835,12 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(workspaceService.getGCPWorkspacesByBillingProjects(any()))
       .thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
 
-    val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
+    val result = Await.result(service.getSpendReportableWorkspaceGoogleProjects(testContext), Duration.Inf)
     result should contain key RawlsBillingProjectName("test-project")
     result(RawlsBillingProjectName("test-project")) should contain(workspace)
   }
 
-  "getOwnedWorkspaceGoogleProjectsInProject" should "throw an exception when user does not have create_workspace action" in {
+  "getSpendReportableWorkspaceGoogleProjectsInBillingProject" should "throw an exception when user does not have read_spend_report action" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
     val service = new SpendReportingService(
@@ -1853,19 +1855,23 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     )
 
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(false))
+    when(samDAO.listResourcesWithActions(any(), any(), any()))
+      .thenReturn(Future.successful(List.empty[FilteredFlatResource]))
 
     val exception = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
-        service.getOwnedWorkspaceGoogleProjectsInProject(RawlsBillingProjectName("test-project"), testContext),
+        service.getSpendReportableWorkspaceGoogleProjectsInBillingProject(RawlsBillingProjectName("test-project"),
+                                                                          testContext
+        ),
         Duration.Inf
       )
     }
 
     exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
-    exception.errorReport.message should include("cannot perform create_workspace on project")
+    exception.errorReport.message should include("cannot perform read_spend_report on project")
   }
 
-  it should "return a map of Google project IDs to workspace names when user has create_workspace action" in {
+  it should "return a map of Google project IDs to workspace names when user has read_spend_report action" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
     val service = spy(
@@ -1889,7 +1895,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(workspaceService.getGCPWorkspacesByBillingProjects(any()))
       .thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
 
-    val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
+    val result = Await.result(service.getSpendReportableWorkspaceGoogleProjects(testContext), Duration.Inf)
     result should contain key RawlsBillingProjectName("test-project")
     result(RawlsBillingProjectName("test-project")) should contain(workspace)
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -669,7 +669,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                                expectedCompute: BigDecimal,
                                expectedStorage: BigDecimal,
                                expectedOther: BigDecimal
-  ) = {
+  ): Unit = {
     actualSpendData.cost shouldBe expectedTotal.toString
     val aggSub = actualSpendData.subAggregation.get
     aggSub.aggregationKey shouldBe SpendReportingAggregationKeys.Category
@@ -680,7 +680,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                                  expectedCompute: BigDecimal,
                                  expectedStorage: BigDecimal,
                                  expectedOther: BigDecimal
-  ) = {
+  ): Unit = {
     actualSpendData.length shouldBe 3
     actualSpendData.foreach { spendData =>
       spendData.category match {
@@ -719,7 +719,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getWorkspaceGoogleProjects(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
@@ -739,19 +739,29 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     val billingRepository = mock[BillingRepository]
     val bpmDAO = mock[BillingProfileManagerDAO]
-    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+
+    val billingProject = RawlsBillingProject(
+      RawlsBillingProjectName("test-project"),
+      CreationStatuses.Ready,
+      Option(RawlsBillingAccountName("test-account")),
+      None,
+      billingProfileId = Option.apply(UUID.randomUUID().toString)
+    )
+
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
     when(
       samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
-                           any(),
-                           mockitoEq(SamBillingProjectActions.createWorkspace),
-                           mockitoEq(testContext)
+        any(),
+        mockitoEq(SamBillingProjectActions.createWorkspace),
+        mockitoEq(testContext)
       )
     ).thenReturn(Future.successful(false))
-    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+
     val service = new SpendReportingService(
       testContext,
       mock[SlickDataSource],
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
       billingRepository,
       bpmDAO,
       samDAO,
@@ -761,16 +771,16 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
-        service.getSpendForGCPBillingProject(
+        service.getOwnedWorkspaceGoogleProjectsInProject(
           billingProject.projectName,
-          DateTime.now().minusDays(1),
-          DateTime.now(),
-          Set.empty
+          testContext
         ),
         Duration.Inf
       )
     }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.Forbidden)
+
+    e.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    e.errorReport.message should include("cannot perform create_workspace on project")
   }
 
   it should "throw an exception if the billing project cannot be found" in {
@@ -780,7 +790,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
     val dataSource = mock[SlickDataSource]
     when(dataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any())).thenReturn(Future.successful(None))
-    val service = new SpendReportingService(
+    val service = spy(new SpendReportingService(
       testContext,
       dataSource,
       Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
@@ -789,7 +799,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       samDAO,
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor
-    )
+    ))
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(service.getSpendExportConfiguration(RawlsBillingProjectName("fakeProject")), Duration.Inf)
@@ -858,7 +868,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getWorkspaceGoogleProjects(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
@@ -975,7 +985,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getWorkspaceGoogleProjects(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1024,7 +1034,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getWorkspaceGoogleProjects(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1798,4 +1808,96 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
+  "getOwnedWorkspaceGoogleProjects" should "return an empty map when no workspaces are owned" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+    val service = new SpendReportingService(
+      testContext,
+      mock[SlickDataSource],
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      spendReportingServiceConfig,
+      _ => workspaceService
+    )
+
+    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List()))
+
+    val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
+    result shouldBe empty
+  }
+
+  it should "return a map of workspaces grouped by billing project" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+    val service = new SpendReportingService(
+      testContext,
+      mock[SlickDataSource],
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      spendReportingServiceConfig,
+      _ => workspaceService
+    )
+
+    val workspace = TestData.workspace1
+
+    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List(new FilteredFlatResource().resourceId(workspace.workspaceId))))
+    when(workspaceService.getGCPWorkspacesByBillingProjects(any())).thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
+
+    val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
+    result should contain key RawlsBillingProjectName("test-project")
+    result(RawlsBillingProjectName("test-project")) should contain(workspace)
+  }
+
+  "getOwnedWorkspaceGoogleProjectsInProject" should "throw an exception when user does not have create_workspace action" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+    val service = new SpendReportingService(
+      testContext,
+      mock[SlickDataSource],
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      spendReportingServiceConfig,
+      _ => workspaceService
+    )
+
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(false))
+
+    val exception = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(service.getOwnedWorkspaceGoogleProjectsInProject(RawlsBillingProjectName("test-project"), testContext), Duration.Inf)
+    }
+
+    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
+    exception.errorReport.message should include("cannot perform create_workspace on project")
+  }
+
+  it should "return a map of Google project IDs to workspace names when user has create_workspace action" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+    val service = spy(new SpendReportingService(
+      testContext,
+      mock[SlickDataSource],
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      spendReportingServiceConfig,
+      _ => workspaceService
+    ))
+
+    val workspace = TestData.workspace1
+
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List(new FilteredFlatResource().resourceId(workspace.workspaceId))))
+    when(workspaceService.getGCPWorkspacesByBillingProjects(any())).thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
+
+    val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
+    result should contain key RawlsBillingProjectName("test-project")
+    result(RawlsBillingProjectName("test-project")) should contain(workspace)
+  }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -2,29 +2,22 @@ package org.broadinstitute.dsde.rawls.spendreporting
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.SpendReportingAggregation.AggregationKeyEnum
 import bio.terra.profile.model.SpendReportingForDateRange.CategoryEnum
-import bio.terra.profile.model.{
-  CloudPlatform => BpmCloudPlatform,
-  ProfileModel,
-  SpendReport => SpendReportBPM,
-  SpendReportingAggregation => SpendReportingAggregationBPM,
-  SpendReportingForDateRange => SpendReportingForDateRangeBPM
-}
+import bio.terra.profile.model.{ProfileModel, CloudPlatform => BpmCloudPlatform, SpendReport => SpendReportBPM, SpendReportingAggregation => SpendReportingAggregationBPM, SpendReportingForDateRange => SpendReportingForDateRangeBPM}
 import cats.effect.{IO, Resource}
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Option => _, _}
-import org.broadinstitute.dsde.rawls.billing.{
-  BillingProfileManagerDAO,
-  BillingRepository,
-  BpmAzureSpendReportApiException
-}
+import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmAzureSpendReportApiException}
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeys, _}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
-import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext}
+import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext, model}
+import org.broadinstitute.dsde.workbench.client.sam.model.FilteredFlatResource
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
@@ -32,18 +25,15 @@ import org.joda.time.format.ISODateTimeFormat
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, Mockito}
+import org.scalatest.RecoverMethods.recoverToExceptionIf
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
 
 import java.util.{Date, UUID}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
-import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
-import org.broadinstitute.dsde.workbench.client.sam.model.FilteredFlatResource
-import org.scalatest.RecoverMethods.recoverToExceptionIf
 
 class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with MockitoTestUtils with SprayJsonSupport {
 
@@ -719,7 +709,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+      .when(service)
+      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
@@ -752,9 +744,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
     when(
       samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
-        any(),
-        mockitoEq(SamBillingProjectActions.createWorkspace),
-        mockitoEq(testContext)
+                           any(),
+                           mockitoEq(SamBillingProjectActions.createWorkspace),
+                           mockitoEq(testContext)
       )
     ).thenReturn(Future.successful(false))
 
@@ -790,16 +782,18 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
     val dataSource = mock[SlickDataSource]
     when(dataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any())).thenReturn(Future.successful(None))
-    val service = spy(new SpendReportingService(
-      testContext,
-      dataSource,
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
-      billingRepository,
-      bpmDAO,
-      samDAO,
-      spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
-    ))
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        dataSource,
+        Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor
+      )
+    )
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(service.getSpendExportConfiguration(RawlsBillingProjectName("fakeProject")), Duration.Inf)
@@ -868,7 +862,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+      .when(service)
+      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
@@ -985,7 +981,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+      .when(service)
+      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1034,7 +1032,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames)).when(service).getOwnedWorkspaceGoogleProjectsInProject(any(), any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+      .when(service)
+      .getOwnedWorkspaceGoogleProjectsInProject(any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1844,8 +1844,10 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     val workspace = TestData.workspace1
 
-    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List(new FilteredFlatResource().resourceId(workspace.workspaceId))))
-    when(workspaceService.getGCPWorkspacesByBillingProjects(any())).thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
+    when(samDAO.listResourcesWithActions(any(), any(), any()))
+      .thenReturn(Future.successful(List(new FilteredFlatResource().resourceId(workspace.workspaceId))))
+    when(workspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
 
     val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
     result should contain key RawlsBillingProjectName("test-project")
@@ -1869,7 +1871,10 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(false))
 
     val exception = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(service.getOwnedWorkspaceGoogleProjectsInProject(RawlsBillingProjectName("test-project"), testContext), Duration.Inf)
+      Await.result(
+        service.getOwnedWorkspaceGoogleProjectsInProject(RawlsBillingProjectName("test-project"), testContext),
+        Duration.Inf
+      )
     }
 
     exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
@@ -1879,22 +1884,26 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   it should "return a map of Google project IDs to workspace names when user has create_workspace action" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
-    val service = spy(new SpendReportingService(
-      testContext,
-      mock[SlickDataSource],
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
-      mock[BillingRepository],
-      mock[BillingProfileManagerDAO],
-      samDAO,
-      spendReportingServiceConfig,
-      _ => workspaceService
-    ))
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+        mock[BillingRepository],
+        mock[BillingProfileManagerDAO],
+        samDAO,
+        spendReportingServiceConfig,
+        _ => workspaceService
+      )
+    )
 
     val workspace = TestData.workspace1
 
     when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
-    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List(new FilteredFlatResource().resourceId(workspace.workspaceId))))
-    when(workspaceService.getGCPWorkspacesByBillingProjects(any())).thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
+    when(samDAO.listResourcesWithActions(any(), any(), any()))
+      .thenReturn(Future.successful(List(new FilteredFlatResource().resourceId(workspace.workspaceId))))
+    when(workspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(Future.successful(Map(RawlsBillingProjectName("test-project") -> Seq(workspace))))
 
     val result = Await.result(service.getOwnedWorkspaceGoogleProjects(testContext), Duration.Inf)
     result should contain key RawlsBillingProjectName("test-project")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -5,18 +5,28 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import bio.terra.profile.model.SpendReportingAggregation.AggregationKeyEnum
 import bio.terra.profile.model.SpendReportingForDateRange.CategoryEnum
-import bio.terra.profile.model.{ProfileModel, CloudPlatform => BpmCloudPlatform, SpendReport => SpendReportBPM, SpendReportingAggregation => SpendReportingAggregationBPM, SpendReportingForDateRange => SpendReportingForDateRangeBPM}
+import bio.terra.profile.model.{
+  CloudPlatform => BpmCloudPlatform,
+  ProfileModel,
+  SpendReport => SpendReportBPM,
+  SpendReportingAggregation => SpendReportingAggregationBPM,
+  SpendReportingForDateRange => SpendReportingForDateRangeBPM
+}
 import cats.effect.{IO, Resource}
 import com.google.cloud.PageImpl
 import com.google.cloud.bigquery.{Option => _, _}
-import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmAzureSpendReportApiException}
+import org.broadinstitute.dsde.rawls.billing.{
+  BillingProfileManagerDAO,
+  BillingRepository,
+  BpmAzureSpendReportApiException
+}
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeys, _}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext, model}
+import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.client.sam.model.FilteredFlatResource
 import org.broadinstitute.dsde.workbench.google2.GoogleBigQueryService
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -695,99 +695,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     }
   }
 
-  "getSpendForGCPBillingProject" should "throw an exception when BQ returns zero rows" in {
-    val samDAO = mock[SamDAO]
-    val billingRepository = mock[BillingRepository]
-    val bpmDAO = mock[BillingProfileManagerDAO]
-    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
-    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
-
-    val bigQueryService = mockBigQuery(List[Map[String, String]]())
-
-    val service = spy(
-      new SpendReportingService(
-        testContext,
-        mock[SlickDataSource],
-        bigQueryService,
-        billingRepository,
-        bpmDAO,
-        samDAO,
-        spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
-      )
-    )
-    val billingProjectSpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
-    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
-      .when(service)
-      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        service.getSpendForGCPBillingProject(
-          RawlsBillingProjectName(""),
-          DateTime.now().minusDays(1),
-          DateTime.now(),
-          Set.empty
-        ),
-        Duration.Inf
-      )
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
-  }
-
-  it should "throw an exception when user does not have read_spend_report" in {
-    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    val billingRepository = mock[BillingRepository]
-    val bpmDAO = mock[BillingProfileManagerDAO]
-    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
-
-    val billingProject = RawlsBillingProject(
-      RawlsBillingProjectName("test-project"),
-      CreationStatuses.Ready,
-      Option(RawlsBillingAccountName("test-account")),
-      None,
-      billingProfileId = Option.apply(UUID.randomUUID().toString)
-    )
-
-    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
-    when(
-      samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
-                           any(),
-                           mockitoEq(SamBillingProjectActions.readSpendReport),
-                           mockitoEq(testContext)
-      )
-    ).thenReturn(Future.successful(false))
-    when(samDAO.listResourcesWithActions(any(), any(), any()))
-      .thenReturn(Future.successful(List.empty[FilteredFlatResource]))
-
-    val service = new SpendReportingService(
-      testContext,
-      mock[SlickDataSource],
-      Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
-      billingRepository,
-      bpmDAO,
-      samDAO,
-      spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
-    )
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        service.getSpendReportableWorkspaceGoogleProjectsInBillingProject(
-          billingProject.projectName,
-          testContext
-        ),
-        Duration.Inf
-      )
-    }
-
-    e.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
-    e.errorReport.message should include("cannot perform read_spend_report on project")
-  }
-
-  it should "throw an exception if the billing project cannot be found" in {
+  "getSpendForGCPBillingProject" should "throw an exception if the billing project cannot be found" in {
     val samDAO = mock[SamDAO]
     val billingRepository = mock[BillingRepository]
     val bpmDAO = mock[BillingProfileManagerDAO]
@@ -842,54 +750,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
     e.errorReport.message shouldBe s"billing account not found on billing project ${projectName.value}"
-  }
-
-  it should "throw an exception if BigQuery results include an unexpected Google project" in {
-    val samDAO = mock[SamDAO]
-    val billingRepository = mock[BillingRepository]
-    val bpmDAO = mock[BillingProfileManagerDAO]
-
-    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
-    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
-    val badRow = Map(
-      "cost" -> "0.10111",
-      "credits" -> "0.0",
-      "currency" -> "USD",
-      "googleProjectId" -> "fakeProject"
-    )
-
-    val bigQueryService = mockBigQuery(badRow :: TestData.Workspace.table)
-    val service = spy(
-      new SpendReportingService(
-        testContext,
-        mock[SlickDataSource],
-        bigQueryService,
-        billingRepository,
-        bpmDAO,
-        samDAO,
-        spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
-      )
-    )
-    val billingProjectSpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
-    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
-      .when(service)
-      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
-
-    val e = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        service.getSpendForGCPBillingProject(
-          RawlsBillingProjectName(""),
-          DateTime.now().minusDays(1),
-          DateTime.now(),
-          Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))
-        ),
-        Duration.Inf
-      )
-    }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
   }
 
   "getSpendForBillingProject" should "get the spend report from BPM for Azure billing projects" in {
@@ -995,7 +855,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
-      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
+      .getSpendForGCPBillingProject(any(), any(), any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1046,7 +906,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
-      .getSpendReportableWorkspaceGoogleProjectsInBillingProject(any(), any())
+      .getSpendForGCPBillingProject(any(), any(), any(), any())
 
     Await.result(
       service.getSpendForBillingProject(
@@ -1794,27 +1654,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
-  "getSpendReportableWorkspaceGoogleProjects" should "return an empty map when no workspaces are owned" in {
-    val samDAO = mock[SamDAO]
-    val workspaceService = mock[WorkspaceService]
-    val service = new SpendReportingService(
-      testContext,
-      mock[SlickDataSource],
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
-      mock[BillingRepository],
-      mock[BillingProfileManagerDAO],
-      samDAO,
-      spendReportingServiceConfig,
-      _ => workspaceService
-    )
-
-    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(Future.successful(List()))
-
-    val result = Await.result(service.getSpendReportableWorkspaceGoogleProjects(testContext), Duration.Inf)
-    result shouldBe empty
-  }
-
-  it should "return a map of workspaces grouped by billing project" in {
+  "getSpendReportableWorkspaceGoogleProjects" should "return a map of workspaces grouped by billing project" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
     val service = new SpendReportingService(
@@ -1838,37 +1678,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val result = Await.result(service.getSpendReportableWorkspaceGoogleProjects(testContext), Duration.Inf)
     result should contain key RawlsBillingProjectName("test-project")
     result(RawlsBillingProjectName("test-project")) should contain(workspace)
-  }
-
-  "getSpendReportableWorkspaceGoogleProjectsInBillingProject" should "throw an exception when user does not have read_spend_report action" in {
-    val samDAO = mock[SamDAO]
-    val workspaceService = mock[WorkspaceService]
-    val service = new SpendReportingService(
-      testContext,
-      mock[SlickDataSource],
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
-      mock[BillingRepository],
-      mock[BillingProfileManagerDAO],
-      samDAO,
-      spendReportingServiceConfig,
-      _ => workspaceService
-    )
-
-    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(false))
-    when(samDAO.listResourcesWithActions(any(), any(), any()))
-      .thenReturn(Future.successful(List.empty[FilteredFlatResource]))
-
-    val exception = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        service.getSpendReportableWorkspaceGoogleProjectsInBillingProject(RawlsBillingProjectName("test-project"),
-                                                                          testContext
-        ),
-        Duration.Inf
-      )
-    }
-
-    exception.errorReport.statusCode shouldBe Some(StatusCodes.Forbidden)
-    exception.errorReport.message should include("cannot perform read_spend_report on project")
   }
 
   it should "return a map of Google project IDs to workspace names when user has read_spend_report action" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1233,32 +1233,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     result shouldBe expectedQuery
   }
 
-  "getWorkspaceGoogleProjects" should "only map v2 workspaces to project names" in {
-    val v1Workspace = TestData.workspace("v1name", GoogleProjectId("v1ProjectId"), WorkspaceVersions.V1)
-    val v2Workspace = TestData.workspace("v2name", GoogleProjectId("v2ProjectId"), WorkspaceVersions.V2)
-    val workspaces = Seq(
-      v1Workspace,
-      v2Workspace
-    )
-
-    val dataSource = mock[SlickDataSource]
-    when(dataSource.inTransaction[Seq[Workspace]](any(), any())).thenReturn(Future.successful(workspaces))
-    val service = new SpendReportingService(
-      testContext,
-      dataSource,
-      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
-      mock[BillingRepository],
-      mock[BillingProfileManagerDAO],
-      mock[SamDAO],
-      spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
-    )
-
-    val result = Await.result(service.getWorkspaceGoogleProjects(RawlsBillingProjectName("")), Duration.Inf)
-
-    result shouldBe Map(GoogleProjectId("v2ProjectId") -> v2Workspace.toWorkspaceName)
-  }
-
   "getAllUserWorkspaceQuery" should "generate a query for a billingProject with its workspace projects" in {
 
     val billingProjectSpendExport =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -695,7 +695,49 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     }
   }
 
-  "getSpendForGCPBillingProject" should "throw an exception if the billing project cannot be found" in {
+  "getSpendForGCPBillingProject" should "throw an exception when BQ returns zero rows" in {
+    val samDAO = mock[SamDAO]
+    val billingRepository = mock[BillingRepository]
+    val bpmDAO = mock[BillingProfileManagerDAO]
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+
+    val bigQueryService = mockBigQuery(List[Map[String, String]]())
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bigQueryService,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+      .when(service)
+      .getSpendReportableWorkspaceGoogleProjects(any())
+
+    val e = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        service.getSpendForGCPBillingProject(
+          RawlsBillingProjectName(""),
+          DateTime.now().minusDays(1),
+          DateTime.now(),
+          Set.empty
+        ),
+        Duration.Inf
+      )
+    }
+    e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+  }
+
+  it should "throw an exception if the billing project cannot be found" in {
     val samDAO = mock[SamDAO]
     val billingRepository = mock[BillingRepository]
     val bpmDAO = mock[BillingProfileManagerDAO]
@@ -750,6 +792,54 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     e.errorReport.statusCode shouldBe Option(StatusCodes.BadRequest)
     e.errorReport.message shouldBe s"billing account not found on billing project ${projectName.value}"
+  }
+
+  it should "throw an exception if BigQuery results include an unexpected Google project" in {
+    val samDAO = mock[SamDAO]
+    val billingRepository = mock[BillingRepository]
+    val bpmDAO = mock[BillingProfileManagerDAO]
+
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+    val badRow = Map(
+      "cost" -> "0.10111",
+      "credits" -> "0.0",
+      "currency" -> "USD",
+      "googleProjectId" -> "fakeProject"
+    )
+
+    val bigQueryService = mockBigQuery(badRow :: TestData.Workspace.table)
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bigQueryService,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+      .when(service)
+      .getSpendReportableWorkspaceGoogleProjects(any())
+
+    val e = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        service.getSpendForGCPBillingProject(
+          RawlsBillingProjectName(""),
+          DateTime.now().minusDays(1),
+          DateTime.now(),
+          Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace))
+        ),
+        Duration.Inf
+      )
+    }
+    e.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
   }
 
   "getSpendForBillingProject" should "get the spend report from BPM for Azure billing projects" in {
@@ -1654,7 +1744,89 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
-  "getSpendReportableWorkspaceGoogleProjects" should "return a map of workspaces grouped by billing project" in {
+  "getSpendReportableWorkspaceGoogleProjects" should "return an empty map when there are no valid workspace IDs" in {
+    val mockSamDAO = mock[SamDAO]
+    val mockWorkspaceServiceConstructor = mock[RawlsRequestContext => WorkspaceService]
+    val mockWorkspaceService = mock[WorkspaceService]
+    val mockContext = mock[RawlsRequestContext]
+
+    val spendReportingService = new SpendReportingService(
+      mockContext,
+      mock[SlickDataSource],
+      mock[cats.effect.Resource[IO, GoogleBigQueryService[IO]]],
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      mockSamDAO,
+      mock[SpendReportingServiceConfig],
+      mockWorkspaceServiceConstructor
+    )
+
+    when(mockSamDAO.listResourcesWithActions(any(), any(), any()))
+      .thenReturn(Future.successful(Seq.empty))
+    when(mockWorkspaceServiceConstructor.apply(any()))
+      .thenReturn(mockWorkspaceService)
+    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(Future.successful(Map.empty))
+
+    spendReportingService.getSpendReportableWorkspaceGoogleProjects(mockContext).map { result =>
+      result shouldBe empty
+    }
+  }
+
+  it should "throw an exception when the user does not have read_spend_report action" in {
+    val mockSamDAO = mock[SamDAO]
+    val mockWorkspaceServiceConstructor = mock[RawlsRequestContext => WorkspaceService]
+    val mockWorkspaceService = mock[WorkspaceService]
+    val mockDataSource = mock[SlickDataSource]
+    val spendReportingServiceConfig = SpendReportingServiceConfig(
+      "fakeTable",
+      "fakeTimePartitionColumn",
+      90,
+      "test.rawls"
+    )
+
+    when(mockDataSource.inTransaction[Option[BillingProjectSpendExport]](any(), any()))
+      .thenReturn(
+        Future.successful(
+          Some(
+            BillingProjectSpendExport(RawlsBillingProjectName("test-project"),
+                                      RawlsBillingAccountName("test-account"),
+                                      None
+            )
+          )
+        )
+      )
+    when(mockSamDAO.listResourcesWithActions(any(), any(), any()))
+      .thenReturn(Future.successful(Seq.empty))
+    when(mockWorkspaceServiceConstructor.apply(any()))
+      .thenReturn(mockWorkspaceService)
+    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(Future.successful(Map.empty))
+
+    val spendReportingService = new SpendReportingService(
+      testContext,
+      mockDataSource,
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      mock[SamDAO],
+      spendReportingServiceConfig,
+      mockWorkspaceServiceConstructor
+    )
+
+    recoverToExceptionIf[RawlsExceptionWithErrorReport] {
+      spendReportingService.getSpendForGCPBillingProject(RawlsBillingProjectName("test-project"),
+                                                         DateTime.now().minusDays(7),
+                                                         DateTime.now(),
+                                                         Set.empty[SpendReportingAggregationKeyWithSub]
+      )
+    } map { ex =>
+      ex.errorReport.statusCode shouldBe StatusCodes.NotFound
+      ex.errorReport.message should include("no spend data found for billing project")
+    }
+  }
+
+  it should "return a map of workspaces grouped by billing project" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
     val service = new SpendReportingService(


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-307

This PR ensures that Billing Project Users can view spend reports for workspaces they own on the billing project workspaces list page. Previously, these costs appeared as N/A, and users would receive a `403 Forbidden error` when attempting to access the billing project spend report. This was due to the requireProjectAction check for `readSpendReport`, which was restricted to project owners. I have updated this to `createWorkspace`, allowing workspace owners to access spend reports across all billing projects.

**Before**
<img width="1791" alt="Before" src="https://github.com/user-attachments/assets/f28afbb1-1149-48fb-8b72-1bb11c65b86b" />

**After**
<img width="1791" alt="After" src="https://github.com/user-attachments/assets/6392fa5b-fe5e-4c08-880c-afb436a84dec" />

---

**PR checklist**

- [X] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [x] Get two thumbsworth of PR review
- [X] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
