### PR TITLE
CORE-291: per-project spend reports support caching

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -492,6 +492,26 @@ class SpendReportingService(
     Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)))
       .equals(aggregations)
 
+  /* reusable method to retrieve per-project spend report from BQ */
+  private def getSpendForGCPBillingProjectFromBigQuery(
+    aggregations: Set[SpendReportingAggregationKeyWithSub],
+    spendExportConf: BillingProjectSpendExport,
+    start: DateTime,
+    end: DateTime,
+    projectNames: Map[GoogleProjectId, WorkspaceName],
+    childContext: RawlsRequestContext
+  ): Future[Option[SpendReportingResults]] = {
+    val query = getQuery(aggregations, spendExportConf)
+    val queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
+
+    runBigQueryJob(queryJob, childContext).map { result =>
+      result.getValues.asScala.toList match {
+        case Nil  => None
+        case rows => Option(extractSpendReportingResults(rows, start, end, projectNames, aggregations))
+      }
+    }
+  }
+
   // single-project report: step 3
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
@@ -501,6 +521,8 @@ class SpendReportingService(
   ): Future[SpendReportingResults] = traceFutureWithParent("getSpendForGCPBillingProject", ctx) { childContext =>
     validateReportParameters(start, end)
     for {
+      // retrieve spend export configuration for this BP
+      // and the Google projects/workspaces in this BP
       spendExportConf <- getSpendExportConfiguration(project)
       projectNames <- getSpendReportableWorkspaceGoogleProjects(ctx).map { workspacesByProject =>
         workspacesByProject
@@ -510,7 +532,6 @@ class SpendReportingService(
           }
           .toMap
       }
-
       _ = if (projectNames.isEmpty) {
         throw RawlsExceptionWithErrorReport(
           StatusCodes.NotFound,
@@ -518,58 +539,54 @@ class SpendReportingService(
         )
       }
 
-      // look for a cached spend report
+      // is this spend report cacheable?
       isCacheable = aggregationsAreCacheable(aggregations)
-      cachedResults <-
-        if (isCacheable)
-          getCachedSpendReportData(projectNames, start, end)
-        else
-          Future.successful(CachedSpendReportingResults(isCacheValid = false, results = None))
 
-      spendResults <-
-        if (cachedResults.isCacheValid) {
-          rawlsCacheHitRate().hit()
-          cachedResults.results match {
-            case Some(report) => Future.successful(report)
-            case None =>
-              Future.failed(
-                RawlsExceptionWithErrorReport(
-                  StatusCodes.NotFound,
-                  s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
-                )
-              )
+      queryResults: Option[SpendReportingResults] <-
+        if (isCacheable) {
+          // look for a cached spend report
+          getCachedSpendReportData(projectNames, start, end) flatMap { cachedResults =>
+            if (cachedResults.isCacheValid) {
+              // cached spend report found; use it
+              rawlsCacheHitRate().hit()
+              Future.successful(cachedResults.results)
+            } else {
+              // cached spend report not found; go to BigQuery for results
+              rawlsCacheHitRate().miss()
+              getSpendForGCPBillingProjectFromBigQuery(aggregations,
+                                                       spendExportConf,
+                                                       start,
+                                                       end,
+                                                       projectNames,
+                                                       childContext
+              ) map { bqResults =>
+                // save the BigQuery results back to cache and return
+                // the writeback to cache is fire-and-forget
+                insertRecordsWithMissingSpendData(bqResults, projectNames, start, end)
+                bqResults
+              }
+            }
           }
         } else {
-          // only log a cache-miss if this report was valid for caching in the first place
-          if (isCacheable) {
-            rawlsCacheHitRate().miss()
-          }
-
-          val query = getQuery(aggregations, spendExportConf)
-          val queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
-
-          val queryResults = runBigQueryJob(queryJob, childContext).map { result =>
-            result.getValues.asScala.toList match {
-              case Nil  => None
-              case rows => Option(extractSpendReportingResults(rows, start, end, projectNames, aggregations))
-            }
-          }
-
-          // write BigQuery results back to cache
-          if (isCacheable) {
-            queryResults.map { res =>
-              insertRecordsWithMissingSpendData(res, projectNames, start, end)
-            }
-          }
-          queryResults.map {
-            case Some(results) => results
-            case None =>
-              throw RawlsExceptionWithErrorReport(
-                StatusCodes.NotFound,
-                s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
-              )
-          }
+          // this spend report is not cacheable; bypass the cache
+          // and ask BigQuery directly
+          getSpendForGCPBillingProjectFromBigQuery(aggregations,
+                                                   spendExportConf,
+                                                   start,
+                                                   end,
+                                                   projectNames,
+                                                   childContext
+          )
         }
+
+      spendResults = queryResults match {
+        case Some(results) => results
+        case None =>
+          throw RawlsExceptionWithErrorReport(
+            StatusCodes.NotFound,
+            s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+          )
+      }
     } yield spendResults
 
   }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -27,7 +27,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.{DateTime, Days}
 
-import java.util.{Base64, UUID}
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.math.BigDecimal.RoundingMode
@@ -485,10 +485,9 @@ class SpendReportingService(
         workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
-  /* As long as no aggregation contains "daily", it is cacheable */
+  /* as of this writing we only support Workspace~Category for caching */
   @VisibleForTesting
   def aggregationsAreCacheable(aggregations: Set[SpendReportingAggregationKeyWithSub]): Boolean =
-    // as of this writing we only support Workspace~Category for caching
     Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)))
       .equals(aggregations)
 
@@ -503,7 +502,6 @@ class SpendReportingService(
   ): Future[Option[SpendReportingResults]] = {
     val query = getQuery(aggregations, spendExportConf)
     val queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
-
     runBigQueryJob(queryJob, childContext).map { result =>
       result.getValues.asScala.toList match {
         case Nil  => None

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.google.cloud.bigquery.{FieldValueList, JobStatistics, Option => _, _}
+import com.google.common.annotations.VisibleForTesting
 import com.typesafe.scalalogging.LazyLogging
 import nl.grons.metrics4.scala.{Counter, Histogram}
 import org.broadinstitute.dsde.rawls.billing.{
@@ -483,6 +484,13 @@ class SpendReportingService(
         workspaceServiceConstructor(childContext).getGCPWorkspacesByBillingProjects(validWorkspaceIds)
       }
 
+  /* As long as no aggregation contains "daily", it is cacheable */
+  @VisibleForTesting
+  def aggregationsAreCacheable(aggregations: Set[SpendReportingAggregationKeyWithSub]): Boolean =
+    !aggregations.exists(x =>
+      x.key == SpendReportingAggregationKeys.Daily || x.subAggregationKey.contains(SpendReportingAggregationKeys.Daily)
+    )
+
   // single-project report: step 3
   def getSpendForGCPBillingProject(
     project: RawlsBillingProjectName,
@@ -509,20 +517,50 @@ class SpendReportingService(
         )
       }
 
-      query = getQuery(aggregations, spendExportConf)
-      queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
+      // look for a cached spend report
+      isCacheable = aggregationsAreCacheable(aggregations)
+      cachedResults <-
+        if (isCacheable)
+          getCachedSpendReportData(projectNames, start, end)
+        else
+          Future.successful(CachedSpendReportingResults(isCacheValid = false, results = None))
 
-      job: Job <- bigQueryService.use(_.runJob(queryJob)).unsafeToFuture().map(_.waitFor())
-      _ = logSpendQueryStats(job.getStatistics[JobStatistics.QueryStatistics])
-      result = job.getQueryResults()
-    } yield result.getValues.asScala.toList match {
-      case Nil =>
-        throw RawlsExceptionWithErrorReport(
-          StatusCodes.NotFound,
-          s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
-        )
-      case rows => extractSpendReportingResults(rows, start, end, projectNames, aggregations)
-    }
+      spendResults <-
+        if (cachedResults.isCacheValid) {
+          rawlsCacheHitRate().hit()
+          cachedResults.results match {
+            case Some(report) => Future.successful(report)
+            case None =>
+              throw RawlsExceptionWithErrorReport(
+                StatusCodes.NotFound,
+                s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+              )
+          }
+        } else {
+          rawlsCacheHitRate().miss()
+          val query = getQuery(aggregations, spendExportConf)
+          val queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
+
+          val queryResults = runBigQueryJob(queryJob, childContext).map { result =>
+            result.getValues.asScala.toList match {
+              case Nil =>
+                throw RawlsExceptionWithErrorReport(
+                  StatusCodes.NotFound,
+                  s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+                )
+              case rows => extractSpendReportingResults(rows, start, end, projectNames, aggregations)
+            }
+          }
+
+          // write BigQuery results back to cache
+          queryResults.map { res =>
+            insertRecordsWithMissingSpendData(Option(res), projectNames, start, end)
+          }
+          queryResults
+
+        }
+    } yield spendResults
+
   }
 
   // single-project report: entry point

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -16,7 +16,8 @@ import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceSpendReportRecord
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.metrics.{GoogleInstrumented, HitRatioGauge, RawlsInstrumented}
-import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeyWithSub, _}
+import org.broadinstitute.dsde.rawls.model.SpendReportingAggregationKeys.Category
+import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeyWithSub, SpendReportingAggregationKeys, _}
 import org.broadinstitute.dsde.rawls.spendreporting.SpendReportingService._
 import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
