### PR TITLE
[CORE-392] Add verifyBillingProjectAction API

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -269,6 +269,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Project does not exist or user does not have permission to view it
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -250,6 +250,27 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           $ref: '#/components/responses/RawlsInternalError'
+  /api/billing/v2/id/{projectUuid}/verifyAction/{action}:
+    get:
+      tags:
+        - billing_v2
+      summary: check if user can perform action on billing project
+      description: check if user can perform action on billing project
+      operationId: verifyBillingProjectAction
+      parameters:
+        - $ref: '#/components/parameters/billingProjectUuidPathParam'
+        - $ref: '#/components/parameters/billingProjectActionPathParam'
+      responses:
+        200:
+          description: OK
+        403:
+          description: User does not have permission to perform action or project does not exist
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /api/billing/v2/{projectId}:
     get:
       tags:
@@ -7285,6 +7306,13 @@ components:
           description: objects that this job has transferred so far
           type: integer
   parameters:
+    billingProjectActionPathParam:
+      name: action
+      in: path
+      description: Action to take on the billing project
+      required: true
+      schema:
+        type: string
     billingProjectUuidPathParam:
         name: projectUuid
         in: path

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -600,6 +600,15 @@ class UserService(
       case ProjectRoles.User  => SamBillingProjectPolicyNames.workspaceCreator
     }
 
+  def verifyBillingProjectAccess(projectUuid: UUID, action: SamResourceAction): Future[Boolean] =
+    for {
+      billingProject <- billingRepository.getBillingProjectById(projectUuid)
+      userHasAction <- billingProject match {
+        case Some(bp) => samDAO.userHasAction(SamResourceTypeNames.billingProject, bp.projectName.value, action, ctx)
+        case None     => Future.successful(false)
+      }
+    } yield userHasAction
+
   def addUserToBillingProject(projectName: RawlsBillingProjectName,
                               projectAccessUpdate: ProjectAccessUpdate
   ): Future[Unit] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/user/UserService.scala
@@ -600,14 +600,17 @@ class UserService(
       case ProjectRoles.User  => SamBillingProjectPolicyNames.workspaceCreator
     }
 
