### PR TITLE
CORE-360: entity service to providers part2

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -179,29 +179,21 @@ class EntityService(protected val ctx: RawlsRequestContext,
         .recover(bigQueryRecover)
     }
 
-  // TODO CORE-360: move to EntityProviders
   def deleteEntityAttributes(workspaceName: WorkspaceName,
                              entityType: String,
                              attributeNames: Set[AttributeName]
   ): Future[Unit] =
-    (getV2WorkspaceContextAndPermissions(workspaceName,
-                                         SamWorkspaceActions.write,
-                                         Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        dataAccess
-          .entityAttributeShardQuery(workspaceContext)
-          .deleteAttributes(workspaceContext, entityType, attributeNames) flatMap {
-          case Vector(0) =>
-            throw new RawlsExceptionWithErrorReport(
-              errorReport = ErrorReport(StatusCodes.BadRequest, s"Could not find any of the given attribute names.")
-            )
-          case _ => DBIO.successful(())
-        }
-      }
-    }).recover(
-      sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
-    )
+    (for {
+      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                              SamWorkspaceActions.write,
+                                                              Some(WorkspaceAttributeSpecs(all = false))
+      )
+      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+      result <- entityProvider.deleteEntityAttributes(entityType, attributeNames)
+    } yield result)
+      .recover(
+        sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
+      )
 
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
     (for {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -291,35 +291,15 @@ class EntityService(protected val ctx: RawlsRequestContext,
       sqlLoggingRecover(s"entityTypeMetadata: $workspaceName")
     )
 
-  /*
-   * Queries the db for a stream of entity attributes.
-   */
-  private def listEntitiesDbSource(workspaceContext: Workspace,
-                                   entityType: String
-  ): Source[EntityAndAttributesResult, NotUsed] = {
-    // note: ReadCommitted transaction isolation level; forward-only/read-only stream.
-    val allAttrsStream = dataSource.dataAccess.entityQuery
-      .streamActiveEntityAttributesOfType(workspaceContext, entityType)
-      .transactionally
-      .withTransactionIsolation(TransactionIsolation.ReadCommitted)
-      .withStatementParameters(rsType = ResultSetType.ForwardOnly,
-                               rsConcurrency = ResultSetConcurrency.ReadOnly,
-                               fetchSize = dataSource.dataAccess.fetchSize
+  def listEntities(workspaceName: WorkspaceName, entityType: String): Future[Source[Entity, NotUsed]] =
+    (for {
+      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                              SamWorkspaceActions.read,
+                                                              Some(WorkspaceAttributeSpecs(all = false))
       )
-
-    // translate the Slick stream to a Source
-    Source.fromPublisher(dataSource.database.stream(allAttrsStream))
-  }
-
-  // TODO CORE-360: move to EntityProviders
-  def listEntities(workspaceName: WorkspaceName, entityType: String) =
-    (getWorkspaceContextAndPermissions(workspaceName,
-                                       SamWorkspaceActions.read,
-                                       Some(WorkspaceAttributeSpecs(all = false))
-    ) map { workspaceContext =>
-      val dbSource = listEntitiesDbSource(workspaceContext, entityType)
-      EntityStreamingUtils.gatherEntities(dataSource, dbSource)
-    }).recover(
+      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+      result = entityProvider.listEntities(entityType)
+    } yield result).recover(
       sqlLoggingRecover(s"listEntities: $workspaceName $entityType")
     )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -203,79 +203,29 @@ class EntityService(protected val ctx: RawlsRequestContext,
       sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
     )
 
-  // TODO CORE-360: move to EntityProviders
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
-    (getV2WorkspaceContextAndPermissions(workspaceName,
-                                         SamWorkspaceActions.write,
-                                         Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-          dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName) flatMap {
-            case None => dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName)
-            case Some(_) =>
-              throw new RawlsExceptionWithErrorReport(
-                errorReport =
-                  ErrorReport(StatusCodes.Conflict, s"Destination ${entity.entityType} ${newName} already exists")
-              )
-          }
-        }
-      }
-    }).recover(
+    (for {
+      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                              SamWorkspaceActions.write,
+                                                              Some(WorkspaceAttributeSpecs(all = false))
+      )
+      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+      result <- entityProvider.renameEntity(entityType, entityName, newName)
+    } yield result).recover(
       sqlLoggingRecover(s"renameEntity: $workspaceName $entityType $entityName")
     )
 