@@ -487,9 +488,9 @@ class SpendReportingService(
   /* As long as no aggregation contains "daily", it is cacheable */
   @VisibleForTesting
   def aggregationsAreCacheable(aggregations: Set[SpendReportingAggregationKeyWithSub]): Boolean =
-    !aggregations.exists(x =>
-      x.key == SpendReportingAggregationKeys.Daily || x.subAggregationKey.contains(SpendReportingAggregationKeys.Daily)
-    )
+    // as of this writing we only support Workspace~Category for caching
+    Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)))
+      .equals(aggregations)
 
   // single-project report: step 3
   def getSpendForGCPBillingProject(

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -546,24 +546,25 @@ class SpendReportingService(
 
           val queryResults = runBigQueryJob(queryJob, childContext).map { result =>
             result.getValues.asScala.toList match {
-              case Nil =>
-                // TODO CORE-291: this needs to write back to cache
-                throw RawlsExceptionWithErrorReport(
-                  StatusCodes.NotFound,
-                  s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
-                )
-              case rows => extractSpendReportingResults(rows, start, end, projectNames, aggregations)
+              case Nil  => None
+              case rows => Option(extractSpendReportingResults(rows, start, end, projectNames, aggregations))
             }
           }
 
           // write BigQuery results back to cache
           if (isCacheable) {
             queryResults.map { res =>
-              insertRecordsWithMissingSpendData(Option(res), projectNames, start, end)
+              insertRecordsWithMissingSpendData(res, projectNames, start, end)
             }
           }
-          queryResults
-
+          queryResults.map {
+            case Some(results) => results
+            case None =>
+              throw RawlsExceptionWithErrorReport(
+                StatusCodes.NotFound,
+                s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+              )
+          }
         }
     } yield spendResults
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -530,13 +530,15 @@ class SpendReportingService(
           rawlsCacheHitRate().hit()
           cachedResults.results match {
             case Some(report) => Future.successful(report)
-            case None =>
+            case None         =>
+              // TODO CORE-291: Future.failed vs. throw
               throw RawlsExceptionWithErrorReport(
                 StatusCodes.NotFound,
                 s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
               )
           }
         } else {
+          // TODO CORE-291: should this log a miss even for Daily aggregations?
           rawlsCacheHitRate().miss()
           val query = getQuery(aggregations, spendExportConf)
           val queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
@@ -544,6 +546,7 @@ class SpendReportingService(
           val queryResults = runBigQueryJob(queryJob, childContext).map { result =>
             result.getValues.asScala.toList match {
               case Nil =>
+                // TODO CORE-291: this needs to write back to cache
                 throw RawlsExceptionWithErrorReport(
                   StatusCodes.NotFound,
                   s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
@@ -553,8 +556,10 @@ class SpendReportingService(
           }
 
           // write BigQuery results back to cache
-          queryResults.map { res =>
-            insertRecordsWithMissingSpendData(Option(res), projectNames, start, end)
+          if (isCacheable) {
+            queryResults.map { res =>
+              insertRecordsWithMissingSpendData(Option(res), projectNames, start, end)
+            }
           }
           queryResults
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -539,8 +539,11 @@ class SpendReportingService(
               )
           }
         } else {
-          // TODO CORE-291: should this log a miss even for Daily aggregations?
-          rawlsCacheHitRate().miss()
+          // only log a cache-miss if this report was valid for caching in the first place
+          if (isCacheable) {
+            rawlsCacheHitRate().miss()
+          }
+
           val query = getQuery(aggregations, spendExportConf)
           val queryJob = setUpQuery(query, spendExportConf, start, end, projectNames)
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingService.scala
@@ -530,11 +530,12 @@ class SpendReportingService(
           rawlsCacheHitRate().hit()
           cachedResults.results match {
             case Some(report) => Future.successful(report)
-            case None         =>
-              // TODO CORE-291: Future.failed vs. throw
-              throw RawlsExceptionWithErrorReport(
-                StatusCodes.NotFound,
-                s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+            case None =>
+              Future.failed(
+                RawlsExceptionWithErrorReport(
+                  StatusCodes.NotFound,
+                  s"no spend data found for billing project ${project.value} between dates ${toISODateString(start)} and ${toISODateString(end)}"
+                )
               )
           }
         } else {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1248,6 +1248,91 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     verify(service, never()).insertRecordsWithMissingSpendData(any(), any(), any(), any())
   }
 
+  it should "write back to cache even when BigQuery returns no results" in {
+    val samDAO = mock[SamDAO]
+    val billingRepository = mock[BillingRepository]
+    val bpmDAO = mock[BillingProfileManagerDAO]
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+
+    // BigQuery returns no results for this timeframe
+    val table: List[Map[String, String]] = List()
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
+    val job = mock[Job]
+    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getStatistics).thenReturn(stats)
+    when(job.waitFor()).thenReturn(job)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
+    val bqServiceResource = Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService)
+
+    val start = DateTime.now().minusDays(1)
+    val end = DateTime.now()
+    val startLocal = SpendReportUtils.convertJodaToJava(Option(start))
+    val endLocal = SpendReportUtils.convertJodaToJava(Option(end))
+
+    // spend report cache is missing one of the workspaces in question (via use of .tail)
+    val spendReportRepoResults = TestData.googleProjectsToWorkspaceNames.keys.toSeq.tail
+      .map(projName =>
+        WorkspaceSpendReport.newWorkspaceSpendReport(projName.value,
+                                                     startLocal,
+                                                     endLocal,
+                                                     "USD",
+                                                     isDataAvailable = true,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None
+        )
+      )
+    val mockSpendReportRepo = mock[WorkspaceSpendReportRepository]
+    when(mockSpendReportRepo.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(spendReportRepoResults))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bqServiceResource,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor,
+        mockSpendReportRepo
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(billingProject.projectName, RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
+      .when(service)
+      .getSpendReportableWorkspaceGoogleProjects(any())
+
+    val e = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        service.getSpendForGCPBillingProject(
+          billingProject.projectName,
+          start,
+          end,
+          Set.empty
+        ),
+        Duration.Inf
+      )
+    }
+    e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+
+    // verify: ask cache for results, this test does not find them
+    verify(mockSpendReportRepo, times(1)).getWorkspaceSpendReports(any(), any(), any())
+    // verify: since cache did not have results, ask BigQuery instead
+    verify(bigQueryService, times(1)).runJob(any(), any())
+    // verify: write BigQuery results back to cache
+    verify(service, times(1)).insertRecordsWithMissingSpendData(any(), any(), any(), any())
+  }
+
   "getSpendForBillingProject" should "get the spend report from BPM for Azure billing projects" in {
     val from = DateTime.now().minusMonths(2)
     val to = from.plusMonths(1)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -24,6 +24,7 @@ import org.broadinstitute.dsde.rawls.config.SpendReportingServiceConfig
 import org.broadinstitute.dsde.rawls.dataaccess.slick.WorkspaceSpendReportRecord
 import org.broadinstitute.dsde.rawls.dataaccess.{SamDAO, SlickDataSource}
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.SpendReportingAggregationKeys.{Workspace => WorkspaceAggKey, _}
 import org.broadinstitute.dsde.rawls.model.{SpendReportingAggregationKeys, _}
 import org.broadinstitute.dsde.rawls.util.MockitoTestUtils
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceService
@@ -42,7 +43,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import java.time.{LocalDateTime, ZoneId}
-import java.util.{Base64, Currency, Date, UUID}
+import java.util.{Currency, Date, UUID}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.jdk.CollectionConverters._
@@ -344,10 +345,10 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       DateTime.now().minusDays(1),
       DateTime.now(),
       Map(),
-      Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily))
+      Set(SpendReportingAggregationKeyWithSub(Daily))
     )
     reportingResults.spendSummary.cost shouldBe TestData.Daily.totalCostRounded.toString
-    reportingResults.spendDetails.head.aggregationKey shouldBe SpendReportingAggregationKeys.Daily
+    reportingResults.spendDetails.head.aggregationKey shouldBe Daily
     reportingResults.spendDetails.head.spendData.foreach { spendForDay =>
       spendForDay.startTime match {
         case Some(date) if date.toLocalDate.equals(TestData.Daily.firstRowDate.toLocalDate) =>
@@ -400,12 +401,12 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       DateTime.now().minusDays(1),
       DateTime.now(),
       Map(),
-      Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category))
+      Set(SpendReportingAggregationKeyWithSub(Category))
     )
 
     reportingResults.spendSummary.cost shouldBe TestData.Category.totalCostRounded
     val categoryAggregation = reportingResults.spendDetails.headOption.get
