### PR TITLE
CORE-406: bucket usage valueInBytes should be a whole number

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAO.scala
@@ -1119,7 +1119,7 @@ class HttpGoogleServicesDAO(val clientSecrets: GoogleClientSecrets,
   ): BucketMetricsResponse = {
     val metrics = ltspResponse.iterateAll().asScala.toSeq.flatMap { timeSeries =>
       timeSeries.getPointsList.asScala.map { point =>
-        BucketMetric(timeSeries.getMetric.getLabelsMap.get("storage_class"), point.getValue.getDoubleValue)
+        BucketMetric(timeSeries.getMetric.getLabelsMap.get("storage_class"), Math.round(point.getValue.getDoubleValue))
       }
     }
     BucketMetricsResponse(metrics)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -291,8 +291,8 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with MockitoTe
     val response = httpGoogleServicesDao.listTimeSeriesPagedResponseToBucketMetricsResponse(mockResponse)
     response.metrics.length shouldBe 2
     val expectedMetrics = Set(
-      BucketMetric("COLDLINE", 123.45),
-      BucketMetric("REGIONAL", 5432.1)
+      BucketMetric("COLDLINE", 123),
+      BucketMetric("REGIONAL", 5432)
     )
     response.metrics.toSet shouldBe expectedMetrics
   }


### PR DESCRIPTION
Ticket: <Link to Jira ticket>

Rounds the `valueInBytes` values in the `GET /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/bucketUsage` API. Our OpenAPI spec declares these are integers, so this PR makes that true. It still uses a Double internally to the code, but rounds that double so it comes across as an integer in json.

Response from this PR:
```json
{
  "metrics": [
    {
      "storageClass": "MULTI_REGIONAL",
      "valueInBytes": 127889799
    },
    {
      "storageClass": "MULTI_REGIONAL",
      "valueInBytes": 122818784
    },
    {
      "storageClass": "MULTI_REGIONAL",
      "valueInBytes": 13660
    }
  ]
}
```

Response from mainline `dev` branch:
```json
{
  "metrics": [
    {
      "storageClass": "MULTI_REGIONAL",
      "valueInBytes": 127889799
    },
    {
      "storageClass": "MULTI_REGIONAL",
      "valueInBytes": 122818784.42307693
    },
    {
      "storageClass": "MULTI_REGIONAL",
      "valueInBytes": 13660
    }
  ]
}
```



---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
