### PR TITLE
[CORE-290] Use/Store consolidated spend report query results in workspace spend report table

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -134,4 +134,5 @@
     <include file="changesets/20250211_add_workspace_spend_report_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250227_update_workspace_spend_report_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250228_add_billing_project_id.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250311_update_workspace_spend_report_dates.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250311_update_workspace_spend_report_dates.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250311_update_workspace_spend_report_dates.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+    <changeSet logicalFilePath="dummy" author="sehsan" id="update_workspace_spend_report_dates">
+        <modifyDataType
+                tableName="WORKSPACE_SPEND_REPORT"
+                columnName="REPORT_START_DATE"
+                newDataType="DATETIME(3)"/>
+        <modifyDataType
+                tableName="WORKSPACE_SPEND_REPORT"
+                columnName="REPORT_END_DATE"
+                newDataType="DATETIME(3)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/Boot.scala
@@ -50,7 +50,7 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.monitor._
 import org.broadinstitute.dsde.rawls.serviceFactory._
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
-import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
+import org.broadinstitute.dsde.rawls.spendreporting.{SpendReportingService, WorkspaceSpendReportRepository}
 import org.broadinstitute.dsde.rawls.status.StatusService
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
@@ -520,7 +520,8 @@ object Boot extends IOApp with LazyLogging {
           billingProfileManagerDAO,
           samDAO,
           spendReportingServiceConfig,
-          workspaceServiceConstructor
+          workspaceServiceConstructor,
+          new WorkspaceSpendReportRepository(slickDataSource)
         )
 
       val billingAdminServiceConstructor: RawlsRequestContext => BillingAdminService =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/DataAccess.scala
@@ -28,7 +28,8 @@ trait DataAccess
     with WorkspaceManagerResourceMonitorRecordComponent
     with FastPassGrantComponent
     with MultiregionalBucketMigrationHistory