-    categoryAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Category
+    categoryAggregation.aggregationKey shouldBe Category
     verifyCategoryAggregation(
       categoryAggregation,
       expectedCompute = TestData.Category.computeRowCostRounded,
@@ -433,9 +434,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       DateTime.now(),
       TestData.googleProjectsToWorkspaceNames,
       Set(
-        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace,
-                                            Option(SpendReportingAggregationKeys.Category)
-        )
+        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category))
       )
     )
 
@@ -453,10 +452,8 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         TestData.workspace2.googleProjectId -> TestData.workspace2.toWorkspaceName
       ),
       Set(
-        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace,
-                                            Option(SpendReportingAggregationKeys.Category)
-        ),
-        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Category)
+        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)),
+        SpendReportingAggregationKeyWithSub(Category)
       )
     )
 
@@ -465,7 +462,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     reportingResults.spendDetails.map {
       case workspaceAggregation @ SpendReportingAggregation(SpendReportingAggregationKeys.Workspace, _) =>
         verifyWorkspaceCategorySubAggregation(workspaceAggregation)
-      case categoryAggregation @ SpendReportingAggregation(SpendReportingAggregationKeys.Category, _) =>
+      case categoryAggregation @ SpendReportingAggregation(Category, _) =>
         verifyCategoryAggregation(
           categoryAggregation,
           expectedCompute = TestData.SubAggregation.computeTotalCostRounded,
@@ -504,7 +501,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     topLevelAggregation.spendData.foreach { spendData =>
       val workspaceGoogleProject = spendData.googleProjectId.get.value
       val subAggregation = spendData.subAggregation.get
-      subAggregation.aggregationKey shouldBe SpendReportingAggregationKeys.Category
+      subAggregation.aggregationKey shouldBe Category
 
       if (workspaceGoogleProject.equals(TestData.workspace1.googleProjectId.value)) {
         spendData.cost shouldBe TestData.SubAggregation.workspace1TotalCostRounded.toString
@@ -550,7 +547,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         DateTime.now().minusDays(1),
         DateTime.now(),
         Map(),
-        Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily))
+        Set(SpendReportingAggregationKeyWithSub(Daily))
       )
     }
     e.errorReport.statusCode shouldBe Option(StatusCodes.InternalServerError)
