### PR TITLE
[AN-411] GHA to run complex canary workflow against GCP Batch

### DIFF
--- a/.github/workflows/workflows-complex-canary-gcp-batch.yaml
+++ b/.github/workflows/workflows-complex-canary-gcp-batch.yaml
@@ -3,8 +3,6 @@ name: workflows-complex-canary-gcp-batch
   schedule:
     - cron: "0 */3 * * *"  # run every 3 hours
   workflow_dispatch:
-  pull_request: # TODO: remove this before merging
-    branches: [ develop ]
 
 jobs:
   run-complex-canary-gcp-batch-test:
@@ -19,7 +17,7 @@ jobs:
           workflow: workflows-canary-prod-test
           run-name: "workflows-complex-canary-gcp-batch-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/sps_complex_canary_batch # TODO: remove this before merging
+          ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 4h
           inputs: '{

--- a/.github/workflows/workflows-complex-canary-gcp-batch.yaml
+++ b/.github/workflows/workflows-complex-canary-gcp-batch.yaml
@@ -19,7 +19,7 @@ jobs:
           workflow: workflows-canary-prod-test
           run-name: "workflows-complex-canary-gcp-batch-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/sps_complex_canary_batch # TODO: remove this before merging
           token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
           wait-for-completion-timeout: 4h
           inputs: '{

--- a/.github/workflows/workflows-complex-canary-gcp-batch.yaml
+++ b/.github/workflows/workflows-complex-canary-gcp-batch.yaml
@@ -1,0 +1,41 @@
+name: workflows-complex-canary-gcp-batch
+'on':
+  schedule:
+    - cron: "0 */3 * * *"  # run every 3 hours
+  workflow_dispatch:
+  pull_request: # TODO: remove this before merging
+    branches: [ develop ]
+
+jobs:
+  run-complex-canary-gcp-batch-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Dispatch to terra-github-workflows
+        uses: broadinstitute/workflow-dispatch@v4.0.0
+        with:
+          workflow: workflows-canary-prod-test
+          run-name: "workflows-complex-canary-gcp-batch-${{ github.run_id }}-${{ github.run_attempt }}"
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          token: ${{ secrets.BROADBOT_TOKEN }} # GitHub token for access to kick off a job in the private repo
+          wait-for-completion-timeout: 4h
+          inputs: '{
+            "run-name": "workflows-complex-canary-gcp-batch-${{ github.run_id }}-${{ github.run_attempt }}",
+            "workspace-namespace": "broad-firecloud-dsde",
+            "workspace-name": "complex-canary-workflow-batch",
+            "method-namespace": "gatk",
+            "method-name": "five-dollar-genome-analysis-pipeline",
+            "entity-type": "sample",
+            "entity-id": "na12878_real_small"
+          }'
+
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    with:
+      notify-slack-channels-upon-workflow-failure: "#dsp-analysis-prod-alerts"
+      notify-slack-custom-icon: ":sad-terra:"
+    permissions:
+      id-token: write


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AN-411

Adds a new GHA that runs complex canary workflow against GCP Batch.

Example GHA runs:

- top-level Rawls GHA **run-complex-canary-gcp-batch-test**: https://github.com/broadinstitute/rawls/actions/runs/13639521001/job/38125998098?pr=3204
- child GHA in terra-github-workflows **run-canary-prod-test**: https://github.com/broadinstitute/terra-github-workflows/actions/runs/13639523448/job/38126006227
