### PR TITLE
CORE-81: strip info from error messages before responding

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/util/HttpClientUtils.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/util/HttpClientUtils.scala
@@ -34,7 +34,7 @@ trait HttpClientUtils extends LazyLogging {
     executeRequest(http, httpRequest) recover { case t: Throwable =>
       throw new RawlsExceptionWithErrorReport(
         ErrorReport(StatusCodes.InternalServerError,
-                    s"HTTP call failed: ${httpRequest.uri}. Response: ${t.getMessage}",
+                    s"HTTP call failed: ${filterPrivate(httpRequest.uri)}. Response: ${t.getMessage}",
                     t
         )
       )
@@ -44,15 +44,15 @@ trait HttpClientUtils extends LazyLogging {
       } else {
         Unmarshal(response.entity).to[String] map { entityAsString =>
           logger.debug(
-            s"HTTP error status ${response.status} calling URI ${httpRequest.uri}. Response: $entityAsString"
+            s"HTTP error status ${response.status} calling URI ${filterPrivate(httpRequest.uri)}. Response: $entityAsString"
           )
           val message =
             if (response.status == StatusCodes.Unauthorized)
               s"The service indicated that this call was unauthorized. " +
                 s"If you believe this is a mistake, please try your request again. " +
-                s"Error occurred calling uri ${httpRequest.uri}"
+                s"Error occurred calling uri ${filterPrivate(httpRequest.uri)}"
             else
-              s"HTTP error calling URI ${httpRequest.uri}. Response: ${entityAsString.take(1000)}"
+              s"HTTP error calling URI ${filterPrivate(httpRequest.uri)}. Response: ${entityAsString.take(1000)}"
           throw new RawlsExceptionWithErrorReport(ErrorReport(response.status, message))
         }
       }
@@ -64,7 +64,7 @@ trait HttpClientUtils extends LazyLogging {
     executeRequest(http, httpRequest) recover { case t: Throwable =>
       throw new RawlsExceptionWithErrorReport(
         ErrorReport(StatusCodes.InternalServerError,
-                    s"HTTP call failed: ${httpRequest.uri}. Response: ${t.getMessage}",
+                    s"HTTP call failed: ${filterPrivate(httpRequest.uri)}. Response: ${t.getMessage}",
                     t
         )
       )
@@ -80,16 +80,22 @@ trait HttpClientUtils extends LazyLogging {
       } else {
         Unmarshal(response.entity).to[String] map { entityAsString =>
           logger.debug(
-            s"HTTP error status ${response.status} calling URI ${httpRequest.uri}. Response: $entityAsString"
+            s"HTTP error status ${response.status} calling URI ${filterPrivate(httpRequest.uri)}. Response: $entityAsString"
           )
           throw new RawlsExceptionWithErrorReport(
-            ErrorReport(response.status,
-                        s"HTTP error calling URI ${httpRequest.uri}. Response: ${entityAsString.take(1000)}"
+            ErrorReport(
+              response.status,
+              s"HTTP error calling URI ${filterPrivate(httpRequest.uri)}. Response: ${entityAsString.take(1000)}"
             )
           )
         }
       }
     }
+
+  // don't display private Uris to end users
+  private def filterPrivate(uri: Uri): String =
+    if (uri.authority.toString().contains("-priv")) "" else uri.toString()
+
 }
 
 case class HttpClientUtilsStandard()(implicit val materializer: Materializer, val executionContext: ExecutionContext)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/RawlsApiService.scala
@@ -57,7 +57,7 @@ object RawlsApiService extends LazyLogging {
         complete(
           withErrorReport.errorReport.statusCode.getOrElse(
             StatusCodes.InternalServerError
-          ) -> withErrorReport.errorReport
+          ) -> withErrorReport.errorReport.copy(stackTrace = Seq())
         )
       case rollback: SQLTransactionRollbackException =>
         logger.error(
@@ -65,7 +65,7 @@ object RawlsApiService extends LazyLogging {
           rollback
         )
         Sentry.captureException(rollback)
-        complete(StatusCodes.InternalServerError -> ErrorReport(rollback))
+        complete(StatusCodes.InternalServerError -> ErrorReport(rollback).copy(stackTrace = Seq()))
       case sql: SQLException =>
         val sentryId = Sentry.captureException(sql)
         logger.error(
@@ -90,7 +90,7 @@ object RawlsApiService extends LazyLogging {
           logger.error(e.getMessage)
         }
         Sentry.captureException(e)
-        complete(StatusCodes.InternalServerError -> ErrorReport(e))
+        complete(StatusCodes.InternalServerError -> ErrorReport(e).copy(stackTrace = Seq()))
     }
   }
 


### PR DESCRIPTION
Ticket: CORE-81

Two changes in this PR to address info disclosure in error messages:
1. In the main exception handler, strip stack traces from the error response.
2. In HttpClientUtils, hide any private uris

Both of these fixes should cover many more cases than the three mentioned in the Jira ticket, though this PR is certainly not a comprehensive audit of info disclosure in error messages.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