@@ -678,7 +675,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   ): Unit = {
     actualSpendData.cost shouldBe expectedTotal.toString
     val aggSub = actualSpendData.subAggregation.get
-    aggSub.aggregationKey shouldBe SpendReportingAggregationKeys.Category
+    aggSub.aggregationKey shouldBe Category
     verifyCategoricalSpendData(aggSub.spendData, expectedCompute, expectedStorage, expectedOther)
   }
 
@@ -1308,7 +1305,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val result = service.getQuery(
       Set(
         SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace),
-        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily)
+        SpendReportingAggregationKeyWithSub(Daily)
       ),
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), Some("NonBroadTable"))
     )
@@ -1343,7 +1340,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val result = service.getQuery(
       Set(
         SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace),
-        SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Daily)
+        SpendReportingAggregationKeyWithSub(Daily)
       ),
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     )
@@ -2595,6 +2592,50 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
 
     val actual = Await.result(service.getCachedSpendReportData(projectNames, from, to), Duration.Inf)
     actual.isCacheValid shouldBe false
+  }
+
+  behavior of "aggregationsAreCacheable"
+
+  val testCases: Map[Set[SpendReportingAggregationKeyWithSub], Boolean] = Map(
+    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, None)) -> true,
+    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, Option(Category))) -> true,
+    Set(SpendReportingAggregationKeyWithSub(Category, None)) -> true,
+    Set(SpendReportingAggregationKeyWithSub(Category, Option(WorkspaceAggKey))) -> true,
+    Set(SpendReportingAggregationKeyWithSub(Daily, None)) -> false,
+    Set(SpendReportingAggregationKeyWithSub(Category, Option(Daily))) -> false,
+    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, Option(Daily))) -> false,
+    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, None),
+        SpendReportingAggregationKeyWithSub(Daily, None)
+    ) -> false,
+    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, None),
+        SpendReportingAggregationKeyWithSub(Category, Option(Daily))
+    ) -> false
+  )
+
+  testCases.foreach { case (aggkeys, expected) =>
+    it should s"be $expected for input of $aggkeys" in {
+      val samDAO = mock[SamDAO]
+      val workspaceService = mock[WorkspaceService]
+
+      val mockWorkspaceSpendReportRepository: WorkspaceSpendReportRepository =
+        mock[WorkspaceSpendReportRepository](RETURNS_SMART_NULLS)
+
+      val service = new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        Resource.pure[IO, GoogleBigQueryService[IO]](mock[GoogleBigQueryService[IO]]),
+        mock[BillingRepository],
+        mock[BillingProfileManagerDAO],
+        samDAO,
+        spendReportingServiceConfig,
+        _ => workspaceService,
+        mockWorkspaceSpendReportRepository
+      )
+
+      val actual = service.aggregationsAreCacheable(aggkeys)
+      actual shouldBe expected
+    }
+
   }
 
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -872,8 +872,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    // TODO CORE-291: this is the wrong return type
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
       .when(service)
       .getSpendReportableWorkspaceGoogleProjects(any())
 