-  // TODO CORE-360: move to EntityProviders
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
-    import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, ReadAction}
-
     validateEntityType(renameInfo.newName)
-    def validateExistingType(dataAccess: DataAccess,
-                             workspaceContext: Workspace,
-                             oldName: String
-    ): ReadAction[Boolean] =
-      dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, oldName) map {
-        case Some(true) => true
-        case Some(false) =>
-          throw new RawlsExceptionWithErrorReport(
-            errorReport = ErrorReport(StatusCodes.NotFound, s"Can't find entity type ${oldName}")
-          )
-        case None =>
-          throw new RawlsExceptionWithErrorReport(
-            errorReport = ErrorReport(StatusCodes.InternalServerError,
-                                      s"Unexpected error; could not determine existence of entity type ${oldName}"
-            )
-          )
-      }
-
-    def validateNewType(dataAccess: DataAccess, workspaceContext: Workspace, newName: String): ReadAction[Boolean] =
-      dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, newName) map {
-        case Some(true) =>
-          throw new RawlsExceptionWithErrorReport(
-            errorReport = ErrorReport(StatusCodes.Conflict, s"${newName} already exists as an entity type")
-          )
-        case Some(false) => false
-        case None =>
-          throw new RawlsExceptionWithErrorReport(
-            errorReport = ErrorReport(StatusCodes.InternalServerError,
-                                      s"Unexpected error; could not determine existence of entity type ${newName}"
-            )
-          )
-      }
-
-    (getV2WorkspaceContextAndPermissions(workspaceName,
-                                         SamWorkspaceActions.write,
-                                         Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      dataSource.inTransaction { dataAccess =>
-        for {
-          _ <- validateNewType(dataAccess, workspaceContext, renameInfo.newName)
-          _ <- validateExistingType(dataAccess, workspaceContext, oldName)
-          renameResult <- dataAccess.entityQuery.changeEntityTypeName(workspaceContext, oldName, renameInfo.newName)
-        } yield renameResult
-      }
-    }).recover(
-      sqlLoggingRecover(s"renameEntityType: $workspaceName $oldName")
+    (for {
+      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                              SamWorkspaceActions.write,
+                                                              Some(WorkspaceAttributeSpecs(all = false))
+      )
+      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+      result <- entityProvider.renameEntityType(oldName, renameInfo)
+    } yield result).recover(
+      sqlLoggingRecover(s"renameEntityType: $workspaceName $workspaceName $oldName")
     )
   }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -221,52 +221,19 @@ class EntityService(protected val ctx: RawlsRequestContext,
     )
   }
 
-  // TODO CORE-360: move to EntityProviders
   def evaluateExpression(workspaceName: WorkspaceName,
                          entityType: String,
                          entityName: String,
                          expression: String
   ): Future[Seq[AttributeValue]] =
-    (getV2WorkspaceContextAndPermissions(workspaceName,
-                                         SamWorkspaceActions.read,
-                                         Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      dataSource.inTransaction(
-        dataAccess =>
-          withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
-            ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
-              evaluator.evalFinalAttribute(workspaceContext, expression).asTry map { tryValuesByEntity =>
-                tryValuesByEntity match {
-                  // parsing failure
-                  case Failure(regret) =>
-                    throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
-                  case Success(valuesByEntity) =>
-                    if (valuesByEntity.size != 1) {
-                      // wrong number of entities?!
-                      throw new RawlsException(
-                        s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
-                      )
-                    } else {
-                      assert(valuesByEntity.head._1 == entityName)
-                      valuesByEntity.head match {
-                        case (_, Success(result)) => result.toSeq
-                        case (_, Failure(regret)) =>
-                          throw new RawlsExceptionWithErrorReport(
-                            errorReport = ErrorReport(
-                              StatusCodes.BadRequest,
-                              "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
-                              ErrorReport(regret)
-                            )
-                          )
-                      }
-                    }
-                }
-              }
-            }
-          },
-        TransactionIsolation.ReadCommitted
+    (for {
+      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                              SamWorkspaceActions.read,
+                                                              Some(WorkspaceAttributeSpecs(all = false))
       )
-    }).recover(
+      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+      result <- entityProvider.evaluateExpression(entityType, entityName, expression)
+    } yield result).recover(
       sqlLoggingRecover(s"evaluateExpression: $workspaceName $entityType $entityName $expression")
     )
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -479,65 +479,20 @@ class EntityService(protected val ctx: RawlsRequestContext,
         sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
       )
 
