### PR TITLE
CORE-308: reuse okhttp client for Leo DAO

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAO.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/HttpLeonardoDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.rawls.dataaccess
 
+import okhttp3.{Dispatcher, Protocol}
 import org.broadinstitute.dsde.rawls.config.LeonardoConfig
 import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.client.leonardo.ApiClient
@@ -11,24 +12,34 @@ import scala.jdk.CollectionConverters._
 
 class HttpLeonardoDAO(leonardoConfig: LeonardoConfig) extends LeonardoDAO {
 
+  private val okHttpClient = {
+    val dispatcher = new Dispatcher()
+    new ApiClient().getHttpClient.newBuilder
+      .protocols(Seq(Protocol.HTTP_1_1).asJava)
+      .dispatcher(dispatcher)
+      .build()
+  }
+
+  protected def getApiClient(accessToken: String): ApiClient = {
+    val leoApiClient = new ApiClient(okHttpClient)
+    leoApiClient.setBasePath(leonardoConfig.baseUrl)
+    leoApiClient.setAccessToken(accessToken)
+
+    leoApiClient
+  }
+
   private def getAppsV2LeonardoApi(accessToken: String): AppsApi = {
-    val apiClient = new ApiClient()
-    apiClient.setAccessToken(accessToken)
-    apiClient.setBasePath(leonardoConfig.baseUrl)
+    val apiClient = getApiClient(accessToken)
     new AppsApi(apiClient)
   }
 
   private def getResourcesLeonardoApi(accessToken: String) = {
-    val apiClient = new ApiClient()
-    apiClient.setAccessToken(accessToken)
-    apiClient.setBasePath(leonardoConfig.baseUrl)
+    val apiClient = getApiClient(accessToken)
     new ResourcesApi(apiClient)
   }
 
   private def getRuntimesV2LeonardoApi(accessToken: String): RuntimesApi = {
-    val apiClient = new ApiClient()
-    apiClient.setAccessToken(accessToken)
-    apiClient.setBasePath(leonardoConfig.baseUrl)
+    val apiClient = getApiClient(accessToken)
     new RuntimesApi(apiClient)
   }
   override def deleteApps(token: String, workspaceId: UUID, deleteDisk: Boolean) =


### PR DESCRIPTION
Ticket: CORE-308

Reuse an underlying `okhttp` client within the Leo DAO.

This PR does NOT do any of the fancier config such as setting max requests or max requests per host or request timeout on the DAO. We can set those later if we find we need them.

See the changes to the Sam DAO in https://github.com/broadinstitute/firecloud-orchestration/pull/1570 as an example.



