### PR TITLE
CORE-336 support requester pays for publicly readable workspace setting

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -241,18 +241,19 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
             )
         }
       allUsersRoleMapping <- getAllUsersRoleMapping(ctx)
+      requesterPays = List(Storage.BucketSourceOption.userProject(workspace.googleProjectId.value))
       iamPolicyAction =
         if (enabled) {
           googleStorageService.setIamPolicy(
             GcsBucketName(workspace.bucketName),
             allUsersRoleMapping,
-            bucketSourceOptions = List(Storage.BucketSourceOption.userProject(workspace.googleProjectId.value))
+            bucketSourceOptions = requesterPays
           )
         } else {
           googleStorageService.removeIamPolicy(
             GcsBucketName(workspace.bucketName),
             allUsersRoleMapping,
-            bucketSourceOptions = List(Storage.BucketSourceOption.userProject(workspace.googleProjectId.value))
+            bucketSourceOptions = requesterPays
           )
         }
       _ <- iamPolicyAction.compile.drain.unsafeToFuture()

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceSettingService.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import com.google.cloud.Identity
 import com.google.cloud.storage.BucketInfo.LifecycleRule.{LifecycleAction, LifecycleCondition}
 import com.google.cloud.storage.BucketInfo.{LifecycleRule, SoftDeletePolicy}
+import com.google.cloud.storage.Storage
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.{GoogleServicesDAO, SamDAO}
 import org.broadinstitute.dsde.rawls.model.WorkspaceSettingConfig._
@@ -242,9 +243,17 @@ class WorkspaceSettingService(protected val ctx: RawlsRequestContext,
       allUsersRoleMapping <- getAllUsersRoleMapping(ctx)
       iamPolicyAction =
         if (enabled) {
-          googleStorageService.setIamPolicy(GcsBucketName(workspace.bucketName), allUsersRoleMapping)
+          googleStorageService.setIamPolicy(
+            GcsBucketName(workspace.bucketName),
+            allUsersRoleMapping,
+            bucketSourceOptions = List(Storage.BucketSourceOption.userProject(workspace.googleProjectId.value))
+          )
         } else {
-          googleStorageService.removeIamPolicy(GcsBucketName(workspace.bucketName), allUsersRoleMapping)
+          googleStorageService.removeIamPolicy(
+            GcsBucketName(workspace.bucketName),
+            allUsersRoleMapping,
+            bucketSourceOptions = List(Storage.BucketSourceOption.userProject(workspace.googleProjectId.value))
+          )
         }
       _ <- iamPolicyAction.compile.drain.unsafeToFuture()
     } yield ()


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-336

in the process of migrating, I found that the publicly readable setting does not support requester pays

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
