### PR TITLE
[CORE-379] Allow longer billing project names and name workspace Google projects after workspace name only

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -123,7 +123,7 @@ class WorkspaceApiSpec
 
       // verify display name (starts with namespace, ends with name, limited to 30 chars)
       val maybeDisplayName = googleProjectDao.getProjectName(createdWorkspaceGoogleProject.value).futureValue
-      maybeDisplayName.getOrElse("") should startWith(createdWorkspaceResponse.workspace.name)
+      maybeDisplayName.getOrElse("") should be(createdWorkspaceResponse.workspace.name.take(30))
 
       // verify labels exist and that we didn't accidentally forget the buffer labels
       val bufferLabels = Map("vpc-network-name" -> "network", "vpc-subnetwork-name" -> "subnetwork")

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/WorkspaceApiSpec.scala
@@ -123,7 +123,7 @@ class WorkspaceApiSpec
 
       // verify display name (starts with namespace, ends with name, limited to 30 chars)
       val maybeDisplayName = googleProjectDao.getProjectName(createdWorkspaceGoogleProject.value).futureValue
-      maybeDisplayName.getOrElse("") should startWith(createdWorkspaceResponse.workspace.namespace)
+      maybeDisplayName.getOrElse("") should startWith(createdWorkspaceResponse.workspace.name)
 
       // verify labels exist and that we didn't accidentally forget the buffer labels
       val bufferLabels = Map("vpc-network-name" -> "network", "vpc-subnetwork-name" -> "subnetwork")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceService.scala
@@ -1704,7 +1704,7 @@ class WorkspaceService(
                                         ""
         )
 
-        googleProjectName = gcsDAO.googleProjectNameSafeString(s"${workspaceName.namespace}--${workspaceName.name}")
+        googleProjectName = gcsDAO.googleProjectNameSafeString(workspaceName.name)
         // RBS projects already come with some labels so combine them to not lose the old ones
         labels = Option(googleProject.getLabels).map(_.asScala).getOrElse(Map.empty) ++ newLabels
         updatedProject = googleProject.setName(googleProjectName).setLabels(labels.toMap.asJava)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -444,7 +444,7 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglong"),
+        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"),
                                                Option(services.gcsDAO.accessibleBillingAccountName),
                                                None,
                                                None,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -444,12 +444,13 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     services =>
       Post(
         "/billing/v2",
-        CreateRawlsV2BillingProjectFullRequest(RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"),
-                                               Option(services.gcsDAO.accessibleBillingAccountName),
-                                               None,
-                                               None,
-                                               None,
-                                               None
+        CreateRawlsV2BillingProjectFullRequest(
+          RawlsBillingProjectName("longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong"),
+          Option(services.gcsDAO.accessibleBillingAccountName),
+          None,
+          None,
+          None,
+          None
         )
       ) ~>
         sealRoute(services.billingRoutesV2()) ~>

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/workspace/WorkspaceServiceSpec.scala
@@ -1701,7 +1701,7 @@ class WorkspaceServiceSpec
         captor.getValue
           .asInstanceOf[Project] // Explicit cast needed since Scala type interference and capturing parameters with Mockito don't play nicely together here
 
-      val expectedProjectName = "short--NS1--plus Long- name to"
+      val expectedProjectName = "plus Long- name to get past 30"
       val actualProjectName = capturedProject.getName
       actualProjectName shouldBe expectedProjectName
   }

--- a/model/src/main/scala/org/broadinstitute/dsde/rawls/StringValidationUtils.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/rawls/StringValidationUtils.scala
@@ -40,8 +40,8 @@ trait StringValidationUtils {
   def validateEntityName(s: String): Unit =
     if (!entityNameRegex.pattern.matcher(s).matches) {
       val msg =
-        s"""Invalid entity name: $s. Input may only contain alphanumeric characters, underscores, dashes, and periods. 
-            If importing a snapshot, making an API call, uploading a TSV, or adding a new row from the Terra UI, 
+        s"""Invalid entity name: $s. Input may only contain alphanumeric characters, underscores, dashes, and periods.
+            If importing a snapshot, making an API call, uploading a TSV, or adding a new row from the Terra UI,
             please modify the impacted name(s) and try again.""".stripMargin
       throw new RawlsExceptionWithErrorReport(
         errorReport = ErrorReport(message = msg, statusCode = StatusCodes.BadRequest)
@@ -66,11 +66,11 @@ trait StringValidationUtils {
       )
     }
 
-  private lazy val billingProjectNameRegex = "[A-z0-9_-]{6,30}".r
+  private lazy val billingProjectNameRegex = "[A-z0-9_-]{6,60}".r
   def validateBillingProjectName(s: String): Future[Unit] =
     if (!billingProjectNameRegex.pattern.matcher(s).matches) {
       val msg =
-        s"Invalid name for billing project. Input must be between 6 and 30 characters in length and may only contain alphanumeric characters, underscores, and dashes."
+        s"Invalid name for billing project. Input must be between 6 and 60 characters in length and may only contain alphanumeric characters, underscores, and dashes."
       Future.failed(
         new RawlsExceptionWithErrorReport(errorReport = ErrorReport(message = msg, statusCode = StatusCodes.BadRequest))
       )


### PR DESCRIPTION
Ticket: [CORE-379(https://broadworkbench.atlassian.net/browse/CORE-379)
* Allow billing project names to be 60 characters
* Use workspace name truncated to 30 characters for Google project name instead of the old format of `{workspaceNamespace}--{workspaceName}`

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