@@ -981,8 +980,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    // TODO CORE-291: this is the wrong return type
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
       .when(service)
       .getSpendReportableWorkspaceGoogleProjects(any())
 
@@ -1268,8 +1266,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    // TODO CORE-291: this is the wrong return type
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
       .when(service)
       .getSpendForGCPBillingProject(any(), any(), any(), any())
 
@@ -1321,8 +1318,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
-    // TODO CORE-291: this is the wrong return type
-    doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
       .when(service)
       .getSpendForGCPBillingProject(any(), any(), any(), any())
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1068,7 +1068,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         billingProject.projectName,
         start,
         end,
-        Set.empty
+        Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)))
       ),
       Duration.Inf
     )
@@ -1088,7 +1088,13 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
 
     val table: List[Map[String, String]] = TestData.googleProjectsToWorkspaceNames.keys.toList.map { projectId =>
-      Map("cost" -> "0.10111", "credits" -> "0.0", "currency" -> "USD", "date" -> DateTime.now().toString)
+      Map("googleProjectId" -> projectId.value,
+          "service" -> "whatever",
+          "cost" -> "0.10111",
+          "credits" -> "0.0",
+          "currency" -> "USD",
+          "date" -> DateTime.now().toString
+      )
     }
 
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
@@ -1151,7 +1157,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
         billingProject.projectName,
         start,
         end,