-  // TODO CORE-360: move to EntityProviders
   def renameAttribute(workspaceName: WorkspaceName,
                       entityType: String,
                       oldAttributeName: AttributeName,
                       attributeRenameRequest: AttributeRename
   ): Future[Int] =
     withAttributeNamespaceCheck(Seq(attributeRenameRequest.newAttributeName)) {
-      getV2WorkspaceContextAndPermissions(workspaceName,
-                                          SamWorkspaceActions.write,
-                                          Some(WorkspaceAttributeSpecs(all = false))
-      ) flatMap { workspaceContext =>
-        def validateNewAttributeName(dataAccess: DataAccess,
-                                     workspaceContext: Workspace,
-                                     entityType: String,
-                                     attributeName: AttributeName
-        ): ReadAction[Boolean] =
-          dataAccess
-            .entityAttributeShardQuery(workspaceContext)
-            .doesAttributeNameAlreadyExist(workspaceContext, entityType, attributeName) map {
-            case Some(false) => false
-            case Some(true) =>
-              throw new RawlsExceptionWithErrorReport(
-                errorReport =
-                  ErrorReport(StatusCodes.Conflict,
-                              s"${AttributeName.toDelimitedName(attributeName)} already exists as an attribute name"
-                  )
-              )
-            case None =>
-              throw new RawlsExceptionWithErrorReport(
-                errorReport = ErrorReport(
-                  StatusCodes.InternalServerError,
-                  s"Unexpected error; could not determine existence of attribute name ${AttributeName.toDelimitedName(attributeName)}"
-                )
-              )
-          }
-
-        def validateRowsUpdated(rowsUpdated: Int, oldAttributeName: AttributeName): Boolean =
-          rowsUpdated match {
-            case 0 =>
-              throw new RawlsExceptionWithErrorReport(
-                errorReport =
-                  ErrorReport(StatusCodes.NotFound,
-                              s"Can't find attribute name ${AttributeName.toDelimitedName(oldAttributeName)}"
-                  )
-              )
-            case _ => true
-          }
-
-        dataSource.inTransaction { dataAccess =>
-          val newAttributeName = attributeRenameRequest.newAttributeName
-          for {
-            _ <- validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName)
-            rowsUpdated <- dataAccess
-              .entityAttributeShardQuery(workspaceContext)
-              .renameAttribute(workspaceContext, entityType, oldAttributeName, newAttributeName)
-            _ = validateRowsUpdated(rowsUpdated, oldAttributeName)
-          } yield rowsUpdated
-        }
-      }
+      for {
+        workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
+                                                                SamWorkspaceActions.write,
+                                                                Some(WorkspaceAttributeSpecs(all = false))
+        )
+        entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
+        result <- entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest)
+      } yield result
     }.recover(
       sqlLoggingRecover(s"renameAttribute: $workspaceName $oldAttributeName $attributeRenameRequest")
     )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -6,32 +6,22 @@ import akka.stream.scaladsl.Source
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.bigquery.BigQueryException
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.dataaccess.slick.{DataAccess, EntityAndAttributesResult, ReadAction}
-import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SamDAO, SlickDataSource}
+import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.entities.exceptions.{
   DataEntityException,
   DeleteEntitiesConflictException,
   DeleteEntitiesOfTypeConflictException,
   EntityNotFoundException
 }