-  def verifyBillingProjectAccess(projectUuid: UUID, action: SamResourceAction): Future[Boolean] =
+  def verifyBillingProjectAccess(projectUuid: UUID, action: SamResourceAction): Future[Option[Boolean]] =
     for {
       billingProject <- billingRepository.getBillingProjectById(projectUuid)
-      userHasAction <- billingProject match {
-        case Some(bp) => samDAO.userHasAction(SamResourceTypeNames.billingProject, bp.projectName.value, action, ctx)
-        case None     => Future.successful(false)
+      userActions <- billingProject match {
+        case Some(bp) =>
+          samDAO
+            .listUserActionsForResource(SamResourceTypeNames.billingProject, bp.projectName.value, ctx)
+            .map(Option(_))
+        case None => Future.successful(None)
       }
-    } yield userHasAction
+    } yield userActions.filter(_.nonEmpty).map(_.contains(action))
 
   def addUserToBillingProject(projectName: RawlsBillingProjectName,
                               projectAccessUpdate: ProjectAccessUpdate

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -78,9 +78,10 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
                     complete {
                       userServiceConstructor(ctx)
                         .verifyBillingProjectAccess(UUID.fromString(id), SamResourceAction(action))
-                        .map { userHasAction =>
-                          if (userHasAction) StatusCodes.OK -> None
-                          else StatusCodes.Forbidden -> None
+                        .map {
+                          case Some(true)  => StatusCodes.OK -> None
+                          case Some(false) => StatusCodes.Forbidden -> None
+                          case None        => StatusCodes.NotFound -> None
                         }
                     }
                   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2.scala
@@ -61,15 +61,31 @@ trait BillingApiServiceV2 extends UserInfoDirectives {
       val ctx = RawlsRequestContext(userInfo, Option(otelContext))
       pathPrefix("billing" / "v2") {
         pathPrefix("id") {
-          path(Segment) { id =>
-            get {
-              complete {
-                userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
-                  case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
-                  case None                  => StatusCodes.NotFound -> None
+          pathPrefix(Segment) { id =>
+            pathEndOrSingleSlash {
+              get {
+                complete {
+                  userServiceConstructor(ctx).getBillingProjectById(UUID.fromString(id)).map {
+                    case Some(projectResponse) => StatusCodes.OK -> Option(projectResponse)
+                    case None                  => StatusCodes.NotFound -> None
+                  }
                 }
               }
-            }
+            } ~
+              pathPrefix("verifyAction") {
+                path(Segment) { action =>
+                  get {
+                    complete {
+                      userServiceConstructor(ctx)
+                        .verifyBillingProjectAccess(UUID.fromString(id), SamResourceAction(action))
+                        .map { userHasAction =>
+                          if (userHasAction) StatusCodes.OK -> None
+                          else StatusCodes.Forbidden -> None
+                        }
+                    }
+                  }
+                }
+              }
           }
         } ~
           pathPrefix("spendReport") {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -24,7 +24,7 @@ import org.broadinstitute.dsde.rawls.serviceperimeter.ServicePerimeterServiceImp
 import org.broadinstitute.dsde.workbench.dataaccess.NotificationDAO
 import org.broadinstitute.dsde.workbench.model.google.{BigQueryDatasetName, BigQueryTableName, GoogleProject}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -1674,6 +1674,58 @@ class UserServiceSpec
 
     Await.result(userService.listBillingProjectsV2(), Duration.Inf) should contain theSameElementsAs expected
     verify(repository).getBillingProjects(ArgumentMatchers.eq(Set(ownerProject.projectName, userProject.projectName)))
+  }
+
+  behavior of "verifyBillingProjectAccess"
+
+  it should "return true if Sam says the user has requested action on the billing project" in {
+    val billingProject = billingProjectFromName("projectName")
+    val action = SamResourceAction("action")
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    when(billingRepository.getBillingProjectById(billingProject.id))
+      .thenReturn(Future.successful(Option(billingProject)))
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(
+      samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
+                           mockitoEq(billingProject.projectName.value),
+                           mockitoEq(action),
+                           any()
+      )
+    )
+      .thenReturn(Future.successful(true))
+    val userService = getUserService(billingRepository = Option(billingRepository), samDAO = samDAO)
+
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual true
+  }
+
+  it should "return false if Sam says the user doesn't have requested action on the billing project" in {
+    val billingProject = billingProjectFromName("projectName")
+    val action = SamResourceAction("action")
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    when(billingRepository.getBillingProjectById(billingProject.id))
+      .thenReturn(Future.successful(Option(billingProject)))
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(
+      samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
+                           mockitoEq(billingProject.projectName.value),
+                           mockitoEq(action),
+                           any()
+      )
+    )
+      .thenReturn(Future.successful(false))
+    val userService = getUserService(billingRepository = Option(billingRepository), samDAO = samDAO)
+
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual false
+  }
+
+  it should "return false if the billing project doesn't exist" in {
+    val billingProject = billingProjectFromName("projectName")
+    val action = SamResourceAction("action")
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    when(billingRepository.getBillingProjectById(billingProject.id)).thenReturn(Future.successful(None))
+    val userService = getUserService(billingRepository = Option(billingRepository))
+
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual false
   }
 
   behavior of "addUserToBillingProjectV2"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/user/UserServiceSpec.scala
@@ -1678,7 +1678,7 @@ class UserServiceSpec
 
   behavior of "verifyBillingProjectAccess"
 
-  it should "return true if Sam says the user has requested action on the billing project" in {
+  it should "return Some(true) if Sam says the user has requested action on the billing project" in {
     val billingProject = billingProjectFromName("projectName")
     val action = SamResourceAction("action")
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
@@ -1686,19 +1686,18 @@ class UserServiceSpec
       .thenReturn(Future.successful(Option(billingProject)))
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(
-      samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
-                           mockitoEq(billingProject.projectName.value),
-                           mockitoEq(action),
-                           any()
+      samDAO.listUserActionsForResource(mockitoEq(SamResourceTypeNames.billingProject),
+                                        mockitoEq(billingProject.projectName.value),
+                                        any()
       )
     )
-      .thenReturn(Future.successful(true))
+      .thenReturn(Future.successful(Set(action)))
     val userService = getUserService(billingRepository = Option(billingRepository), samDAO = samDAO)
 
-    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual true
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual Some(true)
   }
 
-  it should "return false if Sam says the user doesn't have requested action on the billing project" in {
+  it should "return Some(false) if Sam says the user doesn't have requested action on the billing project but has some actions" in {
     val billingProject = billingProjectFromName("projectName")
     val action = SamResourceAction("action")
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
@@ -1706,26 +1705,46 @@ class UserServiceSpec
       .thenReturn(Future.successful(Option(billingProject)))
     val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
     when(
-      samDAO.userHasAction(mockitoEq(SamResourceTypeNames.billingProject),
-                           mockitoEq(billingProject.projectName.value),
-                           mockitoEq(action),
-                           any()
+      samDAO.listUserActionsForResource(mockitoEq(SamResourceTypeNames.billingProject),
+                                        mockitoEq(billingProject.projectName.value),
+                                        any()
       )
     )
-      .thenReturn(Future.successful(false))
+      .thenReturn(Future.successful(Set(SamResourceAction("otherAction"))))
     val userService = getUserService(billingRepository = Option(billingRepository), samDAO = samDAO)
 
-    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual false
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual Some(
+      false
+    )
   }
 
-  it should "return false if the billing project doesn't exist" in {
+  it should "return None if the billing project exists but the user doesn't have any actions on it" in {
+    val billingProject = billingProjectFromName("projectName")
+    val action = SamResourceAction("action")
+    val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
+    when(billingRepository.getBillingProjectById(billingProject.id))
+      .thenReturn(Future.successful(Option(billingProject)))
+    val samDAO = mock[SamDAO](RETURNS_SMART_NULLS)
+    when(
+      samDAO.listUserActionsForResource(mockitoEq(SamResourceTypeNames.billingProject),
+                                        mockitoEq(billingProject.projectName.value),
+                                        any()
+      )
+    )
+      .thenReturn(Future.successful(Set.empty))
+    val userService = getUserService(billingRepository = Option(billingRepository), samDAO = samDAO)
+
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual None
+  }
+
+  it should "return None if the billing project doesn't exist" in {
     val billingProject = billingProjectFromName("projectName")
     val action = SamResourceAction("action")
     val billingRepository = mock[BillingRepository](RETURNS_SMART_NULLS)
     when(billingRepository.getBillingProjectById(billingProject.id)).thenReturn(Future.successful(None))
     val userService = getUserService(billingRepository = Option(billingRepository))
 
-    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual false
+    Await.result(userService.verifyBillingProjectAccess(billingProject.id, action), Duration.Inf) shouldEqual None
   }
 
   behavior of "addUserToBillingProjectV2"

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -974,13 +974,12 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       val project = createProject("projectName")
       val action = "link"
       when(
-        services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-                                      ArgumentMatchers.eq("projectName"),
-                                      ArgumentMatchers.eq(SamResourceAction(action)),
-                                      any()
+        services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                                   ArgumentMatchers.eq("projectName"),
+                                                   any()
         )
       )
-        .thenReturn(Future.successful(true))
+        .thenReturn(Future.successful(Set(SamResourceAction(action))))
 
       Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
         sealRoute(services.billingRoutesV2()) ~> check {
@@ -994,13 +993,12 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
     val project = createProject("projectName")
     val action = "link"
     when(
-      services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
-                                    ArgumentMatchers.eq("projectName"),
-                                    ArgumentMatchers.eq(SamResourceAction(action)),
-                                    any()
+      services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                                 ArgumentMatchers.eq("projectName"),
+                                                 any()
       )
     )
-      .thenReturn(Future.successful(false))
+      .thenReturn(Future.successful(Set(SamResourceAction("notLink"))))
 
     Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
       sealRoute(services.billingRoutesV2()) ~> check {
@@ -1008,6 +1006,32 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
           status
         }
       }
+  }
+
+  it should "return 404 if user has no access to project or project does not exist" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("projectName")
+      val action = "link"
+      when(
+        services.samDAO.listUserActionsForResource(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                                   ArgumentMatchers.eq("projectName"),
+                                                   any()
+        )
+      ).thenReturn(Future.successful(Set.empty))
+
+      Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
+        sealRoute(services.billingRoutesV2()) ~> check {
+          assertResult(StatusCodes.NotFound, responseAs[String]) {
+            status
+          }
+        }
+
+      Get(s"/billing/v2/id/${UUID.randomUUID()}/verifyAction/$action") ~>
+        sealRoute(services.billingRoutesV2()) ~> check {
+          assertResult(StatusCodes.NotFound, responseAs[String]) {
+            status
+          }
+        }
   }
 
   "DELETE /billing/v2/{projectName}" should "return 204 - deleting google project" in withEmptyDatabaseAndApiServices {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
+import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime
@@ -964,6 +965,47 @@ class BillingApiServiceV2Spec extends ApiServiceSpec with MockitoSugar {
       sealRoute(services.billingRoutesV2()) ~>
       check {
         assertResult(StatusCodes.NotFound, responseAs[String]) {
+          status
+        }
+      }
+  }
+
+  "GET /billing/v2/id/{projectId}/verifyAction/{action}" should "return 200 if user has requested action" in withEmptyDatabaseAndApiServices {
+    services =>
+      val project = createProject("projectName")
+      val action = "link"
+      when(
+        services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                      ArgumentMatchers.eq("projectName"),
+                                      ArgumentMatchers.eq(SamResourceAction(action)),
+                                      any()
+        )
+      )
+        .thenReturn(Future.successful(true))
+
+      Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
+        sealRoute(services.billingRoutesV2()) ~> check {
+          assertResult(StatusCodes.OK, responseAs[String]) {
+            status
+          }
+        }
+  }
+
+  it should "return 403 if user does not have requested action" in withEmptyDatabaseAndApiServices { services =>
+    val project = createProject("projectName")
+    val action = "link"
+    when(
+      services.samDAO.userHasAction(ArgumentMatchers.eq(SamResourceTypeNames.billingProject),
+                                    ArgumentMatchers.eq("projectName"),
+                                    ArgumentMatchers.eq(SamResourceAction(action)),
+                                    any()
+      )
+    )
+      .thenReturn(Future.successful(false))
+
+    Get(s"/billing/v2/id/${project.id}/verifyAction/$action") ~>
+      sealRoute(services.billingRoutesV2()) ~> check {
+        assertResult(StatusCodes.Forbidden, responseAs[String]) {
           status
         }
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/webservice/BillingApiServiceV2Spec.scala
@@ -16,7 +16,6 @@ import org.broadinstitute.dsde.rawls.google.MockGooglePubSubDAO
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.openam.MockUserInfoDirectives
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService
-import org.broadinstitute.dsde.rawls.user.UserService
 import org.broadinstitute.dsde.rawls.{model, RawlsException, RawlsExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.joda.time.DateTime


### PR DESCRIPTION
Ticket: [CORE-392](https://broadworkbench.atlassian.net/browse/CORE-392)
* add API to verify that the user has requested action on a billing project given its id

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-392]: https://broadworkbench.atlassian.net/browse/CORE-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