-        Set.empty
+        Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)))
       ),
       Duration.Inf
     )
@@ -1171,7 +1177,13 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
 
     val table: List[Map[String, String]] = TestData.googleProjectsToWorkspaceNames.keys.toList.map { projectId =>
-      Map("cost" -> "0.10111", "credits" -> "0.0", "currency" -> "USD", "date" -> DateTime.now().toString)
+      Map("googleProjectId" -> projectId.value,
+          "service" -> "whatever",
+          "cost" -> "0.10111",
+          "credits" -> "0.0",
+          "currency" -> "USD",
+          "date" -> DateTime.now().toString
+      )
     }
 
     val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
@@ -1318,7 +1330,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
           billingProject.projectName,
           start,
           end,
-          Set.empty
+          Set(SpendReportingAggregationKeyWithSub(SpendReportingAggregationKeys.Workspace, Option(Category)))
         ),
         Duration.Inf
       )
@@ -2937,10 +2949,10 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
   behavior of "aggregationsAreCacheable"
 
   val testCases: Map[Set[SpendReportingAggregationKeyWithSub], Boolean] = Map(
-    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, None)) -> true,
+    Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, None)) -> false,
     Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, Option(Category))) -> true,
-    Set(SpendReportingAggregationKeyWithSub(Category, None)) -> true,
-    Set(SpendReportingAggregationKeyWithSub(Category, Option(WorkspaceAggKey))) -> true,
+    Set(SpendReportingAggregationKeyWithSub(Category, None)) -> false,
+    Set(SpendReportingAggregationKeyWithSub(Category, Option(WorkspaceAggKey))) -> false,
     Set(SpendReportingAggregationKeyWithSub(Daily, None)) -> false,
     Set(SpendReportingAggregationKeyWithSub(Category, Option(Daily))) -> false,
     Set(SpendReportingAggregationKeyWithSub(WorkspaceAggKey, Option(Daily))) -> false,

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -81,6 +81,11 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val workspace1: Workspace = workspace("workspace1", GoogleProjectId("project1"))
     val workspace2: Workspace = workspace("workspace2", GoogleProjectId("project2"))
 
+    val billingProjectsToWorkspaces: Map[RawlsBillingProjectName, Seq[Workspace]] = Map(
+      // workspace 1 and 2 use the same billing project/namespace
+      RawlsBillingProjectName(workspace1.namespace) -> Seq(workspace1, workspace2)
+    )
+
     val googleProjectsToWorkspaceNames: Map[GoogleProjectId, WorkspaceName] = Map(
       workspace1.googleProjectId -> workspace1.toWorkspaceName,
       workspace2.googleProjectId -> workspace2.toWorkspaceName
@@ -867,6 +872,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    // TODO CORE-291: this is the wrong return type
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
       .getSpendReportableWorkspaceGoogleProjects(any())
@@ -975,6 +981,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    // TODO CORE-291: this is the wrong return type
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
       .getSpendReportableWorkspaceGoogleProjects(any())
@@ -991,6 +998,170 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
       )
     }
     e.errorReport.statusCode shouldBe Option(StatusCodes.NotFound)