-import org.broadinstitute.dsde.rawls.expressions.ExpressionEvaluator
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.{
-  AttributeSupport,
-  AttributeUpdateOperationException,
-  EntitySupport,
-  JsonFilterUtils,
-  WorkspaceSupport
-}
+import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
-import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport, StringValidationUtils}
-import slick.jdbc.{ResultSetConcurrency, ResultSetType, TransactionIsolation}
+import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
 
 import java.sql.SQLException
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 object EntityService {
   def constructor(dataSource: SlickDataSource,
@@ -58,7 +48,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
     with JsonFilterUtils
     with StringValidationUtils {
 
-  import dataSource.dataAccess.driver.api._
   implicit override val errorReportSource: ErrorReportSource = ErrorReportSource("rawls")
 
   // used by WorkspaceSupport - in future refactoring, this can be moved into the constructor for better mocking
@@ -97,7 +86,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         .recover { case _: EntityNotFoundException =>
           // could move this error message into EntityNotFoundException and allow it to bubble up
           throw new RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.NotFound, s"${entityType} ${entityName} does not exist in $workspaceName")
+            ErrorReport(StatusCodes.NotFound, s"$entityType $entityName does not exist in $workspaceName")
           )
         }
         .recover(sqlLoggingRecover(s"getEntity: $workspaceName $entityType/$entityName"))
@@ -153,7 +142,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                            entityType: String,
                            dataReference: Option[DataReferenceName],
                            billingProject: Option[GoogleProjectId]
-  ) =
+  ): Future[Int] =
     getV2WorkspaceContextAndPermissions(workspaceName,
                                         SamWorkspaceActions.write,
                                         Some(WorkspaceAttributeSpecs(all = false))

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.base
 
+import akka.NotUsed
 import akka.stream.scaladsl.Source
 import org.broadinstitute.dsde.rawls.entities.base.ExpressionEvaluationSupport.LookupExpression
 import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsResult
@@ -85,6 +86,8 @@ trait EntityProvider {
   def expressionValidator: ExpressionValidator
 
   def getEntity(entityType: String, entityName: String): Future[Entity]
+
+  def listEntities(entityType: String): Source[Entity, NotUsed]
 
   def queryEntities(entityType: String,
                     query: EntityQuery,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -6,6 +6,8 @@ import org.broadinstitute.dsde.rawls.jobexec.MethodConfigResolver.GatherInputsRe
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model.{
   AttributeEntityReference,
+  AttributeName,
+  AttributeRename,
   AttributeValue,
   Entity,
   EntityCopyResponse,
@@ -13,6 +15,7 @@ import org.broadinstitute.dsde.rawls.model.{
   EntityQueryResponse,
   EntityQueryResultMetadata,
   EntityTypeMetadata,
+  EntityTypeRename,
   RawlsRequestContext,
   SubmissionValidationEntityInputs,
   Workspace
@@ -90,6 +93,15 @@ trait EntityProvider {
                           query: EntityQuery,
                           parentContext: RawlsRequestContext
   ): Future[(EntityQueryResultMetadata, Source[Entity, _])]
+
+  def renameAttribute(entityType: String,
+                      oldAttributeName: AttributeName,
+                      attributeRenameRequest: AttributeRename
+  ): Future[Int]
+
+  def renameEntity(entityType: String, entityName: String, newName: String): Future[Int]
+
+  def renameEntityType(oldName: String, renameInfo: EntityTypeRename): Future[Int]
 
   def updateEntity(entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation]): Future[Entity]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -56,6 +56,8 @@ trait EntityProvider {
 
   def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]]
 
+  def evaluateExpression(entityType: String, entityName: String, expression: String): Future[Seq[AttributeValue]]
+
   /**
   The overall approach is:
         - Parse the input expression using ANTLR Extended JSON parser

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -51,6 +51,8 @@ trait EntityProvider {
 
   def deleteEntitiesOfType(entityType: String): Future[Int]
 
+  def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName]): Future[Unit]
+
   def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]]
 
   /**

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -32,8 +32,10 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.EntityUpdat
 import org.broadinstitute.dsde.rawls.model.{
   AttributeBoolean,
   AttributeEntityReference,
+  AttributeName,
   AttributeNull,
   AttributeNumber,
+  AttributeRename,
   AttributeString,
   AttributeUpdateOperations,
   AttributeValue,
@@ -46,6 +48,7 @@ import org.broadinstitute.dsde.rawls.model.{
   EntityQueryResponse,
   EntityQueryResultMetadata,
   EntityTypeMetadata,
+  EntityTypeRename,
   ErrorReport,
   GoogleProjectId,
   RawlsRequestContext,
@@ -549,8 +552,21 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
   ): Future[EntityCopyResponse] =
     throw new UnsupportedEntityOperationException("copy entities not supported by this provider.")
 
+  override def renameAttribute(entityType: EntityName,
+                               oldAttributeName: AttributeName,
+                               attributeRenameRequest: AttributeRename
+  ): Future[Int] =
+    throw new UnsupportedEntityOperationException("rename attribute not supported by this provider.")
+
+  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName): Future[Int] =
+    throw new UnsupportedEntityOperationException("rename entity not supported by this provider.")
+
+  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename): Future[Int] =
+    throw new UnsupportedEntityOperationException("rename entity type not supported by this provider.")
+
   override def updateEntity(entityType: EntityName,
                             entityName: EntityName,
                             operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation]
   ): Future[Entity] = throw new UnsupportedEntityOperationException("update entity not supported by this provider.")
+
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -289,6 +289,12 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
     buffer.toList
   }
 
+  override def evaluateExpression(entityType: EntityName,
+                                  entityName: EntityName,
+                                  expression: EntityName
+  ): Future[Seq[AttributeValue]] =
+    throw new UnsupportedEntityOperationException("evaluate expression not supported by this provider.")
+
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
                                    gatherInputsResult: GatherInputsResult,
                                    workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.entities.datarepo
 
+import akka.NotUsed
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.Source
 import bio.terra.datarepo.model.{SnapshotModel, TableModel}
@@ -144,6 +145,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       queryResultsToEntity(queryResults, entityType, pk)
     resultIO.unsafeToFuture()
   }
+
+  override def listEntities(entityType: EntityName): Source[Entity, NotUsed] =
+    throw new UnsupportedEntityOperationException("list all entities not supported by this provider.")
 
   override def queryEntitiesSource(entityType: EntityName,
                                    query: EntityQuery,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -112,6 +112,9 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
   override def deleteEntitiesOfType(entityType: String): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities of type not supported by this provider.")
 
+  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName]): Future[Unit] =
+    throw new UnsupportedEntityOperationException("delete entity attributes not supported by this provider.")
+
   override def getEntity(entityType: String, entityName: String): Future[Entity] = {
     // extract table definition, with PK, from snapshot schema
     val tableModel = getTableModel(snapshotModel, entityType)

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -7,7 +7,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.LazyLogging
 import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue}
 import io.opentelemetry.api.common.AttributeKey
-import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   DataAccess,
   EntityAndAttributesResult,
@@ -246,6 +246,44 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
         case _ => DBIO.successful(())
       }
     }
+
+  override def evaluateExpression(entityType: EntityName,
+                                  entityName: EntityName,
+                                  expression: EntityName
+  ): Future[Seq[AttributeValue]] =
+    dataSource.inTransaction(
+      dataAccess =>
+        withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
+          ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
+            evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
+              // parsing failure
+              case Failure(regret) =>
+                throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
+              case Success(valuesByEntity) =>
+                if (valuesByEntity.size != 1) {
+                  // wrong number of entities?!
+                  throw new RawlsException(
+                    s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
+                  )
+                } else {
+                  assert(valuesByEntity.head._1 == entityName)
+                  valuesByEntity.head match {
+                    case (_, Success(result)) => result.toSeq
+                    case (_, Failure(regret)) =>
+                      throw new RawlsExceptionWithErrorReport(
+                        errorReport = ErrorReport(
+                          StatusCodes.BadRequest,
+                          "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
+                          ErrorReport(regret)
+                        )
+                      )
+                  }
+                }
+            }
+          }
+        },
+      TransactionIsolation.ReadCommitted
+    )
 
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
                                    gatherInputsResult: GatherInputsResult,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.LazyLogging
-import io.opencensus.trace.{AttributeValue => OpenCensusAttributeValue}
 import io.opentelemetry.api.common.AttributeKey
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.dataaccess.slick.{
@@ -40,7 +39,6 @@ import org.broadinstitute.dsde.rawls.model.{
   AttributeUpdateOperations,
   AttributeValue,
   Entity,
-  EntityCopyDefinition,
   EntityCopyResponse,
   EntityQuery,
   EntityQueryResponse,
@@ -49,12 +47,9 @@ import org.broadinstitute.dsde.rawls.model.{
   EntityTypeRename,
   ErrorReport,
   RawlsRequestContext,
-  SamResourceTypeNames,
-  SamWorkspaceActions,
   SubmissionValidationEntityInputs,
   SubmissionValidationValue,
-  Workspace,
-  WorkspaceAttributeSpecs
+  Workspace
 }
 import org.broadinstitute.dsde.rawls.util.TracingUtils._
 import org.broadinstitute.dsde.rawls.util.{
@@ -522,8 +517,8 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
-  def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition],
-                              upsert: Boolean
+  private def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition],
+                                      upsert: Boolean
   ): Future[Traversable[Entity]] = {
     val namesToCheck = for {
       update <- entityUpdates

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -612,9 +612,62 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     }
   }
 
-  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName): Future[Int] = ???
+  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName): Future[Int] =
+    dataSource.inTransaction { dataAccess =>
+      withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+        dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName) flatMap {
+          case None => dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName)
+          case Some(_) =>
+            throw new RawlsExceptionWithErrorReport(
+              errorReport =
+                ErrorReport(StatusCodes.Conflict, s"Destination ${entity.entityType} ${newName} already exists")
+            )
+        }
+      }
+    }
 
-  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename): Future[Int] = ???
+  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename): Future[Int] = {
+    def validateExistingType(dataAccess: DataAccess,
+                             workspaceContext: Workspace,
+                             oldName: String
+    ): ReadAction[Boolean] =
+      dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, oldName) map {
+        case Some(true) => true
+        case Some(false) =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.NotFound, s"Can't find entity type ${oldName}")
+          )
+        case None =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.InternalServerError,
+                                      s"Unexpected error; could not determine existence of entity type ${oldName}"
+            )
+          )
+      }
+
+    def validateNewType(dataAccess: DataAccess, workspaceContext: Workspace, newName: String): ReadAction[Boolean] =
+      dataAccess.entityQuery.doesEntityTypeAlreadyExist(workspaceContext, newName) map {
+        case Some(true) =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.Conflict, s"${newName} already exists as an entity type")
+          )
+        case Some(false) => false
+        case None =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.InternalServerError,
+                                      s"Unexpected error; could not determine existence of entity type ${newName}"
+            )
+          )
+      }
+
+    dataSource.inTransaction { dataAccess =>
+      for {
+        _ <- validateNewType(dataAccess, workspaceContext, renameInfo.newName)
+        _ <- validateExistingType(dataAccess, workspaceContext, oldName)
+        renameResult <- dataAccess.entityQuery.changeEntityTypeName(workspaceContext, oldName, renameInfo.newName)
+      } yield renameResult
+    }
+  }
 
   override def updateEntity(entityType: EntityName,
                             entityName: EntityName,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -234,6 +234,19 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
+  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName]): Future[Unit] =
+    dataSource.inTransaction { dataAccess =>
+      dataAccess
+        .entityAttributeShardQuery(workspaceContext)
+        .deleteAttributes(workspaceContext, entityType, attributeNames) flatMap {
+        case Vector(0) =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.BadRequest, s"Could not find any of the given attribute names.")
+          )
+        case _ => DBIO.successful(())
+      }
+    }
+
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
                                    gatherInputsResult: GatherInputsResult,
                                    workspaceExpressionResults: Map[LookupExpression, Try[Iterable[AttributeValue]]]

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -317,6 +317,31 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                              TransactionIsolation.ReadCommitted
     )
 
+  /*
+   * Queries the db for a stream of entity attributes.
+   */
+  private def listEntitiesDbSource(workspaceContext: Workspace,
+                                   entityType: String
+  ): Source[EntityAndAttributesResult, NotUsed] = {
+    // note: ReadCommitted transaction isolation level; forward-only/read-only stream.
+    val allAttrsStream = dataSource.dataAccess.entityQuery
+      .streamActiveEntityAttributesOfType(workspaceContext, entityType)
+      .transactionally
+      .withTransactionIsolation(TransactionIsolation.ReadCommitted)
+      .withStatementParameters(rsType = ResultSetType.ForwardOnly,
+                               rsConcurrency = ResultSetConcurrency.ReadOnly,
+                               fetchSize = dataSource.dataAccess.fetchSize
+      )
+
+    // translate the Slick stream to a Source
+    Source.fromPublisher(dataSource.database.stream(allAttrsStream))
+  }
+
+  override def listEntities(entityType: EntityName): Source[Entity, NotUsed] = {
+    val dbSource = listEntitiesDbSource(workspaceContext, entityType)
+    EntityStreamingUtils.gatherEntities(dataSource, dbSource)
+  }
+
   /**
     * Returns the components needed to stream a EntityQueryResponse to an end user in response to the entityQuery API.
     * This method returns fully materialized metadata (row counts, page size, etc) as EntityQueryResultMetadata, and

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -12,6 +12,7 @@ import org.broadinstitute.dsde.rawls.dataaccess.slick.{
   DataAccess,
   EntityAndAttributesResult,
   EntityRecord,
+  ReadAction,
   ReadWriteAction
 }
 import org.broadinstitute.dsde.rawls.dataaccess.{AttributeTempTableType, SlickDataSource}
@@ -35,6 +36,7 @@ import org.broadinstitute.dsde.rawls.model.{
   Attributable,
   AttributeEntityReference,
   AttributeName,
+  AttributeRename,
   AttributeUpdateOperations,
   AttributeValue,
   Entity,
@@ -44,6 +46,7 @@ import org.broadinstitute.dsde.rawls.model.{
   EntityQueryResponse,
   EntityQueryResultMetadata,
   EntityTypeMetadata,
+  EntityTypeRename,
   ErrorReport,
   RawlsRequestContext,
   SamResourceTypeNames,
@@ -556,6 +559,62 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
         )
       }
     )
+
+  override def renameAttribute(entityType: EntityName,
+                               oldAttributeName: AttributeName,
+                               attributeRenameRequest: AttributeRename
+  ): Future[Int] = {
+    def validateNewAttributeName(dataAccess: DataAccess,
+                                 workspaceContext: Workspace,
+                                 entityType: String,
+                                 attributeName: AttributeName
+    ): ReadAction[Boolean] =
+      dataAccess
+        .entityAttributeShardQuery(workspaceContext)
+        .doesAttributeNameAlreadyExist(workspaceContext, entityType, attributeName) map {
+        case Some(false) => false
+        case Some(true) =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport =
+              ErrorReport(StatusCodes.Conflict,
+                          s"${AttributeName.toDelimitedName(attributeName)} already exists as an attribute name"
+              )
+          )
+        case None =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(
+              StatusCodes.InternalServerError,
+              s"Unexpected error; could not determine existence of attribute name ${AttributeName.toDelimitedName(attributeName)}"
+            )
+          )
+      }
+
+    def validateRowsUpdated(rowsUpdated: Int, oldAttributeName: AttributeName): Boolean =
+      rowsUpdated match {
+        case 0 =>
+          throw new RawlsExceptionWithErrorReport(
+            errorReport = ErrorReport(StatusCodes.NotFound,
+                                      s"Can't find attribute name ${AttributeName.toDelimitedName(oldAttributeName)}"
+            )
+          )
+        case _ => true
+      }
+
+    dataSource.inTransaction { dataAccess =>
+      val newAttributeName = attributeRenameRequest.newAttributeName
+      for {
+        _ <- validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName)
+        rowsUpdated <- dataAccess
+          .entityAttributeShardQuery(workspaceContext)
+          .renameAttribute(workspaceContext, entityType, oldAttributeName, newAttributeName)
+        _ = validateRowsUpdated(rowsUpdated, oldAttributeName)
+      } yield rowsUpdated
+    }
+  }
+
+  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName): Future[Int] = ???
+
+  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename): Future[Int] = ???
 
   override def updateEntity(entityType: EntityName,
                             entityName: EntityName,


### PR DESCRIPTION
Ticket: CORE-360

Move all implementations from `EntityService` to an `EntityProvider`:
* deleteEntityAttributes()
* evaluateExpression()
* listEntities()
* renameAttribute()
* renameEntity()
* renameEntityType()
