### PR TITLE
CORE-291: extract getCachedSpendReportData method from consolidated spend report

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -422,6 +422,49 @@ class SpendReportingService(
     bytesProcessedCounter += stats.getEstimatedBytesProcessed
   }
 
+  case class CachedSpendReportingResults(isCacheValid: Boolean, results: Option[SpendReportingResults])
+
+  /**
+    * Query the spend report cache and inspect the cache results to see if they are valid.
+    * @param workspaceNamesByProjectId workspaces/project for which to query
+    * @param start beginning of report timeframe
+    * @param end end of report timeframe
+    * @return potentially-valid cache results
+    */
+  def getCachedSpendReportData(workspaceNamesByProjectId: Map[GoogleProjectId, WorkspaceName],
+                               start: DateTime,
+                               end: DateTime
+  ): Future[CachedSpendReportingResults] = {
+    // set up
+    val startLocalDateTime = SpendReportUtils.convertJodaToJava(Some(start))
+    val endLocalDateTime = SpendReportUtils.convertJodaToJava(Some(end))
+    val projectIds = workspaceNamesByProjectId.keySet.map(_.value)
+
+    // query the cache for possible results
+    val cachedResultsFuture =
+      workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
+
+    cachedResultsFuture.map { cachedResult =>
+      // we consider cached results valid if they return one row for each
+      // requested google project
+      if (cachedResult.size == projectIds.size) {
+        // we may have cached that some projects have no data in this report;
+        // handle those cases
+        val hasDataAvailable = cachedResult.filter(cached => cached.isDataAvailable)
+        if (hasDataAvailable.nonEmpty) {
+          val spendReportingResults =
+            WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable, start, end, workspaceNamesByProjectId)
+          CachedSpendReportingResults(isCacheValid = true, Option(spendReportingResults))
+        } else {
+          CachedSpendReportingResults(isCacheValid = true, None)
+        }
+      } else {
+        // cached results are not valid for these projects/this timeframe
+        CachedSpendReportingResults(isCacheValid = false, None)
+      }
+    }
+  }
+
   // shared between single-project and consolidated reports
   def getSpendReportableWorkspaceGoogleProjects(
     childContext: RawlsRequestContext
@@ -559,8 +602,6 @@ class SpendReportingService(
           )
         }
 
-        startLocalDateTime = SpendReportUtils.convertJodaToJava(Some(start))
-        endLocalDateTime = SpendReportUtils.convertJodaToJava(Some(end))
         // find the distinct export table names in our billingMap
         distinctTableNames: Set[Option[String]] = billingMap.keys.map(_.spendExportTable).toSet
         // for each distinct export table name, generate a query.