-    with WorkspaceSettingComponent {
+    with WorkspaceSettingComponent
+    with WorkspaceSpendReportComponent {
 
   this: DriverComponent =>
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,8 +1,5 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import akka.http.scaladsl.model.StatusCodes
-import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -109,33 +106,26 @@ object WorkspaceSpendReportRecord {
       val currencyCode = Currency.getInstance(currencyString)
       val projectId = record.googleProjectId
 
-      def formatCategoryCost(cost: Option[Float]): String = {
-        cost match {
-          case Some(cost) => toBigDecimal(cost).toString()
-          case None => "N/A"
-        }
-      }
-
-      def toBigDecimal(cost: Float): BigDecimal = {
-        BigDecimal(cost).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
+      def toBigDecimal(cost: Option[Float]): BigDecimal = {
+        BigDecimal(cost.getOrElse(0.0f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
       }
 
       val credits = BigDecimal(0.0).toString() // TODO: Store credits per category
       val subAggregation = List(
         SpendReportingForDateRange(
-          formatCategoryCost(record.otherSpend),
+          toBigDecimal(record.otherSpend).toString(),
           credits,
           currencyCode.toString,
           category = Option(TerraSpendCategories.Other)
         ),
         SpendReportingForDateRange(
-          formatCategoryCost(record.totalStorage),
+          toBigDecimal(record.totalStorage).toString(),
           credits,
           currencyCode.toString,
           category = Option(TerraSpendCategories.Storage)
         ),
         SpendReportingForDateRange(
-          formatCategoryCost(record.totalCompute),
+          toBigDecimal(record.totalCompute).toString(),
           credits,
           currencyCode.toString,
           category = Option(TerraSpendCategories.Compute)
@@ -155,7 +145,7 @@ object WorkspaceSpendReportRecord {
 //        getRoundedNumericValue("other_credits") + getRoundedNumericValue("storage_credits") + getRoundedNumericValue(
 //          "compute_credits"
 //        )
-      total = total + toBigDecimal(total_cost.getOrElse(0.0f))
+      total = total + toBigDecimal(total_cost)
 //      total_credits = total_credits + credits
       start = convertLocalDateTimeToJodaDateTime(record.reportStartDate)
       end = convertLocalDateTimeToJodaDateTime(record.reportEndDate)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -3,11 +3,12 @@ package org.broadinstitute.dsde.rawls.dataaccess.slick
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
+import java.time.{Instant, LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 
+import java.sql.Timestamp
 import java.util.Currency
 import scala.language.{postfixOps, reflectiveCalls}
 import scala.math.BigDecimal.RoundingMode
@@ -15,8 +16,8 @@ import scala.math.BigDecimal.RoundingMode
 case class WorkspaceSpendReportRecord(
   id: Long,
   googleProjectId: String,
-  reportStartDate: LocalDateTime,
-  reportEndDate: LocalDateTime,
+  reportStartDate: Timestamp,
+  reportEndDate: Timestamp,
   currency: String,
   isDataAvailable: Boolean,
   totalCompute: Option[Float],
@@ -33,8 +34,8 @@ object WorkspaceSpendReportRecord {
     WorkspaceSpendReportRecord(
       workspaceSpendReport.id,
       workspaceSpendReport.googleProjectId,
-      workspaceSpendReport.reportStartDate,
-      workspaceSpendReport.reportEndDate,
+      new Timestamp(workspaceSpendReport.reportStartDate.toInstant(ZoneOffset.UTC).toEpochMilli),
+      new Timestamp(workspaceSpendReport.reportEndDate.toInstant(ZoneOffset.UTC).toEpochMilli),
       workspaceSpendReport.currency,
       workspaceSpendReport.isDataAvailable,
       workspaceSpendReport.totalCompute,
@@ -49,8 +50,8 @@ object WorkspaceSpendReportRecord {
     WorkspaceSpendReport(
       record.id,
       record.googleProjectId,
-      record.reportStartDate,
-      record.reportEndDate,
+      LocalDateTime.ofInstant(record.reportStartDate.toInstant, ZoneOffset.UTC),
+      LocalDateTime.ofInstant(record.reportEndDate.toInstant, ZoneOffset.UTC),
       record.currency,
       record.isDataAvailable,
       record.totalCompute,
@@ -231,9 +232,9 @@ trait WorkspaceSpendReportComponent {
 
     def googleProjectId = column[String]("GOOGLE_PROJECT_ID", O.Length(254))
 
-    def reportStartDate = column[LocalDateTime]("REPORT_START_DATE", O.SqlType("DATETIME"))
+    def reportStartDate = column[Timestamp]("REPORT_START_DATE", O.SqlType("DATETIME"))
 
-    def reportEndDate = column[LocalDateTime]("REPORT_END_DATE", O.SqlType("DATETIME"))
+    def reportEndDate = column[Timestamp]("REPORT_END_DATE", O.SqlType("DATETIME"))
 
     def currency = column[String]("CURRENCY", O.Length(100))
 
@@ -284,7 +285,8 @@ trait WorkspaceSpendReportComponent {
         .filter(x =>
           x.googleProjectId.inSetBind(
             projectIds.map(_.value)
-          ) && x.reportStartDate === startDate && x.reportEndDate === endDate
+          ) && x.reportStartDate === new Timestamp(startDate.toInstant(ZoneOffset.UTC).toEpochMilli)
+            && x.reportEndDate === new Timestamp(endDate.toInstant(ZoneOffset.UTC).toEpochMilli)
         )
 
     private def loadWorkspaceSpendReport(lookup: WorkspaceSpendReportQueryType): ReadAction[Seq[WorkspaceSpendReport]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
 import java.time.LocalDateTime
+import java.time.ZoneId
 import org.broadinstitute.dsde.rawls.model._
+import org.joda.time.DateTime
 
 import scala.language.postfixOps
 
@@ -42,6 +44,45 @@ object WorkspaceSpendReportRecord {
       record.otherSpend,
       record.isDataAvailable
     )
+
+  def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime = {
+    dateTimeOpt match {
+      case Some(dateTime) =>
+        val instant = dateTime.toInstant
+        LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(dateTime.getMillis), ZoneId.systemDefault())
+      case None =>
+        throw new IllegalArgumentException("DateTime value is missing")
+    }
+  }
+
+  def fromSpendReportingResults(spendReportingResults: SpendReportingResults): Seq[WorkspaceSpendReport] = {
+    val summary = spendReportingResults.spendSummary
+    spendReportingResults.spendDetails.flatMap {
+      spendDetail => spendDetail.spendData.map {
+        var totalStorage: Option[Float] = None
+        var totalCompute: Option[Float] = None
+        var otherSpend: Option[Float] = None
+        spendData => spendData.subAggregation.get.spendData.foreach({
+          categorySpend => {
+            val categoryCost = Some(categorySpend.cost.toFloat)
+            categorySpend.category match {
+              case Some(TerraSpendCategories.Storage) => totalStorage = categoryCost
+              case Some(TerraSpendCategories.Compute) => totalCompute = categoryCost
+              case Some(TerraSpendCategories.Other) => otherSpend = categoryCost
+              case None => throw new IllegalArgumentException("Spend data has no category") // Does this ever happen?
+            }
+          }
+        })
+        // TODO: Store credits and currency (what about aggregation key)?
+        WorkspaceSpendReport.newWorkspaceSpendReport(
+          spendData.googleProjectId.get.value,
+          convertJodaToJava(summary.startTime),
+          convertJodaToJava(summary.endTime),
+          totalCompute,
+          totalStorage,
+          otherSpend,
+          isDataAvailable = true) // TODO: Handle N/A case
+      }}}
 }
 
 trait WorkspaceSpendReportComponent {
@@ -85,20 +126,19 @@ trait WorkspaceSpendReportComponent {
 
   object WorkspaceSpendReportQuery extends TableQuery(new WorkspaceSpendReportTable(_)) {
 
-    def getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds: Seq[String],
+    def getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds: Set[String],
                                                          startDate: LocalDateTime,
                                                          endDate: LocalDateTime
                                             ): ReadAction[Seq[WorkspaceSpendReport]] =
       loadWorkspaceSpendReport(filterByProjectIdsAndReportDate(projectIds, startDate, endDate))
 
 
-    def filterByProjectIdsAndReportDate(projectIds: Seq[String],
+    def filterByProjectIdsAndReportDate(projectIds: Set[String],
                                 startDate: LocalDateTime,
                                 endDate: LocalDateTime
-                               ): ReadAction[Seq[WorkspaceSpendReportRecord]] =
+                               ) =
       workspaceSpendReportQuery
         .filter(x => x.googleProjectId.inSetBind(projectIds.map(_.value)) && x.reportStartDate === startDate && x.reportEndDate === endDate)
-        .result
 
     private def loadWorkspaceSpendReport(lookup: WorkspaceSpendReportQueryType): ReadAction[Seq[WorkspaceSpendReport]] =
       for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,5 +1,8 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -14,10 +17,14 @@ case class WorkspaceSpendReportRecord(
   googleProjectId: String,
   reportStartDate: LocalDateTime,
   reportEndDate: LocalDateTime,
+  currency: String,
+  isDataAvailable: Boolean,
   totalCompute: Option[Float],
   totalStorage: Option[Float],
   otherSpend: Option[Float],
-  isDataAvailable: Boolean
+  computeCredits: Option[Float],
+  storageCredits: Option[Float],
+  otherCredits: Option[Float]
 )
 
 object WorkspaceSpendReportRecord {
@@ -28,10 +35,14 @@ object WorkspaceSpendReportRecord {
       workspaceSpendReport.googleProjectId,
       workspaceSpendReport.reportStartDate,
       workspaceSpendReport.reportEndDate,
+      workspaceSpendReport.currency,
+      workspaceSpendReport.isDataAvailable,
       workspaceSpendReport.totalCompute,
       workspaceSpendReport.totalStorage,
       workspaceSpendReport.otherSpend,
-      workspaceSpendReport.isDataAvailable
+      workspaceSpendReport.computeCredits,
+      workspaceSpendReport.storageCredits,
+      workspaceSpendReport.otherCredits
     )
 
   def toWorkspaceSpendReport(record: WorkspaceSpendReportRecord): WorkspaceSpendReport =
@@ -40,10 +51,14 @@ object WorkspaceSpendReportRecord {
       record.googleProjectId,
       record.reportStartDate,
       record.reportEndDate,
+      record.currency,
+      record.isDataAvailable,
       record.totalCompute,
       record.totalStorage,
       record.otherSpend,
-      record.isDataAvailable
+      record.computeCredits,
+      record.storageCredits,
+      record.otherCredits
     )
 
   def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime =
@@ -73,26 +88,38 @@ object WorkspaceSpendReportRecord {
         var totalStorage: Option[Float] = None
         var totalCompute: Option[Float] = None
         var otherSpend: Option[Float] = None
+        var storageCredits: Option[Float] = None
+        var computeCredits: Option[Float] = None
+        var otherCredits: Option[Float] = None
         spendData =>
           spendData.subAggregation.get.spendData.foreach { categorySpend =>
             val categoryCost = Some(categorySpend.cost.toFloat)
+            val categoryCredits = Some(categorySpend.credits.toFloat)
             categorySpend.category match {
-              case Some(TerraSpendCategories.Storage) => totalStorage = categoryCost
-              case Some(TerraSpendCategories.Compute) => totalCompute = categoryCost
-              case Some(TerraSpendCategories.Other)   => otherSpend = categoryCost
-              case None => throw new IllegalArgumentException("Spend data has no category") // Does this ever happen?
+              case Some(TerraSpendCategories.Storage) =>
+                totalStorage = categoryCost
+                storageCredits = categoryCredits
+              case Some(TerraSpendCategories.Compute) =>
+                totalCompute = categoryCost
+                computeCredits = categoryCredits
+              case Some(TerraSpendCategories.Other) =>
+                otherSpend = categoryCost
+                otherCredits = categoryCredits
             }
           }
-          // TODO: Store credits and currency (what about aggregation key)?
           WorkspaceSpendReport.newWorkspaceSpendReport(
             spendData.googleProjectId.get.value,
             convertJodaToJava(summary.startTime),
             convertJodaToJava(summary.endTime),
+            summary.currency,
+            isDataAvailable = true,
             totalCompute,
             totalStorage,
             otherSpend,
-            isDataAvailable = true
-          ) // TODO: Handle N/A case
+            computeCredits,
+            storageCredits,
+            otherCredits
+          )
       }
     }
   }
@@ -102,33 +129,42 @@ object WorkspaceSpendReportRecord {
   ): SpendReportingResults = {
     var start: Option[DateTime] = None
     var end: Option[DateTime] = None
-    var total = BigDecimal(0.0)
+    var total_spend = BigDecimal(0.0)
     var total_credits = BigDecimal(0.0)
+    val currency = records.map(_.currency).distinct match {
+      case head :: List() => Currency.getInstance(head)
+      case head :: tail =>
+        throw RawlsExceptionWithErrorReport(
+          StatusCodes.InternalServerError,
+          s"Inconsistent currencies found while aggregating spend data: $head and ${tail.head} cannot be combined"
+        )
+      case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
+    }
+
     val all = records.map { record =>
-      val currencyString = "$"
+      val currencyString = record.currency
       val currencyCode = Currency.getInstance(currencyString)
       val projectId = record.googleProjectId
 
       def toBigDecimal(cost: Option[Float]): BigDecimal =
         BigDecimal(cost.getOrElse(0.0f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
 
-      val credits = BigDecimal(0.0).toString() // TODO: Store credits per category
       val subAggregation = List(
         SpendReportingForDateRange(
           toBigDecimal(record.otherSpend).toString(),
-          credits,
+          toBigDecimal(record.otherCredits).toString(),
           currencyCode.toString,
           category = Option(TerraSpendCategories.Other)
         ),
         SpendReportingForDateRange(
           toBigDecimal(record.totalStorage).toString(),
-          credits,
+          toBigDecimal(record.storageCredits).toString(),
           currencyCode.toString,
           category = Option(TerraSpendCategories.Storage)
         ),
         SpendReportingForDateRange(
           toBigDecimal(record.totalCompute).toString(),
-          credits,
+          toBigDecimal(record.computeCredits).toString(),
           currencyCode.toString,
           category = Option(TerraSpendCategories.Compute)
         )
@@ -137,24 +173,29 @@ object WorkspaceSpendReportRecord {
       val totalCompute: Option[Float] = record.totalCompute
       val totalStorage: Option[Float] = record.totalStorage
       val otherSpend: Option[Float] = record.otherSpend
-      val total_cost: Option[Float] = for {
-        c1 <- totalCompute
-        c2 <- totalStorage
-        c3 <- otherSpend
-      } yield c1 + c2 + c3
+      val cost: Option[Float] = for {
+        cost1 <- totalCompute
+        cost2 <- totalStorage
+        cost3 <- otherSpend
+      } yield cost1 + cost2 + cost3
 
-//      val credits =
-//        getRoundedNumericValue("other_credits") + getRoundedNumericValue("storage_credits") + getRoundedNumericValue(
-//          "compute_credits"
-//        )
-      total = total + toBigDecimal(total_cost)
-//      total_credits = total_credits + credits
+      val computeCredits: Option[Float] = record.computeCredits
+      val storageCredits: Option[Float] = record.storageCredits
+      val otherCredits: Option[Float] = record.otherCredits
+      val credits: Option[Float] = for {
+        credit1 <- computeCredits
+        credit2 <- storageCredits
+        credit3 <- otherCredits
+      } yield credit1 + credit2 + credit3
+
+      total_spend = total_spend + toBigDecimal(cost)
+      total_credits = total_credits + toBigDecimal(credits)
       start = convertLocalDateTimeToJodaDateTime(record.reportStartDate)
       end = convertLocalDateTimeToJodaDateTime(record.reportEndDate)
       val workspaceTotal = SpendReportingForDateRange(
-        total_cost.toString,
-        credits,
-        currencyCode.toString,
+        total_spend.toString,
+        total_credits.toString,
+        currency.toString,
         start,
         end,
         workspace = projectNames.get(GoogleProjectId(projectId)),
@@ -165,9 +206,9 @@ object WorkspaceSpendReportRecord {
     }
 
     val summary = SpendReportingForDateRange(
-      total.toString,
+      total_spend.toString,
       total_credits.toString,
-      "USD",
+      currency.toString,
       start,
       end
     )
@@ -191,22 +232,34 @@ trait WorkspaceSpendReportComponent {
 
     def reportEndDate = column[LocalDateTime]("REPORT_END_DATE", O.SqlType("DATETIME"))
 
+    def currency = column[String]("CURRENCY", O.Length(100))
+
+    def isDataAvailable = column[Boolean]("IS_DATA_AVAILABLE")
+
     def totalCompute = column[Option[Float]]("TOTAL_COMPUTE", O.SqlType("NUMBER(10,2)"))
 
     def totalStorage = column[Option[Float]]("TOTAL_STORAGE", O.SqlType("NUMBER(10,2)"))
 
     def otherSpend = column[Option[Float]]("OTHER_SPEND", O.SqlType("NUMBER(10,2)"))
 
-    def isDataAvailable = column[Boolean]("IS_DATA_AVAILABLE")
+    def computeCredits = column[Option[Float]]("COMPUTE_CREDITS", O.SqlType("NUMBER(10,2)"))
+
+    def storageCredits = column[Option[Float]]("STORAGE_CREDITS", O.SqlType("NUMBER(10,2)"))
+
+    def otherCredits = column[Option[Float]]("OTHER_CREDITS", O.SqlType("NUMBER(10,2)"))
 
     def * = (id,
              googleProjectId,
              reportStartDate,
              reportEndDate,
+             currency,
+             isDataAvailable,
              totalCompute,
              totalStorage,
              otherSpend,
-             isDataAvailable
+             computeCredits,
+             storageCredits,
+             otherCredits
     ) <> ((WorkspaceSpendReportRecord.apply _).tupled, WorkspaceSpendReportRecord.unapply)
 
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -9,8 +9,7 @@ import java.util.Currency
 import scala.language.{postfixOps, reflectiveCalls}
 import scala.math.BigDecimal.RoundingMode
 
-
-case class WorkspaceSpendReportRecord (
+case class WorkspaceSpendReportRecord(
   id: Long,
   googleProjectId: String,
   reportStartDate: LocalDateTime,
@@ -47,7 +46,7 @@ object WorkspaceSpendReportRecord {
       record.isDataAvailable
     )
 
-  def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime = {
+  def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime =
     dateTimeOpt match {
       case Some(dateTime) =>
         val instant = dateTime.toInstant
@@ -55,9 +54,10 @@ object WorkspaceSpendReportRecord {
       case None =>
         throw new IllegalArgumentException("DateTime value is missing")
     }
-  }
 
-  def convertLocalDateTimeToJodaDateTime(localDateTime: LocalDateTime, zoneId: ZoneId = ZoneId.systemDefault()): Option[DateTime] = {
+  def convertLocalDateTimeToJodaDateTime(localDateTime: LocalDateTime,
+                                         zoneId: ZoneId = ZoneId.systemDefault()
+  ): Option[DateTime] =
     Option(localDateTime).map { ldt =>
       // Convert LocalDateTime to ZonedDateTime
       val zonedDateTime: ZonedDateTime = ldt.atZone(zoneId)
@@ -65,38 +65,41 @@ object WorkspaceSpendReportRecord {
       // Convert ZonedDateTime to Joda DateTime using epoch milli
       new DateTime(zonedDateTime.toInstant.toEpochMilli)
     }
-  }
 
   def fromSpendReportingResults(spendReportingResults: SpendReportingResults): Seq[WorkspaceSpendReport] = {
     val summary = spendReportingResults.spendSummary
-    spendReportingResults.spendDetails.flatMap {
-      spendDetail => spendDetail.spendData.map {
+    spendReportingResults.spendDetails.flatMap { spendDetail =>
+      spendDetail.spendData.map {
         var totalStorage: Option[Float] = None
         var totalCompute: Option[Float] = None
         var otherSpend: Option[Float] = None
-        spendData => spendData.subAggregation.get.spendData.foreach({
-          categorySpend => {
+        spendData =>
+          spendData.subAggregation.get.spendData.foreach { categorySpend =>
             val categoryCost = Some(categorySpend.cost.toFloat)
             categorySpend.category match {
               case Some(TerraSpendCategories.Storage) => totalStorage = categoryCost
               case Some(TerraSpendCategories.Compute) => totalCompute = categoryCost
-              case Some(TerraSpendCategories.Other) => otherSpend = categoryCost
+              case Some(TerraSpendCategories.Other)   => otherSpend = categoryCost
               case None => throw new IllegalArgumentException("Spend data has no category") // Does this ever happen?
             }
           }
-        })
-        // TODO: Store credits and currency (what about aggregation key)?
-        WorkspaceSpendReport.newWorkspaceSpendReport(
-          spendData.googleProjectId.get.value,
-          convertJodaToJava(summary.startTime),
-          convertJodaToJava(summary.endTime),
-          totalCompute,
-          totalStorage,
-          otherSpend,
-          isDataAvailable = true) // TODO: Handle N/A case
-      }}}
+          // TODO: Store credits and currency (what about aggregation key)?
+          WorkspaceSpendReport.newWorkspaceSpendReport(
+            spendData.googleProjectId.get.value,
+            convertJodaToJava(summary.startTime),
+            convertJodaToJava(summary.endTime),
+            totalCompute,
+            totalStorage,
+            otherSpend,
+            isDataAvailable = true
+          ) // TODO: Handle N/A case
+      }
+    }
+  }
 
-  def toSpendReportingResults(records: Seq[WorkspaceSpendReport], projectNames: Map[GoogleProjectId, WorkspaceName]): SpendReportingResults = {
+  def toSpendReportingResults(records: Seq[WorkspaceSpendReport],
+                              projectNames: Map[GoogleProjectId, WorkspaceName]
+  ): SpendReportingResults = {
     var start: Option[DateTime] = None
     var end: Option[DateTime] = None
     var total = BigDecimal(0.0)
@@ -106,9 +109,8 @@ object WorkspaceSpendReportRecord {
       val currencyCode = Currency.getInstance(currencyString)
       val projectId = record.googleProjectId
 
-      def toBigDecimal(cost: Option[Float]): BigDecimal = {
+      def toBigDecimal(cost: Option[Float]): BigDecimal =
         BigDecimal(cost.getOrElse(0.0f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
-      }
 
       val credits = BigDecimal(0.0).toString() // TODO: Store credits per category
       val subAggregation = List(
@@ -167,7 +169,7 @@ object WorkspaceSpendReportRecord {
       total_credits.toString,
       "USD",
       start,
-      end,
+      end
     )
     SpendReportingResults(all, summary)
   }
@@ -204,7 +206,7 @@ trait WorkspaceSpendReportComponent {
              totalCompute,
              totalStorage,
              otherSpend,
-             isDataAvailable,
+             isDataAvailable
     ) <> ((WorkspaceSpendReportRecord.apply _).tupled, WorkspaceSpendReportRecord.unapply)
 
   }
@@ -218,16 +220,16 @@ trait WorkspaceSpendReportComponent {
     def getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds: Set[String],
                                                          startDate: LocalDateTime,
                                                          endDate: LocalDateTime
-                                            ): ReadAction[Seq[WorkspaceSpendReport]] =
+    ): ReadAction[Seq[WorkspaceSpendReport]] =
       loadWorkspaceSpendReport(filterByProjectIdsAndReportDate(projectIds, startDate, endDate))
 
-
-    def filterByProjectIdsAndReportDate(projectIds: Set[String],
-                                startDate: LocalDateTime,
-                                endDate: LocalDateTime
-                               ) =
+    def filterByProjectIdsAndReportDate(projectIds: Set[String], startDate: LocalDateTime, endDate: LocalDateTime) =
       workspaceSpendReportQuery
-        .filter(x => x.googleProjectId.inSetBind(projectIds.map(_.value)) && x.reportStartDate === startDate && x.reportEndDate === endDate)
+        .filter(x =>
+          x.googleProjectId.inSetBind(
+            projectIds.map(_.value)
+          ) && x.reportStartDate === startDate && x.reportEndDate === endDate
+        )
 
     private def loadWorkspaceSpendReport(lookup: WorkspaceSpendReportQueryType): ReadAction[Seq[WorkspaceSpendReport]] =
       for {
@@ -237,7 +239,8 @@ trait WorkspaceSpendReportComponent {
       }
 
     def insert(workspaceSpendReport: WorkspaceSpendReport): WriteAction[Long] =
-      workspaceSpendReportQuery returning workspaceSpendReportQuery.map(_.id) += WorkspaceSpendReportRecord.fromWorkspaceSpendReport(workspaceSpendReport)
+      workspaceSpendReportQuery returning workspaceSpendReportQuery.map(_.id) += WorkspaceSpendReportRecord
+        .fromWorkspaceSpendReport(workspaceSpendReport)
   }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -107,7 +107,7 @@ object WorkspaceSpendReportRecord {
                 otherCredits = categoryCredits
               // This is not included in the consolidated spend report
               case Some(TerraSpendCategories.WorkspaceInfrastructure) =>
-              case None =>
+              case None                                               =>
             }
           }
           WorkspaceSpendReport.newWorkspaceSpendReport(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,11 +1,13 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 
-import scala.language.postfixOps
+import java.util.Currency
+import scala.language.{postfixOps, reflectiveCalls}
+import scala.math.BigDecimal.RoundingMode
 
 
 case class WorkspaceSpendReportRecord (
@@ -55,6 +57,16 @@ object WorkspaceSpendReportRecord {
     }
   }
 
+  def convertLocalDateTimeToJodaDateTime(localDateTime: LocalDateTime, zoneId: ZoneId = ZoneId.systemDefault()): Option[DateTime] = {
+    Option(localDateTime).map { ldt =>
+      // Convert LocalDateTime to ZonedDateTime
+      val zonedDateTime: ZonedDateTime = ldt.atZone(zoneId)
+
+      // Convert ZonedDateTime to Joda DateTime using epoch milli
+      new DateTime(zonedDateTime.toInstant.toEpochMilli)
+    }
+  }
+
   def fromSpendReportingResults(spendReportingResults: SpendReportingResults): Seq[WorkspaceSpendReport] = {
     val summary = spendReportingResults.spendSummary
     spendReportingResults.spendDetails.flatMap {
@@ -83,6 +95,91 @@ object WorkspaceSpendReportRecord {
           otherSpend,
           isDataAvailable = true) // TODO: Handle N/A case
       }}}
+
+  def toSpendReportingResults(records: Seq[WorkspaceSpendReport]): SpendReportingResults = {
+    var start: Option[DateTime] = None
+    var end: Option[DateTime] = None
+    var total = BigDecimal(0.0)
+    var total_credits = BigDecimal(0.0)
+    val all = records.map { record =>
+      val currencyString = "$"
+      val currencyCode = Currency.getInstance(currencyString)
+      val projectId = record.googleProjectId
+      //      val workspaceName = // TODO
+
+      def formatCategoryCost(cost: Option[Float]): String = {
+        cost match {
+          case Some(cost) => toBigDecimal(cost).toString()
+          case None => "N/A"
+        }
+      }
+
+      def toBigDecimal(cost: Float): BigDecimal = {
+        BigDecimal(cost).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
+      }
+
+      val credits = BigDecimal(0.0).toString() // TODO: Store credits per category
+      val subAggregation = List(
+        SpendReportingForDateRange(
+          formatCategoryCost(record.otherSpend),
+          credits,
+          currencyCode.toString,
+          category = Option(TerraSpendCategories.Other)
+        ),
+        SpendReportingForDateRange(
+          formatCategoryCost(record.totalStorage),
+          credits,
+          currencyCode.toString,
+          category = Option(TerraSpendCategories.Storage)
+        ),
+        SpendReportingForDateRange(
+          formatCategoryCost(record.totalCompute),
+          credits,
+          currencyCode.toString,
+          category = Option(TerraSpendCategories.Compute)
+        )
+      )
+
+      val totalCompute: Option[Float] = record.totalCompute
+      val totalStorage: Option[Float] = record.totalStorage
+      val otherSpend: Option[Float] = record.otherSpend
+      val total_cost: Option[Float] = for {
+        c1 <- totalCompute
+        c2 <- totalStorage
+        c3 <- otherSpend
+      } yield c1 + c2 + c3
+
+//      val credits =
+//        getRoundedNumericValue("other_credits") + getRoundedNumericValue("storage_credits") + getRoundedNumericValue(
+//          "compute_credits"
+//        )
+      total = total + toBigDecimal(total_cost.getOrElse(0.0f))
+//      total_credits = total_credits + credits
+      start = convertLocalDateTimeToJodaDateTime(record.reportStartDate)
+      end = convertLocalDateTimeToJodaDateTime(record.reportEndDate)
+      val workspaceTotal = SpendReportingForDateRange(
+        total_cost.toString,
+        credits,
+        currencyCode.toString,
+        start,
+        end,
+        workspace = Option.empty, // TODO: workspace name DB lookup -> easier to just store it?
+        googleProjectId = Option(GoogleProject(projectId)),
+        subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
+      )
+      SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(workspaceTotal))
+    }
+
+    val summary = SpendReportingForDateRange(
+      total.toString,
+      total_credits.toString,
+      "USD",
+      start,
+      end,
+    )
+    SpendReportingResults(all, summary)
+  }
+
 }
 
 trait WorkspaceSpendReportComponent {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -108,7 +108,7 @@ object WorkspaceSpendReportRecord {
     var end: Option[DateTime] = None
     var total_spend = BigDecimal(0.0)
     var total_credits = BigDecimal(0.0)
-    val currency: Currency = SpendReportUtils.getCurrency(records.map(_.currency))
+    val currency: Currency = SpendReportUtils.getCurrency(records.map(_.currency).toList)
     val all = records.map { record =>
       val currencyString = record.currency
       val currencyCode = Currency.getInstance(currencyString)
@@ -138,13 +138,15 @@ object WorkspaceSpendReportRecord {
       val cost: Option[Float] = Option(Seq(record.totalCompute, record.totalStorage, record.otherSpend).flatten.sum)
       val credits: Option[Float] =
         Option(Seq(record.computeCredits, record.storageCredits, record.otherCredits).flatten.sum)
-      total_spend = total_spend + SpendReportUtils.toBigDecimal(cost, currencyCode)
-      total_credits = total_credits + SpendReportUtils.toBigDecimal(credits, currencyCode)
+      val workspace_spend: BigDecimal = SpendReportUtils.toBigDecimal(cost, currencyCode)
+      val workspace_credits: BigDecimal = SpendReportUtils.toBigDecimal(credits, currencyCode)
+      total_spend = total_spend + workspace_spend
+      total_credits = total_credits + workspace_credits
       start = SpendReportUtils.convertLocalDateTimeToJodaDateTime(record.reportStartDate)
       end = SpendReportUtils.convertLocalDateTimeToJodaDateTime(record.reportEndDate)
       val workspaceTotal = SpendReportingForDateRange(
-        total_spend.toString,
-        total_credits.toString,
+        workspace_spend.toString,
+        workspace_credits.toString,
         currency.toString,
         start,
         end,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,0 +1,114 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import java.time.LocalDateTime
+import org.broadinstitute.dsde.rawls.model._
+
+import scala.language.postfixOps
+
+
+case class WorkspaceSpendReportRecord (
+  id: Long,
+  googleProjectId: String,
+  reportStartDate: LocalDateTime,
+  reportEndDate: LocalDateTime,
+  totalCompute: Option[Float],
+  totalStorage: Option[Float],
+  otherSpend: Option[Float],
+  isDataAvailable: Boolean
+)
+
+object WorkspaceSpendReportRecord {
+
+  def fromWorkspaceSpendReport(workspaceSpendReport: WorkspaceSpendReport): WorkspaceSpendReportRecord =
+    WorkspaceSpendReportRecord(
+      workspaceSpendReport.id,
+      workspaceSpendReport.googleProjectId,
+      workspaceSpendReport.reportStartDate,
+      workspaceSpendReport.reportEndDate,
+      workspaceSpendReport.totalCompute,
+      workspaceSpendReport.totalStorage,
+      workspaceSpendReport.otherSpend,
+      workspaceSpendReport.isDataAvailable
+    )
+
+  def toWorkspaceSpendReport(record: WorkspaceSpendReportRecord): WorkspaceSpendReport =
+    WorkspaceSpendReport(
+      record.id,
+      record.googleProjectId,
+      record.reportStartDate,
+      record.reportEndDate,
+      record.totalCompute,
+      record.totalStorage,
+      record.otherSpend,
+      record.isDataAvailable
+    )
+}
+
+trait WorkspaceSpendReportComponent {
+  this: DriverComponent =>
+
+  import driver.api._
+
+  class WorkspaceSpendReportTable(tag: Tag) extends Table[WorkspaceSpendReportRecord](tag, "WORKSPACE_SPEND_REPORT") {
+
+    def id = column[Long]("ID", O.PrimaryKey, O.AutoInc)
+
+    def googleProjectId = column[String]("GOOGLE_PROJECT_ID", O.Length(254))
+
+    def reportStartDate = column[LocalDateTime]("REPORT_START_DATE", O.SqlType("DATETIME"))
+
+    def reportEndDate = column[LocalDateTime]("REPORT_END_DATE", O.SqlType("DATETIME"))
+
+    def totalCompute = column[Option[Float]]("TOTAL_COMPUTE", O.SqlType("NUMBER(10,2)"))
+
+    def totalStorage = column[Option[Float]]("TOTAL_STORAGE", O.SqlType("NUMBER(10,2)"))
+
+    def otherSpend = column[Option[Float]]("OTHER_SPEND", O.SqlType("NUMBER(10,2)"))
+
+    def isDataAvailable = column[Boolean]("IS_DATA_AVAILABLE")
+
+    def * = (id,
+             googleProjectId,
+             reportStartDate,
+             reportEndDate,
+             totalCompute,
+             totalStorage,
+             otherSpend,
+             isDataAvailable,
+    ) <> ((WorkspaceSpendReportRecord.apply _).tupled, WorkspaceSpendReportRecord.unapply)
+
+  }
+
+  protected val workspaceSpendReportQuery = TableQuery[WorkspaceSpendReportTable]
+
+  type WorkspaceSpendReportQueryType = driver.api.Query[WorkspaceSpendReportTable, WorkspaceSpendReportRecord, Seq]
+
+  object WorkspaceSpendReportQuery extends TableQuery(new WorkspaceSpendReportTable(_)) {
+
+    def getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds: Seq[String],
+                                                         startDate: LocalDateTime,
+                                                         endDate: LocalDateTime
+                                            ): ReadAction[Seq[WorkspaceSpendReport]] =
+      loadWorkspaceSpendReport(filterByProjectIdsAndReportDate(projectIds, startDate, endDate))
+
+
+    def filterByProjectIdsAndReportDate(projectIds: Seq[String],
+                                startDate: LocalDateTime,
+                                endDate: LocalDateTime
+                               ): ReadAction[Seq[WorkspaceSpendReportRecord]] =
+      workspaceSpendReportQuery
+        .filter(x => x.googleProjectId.inSetBind(projectIds.map(_.value)) && x.reportStartDate === startDate && x.reportEndDate === endDate)
+        .result
+
+    private def loadWorkspaceSpendReport(lookup: WorkspaceSpendReportQueryType): ReadAction[Seq[WorkspaceSpendReport]] =
+      for {
+        records <- lookup.result
+      } yield records.map { record =>
+        WorkspaceSpendReportRecord.toWorkspaceSpendReport(record)
+      }
+
+    def insert(workspaceSpendReport: WorkspaceSpendReport): WriteAction[Long] =
+      workspaceSpendReportQuery returning workspaceSpendReportQuery.map(_.id) += WorkspaceSpendReportRecord.fromWorkspaceSpendReport(workspaceSpendReport)
+  }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -117,8 +117,7 @@ object WorkspaceSpendReportRecord {
                                otherCredits: Float,
                                projectNames: Map[GoogleProjectId, WorkspaceName]
   ): SpendReportingForDateRange = {
-    val currencyString = currency
-    val currencyCode = Currency.getInstance(currencyString)
+    val currencyCode = Currency.getInstance(currency)
     val workspaceName = projectNames.getOrElse(
       GoogleProjectId(projectId),
       throw RawlsExceptionWithErrorReport(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,5 +1,8 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -96,7 +99,7 @@ object WorkspaceSpendReportRecord {
           isDataAvailable = true) // TODO: Handle N/A case
       }}}
 
-  def toSpendReportingResults(records: Seq[WorkspaceSpendReport]): SpendReportingResults = {
+  def toSpendReportingResults(records: Seq[WorkspaceSpendReport], projectNames: Map[GoogleProjectId, WorkspaceName]): SpendReportingResults = {
     var start: Option[DateTime] = None
     var end: Option[DateTime] = None
     var total = BigDecimal(0.0)
@@ -105,7 +108,6 @@ object WorkspaceSpendReportRecord {
       val currencyString = "$"
       val currencyCode = Currency.getInstance(currencyString)
       val projectId = record.googleProjectId
-      //      val workspaceName = // TODO
 
       def formatCategoryCost(cost: Option[Float]): String = {
         cost match {
@@ -163,7 +165,7 @@ object WorkspaceSpendReportRecord {
         currencyCode.toString,
         start,
         end,
-        workspace = Option.empty, // TODO: workspace name DB lookup -> easier to just store it?
+        workspace = projectNames.get(GoogleProjectId(projectId)),
         googleProjectId = Option(GoogleProject(projectId)),
         subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
       )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,17 +1,14 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
-import akka.http.scaladsl.model.StatusCodes
-import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
-
-import java.time.{Instant, LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
+import java.time.{LocalDateTime, ZoneOffset}
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.spendreporting.SpendReportUtils
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.DateTime
 
 import java.sql.Timestamp
 import java.util.Currency
 import scala.language.{postfixOps, reflectiveCalls}
-import scala.math.BigDecimal.RoundingMode
 
 case class WorkspaceSpendReportRecord(
   id: Long,
@@ -62,68 +59,43 @@ object WorkspaceSpendReportRecord {
       record.otherCredits
     )
 
-  def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime =
-    dateTimeOpt match {
-      case Some(dateTime) =>
-        val instant = dateTime.toInstant
-        LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(dateTime.getMillis), ZoneId.systemDefault())
-      case None =>
-        throw new IllegalArgumentException("DateTime value is missing")
-    }
-
-  def convertLocalDateTimeToJodaDateTime(localDateTime: LocalDateTime,
-                                         zoneId: ZoneId = ZoneId.systemDefault()
-  ): Option[DateTime] =
-    Option(localDateTime).map { ldt =>
-      // Convert LocalDateTime to ZonedDateTime
-      val zonedDateTime: ZonedDateTime = ldt.atZone(zoneId)
-
-      // Convert ZonedDateTime to Joda DateTime using epoch milli
-      new DateTime(zonedDateTime.toInstant.toEpochMilli)
-    }
-
   def fromSpendReportingResults(spendReportingResults: SpendReportingResults): Seq[WorkspaceSpendReport] = {
     val summary = spendReportingResults.spendSummary
     spendReportingResults.spendDetails.flatMap { spendDetail =>
-      spendDetail.spendData.map {
-        var totalStorage: Option[Float] = None
-        var totalCompute: Option[Float] = None
-        var otherSpend: Option[Float] = None
-        var storageCredits: Option[Float] = None
-        var computeCredits: Option[Float] = None
-        var otherCredits: Option[Float] = None
-        spendData =>
-          spendData.subAggregation.get.spendData.foreach { categorySpend =>
-            val categoryCost = Some(categorySpend.cost.toFloat)
-            val categoryCredits = Some(categorySpend.credits.toFloat)
-            categorySpend.category match {
-              case Some(TerraSpendCategories.Storage) =>
-                totalStorage = categoryCost
-                storageCredits = categoryCredits
-              case Some(TerraSpendCategories.Compute) =>
-                totalCompute = categoryCost
-                computeCredits = categoryCredits
-              case Some(TerraSpendCategories.Other) =>
-                otherSpend = categoryCost
-                otherCredits = categoryCredits
-              // This is not included in the consolidated spend report
-              case Some(TerraSpendCategories.WorkspaceInfrastructure) =>
-              case None                                               =>
+      spendDetail.spendData.map { spendData =>
+        val spendCategoryMap: Map[Option[TerraSpendCategories.TerraSpendCategory], SpendReportingForDateRange] =
+          spendData.subAggregation
+            .flatMap(_.spendData)
+            .map(datedReport => datedReport.category -> datedReport)
+            .toMap
+
+        // helper to look up the cost and credits for a given category
+        def getCategoryCost(category: TerraSpendCategories.TerraSpendCategory): (Option[Float], Option[Float]) =
+          spendCategoryMap
+            .get(Some(category))
+            .map { categorySpend =>
+              (Option(categorySpend.cost.toFloat), Option(categorySpend.credits.toFloat))
             }
-          }
-          WorkspaceSpendReport.newWorkspaceSpendReport(
-            spendData.googleProjectId.get.value,
-            convertJodaToJava(summary.startTime),
-            convertJodaToJava(summary.endTime),
-            summary.currency,
-            isDataAvailable = true,
-            totalCompute,
-            totalStorage,
-            otherSpend,
-            computeCredits,
-            storageCredits,
-            otherCredits
-          )
+            .getOrElse((None, None))
+
+        // get cost and credits for the categories we care about
+        val (totalStorage, storageCredits) = getCategoryCost(TerraSpendCategories.Storage)
+        val (totalCompute, computeCredits) = getCategoryCost(TerraSpendCategories.Compute)
+        val (otherSpend, otherCredits) = getCategoryCost(TerraSpendCategories.Other)
+
+        WorkspaceSpendReport.newWorkspaceSpendReport(
+          spendData.googleProjectId.get.value,
+          SpendReportUtils.convertJodaToJava(summary.startTime),
+          SpendReportUtils.convertJodaToJava(summary.endTime),
+          summary.currency,
+          isDataAvailable = true,
+          totalCompute,
+          totalStorage,
+          otherSpend,
+          computeCredits,
+          storageCredits,
+          otherCredits
+        )
       }
     }
   }
@@ -135,67 +107,40 @@ object WorkspaceSpendReportRecord {
     var end: Option[DateTime] = None
     var total_spend = BigDecimal(0.0)
     var total_credits = BigDecimal(0.0)
-    val currency = records.map(_.currency).distinct match {
-      case head :: List() => Currency.getInstance(head)
-      case head :: tail =>
-        throw RawlsExceptionWithErrorReport(
-          StatusCodes.InternalServerError,
-          s"Inconsistent currencies found while aggregating spend data: $head and ${tail.head} cannot be combined"
-        )
-      case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
-    }
-
+    val currency: Currency = SpendReportUtils.getCurrency(records.map(_.currency))
     val all = records.map { record =>
       val currencyString = record.currency
       val currencyCode = Currency.getInstance(currencyString)
       val projectId = record.googleProjectId
 
-      def toBigDecimal(cost: Option[Float]): BigDecimal =
-        BigDecimal(cost.getOrElse(0.0f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
-
       val subAggregation = List(
         SpendReportingForDateRange(
-          toBigDecimal(record.otherSpend).toString(),
-          toBigDecimal(record.otherCredits).toString(),
+          SpendReportUtils.toBigDecimal(record.otherSpend, currencyCode).toString(),
+          SpendReportUtils.toBigDecimal(record.otherCredits, currencyCode).toString(),
           currencyCode.toString,
           category = Option(TerraSpendCategories.Other)
         ),
         SpendReportingForDateRange(
-          toBigDecimal(record.totalStorage).toString(),
-          toBigDecimal(record.storageCredits).toString(),
+          SpendReportUtils.toBigDecimal(record.totalStorage, currencyCode).toString(),
+          SpendReportUtils.toBigDecimal(record.storageCredits, currencyCode).toString(),
           currencyCode.toString,
           category = Option(TerraSpendCategories.Storage)
         ),
         SpendReportingForDateRange(
-          toBigDecimal(record.totalCompute).toString(),
-          toBigDecimal(record.computeCredits).toString(),
+          SpendReportUtils.toBigDecimal(record.totalCompute, currencyCode).toString(),
+          SpendReportUtils.toBigDecimal(record.computeCredits, currencyCode).toString(),
           currencyCode.toString,
           category = Option(TerraSpendCategories.Compute)
         )
       )
 
-      val totalCompute: Option[Float] = record.totalCompute
-      val totalStorage: Option[Float] = record.totalStorage
-      val otherSpend: Option[Float] = record.otherSpend
-      val cost: Option[Float] = for {
-        cost1 <- totalCompute
-        cost2 <- totalStorage
-        cost3 <- otherSpend
-      } yield cost1 + cost2 + cost3
-
-      val computeCredits: Option[Float] = record.computeCredits
-      val storageCredits: Option[Float] = record.storageCredits
-      val otherCredits: Option[Float] = record.otherCredits
-      val credits: Option[Float] = for {
-        credit1 <- computeCredits
-        credit2 <- storageCredits
-        credit3 <- otherCredits
-      } yield credit1 + credit2 + credit3
-
-      total_spend = total_spend + toBigDecimal(cost)
-      total_credits = total_credits + toBigDecimal(credits)
-      start = convertLocalDateTimeToJodaDateTime(record.reportStartDate)
-      end = convertLocalDateTimeToJodaDateTime(record.reportEndDate)
+      val cost: Option[Float] = Option(Seq(record.totalCompute, record.totalStorage, record.otherSpend).flatten.sum)
+      val credits: Option[Float] =
+        Option(Seq(record.computeCredits, record.storageCredits, record.otherCredits).flatten.sum)
+      total_spend = total_spend + SpendReportUtils.toBigDecimal(cost, currencyCode)
+      total_credits = total_credits + SpendReportUtils.toBigDecimal(credits, currencyCode)
+      start = SpendReportUtils.convertLocalDateTimeToJodaDateTime(record.reportStartDate)
+      end = SpendReportUtils.convertLocalDateTimeToJodaDateTime(record.reportEndDate)
       val workspaceTotal = SpendReportingForDateRange(
         total_spend.toString,
         total_credits.toString,
@@ -280,7 +225,10 @@ trait WorkspaceSpendReportComponent {
     ): ReadAction[Seq[WorkspaceSpendReport]] =
       loadWorkspaceSpendReport(filterByProjectIdsAndReportDate(projectIds, startDate, endDate))
 
-    def filterByProjectIdsAndReportDate(projectIds: Set[String], startDate: LocalDateTime, endDate: LocalDateTime) =
+    def filterByProjectIdsAndReportDate(projectIds: Set[String],
+                                        startDate: LocalDateTime,
+                                        endDate: LocalDateTime
+    ): Query[WorkspaceSpendReportTable, WorkspaceSpendReportRecord, Seq] =
       workspaceSpendReportQuery
         .filter(x =>
           x.googleProjectId.inSetBind(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -65,7 +65,8 @@ object WorkspaceSpendReportRecord {
       spendDetail.spendData.map { spendData =>
         val spendCategoryMap: Map[Option[TerraSpendCategories.TerraSpendCategory], SpendReportingForDateRange] =
           spendData.subAggregation
-            .flatMap(_.spendData)
+            .map(_.spendData)
+            .getOrElse(Seq())
             .map(datedReport => datedReport.category -> datedReport)
             .toMap
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -1,5 +1,8 @@
 package org.broadinstitute.dsde.rawls.dataaccess.slick
 
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+
 import java.time.{LocalDateTime, ZoneOffset}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportUtils
@@ -9,6 +12,7 @@ import org.joda.time.DateTime
 import java.sql.Timestamp
 import java.util.Currency
 import scala.language.{postfixOps, reflectiveCalls}
+import scala.math.BigDecimal.RoundingMode
 
 case class WorkspaceSpendReportRecord(
   id: Long,
@@ -101,68 +105,100 @@ object WorkspaceSpendReportRecord {
     }
   }
 
+  def toSpendReportAggregation(currency: String,
+                               projectId: String,
+                               start: Option[DateTime],
+                               end: Option[DateTime],
+                               totalStorage: Float,
+                               storageCredits: Float,
+                               totalCompute: Float,
+                               computeCredits: Float,
+                               otherSpend: Float,
+                               otherCredits: Float,
+                               projectNames: Map[GoogleProjectId, WorkspaceName]
+  ): SpendReportingForDateRange = {
+    val currencyString = currency
+    val currencyCode = Currency.getInstance(currencyString)
+    val workspaceName = projectNames.getOrElse(
+      GoogleProjectId(projectId),
+      throw RawlsExceptionWithErrorReport(
+        StatusCodes.InternalServerError,
+        s"unexpected project $projectId returned by BigQuery"
+      )
+    )
+
+    val subAggregation = List(
+      SpendReportingForDateRange(
+        SpendReportUtils.toBigDecimal(otherSpend, currencyCode).toString,
+        SpendReportUtils.toBigDecimal(otherCredits, currencyCode).toString,
+        currencyCode.toString,
+        category = Option(TerraSpendCategories.Other)
+      ),
+      SpendReportingForDateRange(
+        SpendReportUtils.toBigDecimal(totalStorage, currencyCode).toString,
+        SpendReportUtils.toBigDecimal(storageCredits, currencyCode).toString,
+        currencyCode.toString,
+        category = Option(TerraSpendCategories.Storage)
+      ),
+      SpendReportingForDateRange(
+        SpendReportUtils.toBigDecimal(totalCompute, currencyCode).toString,
+        SpendReportUtils.toBigDecimal(computeCredits, currencyCode).toString,
+        currencyCode.toString,
+        category = Option(TerraSpendCategories.Compute)
+      )
+    )
+    val cost: Option[Float] = Option(Seq(totalCompute, totalStorage, otherSpend).sum)
+    val credits: Option[Float] =
+      Option(Seq(computeCredits, storageCredits, otherCredits).sum)
+    val workspace_spend: BigDecimal = SpendReportUtils.toBigDecimal(cost.getOrElse(0.00f), currencyCode)
+    val workspace_credits: BigDecimal = SpendReportUtils.toBigDecimal(credits.getOrElse(0.00f), currencyCode)
+    SpendReportingForDateRange(
+      workspace_spend.toString,
+      workspace_credits.toString,
+      currencyCode.toString,
+      start,
+      end,
+      workspace = projectNames.get(GoogleProjectId(projectId)),
+      googleProjectId = Option(GoogleProject(projectId)),
+      subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
+    )
+  }
+
   def toSpendReportingResults(records: Seq[WorkspaceSpendReport],
+                              start: DateTime,
+                              end: DateTime,
                               projectNames: Map[GoogleProjectId, WorkspaceName]
   ): SpendReportingResults = {
-    var start: Option[DateTime] = None
-    var end: Option[DateTime] = None
     var total_spend = BigDecimal(0.0)
     var total_credits = BigDecimal(0.0)
     val currency: Currency = SpendReportUtils.getCurrency(records.map(_.currency).toList)
     val all = records.map { record =>
       val currencyString = record.currency
-      val currencyCode = Currency.getInstance(currencyString)
       val projectId = record.googleProjectId
-
-      val subAggregation = List(
-        SpendReportingForDateRange(
-          SpendReportUtils.toBigDecimal(record.otherSpend, currencyCode).toString(),
-          SpendReportUtils.toBigDecimal(record.otherCredits, currencyCode).toString(),
-          currencyCode.toString,
-          category = Option(TerraSpendCategories.Other)
-        ),
-        SpendReportingForDateRange(
-          SpendReportUtils.toBigDecimal(record.totalStorage, currencyCode).toString(),
-          SpendReportUtils.toBigDecimal(record.storageCredits, currencyCode).toString(),
-          currencyCode.toString,
-          category = Option(TerraSpendCategories.Storage)
-        ),
-        SpendReportingForDateRange(
-          SpendReportUtils.toBigDecimal(record.totalCompute, currencyCode).toString(),
-          SpendReportUtils.toBigDecimal(record.computeCredits, currencyCode).toString(),
-          currencyCode.toString,
-          category = Option(TerraSpendCategories.Compute)
-        )
+      val spendReportingForDateRange = toSpendReportAggregation(
+        currencyString,
+        projectId,
+        Option(start),
+        Option(end),
+        record.totalStorage.getOrElse(0.00f),
+        record.storageCredits.getOrElse(0.00f),
+        record.totalCompute.getOrElse(0.00f),
+        record.computeCredits.getOrElse(0.00f),
+        record.otherSpend.getOrElse(0.00f),
+        record.otherCredits.getOrElse(0.00f),
+        projectNames
       )
 
-      val cost: Option[Float] = Option(Seq(record.totalCompute, record.totalStorage, record.otherSpend).flatten.sum)
-      val credits: Option[Float] =
-        Option(Seq(record.computeCredits, record.storageCredits, record.otherCredits).flatten.sum)
-      val workspace_spend: BigDecimal = SpendReportUtils.toBigDecimal(cost, currencyCode)
-      val workspace_credits: BigDecimal = SpendReportUtils.toBigDecimal(credits, currencyCode)
-      total_spend = total_spend + workspace_spend
-      total_credits = total_credits + workspace_credits
-      start = SpendReportUtils.convertLocalDateTimeToJodaDateTime(record.reportStartDate)
-      end = SpendReportUtils.convertLocalDateTimeToJodaDateTime(record.reportEndDate)
-      val workspaceTotal = SpendReportingForDateRange(
-        workspace_spend.toString,
-        workspace_credits.toString,
-        currency.toString,
-        start,
-        end,
-        workspace = projectNames.get(GoogleProjectId(projectId)),
-        googleProjectId = Option(GoogleProject(projectId)),
-        subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
-      )
-      SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(workspaceTotal))
+      total_spend = total_spend + BigDecimal(spendReportingForDateRange.cost)
+      total_credits = total_credits + BigDecimal(spendReportingForDateRange.credits)
+      SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(spendReportingForDateRange))
     }
-
     val summary = SpendReportingForDateRange(
       total_spend.toString,
       total_credits.toString,
       currency.toString,
-      start,
-      end
+      Option(start),
+      Option(end)
     )
     SpendReportingResults(all, summary)
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -31,8 +31,8 @@ object WorkspaceSpendReportRecord {
     WorkspaceSpendReportRecord(
       workspaceSpendReport.id,
       workspaceSpendReport.googleProjectId,
-      new Timestamp(workspaceSpendReport.reportStartDate.toInstant(ZoneOffset.UTC).toEpochMilli),
-      new Timestamp(workspaceSpendReport.reportEndDate.toInstant(ZoneOffset.UTC).toEpochMilli),
+      Timestamp.valueOf(workspaceSpendReport.reportStartDate),
+      Timestamp.valueOf(workspaceSpendReport.reportEndDate),
       workspaceSpendReport.currency,
       workspaceSpendReport.isDataAvailable,
       workspaceSpendReport.totalCompute,
@@ -47,8 +47,8 @@ object WorkspaceSpendReportRecord {
     WorkspaceSpendReport(
       record.id,
       record.googleProjectId,
-      LocalDateTime.ofInstant(record.reportStartDate.toInstant, ZoneOffset.UTC),
-      LocalDateTime.ofInstant(record.reportEndDate.toInstant, ZoneOffset.UTC),
+      record.reportStartDate.toLocalDateTime,
+      record.reportEndDate.toLocalDateTime,
       record.currency,
       record.isDataAvailable,
       record.totalCompute,
@@ -234,8 +234,8 @@ trait WorkspaceSpendReportComponent {
         .filter(x =>
           x.googleProjectId.inSetBind(
             projectIds.map(_.value)
-          ) && x.reportStartDate === new Timestamp(startDate.toInstant(ZoneOffset.UTC).toEpochMilli)
-            && x.reportEndDate === new Timestamp(endDate.toInstant(ZoneOffset.UTC).toEpochMilli)
+          ) && x.reportStartDate === Timestamp.valueOf(startDate)
+            && x.reportEndDate === Timestamp.valueOf(endDate)
         )
 
     private def loadWorkspaceSpendReport(lookup: WorkspaceSpendReportQueryType): ReadAction[Seq[WorkspaceSpendReport]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -105,6 +105,7 @@ object WorkspaceSpendReportRecord {
               case Some(TerraSpendCategories.Other) =>
                 otherSpend = categoryCost
                 otherCredits = categoryCredits
+              case None =>
             }
           }
           WorkspaceSpendReport.newWorkspaceSpendReport(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportComponent.scala
@@ -105,6 +105,8 @@ object WorkspaceSpendReportRecord {
               case Some(TerraSpendCategories.Other) =>
                 otherSpend = categoryCost
                 otherCredits = categoryCredits
+              // This is not included in the consolidated spend report
+              case Some(TerraSpendCategories.WorkspaceInfrastructure) =>
               case None =>
             }
           }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportUtils.scala
@@ -22,9 +22,8 @@ object SpendReportUtils {
       case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
     }
 
-  def toBigDecimal(cost: Option[Float], currencyCode: Currency): BigDecimal = {
+  def toBigDecimal(cost: Option[Float], currencyCode: Currency): BigDecimal =
     BigDecimal(cost.getOrElse(0.00f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
-  }
 
   def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime =
     dateTimeOpt match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportUtils.scala
@@ -22,8 +22,8 @@ object SpendReportUtils {
       case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
     }
 
-  def toBigDecimal(cost: Option[Float], currencyCode: Currency): BigDecimal =
-    BigDecimal(cost.getOrElse(0.00f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
+  def toBigDecimal(cost: Float, currencyCode: Currency): BigDecimal =
+    BigDecimal(cost.toString).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
 
   def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime =
     dateTimeOpt match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportUtils.scala
@@ -1,0 +1,47 @@
+package org.broadinstitute.dsde.rawls.spendreporting
+
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+
+import scala.math.BigDecimal.RoundingMode
+import java.time.{Instant, LocalDateTime, ZoneId, ZonedDateTime}
+import org.joda.time.DateTime
+
+import java.util.Currency
+
+object SpendReportUtils {
+
+  def getCurrency(currencies: Seq[String]): Currency =
+    currencies.distinct match {
+      case head :: List() => Currency.getInstance(head)
+      case head :: tail =>
+        throw RawlsExceptionWithErrorReport(
+          StatusCodes.InternalServerError,
+          s"Inconsistent currencies found while aggregating spend data: $head and ${tail.head} cannot be combined"
+        )
+      case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
+    }
+
+  def toBigDecimal(cost: Option[Float], currencyCode: Currency): BigDecimal = {
+    BigDecimal(cost.getOrElse(0.00f)).setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
+  }
+
+  def convertJodaToJava(dateTimeOpt: Option[DateTime]): LocalDateTime =
+    dateTimeOpt match {
+      case Some(dateTime) =>
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(dateTime.getMillis), ZoneId.systemDefault())
+      case None =>
+        throw new IllegalArgumentException("DateTime value is missing")
+    }
+
+  def convertLocalDateTimeToJodaDateTime(localDateTime: LocalDateTime,
+                                         zoneId: ZoneId = ZoneId.systemDefault()
+  ): Option[DateTime] =
+    Option(localDateTime).map { ldt =>
+      // Convert LocalDateTime to ZonedDateTime
+      val zonedDateTime: ZonedDateTime = ldt.atZone(zoneId)
+
+      // Convert ZonedDateTime to Joda DateTime using epoch milli
+      new DateTime(zonedDateTime.toInstant.toEpochMilli)
+    }
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.rawls.billing.{
   BpmAzureSpendReportApiException
 }
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceSpendReportRecord
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.metrics.{GoogleInstrumented, HitRatioGauge, RawlsInstrumented}
 import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeyWithSub, _}
@@ -574,71 +575,86 @@ class SpendReportingService(
           return Future.successful(None)
         }
         projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
-        projectIds = projectNames.keySet.map(x => x.value)
+        projectIds = projectNames.keySet.map(_.value)
         tableToProjectIdsMap: Map[String, Seq[GoogleProjectId]] = billingMap.map { case (table, workspaces) =>
           table -> workspaces.map(_._1)
         }
-
-        cacheResults <- checkCachedWorkspaceSpend(projectIds, start, end)
-        _ = if (cacheResults.size == projectIds.size) {
-          val hasDataAvailable = cacheResults.filter(cached => cached.isDataAvailable)
-          return Future.successful(
-            Some(workspaceSpendReportRepository.toSpendReportResults(hasDataAvailable, projectNames))
-          )
-        }
-        results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
-          val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
-          val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
-          runBigQueryJob(queryJob, childContext)
-            .map { result =>
-              result.getValues.asScala.toList match {
-                case Nil => None
-                case rows =>
-                  val crossBillingResults =
-                    extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
-                  workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
-                  Some(crossBillingResults)
-              }
-            }
-            .recoverWith { case ex: Throwable =>
-              logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
-              Future.successful(None)
-            }
-        })
-        _ = if (results.nonEmpty) {
-          insertRecordsWithMissingSpendData(results, projectNames, start, end)
-        }
-        combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
+        startLocalDateTime =
+          LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
+        endLocalDateTime =
+          LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+        cacheResults <- workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds,
+                                                                                startLocalDateTime,
+                                                                                endLocalDateTime
+        )
+        combinedResults <-
+          if (cacheResults.size == projectIds.size) {
+            val hasDataAvailable = cacheResults.filter(cached => cached.isDataAvailable)
+            Future.successful(Some(WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, projectNames)))
+          } else {
+            getUncachedSpendForAllWorkspaces(tableToProjectIdsMap,
+                                             projectNames,
+                                             start,
+                                             end,
+                                             pageSize,
+                                             offset,
+                                             childContext
+            )
+          }
       } yield combinedResults
     }
 
-  def checkCachedWorkspaceSpend(projectIds: Set[String],
-                                start: DateTime,
-                                end: DateTime
-  ): Future[Seq[WorkspaceSpendReport]] = {
-    val startLocalDateTime =
-      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
-    val endLocalDateTime =
-      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
-    workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
-  }
+  def getUncachedSpendForAllWorkspaces(tableToProjectIdsMap: Map[String, Seq[GoogleProjectId]],
+                                       projectNames: Map[GoogleProjectId, WorkspaceName],
+                                       start: DateTime,
+                                       end: DateTime,
+                                       pageSize: Int,
+                                       offset: Int,
+                                       childContext: RawlsRequestContext
+  ): Future[Option[SpendReportingResults]] =
+    for {
+      results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
+        val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
+        val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+        runBigQueryJob(queryJob, childContext)
+          .map { result =>
+            result.getValues.asScala.toList match {
+              case Nil => None
+              case rows =>
+                val crossBillingResults =
+                  extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
+                workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
+                Some(crossBillingResults)
+            }
+          }
+          .recoverWith { case ex: Throwable =>
+            logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
+            Future.successful(None)
+          }
+      })
+      _ = if (results.nonEmpty) {
+        insertRecordsWithMissingSpendData(results, projectNames, start, end)
+      }
+      combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
+    } yield combinedResults
 
   def insertRecordsWithMissingSpendData(results: Iterable[Option[SpendReportingResults]],
                                         projectNames: Map[GoogleProjectId, WorkspaceName],
                                         start: DateTime,
                                         end: DateTime
   ): Unit = {
-    val reports = results.collect { case Some(report) => report }
-    val googleProjectsWithReports =
-      reports.map(r => r.spendSummary.googleProjectId).collect { case Some(project) => project.toString() }.toSeq
-    val filteredProjectNames: Map[GoogleProjectId, WorkspaceName] = projectNames.filter { case (id, _) =>
-      !googleProjectsWithReports.contains(id.toString())
-    }
+    val googleProjectsWithReports: Set[GoogleProjectId] =
+      results.flatten
+        .flatMap(_.spendSummary.googleProjectId)
+        .map(p => GoogleProjectId(p.value))
+        .toSet
+    // find all supplied project names which are not in the SpendReportingResults projects
+    val missingProjectIds: Set[GoogleProjectId] = projectNames.keySet diff googleProjectsWithReports
     val startLocalDateTime =
       LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
     val endLocalDateTime =
       LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
-    filteredProjectNames.map { case (id, _) =>
+    missingProjectIds.map { id =>
       val spendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
         id.toString(),
         startLocalDateTime,
@@ -650,7 +666,7 @@ class SpendReportingService(
         Option.empty,
         Option.empty,
         Option.empty,
-        Option.empty,
+        Option.empty
       )
       workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -624,9 +624,13 @@ class SpendReportingService(
           val spendResults = cachedResults.flatMap { cachedResult =>
             if (cachedResult.size == projectIds.size) {
               val hasDataAvailable = cachedResult.filter(cached => cached.isDataAvailable)
-              Future.successful(
-                Some(WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, workspaceNamesByProjectId))
-              )
+              if (hasDataAvailable.nonEmpty) {
+                Future.successful(
+                  Some(WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, workspaceNamesByProjectId))
+                )
+              } else {
+                Future.successful(None)
+              }
             } else {
               val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
               val queryJob = setUpAllUserWorkspaceQuery(query, start, end)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -576,7 +576,7 @@ class SpendReportingService(
 
         cacheResults <- checkCachedWorkspaceSpend(projectIds, start, end)
         combinedResults = if (cacheResults.size == projectIds.size) {
-          return Future.successful(Some(workspaceSpendReportRepository.toSpendReportResults(cacheResults)))
+          return Future.successful(Some(workspaceSpendReportRepository.toSpendReportResults(cacheResults, projectNames)))
         }
         results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
             val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -679,7 +679,7 @@ class SpendReportingService(
         "USD"
       )
       workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport).recoverWith { case ex: Throwable =>
-        logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
+        logger.warn(s"Error inserting workspace spend report: ${ex.getMessage}")
         Future.successful(0L)
       }
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -25,12 +25,10 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days}
 
-import java.sql.Timestamp
-import java.util.{Currency, UUID}
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
-import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import scala.util.Try
 
 object SpendReportingService {
@@ -390,10 +388,10 @@ class SpendReportingService(
   }
 
   def setUpAllUserWorkspaceQuery(
-    jobId: String,
     query: String,
     start: DateTime,
-    end: DateTime
+    end: DateTime,
+    exportTableName: String
   ): JobInfo = {
     def queryParam(value: String): QueryParameterValue =
       QueryParameterValue.newBuilder().setType(StandardSQLTypeName.STRING).setValue(value).build()
@@ -402,13 +400,9 @@ class SpendReportingService(
       .newBuilder(query)
       .addNamedParameter("startDate", queryParam(toISODateString(start)))
       .addNamedParameter("endDate", queryParam(toISODateString(end)))
+      .setLabels(Map("exportTableName" -> exportTableName).asJava) // label is only used for unit tests
       .build()
-
-    JobInfo
-      .newBuilder(queryConfig)
-      .setJobId(JobId.of(jobId)) // jobId is only used in unit tests
-      .build()
-
+    JobInfo.newBuilder(queryConfig).build()
   }
 
   def logSpendQueryStats(stats: JobStatistics.QueryStatistics): Unit = {
@@ -557,7 +551,6 @@ class SpendReportingService(
         endLocalDateTime = SpendReportUtils.convertJodaToJava(Some(end))
         // find the distinct export table names in our billingMap
         distinctTableNames: Set[Option[String]] = billingMap.keys.map(_.spendExportTable).toSet
-
         // for each distinct export table name, generate a query.
         results <- Future.sequence(distinctTableNames.map { spendExportTable =>
           // find the subset of the billingMap that we'll use in this query
@@ -597,7 +590,7 @@ class SpendReportingService(
               }
             } else {
               val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
-              val queryJob = setUpAllUserWorkspaceQuery(tableNameForQuery, query, start, end)
+              val queryJob = setUpAllUserWorkspaceQuery(query, start, end, tableNameForQuery)
               val queryResults = runBigQueryJob(queryJob, childContext)
                 .map { result =>
                   result.getValues.asScala.toList match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -155,16 +155,7 @@ object SpendReportingService {
     var total_credits = BigDecimal(0.0)
 
     // TODO: We may want to allow multiple currencies someday
-    val currency = allRows.map(_.get("currency").getStringValue).distinct match {
-      case head :: List() => Currency.getInstance(head)
-      case head :: tail =>
-        throw RawlsExceptionWithErrorReport(
-          StatusCodes.InternalServerError,
-          s"Inconsistent currencies found while aggregating spend data: $head and ${tail.head} cannot be combined"
-        )
-      case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
-    }
-
+    val currency = SpendReportUtils.getCurrency(allRows.map(_.get("currency").getStringValue))
     val all = allRows.map { row =>
       val currencyString = row.get("currency").getStringValue
       val currencyCode = Currency.getInstance(currencyString)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -25,11 +25,12 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days}
 
+import java.sql.Timestamp
 import java.util.{Currency, UUID}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
-import java.time.{LocalDateTime, ZoneId}
+import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import scala.util.Try
 
 object SpendReportingService {
@@ -591,11 +592,8 @@ class SpendReportingService(
           )
         }
 
-        startLocalDateTime =
-          LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
-        endLocalDateTime =
-          LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
-
+        startLocalDateTime = SpendReportUtils.convertJodaToJava(Some(start))
+        endLocalDateTime = SpendReportUtils.convertJodaToJava(Some(end))
         // find the distinct export table names in our billingMap
         distinctTableNames: Set[Option[String]] = billingMap.keys.map(_.spendExportTable).toSet
 
@@ -617,7 +615,6 @@ class SpendReportingService(
           val workspaceNamesByProjectId: Map[GoogleProjectId, WorkspaceName] = billingMapForQuery.values.flatten
             .map(ws => ws.googleProjectId -> ws.toWorkspaceName)
             .toMap
-
           val projectIds = workspaceNamesByProjectId.keySet.map(_.value)
           val cachedResults =
             workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
@@ -625,8 +622,10 @@ class SpendReportingService(
             if (cachedResult.size == projectIds.size) {
               val hasDataAvailable = cachedResult.filter(cached => cached.isDataAvailable)
               if (hasDataAvailable.nonEmpty) {
+                val spendReportingResults =
+                  WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, workspaceNamesByProjectId)
                 Future.successful(
-                  Some(WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, workspaceNamesByProjectId))
+                  Some(spendReportingResults)
                 )
               } else {
                 Future.successful(None)
@@ -634,7 +633,7 @@ class SpendReportingService(
             } else {
               val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
               val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
-              runBigQueryJob(queryJob, childContext)
+              val queryResults = runBigQueryJob(queryJob, childContext)
                 .map { result =>
                   result.getValues.asScala.toList match {
                     case Nil => None
@@ -649,10 +648,11 @@ class SpendReportingService(
                   logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
                   Future.successful(None)
                 }
+              queryResults.flatMap { res =>
+                Future.successful(insertRecordsWithMissingSpendData(res, workspaceNamesByProjectId, start, end))
+              }
+              queryResults
             }
-          }
-          spendResults.flatMap { res =>
-            Future.successful(insertRecordsWithMissingSpendData(res, workspaceNamesByProjectId, start, end))
           }
           spendResults
         })
@@ -666,16 +666,19 @@ class SpendReportingService(
                                         end: DateTime
   ): Set[Future[Long]] = {
     val googleProjectsWithReports: Set[GoogleProjectId] =
-      result
-        .flatMap(_.spendSummary.googleProjectId)
-        .map(p => GoogleProjectId(p.value))
-        .toSet
+      if (result.nonEmpty) {
+        result.get.spendDetails
+          .flatMap(_.spendData)
+          .flatMap(_.googleProjectId)
+          .map(p => GoogleProjectId(p.value))
+          .toSet
+      } else {
+        Set.empty
+      }
     // find all supplied project names which are not in the SpendReportingResults projects
     val missingProjectIds: Set[GoogleProjectId] = projectNames.keySet diff googleProjectsWithReports
-    val startLocalDateTime =
-      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
-    val endLocalDateTime =
-      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+    val startLocalDateTime = SpendReportUtils.convertJodaToJava(Some(start))
+    val endLocalDateTime = SpendReportUtils.convertJodaToJava(Some(end))
     val insertedRecords = missingProjectIds.map { id =>
       val spendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
         id.toString(),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -570,42 +570,42 @@ class SpendReportingService(
         }
         projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
         projectIds = projectNames.keySet.map(x => x.value)
-
-        cacheResults = checkCachedWorkspaceSpend(projectIds, start, end)
-        cacheHit = cacheResults.map { count => count == projectIds.size }
-        // convert cacheResults to workspaceSpend
         tableToProjectIdsMap: Map[String, Seq[GoogleProjectId]] = billingMap.map { case (table, workspaces) =>
           table -> workspaces.map(_._1)
         }
+
+        cacheResults <- checkCachedWorkspaceSpend(projectIds, start, end)
+        combinedResults = if (cacheResults.size == projectIds.size) {
+          return Future.successful(Some(workspaceSpendReportRepository.toSpendReportResults(cacheResults)))
+        }
         results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
-          val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
-          val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
-          runBigQueryJob(queryJob, childContext)
-            .map { result =>
-              result.getValues.asScala.toList match {
-                case Nil  => None
-                case rows =>
-                  val crossBillingResults = extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
-                  workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
-                  Some(crossBillingResults)
+            val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
+            val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+            runBigQueryJob(queryJob, childContext)
+              .map { result =>
+                result.getValues.asScala.toList match {
+                  case Nil  => None
+                  case rows =>
+                    val crossBillingResults = extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
+                    workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
+                    Some(crossBillingResults)
+                }
               }
-            }
-            .recoverWith { case ex: Throwable =>
-              logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
-              Future.successful(None)
-            }
-        })
+              .recoverWith { case ex: Throwable =>
+                logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
+                Future.successful(None)
+              }
+          })
         combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
       } yield combinedResults
-
     }
 
   def checkCachedWorkspaceSpend(projectIds: Set[String],
                                 start: DateTime,
-                                end: DateTime): Future[Int] = {
+                                end: DateTime): Future[Seq[WorkspaceSpendReport]] = {
     val startLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
     val endLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
-    workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime).map(_.size)
+    workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
   }
 
   def runBigQueryJob(queryJob: JobInfo, ctx: RawlsRequestContext): Future[TableResult] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -7,7 +7,11 @@ import cats.effect.unsafe.implicits.global
 import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, JobStatistics, Option => _, _}
 import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, Histogram}
-import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmAzureSpendReportApiException}
+import org.broadinstitute.dsde.rawls.billing.{
+  BillingProfileManagerDAO,
+  BillingRepository,
+  BpmAzureSpendReportApiException
+}
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.metrics.{GoogleInstrumented, HitRatioGauge, RawlsInstrumented}
@@ -216,7 +220,6 @@ object SpendReportingService {
         googleProjectId = Option(GoogleProject(projectId)),
         subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
       )
-      // save query results
       SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(workspaceTotal))
 
     }
@@ -577,28 +580,31 @@ class SpendReportingService(
         cacheResults <- checkCachedWorkspaceSpend(projectIds, start, end)
         _ = if (cacheResults.size == projectIds.size) {
           val hasDataAvailable = cacheResults.filter(cached => cached.isDataAvailable)
-          return Future.successful(Some(workspaceSpendReportRepository.toSpendReportResults(hasDataAvailable, projectNames)))
+          return Future.successful(
+            Some(workspaceSpendReportRepository.toSpendReportResults(hasDataAvailable, projectNames))
+          )
         }
         results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
-            val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
-            val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
-            runBigQueryJob(queryJob, childContext)
-              .map { result =>
-                result.getValues.asScala.toList match {
-                  case Nil  => None
-                  case rows =>
-                    val crossBillingResults = extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
-                    workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
-                    Some(crossBillingResults)
-                }
+          val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
+          val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+          runBigQueryJob(queryJob, childContext)
+            .map { result =>
+              result.getValues.asScala.toList match {
+                case Nil => None
+                case rows =>
+                  val crossBillingResults =
+                    extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
+                  workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
+                  Some(crossBillingResults)
               }
-              .recoverWith { case ex: Throwable =>
-                logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
-                Future.successful(None)
-              }
-          })
+            }
+            .recoverWith { case ex: Throwable =>
+              logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
+              Future.successful(None)
+            }
+        })
         _ = if (results.nonEmpty) {
-          insertRecordsWithMissingSpendData (results, projectNames, start, end)
+          insertRecordsWithMissingSpendData(results, projectNames, start, end)
         }
         combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
       } yield combinedResults
@@ -606,24 +612,30 @@ class SpendReportingService(
 
   def checkCachedWorkspaceSpend(projectIds: Set[String],
                                 start: DateTime,
-                                end: DateTime): Future[Seq[WorkspaceSpendReport]] = {
-    val startLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
-    val endLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+                                end: DateTime
+  ): Future[Seq[WorkspaceSpendReport]] = {
+    val startLocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
+    val endLocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
     workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
   }
 
   def insertRecordsWithMissingSpendData(results: Iterable[Option[SpendReportingResults]],
                                         projectNames: Map[GoogleProjectId, WorkspaceName],
                                         start: DateTime,
-                                        end: DateTime): Unit = {
+                                        end: DateTime
+  ): Unit = {
     val reports = results.collect { case Some(report) => report }
-    val googleProjectsWithReports = reports.map { r => r.spendSummary.googleProjectId }
-      .collect { case Some(project) => project.toString() }.toSeq
-    val filteredProjectNames: Map[GoogleProjectId, WorkspaceName] = projectNames.filter {
-      case (id, _) => !googleProjectsWithReports.contains(id.toString())
+    val googleProjectsWithReports =
+      reports.map(r => r.spendSummary.googleProjectId).collect { case Some(project) => project.toString() }.toSeq
+    val filteredProjectNames: Map[GoogleProjectId, WorkspaceName] = projectNames.filter { case (id, _) =>
+      !googleProjectsWithReports.contains(id.toString())
     }
-    val startLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
-    val endLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+    val startLocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
+    val endLocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
     filteredProjectNames.map { case (id, _) =>
       val spendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
         id.toString(),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -643,10 +643,14 @@ class SpendReportingService(
         id.toString(),
         startLocalDateTime,
         endLocalDateTime,
+        "USD",
+        isDataAvailable = false,
         Option.empty,
         Option.empty,
         Option.empty,
-        isDataAvailable = false
+        Option.empty,
+        Option.empty,
+        Option.empty,
       )
       workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport)
     }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -69,15 +69,7 @@ object SpendReportingService {
     aggregations: Set[SpendReportingAggregationKeyWithSub]
   ): SpendReportingResults = {
 
-    val currency = allRows.map(_.get("currency").getStringValue).distinct match {
-      case head :: List() => Currency.getInstance(head)
-      case head :: tail =>
-        throw RawlsExceptionWithErrorReport(
-          StatusCodes.InternalServerError,
-          s"Inconsistent currencies found while aggregating spend data: $head and ${tail.head} cannot be combined"
-        )
-      case List() => throw RawlsExceptionWithErrorReport(StatusCodes.NotFound, "No currencies found for spend data")
-    }
+    val currency = SpendReportUtils.getCurrency(allRows.map(_.get("currency").getStringValue))
 
     def sum(rows: List[FieldValueList], field: String): String = rows
       .map(row => BigDecimal(row.get(field).getDoubleValue))
@@ -648,8 +640,8 @@ class SpendReportingService(
                   logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
                   Future.successful(None)
                 }
-              queryResults.flatMap { res =>
-                Future.successful(insertRecordsWithMissingSpendData(res, workspaceNamesByProjectId, start, end))
+              queryResults.map { res =>
+                insertRecordsWithMissingSpendData(res, workspaceNamesByProjectId, start, end)
               }
               queryResults
             }
@@ -680,20 +672,16 @@ class SpendReportingService(
     val startLocalDateTime = SpendReportUtils.convertJodaToJava(Some(start))
     val endLocalDateTime = SpendReportUtils.convertJodaToJava(Some(end))
     val insertedRecords = missingProjectIds.map { id =>
-      val spendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
+      val spendReport = WorkspaceSpendReport.newEmptySpendReport(
         id.toString(),
         startLocalDateTime,
         endLocalDateTime,
-        "USD",
-        isDataAvailable = false,
-        Option.empty,
-        Option.empty,
-        Option.empty,
-        Option.empty,
-        Option.empty,
-        Option.empty
+        "USD"
       )
-      workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport)
+      workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport).recoverWith { case ex: Throwable =>
+        logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
+        Future.successful(0L)
+      }
     }
     insertedRecords
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -390,6 +390,7 @@ class SpendReportingService(
   }
 
   def setUpAllUserWorkspaceQuery(
+    jobId: String,
     query: String,
     start: DateTime,
     end: DateTime
@@ -403,7 +404,11 @@ class SpendReportingService(
       .addNamedParameter("endDate", queryParam(toISODateString(end)))
       .build()
 
-    JobInfo.newBuilder(queryConfig).build()
+    JobInfo
+      .newBuilder(queryConfig)
+      .setJobId(JobId.of(jobId)) // jobId is only used in unit tests
+      .build()
+
   }
 
   def logSpendQueryStats(stats: JobStatistics.QueryStatistics): Unit = {
@@ -592,7 +597,7 @@ class SpendReportingService(
               }
             } else {
               val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
-              val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+              val queryJob = setUpAllUserWorkspaceQuery(tableNameForQuery, query, start, end)
               val queryResults = runBigQueryJob(queryJob, childContext)
                 .map { result =>
                   result.getValues.asScala.toList match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -575,8 +575,9 @@ class SpendReportingService(
         }
 
         cacheResults <- checkCachedWorkspaceSpend(projectIds, start, end)
-        combinedResults = if (cacheResults.size == projectIds.size) {
-          return Future.successful(Some(workspaceSpendReportRepository.toSpendReportResults(cacheResults, projectNames)))
+        _ = if (cacheResults.size == projectIds.size) {
+          val hasDataAvailable = cacheResults.filter(cached => cached.isDataAvailable)
+          return Future.successful(Some(workspaceSpendReportRepository.toSpendReportResults(hasDataAvailable, projectNames)))
         }
         results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
             val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
@@ -596,6 +597,9 @@ class SpendReportingService(
                 Future.successful(None)
               }
           })
+        _ = if (results.nonEmpty) {
+          insertRecordsWithMissingSpendData (results, projectNames, start, end)
+        }
         combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
       } yield combinedResults
     }
@@ -606,6 +610,32 @@ class SpendReportingService(
     val startLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
     val endLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
     workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
+  }
+
+  def insertRecordsWithMissingSpendData(results: Iterable[Option[SpendReportingResults]],
+                                        projectNames: Map[GoogleProjectId, WorkspaceName],
+                                        start: DateTime,
+                                        end: DateTime): Unit = {
+    val reports = results.collect { case Some(report) => report }
+    val googleProjectsWithReports = reports.map { r => r.spendSummary.googleProjectId }
+      .collect { case Some(project) => project.toString() }.toSeq
+    val filteredProjectNames: Map[GoogleProjectId, WorkspaceName] = projectNames.filter {
+      case (id, _) => !googleProjectsWithReports.contains(id.toString())
+    }
+    val startLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
+    val endLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+    filteredProjectNames.map { case (id, _) =>
+      val spendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
+        id.toString(),
+        startLocalDateTime,
+        endLocalDateTime,
+        Option.empty,
+        Option.empty,
+        Option.empty,
+        isDataAvailable = false
+      )
+      workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport)
+    }
   }
 
   def runBigQueryJob(queryJob: JobInfo, ctx: RawlsRequestContext): Future[TableResult] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -25,7 +25,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days}
 
-import java.util.UUID
+import java.util.{Base64, UUID}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
@@ -390,8 +390,7 @@ class SpendReportingService(
   def setUpAllUserWorkspaceQuery(
     query: String,
     start: DateTime,
-    end: DateTime,
-    exportTableName: String
+    end: DateTime
   ): JobInfo = {
     def queryParam(value: String): QueryParameterValue =
       QueryParameterValue.newBuilder().setType(StandardSQLTypeName.STRING).setValue(value).build()
@@ -400,8 +399,8 @@ class SpendReportingService(
       .newBuilder(query)
       .addNamedParameter("startDate", queryParam(toISODateString(start)))
       .addNamedParameter("endDate", queryParam(toISODateString(end)))
-      .setLabels(Map("exportTableName" -> exportTableName).asJava) // label is only used for unit tests
       .build()
+
     JobInfo.newBuilder(queryConfig).build()
   }
 
@@ -590,7 +589,7 @@ class SpendReportingService(
               }
             } else {
               val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
-              val queryJob = setUpAllUserWorkspaceQuery(query, start, end, tableNameForQuery)
+              val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
               val queryResults = runBigQueryJob(queryJob, childContext)
                 .map { result =>
                   result.getValues.asScala.toList match {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -151,61 +151,25 @@ object SpendReportingService {
     val currency = SpendReportUtils.getCurrency(allRows.map(_.get("currency").getStringValue))
     val all = allRows.map { row =>
       val currencyString = row.get("currency").getStringValue
-      val currencyCode = Currency.getInstance(currencyString)
       val projectId = row.get("project_id").getStringValue
-      val workspaceName = names.getOrElse(
-        GoogleProjectId(projectId),
-        throw RawlsExceptionWithErrorReport(
-          StatusCodes.InternalServerError,
-          s"unexpected project $projectId returned by BigQuery"
-        )
+      val spendReportingForDateRange = WorkspaceSpendReportRecord.toSpendReportAggregation(
+        currencyString,
+        projectId,
+        Some(start),
+        Some(end),
+        row.get("storage_cost").getDoubleValue.toFloat,
+        row.get("storage_credits").getDoubleValue.toFloat,
+        row.get("compute_cost").getDoubleValue.toFloat,
+        row.get("compute_credits").getDoubleValue.toFloat,
+        row.get("other_cost").getDoubleValue.toFloat,
+        row.get("other_credits").getDoubleValue.toFloat,
+        names
       )
-
-      def getRoundedNumericValue(field: String): BigDecimal =
-        BigDecimal(row.get(field).getDoubleValue)
-          .setScale(currencyCode.getDefaultFractionDigits, RoundingMode.HALF_EVEN)
-
-      val subAggregation = List(
-        SpendReportingForDateRange(
-          getRoundedNumericValue("other_cost").toString,
-          getRoundedNumericValue("other_credits").toString,
-          currencyCode.toString,
-          category = Option(TerraSpendCategories.Other)
-        ),
-        SpendReportingForDateRange(
-          getRoundedNumericValue("storage_cost").toString,
-          getRoundedNumericValue("storage_credits").toString,
-          currencyCode.toString,
-          category = Option(TerraSpendCategories.Storage)
-        ),
-        SpendReportingForDateRange(
-          getRoundedNumericValue("compute_cost").toString,
-          getRoundedNumericValue("compute_credits").toString,
-          currencyCode.toString,
-          category = Option(TerraSpendCategories.Compute)
-        )
-      )
-
-      val total_cost = getRoundedNumericValue("total_cost")
-      val credits =
-        getRoundedNumericValue("other_credits") + getRoundedNumericValue("storage_credits") + getRoundedNumericValue(
-          "compute_credits"
-        )
+      val total_cost = BigDecimal(spendReportingForDateRange.cost)
+      val credits = BigDecimal(spendReportingForDateRange.credits)
       total = total + total_cost
       total_credits = total_credits + credits
-
-      val workspaceTotal = SpendReportingForDateRange(
-        total_cost.toString,
-        credits.toString,
-        currencyCode.toString,
-        Option(start),
-        Option(end),
-        workspace = Option(workspaceName),
-        googleProjectId = Option(GoogleProject(projectId)),
-        subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
-      )
-      SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(workspaceTotal))
-
+      SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(spendReportingForDateRange))
     }
 
     val summary = SpendReportingForDateRange(
@@ -615,7 +579,11 @@ class SpendReportingService(
               val hasDataAvailable = cachedResult.filter(cached => cached.isDataAvailable)
               if (hasDataAvailable.nonEmpty) {
                 val spendReportingResults =
-                  WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, workspaceNamesByProjectId)
+                  WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable,
+                                                                     start,
+                                                                     end,
+                                                                     workspaceNamesByProjectId
+                  )
                 Future.successful(
                   Some(spendReportingResults)
                 )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -7,11 +7,7 @@ import cats.effect.unsafe.implicits.global
 import com.google.cloud.bigquery.{Field, FieldValue, FieldValueList, JobStatistics, Option => _, _}
 import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, Histogram}
-import org.broadinstitute.dsde.rawls.billing.{
-  BillingProfileManagerDAO,
-  BillingRepository,
-  BpmAzureSpendReportApiException
-}
+import org.broadinstitute.dsde.rawls.billing.{BillingProfileManagerDAO, BillingRepository, BpmAzureSpendReportApiException}
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.metrics.{GoogleInstrumented, HitRatioGauge, RawlsInstrumented}
@@ -29,6 +25,7 @@ import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 
+import java.time.{LocalDateTime, ZoneId}
 import scala.util.Try
 
 object SpendReportingService {
@@ -39,7 +36,8 @@ object SpendReportingService {
     bpmDao: BillingProfileManagerDAO,
     samDAO: SamDAO,
     spendReportingServiceConfig: SpendReportingServiceConfig,
-    workspaceServiceConstructor: RawlsRequestContext => WorkspaceService
+    workspaceServiceConstructor: RawlsRequestContext => WorkspaceService,
+    workspaceSpendReportRepository: WorkspaceSpendReportRepository
   )(ctx: RawlsRequestContext)(implicit executionContext: ExecutionContext): SpendReportingService =
     new SpendReportingService(
       ctx,
@@ -49,7 +47,8 @@ object SpendReportingService {
       bpmDao,
       samDAO,
       spendReportingServiceConfig,
-      workspaceServiceConstructor
+      workspaceServiceConstructor,
+      workspaceSpendReportRepository
     )
 
   val SpendReportingMetrics = "spendReporting"
@@ -217,7 +216,7 @@ object SpendReportingService {
         googleProjectId = Option(GoogleProject(projectId)),
         subAggregation = Option(SpendReportingAggregation(SpendReportingAggregationKeys.Category, subAggregation))
       )
-
+      // save query results
       SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, List(workspaceTotal))
 
     }
@@ -242,7 +241,8 @@ class SpendReportingService(
   bpmDao: BillingProfileManagerDAO,
   samDAO: SamDAO,
   spendReportingServiceConfig: SpendReportingServiceConfig,
-  workspaceServiceConstructor: RawlsRequestContext => WorkspaceService
+  workspaceServiceConstructor: RawlsRequestContext => WorkspaceService,
+  workspaceSpendReportRepository: WorkspaceSpendReportRepository
 )(implicit val executionContext: ExecutionContext)
     extends LazyLogging
     with RawlsInstrumented {
@@ -569,6 +569,11 @@ class SpendReportingService(
           return Future.successful(None)
         }
         projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
+        projectIds = projectNames.keySet.map(x => x.value)
+
+        cacheResults = checkCachedWorkspaceSpend(projectIds, start, end)
+        cacheHit = cacheResults.map { count => count == projectIds.size }
+        // convert cacheResults to workspaceSpend
         tableToProjectIdsMap: Map[String, Seq[GoogleProjectId]] = billingMap.map { case (table, workspaces) =>
           table -> workspaces.map(_._1)
         }
@@ -579,7 +584,10 @@ class SpendReportingService(
             .map { result =>
               result.getValues.asScala.toList match {
                 case Nil  => None
-                case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
+                case rows =>
+                  val crossBillingResults = extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames)
+                  workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
+                  Some(crossBillingResults)
               }
             }
             .recoverWith { case ex: Throwable =>
@@ -591,6 +599,14 @@ class SpendReportingService(
       } yield combinedResults
 
     }
+
+  def checkCachedWorkspaceSpend(projectIds: Set[String],
+                                start: DateTime,
+                                end: DateTime): Future[Int] = {
+    val startLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
+    val endLocalDateTime = LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+    workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime).map(_.size)
+  }
 
   def runBigQueryJob(queryJob: JobInfo, ctx: RawlsRequestContext): Future[TableResult] =
     traceFutureWithParent("runBigQueryJob", ctx) { childContext =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -591,6 +591,11 @@ class SpendReportingService(
           )
         }
 
+        startLocalDateTime =
+          LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
+        endLocalDateTime =
+          LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
+
         // find the distinct export table names in our billingMap
         distinctTableNames: Set[Option[String]] = billingMap.keys.map(_.spendExportTable).toSet
 
@@ -613,31 +618,51 @@ class SpendReportingService(
             .map(ws => ws.googleProjectId -> ws.toWorkspaceName)
             .toMap
 
-          val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
-          val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
-          runBigQueryJob(queryJob, childContext)
-            .map { result =>
-              result.getValues.asScala.toList match {
-                case Nil => None
-                case rows =>
-                  Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, workspaceNamesByProjectId))
-              }
+          val projectIds = workspaceNamesByProjectId.keySet.map(_.value)
+          val cachedResults =
+            workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
+          val spendResults = cachedResults.flatMap { cachedResult =>
+            if (cachedResult.size == projectIds.size) {
+              val hasDataAvailable = cachedResult.filter(cached => cached.isDataAvailable)
+              Future.successful(
+                Some(WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, workspaceNamesByProjectId))
+              )
+            } else {
+              val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
+              val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
+              runBigQueryJob(queryJob, childContext)
+                .map { result =>
+                  result.getValues.asScala.toList match {
+                    case Nil => None
+                    case rows =>
+                      val crossBillingResults =
+                        extractCrossBillingProjectSpendReportingResults(rows, start, end, workspaceNamesByProjectId)
+                      workspaceSpendReportRepository.insertSpendReportResults(crossBillingResults)
+                      Some(crossBillingResults)
+                  }
+                }
+                .recoverWith { case ex: Throwable =>
+                  logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
+                  Future.successful(None)
+                }
             }
-            .recoverWith { case ex: Throwable =>
-              logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
-              Future.successful(None)
-            }
+          }
+          spendResults.flatMap { res =>
+            Future.successful(insertRecordsWithMissingSpendData(res, workspaceNamesByProjectId, start, end))
+          }
+          spendResults
         })
         combinedResults = results.flatten.reduceOption((acc, res) => acc + res)
       } yield combinedResults
+    }
 
-  def insertRecordsWithMissingSpendData(results: Iterable[Option[SpendReportingResults]],
+  def insertRecordsWithMissingSpendData(result: Option[SpendReportingResults],
                                         projectNames: Map[GoogleProjectId, WorkspaceName],
                                         start: DateTime,
                                         end: DateTime
-  ): Unit = {
+  ): Set[Future[Long]] = {
     val googleProjectsWithReports: Set[GoogleProjectId] =
-      results.flatten
+      result
         .flatMap(_.spendSummary.googleProjectId)
         .map(p => GoogleProjectId(p.value))
         .toSet
@@ -647,7 +672,7 @@ class SpendReportingService(
       LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(start.getMillis), ZoneId.systemDefault())
     val endLocalDateTime =
       LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(end.getMillis), ZoneId.systemDefault())
-    missingProjectIds.map { id =>
+    val insertedRecords = missingProjectIds.map { id =>
       val spendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
         id.toString(),
         startLocalDateTime,
@@ -663,6 +688,7 @@ class SpendReportingService(
       )
       workspaceSpendReportRepository.insertWorkspaceSpendReport(spendReport)
     }
+    insertedRecords
   }
 
   def runBigQueryJob(queryJob: JobInfo, ctx: RawlsRequestContext): Future[TableResult] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.rawls.spendreporting
 
 import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceSpendReportRecord
-import org.broadinstitute.dsde.rawls.model.{SpendReportingResults, WorkspaceSpendReport}
+import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, SpendReportingResults, WorkspaceName, WorkspaceSpendReport}
 
 import java.time.LocalDateTime
 import scala.concurrent.Future
@@ -12,8 +12,8 @@ import scala.concurrent.Future
  */
 class WorkspaceSpendReportRepository(dataSource: SlickDataSource) {
 
-  def toSpendReportResults(workspaceSpendReports: Seq[WorkspaceSpendReport]): SpendReportingResults =
-   WorkspaceSpendReportRecord.toSpendReportingResults(workspaceSpendReports)
+  def toSpendReportResults(workspaceSpendReports: Seq[WorkspaceSpendReport], projectNames: Map[GoogleProjectId, WorkspaceName]): SpendReportingResults =
+   WorkspaceSpendReportRecord.toSpendReportingResults(workspaceSpendReports, projectNames)
 
 
   def getWorkspaceSpendReports(projectIds: Set[String], startDate: LocalDateTime, endDate: LocalDateTime): Future[Seq[WorkspaceSpendReport]] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
@@ -12,18 +12,18 @@ import scala.concurrent.Future
  */
 class WorkspaceSpendReportRepository(dataSource: SlickDataSource) {
 
-  def toSpendReportResults(workspaceSpendReports: Seq[WorkspaceSpendReport], projectNames: Map[GoogleProjectId, WorkspaceName]): SpendReportingResults =
-   WorkspaceSpendReportRecord.toSpendReportingResults(workspaceSpendReports, projectNames)
-
-
-  def getWorkspaceSpendReports(projectIds: Set[String], startDate: LocalDateTime, endDate: LocalDateTime): Future[Seq[WorkspaceSpendReport]] =
-    dataSource.inTransaction(_.WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate))
-
-  def insertSpendReportResults(spendReportingResults: SpendReportingResults): Seq[Future[Long]] = {
-    WorkspaceSpendReportRecord.fromSpendReportingResults(spendReportingResults).map(
-      workspaceSpendReport => insertWorkspaceSpendReport(workspaceSpendReport)
+  def getWorkspaceSpendReports(projectIds: Set[String],
+                               startDate: LocalDateTime,
+                               endDate: LocalDateTime
+  ): Future[Seq[WorkspaceSpendReport]] =
+    dataSource.inTransaction(
+      _.WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate)
     )
-  }
+
+  def insertSpendReportResults(spendReportingResults: SpendReportingResults): Seq[Future[Long]] =
+    WorkspaceSpendReportRecord
+      .fromSpendReportingResults(spendReportingResults)
+      .map(workspaceSpendReport => insertWorkspaceSpendReport(workspaceSpendReport))
 
   def insertWorkspaceSpendReport(workspaceSpendReport: WorkspaceSpendReport): Future[Long] =
     dataSource.inTransaction { dataAccess =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
@@ -12,6 +12,10 @@ import scala.concurrent.Future
  */
 class WorkspaceSpendReportRepository(dataSource: SlickDataSource) {
 
+  def toSpendReportResults(workspaceSpendReports: Seq[WorkspaceSpendReport]): SpendReportingResults =
+   WorkspaceSpendReportRecord.toSpendReportingResults(workspaceSpendReports)
+
+
   def getWorkspaceSpendReports(projectIds: Set[String], startDate: LocalDateTime, endDate: LocalDateTime): Future[Seq[WorkspaceSpendReport]] =
     dataSource.inTransaction(_.WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate))
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepository.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.rawls.spendreporting
+
+import org.broadinstitute.dsde.rawls.dataaccess.SlickDataSource
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceSpendReportRecord
+import org.broadinstitute.dsde.rawls.model.{SpendReportingResults, WorkspaceSpendReport}
+
+import java.time.LocalDateTime
+import scala.concurrent.Future
+
+/**
+ * Data access for workspace spend report data
+ */
+class WorkspaceSpendReportRepository(dataSource: SlickDataSource) {
+
+  def getWorkspaceSpendReports(projectIds: Set[String], startDate: LocalDateTime, endDate: LocalDateTime): Future[Seq[WorkspaceSpendReport]] =
+    dataSource.inTransaction(_.WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate))
+
+  def insertSpendReportResults(spendReportingResults: SpendReportingResults): Seq[Future[Long]] = {
+    WorkspaceSpendReportRecord.fromSpendReportingResults(spendReportingResults).map(
+      workspaceSpendReport => insertWorkspaceSpendReport(workspaceSpendReport)
+    )
+  }
+
+  def insertWorkspaceSpendReport(workspaceSpendReport: WorkspaceSpendReport): Future[Long] =
+    dataSource.inTransaction { dataAccess =>
+      dataAccess.WorkspaceSpendReportQuery.insert(workspaceSpendReport)
+    }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportSpec.scala
@@ -14,38 +14,38 @@ class WorkspaceSpendReportSpec
     with OptionValues {
   val googleProjectId: String = "test_google_project"
   val projectIds: Set[String] = Set(googleProjectId)
-  val startDate: LocalDateTime = LocalDateTime.now().minusDays(30)
-  val endDate: LocalDateTime = LocalDateTime.now()
-  val workspaceSpendReport: WorkspaceSpendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
-    googleProjectId,
-    startDate,
-    endDate,
-    "USD",
-    isDataAvailable = true,
-    Option(100.00f),
-    Option(50.00f),
-    Option(5.00f),
-    Option(0.00f),
-    Option(0.00f),
-    Option(0.00f)
-  )
+  val endDate: LocalDateTime = LocalDateTime.of(2025, 3, 4, 0, 0, 0)
+  val startDate: LocalDateTime = endDate.minusDays(30)
+
+  def testWorkspaceSpendReport(id: Long): WorkspaceSpendReport =
+    WorkspaceSpendReport(
+      id,
+      googleProjectId,
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option(100.00f),
+      Option(50.00f),
+      Option(5.00f),
+      Option(0.00f),
+      Option(0.00f),
+      Option(0.00f)
+    )
 
   "WorkspaceSpendReportComponent" should "insert and get reports" in withEmptyTestDatabase {
-
     assertResult(Seq()) {
       runAndWait(
         WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate)
       )
     }
-
-    assert(runAndWait(WorkspaceSpendReportQuery.insert(workspaceSpendReport)).isInstanceOf[Long])
-
-    assertResult(Seq(workspaceSpendReport)) {
+    val newRecordId = runAndWait(WorkspaceSpendReportQuery.insert(testWorkspaceSpendReport(-1L)))
+    val newRecord = testWorkspaceSpendReport(newRecordId)
+    assertResult(Seq(newRecord)) {
       runAndWait(
         WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate)
       )
     }
-
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceSpendReportSpec.scala
@@ -1,0 +1,51 @@
+package org.broadinstitute.dsde.rawls.dataaccess.slick
+
+import org.broadinstitute.dsde.rawls.RawlsTestUtils
+import org.broadinstitute.dsde.rawls.model._
+import org.scalatest.OptionValues
+
+import java.time.LocalDateTime
+import scala.language.implicitConversions
+
+class WorkspaceSpendReportSpec
+    extends TestDriverComponentWithFlatSpecAndMatchers
+    with WorkspaceSpendReportComponent
+    with RawlsTestUtils
+    with OptionValues {
+  val googleProjectId: String = "test_google_project"
+  val projectIds: Set[String] = Set(googleProjectId)
+  val startDate: LocalDateTime = LocalDateTime.now().minusDays(30)
+  val endDate: LocalDateTime = LocalDateTime.now()
+  val workspaceSpendReport: WorkspaceSpendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
+    googleProjectId,
+    startDate,
+    endDate,
+    "USD",
+    isDataAvailable = true,
+    Option(100.00f),
+    Option(50.00f),
+    Option(5.00f),
+    Option(0.00f),
+    Option(0.00f),
+    Option(0.00f)
+  )
+
+  "WorkspaceSpendReportComponent" should "insert and get reports" in withEmptyTestDatabase {
+
+    assertResult(Seq()) {
+      runAndWait(
+        WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate)
+      )
+    }
+
+    assert(runAndWait(WorkspaceSpendReportQuery.insert(workspaceSpendReport)).isInstanceOf[Long])
+
+    assertResult(Seq(workspaceSpendReport)) {
+      runAndWait(
+        WorkspaceSpendReportQuery.getWorkspaceSpendReportByProjectIdsAndReportDate(projectIds, startDate, endDate)
+      )
+    }
+
+  }
+
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1887,6 +1887,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     )
     val spendReportingResults = WorkspaceSpendReportRecord.toSpendReportingResults(
       Seq(spendReport2),
+      from,
+      to,
       Map(projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2"))
     )
     verify(mockWorkspaceSpendReportRepository, times(1)).insertSpendReportResults(spendReportingResults)
@@ -2162,7 +2164,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                            projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
     )
 
-    val spendReportingResults = WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1), projectNames)
+    val spendReportingResults =
+      WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1), from, to, projectNames)
     service.insertRecordsWithMissingSpendData(
       Some(spendReportingResults),
       projectNames,
@@ -2181,6 +2184,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   "insertRecordsWithMissingSpendData" should "not insert additional records when all spend data is available" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
+    val mockWorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
     val service = spy(
       new SpendReportingService(
         testContext,
@@ -2239,7 +2243,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                            projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
     )
     val spendReportingResults =
-      WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1, spendReport2), projectNames)
+      WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1, spendReport2), from, to, projectNames)
     service.insertRecordsWithMissingSpendData(
       Some(spendReportingResults),
       projectNames,
@@ -2303,7 +2307,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                            projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
     )
 
-    val spendReportingResults = WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1), projectNames)
+    val spendReportingResults =
+      WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1), from, to, projectNames)
     val records = service.insertRecordsWithMissingSpendData(
       Some(spendReportingResults),
       projectNames,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1651,6 +1651,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       None,
       billingProfileId = Option.apply(billingProfileId1.toString)
     )
+
     val billingProfileId2 = UUID.randomUUID()
     val projectName2 = RawlsBillingProjectName("billingProject2")
     val billingAccount2 = RawlsBillingAccountName("billingAcct2")
@@ -1803,16 +1804,19 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val projectName1 = RawlsBillingProjectName("billingProject1")
     val billingAccount1 = RawlsBillingAccountName("billingAcct1")
     val billingProject1 = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName1,
       CreationStatuses.Ready,
       Option(billingAccount1),
       None,
       billingProfileId = Option.apply(billingProfileId1.toString)
     )
+
     val billingProfileId2 = UUID.randomUUID()
     val projectName2 = RawlsBillingProjectName("billingProject2")
     val billingAccount2 = RawlsBillingAccountName("billingAcct2")
     val billingProject2 = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName2,
       CreationStatuses.Ready,
       Option(billingAccount2),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -71,8 +71,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     _ => mockWorkspaceService
   }
 
-  val mockWorkspaceSpendReportRepositoryConstructor: WorkspaceSpendReportRepository =
-    mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+  val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository]
 
   val testContext: RawlsRequestContext = RawlsRequestContext(userInfo)
   object TestData {
@@ -719,7 +718,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
     val billingProjectSpendExport =
@@ -760,7 +759,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
 
@@ -790,7 +789,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       samDAO,
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val projectName = RawlsBillingProjectName("fakeProject")
 
@@ -827,7 +826,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
     val billingProjectSpendExport =
@@ -895,7 +894,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       samDAO,
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
 
     val result = Await.result(
@@ -949,7 +948,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
     val billingProjectSpendExport =
@@ -1001,7 +1000,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
     val billingProjectSpendExport =
@@ -1068,7 +1067,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       samDAO,
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
 
     val e = intercept[RawlsExceptionWithErrorReport] {
@@ -1092,7 +1091,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[SamDAO],
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val startDate = DateTime.now().minusDays(spendReportingServiceConfig.maxDateRange)
     val endDate = DateTime.now()
@@ -1109,7 +1108,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[SamDAO],
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val startDate = DateTime.now()
     val endDate = DateTime.now().minusDays(1)
@@ -1127,7 +1126,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[SamDAO],
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val startDate = DateTime.now().minusDays(spendReportingServiceConfig.maxDateRange + 1)
     val endDate = DateTime.now()
@@ -1158,7 +1157,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[SamDAO],
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val result = service.getQuery(
       Set(
@@ -1193,7 +1192,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[SamDAO],
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val result = service.getQuery(
       Set(
@@ -1281,7 +1280,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[SamDAO],
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
     val result = service.getAllUserWorkspaceQuery(
       billingProjectSpendExport.spendExportTable.get,
@@ -1392,7 +1391,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
 
@@ -1445,7 +1444,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
 
@@ -1989,7 +1988,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mockSamDAO,
       mock[SpendReportingServiceConfig],
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
 
     when(mockSamDAO.listResourcesWithActions(any(), any(), any()))
@@ -2043,7 +2042,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mockSamDAO,
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
 
     val exception = Await.result(
@@ -2073,7 +2072,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       samDAO,
       spendReportingServiceConfig,
       _ => workspaceService,
-      mockWorkspaceSpendReportRepositoryConstructor
+      mockWorkspaceSpendReportRepository
     )
 
     val workspace = TestData.workspace1
@@ -2101,7 +2100,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         _ => workspaceService,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1811,12 +1811,12 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           case jobInfo: JobInfo =>
             jobInfo.getJobId.getJob match {
               case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job)
-              case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+              case "fakeTable" => IO.raiseError(new RuntimeException("BigQuery has errored"))
+              case x           => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
             }
           case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
         }
       }
-      .thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
 
     val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
       mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -69,10 +69,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     _ => mockWorkspaceService
   }
 
-  val mockWorkspaceSpendReportRepositoryConstructor: WorkspaceSpendReportRepository = {
-    lazy val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository]
-    _ => mockWorkspaceSpendReportRepository
-  }
+  val mockWorkspaceSpendReportRepositoryConstructor: WorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
 
   val testContext: RawlsRequestContext = RawlsRequestContext(userInfo)
   object TestData {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -2108,4 +2108,221 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     result should contain key RawlsBillingProjectName("test-project")
     result(RawlsBillingProjectName("test-project")) should contain(workspace)
   }
+
+  "insertRecordsWithMissingSpendData" should "insert empty records for missing spend data" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+    when(mockWorkspaceSpendReportRepository.insertWorkspaceSpendReport(any())).thenReturn(Future.successful(1L))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+        mock[BillingRepository],
+        mock[BillingProfileManagerDAO],
+        samDAO,
+        spendReportingServiceConfig,
+        _ => workspaceService,
+        mockWorkspaceSpendReportRepository
+      )
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val price1 = 10.22f
+    val price2 = 50.74f
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+    val spendReport1 = WorkspaceSpendReport(
+      1L,
+      projectId1.toString(),
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price1),
+      Option(price2),
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val spendReportingResults = WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1), projectNames)
+    service.insertRecordsWithMissingSpendData(
+      Some(spendReportingResults),
+      projectNames,
+      from,
+      to
+    )
+    val spendReport2 = WorkspaceSpendReport.newEmptySpendReport(
+      projectId2.toString(),
+      startDate,
+      endDate,
+      "USD"
+    )
+    verify(mockWorkspaceSpendReportRepository, times(1)).insertWorkspaceSpendReport(spendReport2)
+  }
+
+  "insertRecordsWithMissingSpendData" should "not insert additional records when all spend data is available" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+        mock[BillingRepository],
+        mock[BillingProfileManagerDAO],
+        samDAO,
+        spendReportingServiceConfig,
+        _ => workspaceService,
+        mockWorkspaceSpendReportRepository
+      )
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val price1 = 10.22f
+    val price2 = 50.74f
+
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+    val spendReport1 = WorkspaceSpendReport(
+      1L,
+      projectId1.toString(),
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price1),
+      Option(price2),
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+    val spendReport2 = WorkspaceSpendReport(
+      2L,
+      projectId2.toString(),
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = false,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+    val spendReportingResults =
+      WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1, spendReport2), projectNames)
+    service.insertRecordsWithMissingSpendData(
+      Some(spendReportingResults),
+      projectNames,
+      from,
+      to
+    )
+    verifyNoInteractions(mockWorkspaceSpendReportRepository)
+  }
+
+  "insertRecordsWithMissingSpendData" should "handle errors when inserting a record" in {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+    when(mockWorkspaceSpendReportRepository.insertWorkspaceSpendReport(any()))
+      .thenReturn(Future.failed(new RuntimeException("Error inserting workspace spend report")))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+        mock[BillingRepository],
+        mock[BillingProfileManagerDAO],
+        samDAO,
+        spendReportingServiceConfig,
+        _ => workspaceService,
+        mockWorkspaceSpendReportRepository
+      )
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val price1 = 10.22f
+    val price2 = 50.74f
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+    val spendReport1 = WorkspaceSpendReport(
+      1L,
+      projectId1.toString(),
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price1),
+      Option(price2),
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val spendReportingResults = WorkspaceSpendReportRecord.toSpendReportingResults(Seq(spendReport1), projectNames)
+    val records = service.insertRecordsWithMissingSpendData(
+      Some(spendReportingResults),
+      projectNames,
+      from,
+      to
+    )
+    val spendReport2 = WorkspaceSpendReport.newEmptySpendReport(
+      projectId2.toString(),
+      startDate,
+      endDate,
+      "USD"
+    )
+    verify(mockWorkspaceSpendReportRepository, times(1)).insertWorkspaceSpendReport(spendReport2)
+    records.size shouldBe 1
+    records.map { record =>
+      record.map { result =>
+        result shouldBe Future.successful(0L)
+      }
+    }
+  }
+
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1706,7 +1706,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           case jobInfo: JobInfo =>
             jobInfo.getJobId.getJob match {
               case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job1)
-              case "fakeTable" => IO(job2)
+              case "fakeTable"                                           => IO(job2)
               case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
             }
           case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
@@ -1815,8 +1815,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
             }
           case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
         }
-      }.thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
-
+      }
+      .thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
 
     val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
       mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -39,7 +39,8 @@ import org.scalatest.RecoverMethods.recoverToExceptionIf
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import java.util.{Date, UUID}
+import java.time.{LocalDateTime, ZoneId}
+import java.util.{Currency, Date, UUID}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
@@ -1615,7 +1616,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       ISODateTimeFormat.date()
     )
     spendSummary.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
-
+    verify(mockWorkspaceSpendReportRepository, times(2)).insertSpendReportResults(any())
   }
 
   "getSpendForAllWorkspaces" should "handle errors from bigquery gracefully" in {
@@ -1773,6 +1774,180 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     )
     spendSummary.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
 
+  }
+
+  "getSpendForAllWorkspaces" should "return cached results" in {
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
+    // Billing projects
+    val billingProfileId1 = UUID.randomUUID()
+    val projectName1 = RawlsBillingProjectName("billingProject1")
+    val billingAccount1 = RawlsBillingAccountName("billingAcct1")
+    val billingProject1 = RawlsBillingProject(
+      projectName1,
+      CreationStatuses.Ready,
+      Option(billingAccount1),
+      None,
+      billingProfileId = Option.apply(billingProfileId1.toString)
+    )
+    val billingProfileId2 = UUID.randomUUID()
+    val projectName2 = RawlsBillingProjectName("billingProject2")
+    val billingAccount2 = RawlsBillingAccountName("billingAcct2")
+    val billingProject2 = RawlsBillingProject(
+      projectName2,
+      CreationStatuses.Ready,
+      Option(billingAccount2),
+      None,
+      billingProfileId = Option.apply(billingProfileId2.toString)
+    )
+
+    // Billing project spend exports
+    val billingProject1SpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
+                                RawlsBillingAccountName("billingAccount1"),
+                                Some("billing1_bq_project.billing1_dataset.billing1_table")
+      )
+
+    val billingProject2SpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
+                                RawlsBillingAccountName("billingAccount2"),
+                                None
+      )
+
+    // Workspaces
+    val workspace1Billing1 =
+      TestData.workspace("workspace1Billing1",
+                         GoogleProjectId("workspace1ProjectId"),
+                         WorkspaceVersions.V1,
+                         "billingProject1"
+      )
+    val workspace2Billing2 =
+      TestData.workspace("workspace2Billing2",
+                         GoogleProjectId("workspace2ProjectId"),
+                         WorkspaceVersions.V2,
+                         "billingProject2"
+      )
+
+    val mockWorkspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
+    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(
+        Future.successful(
+          Map(billingProject1.projectName -> List(workspace1Billing1),
+              billingProject2.projectName -> List(workspace2Billing2)
+          )
+        )
+      )
+
+    val mockWorkspaceServiceConstructor: RawlsRequestContext => WorkspaceService = { _ =>
+      mockWorkspaceService
+    }
+
+    when(billingRepository.getBillingProject(mockitoEq(projectName1)))
+      .thenReturn(Future.successful(Option.apply(billingProject1)))
+    when(billingRepository.getBillingProject(mockitoEq(projectName2)))
+      .thenReturn(Future.successful(Option.apply(billingProject2)))
+
+    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(
+      Future.successful(
+        List(
+          new FilteredFlatResource().resourceId(UUID.randomUUID().toString),
+          new FilteredFlatResource().resourceId(UUID.randomUUID().toString)
+        )
+      )
+    )
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val price1 = 10.22f
+    val price2 = 50.74f
+    val zero = 0.00f
+    val total = price1 + price2
+
+    val projectId1 = "workspace1ProjectId"
+    val projectId2 = "workspace2ProjectId"
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+    val spendReport1 = WorkspaceSpendReport(
+      1L,
+      projectId1,
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price1),
+      Option(price2),
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+    val spendReport2 = WorkspaceSpendReport(
+      2L,
+      projectId2,
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = false,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(Seq(spendReport1, spendReport2)))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepository
+      )
+    )
+    doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
+      .when(service)
+      .getSpendExportConfigurations(
+        any()
+      )
+
+    val result = Await.result(
+      service.getSpendForAllWorkspaces(from, to, 100, 0),
+      Duration.Inf
+    )
+
+    result.get.spendDetails.length shouldBe 1
+
+    val spendSummary = result.get.spendSummary
+
+    def toBigDecimal(cost: String): BigDecimal = BigDecimal(cost)
+      .setScale(Currency.getInstance("USD").getDefaultFractionDigits, RoundingMode.HALF_EVEN)
+
+    spendSummary.credits shouldBe toBigDecimal(zero.toString).toString()
+    spendSummary.cost shouldBe toBigDecimal(total.toString).toString()
+    spendSummary.currency shouldBe "USD"
+    spendSummary.startTime.get.toString(ISODateTimeFormat.date()) shouldBe from.toString(
+      ISODateTimeFormat.date()
+    )
+    spendSummary.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
+    verifyNoInteractions(bigQueryService)
   }
 
   "getSpendReportableWorkspaceGoogleProjects" should "return an empty map when there are no valid workspace IDs" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1575,6 +1575,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(job2.waitFor()).thenReturn(job2)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job1), IO(job2))
 
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(Seq.empty))
+
     val service = spy(
       new SpendReportingService(
         testContext,
@@ -1585,7 +1590,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
     doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
@@ -1727,6 +1732,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       .thenReturn(IO(job))
       .thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
 
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(Seq.empty))
+
     val service = spy(
       new SpendReportingService(
         testContext,
@@ -1737,7 +1747,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         samDAO,
         spendReportingServiceConfig,
         mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepositoryConstructor
+        mockWorkspaceSpendReportRepository
       )
     )
     doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -21,6 +21,7 @@ import org.broadinstitute.dsde.rawls.billing.{
   BpmAzureSpendReportApiException
 }
 import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
+import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceSpendReportRecord
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeys, _}
@@ -697,6 +698,120 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         case _ => fail("Unexpected category")
       }
     }
+  }
+
+  def testGetSpendReportResults(mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository,
+                                bigQueryService: GoogleBigQueryService[IO],
+                                from: DateTime,
+                                to: DateTime
+  ): Option[SpendReportingResults] = {
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+
+    // Billing projects
+    val billingProfileId1 = UUID.randomUUID()
+    val projectName1 = RawlsBillingProjectName("billingProject1")
+    val billingAccount1 = RawlsBillingAccountName("billingAcct1")
+    val billingProject1 = RawlsBillingProject(
+      UUID.randomUUID(),
+      projectName1,
+      CreationStatuses.Ready,
+      Option(billingAccount1),
+      None,
+      billingProfileId = Option.apply(billingProfileId1.toString)
+    )
+    val billingProfileId2 = UUID.randomUUID()
+    val projectName2 = RawlsBillingProjectName("billingProject2")
+    val billingAccount2 = RawlsBillingAccountName("billingAcct2")
+    val billingProject2 = RawlsBillingProject(
+      UUID.randomUUID(),
+      projectName2,
+      CreationStatuses.Ready,
+      Option(billingAccount2),
+      None,
+      billingProfileId = Option.apply(billingProfileId2.toString)
+    )
+
+    // Billing project spend exports
+    val billingProject1SpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
+                                RawlsBillingAccountName("billingAccount1"),
+                                Some("billing1_bq_project.billing1_dataset.billing1_table")
+      )
+
+    val billingProject2SpendExport =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
+                                RawlsBillingAccountName("billingAccount2"),
+                                None
+      )
+
+    // Workspaces
+    val workspace1Billing1 =
+      TestData.workspace("workspace1Billing1",
+                         GoogleProjectId("workspace1ProjectId"),
+                         WorkspaceVersions.V1,
+                         "billingProject1"
+      )
+    val workspace2Billing2 =
+      TestData.workspace("workspace2Billing2",
+                         GoogleProjectId("workspace2ProjectId"),
+                         WorkspaceVersions.V2,
+                         "billingProject2"
+      )
+
+    val mockWorkspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
+    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
+      .thenReturn(
+        Future.successful(
+          Map(billingProject1.projectName -> List(workspace1Billing1),
+              billingProject2.projectName -> List(workspace2Billing2)
+          )
+        )
+      )
+
+    val mockWorkspaceServiceConstructor: RawlsRequestContext => WorkspaceService = { _ =>
+      mockWorkspaceService
+    }
+
+    when(billingRepository.getBillingProject(mockitoEq(projectName1)))
+      .thenReturn(Future.successful(Option.apply(billingProject1)))
+    when(billingRepository.getBillingProject(mockitoEq(projectName2)))
+      .thenReturn(Future.successful(Option.apply(billingProject2)))
+
+    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(
+      Future.successful(
+        List(
+          new FilteredFlatResource().resourceId(UUID.randomUUID().toString),
+          new FilteredFlatResource().resourceId(UUID.randomUUID().toString)
+        )
+      )
+    )
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepository
+      )
+    )
+    doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
+      .when(service)
+      .getSpendExportConfigurations(
+        any()
+      )
+
+    Await.result(
+      service.getSpendForAllWorkspaces(from, to, 100, 0),
+      Duration.Inf
+    )
+
   }
 
   "getSpendForGCPBillingProject" should "throw an exception when BQ returns zero rows" in {
@@ -1459,92 +1574,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   }
 
   it should "get the spend report from multiple billing projects" in {
-    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
-    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
-
-    // Billing projects
-    val billingProfileId1 = UUID.randomUUID()
-    val projectName1 = RawlsBillingProjectName("billingProject1")
-    val billingAccount1 = RawlsBillingAccountName("billingAcct1")
-    val billingProject1 = RawlsBillingProject(
-      UUID.randomUUID(),
-      projectName1,
-      CreationStatuses.Ready,
-      Option(billingAccount1),
-      None,
-      billingProfileId = Option.apply(billingProfileId1.toString)
-    )
-    val billingProfileId2 = UUID.randomUUID()
-    val projectName2 = RawlsBillingProjectName("billingProject2")
-    val billingAccount2 = RawlsBillingAccountName("billingAcct2")
-    val billingProject2 = RawlsBillingProject(
-      UUID.randomUUID(),
-      projectName2,
-      CreationStatuses.Ready,
-      Option(billingAccount2),
-      None,
-      billingProfileId = Option.apply(billingProfileId2.toString)
-    )
-
-    // Billing project spend exports
-    val billingProject1SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
-                                RawlsBillingAccountName("billingAccount1"),
-                                Some("billing1_bq_project.billing1_dataset.billing1_table")
-      )
-
-    val billingProject2SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
-                                RawlsBillingAccountName("billingAccount2"),
-                                None
-      )
-
-    // Workspaces
-    val workspace1Billing1 =
-      TestData.workspace("workspace1Billing1",
-                         GoogleProjectId("workspace1ProjectId"),
-                         WorkspaceVersions.V1,
-                         "billingProject1"
-      )
-    val workspace2Billing2 =
-      TestData.workspace("workspace2Billing2",
-                         GoogleProjectId("workspace2ProjectId"),
-                         WorkspaceVersions.V2,
-                         "billingProject2"
-      )
-
-    val mockWorkspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
-    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
-      .thenReturn(
-        Future.successful(
-          Map(billingProject1.projectName -> List(workspace1Billing1),
-              billingProject2.projectName -> List(workspace2Billing2)
-          )
-        )
-      )
-
-    val mockWorkspaceServiceConstructor: RawlsRequestContext => WorkspaceService = { _ =>
-      mockWorkspaceService
-    }
-
-    when(billingRepository.getBillingProject(mockitoEq(projectName1)))
-      .thenReturn(Future.successful(Option.apply(billingProject1)))
-    when(billingRepository.getBillingProject(mockitoEq(projectName2)))
-      .thenReturn(Future.successful(Option.apply(billingProject2)))
-
-    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(
-      Future.successful(
-        List(
-          new FilteredFlatResource().resourceId(UUID.randomUUID().toString),
-          new FilteredFlatResource().resourceId(UUID.randomUUID().toString)
-        )
-      )
-    )
-
-    val from = DateTime.now().minusMonths(2)
-    val to = from.plusMonths(1)
-
     val price1 = BigDecimal("10.22")
     val price2 = BigDecimal("50.74")
     val zero = BigDecimal("0.00")
@@ -1590,34 +1619,122 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(job2.waitFor()).thenReturn(job2)
     when(bigQueryService.runJob(any(), any())).thenReturn(IO(job1), IO(job2))
 
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
     val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
       mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
     when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
       .thenReturn(Future.successful(Seq.empty))
+    val result = testGetSpendReportResults(mockWorkspaceSpendReportRepository, bigQueryService, from, to)
+    result.get.spendDetails.length shouldBe 2
 
-    val service = spy(
-      new SpendReportingService(
-        testContext,
-        mock[SlickDataSource],
-        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
-        billingRepository,
-        bpmDAO,
-        samDAO,
-        spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepository
+    val spendSummary = result.get.spendSummary
+
+    spendSummary.credits shouldBe zero.toString()
+    spendSummary.cost shouldBe (total + price2).toString()
+    spendSummary.currency shouldBe "USD"
+    spendSummary.startTime.get.toString(ISODateTimeFormat.date()) shouldBe from.toString(
+      ISODateTimeFormat.date()
+    )
+    spendSummary.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
+    verify(mockWorkspaceSpendReportRepository, times(2)).insertSpendReportResults(any())
+  }
+
+  it should "get the spend report from multiple billing projects when cached reports are from different dates" in {
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+    val price1 = BigDecimal("10.22")
+    val price2 = BigDecimal("50.74")
+    val zero = BigDecimal("0.00")
+    val total = price1 + price2
+
+    val table1: List[Map[String, String]] = List(
+      Map(
+        "storage_cost" -> s"$price1",
+        "compute_cost" -> s"$zero",
+        "other_cost" -> s"$price2",
+        "total_cost" -> s"$total",
+        "currency" -> "USD",
+        "project_id" -> "workspace1ProjectId",
+        "project_name" -> "terra-billing-project1",
+        "storage_credits" -> s"$zero",
+        "compute_credits" -> s"$zero",
+        "other_credits" -> s"$zero"
       )
     )
-    doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
-      .when(service)
-      .getSpendExportConfigurations(
-        any()
+    val table2: List[Map[String, String]] = List(
+      Map(
+        "storage_cost" -> s"$price2",
+        "compute_cost" -> s"$zero",
+        "other_cost" -> s"$zero",
+        "total_cost" -> s"$price2",
+        "project_id" -> "workspace2ProjectId",
+        "project_name" -> "terra-billing-project1",
+        "currency" -> "USD",
+        "storage_credits" -> s"$zero",
+        "compute_credits" -> s"$zero",
+        "other_credits" -> s"$zero"
       )
-
-    val result = Await.result(
-      service.getSpendForAllWorkspaces(from, to, 100, 0),
-      Duration.Inf
     )
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val job1 = mock[Job]
+    when(job1.getQueryResults(any())).thenReturn(createTableResult(table1))
+    when(job1.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job1.waitFor()).thenReturn(job1)
+    val job2 = mock[Job]
+    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
+    when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job2.waitFor()).thenReturn(job2)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job1), IO(job2))
+
+    // Records for same projects but different start/end dates
+    val startDate: LocalDateTime = SpendReportUtils.convertJodaToJava(Some(from.minusMonths(1)))
+    val endDate: LocalDateTime = SpendReportUtils.convertJodaToJava(Some(to.minusMonths(1)))
+    val projectId1 = GoogleProjectId("workspace1ProjectId").toString()
+    val spendReport1 = WorkspaceSpendReport(
+      1L,
+      projectId1,
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price1.toFloat),
+      Option(price2.toFloat),
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+    val projectId2 = GoogleProjectId("workspace2ProjectId").toString()
+    val spendReport2 = WorkspaceSpendReport(
+      2L,
+      projectId2,
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = false,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+    val reportFrom = SpendReportUtils.convertJodaToJava(Some(from))
+    val reportTo = SpendReportUtils.convertJodaToJava(Some(to))
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId1), reportFrom, reportTo))
+      .thenReturn(Future.successful(Seq.empty))
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId1), startDate, endDate))
+      .thenReturn(Future.successful(Seq(spendReport1)))
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId2), reportFrom, reportTo))
+      .thenReturn(Future.successful(Seq.empty))
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId2), startDate, endDate))
+      .thenReturn(Future.successful(Seq(spendReport2)))
+    val result = testGetSpendReportResults(mockWorkspaceSpendReportRepository, bigQueryService, from, to)
 
     result.get.spendDetails.length shouldBe 2
 