+  }
+
+  it should "use cached results when available" in {
+    val samDAO = mock[SamDAO]
+    val billingRepository = mock[BillingRepository]
+    val bpmDAO = mock[BillingProfileManagerDAO]
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val data = List[Map[String, String]]()
+    val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
+    val job = mock[Job]
+    when(job.getQueryResults(any())).thenReturn(createTableResult(data))
+    when(job.getStatistics).thenReturn(stats)
+    when(job.waitFor()).thenReturn(job)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
+    val bqServiceResource = Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService)
+
+    val start = DateTime.now().minusDays(1)
+    val end = DateTime.now()
+    val startLocal = SpendReportUtils.convertJodaToJava(Option(start))
+    val endLocal = SpendReportUtils.convertJodaToJava(Option(end))
+
+    // spend report cache returns a row for each workspace in question
+    val spendReportRepoResults = TestData.googleProjectsToWorkspaceNames.keys
+      .map(projName =>
+        WorkspaceSpendReport.newWorkspaceSpendReport(projName.value,
+                                                     startLocal,
+                                                     endLocal,
+                                                     "USD",
+                                                     isDataAvailable = true,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None
+        )
+      )
+      .toSeq
+
+    val mockSpendReportRepo = mock[WorkspaceSpendReportRepository]
+    when(mockSpendReportRepo.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(spendReportRepoResults))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bqServiceResource,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor,
+        mockSpendReportRepo
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(billingProject.projectName, RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
+      .when(service)
+      .getSpendReportableWorkspaceGoogleProjects(any())
+
+    // should not throw
+    Await.result(
+      service.getSpendForGCPBillingProject(
+        billingProject.projectName,
+        start,
+        end,
+        Set.empty
+      ),
+      Duration.Inf
+    )
+    // verify: ask cache for results, find them
+    verify(mockSpendReportRepo, times(1)).getWorkspaceSpendReports(any(), any(), any())
+    // verify: since cache had results, we don't ask anything of BigQuery
+    verify(bigQueryService, never()).runJob(any(), any())
+    // verify: since cache had results, we don't write anything back to cache
+    verify(service, never()).insertRecordsWithMissingSpendData(any(), any(), any(), any())
+  }
+  it should "use BigQuery when cached results are not available, and write back to cache" in {
+    val samDAO = mock[SamDAO]
+    val billingRepository = mock[BillingRepository]
+    val bpmDAO = mock[BillingProfileManagerDAO]
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+
+    val table: List[Map[String, String]] = TestData.googleProjectsToWorkspaceNames.keys.toList.map { projectId =>
+      Map("cost" -> "0.10111", "credits" -> "0.0", "currency" -> "USD", "date" -> DateTime.now().toString)
+    }
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
+    val job = mock[Job]
+    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getStatistics).thenReturn(stats)
+    when(job.waitFor()).thenReturn(job)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
+    val bqServiceResource = Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService)
+
+    val start = DateTime.now().minusDays(1)
+    val end = DateTime.now()
+    val startLocal = SpendReportUtils.convertJodaToJava(Option(start))
+    val endLocal = SpendReportUtils.convertJodaToJava(Option(end))
+
+    // spend report cache is missing one of the workspaces in question (via use of .tail)
+    val spendReportRepoResults = TestData.googleProjectsToWorkspaceNames.keys.toSeq.tail
+      .map(projName =>
+        WorkspaceSpendReport.newWorkspaceSpendReport(projName.value,
+                                                     startLocal,
+                                                     endLocal,
+                                                     "USD",
+                                                     isDataAvailable = true,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None
+        )
+      )
+    val mockSpendReportRepo = mock[WorkspaceSpendReportRepository]
+    when(mockSpendReportRepo.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(spendReportRepoResults))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bqServiceResource,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor,
+        mockSpendReportRepo
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(billingProject.projectName, RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
+      .when(service)
+      .getSpendReportableWorkspaceGoogleProjects(any())
+
+    // should not throw
+    Await.result(
+      service.getSpendForGCPBillingProject(
+        billingProject.projectName,
+        start,
+        end,
+        Set.empty
+      ),
+      Duration.Inf
+    )
+    // verify: ask cache for results, this test does not find them
+    verify(mockSpendReportRepo, times(1)).getWorkspaceSpendReports(any(), any(), any())
+    // verify: since cache did not have results, ask BigQuery instead
+    verify(bigQueryService, times(1)).runJob(any(), any())
+    // verify: write BigQuery results back to cache
+    verify(service, times(1)).insertRecordsWithMissingSpendData(any(), any(), any(), any())
   }
 
   "getSpendForBillingProject" should "get the spend report from BPM for Azure billing projects" in {
@@ -1097,6 +1268,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    // TODO CORE-291: this is the wrong return type
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
       .getSpendForGCPBillingProject(any(), any(), any(), any())
@@ -1149,6 +1321,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     val billingProjectSpendExport =
       BillingProjectSpendExport(RawlsBillingProjectName(""), RawlsBillingAccountName(""), None)
     doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    // TODO CORE-291: this is the wrong return type
     doReturn(Future.successful(TestData.googleProjectsToWorkspaceNames))
       .when(service)
       .getSpendForGCPBillingProject(any(), any(), any(), any())

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1079,6 +1079,7 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     // verify: since cache had results, we don't write anything back to cache
     verify(service, never()).insertRecordsWithMissingSpendData(any(), any(), any(), any())
   }
