### PR TITLE
[CORE-319] Invite new users upon workspace creation

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2015,25 +2015,12 @@ class WorkspaceService(
             .map(_.email)
         )
       )
-      inviteNotifications <- DBIO.from {
-        workspaceRequest.addUsers match {
-          case Some(acls) =>
-            collectMissingUsers(acls.map(_.email).toSet, ctx).flatMap { missingUsers =>
-              Future.sequence(missingUsers.map { email =>
-                samDAO.inviteUser(email, ctx).map { _ =>
-                  Notifications.WorkspaceInvitedNotification(
-                    WorkbenchEmail(email),
-                    WorkbenchUserId(ctx.userInfo.userSubjectId.value),
-                    NotificationWorkspaceName(workspaceRequest.namespace, workspaceRequest.name),
-                    workspaceId // TODO this should be bucketname but we don't have it yet?
-                  )
-                }
-              }.toSeq)
-            }
-          case None => Future.successful(Seq.empty[Notifications.WorkspaceInvitedNotification])
-        }
-      }
-      _ <- DBIO.successful(notificationDAO.fireAndForgetNotifications(inviteNotifications))
+      usersToInvite <- DBIO.from(workspaceRequest.addUsers match {
+        case Some(acls) =>
+          collectMissingUsers(acls.map(_.email).toSet, ctx)
+        case None => Future.successful(Seq.empty[String])
+      })
+      _ <- DBIO.from(Future.traverse(usersToInvite)(email => samDAO.inviteUser(email, ctx)))
 
       resource <- createWorkspaceResourceInSam(workspaceId,
                                                billingProjectOwnerPolicyEmail,
@@ -2148,7 +2135,19 @@ class WorkspaceService(
           samDAO.getPetServiceAccountKeyForUser(savedWorkspace.googleProjectId, ctx.userInfo.userEmail)
         )
       )
-    } yield savedWorkspace
+    } yield {
+      val inviteNotifications = usersToInvite
+        .map(email =>
+          Notifications.WorkspaceInvitedNotification(
+            WorkbenchEmail(email),
+            WorkbenchUserId(ctx.userInfo.userSubjectId.value),
+            NotificationWorkspaceName(workspaceRequest.namespace, workspaceRequest.name),
+            savedWorkspace.bucketName
+          )
+        )
+      notificationDAO.fireAndForgetNotifications(inviteNotifications)
+      savedWorkspace
+    }
   }
 
   def failIfWorkspaceExists(name: WorkspaceName): ReadWriteAction[Unit] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2018,16 +2018,18 @@ class WorkspaceService(
       _ <- DBIO.from {
         workspaceRequest.addUsers match {
           case Some(acls) =>
-            Future.sequence(acls.map { aclUpdate =>
-              samDAO.inviteUser(aclUpdate.email, ctx).map { _ =>
-                Notifications.WorkspaceInvitedNotification(
-                  WorkbenchEmail(aclUpdate.email),
-                  WorkbenchUserId(ctx.userInfo.userSubjectId.value),
-                  NotificationWorkspaceName(workspaceRequest.namespace, workspaceRequest.name),
-                  workspaceId //TODO this should be bucketname but we don't have it yet?
-                )
-              }
-            }).map(_ => ())
+            Future
+              .sequence(acls.map { aclUpdate =>
+                samDAO.inviteUser(aclUpdate.email, ctx).map { _ =>
+                  Notifications.WorkspaceInvitedNotification(
+                    WorkbenchEmail(aclUpdate.email),
+                    WorkbenchUserId(ctx.userInfo.userSubjectId.value),
+                    NotificationWorkspaceName(workspaceRequest.namespace, workspaceRequest.name),
+                    workspaceId // TODO this should be bucketname but we don't have it yet?
+                  )
+                }
+              })
+              .map(_ => ())
           case None => Future.successful(())
         }
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2015,6 +2015,23 @@ class WorkspaceService(
             .map(_.email)
         )
       )
+      _ <- DBIO.from {
+        workspaceRequest.addUsers match {
+          case Some(acls) =>
+            Future.sequence(acls.map { aclUpdate =>
+              samDAO.inviteUser(aclUpdate.email, ctx).map { _ =>
+                Notifications.WorkspaceInvitedNotification(
+                  WorkbenchEmail(aclUpdate.email),
+                  WorkbenchUserId(ctx.userInfo.userSubjectId.value),
+                  NotificationWorkspaceName(workspaceRequest.namespace, workspaceRequest.name),
+                  workspaceId //TODO this should be bucketname but we don't have it yet?
+                )
+              }
+            }).map(_ => ())
+          case None => Future.successful(())
+        }
+      }
+
       resource <- createWorkspaceResourceInSam(workspaceId,
                                                billingProjectOwnerPolicyEmail,
                                                workspaceRequest,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -2015,24 +2015,25 @@ class WorkspaceService(
             .map(_.email)
         )
       )
-      _ <- DBIO.from {
+      inviteNotifications <- DBIO.from {
         workspaceRequest.addUsers match {
           case Some(acls) =>
-            Future
-              .sequence(acls.map { aclUpdate =>
-                samDAO.inviteUser(aclUpdate.email, ctx).map { _ =>
+            collectMissingUsers(acls.map(_.email).toSet, ctx).flatMap { missingUsers =>
+              Future.sequence(missingUsers.map { email =>
+                samDAO.inviteUser(email, ctx).map { _ =>
                   Notifications.WorkspaceInvitedNotification(
-                    WorkbenchEmail(aclUpdate.email),
+                    WorkbenchEmail(email),
                     WorkbenchUserId(ctx.userInfo.userSubjectId.value),
                     NotificationWorkspaceName(workspaceRequest.namespace, workspaceRequest.name),
                     workspaceId // TODO this should be bucketname but we don't have it yet?
                   )
                 }
-              })
-              .map(_ => ())
-          case None => Future.successful(())
+              }.toSeq)
+            }
+          case None => Future.successful(Seq.empty[Notifications.WorkspaceInvitedNotification])
         }
       }
+      _ <- DBIO.successful(notificationDAO.fireAndForgetNotifications(inviteNotifications))
 
       resource <- createWorkspaceResourceInSam(workspaceId,
                                                billingProjectOwnerPolicyEmail,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/mock/MockSamDAO.scala
@@ -95,7 +95,7 @@ class MockSamDAO(dataSource: SlickDataSource)(implicit executionContext: Executi
                                     ctx: RawlsRequestContext
   ): Future[Unit] = Future.successful(())
 
-  override def inviteUser(userEmail: String, ctx: RawlsRequestContext): Future[Unit] = ???
+  override def inviteUser(userEmail: String, ctx: RawlsRequestContext): Future[Unit] = Future.successful(())
 
   override def getUserIdInfoForEmail(userEmail: WorkbenchEmail): Future[UserIdInfo] =
     Future.successful(UserIdInfo("111111111111111", "user@email.example", None))


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-319
https://github.com/broadinstitute/rawls/pull/3192 allowed adding users to a newly created workspace but did not account for the case when the users don't yet exist in the terra system.  This PR invites new users before creating the workspace in Sam.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