@@ -1634,90 +1751,6 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   }
 
   it should "handle errors from bigquery gracefully" in {
-    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
-    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
-
-    // Billing projects
-    val billingProfileId1 = UUID.randomUUID()
-    val projectName1 = RawlsBillingProjectName("billingProject1")
-    val billingAccount1 = RawlsBillingAccountName("billingAcct1")
-    val billingProject1 = RawlsBillingProject(
-      UUID.randomUUID(),
-      projectName1,
-      CreationStatuses.Ready,
-      Option(billingAccount1),
-      None,
-      billingProfileId = Option.apply(billingProfileId1.toString)
-    )
-
-    val billingProfileId2 = UUID.randomUUID()
-    val projectName2 = RawlsBillingProjectName("billingProject2")
-    val billingAccount2 = RawlsBillingAccountName("billingAcct2")
-    val billingProject2 = RawlsBillingProject(
-      UUID.randomUUID(),
-      projectName2,
-      CreationStatuses.Ready,
-      Option(billingAccount2),
-      None,
-      billingProfileId = Option.apply(billingProfileId2.toString)
-    )
-
-    // Billing project spend exports
-    val billingProject1SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
-                                RawlsBillingAccountName("billingAccount1"),
-                                Some("billing1_bq_project.billing1_dataset.billing1_table")
-      )
-
-    val billingProject2SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
-                                RawlsBillingAccountName("billingAccount2"),
-                                None
-      )
-
-    // Workspaces
-    val workspace1Billing1 =
-      TestData.workspace("workspace1Billing1",
-                         GoogleProjectId("workspace1ProjectId"),
-                         WorkspaceVersions.V1,
-                         "billingProject1"
-      )
-    val workspace2Billing2 =
-      TestData.workspace("workspace2Billing2",
-                         GoogleProjectId("workspace2ProjectId"),
-                         WorkspaceVersions.V2,
-                         "billingProject2"
-      )
-
-    val mockWorkspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
-    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
-      .thenReturn(
-        Future.successful(
-          Map(billingProject1.projectName -> List(workspace1Billing1),
-              billingProject2.projectName -> List(workspace2Billing2)
-          )
-        )
-      )
-
-    val mockWorkspaceServiceConstructor: RawlsRequestContext => WorkspaceService = { _ =>
-      mockWorkspaceService
-    }
-
-    when(billingRepository.getBillingProject(mockitoEq(projectName1)))
-      .thenReturn(Future.successful(Option.apply(billingProject1)))
-    when(billingRepository.getBillingProject(mockitoEq(projectName2)))
-      .thenReturn(Future.successful(Option.apply(billingProject2)))
-
-    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(
-      Future.successful(
-        List(
-          new FilteredFlatResource().resourceId(UUID.randomUUID().toString),
-          new FilteredFlatResource().resourceId(UUID.randomUUID().toString)
-        )
-      )
-    )
-
     val from = DateTime.now().minusMonths(2)
     val to = from.plusMonths(1)
 
