### PR TITLE
CORE-350: spend report excludes previous accounts

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -311,6 +311,7 @@ class SpendReportingService(
     )
   }
 
+  // TODO CORE-350: single-project report: query
   def getQuery(aggregations: Set[SpendReportingAggregationKeyWithSub], config: BillingProjectSpendExport): String = {
     // Unbox potentially many SpendReportingAggregationKeyWithSubs for query,
     // all of which have optional subAggregationKeys and convert to Set[SpendReportingAggregationKey]
@@ -337,9 +338,10 @@ class SpendReportingService(
     if (isBroadTable) spendReportingServiceConfig.defaultTimePartitionColumn else "_PARTITIONTIME"
   }
 
+  // TODO CORE-350: consolidated report: query
   def getAllUserWorkspaceQuery(
     spendExportTable: String,
-    workspaces: Seq[GoogleProjectId],
+    billingProjectsByAccount: Map[RawlsBillingAccountName, Seq[GoogleProjectId]],
     pageSize: Int,
     offset: Int
   ): String = {
@@ -357,8 +359,8 @@ class SpendReportingService(
                        |  FROM
                        |    _BILLING_ACCOUNT_TABLE
                        |  where
-                       |    project.id in _PROJECT_ID_LIST AND
-                       |    _PARTITIONTIME BETWEEN @startDate AND @endDate
+                       |    _PARTITIONTIME BETWEEN @startDate AND @endDate and
+                       |    _PROJECT_CLAUSE
                        |  GROUP BY
                        |    project_id,
                        |    spend_category,
@@ -369,11 +371,7 @@ class SpendReportingService(
       baseQuery
         .replace("_PARTITIONTIME", timePartitionColumn)
         .replace("_BILLING_ACCOUNT_TABLE", spendExportTable)
-        .replace("_PROJECT_ID_LIST",
-                 workspaces
-                   .map(projectId => s""""${projectId}"""")
-                   .mkString("(", ", ", ")")
-        )
+        .replace("_PROJECT_CLAUSE", billingProjectsByAccountClause(billingProjectsByAccount))
 
     s"""WITH spend_categories AS (
        |$bpSubQuery
@@ -399,6 +397,17 @@ class SpendReportingService(
        |""".stripMargin.trim
   }
 
+  def billingProjectsByAccountClause(
+    billingProjectsByAccount: Map[RawlsBillingAccountName, Seq[GoogleProjectId]]
+  ): String =
+    billingProjectsByAccount
+      .map { case (billingAccount, projects) =>
+        val quotedProjects = projects.map(p => s"'${p.value}'")
+        s" (billing_account_id = '${billingAccount.withoutPrefix()}' and project.id in ${quotedProjects.mkString("(", ", ", ")")}) "
+      }
+      .mkString(" or ")
+
+  // TODO CORE-350: single-project report: query parameters
   def setUpQuery(
     query: String,
     exportConf: BillingProjectSpendExport,
@@ -450,6 +459,7 @@ class SpendReportingService(
     bytesProcessedCounter += stats.getEstimatedBytesProcessed
   }
 
+  // TODO CORE-350: *** shared between single-project and consolidated reports
   def getSpendReportableWorkspaceGoogleProjects(
     childContext: RawlsRequestContext
   ): Future[Map[RawlsBillingProjectName, Seq[Workspace]]] =
@@ -467,6 +477,7 @@ class SpendReportingService(
         workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
+  // TODO CORE-350: single-project report: step 3
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
     start: DateTime,
@@ -501,6 +512,7 @@ class SpendReportingService(
     }
   }
 
+  // TODO CORE-350: single-project report: entry point
   def getSpendForBillingProject(
     project: RawlsBillingProjectName,
     start: DateTime,
@@ -513,6 +525,7 @@ class SpendReportingService(
       report <- getReportData(billingProject.get, project, start, end, aggregations)
     } yield report
 
+  // TODO CORE-350: single-project report: step 2
   private def getReportData(billingProject: RawlsBillingProject,
                             project: RawlsBillingProjectName,
                             start: DateTime,
@@ -557,6 +570,7 @@ class SpendReportingService(
           Future.failed(RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex)))
       }
 
+  // TODO CORE-350: consolidated report: entry point
   def getSpendForAllWorkspaces(
     start: DateTime,
     end: DateTime,
@@ -566,22 +580,44 @@ class SpendReportingService(
     traceFutureWithParent("getSpendForAllWorkspaces", ctx) { childContext =>
       validateReportParameters(start, end)
       for {
+        // get spend-reportable workspaces, grouped by their spend export config
+        // Map[BillingProjectSpendExport, Seq[Workspace]]
         billingMap <- getBillingWithSpendPermission(childContext)
         _ = if (billingMap.isEmpty) {
           return Future.successful(None)
         }
-        projectNames: Map[GoogleProjectId, WorkspaceName] = billingMap.values.flatten.toMap
-        tableToProjectIdsMap: Map[String, Seq[GoogleProjectId]] = billingMap.map { case (table, workspaces) =>
-          table -> workspaces.map(_._1)
-        }
-        results <- Future.sequence(tableToProjectIdsMap.map { case (spendExportTable, projects) =>
-          val query = getAllUserWorkspaceQuery(spendExportTable, projects, pageSize, offset)
+
+        // find the distinct export table names in our billingMap
+        distinctTableNames: Set[Option[String]] = billingMap.keys.map(_.spendExportTable).toSet
+
+        // for each distinct export table name, generate a query.
+        results <- Future.sequence(distinctTableNames.map { spendExportTable =>
+          // find the subset of the billingMap that we'll use in this query
+          val billingMapForQuery = billingMap.filter(_._1.spendExportTable == spendExportTable)
+          // use default export table if none is specified
+          val tableNameForQuery = spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
+          // find the (billingAccount, billingProjects) pairs for this query
+          val billingProjectsByAccount: Map[RawlsBillingAccountName, Seq[GoogleProjectId]] =
+            billingMapForQuery
+              .groupMap(_._1.billingAccountId)(_._2)
+              .view
+              .mapValues(_.flatten.map(_.googleProjectId).toSeq)
+              .toMap
+
+          // and finally, generate a map of GoogleProjectId->WorkspaceName for extracting the spend results
+          val workspaceNamesByProjectId: Map[GoogleProjectId, WorkspaceName] = billingMapForQuery.values.flatten
+            .map(ws => ws.googleProjectId -> ws.toWorkspaceName)
+            .toMap
+
+          val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
+          logger.warn(query)
           val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
           runBigQueryJob(queryJob, childContext)
             .map { result =>
               result.getValues.asScala.toList match {
-                case Nil  => None
-                case rows => Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, projectNames))
+                case Nil => None
+                case rows =>
+                  Some(extractCrossBillingProjectSpendReportingResults(rows, start, end, workspaceNamesByProjectId))
               }
             }
             .recoverWith { case ex: Throwable =>
@@ -605,28 +641,33 @@ class SpendReportingService(
 
   def getBillingWithSpendPermission(
     parentContext: RawlsRequestContext
-  ): Future[Map[String, Seq[(GoogleProjectId, WorkspaceName)]]] =
+  ): Future[Map[BillingProjectSpendExport, Seq[Workspace]]] =
     traceFutureWithParent("getBillingWithSpendPermission", parentContext) { childContext =>
       for {
-        groupedWorkspaces <- getSpendReportableWorkspaceGoogleProjects(childContext)
-        // Only use the BPs we know exist in the DB and are GCP
+        // Retrieve the workspaces for which the user is allowed to report on spend;
+        // these are grouped by billing project
+        workspacesByBillingProjectName <- getSpendReportableWorkspaceGoogleProjects(childContext)
+        // Retrieve the spend-export configs for each of these billing projects;
+        // this verifies the billing projects exist in the DB and are GCP
         spendConfigs <-
-          if (groupedWorkspaces.isEmpty) {
+          if (workspacesByBillingProjectName.isEmpty) {
             Future.successful(Seq.empty[BillingProjectSpendExport])
           } else {
-            getSpendExportConfigurations(groupedWorkspaces.keys.toList)
+            getSpendExportConfigurations(workspacesByBillingProjectName.keys.toList)
           }
-        groupedByTable = spendConfigs.groupBy(
-          _.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
-        )
-        combinedResults = groupedByTable.map { case (table, configs) =>
-          val combinedWorkspaces = configs.flatMap { config =>
-            groupedWorkspaces
-              .getOrElse(RawlsBillingProjectName(config.billingProjectName.value), Seq.empty)
-              .map(ws => (ws.googleProjectId, ws.toWorkspaceName))
+
+        // Match the workspaces to their spend configs. Filter out any spend configs which
+        // have no workspaces (this is not expected to happen)
+        workspacesBySpendConfig = spendConfigs
+          .map { config =>
+            config -> workspacesByBillingProjectName.getOrElse(config.billingProjectName, Seq.empty[Workspace])
           }
-          table -> combinedWorkspaces
-        }
-      } yield combinedResults
+          .toMap
+          .filter(_._2.nonEmpty)
+
+//        groupedByTable = spendConfigs.groupBy(
+//          _.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
+//        )
+      } yield workspacesBySpendConfig
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -311,7 +311,7 @@ class SpendReportingService(
     )
   }
 
-  // TODO CORE-350: single-project report: query
+  // single-project report: query
   def getQuery(aggregations: Set[SpendReportingAggregationKeyWithSub], config: BillingProjectSpendExport): String = {
     // Unbox potentially many SpendReportingAggregationKeyWithSubs for query,
     // all of which have optional subAggregationKeys and convert to Set[SpendReportingAggregationKey]
@@ -338,7 +338,7 @@ class SpendReportingService(
     if (isBroadTable) spendReportingServiceConfig.defaultTimePartitionColumn else "_PARTITIONTIME"
   }
 
-  // TODO CORE-350: consolidated report: query
+  // consolidated report: query
   def getAllUserWorkspaceQuery(
     spendExportTable: String,
     billingProjectsByAccount: Map[RawlsBillingAccountName, Seq[GoogleProjectId]],
@@ -360,7 +360,7 @@ class SpendReportingService(
                        |    _BILLING_ACCOUNT_TABLE
                        |  where
                        |    _PARTITIONTIME BETWEEN @startDate AND @endDate and
-                       |    _PROJECT_CLAUSE
+                       |    (_PROJECT_CLAUSE)
                        |  GROUP BY
                        |    project_id,
                        |    spend_category,
@@ -407,7 +407,7 @@ class SpendReportingService(
       }
       .mkString(" or ")
 
-  // TODO CORE-350: single-project report: query parameters
+  // single-project report: query parameters
   def setUpQuery(
     query: String,
     exportConf: BillingProjectSpendExport,
@@ -459,7 +459,7 @@ class SpendReportingService(
     bytesProcessedCounter += stats.getEstimatedBytesProcessed
   }
 
-  // TODO CORE-350: *** shared between single-project and consolidated reports
+  // shared between single-project and consolidated reports
   def getSpendReportableWorkspaceGoogleProjects(
     childContext: RawlsRequestContext
   ): Future[Map[RawlsBillingProjectName, Seq[Workspace]]] =
@@ -477,7 +477,7 @@ class SpendReportingService(
         workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
-  // TODO CORE-350: single-project report: step 3
+  // single-project report: step 3
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
     start: DateTime,
@@ -512,7 +512,7 @@ class SpendReportingService(
     }
   }
 
-  // TODO CORE-350: single-project report: entry point
+  // single-project report: entry point
   def getSpendForBillingProject(
     project: RawlsBillingProjectName,
     start: DateTime,
@@ -525,7 +525,7 @@ class SpendReportingService(
       report <- getReportData(billingProject.get, project, start, end, aggregations)
     } yield report
 
-  // TODO CORE-350: single-project report: step 2
+  // single-project report: step 2
   private def getReportData(billingProject: RawlsBillingProject,
                             project: RawlsBillingProjectName,
                             start: DateTime,
@@ -570,7 +570,7 @@ class SpendReportingService(
           Future.failed(RawlsExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex)))
       }
 
-  // TODO CORE-350: consolidated report: entry point
+  // consolidated report: entry point
   def getSpendForAllWorkspaces(
     start: DateTime,
     end: DateTime,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -496,6 +496,13 @@ class SpendReportingService(
           .toMap
       }
 
+      _ = if (projectNames.isEmpty) {
+        throw RawlsExceptionWithErrorReport(
+          StatusCodes.NotFound,
+          s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+        )
+      }
+
       query = getQuery(aggregations, spendExportConf)
       queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
 
@@ -584,7 +591,9 @@ class SpendReportingService(
         // Map[BillingProjectSpendExport, Seq[Workspace]]
         billingMap <- getBillingWithSpendPermission(childContext)
         _ = if (billingMap.isEmpty) {
-          return Future.successful(None)
+          throw new RawlsExceptionWithErrorReport(
+            ErrorReport(StatusCodes.NotFound, "No workspaces eligible for spend report")
+          )
         }
 
         // find the distinct export table names in our billingMap
@@ -610,7 +619,6 @@ class SpendReportingService(
             .toMap
 
           val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
-          logger.warn(query)
           val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
           runBigQueryJob(queryJob, childContext)
             .map { result =>
@@ -665,9 +673,6 @@ class SpendReportingService(
           .toMap
           .filter(_._2.nonEmpty)
 
-//        groupedByTable = spendConfigs.groupBy(
-//          _.spendExportTable.getOrElse(spendReportingServiceConfig.defaultTableName)
-//        )
       } yield workspacesBySpendConfig
     }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1195,11 +1195,20 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                                 RawlsBillingAccountName("billingAccount1"),
                                 Some("billing1_bq_project.billing1_dataset.billing1_table")
       )
+    val billingProjectSpendExport2 =
+      BillingProjectSpendExport(RawlsBillingProjectName("billingProject2"),
+                                RawlsBillingAccountName("billingAccount2"),
+                                Some("billing1_bq_project.billing1_dataset.billing2_table")
+      )
 
     val workspaces = Map(
       RawlsBillingAccountName("billingAccount1") -> Seq(
         GoogleProjectId("workspace2ProjectId"),
         GoogleProjectId("workspace1ProjectId")
+      ),
+      RawlsBillingAccountName("billingAccount2") -> Seq(
+        GoogleProjectId("workspace3ProjectId"),
+        GoogleProjectId("workspace4ProjectId")
       )
     )
 
@@ -1219,7 +1228,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |    billing1_bq_project.billing1_dataset.billing1_table
           |  where
           |    _PARTITIONTIME BETWEEN @startDate AND @endDate
-          |    and (billing_account_id = 'billingAccount1' and project.id in ('workspace2ProjectId', 'workspace1ProjectId'))
+          |    and ( (billing_account_id = 'billingAccount1' and project.id in ('workspace2ProjectId', 'workspace1ProjectId'))
+          |    or (billing_account_id = 'billingAccount2' and project.id in ('workspace3ProjectId', 'workspace4ProjectId')) )
           |  GROUP BY
           |    project_id,
           |    spend_category,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -840,7 +840,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         Duration.Inf
       )
     }
-    e.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
+    e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
   }
 
   "getSpendForBillingProject" should "get the spend report from BPM for Azure billing projects" in {
@@ -1429,16 +1429,17 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       )
     )
 
-    val exceptionFuture = recoverToExceptionIf[RawlsExceptionWithErrorReport] {
-      service.getSpendForAllWorkspaces(from, to, 100, 0)
-    }
-    exceptionFuture.map { e =>
-      e.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
-      e.errorReport.message.contains("no workspaces") shouldBe true
-    }
+    val exception = Await.result(recoverToExceptionIf[RawlsExceptionWithErrorReport] {
+                                   service.getSpendForAllWorkspaces(from, to, 100, 0)
+                                 },
+                                 Duration.Inf
+    )
+
+    exception.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+    exception.errorReport.message.contains("No workspaces eligible for spend report") shouldBe true
   }
 
-  "getSpendForAllWorkspaces" should "get the spend report from multiple billing projects" in {
+  it should "get the spend report from multiple billing projects" in {
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
     val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
@@ -1607,7 +1608,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
   }
 
-  "getSpendForAllWorkspaces" should "handle errors from bigquery gracefully" in {
+  it should "handle errors from bigquery gracefully" in {
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
     val bpmDAO = mock[BillingProfileManagerDAO](RETURNS_SMART_NULLS)
@@ -1825,21 +1826,24 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
       mock[BillingRepository],
       mock[BillingProfileManagerDAO],
-      mock[SamDAO],
+      mockSamDAO,
       spendReportingServiceConfig,
       mockWorkspaceServiceConstructor
     )
 
-    recoverToExceptionIf[RawlsExceptionWithErrorReport] {
-      spendReportingService.getSpendForGCPBillingProject(RawlsBillingProjectName("test-project"),
-                                                         DateTime.now().minusDays(7),
-                                                         DateTime.now(),
-                                                         Set.empty[SpendReportingAggregationKeyWithSub]
-      )
-    } map { ex =>
-      ex.errorReport.statusCode shouldBe StatusCodes.NotFound
-      ex.errorReport.message should include("no spend data found for billing project")
-    }
+    val exception = Await.result(
+      recoverToExceptionIf[RawlsExceptionWithErrorReport] {
+        spendReportingService.getSpendForGCPBillingProject(RawlsBillingProjectName("test-project"),
+                                                           DateTime.now().minusDays(7),
+                                                           DateTime.now(),
+                                                           Set.empty[SpendReportingAggregationKeyWithSub]
+        )
+      },
+      Duration.Inf
+    )
+
+    exception.errorReport.statusCode should contain(StatusCodes.NotFound)
+    exception.errorReport.message should include("no spend data found for billing project")
   }
 
   it should "return a map of workspaces grouped by billing project" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1196,9 +1196,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
                                 Some("billing1_bq_project.billing1_dataset.billing1_table")
       )
 
-    val workspaces = Seq(
-      GoogleProjectId("workspace2ProjectId"),
-      GoogleProjectId("workspace1ProjectId")
+    val workspaces = Map(
+      RawlsBillingAccountName("billingAccount1") -> Seq(
+        GoogleProjectId("workspace2ProjectId"),
+        GoogleProjectId("workspace1ProjectId")
+      )
     )
 
     val expectedQuery =
@@ -1216,8 +1218,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           |  FROM
           |    billing1_bq_project.billing1_dataset.billing1_table
           |  where
-          |    project.id in ("workspace2ProjectId", "workspace1ProjectId") AND
           |    _PARTITIONTIME BETWEEN @startDate AND @endDate
+          |    and (billing_account_id = 'billingAccount1' and project.id in ('workspace2ProjectId', 'workspace1ProjectId'))
           |  GROUP BY
           |    project_id,
           |    spend_category,
@@ -1377,12 +1379,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     )
 
     result shouldBe Map(
-      "billing_bq_project.billing_dataset.billing_table" -> Seq(
-        (workspace1Billing1.googleProjectId, workspace1Billing1.toWorkspaceName),
-        (workspace2Billing1.googleProjectId, workspace2Billing1.toWorkspaceName),
-        (workspace1Billing2.googleProjectId, workspace1Billing2.toWorkspaceName)
-      ),
-      "fakeTable" -> Seq((workspace1Billing3.googleProjectId, workspace1Billing3.toWorkspaceName))
+      billingProject1SpendExport -> Seq(workspace1Billing1, workspace2Billing1),
+      billingProject2SpendExport -> Seq(workspace1Billing2),
+      billingProject3SpendExport -> Seq(workspace1Billing3)
     )
 
   }


### PR DESCRIPTION
Ticket: CORE-350


Objective of this ticket is to only show spend for the _current_ billing account for each workspace; do not include spend for any previous billing accounts. End result is that workspaces will not show the spend incurred while their projects were in a RBS pool.

Implementation-wise, this changes the where clause in the consolidated spend report.

_previous where clause:_
```sql
where …
project.id in ("project1", "project2", "project3", "project4", "project5")
```

_new where clause:_
```sql
where …
(
  (billing_account_id = 'billingAccount1' and project.id in ('project1', 'project2'))
  or
  (billing_account_id = 'billingAccount2' and project.id in ('project3'))
  or
  (billing_account_id = 'billingAccount3' and project.id in ('project4', 'project5'))
)
```

Here's the before/after of the consolidated spend report for me in the dev env. Note the difference in the fourth row for the `nonbroad-billing-dev/TestMissingSpendInfo` workspace.

_before:_
![Screenshot 10-03-2025 at 09 17](https://github.com/user-attachments/assets/5d524853-28aa-4a16-9e81-aff1595d7b91)

_after:_
![Screenshot 10-03-2025 at 09 17 (1)](https://github.com/user-attachments/assets/9b109362-1c59-4d50-b236-43caf74551be)


---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
