### PR TITLE
[CORE-340] Add ID Column to BILLING_PROJECT Table & New getBillingProjectById API

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -133,4 +133,5 @@
     <include file="changesets/20241218_alter_audit_workflow_status_trigger_frequency.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250211_add_workspace_spend_report_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250227_update_workspace_spend_report_table.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250228_add_billing_project_id.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250228_add_billing_project_id.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250228_add_billing_project_id.xml
@@ -2,14 +2,9 @@
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
     <changeSet id="add_billing_project_id" author="kmarete" logicalFilePath="dummy">
         <addColumn tableName="BILLING_PROJECT">
-            <column name="ID" type="BINARY(16)">
+            <column name="ID" type="BINARY(16)" valueComputed="UNHEX(MD5(NAME))">
                 <constraints nullable="false" />
             </column>
         </addColumn>
-
-        <!-- Populate ID column with UUID derived from NAME (Unique PK) -->
-        <update tableName="BILLING_PROJECT">
-            <column name="ID" valueComputed="UNHEX(MD5(NAME))"/>
-        </update>
     </changeSet>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250228_add_billing_project_id.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250228_add_billing_project_id.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+    <changeSet id="add_billing_project_id" author="kmarete" logicalFilePath="dummy">
+        <addColumn tableName="BILLING_PROJECT">
+            <column name="ID" type="BINARY(16)">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+
+        <!-- Populate ID column with UUID derived from NAME (Unique PK) -->
+        <update tableName="BILLING_PROJECT">
+            <column name="ID" valueComputed="UNHEX(MD5(NAME))"/>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -225,6 +225,31 @@ paths:
       security:
         - oidc_google_billing_scope: []
       x-codegen-request-body-name: createProjectRequest
+
+  /api/billing/v2/id/{projectUuid}:
+    get:
+      tags:
+        - billing_v2
+      summary: get billing project by Id
+      description: get billing project by Id
+      operationId: getBillingProjectById
+      parameters:
+        - $ref: '#/components/parameters/billingProjectUuidPathParam'
+      responses:
+        200:
+          description: OK
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/RawlsBillingProjectResponse'
+        404:
+          description: Project Not Found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}:
     get:
       tags:
@@ -7260,6 +7285,14 @@ components:
           description: objects that this job has transferred so far
           type: integer
   parameters:
+    billingProjectUuidPathParam:
+        name: projectUuid
+        in: path
+        description: Billing Project UUID
+        required: true
+        schema:
+            type: string
+            format: uuid
     billingProjectIdPathParam:
       name: projectId
       in: path

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6707,10 +6707,6 @@ components:
         - projectName
       type: object
       properties:
-        id:
-          type: string
-          format: uuid
-          description: the id of the project to create
         projectName:
           type: string
           description: the name of the project to create

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6955,11 +6955,16 @@ components:
           description: the name of the Google Project where the BigQuery dataset resides (cloudPlatform GCP only)
     RawlsBillingProjectResponse:
       required:
+        - id
         - projectName
         - invalidBillingAccount
         - roles
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          description: the uuid of the project
         projectName:
           type: string
           description: the name of the project

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -6707,6 +6707,10 @@ components:
         - projectName
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          description: the id of the project to create
         projectName:
           type: string
           description: the name of the project to create

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -32,7 +32,6 @@ import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValid
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchUserId}
 
