### PR TITLE
[CORE-289] Add additional workspace spend report fields

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -132,4 +132,5 @@
     <include file="changesets/20241121_billing_account_changes_status.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20241218_alter_audit_workflow_status_trigger_frequency.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250211_add_workspace_spend_report_table.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250227_update_workspace_spend_report_table.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250227_update_workspace_spend_report_table.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250227_update_workspace_spend_report_table.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+    <changeSet logicalFilePath="dummy" author="sehsan" id="update_WORKSPACE_SPEND_REPORT_TABLE">
+        <addColumn tableName="WORKSPACE_SPEND_REPORT">
+            <column name="CURRENCY" type="VARCHAR(100)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="WORKSPACE_SPEND_REPORT">
+            <column name="COMPUTE_CREDITS" type="VARCHAR(100)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="WORKSPACE_SPEND_REPORT">
+            <column name="STORAGE_CREDITS" type="VARCHAR(100)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+        <addColumn tableName="WORKSPACE_SPEND_REPORT">
+            <column name="OTHER_CREDITS" type="VARCHAR(100)">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250227_update_workspace_spend_report_table.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250227_update_workspace_spend_report_table.xml
@@ -7,17 +7,17 @@
             </column>
         </addColumn>
         <addColumn tableName="WORKSPACE_SPEND_REPORT">
-            <column name="COMPUTE_CREDITS" type="VARCHAR(100)">
+            <column name="COMPUTE_CREDITS" type="NUMBER(10,2)">
                 <constraints nullable="true" />
             </column>
         </addColumn>
         <addColumn tableName="WORKSPACE_SPEND_REPORT">
-            <column name="STORAGE_CREDITS" type="VARCHAR(100)">
+            <column name="STORAGE_CREDITS" type="NUMBER(10,2)">
                 <constraints nullable="true" />
             </column>
         </addColumn>
         <addColumn tableName="WORKSPACE_SPEND_REPORT">
-            <column name="OTHER_CREDITS" type="VARCHAR(100)">
+            <column name="OTHER_CREDITS" type="NUMBER(10,2)">
                 <constraints nullable="true" />
             </column>
         </addColumn>


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-289

Looking at https://github.com/broadinstitute/rawls/pull/3198, there are a few additional fields that get returned by the spend report APIs that also need to be stored in the `workspace_spend_report_table`.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
