### PR TITLE
[CORE-404] Add perWorkflowCostCap to createSubmission API in Swagger

### DIFF
--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5278,8 +5278,11 @@ components:
           description: When using `monitoringImage`, a user-defined script that runs inside the monitoring container
         perWorkflowCostCap:
           type: number
-          description: The maximum cost for a single workflow in this submission.  If the workflow exceeds this cost, it will be aborted.
+          description: A cost threshold in USD to apply to individual workflows. When the estimated cost is exceeded, the workflow is terminated.
           format: float
+          minimum: 0.01
+          maximum: 9999999999.99
+          multipleOf: 0.01
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionValidationInput:

--- a/core/src/main/resources/swagger/api-docs.yaml
+++ b/core/src/main/resources/swagger/api-docs.yaml
@@ -5276,6 +5276,10 @@ components:
         monitoringImageScript:
           type: string
           description: When using `monitoringImage`, a user-defined script that runs inside the monitoring container
+        perWorkflowCostCap:
+          type: number
+          description: The maximum cost for a single workflow in this submission.  If the workflow exceeds this cost, it will be aborted.
+          format: float
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionValidationInput:


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-404

#### Summary:
Now that the cost threshold feature is in preview, this PR updates the API to include the `perWorkflowCostCap` parameter in the `createSubmission` API in Swagger.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
