### PR TITLE
CORE-360: move updateEntity() from EntityService to EntityProvider

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -104,6 +104,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         .recover(bigQueryRecover)
     }
 
+  // TODO CORE-360: move to EntityProviders
   def updateEntity(workspaceName: WorkspaceName,
                    entityType: String,
                    entityName: String,
@@ -198,6 +199,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         .recover(bigQueryRecover)
     }
 
+  // TODO CORE-360: move to EntityProviders
   def deleteEntityAttributes(workspaceName: WorkspaceName,
                              entityType: String,
                              attributeNames: Set[AttributeName]
@@ -221,6 +223,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
       sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
     )
 
+  // TODO CORE-360: move to EntityProviders
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
     (getV2WorkspaceContextAndPermissions(workspaceName,
                                          SamWorkspaceActions.write,
@@ -242,6 +245,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
       sqlLoggingRecover(s"renameEntity: $workspaceName $entityType $entityName")
     )
 
+  // TODO CORE-360: move to EntityProviders
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
     import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
 
@@ -295,6 +299,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     )
   }
 
+  // TODO CORE-360: move to EntityProviders
   def evaluateExpression(workspaceName: WorkspaceName,
                          entityType: String,
                          entityName: String,
@@ -384,6 +389,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
     Source.fromPublisher(dataSource.database.stream(allAttrsStream))
   }
 
+  // TODO CORE-360: move to EntityProviders
   def listEntities(workspaceName: WorkspaceName, entityType: String) =
     (getWorkspaceContextAndPermissions(workspaceName,
                                        SamWorkspaceActions.read,
@@ -493,6 +499,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
       )
 
+  // TODO CORE-360: move to EntityProviders
   def renameAttribute(workspaceName: WorkspaceName,
                       entityType: String,
                       oldAttributeName: AttributeName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -104,40 +104,20 @@ class EntityService(protected val ctx: RawlsRequestContext,
         .recover(bigQueryRecover)
     }
 
-  // TODO CORE-360: move to EntityProviders
   def updateEntity(workspaceName: WorkspaceName,
                    entityType: String,
                    entityName: String,
                    operations: Seq[AttributeUpdateOperation]
   ): Future[Entity] =
     withAttributeNamespaceCheck(operations.map(_.name)) {
-      getV2WorkspaceContextAndPermissions(workspaceName,
-                                          SamWorkspaceActions.write,
-                                          Some(WorkspaceAttributeSpecs(all = false))
-      ) flatMap { workspaceContext =>
-        dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-          withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-            val updateAction = Try {
-              val updatedEntity = applyOperationsToEntity(entity, operations)
-              dataAccess.entityQuery.save(workspaceContext, updatedEntity)
-            } match {
-              case Success(result) => result
-              case Failure(e: AttributeUpdateOperationException) =>
-                DBIO.failed(
-                  new RawlsExceptionWithErrorReport(
-                    errorReport =
-                      ErrorReport(StatusCodes.BadRequest,
-                                  s"Unable to update entity ${entityType}/${entityName} in ${workspaceName}",
-                                  ErrorReport(e)
-                      )
-                  )
-                )
-              case Failure(regrets) => DBIO.failed(regrets)
-            }
-            updateAction
-          }
-        }
-      }
+      for {
+        workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                                SamWorkspaceActions.write,
+                                                                Some(WorkspaceAttributeSpecs(all = false))
+        )
+        entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+        result <- entityProvider.updateEntity(entityType, entityName, operations)
+      } yield result
     }.recover(sqlLoggingRecover(s"updateEntity: $workspaceName $entityType/$entityName ${operations.size} operations"))
 
   def deleteEntities(workspaceName: WorkspaceName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -29,7 +29,7 @@ trait EntityProvider {
   // entityStoreId is used by subclasses to identify themselves
   def entityStoreId: Option[String]
 
-  // -----
+  // ----- implementation methods follow:
 
   def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -26,15 +26,30 @@ import scala.util.Try
  * trait definition for entity providers.
  */
 trait EntityProvider {
+  // entityStoreId is used by subclasses to identify themselves
   def entityStoreId: Option[String]
 
-  def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]]
+  // -----
+
+  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+
+  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+
+  def copyEntities(sourceWorkspaceContext: Workspace,
+                   destWorkspaceContext: Workspace,
+                   entityType: String,
+                   entityNames: Seq[String],
+                   linkExistingEntities: Boolean,
+                   parentContext: RawlsRequestContext
+  ): Future[EntityCopyResponse]
 
   def createEntity(entity: Entity): Future[Entity]
 
   def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int]
 
   def deleteEntitiesOfType(entityType: String): Future[Int]
