### PR TITLE
[CORE-368] Validate entitytype rename

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/slick/EntityComponent.scala
@@ -1404,17 +1404,8 @@ trait EntityComponent {
     }
 
     // Utility methods
-
     private def validateEntity(entity: Entity): Unit = {
-      if (entity.entityType.equalsIgnoreCase(Attributable.workspaceEntityType)) {
-        throw new RawlsFatalExceptionWithErrorReport(
-          errorReport = ErrorReport(
-            message = s"Entity type ${Attributable.workspaceEntityType} is reserved and cannot be overwritten",
-            statusCode = StatusCodes.BadRequest
-          )
-        )
-      }
-      validateUserDefinedString(entity.entityType)
+      validateEntityType(entity.entityType)
       validateEntityName(entity.name)
       entity.attributes.keys.foreach { attrName =>
         validateUserDefinedString(attrName.name)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -245,7 +245,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
     import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 
-    validateEntityName(renameInfo.newName)
+    validateEntityType(renameInfo.newName)
     def validateExistingType(dataAccess: DataAccess,
                              workspaceContext: Workspace,
                              oldName: String

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -8,25 +8,14 @@ import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityAndAttributesResult, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{
-  DataEntityException,
-  DeleteEntitiesConflictException,
-  DeleteEntitiesOfTypeConflictException,
-  EntityNotFoundException
-}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.{
-  AttributeSupport,
-  AttributeUpdateOperationException,
-  EntitySupport,
-  JsonFilterUtils,
-  WorkspaceSupport
-}
+import org.broadinstitute.dsde.rawls.util.{AttributeSupport, AttributeUpdateOperationException, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, StringValidationUtils}
 import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
 
 import java.sql.SQLException
@@ -55,9 +44,12 @@ class EntityService(protected val ctx: RawlsRequestContext,
     with AttributeSupport
     with LazyLogging
     with RawlsInstrumented
-    with JsonFilterUtils {
+    with JsonFilterUtils
+    with StringValidationUtils {
 
   import dataSource.dataAccess.driver.api._
+  implicit override val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
+
 
   // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
   val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
@@ -243,6 +235,8 @@ class EntityService(protected val ctx: RawlsRequestContext,
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
     import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 
+
+    validateEntityName(renameInfo.newName)
     def validateExistingType(dataAccess: DataAccess,
                              workspaceContext: Workspace,
                              oldName: String

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -8,12 +8,23 @@ import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityAndAttributesResult, ReadAction}
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
-import org.broadinstitute.dsde.rawls.entities.exceptions.{DataEntityException, DeleteEntitiesConflictException, DeleteEntitiesOfTypeConflictException, EntityNotFoundException}
+import org.broadinstitute.dsde.rawls.entities.exceptions.{
+  DataEntityException,
+  DeleteEntitiesConflictException,
+  DeleteEntitiesOfTypeConflictException,
+  EntityNotFoundException
+}
 import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.{AttributeSupport, AttributeUpdateOperationException, EntitySupport, JsonFilterUtils, WorkspaceSupport}
+import org.broadinstitute.dsde.rawls.util.{
+  AttributeSupport,
+  AttributeUpdateOperationException,
+  EntitySupport,
+  JsonFilterUtils,
+  WorkspaceSupport
+}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, StringValidationUtils}
 import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
@@ -49,7 +60,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
   import dataSource.dataAccess.driver.api._
   implicit override val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
-
 
   // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
   val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
@@ -234,7 +244,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
 
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
     import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
-
 
     validateEntityName(renameInfo.newName)
     def validateExistingType(dataAccess: DataAccess,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -347,13 +347,13 @@ class EntityServiceSpec
     val waitDuration = Duration(10, SECONDS)
     val ex = intercept[RawlsExceptionWithErrorReport] {
       Await.result(services.entityService.renameEntityType(testData.wsName,
-        testData.pair1.entityType,
-        EntityTypeRename("invalid/table/name")
-      ),
-        waitDuration
+                                                           testData.pair1.entityType,
+                                                           EntityTypeRename("invalid/table/name")
+                   ),
+                   waitDuration
       )
     }
-    ex.errorReport.message should include ("Invalid entity name")
+    ex.errorReport.message should include("Invalid entity name")
   }
 
   it should "rename an entity type as long as the selected name is not in use" in withTestDataServices { services =>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -343,6 +343,19 @@ class EntityServiceSpec
     ex.errorReport.message shouldBe "Pair already exists as an entity type"
   }
 
+  it should "fail to rename an entity type to a name with invalid characters" in withTestDataServices { services =>
+    val waitDuration = Duration(10, SECONDS)
+    val ex = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(services.entityService.renameEntityType(testData.wsName,
+        testData.pair1.entityType,
+        EntityTypeRename("invalid/table/name")
+      ),
+        waitDuration
+      )
+    }
+    ex.errorReport.message should include ("Invalid entity name")
+  }
+
   it should "rename an entity type as long as the selected name is not in use" in withTestDataServices { services =>
     val waitDuration = Duration(10, SECONDS)
     assertResult(2) {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/EntityServiceSpec.scala
@@ -353,7 +353,7 @@ class EntityServiceSpec
                    waitDuration
       )
     }
-    ex.errorReport.message should include("Invalid entity name")
+    ex.errorReport.message should include("Invalid input")
   }
 
   it should "rename an entity type as long as the selected name is not in use" in withTestDataServices { services =>

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/StringValidationUtils.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/StringValidationUtils.scala
@@ -24,6 +24,18 @@ trait StringValidationUtils {
       )
     }
 
+  def validateEntityType(entityType: String): Unit = {
+    if (entityType.equalsIgnoreCase(Attributable.workspaceEntityType)) {
+      throw new RawlsFatalExceptionWithErrorReport(
+        errorReport = ErrorReport(
+          message = s"Entity type ${Attributable.workspaceEntityType} is reserved and cannot be overwritten",
+          statusCode = StatusCodes.BadRequest
+        )
+      )
+    }
+    validateUserDefinedString(entityType)
+  }
+
   private lazy val entityNameRegex = "[A-z0-9\\._-]+".r
   def validateEntityName(s: String): Unit =
     if (!entityNameRegex.pattern.matcher(s).matches) {


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-368
<Put notes here to help reviewer understand this PR>
Adds in name validation when renaming an entity.  https://github.com/DataBiosphere/terra-ui/pull/5272 also does this from the front end.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