@@ -1755,30 +1788,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
       .thenReturn(Future.successful(Seq.empty))
 
-    val service = spy(
-      new SpendReportingService(
-        testContext,
-        mock[SlickDataSource],
-        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
-        billingRepository,
-        bpmDAO,
-        samDAO,
-        spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepository
-      )
-    )
-    doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
-      .when(service)
-      .getSpendExportConfigurations(
-        any()
-      )
-
-    val result = Await.result(
-      service.getSpendForAllWorkspaces(from, to, 100, 0),
-      Duration.Inf
-    )
-
+    val result = testGetSpendReportResults(mockWorkspaceSpendReportRepository, bigQueryService, from, to)
     result.get.spendDetails.length shouldBe 1
 
     val spendSummary = result.get.spendSummary
@@ -1793,93 +1803,97 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
-  "getSpendForAllWorkspaces" should "return cached results" in {
-    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
-    val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
+  "getSpendForAllWorkspaces" should "handle partial cache hit" in {
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
 
-    // Billing projects
-    val billingProfileId1 = UUID.randomUUID()
-    val projectName1 = RawlsBillingProjectName("billingProject1")
-    val billingAccount1 = RawlsBillingAccountName("billingAcct1")
-    val billingProject1 = RawlsBillingProject(
-      UUID.randomUUID(),
-      projectName1,
-      CreationStatuses.Ready,
-      Option(billingAccount1),
-      None,
-      billingProfileId = Option.apply(billingProfileId1.toString)
-    )
+    val price1 = BigDecimal("10.22")
+    val price2 = BigDecimal("50.74")
+    val zero = BigDecimal("0.00")
+    val total = price1 + price2
 
-    val billingProfileId2 = UUID.randomUUID()
-    val projectName2 = RawlsBillingProjectName("billingProject2")
-    val billingAccount2 = RawlsBillingAccountName("billingAcct2")
-    val billingProject2 = RawlsBillingProject(
-      UUID.randomUUID(),
-      projectName2,
-      CreationStatuses.Ready,
-      Option(billingAccount2),
-      None,
-      billingProfileId = Option.apply(billingProfileId2.toString)
-    )
-
-    // Billing project spend exports
-    val billingProject1SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject1"),
-                                RawlsBillingAccountName("billingAccount1"),
-                                Some("billing1_bq_project.billing1_dataset.billing1_table")
-      )
-
-    val billingProject2SpendExport =
-      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
-                                RawlsBillingAccountName("billingAccount2"),
-                                None
-      )
-
-    // Workspaces
-    val workspace1Billing1 =
-      TestData.workspace("workspace1Billing1",
-                         GoogleProjectId("workspace1ProjectId"),
-                         WorkspaceVersions.V1,
-                         "billingProject1"
-      )
-    val workspace2Billing2 =
-      TestData.workspace("workspace2Billing2",
-                         GoogleProjectId("workspace2ProjectId"),
-                         WorkspaceVersions.V2,
-                         "billingProject2"
-      )
-
-    val mockWorkspaceService = mock[WorkspaceService](RETURNS_SMART_NULLS)
-    when(mockWorkspaceService.getGCPWorkspacesByBillingProjects(any()))
-      .thenReturn(
-        Future.successful(
-          Map(billingProject1.projectName -> List(workspace1Billing1),
-              billingProject2.projectName -> List(workspace2Billing2)
-          )
-        )
-      )
-
-    val mockWorkspaceServiceConstructor: RawlsRequestContext => WorkspaceService = { _ =>
-      mockWorkspaceService
-    }
-
-    when(billingRepository.getBillingProject(mockitoEq(projectName1)))
-      .thenReturn(Future.successful(Option.apply(billingProject1)))
-    when(billingRepository.getBillingProject(mockitoEq(projectName2)))
-      .thenReturn(Future.successful(Option.apply(billingProject2)))
-
-    when(samDAO.listResourcesWithActions(any(), any(), any())).thenReturn(
-      Future.successful(
-        List(
-          new FilteredFlatResource().resourceId(UUID.randomUUID().toString),
-          new FilteredFlatResource().resourceId(UUID.randomUUID().toString)
-        )
+    val table2: List[Map[String, String]] = List(
+      Map(
+        "storage_cost" -> s"$price2",
+        "compute_cost" -> s"$zero",
+        "other_cost" -> s"$zero",
+        "total_cost" -> s"$price2",
+        "project_id" -> "workspace2ProjectId",
+        "project_name" -> "terra-billing-project1",
+        "currency" -> "USD",
+        "storage_credits" -> s"$zero",
+        "compute_credits" -> s"$zero",
+        "other_credits" -> s"$zero"
       )
     )
 
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val job2 = mock[Job]
+    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
+    when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job2.waitFor()).thenReturn(job2)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job2))
 