@@ -581,27 +622,15 @@ class SpendReportingService(
           val workspaceNamesByProjectId: Map[GoogleProjectId, WorkspaceName] = billingMapForQuery.values.flatten
             .map(ws => ws.googleProjectId -> ws.toWorkspaceName)
             .toMap
-          val projectIds = workspaceNamesByProjectId.keySet.map(_.value)
-          val cachedResults =
-            workspaceSpendReportRepository.getWorkspaceSpendReports(projectIds, startLocalDateTime, endLocalDateTime)
-          val spendResults = cachedResults.flatMap { cachedResult =>
-            if (cachedResult.size == projectIds.size) {
+
+          // look for results in cache
+          val spendResults = getCachedSpendReportData(workspaceNamesByProjectId, start, end).flatMap { cachedResults =>
+            if (cachedResults.isCacheValid) {
+              // we have valid cache results; use them
               rawlsCacheHitRate().hit()
-              val hasDataAvailable = cachedResult.filter(cached => cached.isDataAvailable)
-              if (hasDataAvailable.nonEmpty) {
-                val spendReportingResults =
-                  WorkspaceSpendReportRecord.toSpendReportingResults(hasDataAvailable,
-                                                                     start,
-                                                                     end,
-                                                                     workspaceNamesByProjectId
-                  )
-                Future.successful(
-                  Some(spendReportingResults)
-                )
-              } else {
-                Future.successful(None)
-              }
+              Future.successful(cachedResults.results)
             } else {
+              // cached results are invalid; ask BigQuery for results
               rawlsCacheHitRate().miss()
               val query = getAllUserWorkspaceQuery(tableNameForQuery, billingProjectsByAccount, pageSize, offset)
               val queryJob = setUpAllUserWorkspaceQuery(query, start, end)
@@ -620,6 +649,7 @@ class SpendReportingService(
                   logger.warn(s"Error fetching results from BigQuery: ${ex.getMessage}")
                   Future.successful(None)
                 }
+              // write BigQuery results back to cache
               queryResults.map { res =>
                 insertRecordsWithMissingSpendData(res, workspaceNamesByProjectId, start, end)
               }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -2208,7 +2208,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     verify(mockWorkspaceSpendReportRepository, times(1)).insertWorkspaceSpendReport(spendReport2)
   }
 
-  "insertRecordsWithMissingSpendData" should "not insert additional records when all spend data is available" in {
+  it should "not insert additional records when all spend data is available" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
     val mockWorkspaceSpendReportRepository = mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
@@ -2280,7 +2280,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     verifyNoInteractions(mockWorkspaceSpendReportRepository)
   }
 
-  "insertRecordsWithMissingSpendData" should "handle errors when inserting a record" in {
+  it should "handle errors when inserting a record" in {
     val samDAO = mock[SamDAO]
     val workspaceService = mock[WorkspaceService]
 
@@ -2355,6 +2355,246 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         result shouldBe Future.successful(0L)
       }
     }
+  }
+
+  behavior of "getCachedSpendReportData"
+
+  private def setUpCacheTestReturning(returns: Seq[WorkspaceSpendReport]): SpendReportingService = {
+    val samDAO = mock[SamDAO]
+    val workspaceService = mock[WorkspaceService]
+
+    val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+      mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+    // cache returns results for only 1 project
+    when(mockWorkspaceSpendReportRepository.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(returns))
+
+    new SpendReportingService(
+      testContext,
+      mock[SlickDataSource],
+      Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+      mock[BillingRepository],
+      mock[BillingProfileManagerDAO],
+      samDAO,
+      spendReportingServiceConfig,
+      _ => workspaceService,
+      mockWorkspaceSpendReportRepository
+    )
+  }
+
+  it should "return valid if results match requested projects" in {
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+
+    val mockReturn = Seq(
+      WorkspaceSpendReport(1,
+                           projectId1.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = true,
+                           Option(1.2f),
+                           Option(2.3f),
+                           Option(4.5f),
+                           Option(6.7f),
+                           Option(8.9f),
+                           Option(0.1f)
+      ),
+      WorkspaceSpendReport(1,
+                           projectId2.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = true,
+                           Option(2.1f),
+                           Option(3.2f),
+                           Option(5.4f),
+                           Option(7.6f),
+                           Option(9.8f),
+                           Option(1.0f)
+      )
+    )
+    // cache returns two projects; we are requesting two
+    val service = setUpCacheTestReturning(mockReturn)
+    val actual = Await.result(service.getCachedSpendReportData(projectNames, from, to), Duration.Inf)
+    actual.isCacheValid shouldBe true
+    actual.results should not be empty
+  }
+
+  it should "return valid if results match requested projects but some data isn't available" in {
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+
+    val mockReturn = Seq(
+      WorkspaceSpendReport(1,
+                           projectId1.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = true,
+                           Option(1.2f),
+                           Option(2.3f),
+                           Option(4.5f),
+                           Option(6.7f),
+                           Option(8.9f),
+                           Option(0.1f)
+      ),
+      WorkspaceSpendReport(1,
+                           projectId2.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = false,
+                           Option(2.1f),
+                           Option(3.2f),
+                           Option(5.4f),
+                           Option(7.6f),
+                           Option(9.8f),
+                           Option(1.0f)
+      )
+    )
+    // cache returns two projects, one with isDataAvailable=false; we are requesting two
+    val service = setUpCacheTestReturning(mockReturn)
+    val actual = Await.result(service.getCachedSpendReportData(projectNames, from, to), Duration.Inf)
+    actual.isCacheValid shouldBe true
+    actual.results should not be empty
+  }
+
+  it should "return valid but empty if results match requested projects but no data found" in {
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+
+    val mockReturn = Seq(
+      WorkspaceSpendReport(1,
+                           projectId1.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = false,
+                           Option(1.2f),
+                           Option(2.3f),
+                           Option(4.5f),
+                           Option(6.7f),
+                           Option(8.9f),
+                           Option(0.1f)
+      ),
+      WorkspaceSpendReport(1,
+                           projectId2.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = false,
+                           Option(2.1f),
+                           Option(3.2f),
+                           Option(5.4f),
+                           Option(7.6f),
+                           Option(9.8f),
+                           Option(1.0f)
+      )
+    )
+    // cache returns two projects with isDataAvailable=false; we are requesting two
+    val service = setUpCacheTestReturning(mockReturn)
+    val actual = Await.result(service.getCachedSpendReportData(projectNames, from, to), Duration.Inf)
+    actual.isCacheValid shouldBe true
+    actual.results shouldBe empty
+  }
+
+  it should "return invalid if results don't match requested projects" in {
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+
+    val mockReturn = Seq(
+      WorkspaceSpendReport(1,
+                           projectId1.value,
+                           startDate,
+                           endDate,
+                           "USD",
+                           isDataAvailable = true,
+                           Option(1.2f),
+                           Option(2.3f),
+                           Option(4.5f),
+                           Option(6.7f),
+                           Option(8.9f),
+                           Option(0.1f)
+      )
+    )
+
+    val service = setUpCacheTestReturning(mockReturn)
+
+    val actual = Await.result(service.getCachedSpendReportData(projectNames, from, to), Duration.Inf)
+    actual.isCacheValid shouldBe false
+  }
+
+  it should "return invalid if nothing in cache" in {
+    val projectId1 = GoogleProjectId("workspace1ProjectId")
+    val projectId2 = GoogleProjectId("workspace2ProjectId")
+
+    val projectNames = Map(projectId1 -> WorkspaceName("billingProject1", "workspace2Billing1"),
+                           projectId2 -> WorkspaceName("billingProject2", "workspace2Billing2")
+    )
+
+    val from = DateTime.now().minusMonths(2)
+    val to = from.plusMonths(1)
+
+    val startDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(from.getMillis), ZoneId.systemDefault())
+    val endDate: LocalDateTime =
+      LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(to.getMillis), ZoneId.systemDefault())
+
+    val mockReturn = Seq()
+
+    val service = setUpCacheTestReturning(mockReturn)
+
+    val actual = Await.result(service.getCachedSpendReportData(projectNames, from, to), Duration.Inf)
+    actual.isCacheValid shouldBe false
   }
 
 }


### PR DESCRIPTION
Ticket: CORE-291

No functional changes. This is a refactor that pulls out some reusable logic out of the consolidated spend report into a new `getCachedSpendReportData()` method. In a future PR, I'll make use of that new method in the per-project spend report.

