### PR TITLE
CORE-388 update azure-identity, which updates json-smart

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,7 +112,7 @@ object Dependencies {
 
   val circeYAML: ModuleID = "io.circe" %% "circe-yaml" % "1.15.0"
 
-  val azureIdentity: ModuleID = "com.azure" % "azure-identity" % "1.15.3"
+  val azureIdentity: ModuleID = "com.azure" % "azure-identity" % "1.15.4"
   val azureCoreManagement: ModuleID = "com.azure" % "azure-core-management" % "1.16.2"
 
   def excludeOpenTelemetry = ExclusionRule("io.opentelemetry.instrumentation")


### PR DESCRIPTION
Ticket: CORE-388

CORE-388 is a security finding on `json-smart`.

`json-smart` is pulled in by `com.azure:azure-identity`.

This PR updates `com.azure:azure-identity`, which in turn updates `json-smart`.

Part of a group of PRs:
* https://github.com/broadinstitute/rawls/pull/3240
* https://github.com/DataBiosphere/terra-resource-buffer/pull/422
* https://github.com/broadinstitute/thurloe/pull/377