+    val startDate: LocalDateTime = SpendReportUtils.convertJodaToJava(Some(from))
+    val endDate: LocalDateTime = SpendReportUtils.convertJodaToJava(Some(to))
+    val projectId1 = GoogleProjectId("workspace1ProjectId").toString()
+    val spendReport1 = WorkspaceSpendReport(
+      1L,
+      projectId1,
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price1.toFloat),
+      Option(price2.toFloat),
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId1), startDate, endDate))
+      .thenReturn(Future.successful(Seq(spendReport1)))
+
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId2.toString()), startDate, endDate))
+      .thenReturn(Future.successful(Seq()))
+
+    val result = testGetSpendReportResults(mockWorkspaceSpendReportRepository, bigQueryService, from, to)
+    result.get.spendDetails.length shouldBe 2
+
+    val spendSummary = result.get.spendSummary
+    spendSummary.credits shouldBe zero.toString()
+    spendSummary.cost shouldBe (total + price2).toString()
+    spendSummary.currency shouldBe "USD"
+    spendSummary.startTime.get.toString(ISODateTimeFormat.date()) shouldBe from.toString(
+      ISODateTimeFormat.date()
+    )
+    spendSummary.endTime.get.toString(ISODateTimeFormat.date()) shouldBe to.toString(ISODateTimeFormat.date())
+
+    val spendReport2 = WorkspaceSpendReport(
+      2L,
+      projectId2.toString(),
+      startDate,
+      endDate,
+      "USD",
+      isDataAvailable = true,
+      Option.empty,
+      Option(price2.toFloat),
+      Option.empty,
+      Option.empty,
+      Option.empty,
+      Option.empty
+    )
+    val spendReportingResults = WorkspaceSpendReportRecord.toSpendReportingResults(
+      Seq(spendReport2),
+      Map(projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2"))
+    )
+    verify(mockWorkspaceSpendReportRepository, times(1)).insertSpendReportResults(spendReportingResults)
+  }
+
+  "getSpendForAllWorkspaces" should "handle full cache hit" in {
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
       mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
 
@@ -1891,8 +1905,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val zero = 0.00f
     val total = price1 + price2
 
-    val projectId1 = "workspace1ProjectId"
-    val projectId2 = "workspace2ProjectId"
+    val projectId1 = GoogleProjectId("workspace1ProjectId").toString()
+    val projectId2 = GoogleProjectId("workspace2ProjectId").toString()
     val startDate: LocalDateTime =
       LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
     val endDate: LocalDateTime =
@@ -1932,29 +1946,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId2), startDate, endDate))
       .thenReturn(Future.successful(Seq(spendReport2)))
 