+
+  def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]]
 
   /**
   The overall approach is:
@@ -67,25 +82,14 @@ trait EntityProvider {
 
   def getEntity(entityType: String, entityName: String): Future[Entity]
 
-  def queryEntitiesSource(entityType: String,
-                          query: EntityQuery,
-                          parentContext: RawlsRequestContext
-  ): Future[(EntityQueryResultMetadata, Source[Entity, _])]
-
   def queryEntities(entityType: String,
                     query: EntityQuery,
                     parentContext: RawlsRequestContext
   ): Future[EntityQueryResponse]
 
-  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+  def queryEntitiesSource(entityType: String,
+                          query: EntityQuery,
+                          parentContext: RawlsRequestContext
+  ): Future[(EntityQueryResultMetadata, Source[Entity, _])]
 
-  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
-
-  def copyEntities(sourceWorkspaceContext: Workspace,
-                   destWorkspaceContext: Workspace,
-                   entityType: String,
-                   entityNames: Seq[String],
-                   linkExistingEntities: Boolean,
-                   parentContext: RawlsRequestContext
-  ): Future[EntityCopyResponse]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -3,12 +3,11 @@ package org.broadinstitute.dsde.rawls.entities.base
 import akka.stream.scaladsl.Source
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdateDefinition
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
   AttributeValue,
   Entity,
-  EntityCopyDefinition,
   EntityCopyResponse,
   EntityQuery,
   EntityQueryResponse,
@@ -92,4 +91,5 @@ trait EntityProvider {
                           parentContext: RawlsRequestContext
   ): Future[(EntityQueryResultMetadata, Source[Entity, _])]
 
+  def updateEntity(entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation]): Future[Entity]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -35,6 +35,7 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeNull,
   AttributeNumber,
   AttributeString,
+  AttributeUpdateOperations,
   AttributeValue,
   AttributeValueList,
   AttributeValueRawJson,
@@ -547,4 +548,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] =
     throw new UnsupportedEntityOperationException("copy entities not supported by this provider.")
+
+  override def updateEntity(entityType: EntityName,
+                            entityName: EntityName,
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation]
+  ): Future[Entity] = throw new UnsupportedEntityOperationException("update entity not supported by this provider.")
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -35,6 +35,7 @@ import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeEntityReference,
   AttributeName,
+  AttributeUpdateOperations,
   AttributeValue,
   Entity,
   EntityCopyDefinition,
@@ -53,7 +54,12 @@ import org.broadinstitute.dsde.rawls.model.{
   WorkspaceAttributeSpecs
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
-import org.broadinstitute.dsde.rawls.util.{AttributeSupport, CollectionUtils, EntitySupport}
+import org.broadinstitute.dsde.rawls.util.{
+  AttributeSupport,
+  AttributeUpdateOperationException,
+  CollectionUtils,
+  EntitySupport
+}
 import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
 
 import java.time.Duration
@@ -550,4 +556,32 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
         )
       }
     )
+
+  override def updateEntity(entityType: EntityName,
+                            entityName: EntityName,
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation]
+  ): Future[Entity] =
+    dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
+      withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+        val updateAction = Try {
+          val updatedEntity = applyOperationsToEntity(entity, operations)
+          dataAccess.entityQuery.save(workspaceContext, updatedEntity)
+        } match {
+          case Success(result) => result
+          case Failure(e: AttributeUpdateOperationException) =>
+            DBIO.failed(
+              new RawlsExceptionWithErrorReport(
+                errorReport = ErrorReport(
+                  StatusCodes.BadRequest,
+                  s"Unable to update entity ${entityType}/${entityName} in ${workspaceContext.toWorkspaceName}",
+                  ErrorReport(e)
+                )
+              )
+            )
+          case Failure(regrets) => DBIO.failed(regrets)
+        }
+        updateAction
+      }
+    }
+
 }


### PR DESCRIPTION
Ticket: CORE-360

Early prefactoring:
* add TODO comments for the tasks in CORE-360
* alphabetize (mostly) the methods in the `EntityProvider` trait
* move `updateEntity` from `EntityService` to `EntityProvider`; I'm just doing one method in this PR as an example for future PRs