+
   it should "use BigQuery when cached results are not available, and write back to cache" in {
     val samDAO = mock[SamDAO]
     val billingRepository = mock[BillingRepository]
@@ -1160,6 +1161,91 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     verify(bigQueryService, times(1)).runJob(any(), any())
     // verify: write BigQuery results back to cache
     verify(service, times(1)).insertRecordsWithMissingSpendData(any(), any(), any(), any())
+  }
+
+  it should "use BigQuery for daily aggregations and not write back to cache" in {
+    val samDAO = mock[SamDAO]
+    val billingRepository = mock[BillingRepository]
+    val bpmDAO = mock[BillingProfileManagerDAO]
+    when(samDAO.userHasAction(any(), any(), any(), any())).thenReturn(Future.successful(true))
+    when(billingRepository.getBillingProject(any())).thenReturn(Future.successful(Option.apply(billingProject)))
+
+    val table: List[Map[String, String]] = TestData.googleProjectsToWorkspaceNames.keys.toList.map { projectId =>
+      Map("cost" -> "0.10111", "credits" -> "0.0", "currency" -> "USD", "date" -> DateTime.now().toString)
+    }
+
+    val bigQueryService = mock[GoogleBigQueryService[IO]](RETURNS_SMART_NULLS)
+    val stats = mock[JobStatistics.QueryStatistics](RETURNS_SMART_NULLS)
+    val job = mock[Job]
+    when(job.getQueryResults(any())).thenReturn(createTableResult(table))
+    when(job.getStatistics).thenReturn(stats)
+    when(job.waitFor()).thenReturn(job)
+    when(bigQueryService.runJob(any(), any())).thenReturn(IO(job))
+    val bqServiceResource = Resource.pure[IO, GoogleBigQueryService[IO]](bigQueryService)
+
+    val start = DateTime.now().minusDays(1)
+    val end = DateTime.now()
+    val startLocal = SpendReportUtils.convertJodaToJava(Option(start))
+    val endLocal = SpendReportUtils.convertJodaToJava(Option(end))
+
+    // spend report cache returns a row for each workspace in question, so is valid - but
+    // the daily aggregation should not even query cache
+    val spendReportRepoResults = TestData.googleProjectsToWorkspaceNames.keys
+      .map(projName =>
+        WorkspaceSpendReport.newWorkspaceSpendReport(projName.value,
+                                                     startLocal,
+                                                     endLocal,
+                                                     "USD",
+                                                     isDataAvailable = true,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None,
+                                                     None
+        )
+      )
+      .toSeq
+    val mockSpendReportRepo = mock[WorkspaceSpendReportRepository]
+    when(mockSpendReportRepo.getWorkspaceSpendReports(any(), any(), any()))
+      .thenReturn(Future.successful(spendReportRepoResults))
+
+    val service = spy(
+      new SpendReportingService(
+        testContext,
+        mock[SlickDataSource],
+        bqServiceResource,
+        billingRepository,
+        bpmDAO,
+        samDAO,
+        spendReportingServiceConfig,
+        mockWorkspaceServiceConstructor,
+        mockSpendReportRepo
+      )
+    )
+    val billingProjectSpendExport =
+      BillingProjectSpendExport(billingProject.projectName, RawlsBillingAccountName(""), None)
+    doReturn(Future.successful(billingProjectSpendExport)).when(service).getSpendExportConfiguration(any())
+    doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
+      .when(service)
+      .getSpendReportableWorkspaceGoogleProjects(any())
+
+    // should not throw
+    Await.result(
+      service.getSpendForGCPBillingProject(
+        billingProject.projectName,
+        start,
+        end,
+        Set(SpendReportingAggregationKeyWithSub(Daily))
+      ),
+      Duration.Inf
+    )
+    // verify: daily aggregation skips cache
+    verify(mockSpendReportRepo, never()).getWorkspaceSpendReports(any(), any(), any())
+    // verify: since we skipped cache, ask BigQuery instead
+    verify(bigQueryService, times(1)).runJob(any(), any())
+    // verify: daily aggregation does not write back to cache
+    verify(service, never()).insertRecordsWithMissingSpendData(any(), any(), any(), any())
   }
 
   "getSpendForBillingProject" should "get the spend report from BPM for Azure billing projects" in {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/spendreporting/SpendReportingServiceSpec.scala
@@ -1323,6 +1323,9 @@ class SpendReportingServiceSpec extends AnyFlatSpecLike with Matchers with Mocki
     doReturn(Future.successful(TestData.billingProjectsToWorkspaces))
       .when(service)
       .getSpendReportableWorkspaceGoogleProjects(any())
+    doReturn(Set())
+      .when(service)
+      .insertRecordsWithMissingSpendData(any(), any(), any(), any())
 
     val e = intercept[RawlsExceptionWithErrorReport] {
       Await.result(


### PR DESCRIPTION
Ticket: CORE-291

Incorporates the spend report cache into the per-project spend reports.