-    val service = spy(
-      new SpendReportingService(
-        testContext,
-        mock[SlickDataSource],
-        Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService),
-        billingRepository,
-        bpmDAO,
-        samDAO,
-        spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor,
-        mockWorkspaceSpendReportRepository
-      )
-    )
-    doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
-      .when(service)
-      .getSpendExportConfigurations(
-        any()
-      )
-
-    val result = Await.result(
-      service.getSpendForAllWorkspaces(from, to, 100, 0),
-      Duration.Inf
-    )
+    val result = testGetSpendReportResults(mockWorkspaceSpendReportRepository, bigQueryService, from, to)
 
     result.get.spendDetails.length shouldBe 1
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1617,7 +1617,20 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
     when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job2.waitFor()).thenReturn(job2)
-    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job1), IO(job2))
+
+    when(bigQueryService.runJob(any(), any()))
+      .thenAnswer { invocation =>
+        val args = invocation.getArguments
+        args(0) match {
+          case jobInfo: JobInfo =>
+            jobInfo.getJobId.getJob match {
+              case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job1)
+              case "fakeTable"                                           => IO(job2)
+              case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+            }
+          case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+        }
+      }
 
     val from = DateTime.now().minusMonths(2)
     val to = from.plusMonths(1)
@@ -1686,7 +1699,19 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
     when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job2.waitFor()).thenReturn(job2)
