### PR TITLE
[CORE-419] Change Scala Steward Updates to Run Monthly

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,7 +23,7 @@
 #     the given expression.
 #
 #
-pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
+pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-419

Currently, Scala Steward updates run weekly, resulting in frequent PRs. To reduce PR overhead while still maintaining necessary security updates, this PR updates the schedule to run on the first day of each month.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
