### PR TITLE
[CORE-255] Drop audit workflow and submission status tables

### DIFF
--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changelog.xml
@@ -137,4 +137,5 @@
     <include file="changesets/20250311_update_workspace_spend_report_dates.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250317_add_google_project_registration_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/20250401_drop_cromwell_backend_column.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
+
+    <changeSet logicalFilePath="dummy" author="sehsan" id="drop-AUDIT_WORKFLOW_STATUS">
+        <sql stripComments="true">
+            drop table AUDIT_WORKFLOW_STATUS;
+        </sql>
+    </changeSet>
+
+    <changeSet logicalFilePath="dummy" author="sehsan" id="drop-AUDIT_SUBMISSION_STATUS">
+        <sql stripComments="true">
+            drop table AUDIT_SUBMISSION_STATUS;
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
 
+    <changeSet logicalFilePath="dummy" author="davidan" id="drop_status_change_log_triggers">
+        <sql stripComments="true">
+            DROP TRIGGER IF EXISTS after_workflow_insert;
+            DROP TRIGGER IF EXISTS after_workflow_update;
+            DROP TRIGGER IF EXISTS after_submission_insert;
+            DROP TRIGGER IF EXISTS after_submission_update;
+        </sql>
+    </changeSet>
+
     <changeSet logicalFilePath="dummy" author="sehsan" id="drop-AUDIT_WORKFLOW_STATUS">
         <sql stripComments="true">
             drop table AUDIT_WORKFLOW_STATUS;
@@ -10,15 +19,6 @@
     <changeSet logicalFilePath="dummy" author="sehsan" id="drop-AUDIT_SUBMISSION_STATUS">
         <sql stripComments="true">
             drop table AUDIT_SUBMISSION_STATUS;
-        </sql>
-    </changeSet>
-
-    <changeSet logicalFilePath="dummy" author="davidan" id="drop_status_change_log_triggers">
-        <sql stripComments="true">
-            DROP TRIGGER IF EXISTS after_workflow_insert;
-            DROP TRIGGER IF EXISTS after_workflow_update;
-            DROP TRIGGER IF EXISTS after_submission_insert;
-            DROP TRIGGER IF EXISTS after_submission_update;
         </sql>
     </changeSet>
 

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
@@ -13,4 +13,13 @@
         </sql>
     </changeSet>
 
+    <changeSet logicalFilePath="dummy" author="davidan" id="drop_status_change_log_triggers">
+        <sql stripComments="true">
+            DROP TRIGGER IF EXISTS after_workflow_insert;
+            DROP TRIGGER IF EXISTS after_workflow_update;
+            DROP TRIGGER IF EXISTS after_submission_insert;
+            DROP TRIGGER IF EXISTS after_submission_update;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
+++ b/core/src/main/resources/org/broadinstitute/dsde/rawls/liquibase/changesets/20250331_drop_audit_workflow_and_submission_status_tables.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog logicalFilePath="dummy" xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.30.xsd">
 
-    <changeSet logicalFilePath="dummy" author="davidan" id="drop_status_change_log_triggers">
+    <changeSet logicalFilePath="dummy" author="sehsan" id="drop_status_change_log_triggers">
         <sql stripComments="true">
             DROP TRIGGER IF EXISTS after_workflow_insert;
             DROP TRIGGER IF EXISTS after_workflow_update;


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-255

Note this must be merged AFTER https://github.com/broadinstitute/rawls/pull/3242

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