-    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job1), IO(job2))
+    when(bigQueryService.runJob(any(), any()))
+      .thenAnswer { invocation =>
+        val args = invocation.getArguments
+        args(0) match {
+          case jobInfo: JobInfo =>
+            jobInfo.getJobId.getJob match {
+              case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job1)
+              case "fakeTable" => IO(job2)
+              case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+            }
+          case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+        }
+      }
 
     // Records for same projects but different start/end dates
     val startDate: LocalDateTime = SpendReportUtils.convertJodaToJava(Some(from.minusMonths(1)))
@@ -1780,8 +1805,18 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(job.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
     when(job.waitFor()).thenReturn(job)
     when(bigQueryService.runJob(any(), any()))
-      .thenReturn(IO(job))
-      .thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
+      .thenAnswer { invocation =>
+        val args = invocation.getArguments
+        args(0) match {
+          case jobInfo: JobInfo =>
+            jobInfo.getJobId.getJob match {
+              case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job)
+              case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+            }
+          case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+        }
+      }.thenAnswer(_ => IO.raiseError(new RuntimeException("BigQuery has errored")))
+
 
     val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
       mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1927,8 +1927,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       Option.empty
     )
 
-    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
-      .thenReturn(Future.successful(Seq(spendReport1, spendReport2)))
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId1), startDate, endDate))
+      .thenReturn(Future.successful(Seq(spendReport1)))
+
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(Set(projectId2), startDate, endDate))
+      .thenReturn(Future.successful(Seq(spendReport2)))
 
     val service = spy(
       new SpendReportingService(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -69,6 +69,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     _ => mockWorkspaceService
   }
 
+  val mockWorkspaceSpendReportRepositoryConstructor: WorkspaceSpendReportRepository = {
+    lazy val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository]
+    _ => mockWorkspaceSpendReportRepository
+  }
+
   val testContext: RawlsRequestContext = RawlsRequestContext(userInfo)
   object TestData {
     val workspace1: Workspace = workspace("workspace1", GoogleProjectId("project1"))
@@ -713,7 +718,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
     val billingProjectSpendExport =
@@ -753,7 +759,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
 
@@ -782,7 +789,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       bpmDAO,
       samDAO,
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val projectName = RawlsBillingProjectName("fakeProject")
 
@@ -818,7 +826,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
     val billingProjectSpendExport =
@@ -884,7 +893,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       bpmDAO,
       samDAO,
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
 
     val result = Await.result(
@@ -937,7 +947,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
     val billingProjectSpendExport =
@@ -988,7 +999,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
     val billingProjectSpendExport =
@@ -1053,7 +1065,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       bpmDAO,
       samDAO,
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
 
     val e = intercept[RawlsExceptionWithErrorReport] {
@@ -1076,7 +1089,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val startDate = DateTime.now().minusDays(spendReportingServiceConfig.maxDateRange)
     val endDate = DateTime.now()
@@ -1092,7 +1106,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val startDate = DateTime.now()
     val endDate = DateTime.now().minusDays(1)
@@ -1109,7 +1124,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val startDate = DateTime.now().minusDays(spendReportingServiceConfig.maxDateRange + 1)
     val endDate = DateTime.now()
@@ -1139,7 +1155,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val result = service.getQuery(
       Set(
@@ -1173,7 +1190,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val result = service.getQuery(
       Set(
@@ -1248,7 +1266,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
     val result = service.getAllUserWorkspaceQuery(
       billingProjectSpendExport.spendExportTable.get,
@@ -1358,7 +1377,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         mock[BillingProfileManagerDAO],
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
 
@@ -1413,7 +1433,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
 
@@ -1565,7 +1586,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
     doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
@@ -1716,7 +1738,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         bpmDAO,
         samDAO,
         spendReportingServiceConfig,
-        mockWorkspaceServiceConstructor
+        mockWorkspaceServiceConstructor,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
     doReturn(Future.successful(Seq(billingProject1SpendExport, billingProject2SpendExport)))
@@ -1758,7 +1781,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mockSamDAO,
       mock[SpendReportingServiceConfig],
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
 
     when(mockSamDAO.listResourcesWithActions(any(), any(), any()))
@@ -1811,7 +1835,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       mock[SamDAO],
       spendReportingServiceConfig,
-      mockWorkspaceServiceConstructor
+      mockWorkspaceServiceConstructor,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
 
     recoverToExceptionIf[RawlsExceptionWithErrorReport] {
@@ -1837,7 +1862,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       mock[BillingProfileManagerDAO],
       samDAO,
       spendReportingServiceConfig,
-      _ => workspaceService
+      _ => workspaceService,
+      mockWorkspaceSpendReportRepositoryConstructor
     )
 
     val workspace = TestData.workspace1
@@ -1864,7 +1890,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         mock[BillingProfileManagerDAO],
         samDAO,
         spendReportingServiceConfig,
-        _ => workspaceService
+        _ => workspaceService,
+        mockWorkspaceSpendReportRepositoryConstructor
       )
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -35,6 +35,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
+import org.mockito.stubbing.OngoingStubbing
 import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest.RecoverMethods.recoverToExceptionIf
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -698,6 +699,36 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         case _ => fail("Unexpected category")
       }
     }
+  }
+
+  def mockBigQueryJobs(bigQueryService: GoogleBigQueryService[IO],
+                       table1: List[Map[String, String]],
+                       table2: List[Map[String, String]]
+  ): OngoingStubbing[IO[Job]] = {
+    val job1 = mock[Job]
+    when(job1.getQueryResults(any())).thenReturn(createTableResult(table1))
+    when(job1.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job1.waitFor()).thenReturn(job1)
+    val job2 = mock[Job]
+    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
+    when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
+    when(job2.waitFor()).thenReturn(job2)
+    when(bigQueryService.runJob(any(), any()))
+      .thenAnswer { invocation =>
+        val args = invocation.getArguments
+        args(0) match {
+          case jobInfo: JobInfo =>
+            val config = jobInfo.getConfiguration.toString
+            if (config.contains("billing1_bq_project.billing1_dataset.billing1_table")) {
+              IO(job1)
+            } else if (config.contains("fakeTable")) {
+              IO(job2)
+            } else {
+              IO.raiseError(new RuntimeException(s"unit test failure - no matching label for exportTableName"))
+            }
+          case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+        }
+      }
   }
 
   def testGetSpendReportResults(mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository,
@@ -1609,28 +1640,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     )
 
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
-    val job1 = mock[Job]
-    when(job1.getQueryResults(any())).thenReturn(createTableResult(table1))
-    when(job1.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
-    when(job1.waitFor()).thenReturn(job1)
-    val job2 = mock[Job]
-    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
-    when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
-    when(job2.waitFor()).thenReturn(job2)
-
-    when(bigQueryService.runJob(any(), any()))
-      .thenAnswer { invocation =>
-        val args = invocation.getArguments
-        args(0) match {
-          case jobInfo: JobInfo =>
-            jobInfo.getJobId.getJob match {
-              case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job1)
-              case "fakeTable"                                           => IO(job2)
-              case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
-            }
-          case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
-        }
-      }
+    mockBigQueryJobs(bigQueryService, table1, table2)
 
     val from = DateTime.now().minusMonths(2)
     val to = from.plusMonths(1)
@@ -1661,6 +1671,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val zero = BigDecimal("0.00")
     val total = price1 + price2
 
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
     val table1: List[Map[String, String]] = List(
       Map(
         "storage_cost" -> s"$price1",
@@ -1689,29 +1700,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         "other_credits" -> s"$zero"
       )
     )
-
-    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
-    val job1 = mock[Job]
-    when(job1.getQueryResults(any())).thenReturn(createTableResult(table1))
-    when(job1.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
-    when(job1.waitFor()).thenReturn(job1)
-    val job2 = mock[Job]
-    when(job2.getQueryResults(any())).thenReturn(createTableResult(table2))
-    when(job2.getStatistics).thenReturn(mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS))
-    when(job2.waitFor()).thenReturn(job2)
-    when(bigQueryService.runJob(any(), any()))
-      .thenAnswer { invocation =>
-        val args = invocation.getArguments
-        args(0) match {
-          case jobInfo: JobInfo =>
-            jobInfo.getJobId.getJob match {
-              case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job1)
-              case "fakeTable"                                           => IO(job2)
-              case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
-            }
-          case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
-        }
-      }
+    mockBigQueryJobs(bigQueryService, table1, table2)
 
     // Records for same projects but different start/end dates
     val startDate: LocalDateTime = SpendReportUtils.convertJodaToJava(Some(from.minusMonths(1)))
@@ -1809,10 +1798,13 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         val args = invocation.getArguments
         args(0) match {
           case jobInfo: JobInfo =>
-            jobInfo.getJobId.getJob match {
-              case "billing1_bq_project.billing1_dataset.billing1_table" => IO(job)
-              case "fakeTable" => IO.raiseError(new RuntimeException("BigQuery has errored"))
-              case x           => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
+            val config = jobInfo.getConfiguration.toString
+            if (config.contains("billing1_bq_project.billing1_dataset.billing1_table")) {
+              IO(job)
+            } else if (config.contains("fakeTable")) {
+              IO.raiseError(new RuntimeException("BigQuery has errored"))
+            } else {
+              IO.raiseError(new RuntimeException(s"unit test failure - no matching label for exportTableName"))
             }
           case x => IO.raiseError(new RuntimeException(s"unit test failure with input $x"))
         }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -42,7 +42,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import java.time.{LocalDateTime, ZoneId}
-import java.util.{Currency, Date, UUID}
+import java.util.{Base64, Currency, Date, UUID}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -69,7 +69,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     _ => mockWorkspaceService
   }
 
-  val mockWorkspaceSpendReportRepositoryConstructor: WorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+  val mockWorkspaceSpendReportRepositoryConstructor: WorkspaceSpendReportRepository =
+    mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
 
   val testContext: RawlsRequestContext = RawlsRequestContext(userInfo)
   object TestData {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepositorySpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import java.time.LocalDateTime
+import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -23,8 +24,8 @@ class WorkspaceSpendReportRepositorySpec
 
   val projectId = "fake-google-project"
   val projectIds: Set[String] = Set(projectId)
-  val startDate: LocalDateTime = LocalDateTime.now().minusDays(30)
-  val endDate: LocalDateTime = LocalDateTime.now()
+  val endDate: LocalDateTime = LocalDateTime.of(2025, 3, 4, 0, 0, 0)
+  val startDate: LocalDateTime = endDate.minusDays(30)
   def makeWorkspaceSpendReport(projectId: String): WorkspaceSpendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
     projectId,
     startDate,
@@ -41,6 +42,9 @@ class WorkspaceSpendReportRepositorySpec
 
   it should "get workspace spend reports for given report date if present" in {
     val repo = new WorkspaceSpendReportRepository(slickDataSource)
+    val noResults = Await.result(repo.getWorkspaceSpendReports(projectIds, startDate, endDate), Duration.Inf)
+    assertResult(0)(noResults.size)
+
     val report: WorkspaceSpendReport = makeWorkspaceSpendReport(projectId)
     Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
 
@@ -48,24 +52,19 @@ class WorkspaceSpendReportRepositorySpec
     assertResult(1)(results.size)
     results.map { result =>
       assertResult(projectId)(result.googleProjectId)
+      assertResult(startDate)(result.reportStartDate)
+      assertResult(endDate)(result.reportEndDate)
     }
-  }
-
-  it should "return none if no workspace spend reports present" in {
-    val repo = new WorkspaceSpendReportRepository(slickDataSource)
-    val result = Await.result(repo.getWorkspaceSpendReports(projectIds, startDate, endDate), Duration.Inf)
-    assertResult(Seq())(result)
   }
 
   behavior of "insertSpendReport"
 
   it should "error if insert violates unique constraint on google project id, start and end date" in {
     val repo = new WorkspaceSpendReportRepository(slickDataSource)
-    val report: WorkspaceSpendReport = makeWorkspaceSpendReport(projectId)
-    val success = Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
-    val thrown = intercept[java.sql.SQLIntegrityConstraintViolationException] {
+    val report: WorkspaceSpendReport = makeWorkspaceSpendReport(UUID.randomUUID().toString)
+    Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
+    intercept[java.sql.SQLIntegrityConstraintViolationException] {
       Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
     }
-    thrown.getErrorCode shouldBe Some(StatusCodes.Conflict)
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepositorySpec.scala
@@ -1,0 +1,71 @@
+package org.broadinstitute.dsde.rawls.spendreporting
+
+import akka.http.scaladsl.model.StatusCodes
+import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
+import org.broadinstitute.dsde.rawls.model.WorkspaceSpendReport
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.time.LocalDateTime
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class WorkspaceSpendReportRepositorySpec
+    extends AnyFlatSpec
+    with MockitoSugar
+    with ScalaFutures
+    with Matchers
+    with TestDriverComponent {
+
+  behavior of "getWorkspace"
+
+  val projectId = "fake-google-project"
+  val projectIds: Set[String] = Set(projectId)
+  val startDate: LocalDateTime = LocalDateTime.now().minusDays(30)
+  val endDate: LocalDateTime = LocalDateTime.now()
+  def makeWorkspaceSpendReport(projectId: String): WorkspaceSpendReport = WorkspaceSpendReport.newWorkspaceSpendReport(
+    projectId,
+    startDate,
+    endDate,
+    "USD",
+    isDataAvailable = true,
+    Option(100.00f),
+    Option(50.00f),
+    Option(5.00f),
+    Option(0.00f),
+    Option(0.00f),
+    Option(0.00f)
+  )
+
+  it should "get workspace spend reports for given report date if present" in {
+    val repo = new WorkspaceSpendReportRepository(slickDataSource)
+    val report: WorkspaceSpendReport = makeWorkspaceSpendReport(projectId)
+    Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
+
+    val results = Await.result(repo.getWorkspaceSpendReports(projectIds, startDate, endDate), Duration.Inf)
+    assertResult(1)(results.size)
+    results.map { result =>
+      assertResult(projectId)(result.googleProjectId)
+    }
+  }
+
+  it should "return none if no workspace spend reports present" in {
+    val repo = new WorkspaceSpendReportRepository(slickDataSource)
+    val result = Await.result(repo.getWorkspaceSpendReports(projectIds, startDate, endDate), Duration.Inf)
+    assertResult(Seq())(result)
+  }
+
+  behavior of "insertSpendReport"
+
+  it should "error if insert violates unique constraint on google project id, start and end date" in {
+    val repo = new WorkspaceSpendReportRepository(slickDataSource)
+    val report: WorkspaceSpendReport = makeWorkspaceSpendReport(projectId)
+    val success = Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
+    val thrown = intercept[java.sql.SQLIntegrityConstraintViolationException] {
+      Await.result(repo.insertWorkspaceSpendReport(report), Duration.Inf)
+    }
+    thrown.getErrorCode shouldBe Some(StatusCodes.Conflict)
+  }
+}

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/WorkspaceSpendReportRepositorySpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.rawls.spendreporting
 
-import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.rawls.dataaccess.slick.TestDriverComponent
 import org.broadinstitute.dsde.rawls.model.WorkspaceSpendReport
 import org.scalatest.concurrent.ScalaFutures

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/ApiServiceSpec.scala
@@ -46,7 +46,7 @@ import org.broadinstitute.dsde.rawls.monitor.HealthMonitor
 import org.broadinstitute.dsde.rawls.resourcebuffer.ResourceBufferServiceImpl
 import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImpl
 import org.broadinstitute.dsde.rawls.snapshot.SnapshotService
-import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
+import org.broadinstitute.dsde.rawls.spendreporting.{SpendReportingService, WorkspaceSpendReportRepository}
 import org.broadinstitute.dsde.rawls.status.StatusService
 import org.broadinstitute.dsde.rawls.submissions.SubmissionsService
 import org.broadinstitute.dsde.rawls.user.UserService
@@ -419,7 +419,8 @@ trait ApiServiceSpec
       mock[BillingProfileManagerDAO],
       samDAO,
       spendReportingServiceConfig,
-      workspaceServiceConstructor
+      workspaceServiceConstructor,
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
     )
 
     override val methodConfigurationServiceConstructor: RawlsRequestContext => MethodConfigurationService =

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
@@ -28,6 +28,25 @@ object WorkspaceSpendReport {
     storageCredits,
     otherCredits
   )
+
+  def newEmptySpendReport(googleProjectId: String,
+                          reportStartDate: LocalDateTime,
+                          reportEndDate: LocalDateTime,
+                          currency: String
+  ) = WorkspaceSpendReport(
+    -1L,
+    googleProjectId,
+    reportStartDate,
+    reportEndDate,
+    currency,
+    isDataAvailable = false,
+    Option.empty,
+    Option.empty,
+    Option.empty,
+    Option.empty,
+    Option.empty,
+    Option.empty
+  )
 }
 
 case class WorkspaceSpendReport(id: Long,

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
@@ -6,18 +6,26 @@ object WorkspaceSpendReport {
   def newWorkspaceSpendReport(googleProjectId: String,
                               reportStartDate: LocalDateTime,
                               reportEndDate: LocalDateTime,
+                              currency: String,
+                              isDataAvailable: Boolean,
                               totalCompute: Option[Float],
                               totalStorage: Option[Float],
                               otherSpend: Option[Float],
-                              isDataAvailable: Boolean
+                              computeCredits: Option[Float],
+                              storageCredits: Option[Float],
+                              otherCredits: Option[Float],
   ) = WorkspaceSpendReport(-1L,
     googleProjectId,
     reportStartDate,
     reportEndDate,
+    currency,
+    isDataAvailable,
     totalCompute,
     totalStorage,
     otherSpend,
-    isDataAvailable
+    computeCredits,
+    storageCredits,
+    otherCredits
   )
 }
 
@@ -25,8 +33,12 @@ case class WorkspaceSpendReport(id: Long,
                                 googleProjectId: String,
                                 reportStartDate: LocalDateTime,
                                 reportEndDate: LocalDateTime,
+                                currency: String,
+                                isDataAvailable: Boolean,
                                 totalCompute: Option[Float],
                                 totalStorage: Option[Float],
                                 otherSpend: Option[Float],
-                                isDataAvailable: Boolean)
+                                computeCredits: Option[Float],
+                                storageCredits: Option[Float],
+                                otherCredits: Option[Float])
 

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
@@ -1,0 +1,32 @@
+package org.broadinstitute.dsde.rawls.model
+
+import java.time.LocalDateTime
+
+object WorkspaceSpendReport {
+  def newWorkspaceSpendReport(googleProjectId: String,
+                              reportStartDate: LocalDateTime,
+                              reportEndDate: LocalDateTime,
+                              totalCompute: Option[Float],
+                              totalStorage: Option[Float],
+                              otherSpend: Option[Float],
+                              isDataAvailable: Boolean
+  ) = WorkspaceSpendReport(-1L,
+    googleProjectId,
+    reportStartDate,
+    reportEndDate,
+    totalCompute,
+    totalStorage,
+    otherSpend,
+    isDataAvailable
+  )
+}
+
+case class WorkspaceSpendReport(id: Long,
+                                googleProjectId: String,
+                                reportStartDate: LocalDateTime,
+                                reportEndDate: LocalDateTime,
+                                totalCompute: Option[Float],
+                                totalStorage: Option[Float],
+                                otherSpend: Option[Float],
+                                isDataAvailable: Boolean)
+

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/model/WorkspaceSpendReportModel.scala
@@ -13,8 +13,9 @@ object WorkspaceSpendReport {
                               otherSpend: Option[Float],
                               computeCredits: Option[Float],
                               storageCredits: Option[Float],
-                              otherCredits: Option[Float],
-  ) = WorkspaceSpendReport(-1L,
+                              otherCredits: Option[Float]
+  ) = WorkspaceSpendReport(
+    -1L,
     googleProjectId,
     reportStartDate,
     reportEndDate,
@@ -40,5 +41,5 @@ case class WorkspaceSpendReport(id: Long,
                                 otherSpend: Option[Float],
                                 computeCredits: Option[Float],
                                 storageCredits: Option[Float],
-                                otherCredits: Option[Float])
-
+                                otherCredits: Option[Float]
+)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-290

Changes:
- Query the workspace spend report table in Rawls for rows that match the given google project ids, start date and end date
- If there is a result for all project ids (a full cache hit), use those results and filter out any records where `isDataAvailable = false`
- Otherwise:
  - Run the bigQuery job and store those results in the workspace spend report table
  - For every google project id that does not have any query results, store a "dummy record" for that project id, start and end date in the database with `isDataAvailable = false` and no cost data. Otherwise subsequent calls will get a cache miss.

To-Do:
- [x] Handle the case where workspace spend is unavailable
- [x] Handle credits (need to add credits per category to the db table first) 
- [ ] Make matching by start/end more flexible (just check M/D/Y and not the exact timestamp)?
- [ ] Delete records older than X days (could make this a follow-on PR)
- [x] Tests!

---

**PR checklist**

- [x] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
