### PR TITLE
CORE-308 expand concurrent requests to sam

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -139,7 +139,10 @@ leonardo {
     server = "add-leo-hostname-here"
 }
 
-sam.timeout = 3 minutes
+sam {
+  timeout = 3 minutes
+  maxConcurrentRequests = 15
+}
 
 prometheus {
   endpointPort = 9098

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAO.scala
@@ -7,7 +7,7 @@ import bio.terra.common.tracing.OkHttpClientTracingInterceptor
 import com.typesafe.scalalogging.LazyLogging
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
-import okhttp3.{Interceptor, Protocol, Response}
+import okhttp3.{Dispatcher, Interceptor, Protocol, Response}
 import org.broadinstitute.dsde.rawls.credentials.RawlsCredential
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model._
@@ -38,7 +38,11 @@ import scala.util.{Try, Using}
 /**
   * Created by mbemis on 9/11/17.
   */
-class HttpSamDAO(baseSamServiceURL: String, rawlsCredential: RawlsCredential, timeout: FiniteDuration)(implicit
+class HttpSamDAO(baseSamServiceURL: String,
+                 rawlsCredential: RawlsCredential,
+                 timeout: FiniteDuration,
+                 maxConcurrentRequests: Int
+)(implicit
   val system: ActorSystem,
   val executionContext: ExecutionContext
 ) extends SamDAO
@@ -48,19 +52,27 @@ class HttpSamDAO(baseSamServiceURL: String, rawlsCredential: RawlsCredential, ti
 
   private val samServiceURL = baseSamServiceURL
 
-  private val okHttpClient = new ApiClient().getHttpClient
+  private val okHttpClient = {
+    val dispatcher = new Dispatcher()
+    dispatcher.setMaxRequests(maxConcurrentRequests)
+    dispatcher.setMaxRequestsPerHost(maxConcurrentRequests)
+    new ApiClient().getHttpClient.newBuilder
+      .readTimeout(timeout.toJava)
+      .protocols(Seq(Protocol.HTTP_1_1).asJava)
+      .dispatcher(dispatcher)
+      .build()
+  }
 
   protected def getApiClient(ctx: RawlsRequestContext): ApiClient = {
 
     val okHttpClientWithTracingBuilder = okHttpClient.newBuilder
-      .readTimeout(timeout.toJava)
     ctx.otelContext.foreach(otelContext =>
       okHttpClientWithTracingBuilder
         .addInterceptor(new OtelContextSettingInterceptor(otelContext))
         .addInterceptor(new OkHttpClientTracingInterceptor(GlobalOpenTelemetry.get()))
     )
 
-    val samApiClient = new ApiClient(okHttpClientWithTracingBuilder.protocols(Seq(Protocol.HTTP_1_1).asJava).build())
+    val samApiClient = new ApiClient(okHttpClientWithTracingBuilder.build())
     samApiClient.setBasePath(samServiceURL)
     samApiClient.setAccessToken(ctx.userInfo.accessToken.token)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/SamDAOFactory.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/serviceFactory/SamDAOFactory.scala
@@ -17,7 +17,8 @@ object SamDAOFactory {
     new HttpSamDAO(
       samConfig.getString("server"),
       RawlsCredential.getCredential(appConfigManager),
-      toScalaDuration(samConfig.getDuration("timeout"))
+      toScalaDuration(samConfig.getDuration("timeout")),
+      samConfig.getInt("maxConcurrentRequests")
     )
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpSamDAOSpec.scala
@@ -57,7 +57,8 @@ class HttpSamDAOSpec
     val dao =
       new HttpSamDAO(mockServer.mockServerBaseUrl,
                      FakeRawlsCredentials(UUID.randomUUID().toString, Instant.now()),
-                     1 minute
+                     1 minute,
+                     15
       )
     assertResult(None) {
       Await.result(
@@ -74,7 +75,8 @@ class HttpSamDAOSpec
     val dao =
       new HttpSamDAO(mockServer.mockServerBaseUrl,
                      FakeRawlsCredentials(UUID.randomUUID().toString, Instant.now()),
-                     1 minute
+                     1 minute,
+                     15
       )
     assertResult(SamDAO.NotUser) {
       Await.result(
@@ -91,7 +93,8 @@ class HttpSamDAOSpec
     val dao =
       new HttpSamDAO(mockServer.mockServerBaseUrl,
                      FakeRawlsCredentials(UUID.randomUUID().toString, Instant.now()),
-                     1 minute
+                     1 minute,
+                     15
       )
     assertResult(SamDAO.NotFound) {
       Await.result(dao.getUserIdInfo(
@@ -132,7 +135,8 @@ class HttpSamDAOSpec
     val dao =
       new HttpSamDAO(mockServer.mockServerBaseUrl,
                      FakeRawlsCredentials(UUID.randomUUID().toString, Instant.now()),
-                     1 minute
+                     1 minute,
+                     15
       )
 
     val errorReportResponse = intercept[RawlsExceptionWithErrorReport] {
@@ -167,7 +171,8 @@ class HttpSamDAOSpec
     val dao =
       new HttpSamDAO(mockServer.mockServerBaseUrl,
                      FakeRawlsCredentials(UUID.randomUUID().toString, Instant.now()),
-                     1 minute
+                     1 minute,
+                     15
       )
 
     val junkResponseError = intercept[RawlsExceptionWithErrorReport] {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSupervisorSpec.scala
@@ -57,7 +57,8 @@ class SubmissionSupervisorSpec
   val mockSamDAO =
     new HttpSamDAO(mockServer.mockServerBaseUrl,
                    FakeRawlsCredentials(UUID.randomUUID().toString, Instant.now()),
-                   1 minute
+                   1 minute,
+                   15
     )
   val mockNotificationDAO: NotificationDAO = mock[NotificationDAO]
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-308

increases rawls' concurrent requests to sam from 5 (the default) to 15 in an attempt to decrease connect timed out errors

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
