### PR TITLE
[CORE-407] Reduce calls to DRSHub and check signedUrl instead of SA

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubModel.scala
@@ -2,9 +2,9 @@ package org.broadinstitute.dsde.rawls.dataaccess.drs
 
 import spray.json.RootJsonFormat
 
-case class DrsHubRequest(url: String, fields: Array[String])
+case class DrsHubRequest(dataObjectUri: String, fields: Array[String])
 
-case class DrsHubMinimalResponse(googleServiceAccount: Option[ServiceAccountPayload])
+case class DrsHubMinimalResponse(accessUrl: Option[String])
 
 object DrsHubJsonSupport {
   import spray.json.DefaultJsonProtocol._

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubModel.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubModel.scala
@@ -2,15 +2,15 @@ package org.broadinstitute.dsde.rawls.dataaccess.drs
 
 import spray.json.RootJsonFormat
 
-case class DrsHubRequest(dataObjectUri: String, fields: Array[String])
+case class DrsHubRequest(url: String, fields: Array[String])
 
-case class DrsHubMinimalResponse(accessUrl: Option[String])
+case class DrsHubAccessUrl(url: Option[String], headers: Option[Map[String, String]])
+case class DrsHubMinimalResponse(accessUrl: Option[DrsHubAccessUrl])
 
 object DrsHubJsonSupport {
   import spray.json.DefaultJsonProtocol._
 
   implicit val DrsHubRequestFormat: RootJsonFormat[DrsHubRequest] = jsonFormat2(DrsHubRequest)
-  implicit val ServiceAccountEmailFormat: RootJsonFormat[ServiceAccountEmail] = jsonFormat1(ServiceAccountEmail)
-  implicit val DrsHubV2ResponseDataFormat: RootJsonFormat[ServiceAccountPayload] = jsonFormat1(ServiceAccountPayload)
+  implicit val DrsHubAccessUrlFormat: RootJsonFormat[DrsHubAccessUrl] = jsonFormat2(DrsHubAccessUrl)
   implicit val DrsHubV2ResponseFormat: RootJsonFormat[DrsHubMinimalResponse] = jsonFormat1(DrsHubMinimalResponse)
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
@@ -47,7 +47,7 @@ class DrsHubResolver(drsHubUrl: String)(implicit
     resolveDrs(drsUrl, userInfo).map { resp =>
       // The email field must remain an `Option` because DRS servers that do not use Bond (HCA, JDR) do not return a service account
       // AEN 2020-09-08 [WA-325]
-      //TODO can it be not an Option now?
+      // TODO can it be not an Option now?
       val signedUrl: Option[String] = resp.accessUrl
 
       if (signedUrl.isEmpty) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
@@ -45,12 +45,15 @@ class DrsHubResolver(drsHubUrl: String)(implicit
 
   override def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]] =
     resolveDrs(drsUrl, userInfo).map { resp =>
-      val signedUrl: Option[String] = resp.accessUrl
-
-      if (signedUrl.isEmpty) {
-        logger.info(s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
+      resp.accessUrl match {
+        case Some(accessUrl) =>
+          val signedUrl = accessUrl.url
+          if (signedUrl.isEmpty)
+            logger.info(s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
+          signedUrl
+        case None =>
+          logger.info(s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
+          None
       }
-
-      signedUrl
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
@@ -23,7 +23,7 @@ class DrsHubResolver(drsHubUrl: String)(implicit
     with Retry {
 
   // the list of fields we want in DrsHub response. More info can be found here: https://github.com/broadinstitute/drsHub#drsHub-v3
-  private val DrsHubRequestFieldsKey: Array[String] = Array("googleServiceAccount")
+  private val DrsHubRequestFieldsKey: Array[String] = Array("accessUrl")
   private val DrsHubHeaders: Seq[HttpHeader] = HttpHeader.parse("X-App-ID", "rawls") match {
     case HttpHeader.ParsingResult.Ok(header, _) => Seq(header)
     case _                                      => Seq()
@@ -33,8 +33,6 @@ class DrsHubResolver(drsHubUrl: String)(implicit
   val httpClientUtils: HttpClientUtilsStandard = HttpClientUtilsStandard()
 
   private def resolveDrs(drsUrl: String, userInfo: UserInfo): Future[DrsHubMinimalResponse] = {
-    // Evan idea 2020-09-08:
-    // Have Rawls call an "SA-only" endpoint in DrsHub because it doesn't need any URI info (calls Bond but not overloaded DRS servers)
     val requestObj = DrsHubRequest(drsUrl, DrsHubRequestFieldsKey)
     Marshal(requestObj).to[RequestEntity] flatMap { entity =>
       retry[DrsHubMinimalResponse](when5xx) { () =>
@@ -45,16 +43,17 @@ class DrsHubResolver(drsHubUrl: String)(implicit
     }
   }
 
-  override def drsServiceAccountEmail(drsUrl: String, userInfo: UserInfo): Future[Option[String]] =
+  override def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]] =
     resolveDrs(drsUrl, userInfo).map { resp =>
       // The email field must remain an `Option` because DRS servers that do not use Bond (HCA, JDR) do not return a service account
       // AEN 2020-09-08 [WA-325]
-      val saEmail: Option[String] = resp.googleServiceAccount.flatMap(_.data.map(_.client_email))
+      //TODO can it be not an Option now?
+      val signedUrl: Option[String] = resp.accessUrl
 
-      if (saEmail.isEmpty) {
-        logger.info(s"DrsHubResolver.drsServiceAccountEmail returned no SA for DRS url $drsUrl")
+      if (signedUrl.isEmpty) {
+        logger.info(s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
       }
 
-      saEmail
+      signedUrl
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
@@ -4,11 +4,12 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.{HttpHeader, RequestEntity}
+import akka.http.scaladsl.model.{HttpHeader, RequestEntity, StatusCodes}
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.stream.Materializer
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.dataaccess.DsdeHttpDAO
-import org.broadinstitute.dsde.rawls.model.UserInfo
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, UserInfo}
 import org.broadinstitute.dsde.rawls.util.{HttpClientUtilsStandard, Retry}
 import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsHubJsonSupport._
 
@@ -49,11 +50,14 @@ class DrsHubResolver(drsHubUrl: String)(implicit
         case Some(accessUrl) =>
           val signedUrl = accessUrl.url
           if (signedUrl.isEmpty)
-            logger.info(s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
+            throw new RawlsExceptionWithErrorReport(errorReport =
+              ErrorReport(StatusCodes.BadRequest, s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
+            )
           signedUrl
         case None =>
-          logger.info(s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
-          None
+          throw new RawlsExceptionWithErrorReport(errorReport =
+            ErrorReport(StatusCodes.BadRequest, s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
+          )
       }
     }
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
@@ -45,9 +45,6 @@ class DrsHubResolver(drsHubUrl: String)(implicit
 
   override def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]] =
     resolveDrs(drsUrl, userInfo).map { resp =>
-      // The email field must remain an `Option` because DRS servers that do not use Bond (HCA, JDR) do not return a service account
-      // AEN 2020-09-08 [WA-325]
-      // TODO can it be not an Option now?
       val signedUrl: Option[String] = resp.accessUrl
 
       if (signedUrl.isEmpty) {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolver.scala
@@ -44,17 +44,12 @@ class DrsHubResolver(drsHubUrl: String)(implicit
     }
   }
 
-  override def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]] =
+  override def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[String] =
     resolveDrs(drsUrl, userInfo).map { resp =>
       resp.accessUrl match {
-        case Some(accessUrl) =>
-          val signedUrl = accessUrl.url
-          if (signedUrl.isEmpty)
-            throw new RawlsExceptionWithErrorReport(errorReport =
-              ErrorReport(StatusCodes.BadRequest, s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
-            )
-          signedUrl
-        case None =>
+        case Some(DrsHubAccessUrl(Some(url), _)) =>
+          url
+        case _ =>
           throw new RawlsExceptionWithErrorReport(errorReport =
             ErrorReport(StatusCodes.BadRequest, s"DrsHubResolver.accessUrl returned no url for DRS url $drsUrl")
           )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
@@ -25,19 +25,20 @@ object DrsResolver {
     try
       Option(new URI(uri).getHost) match {
         case Some(host) => Some(host)
-        case None       => throw new Throwable()
+        case None       => getProviderFromId(uri)
       }
     catch {
-      case _: Throwable =>
-        hostNameRegex.findFirstMatchIn(uri) match {
-          case Some(matchGroup) => Some(matchGroup.group("hostname"))
-          case None =>
-            compactIdRegex.findFirstMatchIn(uri) match {
-              case Some(matchGroup) => Some(matchGroup.group("compactIdPrefix"))
-              case None             => None
-            }
-        }
+      case _: Throwable => getProviderFromId(uri)
+    }
 
+  def getProviderFromId(uri: String): Option[String] =
+    hostNameRegex.findFirstMatchIn(uri) match {
+      case Some(matchGroup) => Some(matchGroup.group("hostname"))
+      case None =>
+        compactIdRegex.findFirstMatchIn(uri) match {
+          case Some(matchGroup) => Some(matchGroup.group("compactIdPrefix"))
+          case None             => None
+        }
     }
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.rawls.model.UserInfo
 import scala.concurrent.Future
 
 trait DrsResolver {
-  def drsServiceAccountEmail(drsUrl: String, userInfo: UserInfo): Future[Option[String]]
+  def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]]
 }
 
 object DrsResolver {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 import scala.util.matching.Regex
 
 trait DrsResolver {
-  def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]]
+  def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[String]
 }
 
 object DrsResolver {

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
@@ -1,9 +1,8 @@
 package org.broadinstitute.dsde.rawls.dataaccess.drs
 
-import io.lemonlabs.uri.Uri
 import org.broadinstitute.dsde.rawls.model.UserInfo
 
-import java.net.URI
+import java.net.{URI, URISyntaxException}
 import scala.concurrent.Future
 import scala.util.matching.Regex
 
@@ -28,7 +27,7 @@ object DrsResolver {
         case None       => getProviderFromId(uri)
       }
     catch {
-      case _: Throwable => getProviderFromId(uri)
+      case _: URISyntaxException => getProviderFromId(uri)
     }
 
   def getProviderFromId(uri: String): Option[String] =

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsResolver.scala
@@ -1,8 +1,11 @@
 package org.broadinstitute.dsde.rawls.dataaccess.drs
 
+import io.lemonlabs.uri.Uri
 import org.broadinstitute.dsde.rawls.model.UserInfo
 
+import java.net.URI
 import scala.concurrent.Future
+import scala.util.matching.Regex
 
 trait DrsResolver {
   def drsSignedUrl(drsUrl: String, userInfo: UserInfo): Future[Option[String]]
@@ -10,7 +13,31 @@ trait DrsResolver {
 
 object DrsResolver {
   val dosDrsUriPattern: String = "^(dos|drs)://.*"
-}
+  /*Source: https://github.com/DataBiosphere/terra-drs-hub/blob/dev/service/src/main/java/bio/terra/drshub/services/DrsProviderService.java#L24
+   * <p>Hostname ID: drs://hostname/id
+   * <p>https://drs.example.org/ga4gh/drs/v1/objects/314159
+   * <p>Compact ID: drs://prefix:accession
+   * <p>drs://dg.anv0:f51fc329-b09e-4e16-b1a9-2f60ebc428ab
+   */
+  val compactIdRegex: Regex = "(?<scheme>dos|drs)://(?<compactIdPrefix>(dg|drs)\\.[0-9a-z-]+):(?<path>.*)".r
+  val hostNameRegex: Regex = "(?<scheme>dos|drs)://(?<hostname>[^?/:]+\\.[^?/:]+)/(?<path>.*)".r
+  def getProvider(uri: String): Option[String] =
+    try
+      Option(new URI(uri).getHost) match {
+        case Some(host) => Some(host)
+        case None       => throw new Throwable()
+      }
+    catch {
+      case _: Throwable =>
+        hostNameRegex.findFirstMatchIn(uri) match {
+          case Some(matchGroup) => Some(matchGroup.group("hostname"))
+          case None =>
+            compactIdRegex.findFirstMatchIn(uri) match {
+              case Some(matchGroup) => Some(matchGroup.group("compactIdPrefix"))
+              case None             => None
+            }
+        }
 
-case class ServiceAccountPayload(data: Option[ServiceAccountEmail])
-case class ServiceAccountEmail(client_email: String)
+    }
+
+}

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.rawls.metrics.logEvents.SubmissionEvent
 import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureMode
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.{FutureSupport, MethodWiths, addJitter}
+import org.broadinstitute.dsde.rawls.util.{addJitter, FutureSupport, MethodWiths}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceSettingRepository
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import spray.json.DefaultJsonProtocol._
@@ -382,10 +382,13 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
     }
 
   def resolveDrsSignedUrls(drsUris: Set[String], userInfo: UserInfo)(implicit
-                                                                                     executionContext: ExecutionContext
+    executionContext: ExecutionContext
   ): Future[Set[String]] = {
-    //TODO should this be done in this method or before calling this method?
-    val urisByProvider = drsUris.flatMap(Uri.parseOption).map(_.toUrl).groupBy(_.hostOption.map(_.value).getOrElse("unknown")).map { case (provider, uris) => uris.head.toString() }
+    // TODO should this be done in this method or before calling this method?
+    val urisByProvider =
+      drsUris.flatMap(Uri.parseOption).map(_.toUrl).groupBy(_.hostOption.map(_.value).getOrElse("unknown")).map {
+        case (provider, uris) => uris.head.toString()
+      }
 
     Future
       .traverse(urisByProvider) { drsUri =>
@@ -523,7 +526,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       // AEN 2020-09-08 [WA-325]
       _ <-
         if (dosSignedUrls.isEmpty) Future.successful(false)
-        else Future.successful(true) //TODO Is this correct? Or just don't check that it's empty at all?
+        else Future.successful(true) // TODO Is this correct? Or just don't check that it's empty at all?
 //          googleServicesDAO.addPolicyBindings(GoogleProjectId(wfOpts.google_project),
 //                                              Map(requesterPaysRole -> dosSignedUrls.map("serviceAccount:" + _))
 //          )

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -384,11 +384,15 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
   def resolveDrsSignedUrls(drsUris: Set[String], userInfo: UserInfo)(implicit
     executionContext: ExecutionContext
   ): Future[Set[String]] = {
-    // TODO should this be done in this method or before calling this method?
     val urisByProvider =
-      drsUris.flatMap(Uri.parseOption).map(_.toUrl).groupBy(_.hostOption.map(_.value).getOrElse("unknown")).map {
-        case (provider, uris) => uris.head.toString()
+      drsUris.flatMap(Uri.parseOption).map(_.toUrl).groupBy(_.hostOption).map { case (_, uris) =>
+        uris.head.toString
       }
+
+    val parsedUris = drsUris.flatMap(Uri.parseOption)
+    if (parsedUris.size != drsUris.size) {
+      logger.warn("Some URIs were unparsable")
+    }
 
     Future
       .traverse(urisByProvider) { drsUri =>
@@ -519,14 +523,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
     val cromwellSubmission = for {
       (wdl, workflowRecs, wfInputsBatch, wfOpts, wfLabels, wfCollection, dosUris, petUserInfo, methodConfig) <-
         workflowBatchFuture
-      dosSignedUrls <- resolveDrsSignedUrls(dosUris, petUserInfo)
-      // For Jade, HCA, anyone who doesn't use Bond, we won't get an SA back and the following line is a no-op
-      // We still call DRSHub for those because we can verify the user has permission on the DRS object as
-      // early as possible, rather than letting the workflow(s) launch and fail
-      // AEN 2020-09-08 [WA-325]
-      _ <-
-        if (dosSignedUrls.isEmpty) Future.successful(false)
-        else Future.successful(true) // TODO Is this correct? Or just don't check that it's empty at all?
+      _ <- resolveDrsSignedUrls(dosUris, petUserInfo)
       // Should labels be an Option? It's not optional for rawls (but then wfOpts are options too)
       workflowSubmitResult <- executionServiceCluster.submitWorkflows(workflowRecs,
                                                                       wdl,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -388,19 +388,25 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
     val urisByProvider: Map[Option[String], List[String]] = drsUris.toList.groupBy(DrsResolver.getProvider)
 
     if (urisByProvider.contains(None)) {
-      logger.warn(s"Some URIs were unparsable: ${urisByProvider(None)}") // TODO should this throw an error
+      logger.warn(s"Some URIs were unparsable: ${urisByProvider(None)}") // TODO What should be logged vs. thrown?
+      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, "Unable to parse URI"))
     }
 
-    val urisToParse = urisByProvider.values.map(_.head).toList // TODO exclude None
+    val urisToParse = urisByProvider.values.map(_.head).toList
 
     Future
       .traverse(urisToParse) { drsUri =>
         drsResolver.drsSignedUrl(drsUri, userInfo)
       }
       .map { urls =>
-        val collected = urls.collect { case Some(url) =>
-          url
-        }.toSet
+        val collected = urls.collect { case Some(url) => url }.toSet
+        if (collected.size != urls.size) {
+          throw new RawlsExceptionWithErrorReport(errorReport =
+            ErrorReport(StatusCodes.InternalServerError,
+                        "One or more URLs could not be resolved"
+            ) // TODO what should the status code be
+          )
+        }
         logger.debug(s"resolveDrsSignedUrls found ${collected.size} urls for ${drsUris.size} DRS URIs")
         collected
       }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -527,9 +527,6 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       _ <-
         if (dosSignedUrls.isEmpty) Future.successful(false)
         else Future.successful(true) // TODO Is this correct? Or just don't check that it's empty at all?
-//          googleServicesDAO.addPolicyBindings(GoogleProjectId(wfOpts.google_project),
-//                                              Map(requesterPaysRole -> dosSignedUrls.map("serviceAccount:" + _))
-//          )
       // Should labels be an Option? It's not optional for rawls (but then wfOpts are options too)
       workflowSubmitResult <- executionServiceCluster.submitWorkflows(workflowRecs,
                                                                       wdl,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -384,18 +384,17 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
   def resolveDrsSignedUrls(drsUris: Set[String], userInfo: UserInfo)(implicit
     executionContext: ExecutionContext
   ): Future[Set[String]] = {
-    val urisByProvider =
-      drsUris.flatMap(Uri.parseOption).map(_.toUrl).groupBy(_.hostOption).map { case (_, uris) =>
-        uris.head.toString
-      }
 
-    val parsedUris = drsUris.flatMap(Uri.parseOption)
-    if (parsedUris.size != drsUris.size) {
-      logger.warn("Some URIs were unparsable")
+    val urisByProvider: Map[Option[String], List[String]] = drsUris.toList.groupBy(DrsResolver.getProvider)
+
+    if (urisByProvider.contains(None)) {
+      logger.warn(s"Some URIs were unparsable: ${urisByProvider(None)}") // TODO should this throw an error
     }
 
+    val urisToParse = urisByProvider.values.map(_.head).toList // TODO exclude None
+
     Future
-      .traverse(urisByProvider) { drsUri =>
+      .traverse(urisToParse) { drsUri =>
         drsResolver.drsSignedUrl(drsUri, userInfo)
       }
       .map { urls =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -381,15 +381,16 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       case err: JsValue  => AttributeString(err.toString)
     }
 
-  def resolveDrsSignedUrls(drsUris: Set[String], userInfo: UserInfo)(implicit
+  def validateDrsProviderAccess(drsUris: Set[String], userInfo: UserInfo)(implicit
     executionContext: ExecutionContext
   ): Future[Set[String]] = {
 
     val urisByProvider: Map[Option[String], List[String]] = drsUris.toList.groupBy(DrsResolver.getProvider)
 
     if (urisByProvider.contains(None)) {
-      logger.warn(s"Some URIs were unparsable: ${urisByProvider(None)}") // TODO What should be logged vs. thrown?
-      throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.NotFound, "Unable to parse URI"))
+      throw new RawlsExceptionWithErrorReport(errorReport =
+        ErrorReport(StatusCodes.BadRequest, s"Unable to parse URIs: ${urisByProvider(None)}")
+      )
     }
 
     val urisToParse = urisByProvider.values.map(_.head).toList
@@ -400,13 +401,6 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       }
       .map { urls =>
         val collected = urls.collect { case Some(url) => url }.toSet
-        if (collected.size != urls.size) {
-          throw new RawlsExceptionWithErrorReport(errorReport =
-            ErrorReport(StatusCodes.InternalServerError,
-                        "One or more URLs could not be resolved"
-            ) // TODO what should the status code be
-          )
-        }
         logger.debug(s"resolveDrsSignedUrls found ${collected.size} urls for ${drsUris.size} DRS URIs")
         collected
       }
@@ -528,7 +522,7 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
     val cromwellSubmission = for {
       (wdl, workflowRecs, wfInputsBatch, wfOpts, wfLabels, wfCollection, dosUris, petUserInfo, methodConfig) <-
         workflowBatchFuture
-      _ <- resolveDrsSignedUrls(dosUris, petUserInfo)
+      _ <- validateDrsProviderAccess(dosUris, petUserInfo)
       // Should labels be an Option? It's not optional for rawls (but then wfOpts are options too)
       workflowSubmitResult <- executionServiceCluster.submitWorkflows(workflowRecs,
                                                                       wdl,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -4,6 +4,7 @@ import akka.actor._
 import akka.http.scaladsl.model.StatusCodes
 import akka.pattern._
 import com.typesafe.scalalogging.LazyLogging
+import io.lemonlabs.uri.Uri
 import org.broadinstitute.dsde.rawls.dataaccess._
 import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsResolver
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
@@ -13,7 +14,7 @@ import org.broadinstitute.dsde.rawls.metrics.logEvents.SubmissionEvent
 import org.broadinstitute.dsde.rawls.model.WorkflowFailureModes.WorkflowFailureMode
 import org.broadinstitute.dsde.rawls.model.WorkflowStatuses.WorkflowStatus
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.rawls.util.{addJitter, FutureSupport, MethodWiths}
+import org.broadinstitute.dsde.rawls.util.{FutureSupport, MethodWiths, addJitter}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceSettingRepository
 import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
 import spray.json.DefaultJsonProtocol._
@@ -380,20 +381,24 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
       case err: JsValue  => AttributeString(err.toString)
     }
 
-  private def resolveDrsUriServiceAccounts(drsUris: Set[String], userInfo: UserInfo)(implicit
-    executionContext: ExecutionContext
-  ): Future[Set[String]] =
+  def resolveDrsSignedUrls(drsUris: Set[String], userInfo: UserInfo)(implicit
+                                                                                     executionContext: ExecutionContext
+  ): Future[Set[String]] = {
+    //TODO should this be done in this method or before calling this method?
+    val urisByProvider = drsUris.flatMap(Uri.parseOption).map(_.toUrl).groupBy(_.hostOption.map(_.value).getOrElse("unknown")).map { case (provider, uris) => uris.head.toString() }
+
     Future
-      .traverse(drsUris) { drsUri =>
-        drsResolver.drsServiceAccountEmail(drsUri, userInfo)
+      .traverse(urisByProvider) { drsUri =>
+        drsResolver.drsSignedUrl(drsUri, userInfo)
       }
-      .map { emails =>
-        val collected = emails.collect { case Some(email) =>
-          email
-        }
-        logger.debug(s"resolveDrsUriServiceAccounts found ${collected.size} emails for ${drsUris.size} DRS URIs")
+      .map { urls =>
+        val collected = urls.collect { case Some(url) =>
+          url
+        }.toSet
+        logger.debug(s"resolveDrsSignedUrls found ${collected.size} urls for ${drsUris.size} DRS URIs")
         collected
       }
+  }
 
   private def collectDosUris(workflowBatch: Seq[Workflow]): Set[String] = {
     val dosUris = for {
@@ -511,17 +516,17 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
     val cromwellSubmission = for {
       (wdl, workflowRecs, wfInputsBatch, wfOpts, wfLabels, wfCollection, dosUris, petUserInfo, methodConfig) <-
         workflowBatchFuture
-      dosServiceAccounts <- resolveDrsUriServiceAccounts(dosUris, petUserInfo)
+      dosSignedUrls <- resolveDrsSignedUrls(dosUris, petUserInfo)
       // For Jade, HCA, anyone who doesn't use Bond, we won't get an SA back and the following line is a no-op
       // We still call DRSHub for those because we can verify the user has permission on the DRS object as
       // early as possible, rather than letting the workflow(s) launch and fail
       // AEN 2020-09-08 [WA-325]
       _ <-
-        if (dosServiceAccounts.isEmpty) Future.successful(false)
-        else
-          googleServicesDAO.addPolicyBindings(GoogleProjectId(wfOpts.google_project),
-                                              Map(requesterPaysRole -> dosServiceAccounts.map("serviceAccount:" + _))
-          )
+        if (dosSignedUrls.isEmpty) Future.successful(false)
+        else Future.successful(true) //TODO Is this correct? Or just don't check that it's empty at all?
+//          googleServicesDAO.addPolicyBindings(GoogleProjectId(wfOpts.google_project),
+//                                              Map(requesterPaysRole -> dosSignedUrls.map("serviceAccount:" + _))
+//          )
       // Should labels be an Option? It's not optional for rawls (but then wfOpts are options too)
       workflowSubmitResult <- executionServiceCluster.submitWorkflows(workflowRecs,
                                                                       wdl,

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionActor.scala
@@ -400,9 +400,8 @@ trait WorkflowSubmission extends FutureSupport with LazyLogging with MethodWiths
         drsResolver.drsSignedUrl(drsUri, userInfo)
       }
       .map { urls =>
-        val collected = urls.collect { case Some(url) => url }.toSet
-        logger.debug(s"resolveDrsSignedUrls found ${collected.size} urls for ${drsUris.size} DRS URIs")
-        collected
+        logger.debug(s"resolveDrsSignedUrls found ${urls.size} urls for ${drsUris.size} DRS URIs")
+        urls.toSet
       }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -23,7 +23,6 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
   when(mockUserInfo.accessToken).thenReturn(OAuth2BearerToken("access_token"))
   behavior of "DrsHubResolver"
 
-  // TODO update result to be a url
   it should "get the signed url for a drs object" in {
     doReturn(
       Future.successful(

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -23,11 +23,11 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
   when(mockUserInfo.accessToken).thenReturn(OAuth2BearerToken("access_token"))
   behavior of "DrsHubResolver"
 
-  //TODO update result to be a url
+  // TODO update result to be a url
   it should "get the signed url for a drs object" in {
     doReturn(
       Future.successful(
-        DrsHubMinimalResponse(Option(("https://signed-url.com/file?key=123")))
+        DrsHubMinimalResponse(Option("https://signed-url.com/file?key=123"))
       )
     )
       .when(mockDrsHubResolver)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -26,7 +26,7 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
   it should "get the signed url for a drs object" in {
     doReturn(
       Future.successful(
-        DrsHubMinimalResponse(Option("https://signed-url.com/file?key=123"))
+        DrsHubMinimalResponse(Some(DrsHubAccessUrl(Some("https://signed-url.com/file?key=123"), None)))
       )
     )
       .when(mockDrsHubResolver)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -9,6 +9,8 @@ import org.broadinstitute.dsde.rawls.model.UserInfo
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doReturn, spy, when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.must.Matchers.be
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.duration.DurationInt
@@ -45,5 +47,17 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
     assertResult(None) {
       Await.result(response, 1 minute)
     }
+  }
+
+  "getProvider" should "get correct providers" in {
+    DrsResolver.getProvider("drs://dg.anv0:f51fc329-b09e-4e16-b1a9-2f60ebc428ab") shouldBe Some("dg.anv0")
+    DrsResolver.getProvider("drs://drs.example.org/ga4gh/drs/v1/objects/314159") shouldBe Some("drs.example.org")
+    DrsResolver.getProvider("https://storage.googleapis.com/v1_abc-123?key=54321") shouldBe Some(
+      "storage.googleapis.com"
+    )
+    DrsResolver.getProvider("drs://jade.datarepo-dev.broadinstitute.org/v1_abcd-123-efg") shouldBe Some(
+      "jade.datarepo-dev.broadinstitute.org"
+    )
+    DrsResolver.getProvider("invalid-url") shouldBe None
   }
 }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -35,7 +35,7 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
       .when(mockDrsHubResolver)
       .executeRequestWithToken(any[OAuth2BearerToken])(any[HttpRequest])(any())
     val response = mockDrsHubResolver.drsSignedUrl("drs://drs-provider.com/v1_foo_bar", mockUserInfo)
-    assertResult(Option("https://signed-url.com/file?key=123")) {
+    assertResult("https://signed-url.com/file?key=123") {
       Await.result(response, 1 minute)
     }
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -23,25 +23,26 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
   when(mockUserInfo.accessToken).thenReturn(OAuth2BearerToken("access_token"))
   behavior of "DrsHubResolver"
 
-  it should "get the service account of a drs object" in {
+  //TODO update result to be a url
+  it should "get the signed url for a drs object" in {
     doReturn(
       Future.successful(
-        DrsHubMinimalResponse(Option(ServiceAccountPayload(Option(ServiceAccountEmail("foo@bar.com")))))
+        DrsHubMinimalResponse(Option(("https://signed-url.com/file?key=123")))
       )
     )
       .when(mockDrsHubResolver)
       .executeRequestWithToken(any[OAuth2BearerToken])(any[HttpRequest])(any())
-    val response = mockDrsHubResolver.drsServiceAccountEmail("drs://drs-provider.com/v1_foo_bar", mockUserInfo)
-    assertResult(Option("foo@bar.com")) {
+    val response = mockDrsHubResolver.drsSignedUrl("drs://drs-provider.com/v1_foo_bar", mockUserInfo)
+    assertResult(Option("https://signed-url.com/file?key=123")) {
       Await.result(response, 1 minute)
     }
   }
 
-  it should "handle no service account for a drs object" in {
-    doReturn(Future.successful(DrsHubMinimalResponse(Option(ServiceAccountPayload(None)))))
+  it should "handle no signed url for a drs object" in {
+    doReturn(Future.successful(DrsHubMinimalResponse(None)))
       .when(mockDrsHubResolver)
       .executeRequestWithToken(any[OAuth2BearerToken])(any[HttpRequest])(any())
-    val response = mockDrsHubResolver.drsServiceAccountEmail("drs://drs-provider.com/v1_foo_bar", mockUserInfo)
+    val response = mockDrsHubResolver.drsSignedUrl("drs://drs-provider.com/v1_foo_bar", mockUserInfo)
     assertResult(None) {
       Await.result(response, 1 minute)
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/dataaccess/drs/DrsHubResolverSpec.scala
@@ -2,9 +2,10 @@ package org.broadinstitute.dsde.rawls.dataaccess.drs
 
 import akka.actor.ActorSystem
 import org.scalatestplus.mockito.MockitoSugar.mock
-import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.testkit.TestKit
+import org.broadinstitute.dsde.rawls.RawlsExceptionWithErrorReport
 import org.broadinstitute.dsde.rawls.model.UserInfo
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doReturn, spy, when, RETURNS_SMART_NULLS}
@@ -39,13 +40,15 @@ class DrsHubResolverSpec extends TestKit(ActorSystem("DrsHubResolverSpec")) with
     }
   }
 
-  it should "handle no signed url for a drs object" in {
+  it should "error on no signed url for a drs object" in {
     doReturn(Future.successful(DrsHubMinimalResponse(None)))
       .when(mockDrsHubResolver)
       .executeRequestWithToken(any[OAuth2BearerToken])(any[HttpRequest])(any())
-    val response = mockDrsHubResolver.drsSignedUrl("drs://drs-provider.com/v1_foo_bar", mockUserInfo)
-    assertResult(None) {
-      Await.result(response, 1 minute)
+    val resolveFailure = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(mockDrsHubResolver.drsSignedUrl("drs://drs-provider.com/v1_foo_bar", mockUserInfo), 1 minute)
+    }
+    assertResult(Some(StatusCodes.BadRequest)) {
+      resolveFailure.errorReport.statusCode
     }
   }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -500,7 +500,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
   it should "fail if any URIs fail to resolve" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+      .thenReturn(Future.successful(DrsTestVals.dosSignedUrl))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
       .thenReturn(
         Future.failed(
@@ -1060,13 +1060,13 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
   "resolveDrsSignedUrls" should "only resolve once per provider" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Some(DrsTestVals.dosSignedUrl)))
+      .thenReturn(Future.successful(DrsTestVals.dosSignedUrl))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
-      .thenReturn(Future.successful(Some(DrsTestVals.drsSignedUrl1)))
+      .thenReturn(Future.successful(DrsTestVals.drsSignedUrl1))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
-      .thenReturn(Future.successful(Some(DrsTestVals.drsUrlTDR2)))
+      .thenReturn(Future.successful(DrsTestVals.drsUrlTDR2))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Some(DrsTestVals.drsCompactSignedUrl)))
+      .thenReturn(Future.successful(DrsTestVals.drsCompactSignedUrl))
 
     val data = testData
     // Set up system under test
@@ -1092,11 +1092,11 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
   it should "error on unparseable URIs" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+      .thenReturn(Future.successful(DrsTestVals.dosSignedUrl))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl1)))
+      .thenReturn(Future.successful(DrsTestVals.drsSignedUrl1))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsCompactSignedUrl)))
+      .thenReturn(Future.successful(DrsTestVals.drsCompactSignedUrl))
 
     val data = testData
     // Set up system under test

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -588,7 +588,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Duration.Inf
       )
 
-      //TODO what to verify
+      // TODO what to verify
 //      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
 //        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
 //             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
@@ -659,7 +659,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Duration.Inf
       )
 
-      //TODO what to verify
+      // TODO what to verify
 //      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
 //        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
 //             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
@@ -730,7 +730,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Duration.Inf
       )
 
-      //TODO what to verify
+      // TODO what to verify
 //      val expectedClientEmail =
 //        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
 //             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
@@ -1321,10 +1321,16 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
       override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
     }
 
-    val result = Await.result(workflowSubmission.resolveDrsSignedUrls(Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR, DrsTestVals.dosUrlDiff, DrsTestVals.dosUrl3), userInfo), Duration.Inf)
+    val result = Await.result(
+      workflowSubmission.resolveDrsSignedUrls(
+        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR, DrsTestVals.dosUrlDiff, DrsTestVals.dosUrl3),
+        userInfo
+      ),
+      Duration.Inf
+    )
 
-    //dosUrl and dosUrl3 have the same provider, so only one result for the pair
-    assertResult(3){
+    // dosUrl and dosUrl3 have the same provider, so only one result for the pair
+    assertResult(3) {
       result.size
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -512,7 +512,13 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.failed(new RuntimeException("403"))) // TODO what will actually be thrown
+      .thenReturn(
+        Future.failed(
+          new RawlsExceptionWithErrorReport(errorReport =
+            ErrorReport(StatusCodes.Forbidden, "User does not have access")
+          )
+        )
+      )
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -565,292 +565,6 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     }
   }
 
-//  it should "resolve DOS URIs when submitting workflows" in withDefaultTestDatabase {
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
-//
-//    val data = testData
-//    // Set up system under test
-//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-//    }
-//
-//    withWorkspaceContext(data.workspace) { ctx =>
-//      // Create test submission data
-//      val sample = Entity("sample", "Sample", Map())
-//      val sampleSet =
-//        Entity("sampleset",
-//               "sample_set",
-//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-//        )
-//      val inputResolutions = Seq(
-//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
-//        SubmissionValidationValue(
-//          Option(
-//            AttributeValueList(
-//              Seq(AttributeString(DrsTestVals.dosUrl1),
-//                  AttributeString(DrsTestVals.dosUrlDiff),
-//                  AttributeString(DrsTestVals.dosUrl3)
-//              )
-//            )
-//          ),
-//          None,
-//          "test_input_dos_array"
-//        )
-//      )
-//      val submissionDos = createTestSubmission(
-//        data.workspace,
-//        data.agoraMethodConfig,
-//        sampleSet,
-//        WorkbenchEmail(data.userOwner.userEmail.value),
-//        Seq(sample),
-//        Map(sample -> inputResolutions),
-//        Seq(),
-//        Map()
-//      )
-//
-//      runAndWait(entityQuery.save(ctx, sample))
-//      runAndWait(entityQuery.save(ctx, sampleSet))
-//      runAndWait(submissionQuery.create(ctx, submissionDos))
-//      val (workflowRecs, submissionRec, workspaceRec) =
-//        getWorkflowSubmissionWorkspaceRecords(submissionDos, data.workspace)
-//
-//      // Submit workflow!
-//      Await.result(
-//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-//        Duration.Inf
-//      )
-//
-//      // TODO what to verify
-////      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
-////        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-////             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
-////        )
-//    }
-//  }
-//
-//  it should "resolve DRS URIs when submitting workflows" in withDefaultTestDatabase {
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
-//
-//    val data = testData
-//    // Set up system under test
-//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-//    }
-//
-//    withWorkspaceContext(data.workspace) { ctx =>
-//      // Create test submission data
-//      val sample = Entity("sample", "Sample", Map())
-//      val sampleSet =
-//        Entity("sampleset",
-//               "sample_set",
-//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-//        )
-//      val inputResolutions = Seq(
-//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
-//        SubmissionValidationValue(
-//          Option(
-//            AttributeValueList(
-//              Seq(AttributeString(DrsTestVals.dosUrl1),
-//                  AttributeString(DrsTestVals.dosUrlDiff),
-//                  AttributeString(DrsTestVals.dosUrl3)
-//              )
-//            )
-//          ),
-//          None,
-//          "test_input_dos_array"
-//        )
-//      )
-//      val submissionDrs = createTestSubmission(
-//        data.workspace,
-//        data.agoraMethodConfig,
-//        sampleSet,
-//        WorkbenchEmail(data.userOwner.userEmail.value),
-//        Seq(sample),
-//        Map(sample -> inputResolutions),
-//        Seq(),
-//        Map()
-//      )
-//
-//      runAndWait(entityQuery.save(ctx, sample))
-//      runAndWait(entityQuery.save(ctx, sampleSet))
-//      runAndWait(submissionQuery.create(ctx, submissionDrs))
-//      val (workflowRecs, submissionRec, workspaceRec) =
-//        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
-//
-//      // Submit workflow!
-//      Await.result(
-//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-//        Duration.Inf
-//      )
-//
-//      // TODO what to verify
-////      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
-////        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-////             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
-////        )
-//    }
-//  }
-//
-//  it should "resolve DRS URIs containing Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
-//
-//    val data = testData
-//    // Set up system under test
-//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-//    }
-//
-//    withWorkspaceContext(data.workspace) { ctx =>
-//      // Create test submission data
-//      val sample = Entity("sample", "Sample", Map())
-//      val sampleSet =
-//        Entity("sampleset",
-//               "sample_set",
-//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-//        )
-//      val inputResolutions = Seq(
-//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
-//        SubmissionValidationValue(
-//          Option(
-//            AttributeValueList(
-//              Seq(AttributeString(DrsTestVals.drsUrlTDR),
-//                  AttributeString(DrsTestVals.dosUrlDiff),
-//                  AttributeString(DrsTestVals.dosUrl3)
-//              )
-//            )
-//          ),
-//          None,
-//          "test_input_dos_array"
-//        )
-//      )
-//      val submissionDrs = createTestSubmission(
-//        data.workspace,
-//        data.agoraMethodConfig,
-//        sampleSet,
-//        WorkbenchEmail(data.userOwner.userEmail.value),
-//        Seq(sample),
-//        Map(sample -> inputResolutions),
-//        Seq(),
-//        Map()
-//      )
-//
-//      runAndWait(entityQuery.save(ctx, sample))
-//      runAndWait(entityQuery.save(ctx, sampleSet))
-//      runAndWait(submissionQuery.create(ctx, submissionDrs))
-//      val (workflowRecs, submissionRec, workspaceRec) =
-//        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
-//
-//      // Submit workflow!
-//      Await.result(
-//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-//        Duration.Inf
-//      )
-//
-//      // TODO what to verify
-////      val expectedClientEmail =
-////        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-////             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
-////        )
-////      mockGoogleServicesDAO.policies(ctx.googleProjectId)(
-////        requesterPaysRole
-////      ) should contain theSameElementsAs expectedClientEmail
-//    }
-//  }
-//
-//  it should "resolve DRS URIs containing only Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-//      .thenReturn(Future.successful(None))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
-//      .thenReturn(Future.successful(None))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
-//      .thenReturn(Future.successful(None))
-//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR3), any[UserInfo]))
-//      .thenReturn(Future.successful(None))
-//
-//    val data = testData
-//    // Set up system under test
-//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-//    }
-//
-//    withWorkspaceContext(data.workspace) { ctx =>
-//      // Create test submission data
-//      val sample = Entity("sample", "Sample", Map())
-//      val sampleSet =
-//        Entity("sampleset",
-//               "sample_set",
-//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-//        )
-//      val inputResolutions = Seq(
-//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.drsUrlTDR)), None, "test_input_dos"),
-//        SubmissionValidationValue(
-//          Option(
-//            AttributeValueList(
-//              Seq(
-//                AttributeString(DrsTestVals.drsUrlTDR1),
-//                AttributeString(DrsTestVals.drsUrlTDR2),
-//                AttributeString(DrsTestVals.drsUrlTDR3)
-//              )
-//            )
-//          ),
-//          None,
-//          "test_input_dos_array"
-//        )
-//      )
-//      val submissionDrs = createTestSubmission(
-//        data.workspace,
-//        data.agoraMethodConfig,
-//        sampleSet,
-//        WorkbenchEmail(data.userOwner.userEmail.value),
-//        Seq(sample),
-//        Map(sample -> inputResolutions),
-//        Seq(),
-//        Map()
-//      )
-//
-//      runAndWait(entityQuery.save(ctx, sample))
-//      runAndWait(entityQuery.save(ctx, sampleSet))
-//      runAndWait(submissionQuery.create(ctx, submissionDrs))
-//      val (workflowRecs, submissionRec, workspaceRec) =
-//        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
-//
-//      // Submit workflow!
-//      Await.result(
-//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-//        Duration.Inf
-//      )
-//
-//      // Verify
-//      // since no SA was returned from DRSHub for JDR urls, requester pays role was never added to the polices. Hence it should be empty
-//      mockGoogleServicesDAO.policies shouldBe TrieMap.empty[RawlsBillingProjectName, Map[String, Set[String]]]
-//    }
-//  }
-
   it should "match workflows to entities they run on in the right order" in withDefaultTestDatabase {
     val workflowSubmission = new TestWorkflowSubmissionWithMockExecSvc(slickDataSource)
 
@@ -1376,12 +1090,10 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
   }
 
-  it should "handle null accessUrls" in withDefaultTestDatabase {
+  it should "error on null accessUrls" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl1)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
       .thenReturn(Future.successful(None))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.drsCompactSignedUrl)))
@@ -1393,18 +1105,41 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
       override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
     }
 
-    val result = Await.result(
-      workflowSubmission.resolveDrsSignedUrls(
-        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, DrsTestVals.drsUrlTDR2, DrsTestVals.drsCompactUrl),
-        userInfo
-      ),
-      Duration.Inf
-    )
+    val resolveFailure = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        workflowSubmission.resolveDrsSignedUrls(
+          Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, DrsTestVals.drsCompactUrl),
+          userInfo
+        ),
+        Duration.Inf
+      )
+    }
 
-    // Lack of accessUrl should simply result in a shorter result
-    // TODO or should it fail?
-    assertResult(2) {
-      result.size
+  }
+
+  it should "error on unparseable URIs" in withDefaultTestDatabase {
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsCompactSignedUrl)))
+
+    val data = testData
+    // Set up system under test
+    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+    }
+
+    val resolveFailure = intercept[RawlsExceptionWithErrorReport] {
+      Await.result(
+        workflowSubmission.resolveDrsSignedUrls(
+          Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, "not a valid uri", DrsTestVals.drsCompactUrl),
+          userInfo
+        ),
+        Duration.Inf
+      )
     }
 
   }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -81,28 +81,36 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     val jdrDevUrl = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4"
     val dgUrl = "drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0"
 
-    val mrBeanEmail: ServiceAccountEmail = ServiceAccountEmail("mr_bean@gmail.com")
-    val mrBeanSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(mrBeanEmail))
-    val mrBeanSAMinimalResponse: DrsHubMinimalResponse = DrsHubMinimalResponse(Option(mrBeanSAPayload))
+//    val mrBeanEmail: ServiceAccountEmail = ServiceAccountEmail("mr_bean@gmail.com")
+//    val mrBeanSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(mrBeanEmail))
+//    val mrBeanSAMinimalResponse: DrsHubMinimalResponse = DrsHubMinimalResponse(Option("https://signed-url.url"))
 
-    val drsServiceAccount = "serviceaccount@foo.com"
-    val drsSAEmail: ServiceAccountEmail = ServiceAccountEmail(drsServiceAccount)
-    val drsSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(drsSAEmail))
-    val drsSAMinimalResponse: drs.DrsHubMinimalResponse = DrsHubMinimalResponse(Option(drsSAPayload))
+//    val drsServiceAccount = "serviceaccount@foo.com"
+//    val drsSAEmail: ServiceAccountEmail = ServiceAccountEmail(drsServiceAccount)
+//    val drsSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(drsSAEmail))
+//    val drsSAMinimalResponse: drs.DrsHubMinimalResponse = DrsHubMinimalResponse(Option("https://signed-url.url"))
 
-    val differentDrsServiceAccount = "differentserviceaccount@foo.com"
-    val differentDrsSAEmail: ServiceAccountEmail = ServiceAccountEmail(differentDrsServiceAccount)
-    val differentDrsSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(differentDrsSAEmail))
-    val differentDrsSAMinimalResponse: drs.DrsHubMinimalResponse = DrsHubMinimalResponse(Option(differentDrsSAPayload))
+//    val differentDrsServiceAccount = "differentserviceaccount@foo.com"
+//    val differentDrsSAEmail: ServiceAccountEmail = ServiceAccountEmail(differentDrsServiceAccount)
+//    val differentDrsSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(differentDrsSAEmail))
+//    val differentDrsSAMinimalResponse: drs.DrsHubMinimalResponse = DrsHubMinimalResponse(Option("https://signed-url.url"))
 
     val dosUrl = "dos://foo/bar"
+    val dosSignedUrl = "https://dos.com/signed-url?key=12345"
     val dosUrl1 = "dos://foo/bar1"
+    val dosSignedUrl1 = "https://dos.com/signed-url1?key=6789"
     val dosUrl3 = "dos://foo/bar3"
+    val dosSignedUrl3 = "https://dos.com/signed-url3?key=98765"
     val dosUrlDiff = "dos://different"
+    val dosSignedUrlDiff = "https://dos2.com/signed-diff?key=0001"
     val drsUrlTDR = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-123"
+    val drsSignedUrl = "https://storage.googleapis.com/v1_abc-123?key=54321"
     val drsUrlTDR1 = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-1234"
+    val drsSignedUrl1 = "https://storage.googleapis.com/v1_abc-1234?key=65432"
     val drsUrlTDR2 = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-12345"
+    val drsSignedUrl2 = "https://storage.googleapis.com/v1_abc-12345?key=12345"
     val drsUrlTDR3 = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-123456"
+    val drsSignedUrl3 = "https://storage.googleapis.com/v1_abc-123456?key=54321"
   }
 
   /** Extension of WorkflowSubmission to allow us to intercept and validate calls to the execution service.
@@ -518,14 +526,14 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
   }
 
   it should "resolve DOS URIs when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.differentDrsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
 
     val data = testData
     // Set up system under test
@@ -580,23 +588,23 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Duration.Inf
       )
 
-      // Verify
-      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
-        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
-        )
+      //TODO what to verify
+//      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
+//        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
+//             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+//        )
     }
   }
 
   it should "resolve DRS URIs when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.differentDrsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
 
     val data = testData
     // Set up system under test
@@ -651,23 +659,23 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Duration.Inf
       )
 
-      // Verify
-      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
-        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
-        )
+      //TODO what to verify
+//      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
+//        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
+//             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+//        )
     }
   }
 
   it should "resolve DRS URIs containing Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.differentDrsServiceAccount)))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsServiceAccount)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
 
     val data = testData
     // Set up system under test
@@ -722,25 +730,25 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         Duration.Inf
       )
 
-      // Verify
-      val expectedClientEmail =
-        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
-        )
-      mockGoogleServicesDAO.policies(ctx.googleProjectId)(
-        requesterPaysRole
-      ) should contain theSameElementsAs expectedClientEmail
+      //TODO what to verify
+//      val expectedClientEmail =
+//        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
+//             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+//        )
+//      mockGoogleServicesDAO.policies(ctx.googleProjectId)(
+//        requesterPaysRole
+//      ) should contain theSameElementsAs expectedClientEmail
     }
   }
 
   it should "resolve DRS URIs containing only Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
       .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
       .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
       .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsServiceAccountEmail(mockitoEq(DrsTestVals.drsUrlTDR3), any[UserInfo]))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR3), any[UserInfo]))
       .thenReturn(Future.successful(None))
 
     val data = testData
@@ -1294,6 +1302,32 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
       .map(_.parseJson.convertTo[ExecutionServiceWorkflowOptions])
 
     workflowOptions.get.backend should be(CromwellBackend("PAPIv2-CloudNAT"))
+  }
+
+  "resolveDrsSignedUrls" should "only resolve once per provider" in withDefaultTestDatabase {
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
+
+    val data = testData
+    // Set up system under test
+    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+    }
+
+    val result = Await.result(workflowSubmission.resolveDrsSignedUrls(Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR, DrsTestVals.dosUrlDiff, DrsTestVals.dosUrl3), userInfo), Duration.Inf)
+
+    //dosUrl and dosUrl3 have the same provider, so only one result for the pair
+    assertResult(3){
+      result.size
+    }
+
   }
 
   private def setWorkflowBatchToQueued(batchSize: Int, submissionId: String): Seq[WorkflowRecord] =

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -78,20 +78,12 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
     val dosUrl = "dos://foo/bar"
     val dosSignedUrl = "https://dos.com/signed-url?key=12345"
-    val dosUrl1 = "dos://foo/bar1"
-    val dosSignedUrl1 = "https://dos.com/signed-url1?key=6789"
-    val dosUrl3 = "dos://foo/bar3"
-    val dosSignedUrl3 = "https://dos.com/signed-url3?key=98765"
-    val dosUrlDiff = "dos://different"
-    val dosSignedUrlDiff = "https://dos2.com/signed-diff?key=0001"
-    val drsUrlTDR = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-123"
-    val drsSignedUrl = "https://storage.googleapis.com/v1_abc-123?key=54321"
     val drsUrlTDR1 = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-1234"
     val drsSignedUrl1 = "https://storage.googleapis.com/v1_abc-1234?key=65432"
     val drsUrlTDR2 = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-12345"
     val drsSignedUrl2 = "https://storage.googleapis.com/v1_abc-12345?key=12345"
-    val drsUrlTDR3 = "drs://jade.datarepo-dev.broadinstitute.org/v1_abc-123456"
-    val drsSignedUrl3 = "https://storage.googleapis.com/v1_abc-123456?key=54321"
+    val drsCompactUrl = "drs://dg.anv:123-abc/v1_abc-123456"
+    val drsCompactSignedUrl = "https://storage.googleapis.com/v1_abc-123456?key=54321"
   }
 
   /** Extension of WorkflowSubmission to allow us to intercept and validate calls to the execution service.
@@ -509,9 +501,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
   it should "fail if any URIs fail to resolve" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
       .thenReturn(
         Future.failed(
           new RawlsExceptionWithErrorReport(errorReport =
@@ -519,8 +509,6 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
           )
         )
       )
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
 
     val data = testData
     // Set up system under test
@@ -538,14 +526,10 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
                Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
         )
       val inputResolutions = Seq(
-        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
         SubmissionValidationValue(
           Option(
             AttributeValueList(
-              Seq(AttributeString(DrsTestVals.dosUrl1),
-                  AttributeString(DrsTestVals.dosUrlDiff),
-                  AttributeString(DrsTestVals.dosUrl3)
-              )
+              Seq(AttributeString(DrsTestVals.dosUrl), AttributeString(DrsTestVals.drsUrlTDR1))
             )
           ),
           None,
@@ -1362,13 +1346,13 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
   "resolveDrsSignedUrls" should "only resolve once per provider" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
+      .thenReturn(Future.successful(Some(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
+      .thenReturn(Future.successful(Some(DrsTestVals.drsSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
+      .thenReturn(Future.successful(Some(DrsTestVals.drsUrlTDR2)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Some(DrsTestVals.drsCompactSignedUrl)))
 
     val data = testData
     // Set up system under test
@@ -1379,13 +1363,13 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
     val result = Await.result(
       workflowSubmission.resolveDrsSignedUrls(
-        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR, DrsTestVals.dosUrlDiff, DrsTestVals.dosUrl3),
+        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, DrsTestVals.drsUrlTDR2, DrsTestVals.drsCompactUrl),
         userInfo
       ),
       Duration.Inf
     )
 
-    // dosUrl and dosUrl3 have the same provider, so only one result for the pair
+    // drsUrlTDR1 and drsUrlTDR2 have the same provider, so only one result for the pair
     assertResult(3) {
       result.size
     }
@@ -1395,12 +1379,12 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
   it should "handle null accessUrls" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(None))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl1)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
+      .thenReturn(Future.successful(None))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsCompactSignedUrl)))
 
     val data = testData
     // Set up system under test
@@ -1411,13 +1395,14 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
     val result = Await.result(
       workflowSubmission.resolveDrsSignedUrls(
-        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR, DrsTestVals.dosUrlDiff, DrsTestVals.dosUrl3),
+        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, DrsTestVals.drsUrlTDR2, DrsTestVals.drsCompactUrl),
         userInfo
       ),
       Duration.Inf
     )
 
     // Lack of accessUrl should simply result in a shorter result
+    // TODO or should it fail?
     assertResult(2) {
       result.size
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -6,13 +6,8 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import com.google.api.client.auth.oauth2.Credential
 import org.broadinstitute.dsde.rawls.config.MethodRepoConfig
-import org.broadinstitute.dsde.rawls.dataaccess.{drs, _}
-import org.broadinstitute.dsde.rawls.dataaccess.drs.{
-  DrsHubMinimalResponse,
-  DrsHubResolver,
-  ServiceAccountEmail,
-  ServiceAccountPayload
-}
+import org.broadinstitute.dsde.rawls.dataaccess._
+import org.broadinstitute.dsde.rawls.dataaccess.drs.DrsHubResolver
 import org.broadinstitute.dsde.rawls.dataaccess.slick._
 import org.broadinstitute.dsde.rawls.jobexec.WorkflowSubmissionActor.{
   ProcessNextWorkflow,
@@ -80,20 +75,6 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
   object DrsTestVals {
     val jdrDevUrl = "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4"
     val dgUrl = "drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0"
-
-//    val mrBeanEmail: ServiceAccountEmail = ServiceAccountEmail("mr_bean@gmail.com")
-//    val mrBeanSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(mrBeanEmail))
-//    val mrBeanSAMinimalResponse: DrsHubMinimalResponse = DrsHubMinimalResponse(Option("https://signed-url.url"))
-
-//    val drsServiceAccount = "serviceaccount@foo.com"
-//    val drsSAEmail: ServiceAccountEmail = ServiceAccountEmail(drsServiceAccount)
-//    val drsSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(drsSAEmail))
-//    val drsSAMinimalResponse: drs.DrsHubMinimalResponse = DrsHubMinimalResponse(Option("https://signed-url.url"))
-
-//    val differentDrsServiceAccount = "differentserviceaccount@foo.com"
-//    val differentDrsSAEmail: ServiceAccountEmail = ServiceAccountEmail(differentDrsServiceAccount)
-//    val differentDrsSAPayload: ServiceAccountPayload = ServiceAccountPayload(Option(differentDrsSAEmail))
-//    val differentDrsSAMinimalResponse: drs.DrsHubMinimalResponse = DrsHubMinimalResponse(Option("https://signed-url.url"))
 
     val dosUrl = "dos://foo/bar"
     val dosSignedUrl = "https://dos.com/signed-url?key=12345"
@@ -1331,6 +1312,38 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
     // dosUrl and dosUrl3 have the same provider, so only one result for the pair
     assertResult(3) {
+      result.size
+    }
+
+  }
+
+  it should "handle null accessUrls" in withDefaultTestDatabase {
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+      .thenReturn(Future.successful(None))
+    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
+      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl1)))
+
+    val data = testData
+    // Set up system under test
+    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+    }
+
+    val result = Await.result(
+      workflowSubmission.resolveDrsSignedUrls(
+        Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR, DrsTestVals.dosUrlDiff, DrsTestVals.dosUrl3),
+        userInfo
+      ),
+      Duration.Inf
+    )
+
+    // Lack of accessUrl should simply result in a shorter result
+    assertResult(2) {
       result.size
     }
 

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -1076,7 +1076,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     }
 
     val result = Await.result(
-      workflowSubmission.resolveDrsSignedUrls(
+      workflowSubmission.validateDrsProviderAccess(
         Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, DrsTestVals.drsUrlTDR2, DrsTestVals.drsCompactUrl),
         userInfo
       ),
@@ -1086,33 +1086,6 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     // drsUrlTDR1 and drsUrlTDR2 have the same provider, so only one result for the pair
     assertResult(3) {
       result.size
-    }
-
-  }
-
-  it should "error on null accessUrls" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
-      .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsCompactUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsCompactSignedUrl)))
-
-    val data = testData
-    // Set up system under test
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-    }
-
-    val resolveFailure = intercept[RawlsExceptionWithErrorReport] {
-      Await.result(
-        workflowSubmission.resolveDrsSignedUrls(
-          Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, DrsTestVals.drsCompactUrl),
-          userInfo
-        ),
-        Duration.Inf
-      )
     }
 
   }
@@ -1134,7 +1107,7 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
 
     val resolveFailure = intercept[RawlsExceptionWithErrorReport] {
       Await.result(
-        workflowSubmission.resolveDrsSignedUrls(
+        workflowSubmission.validateDrsProviderAccess(
           Set(DrsTestVals.dosUrl, DrsTestVals.drsUrlTDR1, "not a valid uri", DrsTestVals.drsCompactUrl),
           userInfo
         ),

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/jobexec/WorkflowSubmissionSpec.scala
@@ -506,13 +506,13 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
     }
   }
 
-  it should "resolve DOS URIs when submitting workflows" in withDefaultTestDatabase {
+  it should "fail if any URIs fail to resolve" in withDefaultTestDatabase {
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
+      .thenReturn(Future.failed(new RuntimeException("403"))) // TODO what will actually be thrown
     when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
       .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
 
@@ -564,233 +564,302 @@ class WorkflowSubmissionSpec(_system: ActorSystem)
         getWorkflowSubmissionWorkspaceRecords(submissionDos, data.workspace)
 
       // Submit workflow!
-      Await.result(
-        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-        Duration.Inf
-      )
+      val submitFailureExc = intercept[RawlsExceptionWithErrorReport] {
+        Await.result(
+          workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
+          Duration.Inf
+        )
+      }
+      assert(submitFailureExc.errorReport.statusCode.contains(StatusCodes.Forbidden))
 
-      // TODO what to verify
-//      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
-//        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-//             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+    }
+  }
+
+//  it should "resolve DOS URIs when submitting workflows" in withDefaultTestDatabase {
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
+//
+//    val data = testData
+//    // Set up system under test
+//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+//    }
+//
+//    withWorkspaceContext(data.workspace) { ctx =>
+//      // Create test submission data
+//      val sample = Entity("sample", "Sample", Map())
+//      val sampleSet =
+//        Entity("sampleset",
+//               "sample_set",
+//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
 //        )
-    }
-  }
-
-  it should "resolve DRS URIs when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
-
-    val data = testData
-    // Set up system under test
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-    }
-
-    withWorkspaceContext(data.workspace) { ctx =>
-      // Create test submission data
-      val sample = Entity("sample", "Sample", Map())
-      val sampleSet =
-        Entity("sampleset",
-               "sample_set",
-               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-        )
-      val inputResolutions = Seq(
-        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
-        SubmissionValidationValue(
-          Option(
-            AttributeValueList(
-              Seq(AttributeString(DrsTestVals.dosUrl1),
-                  AttributeString(DrsTestVals.dosUrlDiff),
-                  AttributeString(DrsTestVals.dosUrl3)
-              )
-            )
-          ),
-          None,
-          "test_input_dos_array"
-        )
-      )
-      val submissionDrs = createTestSubmission(
-        data.workspace,
-        data.agoraMethodConfig,
-        sampleSet,
-        WorkbenchEmail(data.userOwner.userEmail.value),
-        Seq(sample),
-        Map(sample -> inputResolutions),
-        Seq(),
-        Map()
-      )
-
-      runAndWait(entityQuery.save(ctx, sample))
-      runAndWait(entityQuery.save(ctx, sampleSet))
-      runAndWait(submissionQuery.create(ctx, submissionDrs))
-      val (workflowRecs, submissionRec, workspaceRec) =
-        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
-
-      // Submit workflow!
-      Await.result(
-        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-        Duration.Inf
-      )
-
-      // TODO what to verify
-//      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
-//        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-//             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+//      val inputResolutions = Seq(
+//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
+//        SubmissionValidationValue(
+//          Option(
+//            AttributeValueList(
+//              Seq(AttributeString(DrsTestVals.dosUrl1),
+//                  AttributeString(DrsTestVals.dosUrlDiff),
+//                  AttributeString(DrsTestVals.dosUrl3)
+//              )
+//            )
+//          ),
+//          None,
+//          "test_input_dos_array"
 //        )
-    }
-  }
-
-  it should "resolve DRS URIs containing Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
-      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
-
-    val data = testData
-    // Set up system under test
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-    }
-
-    withWorkspaceContext(data.workspace) { ctx =>
-      // Create test submission data
-      val sample = Entity("sample", "Sample", Map())
-      val sampleSet =
-        Entity("sampleset",
-               "sample_set",
-               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-        )
-      val inputResolutions = Seq(
-        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
-        SubmissionValidationValue(
-          Option(
-            AttributeValueList(
-              Seq(AttributeString(DrsTestVals.drsUrlTDR),
-                  AttributeString(DrsTestVals.dosUrlDiff),
-                  AttributeString(DrsTestVals.dosUrl3)
-              )
-            )
-          ),
-          None,
-          "test_input_dos_array"
-        )
-      )
-      val submissionDrs = createTestSubmission(
-        data.workspace,
-        data.agoraMethodConfig,
-        sampleSet,
-        WorkbenchEmail(data.userOwner.userEmail.value),
-        Seq(sample),
-        Map(sample -> inputResolutions),
-        Seq(),
-        Map()
-      )
-
-      runAndWait(entityQuery.save(ctx, sample))
-      runAndWait(entityQuery.save(ctx, sampleSet))
-      runAndWait(submissionQuery.create(ctx, submissionDrs))
-      val (workflowRecs, submissionRec, workspaceRec) =
-        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
-
-      // Submit workflow!
-      Await.result(
-        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-        Duration.Inf
-      )
-
-      // TODO what to verify
-//      val expectedClientEmail =
-//        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
-//             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+//      )
+//      val submissionDos = createTestSubmission(
+//        data.workspace,
+//        data.agoraMethodConfig,
+//        sampleSet,
+//        WorkbenchEmail(data.userOwner.userEmail.value),
+//        Seq(sample),
+//        Map(sample -> inputResolutions),
+//        Seq(),
+//        Map()
+//      )
+//
+//      runAndWait(entityQuery.save(ctx, sample))
+//      runAndWait(entityQuery.save(ctx, sampleSet))
+//      runAndWait(submissionQuery.create(ctx, submissionDos))
+//      val (workflowRecs, submissionRec, workspaceRec) =
+//        getWorkflowSubmissionWorkspaceRecords(submissionDos, data.workspace)
+//
+//      // Submit workflow!
+//      Await.result(
+//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
+//        Duration.Inf
+//      )
+//
+//      // TODO what to verify
+////      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
+////        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
+////             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+////        )
+//    }
+//  }
+//
+//  it should "resolve DRS URIs when submitting workflows" in withDefaultTestDatabase {
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl1), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrlDiff)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
+//
+//    val data = testData
+//    // Set up system under test
+//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+//    }
+//
+//    withWorkspaceContext(data.workspace) { ctx =>
+//      // Create test submission data
+//      val sample = Entity("sample", "Sample", Map())
+//      val sampleSet =
+//        Entity("sampleset",
+//               "sample_set",
+//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
 //        )
-//      mockGoogleServicesDAO.policies(ctx.googleProjectId)(
-//        requesterPaysRole
-//      ) should contain theSameElementsAs expectedClientEmail
-    }
-  }
-
-  it should "resolve DRS URIs containing only Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
-      .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
-      .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
-      .thenReturn(Future.successful(None))
-    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR3), any[UserInfo]))
-      .thenReturn(Future.successful(None))
-
-    val data = testData
-    // Set up system under test
-    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
-    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
-      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
-    }
-
-    withWorkspaceContext(data.workspace) { ctx =>
-      // Create test submission data
-      val sample = Entity("sample", "Sample", Map())
-      val sampleSet =
-        Entity("sampleset",
-               "sample_set",
-               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
-        )
-      val inputResolutions = Seq(
-        SubmissionValidationValue(Option(AttributeString(DrsTestVals.drsUrlTDR)), None, "test_input_dos"),
-        SubmissionValidationValue(
-          Option(
-            AttributeValueList(
-              Seq(
-                AttributeString(DrsTestVals.drsUrlTDR1),
-                AttributeString(DrsTestVals.drsUrlTDR2),
-                AttributeString(DrsTestVals.drsUrlTDR3)
-              )
-            )
-          ),
-          None,
-          "test_input_dos_array"
-        )
-      )
-      val submissionDrs = createTestSubmission(
-        data.workspace,
-        data.agoraMethodConfig,
-        sampleSet,
-        WorkbenchEmail(data.userOwner.userEmail.value),
-        Seq(sample),
-        Map(sample -> inputResolutions),
-        Seq(),
-        Map()
-      )
-
-      runAndWait(entityQuery.save(ctx, sample))
-      runAndWait(entityQuery.save(ctx, sampleSet))
-      runAndWait(submissionQuery.create(ctx, submissionDrs))
-      val (workflowRecs, submissionRec, workspaceRec) =
-        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
-
-      // Submit workflow!
-      Await.result(
-        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
-        Duration.Inf
-      )
-
-      // Verify
-      // since no SA was returned from DRSHub for JDR urls, requester pays role was never added to the polices. Hence it should be empty
-      mockGoogleServicesDAO.policies shouldBe TrieMap.empty[RawlsBillingProjectName, Map[String, Set[String]]]
-    }
-  }
+//      val inputResolutions = Seq(
+//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
+//        SubmissionValidationValue(
+//          Option(
+//            AttributeValueList(
+//              Seq(AttributeString(DrsTestVals.dosUrl1),
+//                  AttributeString(DrsTestVals.dosUrlDiff),
+//                  AttributeString(DrsTestVals.dosUrl3)
+//              )
+//            )
+//          ),
+//          None,
+//          "test_input_dos_array"
+//        )
+//      )
+//      val submissionDrs = createTestSubmission(
+//        data.workspace,
+//        data.agoraMethodConfig,
+//        sampleSet,
+//        WorkbenchEmail(data.userOwner.userEmail.value),
+//        Seq(sample),
+//        Map(sample -> inputResolutions),
+//        Seq(),
+//        Map()
+//      )
+//
+//      runAndWait(entityQuery.save(ctx, sample))
+//      runAndWait(entityQuery.save(ctx, sampleSet))
+//      runAndWait(submissionQuery.create(ctx, submissionDrs))
+//      val (workflowRecs, submissionRec, workspaceRec) =
+//        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
+//
+//      // Submit workflow!
+//      Await.result(
+//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
+//        Duration.Inf
+//      )
+//
+//      // TODO what to verify
+////      mockGoogleServicesDAO.policies(ctx.googleProjectId)(requesterPaysRole) should contain theSameElementsAs
+////        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
+////             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+////        )
+//    }
+//  }
+//
+//  it should "resolve DRS URIs containing Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.drsSignedUrl)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrlDiff), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl1)))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.dosUrl3), any[UserInfo]))
+//      .thenReturn(Future.successful(Option(DrsTestVals.dosSignedUrl3)))
+//
+//    val data = testData
+//    // Set up system under test
+//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+//    }
+//
+//    withWorkspaceContext(data.workspace) { ctx =>
+//      // Create test submission data
+//      val sample = Entity("sample", "Sample", Map())
+//      val sampleSet =
+//        Entity("sampleset",
+//               "sample_set",
+//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
+//        )
+//      val inputResolutions = Seq(
+//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.dosUrl)), None, "test_input_dos"),
+//        SubmissionValidationValue(
+//          Option(
+//            AttributeValueList(
+//              Seq(AttributeString(DrsTestVals.drsUrlTDR),
+//                  AttributeString(DrsTestVals.dosUrlDiff),
+//                  AttributeString(DrsTestVals.dosUrl3)
+//              )
+//            )
+//          ),
+//          None,
+//          "test_input_dos_array"
+//        )
+//      )
+//      val submissionDrs = createTestSubmission(
+//        data.workspace,
+//        data.agoraMethodConfig,
+//        sampleSet,
+//        WorkbenchEmail(data.userOwner.userEmail.value),
+//        Seq(sample),
+//        Map(sample -> inputResolutions),
+//        Seq(),
+//        Map()
+//      )
+//
+//      runAndWait(entityQuery.save(ctx, sample))
+//      runAndWait(entityQuery.save(ctx, sampleSet))
+//      runAndWait(submissionQuery.create(ctx, submissionDrs))
+//      val (workflowRecs, submissionRec, workspaceRec) =
+//        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
+//
+//      // Submit workflow!
+//      Await.result(
+//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
+//        Duration.Inf
+//      )
+//
+//      // TODO what to verify
+////      val expectedClientEmail =
+////        List("serviceAccount:" + DrsTestVals.drsServiceAccount,
+////             "serviceAccount:" + DrsTestVals.differentDrsServiceAccount
+////        )
+////      mockGoogleServicesDAO.policies(ctx.googleProjectId)(
+////        requesterPaysRole
+////      ) should contain theSameElementsAs expectedClientEmail
+//    }
+//  }
+//
+//  it should "resolve DRS URIs containing only Jade Data Repo urls when submitting workflows" in withDefaultTestDatabase {
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR), any[UserInfo]))
+//      .thenReturn(Future.successful(None))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR1), any[UserInfo]))
+//      .thenReturn(Future.successful(None))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR2), any[UserInfo]))
+//      .thenReturn(Future.successful(None))
+//    when(mockDrsResolver.drsSignedUrl(mockitoEq(DrsTestVals.drsUrlTDR3), any[UserInfo]))
+//      .thenReturn(Future.successful(None))
+//
+//    val data = testData
+//    // Set up system under test
+//    val mockExecCluster = MockShardedExecutionServiceCluster.fromDAO(new MockExecutionServiceDAO(), slickDataSource)
+//    val workflowSubmission = new TestWorkflowSubmission(slickDataSource) {
+//      override val executionServiceCluster: ExecutionServiceCluster = mockExecCluster
+//    }
+//
+//    withWorkspaceContext(data.workspace) { ctx =>
+//      // Create test submission data
+//      val sample = Entity("sample", "Sample", Map())
+//      val sampleSet =
+//        Entity("sampleset",
+//               "sample_set",
+//               Map(AttributeName.withDefaultNS("samples") -> AttributeEntityReferenceList(Seq(sample.toReference)))
+//        )
+//      val inputResolutions = Seq(
+//        SubmissionValidationValue(Option(AttributeString(DrsTestVals.drsUrlTDR)), None, "test_input_dos"),
+//        SubmissionValidationValue(
+//          Option(
+//            AttributeValueList(
+//              Seq(
+//                AttributeString(DrsTestVals.drsUrlTDR1),
+//                AttributeString(DrsTestVals.drsUrlTDR2),
+//                AttributeString(DrsTestVals.drsUrlTDR3)
+//              )
+//            )
+//          ),
+//          None,
+//          "test_input_dos_array"
+//        )
+//      )
+//      val submissionDrs = createTestSubmission(
+//        data.workspace,
+//        data.agoraMethodConfig,
+//        sampleSet,
+//        WorkbenchEmail(data.userOwner.userEmail.value),
+//        Seq(sample),
+//        Map(sample -> inputResolutions),
+//        Seq(),
+//        Map()
+//      )
+//
+//      runAndWait(entityQuery.save(ctx, sample))
+//      runAndWait(entityQuery.save(ctx, sampleSet))
+//      runAndWait(submissionQuery.create(ctx, submissionDrs))
+//      val (workflowRecs, submissionRec, workspaceRec) =
+//        getWorkflowSubmissionWorkspaceRecords(submissionDrs, data.workspace)
+//
+//      // Submit workflow!
+//      Await.result(
+//        workflowSubmission.submitWorkflowBatch(WorkflowBatch(workflowRecs.map(_.id), submissionRec, workspaceRec)),
+//        Duration.Inf
+//      )
+//
+//      // Verify
+//      // since no SA was returned from DRSHub for JDR urls, requester pays role was never added to the polices. Hence it should be empty
+//      mockGoogleServicesDAO.policies shouldBe TrieMap.empty[RawlsBillingProjectName, Map[String, Set[String]]]
+//    }
+//  }
 
   it should "match workflows to entities they run on in the right order" in withDefaultTestDatabase {
     val workflowSubmission = new TestWorkflowSubmissionWithMockExecSvc(slickDataSource)


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-407

Instead of getting one service account per URI, rawls now simply requests a signed url per provider to verify access, without making excess calls.  Any issue contacting the provider or lack of signed url throws an error.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