-import java.security.MessageDigest
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -161,11 +160,7 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
       )
       _ <- billingRepository.createBillingProject(
         RawlsBillingProject(
-          createProjectRequest.id.getOrElse { // if no id is provided, generate one from the project name
-            UUID.nameUUIDFromBytes(
-              MessageDigest.getInstance("MD5").digest(createProjectRequest.projectName.value.getBytes)
-            )
-          },
+          UUID.randomUUID(), // New ID[UUID] not PK of the billing project
           createProjectRequest.projectName,
           CreationStatuses.Creating,
           createProjectRequest.billingAccount,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -159,12 +159,14 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
         None
       )
       _ <- billingRepository.createBillingProject(
-        RawlsBillingProject(createProjectRequest.projectName,
-                            CreationStatuses.Creating,
-                            createProjectRequest.billingAccount,
-                            None,
-                            None,
-                            createProjectRequest.servicePerimeter
+        RawlsBillingProject(
+          UUID.randomUUID(), // New ID[UUID] not PK of the billing project
+          createProjectRequest.projectName,
+          CreationStatuses.Creating,
+          createProjectRequest.billingAccount,
+          None,
+          None,
+          createProjectRequest.servicePerimeter
         )
       )
     } yield notificationDAO.fireAndForgetNotifications(invites)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestrator.scala
@@ -32,6 +32,7 @@ import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValid
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.{Notifications, WorkbenchEmail, WorkbenchUserId}
 
+import java.security.MessageDigest
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -160,7 +161,11 @@ class BillingProjectOrchestrator(ctx: RawlsRequestContext,
       )
       _ <- billingRepository.createBillingProject(
         RawlsBillingProject(
-          UUID.randomUUID(), // New ID[UUID] not PK of the billing project
+          createProjectRequest.id.getOrElse { // if no id is provided, generate one from the project name
+            UUID.nameUUIDFromBytes(
+              MessageDigest.getInstance("MD5").digest(createProjectRequest.projectName.value.getBytes)
+            )
+          },
           createProjectRequest.projectName,
           CreationStatuses.Creating,
           createProjectRequest.billingAccount,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/billing/BillingRepository.scala
@@ -34,6 +34,11 @@ class BillingRepository(dataSource: SlickDataSource) {
       dataAccess.rawlsBillingProjectQuery.load(projectName)
     }
 
+  def getBillingProjectById(id: UUID): Future[Option[RawlsBillingProject]] =
+    dataSource.inTransaction { dataAccess =>
+      dataAccess.rawlsBillingProjectQuery.loadById(id)
+    }
+
   def getBillingProjects(projectNames: Set[RawlsBillingProjectName]): Future[Seq[RawlsBillingProject]] =
     dataSource.inTransaction(_.rawlsBillingProjectQuery.getBillingProjects(projectNames))
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -339,6 +339,12 @@ trait RawlsBillingProjectComponent {
         .read
         .map(_.headOption)
 
+    def loadById(id: UUID): ReadWriteAction[Option[RawlsBillingProject]] =
+      rawlsBillingProjectQuery
+        .withId(id)
+        .read
+        .map(_.headOption)
+
     def delete(billingProjectName: RawlsBillingProjectName): ReadWriteAction[Boolean] =
       rawlsBillingProjectQuery.withProjectName(billingProjectName).delete.map(_ > 0)
 
@@ -417,6 +423,9 @@ trait RawlsBillingProjectComponent {
       } yield projectRecords.map(RawlsBillingProjectRecord.toBillingProject)
 
     // filters
+    def withId(projectId: UUID): RawlsBillingProjectQuery =
+      query.filter(_.id === projectId)
+
     def withProjectName(projectName: RawlsBillingProjectName): RawlsBillingProjectQuery =
       query.filter(_.projectName === projectName.value)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponent.scala
@@ -21,7 +21,8 @@ import java.time.Instant
 import java.util.UUID
 import scala.util.Try
 
-final case class RawlsBillingProjectRecord(projectName: String,
+final case class RawlsBillingProjectRecord(id: UUID,
+                                           projectName: String,
                                            creationStatus: String,
                                            billingAccount: Option[String],
                                            message: Option[String],
@@ -39,6 +40,7 @@ final case class RawlsBillingProjectRecord(projectName: String,
 object RawlsBillingProjectRecord {
   def fromBillingProject(billingProject: RawlsBillingProject): RawlsBillingProjectRecord =
     RawlsBillingProjectRecord(
+      billingProject.id,
       billingProject.projectName.value,
       billingProject.status.toString,
       billingProject.billingAccount.map(_.value),
@@ -56,6 +58,7 @@ object RawlsBillingProjectRecord {
 
   def toBillingProject(projectRecord: RawlsBillingProjectRecord): RawlsBillingProject =
     RawlsBillingProject(
+      projectRecord.id,
       RawlsBillingProjectName(projectRecord.projectName),
       CreationStatuses.withName(projectRecord.creationStatus),
       projectRecord.billingAccount.map(RawlsBillingAccountName),
@@ -128,6 +131,8 @@ trait RawlsBillingProjectComponent {
   import driver.api._
 
   class RawlsBillingProjectTable(tag: Tag) extends Table[RawlsBillingProjectRecord](tag, "BILLING_PROJECT") {
+    def id = column[UUID]("ID")
+
     def projectName = column[String]("NAME", O.PrimaryKey, O.Length(254))
 
     def creationStatus = column[String]("CREATION_STATUS", O.Length(20))
@@ -154,7 +159,8 @@ trait RawlsBillingProjectComponent {
 
     def landingZoneId = column[Option[UUID]]("LANDING_ZONE_ID")
 
-    def * = (projectName,
+    def * = (id,
+             projectName,
              creationStatus,
              billingAccount,
              message,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -95,7 +95,7 @@ case class WorkspaceBillingAccount(
 case class RawlsBillingProjectOrganization(enterprise: Boolean, limits: Map[String, String])
 
 case class RawlsBillingProjectResponse(
-  id: String,
+  id: UUID,
   projectName: RawlsBillingProjectName,
   billingAccount: Option[RawlsBillingAccountName],
   servicePerimeter: Option[ServicePerimeterName],
@@ -120,7 +120,7 @@ object RawlsBillingProjectResponse {
     region: Option[String] = None,
     organization: Option[RawlsBillingProjectOrganization] = None
   ): RawlsBillingProjectResponse = this(
-    project.id.toString,
+    project.id,
     project.projectName,
     project.billingAccount,
     project.servicePerimeter,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -67,6 +67,7 @@ case class ManagedGroup(membersGroup: RawlsGroup, adminsGroup: RawlsGroup) exten
 
 case class RawlsBillingAccount(accountName: RawlsBillingAccountName, firecloudHasAccess: Boolean, displayName: String)
 case class RawlsBillingProject(
+  id: UUID,
   projectName: RawlsBillingProjectName,
   status: CreationStatuses.CreationStatus,
   billingAccount: Option[RawlsBillingAccountName],
@@ -94,6 +95,7 @@ case class WorkspaceBillingAccount(
 case class RawlsBillingProjectOrganization(enterprise: Boolean, limits: Map[String, String])
 
 case class RawlsBillingProjectResponse(
+  id: String,
   projectName: RawlsBillingProjectName,
   billingAccount: Option[RawlsBillingAccountName],
   servicePerimeter: Option[ServicePerimeterName],
@@ -118,6 +120,7 @@ object RawlsBillingProjectResponse {
     region: Option[String] = None,
     organization: Option[RawlsBillingProjectOrganization] = None
   ): RawlsBillingProjectResponse = this(
+    project.id.toString,
     project.projectName,
     project.billingAccount,
     project.servicePerimeter,
@@ -279,7 +282,7 @@ class UserAuthJsonSupport extends JsonSupport {
 
   implicit val RawlsGroupMemberListFormat: RootJsonFormat[RawlsGroupMemberList] = jsonFormat4(RawlsGroupMemberList)
 
-  implicit val RawlsBillingProjectFormat: RootJsonFormat[RawlsBillingProject] = jsonFormat14(RawlsBillingProject)
+  implicit val RawlsBillingProjectFormat: RootJsonFormat[RawlsBillingProject] = jsonFormat15(RawlsBillingProject)
 
   implicit val RawlsBillingAccountFormat: RootJsonFormat[RawlsBillingAccount] = jsonFormat3(RawlsBillingAccount)
 
@@ -339,7 +342,7 @@ class UserAuthJsonSupport extends JsonSupport {
   )
 
   implicit val RawlsBillingProjectResponseFormat: RootJsonFormat[RawlsBillingProjectResponse] =
-    jsonFormat13(RawlsBillingProjectResponse.apply)
+    jsonFormat14(RawlsBillingProjectResponse.apply)
 }
 
 object UserAuthJsonSupport extends UserAuthJsonSupport

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -201,7 +201,6 @@ object CreationStatuses {
 // and prone to false positives, but for users who are making use of a service
 // perimeter, we found that they needed the extra security.
 case class CreateRawlsV2BillingProjectFullRequest(
-  id: Option[UUID] = None,
   projectName: RawlsBillingProjectName,
   billingAccount: Option[RawlsBillingAccountName],
   servicePerimeter: Option[ServicePerimeterName],
@@ -310,7 +309,7 @@ class UserAuthJsonSupport extends JsonSupport {
   )
 
   implicit val CreateRawlsV2BillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsV2BillingProjectFullRequest] =
-    jsonFormat9(CreateRawlsV2BillingProjectFullRequest)
+    jsonFormat8(CreateRawlsV2BillingProjectFullRequest)
 
   implicit val UpdateRawlsBillingAccountRequestFormat: RootJsonFormat[UpdateRawlsBillingAccountRequest] = jsonFormat1(
     UpdateRawlsBillingAccountRequest

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/model/UserAuth.scala
@@ -201,6 +201,7 @@ object CreationStatuses {
 // and prone to false positives, but for users who are making use of a service
 // perimeter, we found that they needed the extra security.
 case class CreateRawlsV2BillingProjectFullRequest(
+  id: Option[UUID] = None,
   projectName: RawlsBillingProjectName,
   billingAccount: Option[RawlsBillingAccountName],
   servicePerimeter: Option[ServicePerimeterName],
@@ -309,7 +310,7 @@ class UserAuthJsonSupport extends JsonSupport {
   )
 
   implicit val CreateRawlsV2BillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsV2BillingProjectFullRequest] =
-    jsonFormat8(CreateRawlsV2BillingProjectFullRequest)
+    jsonFormat9(CreateRawlsV2BillingProjectFullRequest)
 
   implicit val UpdateRawlsBillingAccountRequestFormat: RootJsonFormat[UpdateRawlsBillingAccountRequest] = jsonFormat1(
     UpdateRawlsBillingAccountRequest

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsService.scala
@@ -764,6 +764,7 @@ class SubmissionsService(
                                     _,
                                     _,
                                     _,
+                                    _,
                                     Some(spendReportDataset),
                                     Some(spendReportTable),
                                     Some(spendReportDatasetGoogleProject),

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -269,23 +269,34 @@ class UserService(
     statusFuture
   }
 
-  def getBillingProject(projectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectResponse]] = for {
-    roles <- samDAO
-      .listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, ctx)
-      .map(resourceRoles => samRolesToProjectRoles(resourceRoles))
-    billingProject <- billingRepository.getBillingProject(projectName)
-    billingProfile = billingProject.flatMap {
-      _.billingProfileId.flatMap(id => billingProfileManagerDAO.getBillingProfile(UUID.fromString(id), ctx))
+  private def getBillingProjectResponse(
+    billingProjectFuture: Future[Option[RawlsBillingProject]]
+  ): Future[Option[RawlsBillingProjectResponse]] =
+    billingProjectFuture.flatMap {
+      case Some(project) =>
+        val rolesFuture = samDAO
+          .listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, ctx)
+          .map(samRolesToProjectRoles)
+
+        val billingProfileFuture = Future.successful {
+          project.billingProfileId.flatMap(id => billingProfileManagerDAO.getBillingProfile(UUID.fromString(id), ctx))
+        }
+
+        for {
+          roles <- rolesFuture
+          billingProfile <- billingProfileFuture
+        } yield
+          if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(project, billingProfile, roles, workspaceManagerDAO))
+          else None
+
+      case None => Future.successful(None)
     }
-  } yield billingProject.flatMap(p =>
-    if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(p, billingProfile, roles, workspaceManagerDAO)) else None
-  )
+
+  def getBillingProject(projectName: RawlsBillingProjectName): Future[Option[RawlsBillingProjectResponse]] =
+    getBillingProjectResponse(billingRepository.getBillingProject(projectName))
 
   def getBillingProjectById(id: UUID): Future[Option[RawlsBillingProjectResponse]] =
-    billingRepository.getBillingProjectById(id).flatMap {
-      case Some(billingProject) => getBillingProject(billingProject.projectName)
-      case None                 => Future.successful(None)
-    }
+    getBillingProjectResponse(billingRepository.getBillingProjectById(id))
 
   def listBillingProjectsV2(): Future[List[RawlsBillingProjectResponse]] = for {
     samUserResources <- samDAO.listUserResources(SamResourceTypeNames.billingProject, ctx)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -495,7 +495,7 @@ class UserService(
 
         billingAccountId <- dataSource.inTransaction { dataAccess =>
           dataAccess.rawlsBillingProjectQuery.load(billingProjectName).map {
-            case Some(RawlsBillingProject(_, _, Some(billingAccountName), _, _, _, _, false, _, _, _, _, _, _)) =>
+            case Some(RawlsBillingProject(_, _, _, Some(billingAccountName), _, _, _, _, false, _, _, _, _, _, _)) =>
               billingAccountName.withoutPrefix()
             case _ =>
               throw new RawlsExceptionWithErrorReport(
@@ -547,6 +547,7 @@ class UserService(
         dataAccess.rawlsBillingProjectQuery.load(billingProjectName).map {
           case Some(
                 RawlsBillingProject(_,
+                                    _,
                                     _,
                                     _,
                                     _,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -281,6 +281,12 @@ class UserService(
     if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(p, billingProfile, roles, workspaceManagerDAO)) else None
   )
 
+  def getBillingProjectById(id: UUID): Future[Option[RawlsBillingProjectResponse]] =
+    billingRepository.getBillingProjectById(id).flatMap {
+      case Some(billingProject) => getBillingProject(billingProject.projectName)
+      case None                 => Future.successful(None)
+    }
+
   def listBillingProjectsV2(): Future[List[RawlsBillingProjectResponse]] = for {
     samUserResources <- samDAO.listUserResources(SamResourceTypeNames.billingProject, ctx)
     rolesByResourceId: Map[String, Set[ProjectRole]] = samUserResources

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -274,21 +274,19 @@ class UserService(
   ): Future[Option[RawlsBillingProjectResponse]] =
     billingProjectFuture.flatMap {
       case Some(project) =>
-        val rolesFuture = samDAO
+        samDAO
           .listUserRolesForResource(SamResourceTypeNames.billingProject, project.projectName.value, ctx)
-          .map(samRolesToProjectRoles)
-
-        val billingProfileFuture = Future.successful {
-          project.billingProfileId.flatMap(id => billingProfileManagerDAO.getBillingProfile(UUID.fromString(id), ctx))
+          .map(samRolesToProjectRoles) map { roles =>
+          if (roles.nonEmpty) {
+            val billingProfile =
+              project.billingProfileId.flatMap(id =>
+                billingProfileManagerDAO.getBillingProfile(UUID.fromString(id), ctx)
+              )
+            Some(mapCloudPlatformAndPolicies(project, billingProfile, roles, workspaceManagerDAO))
+          } else {
+            None
+          }
         }
-
-        for {
-          roles <- rolesFuture
-          billingProfile <- billingProfileFuture
-        } yield
-          if (roles.nonEmpty) Some(mapCloudPlatformAndPolicies(project, billingProfile, roles, workspaceManagerDAO))
-          else None
-
       case None => Future.successful(None)
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -61,14 +61,12 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
       val ctx = RawlsRequestContext(userInfo, Option(otelContext))
       pathPrefix("billing" / "v2") {
         pathPrefix("id") {
-          pathPrefix(Segment) { id =>
-            pathEnd {
-              get {
-                complete {
-                  userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
-                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
-                    case None                  => StatusCodes.NotFound -> None
-                  }
+          path(Segment) { id =>
+            get {
+              complete {
+                userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
+                  case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
+                  case None                  => StatusCodes.NotFound -> None
                 }
               }
             }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller
 import io.opentelemetry.context.Context
 import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.billing.BillingProjectOrchestrator
-import org.broadinstitute.dsde.rawls.bucketMigration.{BucketMigrationService, BucketMigrationServiceImpl}
+import org.broadinstitute.dsde.rawls.bucketMigration.BucketMigrationService
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.UserInfoDirectives
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
@@ -16,7 +16,6 @@ import org.joda.time.DateTime
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success, Try}
 
 /**
   * Created by dvoet on 11/2/2020.
@@ -61,40 +60,48 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
     requireUserInfo(Option(otelContext)) { userInfo =>
       val ctx = RawlsRequestContext(userInfo, Option(otelContext))
       pathPrefix("billing" / "v2") {
-        pathPrefix("spendReport") {
-          pathEndOrSingleSlash {
-            get {
-              parameters(
-                "startDate".as[DateTime],
-                "endDate".as[DateTime],
-                "pageSize".as[Int],
-                "offset".as[Int]
-              ) { (startDate, endDate, pageSize, offset) =>
+        pathPrefix("id") {
+          pathPrefix(Segment) { id =>
+            pathEnd {
+              get {
                 complete {
-                  spendReportingConstructor(ctx).getSpendForAllWorkspaces(
-                    startDate,
-                    endDate.plusDays(1).minusMillis(1),
-                    pageSize,
-                    offset
-                  )
+                  import spray.json._
+                  userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
+                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse).toJson
+                    case None => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
+                  }
                 }
               }
             }
           }
         } ~
+          pathPrefix("spendReport") {
+            pathEndOrSingleSlash {
+              get {
+                parameters(
+                  "startDate".as[DateTime],
+                  "endDate".as[DateTime],
+                  "pageSize".as[Int],
+                  "offset".as[Int]
+                ) { (startDate, endDate, pageSize, offset) =>
+                  complete {
+                    spendReportingConstructor(ctx).getSpendForAllWorkspaces(
+                      startDate,
+                      endDate.plusDays(1).minusMillis(1),
+                      pageSize,
+                      offset
+                    )
+                  }
+                }
+              }
+            }
+          } ~
           pathPrefix(Segment) { projectId =>
             pathEnd {
               get {
                 complete {
                   import spray.json._
-
-                  // Check if the projectId is a UUID or a billingProjectName
-                  val billingProjects = Try(UUID.fromString(projectId)) match {
-                    case Success(id) => userServiceConstructor(ctx).getBillingProjectById(id)
-                    case Failure(_) => userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId))
-                  }
-
-                  billingProjects.map {
+                  userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId)).map {
                     case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse).toJson
                     case None => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
                   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -65,10 +65,9 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
             pathEnd {
               get {
                 complete {
-                  import spray.json._
                   userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
-                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse).toJson
-                    case None => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
+                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
+                    case None                  => StatusCodes.NotFound -> None
                   }
                 }
               }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -14,7 +14,9 @@ import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
 import org.broadinstitute.dsde.rawls.user.UserService
 import org.joda.time.DateTime
 
+import java.util.UUID
 import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by dvoet on 11/2/2020.
@@ -85,7 +87,14 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
               get {
                 complete {
                   import spray.json._
-                  userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId)).map {
+
+                  // Check if the projectId is a UUID or a billingProjectName
+                  val billingProjects = Try(UUID.fromString(projectId)) match {
+                    case Success(id) => userServiceConstructor(ctx).getBillingProjectById(id)
+                    case Failure(_) => userServiceConstructor(ctx).getBillingProject(RawlsBillingProjectName(projectId))
+                  }
+
+                  billingProjects.map {
                     case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse).toJson
                     case None => StatusCodes.NotFound -> Option(StatusCodes.NotFound.defaultMessage).toJson
                   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -564,7 +564,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(createRequest.projectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              createRequest.projectName,
                               CreationStatuses.Ready,
                               None,
                               None,
@@ -623,7 +624,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(createRequest.projectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              createRequest.projectName,
                               CreationStatuses.Ready,
                               None,
                               None,
@@ -677,7 +679,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(createRequest.projectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              createRequest.projectName,
                               CreationStatuses.Ready,
                               None,
                               None,
@@ -740,7 +743,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(createRequest.projectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              createRequest.projectName,
                               CreationStatuses.Ready,
                               None,
                               None,
@@ -810,7 +814,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(createRequest.projectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              createRequest.projectName,
                               CreationStatuses.Ready,
                               None,
                               None,
@@ -901,7 +906,8 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(billingProfileId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(billingProjectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              billingProjectName,
                               CreationStatuses.Ready,
                               None,
                               None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -47,6 +47,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
   val coords: AzureManagedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
   val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
   val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
+    None,
     billingProjectName,
     None,
     None,
@@ -55,6 +56,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     None
   )
   val createProtectedRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
+    None,
     billingProjectName,
     None,
     None,
@@ -95,6 +97,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
       mock[WorkspaceManagerResourceMonitorRecordDao]
     )
     val gcpCreateRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       billingProjectName,
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -172,6 +175,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
+      None,
       billingProjectName,
       None,
       None,
@@ -227,6 +231,7 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
         landingZoneAllowAttach = true
       )
     val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
+      None,
       billingProjectName,
       None,
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/AzureBillingProjectLifecycleSpec.scala
@@ -47,7 +47,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
   val coords: AzureManagedAppCoordinates = AzureManagedAppCoordinates(UUID.randomUUID, UUID.randomUUID, "fake")
   val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
   val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
-    None,
     billingProjectName,
     None,
     None,
@@ -56,7 +55,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     None
   )
   val createProtectedRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
-    None,
     billingProjectName,
     None,
     None,
@@ -97,7 +95,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
       mock[WorkspaceManagerResourceMonitorRecordDao]
     )
     val gcpCreateRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       billingProjectName,
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -175,7 +172,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bpm = mock[BillingProfileManagerDAO]
     val workspaceManagerDAO = mock[HttpWorkspaceManagerDAO]
     val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
-      None,
       billingProjectName,
       None,
       None,
@@ -231,7 +227,6 @@ class AzureBillingProjectLifecycleSpec extends AnyFlatSpec {
         landingZoneAllowAttach = true
       )
     val createRequestWithExistingLz = CreateRawlsV2BillingProjectFullRequest(
-      None,
       billingProjectName,
       None,
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingAdminServiceUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingAdminServiceUnitTests.scala
@@ -57,7 +57,8 @@ class BillingAdminServiceUnitTests extends AnyFlatSpec with MockitoTestUtils {
     )
 
   "getBillingProject" should "return the billing project with a list of its workspaces" in {
-    val billingProject: RawlsBillingProject = RawlsBillingProject(RawlsBillingProjectName("project"),
+    val billingProject: RawlsBillingProject = RawlsBillingProject(UUID.randomUUID(),
+                                                                  RawlsBillingProjectName("project"),
                                                                   CreationStatuses.Ready,
                                                                   Option(RawlsBillingAccountName("account")),
                                                                   None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectDeletionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectDeletionSpec.scala
@@ -57,6 +57,7 @@ class BillingProjectDeletionSpec extends AnyFlatSpec {
       Future.successful(
         Seq(
           RawlsBillingProject(
+            UUID.randomUUID(),
             billingProjectName,
             CreationStatuses.Ready,
             None,
@@ -88,17 +89,20 @@ class BillingProjectDeletionSpec extends AnyFlatSpec {
     when(repo.getBillingProjectsWithProfile(Some(profileModel.getId))).thenReturn(
       Future.successful(
         Seq(
-          RawlsBillingProject(billingProjectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              billingProjectName,
                               CreationStatuses.Ready,
                               None,
                               None,
                               billingProfileId = Some(profileModel.getId.toString)
           ),
-          RawlsBillingProject(RawlsBillingProjectName("other_billing_project"),
-                              CreationStatuses.Ready,
-                              None,
-                              None,
-                              billingProfileId = Some(profileModel.getId.toString)
+          RawlsBillingProject(
+            UUID.randomUUID(),
+            RawlsBillingProjectName("other_billing_project"),
+            CreationStatuses.Ready,
+            None,
+            None,
+            billingProfileId = Some(profileModel.getId.toString)
           )
         )
       )

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectDeletionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectDeletionSpec.scala
@@ -36,7 +36,6 @@ class BillingProjectDeletionSpec extends AnyFlatSpec {
 
   val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
   val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
-    None,
     billingProjectName,
     Some(RawlsBillingAccountName("fake_billing_account_name")),
     None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectDeletionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectDeletionSpec.scala
@@ -36,6 +36,7 @@ class BillingProjectDeletionSpec extends AnyFlatSpec {
 
   val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
   val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
+    None,
     billingProjectName,
     Some(RawlsBillingAccountName("fake_billing_account_name")),
     None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -35,7 +35,6 @@ import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-import java.security.MessageDigest
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -75,7 +74,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   it should "fail when the billing project fails validation" in {
     val samDAO = mock[SamDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("!@B#$"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -109,98 +107,12 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   behavior of "billing project creation"
 
-  it should "create a billing project record when provided a valid request [No Id] and set the correct creation status" in {
+  it should "create a billing project record when provided a valid request and set the correct creation status" in {
     val samDAO = mock[SamDAO]
     val gcsDAO = mock[GoogleServicesDAO]
     when(gcsDAO.testTerraAndUserBillingAccountAccess(any[RawlsBillingAccountName], ArgumentMatchers.eq(userInfo)))
       .thenReturn(Future.successful(true))
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
-      RawlsBillingProjectName("fake_project_name"),
-      Some(RawlsBillingAccountName("fake_billing_account_name")),
-      None,
-      None,
-      None,
-      None
-    )
-    val billingProjectDeletion = mock[BillingProjectDeletion]
-
-    val bpCreator = mock[GoogleBillingProjectLifecycle]
-    val bpCreatorReturnedStatus = CreationStatuses.CreatingLandingZone
-
-    when(bpCreator.validateBillingProjectCreationRequest(createRequest, testContext)).thenReturn(Future.successful())
-    when(bpCreator.postCreationSteps(createRequest, multiCloudWorkspaceConfig, billingProjectDeletion, testContext))
-      .thenReturn(Future.successful(bpCreatorReturnedStatus))
-    val billingRepository = mock[BillingRepository]
-    val expectedUUID =
-      UUID.nameUUIDFromBytes(MessageDigest.getInstance("MD5").digest(createRequest.projectName.value.getBytes))
-
-    when(billingRepository.getBillingProject(ArgumentMatchers.eq(createRequest.projectName)))
-      .thenReturn(Future.successful(None))
-    when(billingRepository.createBillingProject(any[RawlsBillingProject])).thenReturn(
-      Future.successful(
-        RawlsBillingProject(UUID.randomUUID(),
-                            RawlsBillingProjectName(createRequest.projectName.value),
-                            CreationStatuses.Creating,
-                            None,
-                            None
-        )
-      )
-    )
-    when(
-      billingRepository.updateCreationStatus(ArgumentMatchers.eq(createRequest.projectName),
-                                             ArgumentMatchers.eq(bpCreatorReturnedStatus),
-                                             any()
-      )
-    ).thenReturn(Future.successful(1))
-    when(
-      samDAO.createResourceFull(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(BillingProjectOrchestrator.buildBillingProjectPolicies(Set.empty, testContext)),
-        ArgumentMatchers.eq(Set.empty),
-        any[RawlsRequestContext],
-        ArgumentMatchers.eq(None)
-      )
-    ).thenReturn(Future.successful(SamCreateResourceResponse("test", "test", Set.empty, Set.empty)))
-    when(
-      samDAO.syncPolicyToGoogle(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(createRequest.projectName.value),
-        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
-      )
-    ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
-    val bpo = new BillingProjectOrchestrator(
-      testContext,
-      samDAO,
-      mock[NotificationDAO],
-      billingRepository,
-      bpCreator,
-      mock[AzureBillingProjectLifecycle],
-      billingProjectDeletion,
-      multiCloudWorkspaceConfig,
-      mock[WorkspaceManagerResourceMonitorRecordDao]
-    )
-
-    Await.result(bpo.createBillingProjectV2(createRequest), Duration.Inf)
-
-    verify(billingRepository, Mockito.times(1)).updateCreationStatus(ArgumentMatchers.eq(createRequest.projectName),
-                                                                     ArgumentMatchers.eq(bpCreatorReturnedStatus),
-                                                                     ArgumentMatchers.eq(None)
-    )
-    verify(billingRepository).createBillingProject(argThat { project: RawlsBillingProject =>
-      project.projectName == createRequest.projectName && project.id == createRequest.id.getOrElse(expectedUUID)
-    }) // If `id` is not set, it is derived from the project name as a UUID
-  }
-
-  it should "create a billing project record when provided a valid request [With Id] and set the correct creation status" in {
-    val samDAO = mock[SamDAO]
-    val gcsDAO = mock[GoogleServicesDAO]
-    when(gcsDAO.testTerraAndUserBillingAccountAccess(any[RawlsBillingAccountName], ArgumentMatchers.eq(userInfo)))
-      .thenReturn(Future.successful(true))
-    val projectId = UUID.randomUUID()
-    val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      Some(projectId),
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -271,9 +183,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
                                                                      ArgumentMatchers.eq(bpCreatorReturnedStatus),
                                                                      ArgumentMatchers.eq(None)
     )
-    verify(billingRepository).createBillingProject(argThat { project: RawlsBillingProject =>
-      project.projectName == createRequest.projectName && project.id == createRequest.id.getOrElse(projectId)
-    }) // If `id` is set, then it is used as the project ID
   }
 
   it should "fail when a duplicate project already exists" in {
@@ -282,7 +191,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     when(gcsDAO.testTerraAndUserBillingAccountAccess(any[RawlsBillingAccountName], ArgumentMatchers.eq(userInfo)))
       .thenReturn(Future.successful(true))
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("fake_project"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -324,7 +232,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   it should "fail when provided an invalid billing project name" in {
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("!@B#$"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -355,7 +262,6 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   it should "delete the billing project and throw an exception if post creation steps fail" in {
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -29,12 +29,13 @@ import org.broadinstitute.dsde.rawls.model.{
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, TestExecutionContext}
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, argThat}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 
+import java.security.MessageDigest
 import java.util.UUID
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -74,6 +75,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
   it should "fail when the billing project fails validation" in {
     val samDAO = mock[SamDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("!@B#$"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -107,12 +109,13 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   behavior of "billing project creation"
 
-  it should "create a billing project record when provided a valid request and set the correct creation status" in {
+  it should "create a billing project record when provided a valid request [No Id] and set the correct creation status" in {
     val samDAO = mock[SamDAO]
     val gcsDAO = mock[GoogleServicesDAO]
     when(gcsDAO.testTerraAndUserBillingAccountAccess(any[RawlsBillingAccountName], ArgumentMatchers.eq(userInfo)))
       .thenReturn(Future.successful(true))
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -129,6 +132,9 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     when(bpCreator.postCreationSteps(createRequest, multiCloudWorkspaceConfig, billingProjectDeletion, testContext))
       .thenReturn(Future.successful(bpCreatorReturnedStatus))
     val billingRepository = mock[BillingRepository]
+    val expectedUUID =
+      UUID.nameUUIDFromBytes(MessageDigest.getInstance("MD5").digest(createRequest.projectName.value.getBytes))
+
     when(billingRepository.getBillingProject(ArgumentMatchers.eq(createRequest.projectName)))
       .thenReturn(Future.successful(None))
     when(billingRepository.createBillingProject(any[RawlsBillingProject])).thenReturn(
@@ -182,6 +188,92 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
                                                                      ArgumentMatchers.eq(bpCreatorReturnedStatus),
                                                                      ArgumentMatchers.eq(None)
     )
+    verify(billingRepository).createBillingProject(argThat { project: RawlsBillingProject =>
+      project.projectName == createRequest.projectName && project.id == createRequest.id.getOrElse(expectedUUID)
+    }) // If `id` is not set, it is derived from the project name as a UUID
+  }
+
+  it should "create a billing project record when provided a valid request [With Id] and set the correct creation status" in {
+    val samDAO = mock[SamDAO]
+    val gcsDAO = mock[GoogleServicesDAO]
+    when(gcsDAO.testTerraAndUserBillingAccountAccess(any[RawlsBillingAccountName], ArgumentMatchers.eq(userInfo)))
+      .thenReturn(Future.successful(true))
+    val projectId = UUID.randomUUID()
+    val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      Some(projectId),
+      RawlsBillingProjectName("fake_project_name"),
+      Some(RawlsBillingAccountName("fake_billing_account_name")),
+      None,
+      None,
+      None,
+      None
+    )
+    val billingProjectDeletion = mock[BillingProjectDeletion]
+
+    val bpCreator = mock[GoogleBillingProjectLifecycle]
+    val bpCreatorReturnedStatus = CreationStatuses.CreatingLandingZone
+
+    when(bpCreator.validateBillingProjectCreationRequest(createRequest, testContext)).thenReturn(Future.successful())
+    when(bpCreator.postCreationSteps(createRequest, multiCloudWorkspaceConfig, billingProjectDeletion, testContext))
+      .thenReturn(Future.successful(bpCreatorReturnedStatus))
+    val billingRepository = mock[BillingRepository]
+
+    when(billingRepository.getBillingProject(ArgumentMatchers.eq(createRequest.projectName)))
+      .thenReturn(Future.successful(None))
+    when(billingRepository.createBillingProject(any[RawlsBillingProject])).thenReturn(
+      Future.successful(
+        RawlsBillingProject(UUID.randomUUID(),
+                            RawlsBillingProjectName(createRequest.projectName.value),
+                            CreationStatuses.Creating,
+                            None,
+                            None
+        )
+      )
+    )
+    when(
+      billingRepository.updateCreationStatus(ArgumentMatchers.eq(createRequest.projectName),
+                                             ArgumentMatchers.eq(bpCreatorReturnedStatus),
+                                             any()
+      )
+    ).thenReturn(Future.successful(1))
+    when(
+      samDAO.createResourceFull(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(createRequest.projectName.value),
+        ArgumentMatchers.eq(BillingProjectOrchestrator.buildBillingProjectPolicies(Set.empty, testContext)),
+        ArgumentMatchers.eq(Set.empty),
+        any[RawlsRequestContext],
+        ArgumentMatchers.eq(None)
+      )
+    ).thenReturn(Future.successful(SamCreateResourceResponse("test", "test", Set.empty, Set.empty)))
+    when(
+      samDAO.syncPolicyToGoogle(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(createRequest.projectName.value),
+        ArgumentMatchers.eq(SamBillingProjectPolicyNames.owner)
+      )
+    ).thenReturn(Future.successful(Map(WorkbenchEmail(userInfo.userEmail.value) -> Seq())))
+    val bpo = new BillingProjectOrchestrator(
+      testContext,
+      samDAO,
+      mock[NotificationDAO],
+      billingRepository,
+      bpCreator,
+      mock[AzureBillingProjectLifecycle],
+      billingProjectDeletion,
+      multiCloudWorkspaceConfig,
+      mock[WorkspaceManagerResourceMonitorRecordDao]
+    )
+
+    Await.result(bpo.createBillingProjectV2(createRequest), Duration.Inf)
+
+    verify(billingRepository, Mockito.times(1)).updateCreationStatus(ArgumentMatchers.eq(createRequest.projectName),
+                                                                     ArgumentMatchers.eq(bpCreatorReturnedStatus),
+                                                                     ArgumentMatchers.eq(None)
+    )
+    verify(billingRepository).createBillingProject(argThat { project: RawlsBillingProject =>
+      project.projectName == createRequest.projectName && project.id == createRequest.id.getOrElse(projectId)
+    }) // If `id` is set, then it is used as the project ID
   }
 
   it should "fail when a duplicate project already exists" in {
@@ -190,6 +282,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     when(gcsDAO.testTerraAndUserBillingAccountAccess(any[RawlsBillingAccountName], ArgumentMatchers.eq(userInfo)))
       .thenReturn(Future.successful(true))
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_project"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -231,6 +324,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   it should "fail when provided an invalid billing project name" in {
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("!@B#$"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -261,6 +355,7 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
 
   it should "delete the billing project and throw an exception if post creation steps fail" in {
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingProjectOrchestratorSpec.scala
@@ -133,7 +133,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful(None))
     when(billingRepository.createBillingProject(any[RawlsBillingProject])).thenReturn(
       Future.successful(
-        RawlsBillingProject(RawlsBillingProjectName(createRequest.projectName.value),
+        RawlsBillingProject(UUID.randomUUID(),
+                            RawlsBillingProjectName(createRequest.projectName.value),
                             CreationStatuses.Creating,
                             None,
                             None
@@ -198,7 +199,11 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
     )
     val billingRepository = mock[BillingRepository]
     when(billingRepository.getBillingProject(ArgumentMatchers.eq(createRequest.projectName))).thenReturn(
-      Future.successful(Some(RawlsBillingProject(RawlsBillingProjectName("fake"), CreationStatuses.Ready, None, None)))
+      Future.successful(
+        Some(
+          RawlsBillingProject(UUID.randomUUID(), RawlsBillingProjectName("fake"), CreationStatuses.Ready, None, None)
+        )
+      )
     )
     val bpCreator = mock[GoogleBillingProjectLifecycle]
     when(bpCreator.validateBillingProjectCreationRequest(createRequest, testContext)).thenReturn(Future.successful())
@@ -281,7 +286,8 @@ class BillingProjectOrchestratorSpec extends AnyFlatSpec {
       .thenReturn(Future.successful(None))
     when(repo.createBillingProject(any[RawlsBillingProject])).thenReturn(
       Future.successful(
-        RawlsBillingProject(RawlsBillingProjectName(createRequest.projectName.value),
+        RawlsBillingProject(UUID.randomUUID(),
+                            RawlsBillingProjectName(createRequest.projectName.value),
                             CreationStatuses.Ready,
                             None,
                             None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
@@ -68,11 +68,36 @@ class BillingRepositorySpec extends AnyFlatSpec with TestDriverComponent {
     }
   }
 
+  it should "retrieve a previously created record by Id" in withDefaultTestDatabase {
+    val repo = new BillingRepository(slickDataSource)
+    val billingProject = makeBillingProject()
+
+    Await.result(repo.createBillingProject(billingProject), Duration.Inf)
+    val result = Await.result(repo.getBillingProjectById(billingProject.id), Duration.Inf)
+
+    assertResult(billingProject) {
+      result.get
+    }
+  }
+
   it should "give back none for a missing project" in withDefaultTestDatabase {
     val repo = new BillingRepository(slickDataSource)
 
     val result = Await.result(
       repo.getBillingProject(RawlsBillingProjectName(UUID.randomUUID().toString)),
+      Duration.Inf
+    )
+
+    assertResult(result) {
+      None
+    }
+  }
+
+  it should "give back none for a missing project by Id" in withDefaultTestDatabase {
+    val repo = new BillingRepository(slickDataSource)
+
+    val result = Await.result(
+      repo.getBillingProjectById(UUID.randomUUID()),
       Duration.Inf
     )
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/BillingRepositorySpec.scala
@@ -27,6 +27,7 @@ class BillingRepositorySpec extends AnyFlatSpec with TestDriverComponent {
   behavior of "createBillingProject"
 
   def makeBillingProject() = RawlsBillingProject(
+    UUID.randomUUID(),
     RawlsBillingProjectName(UUID.randomUUID().toString),
     CreationStatuses.Ready,
     Some(RawlsBillingAccountName("fake_account")),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
@@ -42,6 +42,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
   val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
   val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
+    None,
     billingProjectName,
     Some(RawlsBillingAccountName("fake_billing_account_name")),
     None,
@@ -56,6 +57,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
   it should "fail when creating a billing project against an billing account with no access" in {
     val samDAO = mock[SamDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -94,6 +96,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     ).thenReturn(Future.successful(false))
 
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_billing_project"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       Some(servicePerimeterName),
@@ -124,6 +127,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     val samDAO = mock[SamDAO]
     val bpm = mock[BillingProfileManagerDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -179,6 +183,7 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bp = new GoogleBillingProjectLifecycle(repo, bpm, samDAO, mock[GoogleServicesDAO])
 
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
+      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/billing/GoogleBillingProjectLifecycleSpec.scala
@@ -42,7 +42,6 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
 
   val billingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("fake_name")
   val createRequest: CreateRawlsV2BillingProjectFullRequest = CreateRawlsV2BillingProjectFullRequest(
-    None,
     billingProjectName,
     Some(RawlsBillingAccountName("fake_billing_account_name")),
     None,
@@ -57,7 +56,6 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
   it should "fail when creating a billing project against an billing account with no access" in {
     val samDAO = mock[SamDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -96,7 +94,6 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     ).thenReturn(Future.successful(false))
 
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("fake_billing_project"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       Some(servicePerimeterName),
@@ -127,7 +124,6 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     val samDAO = mock[SamDAO]
     val bpm = mock[BillingProfileManagerDAO]
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,
@@ -183,7 +179,6 @@ class GoogleBillingProjectLifecycleSpec extends AnyFlatSpec {
     val bp = new GoogleBillingProjectLifecycle(repo, bpm, samDAO, mock[GoogleServicesDAO])
 
     val createRequest = CreateRawlsV2BillingProjectFullRequest(
-      None,
       RawlsBillingProjectName("fake_project_name"),
       Some(RawlsBillingAccountName("fake_billing_account_name")),
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -13,7 +13,7 @@ class RawlsBillingProjectComponentSpec
     with OptionValues
     with RawSqlQuery {
 
-  "RawlsBillingProjectComponent" should "save, load and delete" in withDefaultTestDatabase {
+  "RawlsBillingProjectComponent" should "save, load, loadById and delete" in withDefaultTestDatabase {
     // note that create is called in test data save
     val project = testData.testProject1
     assertResult(Some(project)) {
@@ -30,6 +30,10 @@ class RawlsBillingProjectComponentSpec
 
     assertResult(None) {
       runAndWait(rawlsBillingProjectQuery.load(project.projectName))
+    }
+
+    assertResult(None) {
+      runAndWait(rawlsBillingProjectQuery.loadById(project.id))
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/RawlsBillingProjectComponentSpec.scala
@@ -20,6 +20,10 @@ class RawlsBillingProjectComponentSpec
       runAndWait(rawlsBillingProjectQuery.load(project.projectName))
     }
 
+    assertResult(Some(project)) {
+      runAndWait(rawlsBillingProjectQuery.loadById(project.id))
+    }
+
     assertResult(true) {
       runAndWait(rawlsBillingProjectQuery.delete(project.projectName))
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/TestDriverComponent.scala
@@ -198,10 +198,11 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   }
 
   def billingProjectFromName(name: String) =
-    RawlsBillingProject(RawlsBillingProjectName(name), CreationStatuses.Ready, None, None)
+    RawlsBillingProject(UUID.randomUUID(), RawlsBillingProjectName(name), CreationStatuses.Ready, None, None)
 
   def billingProjectFromName(name: String, billingProfileId: UUID) =
-    RawlsBillingProject(RawlsBillingProjectName(name),
+    RawlsBillingProject(UUID.randomUUID(),
+                        RawlsBillingProjectName(name),
                         CreationStatuses.Ready,
                         None,
                         None,
@@ -465,20 +466,24 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
     val billingAccountName = RawlsBillingAccountName("fakeBillingAcct")
 
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName(wsName.namespace),
+    val billingProject = RawlsBillingProject(UUID.randomUUID(),
+                                             RawlsBillingProjectName(wsName.namespace),
                                              CreationStatuses.Ready,
                                              Option(billingAccountName),
                                              None
     )
 
     val testProject1Name = RawlsBillingProjectName("arbitrary")
-    val testProject1 = RawlsBillingProject(testProject1Name, CreationStatuses.Ready, Option(billingAccountName), None)
+    val testProject1 =
+      RawlsBillingProject(UUID.randomUUID(), testProject1Name, CreationStatuses.Ready, Option(billingAccountName), None)
 
     val testProject2Name = RawlsBillingProjectName("project2")
-    val testProject2 = RawlsBillingProject(testProject2Name, CreationStatuses.Ready, Option(billingAccountName), None)
+    val testProject2 =
+      RawlsBillingProject(UUID.randomUUID(), testProject2Name, CreationStatuses.Ready, Option(billingAccountName), None)
 
     val testProject3Name = RawlsBillingProjectName("project3")
-    val testProject3 = RawlsBillingProject(testProject3Name, CreationStatuses.Ready, Option(billingAccountName), None)
+    val testProject3 =
+      RawlsBillingProject(UUID.randomUUID(), testProject3Name, CreationStatuses.Ready, Option(billingAccountName), None)
 
     val azureBillingProfile = new ProfileModel()
       .id(UUID.randomUUID())
@@ -490,6 +495,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
     val azureBillingProjectName = RawlsBillingProjectName("azure-billing-project")
     val azureBillingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       azureBillingProjectName,
       CreationStatuses.Ready,
       Option(billingAccountName),
@@ -506,6 +512,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
       .managedResourceGroupId("fake-mrg")
       .createdDate("2023-09-11T22:20:48.949Z")
     val oldAzureBillingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName("old-azure-billing-project"),
       CreationStatuses.Ready,
       Option(billingAccountName),
@@ -2034,6 +2041,7 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
 
   class MinimalTestData() extends TestData {
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName("myNamespace"),
       CreationStatuses.Ready,
       Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
@@ -2085,10 +2093,12 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
   }
 
   class ProtectedWorkspaceTestData() extends TestData {
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("myNamespace"),
-                                             CreationStatuses.Ready,
-                                             Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
-                                             None
+    val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
+      RawlsBillingProjectName("myNamespace"),
+      CreationStatuses.Ready,
+      Option(RawlsBillingAccountName("billingAccounts/000000-111111-222222")),
+      None
     )
     val wsName = WorkspaceName(billingProject.projectName.value, "myWorkspace")
     val protectedWsName = WorkspaceName(billingProject.projectName.value, "myProtectedWorkspace")
@@ -2212,7 +2222,12 @@ trait TestDriverComponent extends DriverComponent with DataAccess with DefaultIn
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set(userReader))
 
     val billingProject =
-      RawlsBillingProject(RawlsBillingProjectName(wsName.namespace), CreationStatuses.Ready, None, None)
+      RawlsBillingProject(UUID.randomUUID(),
+                          RawlsBillingProjectName(wsName.namespace),
+                          CreationStatuses.Ready,
+                          None,
+                          None
+      )
 
     val wsAttrs = Map(
       AttributeName.withDefaultNS("string") -> AttributeString("yep, it's a string"),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/WorkspaceComponentSpec.scala
@@ -175,7 +175,8 @@ class WorkspaceComponentSpec
     val billingProjectNameInOtherPerimeter = RawlsBillingProjectName("projectInOtherPerimeter")
 
     // 3 Billing Projects with same Perimeter
-    val billingProject1 = RawlsBillingProject(billingProject1Name,
+    val billingProject1 = RawlsBillingProject(UUID.randomUUID(),
+                                              billingProject1Name,
                                               CreationStatuses.Ready,
                                               Option(billingAccountName),
                                               None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/SubmissionSpec.scala
@@ -114,7 +114,12 @@ class SubmissionSpec(_system: ActorSystem)
 
   class SubmissionTestData() extends TestData {
     val billingProject =
-      RawlsBillingProject(RawlsBillingProjectName("myNamespacexxx"), CreationStatuses.Ready, None, None)
+      RawlsBillingProject(UUID.randomUUID(),
+                          RawlsBillingProjectName("myNamespacexxx"),
+                          CreationStatuses.Ready,
+                          None,
+                          None
+      )
     val wsName = WorkspaceName(billingProject.projectName.value, "myWorkspace")
     val user = RawlsUser(userInfo)
     val ownerGroup = makeRawlsGroup("workspaceOwnerGroup", Set(user))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/BillingAccountChangeSynchronizerSpec.scala
@@ -56,11 +56,13 @@ class BillingAccountChangeSynchronizerSpec
   "BillingAccountChangeSynchronizer" should "update the billing account on workspaces in a billing project" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val billingAccountName = defaultBillingAccountName
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(billingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(billingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
 
       val v2Workspace = Workspace(
@@ -130,11 +132,13 @@ class BillingAccountChangeSynchronizerSpec
   it should "not endlessly retry when it fails to get billing info for google projects" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Option(defaultBillingAccountName)
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               originalBillingAccount,
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        originalBillingAccount,
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val workspace = Workspace(
         billingProject.projectName.value,
@@ -196,11 +200,13 @@ class BillingAccountChangeSynchronizerSpec
   it should "not endlessly retry when it fails to set billing info for the google project" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Option(defaultBillingAccountName)
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               originalBillingAccount,
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        originalBillingAccount,
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val workspace = Workspace(
         billingProject.projectName.value,
@@ -264,11 +270,13 @@ class BillingAccountChangeSynchronizerSpec
   it should "not try to update the billing account if the new value is the same as the old value" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Some(defaultBillingAccountName)
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               originalBillingAccount,
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        originalBillingAccount,
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val workspace = Workspace(
         billingProject.projectName.value,
@@ -334,11 +342,13 @@ class BillingAccountChangeSynchronizerSpec
   it should "continue to update other workspace google projects even if one fails to update" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Option(defaultBillingAccountName)
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               originalBillingAccount,
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        originalBillingAccount,
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val workspace1 = Workspace(
         billingProject.projectName.value,
@@ -778,7 +788,8 @@ class BillingAccountChangeSynchronizerSpec
   it should "not try to update the (non-existent) google project of a v2 billing project" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val originalBillingAccount = Option(RawlsBillingAccountName("original-ba"))
-      val billingProject = RawlsBillingProject(RawlsBillingProjectName("v2-Billing-Project"),
+      val billingProject = RawlsBillingProject(UUID.randomUUID(),
+                                               RawlsBillingProjectName("v2-Billing-Project"),
                                                CreationStatuses.Ready,
                                                originalBillingAccount,
                                                None,
@@ -851,11 +862,13 @@ class BillingAccountChangeSynchronizerSpec
   it should "work with v2 workspaces that use the billing project's old Google project" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
       val billingAccountName = defaultBillingAccountName
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(billingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(billingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
 
       val workspaceWithBillingProjectGoogleProject = Workspace(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/CloneWorkspaceFileTransferMonitorSpec.scala
@@ -54,11 +54,13 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
   "CloneWorkspaceFileTransferMonitor" should "eventually copy files from the source bucket to the destination bucket" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(defaultBillingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(defaultBillingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val sourceBucketName = "sourceBucket"
       val destinationBucketName = "destinationBucket"
@@ -151,11 +153,13 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
   it should "continue trying to transfer files when receiving 403s from Google while listing objects" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(defaultBillingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(defaultBillingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val sourceBucketName = "sourceBucket"
       val destinationBucketName = "destinationBucket"
@@ -239,11 +243,13 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
   it should "continue trying to transfer files when receiving 403s from Google while copying objects" in
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(defaultBillingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(defaultBillingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val sourceBucketName = "sourceBucket"
       val destinationBucketName = "destinationBucket"
@@ -339,11 +345,13 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
   it should "continue trying to copy the files until all copies succeed" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(defaultBillingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(defaultBillingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val sourceBucketName = "sourceBucket"
       val destinationBucketName = "destinationBucket"
@@ -456,11 +464,13 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
   it should "copy files for good workspaces even when problematic workspaces are failing" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(defaultBillingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(defaultBillingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val sourceBucketName = "sourceBucket"
       val badDestinationBucketName = "badBucket"
@@ -615,11 +625,13 @@ class CloneWorkspaceFileTransferMonitorSpec(_system: ActorSystem)
 
   it should "eventually stop trying to copy files" in {
     withEmptyTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(defaultBillingProjectName,
-                                               CreationStatuses.Ready,
-                                               Option(defaultBillingAccountName),
-                                               None,
-                                               googleProjectNumber = Option(defaultGoogleProjectNumber)
+      val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
+        defaultBillingProjectName,
+        CreationStatuses.Ready,
+        Option(defaultBillingAccountName),
+        None,
+        googleProjectNumber = Option(defaultGoogleProjectNumber)
       )
       val sourceBucketName = "sourceBucket"
       val destinationBucketName = "destinationBucket"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/serviceperimeter/ServicePerimeterServiceSpec.scala
@@ -231,9 +231,15 @@ class ServicePerimeterServiceSpec
       val service = new ServicePerimeterServiceImpl(dataSource, gcsDAO, defaultConfig)
 
       val billingProject1 =
-        testData.testProject1.copy(RawlsBillingProjectName("bp1"), servicePerimeter = servicePerimeterName.some)
+        testData.testProject1.copy(UUID.randomUUID(),
+                                   RawlsBillingProjectName("bp1"),
+                                   servicePerimeter = servicePerimeterName.some
+        )
       val billingProject2 =
-        testData.testProject1.copy(RawlsBillingProjectName("bp2"), servicePerimeter = servicePerimeterName.some)
+        testData.testProject1.copy(UUID.randomUUID(),
+                                   RawlsBillingProjectName("bp2"),
+                                   servicePerimeter = servicePerimeterName.some
+        )
 
       runAndWait {
         for {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -58,7 +58,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   val billingAccountName: RawlsBillingAccountName = RawlsBillingAccountName("fakeBillingAcct")
 
-  val billingProject: RawlsBillingProject = RawlsBillingProject(RawlsBillingProjectName(wsName.namespace),
+  val billingProject: RawlsBillingProject = RawlsBillingProject(UUID.randomUUID(),
+                                                                RawlsBillingProjectName(wsName.namespace),
                                                                 CreationStatuses.Ready,
                                                                 Option(billingAccountName),
                                                                 None
@@ -857,6 +858,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProfileId = UUID.randomUUID()
     val projectName = RawlsBillingProjectName(wsName.namespace)
     val azureBillingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       Option(billingAccountName),
@@ -1036,6 +1038,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProfileId = UUID.randomUUID()
     val projectName = RawlsBillingProjectName(wsName.namespace)
     val azureBillingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       Option(billingAccountName),
@@ -1436,6 +1439,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val projectName1 = RawlsBillingProjectName("billingProject1")
     val billingAccount1 = RawlsBillingAccountName("billingAcct1")
     val billingProject1 = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName1,
       CreationStatuses.Ready,
       Option(billingAccount1),
@@ -1446,6 +1450,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val projectName2 = RawlsBillingProjectName("billingProject2")
     val billingAccount2 = RawlsBillingAccountName("billingAcct2")
     val billingProject2 = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName2,
       CreationStatuses.Ready,
       Option(billingAccount2),
@@ -1603,6 +1608,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val projectName1 = RawlsBillingProjectName("billingProject1")
     val billingAccount1 = RawlsBillingAccountName("billingAcct1")
     val billingProject1 = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName1,
       CreationStatuses.Ready,
       Option(billingAccount1),
@@ -1613,6 +1619,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val projectName2 = RawlsBillingProjectName("billingProject2")
     val billingAccount2 = RawlsBillingAccountName("billingAcct2")
     val billingProject2 = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName2,
       CreationStatuses.Ready,
       Option(billingAccount2),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/submissions/SubmissionsServiceSpec.scala
@@ -499,6 +499,7 @@ class SubmissionsServiceSpec
     services =>
       val billingProjectName = RawlsBillingProjectName("test-project")
       val billingProject = RawlsBillingProject(
+        UUID.randomUUID(),
         billingProjectName,
         CreationStatuses.Ready,
         None,
@@ -520,7 +521,8 @@ class SubmissionsServiceSpec
 
   it should "return None if the spend report config is not set" in withTestDataServices { services =>
     val billingProjectName = RawlsBillingProjectName("test-project")
-    val billingProject = RawlsBillingProject(billingProjectName,
+    val billingProject = RawlsBillingProject(UUID.randomUUID(),
+                                             billingProjectName,
                                              CreationStatuses.Ready,
                                              None,
                                              None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1224,6 +1224,38 @@ class UserServiceSpec
 
   behavior of "getBillingProject"
 
+  it should "return the project when it exists" in {
+    val projectId = UUID.randomUUID()
+    val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
+    val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
+    val repository = mock[BillingRepository]
+    when(repository.getBillingProjectById(ArgumentMatchers.eq(projectId))).thenReturn(Future.successful(Some(project)))
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
+      .thenReturn(Future.successful(Set(SamResourceRole(SamBillingProjectRoles.owner.value))))
+
+    val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
+
+    Await.result(userService.getBillingProjectById(projectId), Duration.Inf) shouldEqual Some(project)
+  }
+
+  it should "return None when project does not exist" in {
+    val projectId = UUID.randomUUID()
+    val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
+    val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
+    val repository = mock[BillingRepository]
+    when(repository.getBillingProjectById(ArgumentMatchers.eq(projectId))).thenReturn(Future.successful(Some(project)))
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
+      .thenReturn(Future.successful(Set.empty))
+
+    val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
+
+    Await.result(userService.getBillingProjectById(projectId), Duration.Inf) shouldEqual None
+  }
+
   it should "return None if the user doesn't have any roles on a billing project" in {
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val project = RawlsBillingProject(UUID.randomUUID(), projectName, CreationStatuses.Ready, None, None)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1230,6 +1230,7 @@ class UserServiceSpec
     val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
     when(repository.getBillingProjectById(projectId)).thenReturn(Future.successful(Some(project)))
+    when(repository.getBillingProject(projectName)).thenReturn(Future.successful(Some(project)))
 
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
@@ -1237,20 +1238,22 @@ class UserServiceSpec
 
     val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
 
-    Await.result(userService.getBillingProjectById(projectId), Duration.Inf) shouldEqual Some(project)
+    Await.result(userService.getBillingProjectById(projectId), Duration.Inf) shouldEqual Some(
+      RawlsBillingProjectResponse(
+        Set(ProjectRoles.Owner),
+        project,
+        CloudPlatform.GCP,
+        protectedData = None
+      )
+    )
   }
 
   it should "return None when project does not exist" in {
     val projectId = UUID.randomUUID()
-    val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
-    val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
-    when(repository.getBillingProjectById(projectId)).thenReturn(Future.successful(Some(project)))
+    when(repository.getBillingProjectById(projectId)).thenReturn(Future.successful(None))
 
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
-    when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
-      .thenReturn(Future.successful(Set.empty))
-
     val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
 
     Await.result(userService.getBillingProjectById(projectId), Duration.Inf) shouldEqual None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1229,7 +1229,7 @@ class UserServiceSpec
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
-    when(repository.getBillingProjectById(ArgumentMatchers.eq(projectId))).thenReturn(Future.successful(Some(project)))
+    when(repository.getBillingProjectById(projectId)).thenReturn(Future.successful(Some(project)))
 
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
@@ -1245,7 +1245,7 @@ class UserServiceSpec
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
-    when(repository.getBillingProjectById(ArgumentMatchers.eq(projectId))).thenReturn(Future.successful(Some(project)))
+    when(repository.getBillingProjectById(projectId)).thenReturn(Future.successful(Some(project)))
 
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1222,7 +1222,7 @@ class UserServiceSpec
       actual.errorReport.statusCode.get shouldEqual StatusCodes.NotFound
     }
 
-  behavior of "getBillingProject"
+  behavior of "getBillingProjectById"
 
   it should "return the project when it exists" in {
     val projectId = UUID.randomUUID()
@@ -1230,7 +1230,6 @@ class UserServiceSpec
     val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
     when(repository.getBillingProjectById(projectId)).thenReturn(Future.successful(Some(project)))
-    when(repository.getBillingProject(projectName)).thenReturn(Future.successful(Some(project)))
 
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
@@ -1257,6 +1256,42 @@ class UserServiceSpec
     val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
 
     Await.result(userService.getBillingProjectById(projectId), Duration.Inf) shouldEqual None
+  }
+
+  behavior of "getBillingProject"
+
+  it should "return the project when it exists" in {
+    val projectId = UUID.randomUUID()
+    val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
+    val project = RawlsBillingProject(projectId, projectName, CreationStatuses.Ready, None, None)
+    val repository = mock[BillingRepository]
+    when(repository.getBillingProject(projectName)).thenReturn(Future.successful(Some(project)))
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(samDAO.listUserRolesForResource(SamResourceTypeNames.billingProject, projectName.value, testContext))
+      .thenReturn(Future.successful(Set(SamResourceRole(SamBillingProjectRoles.owner.value))))
+
+    val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
+
+    Await.result(userService.getBillingProject(projectName), Duration.Inf) shouldEqual Some(
+      RawlsBillingProjectResponse(
+        Set(ProjectRoles.Owner),
+        project,
+        CloudPlatform.GCP,
+        protectedData = None
+      )
+    )
+  }
+
+  it should "return None when project does not exist" in {
+    val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
+    val repository = mock[BillingRepository]
+    when(repository.getBillingProject(projectName)).thenReturn(Future.successful(None))
+
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    val userService = getUserService(samDAO = samDAO, billingRepository = Some(repository))
+
+    Await.result(userService.getBillingProject(projectName), Duration.Inf) shouldEqual None
   }
 
   it should "return None if the user doesn't have any roles on a billing project" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -54,7 +54,8 @@ class UserServiceSpec
   val urlEncodedDefaultServicePerimeterName: String = URLEncoder.encode(defaultServicePerimeterName.value, UTF_8.name)
   val defaultGoogleProjectNumber: GoogleProjectNumber = GoogleProjectNumber("42")
   val defaultBillingProjectName: RawlsBillingProjectName = RawlsBillingProjectName("test-bp")
-  val defaultBillingProject: RawlsBillingProject = RawlsBillingProject(defaultBillingProjectName,
+  val defaultBillingProject: RawlsBillingProject = RawlsBillingProject(UUID.randomUUID(),
+                                                                       defaultBillingProjectName,
                                                                        CreationStatuses.Ready,
                                                                        None,
                                                                        None,
@@ -632,7 +633,12 @@ class UserServiceSpec
   it should "throw a RawlsExceptionWithErrorReport when setting the spend configuration if the table does not exist or can't be accessed" in
     withMinimalTestDatabase { dataSource: SlickDataSource =>
       val billingProject =
-        RawlsBillingProject(RawlsBillingProjectName("project_without_table"), CreationStatuses.Ready, None, None)
+        RawlsBillingProject(UUID.randomUUID(),
+                            RawlsBillingProjectName("project_without_table"),
+                            CreationStatuses.Ready,
+                            None,
+                            None
+        )
       runAndWait(dataSource.dataAccess.rawlsBillingProjectQuery.create(billingProject))
 
       val spendReportDatasetName = BigQueryDatasetName("some_dataset")
@@ -662,7 +668,8 @@ class UserServiceSpec
 
   it should "throw a RawlsExceptionWithErrorReport when setting the spend configuration if the billing project does not have a billing account associated with it" in
     withMinimalTestDatabase { dataSource: SlickDataSource =>
-      val billingProject = RawlsBillingProject(RawlsBillingProjectName("project_without_billing_account"),
+      val billingProject = RawlsBillingProject(UUID.randomUUID(),
+                                               RawlsBillingProjectName("project_without_billing_account"),
                                                CreationStatuses.Ready,
                                                None,
                                                None
@@ -1219,7 +1226,7 @@ class UserServiceSpec
 
   it should "return None if the user doesn't have any roles on a billing project" in {
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
-    val project = RawlsBillingProject(projectName, CreationStatuses.Ready, None, None)
+    val project = RawlsBillingProject(UUID.randomUUID(), projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
     when(repository.getBillingProject(ArgumentMatchers.eq(projectName))).thenReturn(Future.successful(Some(project)))
 
@@ -1234,7 +1241,7 @@ class UserServiceSpec
 
   it should "set the project as GCP if there is no billing profile set" in {
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
-    val project = RawlsBillingProject(projectName, CreationStatuses.Ready, None, None)
+    val project = RawlsBillingProject(UUID.randomUUID(), projectName, CreationStatuses.Ready, None, None)
     val repository = mock[BillingRepository]
     when(repository.getBillingProject(ArgumentMatchers.eq(projectName))).thenReturn(Future.successful(Some(project)))
 
@@ -1258,6 +1265,7 @@ class UserServiceSpec
     val landingZoneId = UUID.randomUUID()
     val lzRegion = "dummy-region"
     val project = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       None,
@@ -1301,6 +1309,7 @@ class UserServiceSpec
     val billingProfileId = UUID.randomUUID()
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val project = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       None,
@@ -1336,6 +1345,7 @@ class UserServiceSpec
     val landingZoneId = UUID.randomUUID()
     val lzRegion = "dummy-region"
     val project = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       None,
@@ -1384,6 +1394,7 @@ class UserServiceSpec
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val landingZoneId = UUID.randomUUID()
     val project = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       None,
@@ -1431,6 +1442,7 @@ class UserServiceSpec
     val billingProfileId = UUID.randomUUID()
     val projectName = RawlsBillingProjectName(UUID.randomUUID().toString)
     val project = RawlsBillingProject(
+      UUID.randomUUID(),
       projectName,
       CreationStatuses.Ready,
       None,
@@ -1458,11 +1470,17 @@ class UserServiceSpec
   it should "return the list of billing projects including azure data when enabled" in {
     // GCP, Rawls-only project
     val ownerProject =
-      RawlsBillingProject(RawlsBillingProjectName(UUID.randomUUID().toString), CreationStatuses.Ready, None, None)
+      RawlsBillingProject(UUID.randomUUID(),
+                          RawlsBillingProjectName(UUID.randomUUID().toString),
+                          CreationStatuses.Ready,
+                          None,
+                          None
+      )
 
     // Azure, BPM-backed project
     val bpmBillingProfile = new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BPMCloudPlatform.AZURE)
     val billingProfileBackedProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(UUID.randomUUID().toString),
       CreationStatuses.Ready,
       None,
@@ -1478,6 +1496,7 @@ class UserServiceSpec
     val bpmProtectedDataBillingProfile =
       new ProfileModel().id(UUID.randomUUID()).cloudPlatform(BPMCloudPlatform.AZURE).policies(policies)
     val protectedDataBillingProfileBackedProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(UUID.randomUUID().toString),
       CreationStatuses.Ready,
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/AdminApiServiceSpec.scala
@@ -349,7 +349,8 @@ class AdminApiServiceSpec extends ApiServiceSpec {
     when(billingAdminService.getBillingProjectSupportSummary(billingProjectName)).thenReturn(
       Future.successful(
         BillingProjectAdminResponse(
-          RawlsBillingProject(billingProjectName,
+          RawlsBillingProject(UUID.randomUUID(),
+                              billingProjectName,
                               CreationStatuses.Ready,
                               Option(RawlsBillingAccountName("account")),
                               None

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -41,7 +41,9 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     when(workspaceManagerResourceMonitorRecordDao.create(ArgumentMatchers.any())).thenReturn(Future.successful())
 
     override val googleBillingProjectLifecycle: GoogleBillingProjectLifecycle = spy(
-      new GoogleBillingProjectLifecycle(billingRepository, mock[BillingProfileManagerDAO], samDAO, gcsDAO)
+      new GoogleBillingProjectLifecycle(billingRepository, mock[BillingProfileManagerDAO], samDAO, gcsDAO)(
+        executionContext
+      )
     )
     when(
       samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
@@ -855,6 +857,108 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     ).thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
     Get(s"/billing/v2/${project.projectName.value}") ~>
+      sealRoute(services.billingRoutesV2()) ~>
+      check {
+        assertResult(StatusCodes.NotFound, responseAs[String]) {
+          status
+        }
+      }
+  }
+
+  "GET /billing/v2/{projectId}" should "return 200 with owner role" in withEmptyDatabaseAndApiServices { services =>
+    val project = createProject("project")
+    when(
+      services.samDAO.listUserRolesForResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(project.projectName.value),
+        ArgumentMatchers.argThat(userInfoEq(testContext))
+      )
+    ).thenReturn(
+      Future.successful(
+        Set(
+          SamBillingProjectRoles.workspaceCreator,
+          SamBillingProjectRoles.owner
+        )
+      )
+    )
+
+    Get(s"/billing/v2/${project.id}") ~>
+      sealRoute(services.billingRoutesV2()) ~>
+      check {
+        assertResult(StatusCodes.OK, responseAs[String]) {
+          status
+        }
+        responseAs[RawlsBillingProjectResponse] shouldEqual RawlsBillingProjectResponse(
+          Set(ProjectRoles.Owner, ProjectRoles.User),
+          project,
+          CloudPlatform.GCP
+        )
+
+      }
+  }
+
+  it should "return 200 with user role" in withEmptyDatabaseAndApiServices { services =>
+    val project = createProject("project")
+    when(
+      services.samDAO.listUserRolesForResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(project.projectName.value),
+        ArgumentMatchers.argThat(userInfoEq(testContext))
+      )
+    ).thenReturn(
+      Future.successful(
+        Set(
+          SamBillingProjectRoles.workspaceCreator
+        )
+      )
+    )
+
+    Get(s"/billing/v2/${project.id}") ~>
+      sealRoute(services.billingRoutesV2()) ~>
+      check {
+        assertResult(StatusCodes.OK, responseAs[String]) {
+          status
+        }
+        responseAs[RawlsBillingProjectResponse] shouldEqual RawlsBillingProjectResponse(
+          Set(ProjectRoles.User),
+          project,
+          CloudPlatform.GCP
+        )
+
+      }
+  }
+
+  it should "return 404 if project does not exist" in withEmptyDatabaseAndApiServices { services =>
+    val projectId = UUID.randomUUID()
+    val projectName = "does_not_exist"
+    when(
+      services.samDAO.listUserRolesForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                               ArgumentMatchers.eq(projectName),
+                                               ArgumentMatchers.argThat(userInfoEq(testContext))
+      )
+    )
+      .thenReturn(Future.successful(Set.empty[SamResourceRole]))
+
+    Get(s"/billing/v2/$projectId") ~>
+      sealRoute(services.billingRoutesV2()) ~>
+      check {
+        assertResult(StatusCodes.NotFound, responseAs[String]) {
+          status
+        }
+      }
+  }
+
+  it should "return 404 if user has no access" in withEmptyDatabaseAndApiServices { services =>
+    val project = createProject("project")
+    when(
+      services.samDAO.listUserRolesForResource(
+        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+        ArgumentMatchers.eq(project.projectName.value),
+        ArgumentMatchers.argThat(userInfoEq(testContext))
+      )
+    ).thenReturn(Future.successful(Set.empty[SamResourceRole]))
+
+    Get(s"/billing/v2/${project.id}") ~>
       sealRoute(services.billingRoutesV2()) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -307,7 +307,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       mockPositiveBillingProjectCreation(services, projectName)
 
       Post("/billing/v2",
-           CreateRawlsV2BillingProjectFullRequest(projectName,
+           CreateRawlsV2BillingProjectFullRequest(None,
+                                                  projectName,
                                                   Some(services.gcsDAO.accessibleBillingAccountName),
                                                   None,
                                                   None,
@@ -346,6 +347,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       Post(
         "/billing/v2",
         CreateRawlsV2BillingProjectFullRequest(
+          None,
           projectName,
           Some(services.gcsDAO.accessibleBillingAccountName),
           None,
@@ -376,6 +378,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       Post(
         "/billing/v2",
         CreateRawlsV2BillingProjectFullRequest(
+          None,
           projectName,
           Some(services.gcsDAO.accessibleBillingAccountName),
           None,
@@ -394,7 +397,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 400 when creating a project with inaccessible to firecloud billing account" in withEmptyDatabaseAndApiServices {
     services =>
-      val request = CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("test_bad1"),
+      val request = CreateRawlsV2BillingProjectFullRequest(None,
+                                                           RawlsBillingProjectName("test_bad1"),
                                                            Some(services.gcsDAO.inaccessibleBillingAccountName),
                                                            None,
                                                            None,
@@ -424,7 +428,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("short"),
+        CreateRawlsV2BillingProjectFullRequest(None,
+                                               RawlsBillingProjectName("short"),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,
@@ -444,7 +449,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"),
+        CreateRawlsV2BillingProjectFullRequest(None,
+                                               RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,
@@ -464,7 +470,8 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("!@#$%^&*()=+,. "),
+        CreateRawlsV2BillingProjectFullRequest(None,
+                                               RawlsBillingProjectName("!@#$%^&*()=+,. "),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -865,36 +865,37 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       }
   }
 
-  "GET /billing/v2/{projectId}" should "return 200 with owner role" in withEmptyDatabaseAndApiServices { services =>
-    val project = createProject("project")
-    when(
-      services.samDAO.listUserRolesForResource(
-        ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-        ArgumentMatchers.eq(project.projectName.value),
-        ArgumentMatchers.argThat(userInfoEq(testContext))
-      )
-    ).thenReturn(
-      Future.successful(
-        Set(
-          SamBillingProjectRoles.workspaceCreator,
-          SamBillingProjectRoles.owner
+  "GET /billing/v2/id/{projectUuid}" should "return 200 with owner role" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("project")
+      when(
+        services.samDAO.listUserRolesForResource(
+          ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+          ArgumentMatchers.eq(project.projectName.value),
+          ArgumentMatchers.argThat(userInfoEq(testContext))
+        )
+      ).thenReturn(
+        Future.successful(
+          Set(
+            SamBillingProjectRoles.workspaceCreator,
+            SamBillingProjectRoles.owner
+          )
         )
       )
-    )
 
-    Get(s"/billing/v2/${project.id}") ~>
-      sealRoute(services.billingRoutesV2()) ~>
-      check {
-        assertResult(StatusCodes.OK, responseAs[String]) {
-          status
+      Get(s"/billing/v2/id/${project.id}") ~>
+        sealRoute(services.billingRoutesV2()) ~>
+        check {
+          assertResult(StatusCodes.OK, responseAs[String]) {
+            status
+          }
+          responseAs[RawlsBillingProjectResponse] shouldEqual RawlsBillingProjectResponse(
+            Set(ProjectRoles.Owner, ProjectRoles.User),
+            project,
+            CloudPlatform.GCP
+          )
+
         }
-        responseAs[RawlsBillingProjectResponse] shouldEqual RawlsBillingProjectResponse(
-          Set(ProjectRoles.Owner, ProjectRoles.User),
-          project,
-          CloudPlatform.GCP
-        )
-
-      }
   }
 
   it should "return 200 with user role" in withEmptyDatabaseAndApiServices { services =>
@@ -913,7 +914,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       )
     )
 
-    Get(s"/billing/v2/${project.id}") ~>
+    Get(s"/billing/v2/id/${project.id}") ~>
       sealRoute(services.billingRoutesV2()) ~>
       check {
         assertResult(StatusCodes.OK, responseAs[String]) {
@@ -939,7 +940,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     )
       .thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
-    Get(s"/billing/v2/$projectId") ~>
+    Get(s"/billing/v2/id/$projectId") ~>
       sealRoute(services.billingRoutesV2()) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
@@ -958,7 +959,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       )
     ).thenReturn(Future.successful(Set.empty[SamResourceRole]))
 
-    Get(s"/billing/v2/${project.id}") ~>
+    Get(s"/billing/v2/id/${project.id}") ~>
       sealRoute(services.billingRoutesV2()) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -307,8 +307,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       mockPositiveBillingProjectCreation(services, projectName)
 
       Post("/billing/v2",
-           CreateRawlsV2BillingProjectFullRequest(None,
-                                                  projectName,
+           CreateRawlsV2BillingProjectFullRequest(projectName,
                                                   Some(services.gcsDAO.accessibleBillingAccountName),
                                                   None,
                                                   None,
@@ -347,7 +346,6 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       Post(
         "/billing/v2",
         CreateRawlsV2BillingProjectFullRequest(
-          None,
           projectName,
           Some(services.gcsDAO.accessibleBillingAccountName),
           None,
@@ -378,7 +376,6 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       Post(
         "/billing/v2",
         CreateRawlsV2BillingProjectFullRequest(
-          None,
           projectName,
           Some(services.gcsDAO.accessibleBillingAccountName),
           None,
@@ -397,8 +394,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
 
   it should "return 400 when creating a project with inaccessible to firecloud billing account" in withEmptyDatabaseAndApiServices {
     services =>
-      val request = CreateRawlsV2BillingProjectFullRequest(None,
-                                                           RawlsBillingProjectName("test_bad1"),
+      val request = CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("test_bad1"),
                                                            Some(services.gcsDAO.inaccessibleBillingAccountName),
                                                            None,
                                                            None,
@@ -428,8 +424,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(None,
-                                               RawlsBillingProjectName("short"),
+        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("short"),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,
@@ -449,8 +444,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(None,
-                                               RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"),
+        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,
@@ -470,8 +464,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(None,
-                                               RawlsBillingProjectName("!@#$%^&*()=+,. "),
+        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("!@#$%^&*()=+,. "),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/PetSASpec.scala
@@ -218,7 +218,8 @@ class PetSASpec extends ApiServiceSpec {
     )
     val userSAProjectOwner = RawlsUser(userSAProjectOwnerUserInfo)
 
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
+    val billingProject =
+      RawlsBillingProject(UUID.randomUUID(), RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
 
     val workspaceName = WorkspaceName(billingProject.projectName.value, "testworkspace")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/SubmissionApiServiceSpec.scala
@@ -972,7 +972,12 @@ class SubmissionApiServiceSpec extends ApiServiceSpec with TableDrivenPropertyCh
     val writerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-WRITER", Set())
     val readerGroup = makeRawlsGroup(s"${wsName.namespace}-${wsName.name}-READER", Set())
     val billingProject =
-      RawlsBillingProject(RawlsBillingProjectName(wsName.namespace), CreationStatuses.Ready, None, None)
+      RawlsBillingProject(UUID.randomUUID(),
+                          RawlsBillingProjectName(wsName.namespace),
+                          CreationStatuses.Ready,
+                          None,
+                          None
+      )
 
     val workspace = Workspace(wsName.namespace,
                               wsName.name,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiGetOptionsSpec.scala
@@ -104,7 +104,8 @@ class WorkspaceApiGetOptionsSpec extends ApiServiceSpec {
       )
     )
 
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
+    val billingProject =
+      RawlsBillingProject(UUID.randomUUID(), RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
 
     val workspaceName = WorkspaceName(billingProject.projectName.value, "testworkspace")
     val workspace2Name = WorkspaceName(billingProject.projectName.value, "emptyattrs")

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/WorkspaceApiListOptionsSpec.scala
@@ -75,7 +75,8 @@ class WorkspaceApiListOptionsSpec extends ApiServiceSpec {
       )
     )
 
-    val billingProject = RawlsBillingProject(RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
+    val billingProject =
+      RawlsBillingProject(UUID.randomUUID(), RawlsBillingProjectName("ns"), CreationStatuses.Ready, None, None)
 
     val workspaceName = WorkspaceName(billingProject.projectName.value, "testworkspace")
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceAclManagerUnitTests.scala
@@ -63,6 +63,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
       Future.successful(
         Option(
           RawlsBillingProject(
+            UUID.randomUUID(),
             RawlsBillingProjectName(defaultWorkspaceName.namespace),
             CreationStatuses.Ready,
             None,
@@ -124,6 +125,7 @@ class MultiCloudWorkspaceAclManagerUnitTests extends AnyFlatSpec with MockitoTes
       Future.successful(
         Option(
           RawlsBillingProject(
+            UUID.randomUUID(),
             RawlsBillingProjectName(defaultWorkspaceName.namespace),
             CreationStatuses.Ready,
             None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceCloneSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceCloneSpec.scala
@@ -146,6 +146,7 @@ class MultiCloudWorkspaceServiceCloneSpec
     when(workspaceRepository.getWorkspace(sourceWorkspace.toWorkspaceName, None))
       .thenReturn(Future(Some(sourceWorkspace)))
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceName.namespace),
       CreationStatuses.Ready,
       None,
@@ -209,6 +210,7 @@ class MultiCloudWorkspaceServiceCloneSpec
       .thenReturn(Future(Some(sourceWorkspace)))
 
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceName.namespace),
       CreationStatuses.Ready,
       None,
@@ -273,6 +275,7 @@ class MultiCloudWorkspaceServiceCloneSpec
     when(workspaceRepository.getWorkspace(sourceWorkspace.toWorkspaceName, None))
       .thenReturn(Future(Some(sourceWorkspace)))
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceName.namespace),
       CreationStatuses.Ready,
       None,
@@ -343,6 +346,7 @@ class MultiCloudWorkspaceServiceCloneSpec
       .thenReturn(Future(Some(sourceWorkspace)))
     val billingProfile = new ProfileModel().id(UUID.randomUUID()).cloudPlatform(CloudPlatform.GCP)
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceName.namespace),
       CreationStatuses.Ready,
       None,
@@ -416,6 +420,7 @@ class MultiCloudWorkspaceServiceCloneSpec
       .thenReturn(Future(Some(sourceWorkspace)))
     val billingProfile = new ProfileModel().id(UUID.randomUUID()).cloudPlatform(CloudPlatform.AZURE)
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceName.namespace),
       CreationStatuses.Ready,
       None,
@@ -485,6 +490,7 @@ class MultiCloudWorkspaceServiceCloneSpec
     when(workspaceRepository.getWorkspace(sourceWorkspace.toWorkspaceName, None))
       .thenReturn(Future(Some(sourceWorkspace)))
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceName.namespace),
       CreationStatuses.Ready,
       None,
@@ -1051,6 +1057,7 @@ class MultiCloudWorkspaceServiceCloneSpec
     val destWorkspaceRequest = WorkspaceRequest("dest-namespace", "dest-name", Map())
     val billingProfileId = UUID.randomUUID()
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceRequest.namespace),
       CreationStatuses.Ready,
       None,
@@ -1127,6 +1134,7 @@ class MultiCloudWorkspaceServiceCloneSpec
     val destWorkspaceRequest = WorkspaceRequest("dest-namespace", "dest-name", Map(), authorizationDomain = authDomain)
     val billingProfileId = UUID.randomUUID()
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName(destWorkspaceRequest.namespace),
       CreationStatuses.Ready,
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceCreateSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/MultiCloudWorkspaceServiceCreateSpec.scala
@@ -94,6 +94,7 @@ class MultiCloudWorkspaceServiceCreateSpec
 
   it should "return forbidden if the user does not have the createWorkspace action for the billing project" in {
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName("azure-billing-project"),
       CreationStatuses.Ready,
       None,
@@ -143,6 +144,7 @@ class MultiCloudWorkspaceServiceCreateSpec
 
   it should "throw an exception if the billing profile is not found in BPM" in {
     val billingProject = RawlsBillingProject(
+      UUID.randomUUID(),
       RawlsBillingProjectName("azure-billing-project"),
       CreationStatuses.Ready,
       None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1682,7 +1682,8 @@ class WorkspaceServiceSpec
       val newWorkspaceNamespace = "short_-NS1"
       val newWorkspaceName =
         "plus Long_ name to get past 30 chars since the google-project name is truncated at 30 chars and formatted as namespace--name"
-      val billingProject = RawlsBillingProject(RawlsBillingProjectName(newWorkspaceNamespace),
+      val billingProject = RawlsBillingProject(UUID.randomUUID(),
+                                               RawlsBillingProjectName(newWorkspaceNamespace),
                                                CreationStatuses.Ready,
                                                Option(RawlsBillingAccountName("fakeBillingAcct")),
                                                None
@@ -1709,7 +1710,8 @@ class WorkspaceServiceSpec
     services =>
       val newWorkspaceNamespace = "Long_Namespace---30-char-limit"
       val newWorkspaceName = "Plus Long_ name to get past 63 chars since the labels are truncated at 63 chars"
-      val billingProject = RawlsBillingProject(RawlsBillingProjectName(newWorkspaceNamespace),
+      val billingProject = RawlsBillingProject(UUID.randomUUID(),
+                                               RawlsBillingProjectName(newWorkspaceNamespace),
                                                CreationStatuses.Ready,
                                                Option(RawlsBillingAccountName("fakeBillingAcct")),
                                                None


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-340

This PR has the following changes:

- Adds a new non-nullable `ID` column (UUID) to the `BILLING_PROJECT` table in Rawls. While the `NAME` column remains the primary identifier, this UUID will support TDR’s transition to using UUID-based references.
- Adds a new API `/api/billing/v2/id/{projectUuid}` to fetch a billing project by id, mirroring the existing getBillingProject API.

Updated 
---

**PR checklist**

- [X] Include the JIRA issue number in the PR description and title
- [x] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [X] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [x] Get two thumbsworth of PR review
- [X] Verify all tests go green, including CI tests
- [x] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
