### PR TITLE
[CORE-359] Trace EntityService methods

### DIFF
--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -16,6 +16,7 @@ import org.broadinstitute.dsde.rawls.entities.exceptions.{
 import org.broadinstitute.dsde.rawls.metrics.RawlsInstrumented
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, EntityUpdateDefinition}
 import org.broadinstitute.dsde.rawls.model._
+import org.broadinstitute.dsde.rawls.util.TracingUtils.traceFutureWithParent
 import org.broadinstitute.dsde.rawls.util.{AttributeSupport, EntitySupport, JsonFilterUtils, WorkspaceSupport}
 import org.broadinstitute.dsde.rawls.workspace.WorkspaceRepository
 import org.broadinstitute.dsde.rawls.{RawlsExceptionWithErrorReport, StringValidationUtils}
@@ -54,160 +55,194 @@ class EntityService(protected val ctx: RawlsRequestContext,
   val workspaceRepository: WorkspaceRepository = new WorkspaceRepository(dataSource)
 
   def createEntity(workspaceName: WorkspaceName, entity: Entity): Future[Entity] =
-    withAttributeNamespaceCheck(entity) {
-      for {
-        workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                                SamWorkspaceActions.write,
-                                                                Some(WorkspaceAttributeSpecs(all = false))
-        )
-        entityManager <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-        result <- entityManager.createEntity(entity)
-      } yield result
-    }.recover(sqlLoggingRecover(s"createEntity: $workspaceName"))
+    traceFutureWithParent("EntityService.createEntity", ctx) { localContext =>
+      withAttributeNamespaceCheck(entity) {
+        for {
+          workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+            getV2WorkspaceContextAndPermissions(workspaceName,
+                                                SamWorkspaceActions.write,
+                                                Some(WorkspaceAttributeSpecs(all = false))
+            )
+          }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+          result <- traceFutureWithParent("EntityProvider.createEntity", localContext) { s =>
+            entityProvider.createEntity(entity, s)
+          }
+        } yield result
+      }.recover(sqlLoggingRecover(s"createEntity: $workspaceName"))
+    }
 
   def getEntity(workspaceName: WorkspaceName,
                 entityType: String,
                 entityName: String,
                 dataReference: Option[DataReferenceName],
                 billingProject: Option[GoogleProjectId]
-  ): Future[Entity] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.read,
-                                        Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+  ): Future[Entity] = {
+    traceFutureWithParent("EntityService.getEntity", ctx) { localContext =>
+      traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+        getV2WorkspaceContextAndPermissions(workspaceName,
+          SamWorkspaceActions.read,
+          Some(WorkspaceAttributeSpecs(all = false))
+        )
+      } flatMap { workspaceContext =>
+        val entityFuture = for {
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+          entity <- traceFutureWithParent("EntityProvider.getEntity", localContext) { s =>
+            entityProvider.getEntity(entityType, entityName, s)
+          }
+        } yield entity
 
-      val entityFuture = for {
-        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        entity <- entityProvider.getEntity(entityType, entityName)
-      } yield entity
-
-      entityFuture
-        .recover { case _: EntityNotFoundException =>
-          // could move this error message into EntityNotFoundException and allow it to bubble up
-          throw new RawlsExceptionWithErrorReport(
-            ErrorReport(StatusCodes.NotFound, s"$entityType $entityName does not exist in $workspaceName")
-          )
-        }
-        .recover(sqlLoggingRecover(s"getEntity: $workspaceName $entityType/$entityName"))
-        .recover(bigQueryRecover)
+        entityFuture
+          .recover { case _: EntityNotFoundException =>
+            // could move this error message into EntityNotFoundException and allow it to bubble up
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(StatusCodes.NotFound, s"$entityType $entityName does not exist in $workspaceName")
+            )
+          }
+          .recover(sqlLoggingRecover(s"getEntity: $workspaceName $entityType/$entityName"))
+          .recover(bigQueryRecover)
+      }
     }
+  }
 
   def updateEntity(workspaceName: WorkspaceName,
                    entityType: String,
                    entityName: String,
                    operations: Seq[AttributeUpdateOperation]
-  ): Future[Entity] =
-    withAttributeNamespaceCheck(operations.map(_.name)) {
-      for {
-        workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                                SamWorkspaceActions.write,
-                                                                Some(WorkspaceAttributeSpecs(all = false))
-        )
-        entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-        result <- entityProvider.updateEntity(entityType, entityName, operations)
-      } yield result
-    }.recover(sqlLoggingRecover(s"updateEntity: $workspaceName $entityType/$entityName ${operations.size} operations"))
+  ): Future[Entity] = {
+    traceFutureWithParent("EntityService.updateEntity", ctx) { localContext =>
+      withAttributeNamespaceCheck(operations.map(_.name)) {
+        for {
+          workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+            getV2WorkspaceContextAndPermissions(workspaceName,
+              SamWorkspaceActions.write,
+              Some(WorkspaceAttributeSpecs(all = false))
+            )
+          }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+          result <- traceFutureWithParent("EntityProvider.updateEntity", localContext) { s => entityProvider.updateEntity(entityType, entityName, operations, s) }
+        } yield result
+      }.recover(sqlLoggingRecover(s"updateEntity: $workspaceName $entityType/$entityName ${operations.size} operations"))
+    }
+  }
 
   def deleteEntities(workspaceName: WorkspaceName,
                      entRefs: Seq[AttributeEntityReference],
                      dataReference: Option[DataReferenceName],
                      billingProject: Option[GoogleProjectId]
-  ): Future[Set[AttributeEntityReference]] =
-    // short-circuit: if caller requested to delete nothing, then we do nothing
-    if (entRefs.isEmpty) {
-      Future.successful(Set.empty)
-    } else {
-      getV2WorkspaceContextAndPermissions(workspaceName,
-                                          SamWorkspaceActions.write,
-                                          Some(WorkspaceAttributeSpecs(all = false))
-      ) flatMap { workspaceContext =>
-        val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+  ): Future[Set[AttributeEntityReference]] = {
+    traceFutureWithParent("EntityService.deleteEntities", ctx) { localContext =>
+      // short-circuit: if caller requested to delete nothing, then we do nothing
+      if (entRefs.isEmpty) {
+        Future.successful(Set.empty)
+      } else {
+        traceFutureWithParent("getWorkspaceContextAndPermissions", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+            SamWorkspaceActions.write,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        } flatMap { workspaceContext =>
+          val deleteFuture = for {
+            entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+            _ <- traceFutureWithParent("entityProvider.deleteEntities", localContext) { s =>
+              entityProvider.deleteEntities(entRefs, s)
+            }
+          } yield Set[AttributeEntityReference]()
 
-        val deleteFuture = for {
-          entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-          _ <- entityProvider.deleteEntities(entRefs)
-        } yield Set[AttributeEntityReference]()
-
-        deleteFuture
-          .recover { case delEx: DeleteEntitiesConflictException =>
-            delEx.referringEntities
-          }
-          .recover(sqlLoggingRecover(s"deleteEntities: $workspaceName ${entRefs.size} entities"))
-          .recover(bigQueryRecover)
+          deleteFuture
+            .recover { case delEx: DeleteEntitiesConflictException =>
+              delEx.referringEntities
+            }
+            .recover(sqlLoggingRecover(s"deleteEntities: $workspaceName ${entRefs.size} entities"))
+            .recover(bigQueryRecover)
+        }
       }
     }
+  }
 
   def deleteEntitiesOfType(workspaceName: WorkspaceName,
                            entityType: String,
                            dataReference: Option[DataReferenceName],
                            billingProject: Option[GoogleProjectId]
   ): Future[Int] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+    traceFutureWithParent("EntityService.deleteEntitiesOfType", ctx) { localContext =>
+      traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+        getV2WorkspaceContextAndPermissions(workspaceName,
+          SamWorkspaceActions.write,
+          Some(WorkspaceAttributeSpecs(all = false))
+        )
+      } flatMap { workspaceContext =>
+        val deleteFuture = for {
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+          numberOfEntitiesDeleted <- traceFutureWithParent("EntityProvider.deleteEntitiesOfType", localContext) { s => entityProvider.deleteEntitiesOfType(entityType, s) }
+        } yield numberOfEntitiesDeleted
 
-      val deleteFuture = for {
-        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        numberOfEntitiesDeleted <- entityProvider.deleteEntitiesOfType(entityType)
-      } yield numberOfEntitiesDeleted
-
-      deleteFuture
-        .recover { case delEx: DeleteEntitiesOfTypeConflictException =>
-          throw new RawlsExceptionWithErrorReport(
-            ErrorReport(
-              StatusCodes.Conflict,
-              s"Entity type [$entityType] cannot be deleted because there are ${delEx.conflictCount} references " +
-                s"to this entity type. All references must be removed before deleting a type."
+        deleteFuture
+          .recover { case delEx: DeleteEntitiesOfTypeConflictException =>
+            throw new RawlsExceptionWithErrorReport(
+              ErrorReport(
+                StatusCodes.Conflict,
+                s"Entity type [$entityType] cannot be deleted because there are ${delEx.conflictCount} references " +
+                  s"to this entity type. All references must be removed before deleting a type."
+              )
             )
-          )
-        }
-        .recover(sqlLoggingRecover(s"deleteEntitiesOfType: $workspaceName $entityType"))
-        .recover(bigQueryRecover)
+          }
+          .recover(sqlLoggingRecover(s"deleteEntitiesOfType: $workspaceName $entityType"))
+          .recover(bigQueryRecover)
+      }
     }
 
   def deleteEntityAttributes(workspaceName: WorkspaceName,
                              entityType: String,
                              attributeNames: Set[AttributeName]
   ): Future[Unit] =
-    (for {
-      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.write,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
-      )
-      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-      result <- entityProvider.deleteEntityAttributes(entityType, attributeNames)
+    traceFutureWithParent("deleteEntityAttributes", ctx) { localContext => (for {
+      workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+        getV2WorkspaceContextAndPermissions(workspaceName,
+          SamWorkspaceActions.write,
+          Some(WorkspaceAttributeSpecs(all = false))
+        )
+      }
+      entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+      result <- traceFutureWithParent("EntityProvider.deleteEntityAttributes", localContext) { s => entityProvider.deleteEntityAttributes(entityType, attributeNames, s) }
     } yield result)
       .recover(
         sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
       )
+    }
 
   def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
-    (for {
-      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.write,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
+    traceFutureWithParent("renameEntity", ctx) { localContext =>
+      (for {
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+            SamWorkspaceActions.write,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+        result <- traceFutureWithParent("EntityProvider.renameEntity", localContext) { s => entityProvider.renameEntity(entityType, entityName, newName, s) }
+      } yield result).recover(
+        sqlLoggingRecover(s"renameEntity: $workspaceName $entityType $entityName")
       )
-      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-      result <- entityProvider.renameEntity(entityType, entityName, newName)
-    } yield result).recover(
-      sqlLoggingRecover(s"renameEntity: $workspaceName $entityType $entityName")
-    )
+    }
 
   def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
-    validateEntityType(renameInfo.newName)
-    (for {
-      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.write,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
+    traceFutureWithParent("renameEntityType", ctx) { localContext =>
+      validateEntityType(renameInfo.newName)
+      (for {
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+            SamWorkspaceActions.write,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+        result <- traceFutureWithParent("EntityProvider.renameEntityType", localContext) { s => entityProvider.renameEntityType(oldName, renameInfo, s) }
+      } yield result).recover(
+        sqlLoggingRecover(s"renameEntityType: $workspaceName $workspaceName $oldName")
       )
-      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-      result <- entityProvider.renameEntityType(oldName, renameInfo)
-    } yield result).recover(
-      sqlLoggingRecover(s"renameEntityType: $workspaceName $workspaceName $oldName")
-    )
+    }
   }
 
   def evaluateExpression(workspaceName: WorkspaceName,
@@ -215,49 +250,57 @@ class EntityService(protected val ctx: RawlsRequestContext,
                          entityName: String,
                          expression: String
   ): Future[Seq[AttributeValue]] =
-    (for {
-      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.read,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
+    traceFutureWithParent("evaluateExpression", ctx) { localContext =>
+      (for {
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+            SamWorkspaceActions.read,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+        result <- traceFutureWithParent("EntityProvider.evaluateExpression", localContext) { s => entityProvider.evaluateExpression(entityType, entityName, expression, s) }
+      } yield result).recover(
+        sqlLoggingRecover(s"evaluateExpression: $workspaceName $entityType $entityName $expression")
       )
-      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-      result <- entityProvider.evaluateExpression(entityType, entityName, expression)
-    } yield result).recover(
-      sqlLoggingRecover(s"evaluateExpression: $workspaceName $entityType $entityName $expression")
-    )
+    }
 
   def entityTypeMetadata(workspaceName: WorkspaceName,
                          dataReference: Option[DataReferenceName],
                          billingProject: Option[GoogleProjectId],
                          useCache: Boolean
   ): Future[Map[String, EntityTypeMetadata]] =
-    (getV2WorkspaceContextAndPermissions(workspaceName,
-                                         SamWorkspaceActions.read,
-                                         Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+    traceFutureWithParent("entityTypeMetadata", ctx) { localContext =>
+      (traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>  getV2WorkspaceContextAndPermissions(workspaceName,
+        SamWorkspaceActions.read,
+        Some(WorkspaceAttributeSpecs(all = false))
+      )} flatMap { workspaceContext =>
+        val metadataFuture = for {
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+          metadata <- traceFutureWithParent("EntityProvider.entityTypeMetadata", localContext) { s => entityProvider.entityTypeMetadata(useCache, s) }
+        } yield metadata
 
-      val metadataFuture = for {
-        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        metadata <- entityProvider.entityTypeMetadata(useCache)
-      } yield metadata
-
-      metadataFuture.recover(bigQueryRecover)
-    }).recover(
-      sqlLoggingRecover(s"entityTypeMetadata: $workspaceName")
-    )
+        metadataFuture.recover(bigQueryRecover)
+      }).recover(
+        sqlLoggingRecover(s"entityTypeMetadata: $workspaceName")
+      )
+    }
 
   def listEntities(workspaceName: WorkspaceName, entityType: String): Future[Source[Entity, NotUsed]] =
-    (for {
-      workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                              SamWorkspaceActions.read,
-                                                              Some(WorkspaceAttributeSpecs(all = false))
+    traceFutureWithParent("listEntities", ctx) { localContext =>
+      (for {
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+            SamWorkspaceActions.read,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+        result = entityProvider.listEntities(entityType)
+      } yield result).recover(
+        sqlLoggingRecover(s"listEntities: $workspaceName $entityType")
       )
-      entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-      result = entityProvider.listEntities(entityType)
-    } yield result).recover(
-      sqlLoggingRecover(s"listEntities: $workspaceName $entityType")
-    )
+    }
 
   def queryEntitiesSource(workspaceName: WorkspaceName,
                           dataReference: Option[DataReferenceName],
@@ -265,74 +308,80 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           query: EntityQuery,
                           billingProject: Option[GoogleProjectId]
   ): Future[(EntityQueryResultMetadata, Source[Entity, _])] = {
-    if (query.pageSize > pageSizeLimit) {
-      throw new RawlsExceptionWithErrorReport(
-        ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $pageSizeLimit")
-      )
-    }
+    traceFutureWithParent("queryEntitiesSource", ctx) { localContext =>
+      if (query.pageSize > pageSizeLimit) {
+        throw new RawlsExceptionWithErrorReport(
+          ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $pageSizeLimit")
+        )
+      }
 
-    getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.read,
-                                        Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+      traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ => getV2WorkspaceContextAndPermissions(workspaceName,
+        SamWorkspaceActions.read,
+        Some(WorkspaceAttributeSpecs(all = false))
+      )} flatMap { workspaceContext =>
+        val queryFuture = for {
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+          metadataAndEntitySource <- traceFutureWithParent("EntityProvider.queryEntitiesSource", localContext) { s => entityProvider.queryEntitiesSource(entityType, query, s) }
+        } yield metadataAndEntitySource
 
-      val queryFuture = for {
-        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-        metadataAndEntitySource <- entityProvider.queryEntitiesSource(entityType, query, ctx)
-      } yield metadataAndEntitySource
-
-      queryFuture.recover(bigQueryRecover)
+        queryFuture.recover(bigQueryRecover)
+      }
     }
   }
 
   def copyEntities(entityCopyDef: EntityCopyDefinition, linkExistingEntities: Boolean): Future[EntityCopyResponse] =
-    (for {
-      destWsCtx <- getV2WorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
-                                                       SamWorkspaceActions.write,
-                                                       Some(WorkspaceAttributeSpecs(all = false))
-      )
-      sourceWsCtx <- getV2WorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,
-                                                         SamWorkspaceActions.read,
-                                                         Some(WorkspaceAttributeSpecs(all = false))
-      )
-      sourceAD <- samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, sourceWsCtx.workspaceId, ctx)
-      destAD <- samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, destWsCtx.workspaceId, ctx)
-      _ = authDomainCheck(sourceAD.toSet, destAD.toSet)
-      entityRequestArguments = EntityRequestArguments(destWsCtx, ctx, None, None)
-      entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
-      entityCopyResponse <- entityProvider
-        .copyEntities(sourceWsCtx,
-                      destWsCtx,
-                      entityCopyDef.entityType,
-                      entityCopyDef.entityNames,
-                      linkExistingEntities,
-                      ctx
+    traceFutureWithParent("copyEntities", ctx) { localContext =>
+      (for {
+        destWsCtx <- traceFutureWithParent("getV2WorkspaceContextAndPermissions destWs", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
+            SamWorkspaceActions.write,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        sourceWsCtx <- traceFutureWithParent("getV2WorkspaceContextAndPermissions sourceWs", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,
+            SamWorkspaceActions.read,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        sourceAD <- traceFutureWithParent("getSourceAuthDomain", localContext) { s => samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, sourceWsCtx.workspaceId, s) }
+        destAD <- traceFutureWithParent("getDestAuthDomain", localContext) { s => samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, destWsCtx.workspaceId, s) }
+        _ = authDomainCheck(sourceAD.toSet, destAD.toSet)
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(destWsCtx, s, None, None)) }
+        entityCopyResponse <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityProvider
+          .copyEntities(sourceWsCtx,
+            destWsCtx,
+            entityCopyDef.entityType,
+            entityCopyDef.entityNames,
+            linkExistingEntities,
+            s
+          )
+          .recover(bigQueryRecover)
+        }
+      } yield entityCopyResponse)
+        .recover(
+          sqlLoggingRecover(s"copyEntities: $entityCopyDef $linkExistingEntities")
         )
-        .recover(bigQueryRecover)
-    } yield entityCopyResponse)
-      .recover(
-        sqlLoggingRecover(s"copyEntities: $entityCopyDef $linkExistingEntities")
-      )
+    }
 
   def batchUpdateEntitiesInternal(workspaceName: WorkspaceName,
                                   entityUpdates: Seq[EntityUpdateDefinition],
                                   upsert: Boolean,
                                   dataReference: Option[DataReferenceName],
-                                  billingProject: Option[GoogleProjectId]
+                                  billingProject: Option[GoogleProjectId],
+                                  parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
-    getV2WorkspaceContextAndPermissions(workspaceName,
+    traceFutureWithParent("getV2WorkspaceContextAndPermissions", parentContext) { _ => getV2WorkspaceContextAndPermissions(workspaceName,
                                         SamWorkspaceActions.write,
                                         Some(WorkspaceAttributeSpecs(all = false))
-    ) flatMap { workspaceContext =>
-      val entityRequestArguments = EntityRequestArguments(workspaceContext, ctx, dataReference, billingProject)
+    ) } flatMap { workspaceContext =>
       for {
-        entityProvider <- entityManager.resolveProviderFuture(entityRequestArguments)
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", parentContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
         entities <-
           if (upsert) {
-            entityProvider.batchUpsertEntities(entityUpdates)
+            traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s => entityProvider.batchUpsertEntities(entityUpdates, s) }
           } else {
-            entityProvider.batchUpdateEntities(entityUpdates)
+            traceFutureWithParent("EntityProvider.batchUpdateEntities", parentContext) { s => entityProvider.batchUpdateEntities(entityUpdates, s) }
           }
       } yield entities
     }
@@ -342,38 +391,45 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
-    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject)
-      .recover(
-        sqlLoggingRecover(s"batchUpdateEntities: $workspaceName ${entityUpdates.size} updates")
-      )
+    traceFutureWithParent("batchUpdateEntities", ctx) { s =>
+      batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
+        .recover(
+          sqlLoggingRecover(s"batchUpdateEntities: $workspaceName ${entityUpdates.size} updates")
+        )
+    }
 
   def batchUpsertEntities(workspaceName: WorkspaceName,
                           entityUpdates: Seq[EntityUpdateDefinition],
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
-    batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject)
-      .recover(
-        sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
-      )
+    traceFutureWithParent("batchUpsertEntities", ctx) { s =>
+      batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
+        .recover(
+          sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
+        )
+    }
 
   def renameAttribute(workspaceName: WorkspaceName,
                       entityType: String,
                       oldAttributeName: AttributeName,
                       attributeRenameRequest: AttributeRename
-  ): Future[Int] =
+  ): Future[Int] = traceFutureWithParent("renameAttribute", ctx) { localContext =>
     withAttributeNamespaceCheck(Seq(attributeRenameRequest.newAttributeName)) {
       for {
-        workspaceContext <- getV2WorkspaceContextAndPermissions(workspaceName,
-                                                                SamWorkspaceActions.write,
-                                                                Some(WorkspaceAttributeSpecs(all = false))
-        )
-        entityProvider <- entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, ctx))
-        result <- entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest)
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", ctx) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+            SamWorkspaceActions.write,
+            Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+        result <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest, s) }
       } yield result
     }.recover(
       sqlLoggingRecover(s"renameAttribute: $workspaceName $oldAttributeName $attributeRenameRequest")
     )
+  }
 
   private def sqlLoggingRecover[U](logHint: String): PartialFunction[Throwable, U] = {
     case sqlException: SQLException =>

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -64,7 +64,9 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                                 Some(WorkspaceAttributeSpecs(all = false))
             )
           }
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+            entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+          }
           result <- traceFutureWithParent("EntityProvider.createEntity", localContext) { s =>
             entityProvider.createEntity(entity, s)
           }
@@ -77,16 +79,20 @@ class EntityService(protected val ctx: RawlsRequestContext,
                 entityName: String,
                 dataReference: Option[DataReferenceName],
                 billingProject: Option[GoogleProjectId]
-  ): Future[Entity] = {
+  ): Future[Entity] =
     traceFutureWithParent("EntityService.getEntity", ctx) { localContext =>
       traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
         getV2WorkspaceContextAndPermissions(workspaceName,
-          SamWorkspaceActions.read,
-          Some(WorkspaceAttributeSpecs(all = false))
+                                            SamWorkspaceActions.read,
+                                            Some(WorkspaceAttributeSpecs(all = false))
         )
       } flatMap { workspaceContext =>
         val entityFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+            entityManager.resolveProviderFuture(
+              EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
+            )
+          }
           entity <- traceFutureWithParent("EntityProvider.getEntity", localContext) { s =>
             entityProvider.getEntity(entityType, entityName, s)
           }
@@ -103,34 +109,38 @@ class EntityService(protected val ctx: RawlsRequestContext,
           .recover(bigQueryRecover)
       }
     }
-  }
 
   def updateEntity(workspaceName: WorkspaceName,
                    entityType: String,
                    entityName: String,
                    operations: Seq[AttributeUpdateOperation]
-  ): Future[Entity] = {
+  ): Future[Entity] =
     traceFutureWithParent("EntityService.updateEntity", ctx) { localContext =>
       withAttributeNamespaceCheck(operations.map(_.name)) {
         for {
           workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
             getV2WorkspaceContextAndPermissions(workspaceName,
-              SamWorkspaceActions.write,
-              Some(WorkspaceAttributeSpecs(all = false))
+                                                SamWorkspaceActions.write,
+                                                Some(WorkspaceAttributeSpecs(all = false))
             )
           }
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
-          result <- traceFutureWithParent("EntityProvider.updateEntity", localContext) { s => entityProvider.updateEntity(entityType, entityName, operations, s) }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+            entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+          }
+          result <- traceFutureWithParent("EntityProvider.updateEntity", localContext) { s =>
+            entityProvider.updateEntity(entityType, entityName, operations, s)
+          }
         } yield result
-      }.recover(sqlLoggingRecover(s"updateEntity: $workspaceName $entityType/$entityName ${operations.size} operations"))
+      }.recover(
+        sqlLoggingRecover(s"updateEntity: $workspaceName $entityType/$entityName ${operations.size} operations")
+      )
     }
-  }
 
   def deleteEntities(workspaceName: WorkspaceName,
                      entRefs: Seq[AttributeEntityReference],
                      dataReference: Option[DataReferenceName],
                      billingProject: Option[GoogleProjectId]
-  ): Future[Set[AttributeEntityReference]] = {
+  ): Future[Set[AttributeEntityReference]] =
     traceFutureWithParent("EntityService.deleteEntities", ctx) { localContext =>
       // short-circuit: if caller requested to delete nothing, then we do nothing
       if (entRefs.isEmpty) {
@@ -138,12 +148,16 @@ class EntityService(protected val ctx: RawlsRequestContext,
       } else {
         traceFutureWithParent("getWorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
-            SamWorkspaceActions.write,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.write,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         } flatMap { workspaceContext =>
           val deleteFuture = for {
-            entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+            entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+              entityManager.resolveProviderFuture(
+                EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
+              )
+            }
             _ <- traceFutureWithParent("entityProvider.deleteEntities", localContext) { s =>
               entityProvider.deleteEntities(entRefs, s)
             }
@@ -158,7 +172,6 @@ class EntityService(protected val ctx: RawlsRequestContext,
         }
       }
     }
-  }
 
   def deleteEntitiesOfType(workspaceName: WorkspaceName,
                            entityType: String,
@@ -168,13 +181,19 @@ class EntityService(protected val ctx: RawlsRequestContext,
     traceFutureWithParent("EntityService.deleteEntitiesOfType", ctx) { localContext =>
       traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
         getV2WorkspaceContextAndPermissions(workspaceName,
-          SamWorkspaceActions.write,
-          Some(WorkspaceAttributeSpecs(all = false))
+                                            SamWorkspaceActions.write,
+                                            Some(WorkspaceAttributeSpecs(all = false))
         )
       } flatMap { workspaceContext =>
         val deleteFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
-          numberOfEntitiesDeleted <- traceFutureWithParent("EntityProvider.deleteEntitiesOfType", localContext) { s => entityProvider.deleteEntitiesOfType(entityType, s) }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+            entityManager.resolveProviderFuture(
+              EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
+            )
+          }
+          numberOfEntitiesDeleted <- traceFutureWithParent("EntityProvider.deleteEntitiesOfType", localContext) { s =>
+            entityProvider.deleteEntitiesOfType(entityType, s)
+          }
         } yield numberOfEntitiesDeleted
 
         deleteFuture
@@ -196,70 +215,88 @@ class EntityService(protected val ctx: RawlsRequestContext,
                              entityType: String,
                              attributeNames: Set[AttributeName]
   ): Future[Unit] =
-    traceFutureWithParent("deleteEntityAttributes", ctx) { localContext => (for {
-      workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
-        getV2WorkspaceContextAndPermissions(workspaceName,
-          SamWorkspaceActions.write,
-          Some(WorkspaceAttributeSpecs(all = false))
-        )
-      }
-      entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
-      result <- traceFutureWithParent("EntityProvider.deleteEntityAttributes", localContext) { s => entityProvider.deleteEntityAttributes(entityType, attributeNames, s) }
-    } yield result)
-      .recover(
-        sqlLoggingRecover(s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names")
-      )
-    }
-
-  def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
-    traceFutureWithParent("renameEntity", ctx) { localContext =>
+    traceFutureWithParent("EntityService.deleteEntityAttributes", ctx) { localContext =>
       (for {
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
-            SamWorkspaceActions.write,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.write,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
-        result <- traceFutureWithParent("EntityProvider.renameEntity", localContext) { s => entityProvider.renameEntity(entityType, entityName, newName, s) }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+        }
+        result <- traceFutureWithParent("EntityProvider.deleteEntityAttributes", localContext) { s =>
+          entityProvider.deleteEntityAttributes(entityType, attributeNames, s)
+        }
+      } yield result)
+        .recover(
+          sqlLoggingRecover(
+            s"deleteEntityAttributes: $workspaceName $entityType ${attributeNames.size} attribute names"
+          )
+        )
+    }
+
+  def renameEntity(workspaceName: WorkspaceName, entityType: String, entityName: String, newName: String): Future[Int] =
+    traceFutureWithParent("EntityService.renameEntity", ctx) { localContext =>
+      (for {
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+          getV2WorkspaceContextAndPermissions(workspaceName,
+                                              SamWorkspaceActions.write,
+                                              Some(WorkspaceAttributeSpecs(all = false))
+          )
+        }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+        }
+        result <- traceFutureWithParent("EntityProvider.renameEntity", localContext) { s =>
+          entityProvider.renameEntity(entityType, entityName, newName, s)
+        }
       } yield result).recover(
         sqlLoggingRecover(s"renameEntity: $workspaceName $entityType $entityName")
       )
     }
 
-  def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] = {
-    traceFutureWithParent("renameEntityType", ctx) { localContext =>
+  def renameEntityType(workspaceName: WorkspaceName, oldName: String, renameInfo: EntityTypeRename): Future[Int] =
+    traceFutureWithParent("EntityService.renameEntityType", ctx) { localContext =>
       validateEntityType(renameInfo.newName)
       (for {
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
-            SamWorkspaceActions.write,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.write,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
-        result <- traceFutureWithParent("EntityProvider.renameEntityType", localContext) { s => entityProvider.renameEntityType(oldName, renameInfo, s) }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+        }
+        result <- traceFutureWithParent("EntityProvider.renameEntityType", localContext) { s =>
+          entityProvider.renameEntityType(oldName, renameInfo, s)
+        }
       } yield result).recover(
         sqlLoggingRecover(s"renameEntityType: $workspaceName $workspaceName $oldName")
       )
     }
-  }
 
   def evaluateExpression(workspaceName: WorkspaceName,
                          entityType: String,
                          entityName: String,
                          expression: String
   ): Future[Seq[AttributeValue]] =
-    traceFutureWithParent("evaluateExpression", ctx) { localContext =>
+    traceFutureWithParent("EntityService.evaluateExpression", ctx) { localContext =>
       (for {
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
-            SamWorkspaceActions.read,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.read,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
-        result <- traceFutureWithParent("EntityProvider.evaluateExpression", localContext) { s => entityProvider.evaluateExpression(entityType, entityName, expression, s) }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+        }
+        result <- traceFutureWithParent("EntityProvider.evaluateExpression", localContext) { s =>
+          entityProvider.evaluateExpression(entityType, entityName, expression, s)
+        }
       } yield result).recover(
         sqlLoggingRecover(s"evaluateExpression: $workspaceName $entityType $entityName $expression")
       )
@@ -270,14 +307,22 @@ class EntityService(protected val ctx: RawlsRequestContext,
                          billingProject: Option[GoogleProjectId],
                          useCache: Boolean
   ): Future[Map[String, EntityTypeMetadata]] =
-    traceFutureWithParent("entityTypeMetadata", ctx) { localContext =>
-      (traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>  getV2WorkspaceContextAndPermissions(workspaceName,
-        SamWorkspaceActions.read,
-        Some(WorkspaceAttributeSpecs(all = false))
-      )} flatMap { workspaceContext =>
+    traceFutureWithParent("EntityService.entityTypeMetadata", ctx) { localContext =>
+      (traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+        getV2WorkspaceContextAndPermissions(workspaceName,
+                                            SamWorkspaceActions.read,
+                                            Some(WorkspaceAttributeSpecs(all = false))
+        )
+      } flatMap { workspaceContext =>
         val metadataFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
-          metadata <- traceFutureWithParent("EntityProvider.entityTypeMetadata", localContext) { s => entityProvider.entityTypeMetadata(useCache, s) }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+            entityManager.resolveProviderFuture(
+              EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
+            )
+          }
+          metadata <- traceFutureWithParent("EntityProvider.entityTypeMetadata", localContext) { s =>
+            entityProvider.entityTypeMetadata(useCache, s)
+          }
         } yield metadata
 
         metadataFuture.recover(bigQueryRecover)
@@ -287,15 +332,17 @@ class EntityService(protected val ctx: RawlsRequestContext,
     }
 
   def listEntities(workspaceName: WorkspaceName, entityType: String): Future[Source[Entity, NotUsed]] =
-    traceFutureWithParent("listEntities", ctx) { localContext =>
+    traceFutureWithParent("EntityService.listEntities", ctx) { localContext =>
       (for {
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
-            SamWorkspaceActions.read,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.read,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+        }
         result = entityProvider.listEntities(entityType)
       } yield result).recover(
         sqlLoggingRecover(s"listEntities: $workspaceName $entityType")
@@ -307,56 +354,70 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           entityType: String,
                           query: EntityQuery,
                           billingProject: Option[GoogleProjectId]
-  ): Future[(EntityQueryResultMetadata, Source[Entity, _])] = {
-    traceFutureWithParent("queryEntitiesSource", ctx) { localContext =>
+  ): Future[(EntityQueryResultMetadata, Source[Entity, _])] =
+    traceFutureWithParent("EntityService.queryEntitiesSource", ctx) { localContext =>
       if (query.pageSize > pageSizeLimit) {
         throw new RawlsExceptionWithErrorReport(
           ErrorReport(StatusCodes.BadRequest, s"Page size cannot exceed $pageSizeLimit")
         )
       }
 
-      traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ => getV2WorkspaceContextAndPermissions(workspaceName,
-        SamWorkspaceActions.read,
-        Some(WorkspaceAttributeSpecs(all = false))
-      )} flatMap { workspaceContext =>
+      traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
+        getV2WorkspaceContextAndPermissions(workspaceName,
+                                            SamWorkspaceActions.read,
+                                            Some(WorkspaceAttributeSpecs(all = false))
+        )
+      } flatMap { workspaceContext =>
         val queryFuture = for {
-          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
-          metadataAndEntitySource <- traceFutureWithParent("EntityProvider.queryEntitiesSource", localContext) { s => entityProvider.queryEntitiesSource(entityType, query, s) }
+          entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+            entityManager.resolveProviderFuture(
+              EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
+            )
+          }
+          metadataAndEntitySource <- traceFutureWithParent("EntityProvider.queryEntitiesSource", localContext) { s =>
+            entityProvider.queryEntitiesSource(entityType, query, s)
+          }
         } yield metadataAndEntitySource
 
         queryFuture.recover(bigQueryRecover)
       }
     }
-  }
 
   def copyEntities(entityCopyDef: EntityCopyDefinition, linkExistingEntities: Boolean): Future[EntityCopyResponse] =
-    traceFutureWithParent("copyEntities", ctx) { localContext =>
+    traceFutureWithParent("EntityService.copyEntities", ctx) { localContext =>
       (for {
         destWsCtx <- traceFutureWithParent("getV2WorkspaceContextAndPermissions destWs", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(entityCopyDef.destinationWorkspace,
-            SamWorkspaceActions.write,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.write,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
         sourceWsCtx <- traceFutureWithParent("getV2WorkspaceContextAndPermissions sourceWs", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(entityCopyDef.sourceWorkspace,
-            SamWorkspaceActions.read,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.read,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        sourceAD <- traceFutureWithParent("getSourceAuthDomain", localContext) { s => samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, sourceWsCtx.workspaceId, s) }
-        destAD <- traceFutureWithParent("getDestAuthDomain", localContext) { s => samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, destWsCtx.workspaceId, s) }
+        sourceAD <- traceFutureWithParent("getSourceAuthDomain", localContext) { s =>
+          samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, sourceWsCtx.workspaceId, s)
+        }
+        destAD <- traceFutureWithParent("getDestAuthDomain", localContext) { s =>
+          samDAO.getResourceAuthDomain(SamResourceTypeNames.workspace, destWsCtx.workspaceId, s)
+        }
         _ = authDomainCheck(sourceAD.toSet, destAD.toSet)
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(destWsCtx, s, None, None)) }
-        entityCopyResponse <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityProvider
-          .copyEntities(sourceWsCtx,
-            destWsCtx,
-            entityCopyDef.entityType,
-            entityCopyDef.entityNames,
-            linkExistingEntities,
-            s
-          )
-          .recover(bigQueryRecover)
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(destWsCtx, s, None, None))
+        }
+        entityCopyResponse <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityProvider
+            .copyEntities(sourceWsCtx,
+                          destWsCtx,
+                          entityCopyDef.entityType,
+                          entityCopyDef.entityNames,
+                          linkExistingEntities,
+                          s
+            )
+            .recover(bigQueryRecover)
         }
       } yield entityCopyResponse)
         .recover(
@@ -371,17 +432,27 @@ class EntityService(protected val ctx: RawlsRequestContext,
                                   billingProject: Option[GoogleProjectId],
                                   parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] =
-    traceFutureWithParent("getV2WorkspaceContextAndPermissions", parentContext) { _ => getV2WorkspaceContextAndPermissions(workspaceName,
-                                        SamWorkspaceActions.write,
-                                        Some(WorkspaceAttributeSpecs(all = false))
-    ) } flatMap { workspaceContext =>
+    traceFutureWithParent("getV2WorkspaceContextAndPermissions", parentContext) { _ =>
+      getV2WorkspaceContextAndPermissions(workspaceName,
+                                          SamWorkspaceActions.write,
+                                          Some(WorkspaceAttributeSpecs(all = false))
+      )
+    } flatMap { workspaceContext =>
       for {
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", parentContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s, dataReference, billingProject)) }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", parentContext) { s =>
+          entityManager.resolveProviderFuture(
+            EntityRequestArguments(workspaceContext, s, dataReference, billingProject)
+          )
+        }
         entities <-
           if (upsert) {
-            traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s => entityProvider.batchUpsertEntities(entityUpdates, s) }
+            traceFutureWithParent("EntityProvider.batchUpsertEntities", parentContext) { s =>
+              entityProvider.batchUpsertEntities(entityUpdates, s)
+            }
           } else {
-            traceFutureWithParent("EntityProvider.batchUpdateEntities", parentContext) { s => entityProvider.batchUpdateEntities(entityUpdates, s) }
+            traceFutureWithParent("EntityProvider.batchUpdateEntities", parentContext) { s =>
+              entityProvider.batchUpdateEntities(entityUpdates, s)
+            }
           }
       } yield entities
     }
@@ -391,7 +462,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
-    traceFutureWithParent("batchUpdateEntities", ctx) { s =>
+    traceFutureWithParent("EntityService.batchUpdateEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = false, dataReference, billingProject, s)
         .recover(
           sqlLoggingRecover(s"batchUpdateEntities: $workspaceName ${entityUpdates.size} updates")
@@ -403,7 +474,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
                           dataReference: Option[DataReferenceName],
                           billingProject: Option[GoogleProjectId]
   ): Future[Traversable[Entity]] =
-    traceFutureWithParent("batchUpsertEntities", ctx) { s =>
+    traceFutureWithParent("EntityService.batchUpsertEntities", ctx) { s =>
       batchUpdateEntitiesInternal(workspaceName, entityUpdates, upsert = true, dataReference, billingProject, s)
         .recover(
           sqlLoggingRecover(s"batchUpsertEntities: $workspaceName ${entityUpdates.size} upserts")
@@ -414,17 +485,21 @@ class EntityService(protected val ctx: RawlsRequestContext,
                       entityType: String,
                       oldAttributeName: AttributeName,
                       attributeRenameRequest: AttributeRename
-  ): Future[Int] = traceFutureWithParent("renameAttribute", ctx) { localContext =>
+  ): Future[Int] = traceFutureWithParent("EntityService.renameAttribute", ctx) { localContext =>
     withAttributeNamespaceCheck(Seq(attributeRenameRequest.newAttributeName)) {
       for {
         workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", ctx) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
-            SamWorkspaceActions.write,
-            Some(WorkspaceAttributeSpecs(all = false))
+                                              SamWorkspaceActions.write,
+                                              Some(WorkspaceAttributeSpecs(all = false))
           )
         }
-        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s)) }
-        result <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s => entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest, s) }
+        entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
+        }
+        result <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+          entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest, s)
+        }
       } yield result
     }.recover(
       sqlLoggingRecover(s"renameAttribute: $workspaceName $oldAttributeName $attributeRenameRequest")

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/EntityService.scala
@@ -146,7 +146,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
       if (entRefs.isEmpty) {
         Future.successful(Set.empty)
       } else {
-        traceFutureWithParent("getWorkspaceContextAndPermissions", localContext) { _ =>
+        traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
                                               SamWorkspaceActions.write,
                                               Some(WorkspaceAttributeSpecs(all = false))
@@ -488,7 +488,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
   ): Future[Int] = traceFutureWithParent("EntityService.renameAttribute", ctx) { localContext =>
     withAttributeNamespaceCheck(Seq(attributeRenameRequest.newAttributeName)) {
       for {
-        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", ctx) { _ =>
+        workspaceContext <- traceFutureWithParent("getV2WorkspaceContextAndPermissions", localContext) { _ =>
           getV2WorkspaceContextAndPermissions(workspaceName,
                                               SamWorkspaceActions.write,
                                               Some(WorkspaceAttributeSpecs(all = false))
@@ -497,7 +497,7 @@ class EntityService(protected val ctx: RawlsRequestContext,
         entityProvider <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
           entityManager.resolveProviderFuture(EntityRequestArguments(workspaceContext, s))
         }
-        result <- traceFutureWithParent("EntityManager.resolveProviderFuture", localContext) { s =>
+        result <- traceFutureWithParent("EntityProvider.renameAttribute", localContext) { s =>
           entityProvider.renameAttribute(entityType, oldAttributeName, attributeRenameRequest, s)
         }
       } yield result

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/base/EntityProvider.scala
@@ -34,9 +34,9 @@ trait EntityProvider {
 
   // ----- implementation methods follow:
 
-  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+  def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]]
 
-  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]]
+  def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]]
 
   def copyEntities(sourceWorkspaceContext: Workspace,
                    destWorkspaceContext: Workspace,
@@ -46,17 +46,17 @@ trait EntityProvider {
                    parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse]
 
-  def createEntity(entity: Entity): Future[Entity]
+  def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity]
 
-  def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int]
+  def deleteEntities(entityRefs: Seq[AttributeEntityReference], parentContext: RawlsRequestContext): Future[Int]
 
-  def deleteEntitiesOfType(entityType: String): Future[Int]
+  def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int]
 
-  def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName]): Future[Unit]
+  def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit]
 
-  def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]]
+  def entityTypeMetadata(useCache: Boolean, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]]
 
-  def evaluateExpression(entityType: String, entityName: String, expression: String): Future[Seq[AttributeValue]]
+  def evaluateExpression(entityType: String, entityName: String, expression: String, parentContext: RawlsRequestContext): Future[Seq[AttributeValue]]
 
   /**
   The overall approach is:
@@ -87,7 +87,7 @@ trait EntityProvider {
 
   def expressionValidator: ExpressionValidator
 
-  def getEntity(entityType: String, entityName: String): Future[Entity]
+  def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity]
 
   def listEntities(entityType: String): Source[Entity, NotUsed]
 
@@ -103,12 +103,13 @@ trait EntityProvider {
 
   def renameAttribute(entityType: String,
                       oldAttributeName: AttributeName,
-                      attributeRenameRequest: AttributeRename
+                      attributeRenameRequest: AttributeRename,
+                      parentContext: RawlsRequestContext
   ): Future[Int]
 
-  def renameEntity(entityType: String, entityName: String, newName: String): Future[Int]
+  def renameEntity(entityType: String, entityName: String, newName: String, parentContext: RawlsRequestContext): Future[Int]
 
-  def renameEntityType(oldName: String, renameInfo: EntityTypeRename): Future[Int]
+  def renameEntityType(oldName: String, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int]
 
-  def updateEntity(entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation]): Future[Entity]
+  def updateEntity(entityType: String, entityName: String, operations: Seq[AttributeUpdateOperation], parentContext: RawlsRequestContext): Future[Entity]
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/compact/CompactEntityProvider.scala
@@ -37,11 +37,11 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
   override def entityStoreId: Option[String] = ???
 
   override def batchUpdateEntities(
-    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition]
+    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition], parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = ???
 
   override def batchUpsertEntities(
-    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition]
+    entityUpdates: Seq[AttributeUpdateOperations.EntityUpdateDefinition], parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = ???
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
@@ -52,19 +52,19 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
                             parentContext: RawlsRequestContext
   ): Future[EntityCopyResponse] = ???
 
-  override def createEntity(entity: Entity): Future[Entity] = ???
+  override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] = ???
 
-  override def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int] = ???
+  override def deleteEntities(entityRefs: Seq[AttributeEntityReference], parentContext: RawlsRequestContext): Future[Int] = ???
 
-  override def deleteEntitiesOfType(entityType: String): Future[Int] = ???
+  override def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int] = ???
 
-  override def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName]): Future[Unit] = ???
+  override def deleteEntityAttributes(entityType: String, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit] = ???
 
-  override def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]] = ???
+  override def entityTypeMetadata(useCache: Boolean, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]] = ???
 
   override def evaluateExpression(entityType: String,
                                   entityName: String,
-                                  expression: String
+                                  expression: String, parentContext: RawlsRequestContext
   ): Future[Seq[AttributeValue]] = ???
 
   override def evaluateExpressions(expressionEvaluationContext: ExpressionEvaluationContext,
@@ -74,7 +74,7 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
 
   override def expressionValidator: ExpressionValidator = ???
 
-  override def getEntity(entityType: String, entityName: String): Future[Entity] = ???
+  override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] = ???
 
   override def listEntities(entityType: String): Source[Entity, NotUsed] = ???
 
@@ -90,15 +90,15 @@ class CompactEntityProvider(implicit protected val executionContext: ExecutionCo
 
   override def renameAttribute(entityType: String,
                                oldAttributeName: AttributeName,
-                               attributeRenameRequest: AttributeRename
+                               attributeRenameRequest: AttributeRename, parentContext: RawlsRequestContext
   ): Future[Int] = ???
 
-  override def renameEntity(entityType: String, entityName: String, newName: String): Future[Int] = ???
+  override def renameEntity(entityType: String, entityName: String, newName: String, parentContext: RawlsRequestContext): Future[Int] = ???
 
-  override def renameEntityType(oldName: String, renameInfo: EntityTypeRename): Future[Int] = ???
+  override def renameEntityType(oldName: String, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int] = ???
 
   override def updateEntity(entityType: String,
                             entityName: String,
-                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation]
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation], parentContext: RawlsRequestContext
   ): Future[Entity] = ???
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProvider.scala
@@ -89,7 +89,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
       case None          => requestArguments.workspace.googleProjectId
     }
 
-  override def entityTypeMetadata(useCache: Boolean = false): Future[Map[String, EntityTypeMetadata]] = {
+  override def entityTypeMetadata(useCache: Boolean = false, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]] = {
 
     // TODO: AS-321 auto-switch to see if the ref supplied in argument is a UUID or a name?? Use separate query params? Never allow ID?
 
@@ -104,19 +104,19 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   }
 
-  override def createEntity(entity: Entity): Future[Entity] =
+  override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] =
     throw new UnsupportedEntityOperationException("create entity not supported by this provider.")
 
-  override def deleteEntities(entityRefs: Seq[AttributeEntityReference]): Future[Int] =
+  override def deleteEntities(entityRefs: Seq[AttributeEntityReference], parentContext: RawlsRequestContext): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities not supported by this provider.")
 
-  override def deleteEntitiesOfType(entityType: String): Future[Int] =
+  override def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int] =
     throw new UnsupportedEntityOperationException("delete entities of type not supported by this provider.")
 
-  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName]): Future[Unit] =
+  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit] =
     throw new UnsupportedEntityOperationException("delete entity attributes not supported by this provider.")
 
-  override def getEntity(entityType: String, entityName: String): Future[Entity] = {
+  override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] = {
     // extract table definition, with PK, from snapshot schema
     val tableModel = getTableModel(snapshotModel, entityType)
 
@@ -291,7 +291,7 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def evaluateExpression(entityType: EntityName,
                                   entityName: EntityName,
-                                  expression: EntityName
+                                  expression: EntityName, parentContext: RawlsRequestContext
   ): Future[Seq[AttributeValue]] =
     throw new UnsupportedEntityOperationException("evaluate expression not supported by this provider.")
 
@@ -550,10 +550,10 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def expressionValidator: ExpressionValidator = new DataRepoEntityExpressionValidator(snapshotModel)
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
+  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-update entities not supported by this provider.")
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
     throw new UnsupportedEntityOperationException("batch-upsert entities not supported by this provider.")
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
@@ -567,19 +567,19 @@ class DataRepoEntityProvider(snapshotModel: SnapshotModel,
 
   override def renameAttribute(entityType: EntityName,
                                oldAttributeName: AttributeName,
-                               attributeRenameRequest: AttributeRename
+                               attributeRenameRequest: AttributeRename, parentContext: RawlsRequestContext
   ): Future[Int] =
     throw new UnsupportedEntityOperationException("rename attribute not supported by this provider.")
 
-  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName): Future[Int] =
+  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName, parentContext: RawlsRequestContext): Future[Int] =
     throw new UnsupportedEntityOperationException("rename entity not supported by this provider.")
 
-  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename): Future[Int] =
+  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int] =
     throw new UnsupportedEntityOperationException("rename entity type not supported by this provider.")
 
   override def updateEntity(entityType: EntityName,
                             entityName: EntityName,
-                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation]
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation], parentContext: RawlsRequestContext
   ): Future[Entity] = throw new UnsupportedEntityOperationException("update entity not supported by this provider.")
 
 }

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProvider.scala
@@ -89,9 +89,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
 
   final private val queryTimeoutSeconds: Int = queryTimeout.getSeconds.toInt
 
-  override def entityTypeMetadata(useCache: Boolean): Future[Map[String, EntityTypeMetadata]] =
+  override def entityTypeMetadata(useCache: Boolean, parentContext: RawlsRequestContext): Future[Map[String, EntityTypeMetadata]] =
     // start performance tracing
-    traceFutureWithParent("LocalEntityProvider.entityTypeMetadata", requestArguments.ctx) { localContext =>
+    traceFutureWithParent("LocalEntityProvider.entityTypeMetadata", parentContext) { localContext =>
       setTraceSpanAttribute(localContext,
                             AttributeKey.stringKey("workspace"),
                             workspaceContext.toWorkspaceName.toString
@@ -168,9 +168,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       ) // end transaction
     } // end root trace
 
-  override def createEntity(entity: Entity): Future[Entity] =
+  override def createEntity(entity: Entity, parentContext: RawlsRequestContext): Future[Entity] =
     dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-      dataAccess.entityQuery.get(workspaceContext, entity.entityType, entity.name) flatMap {
+      traceDBIOWithParent("getEntity", parentContext) { _ => dataAccess.entityQuery.get(workspaceContext, entity.entityType, entity.name) } flatMap {
         case Some(_) =>
           DBIO.failed(
             new RawlsExceptionWithErrorReport(
@@ -180,15 +180,15 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
                 )
             )
           )
-        case None => dataAccess.entityQuery.save(workspaceContext, entity)
+        case None => traceDBIOWithParent("saveEntity", parentContext) { _ => dataAccess.entityQuery.save(workspaceContext, entity) }
       }
     }
 
   // EntityApiServiceSpec has good test coverage for this api
-  override def deleteEntities(entRefs: Seq[AttributeEntityReference]): Future[Int] =
+  override def deleteEntities(entRefs: Seq[AttributeEntityReference], parentContext: RawlsRequestContext): Future[Int] =
     dataSource.inTransaction { dataAccess =>
       // withAllEntityRefs throws exception if some entities not found; passes through if all ok
-      traceDBIOWithParent("LocalEntityProvider.deleteEntities", requestArguments.ctx) { localContext =>
+      traceDBIOWithParent("LocalEntityProvider.deleteEntities", parentContext) { localContext =>
         setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
         setTraceSpanAttribute(localContext, AttributeKey.longKey("numEntities"), java.lang.Long.valueOf(entRefs.length))
         withAllEntityRefs(workspaceContext, dataAccess, entRefs, localContext) { _ =>
@@ -210,9 +210,9 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
-  override def deleteEntitiesOfType(entityType: String): Future[Int] =
+  override def deleteEntitiesOfType(entityType: String, parentContext: RawlsRequestContext): Future[Int] =
     dataSource.inTransaction { dataAccess =>
-      traceDBIOWithParent("LocalEntityProvider.deleteEntitiesOfType", requestArguments.ctx) { localContext =>
+      traceDBIOWithParent("LocalEntityProvider.deleteEntitiesOfType", parentContext) { localContext =>
         setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
         setTraceSpanAttribute(localContext, AttributeKey.stringKey("entityType"), entityType)
 
@@ -229,53 +229,58 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
       }
     }
 
-  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName]): Future[Unit] =
+  override def deleteEntityAttributes(entityType: EntityName, attributeNames: Set[AttributeName], parentContext: RawlsRequestContext): Future[Unit] =
     dataSource.inTransaction { dataAccess =>
-      dataAccess
+      traceDBIOWithParent("deleteEntityAttributes", parentContext) { _ => dataAccess
         .entityAttributeShardQuery(workspaceContext)
-        .deleteAttributes(workspaceContext, entityType, attributeNames) flatMap {
+        .deleteAttributes(workspaceContext, entityType, attributeNames) } flatMap {
         case Vector(0) =>
           throw new RawlsExceptionWithErrorReport(
             errorReport = ErrorReport(StatusCodes.BadRequest, s"Could not find any of the given attribute names.")
           )
         case _ => DBIO.successful(())
       }
+
     }
 
   override def evaluateExpression(entityType: EntityName,
                                   entityName: EntityName,
-                                  expression: EntityName
+                                  expression: EntityName,
+                                  parentContext: RawlsRequestContext
   ): Future[Seq[AttributeValue]] =
     dataSource.inTransaction(
       dataAccess =>
-        withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
-          ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
-            evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
-              // parsing failure
-              case Failure(regret) =>
-                throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
-              case Success(valuesByEntity) =>
-                if (valuesByEntity.size != 1) {
-                  // wrong number of entities?!
-                  throw new RawlsException(
-                    s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
-                  )
-                } else {
-                  assert(valuesByEntity.head._1 == entityName)
-                  valuesByEntity.head match {
-                    case (_, Success(result)) => result.toSeq
-                    case (_, Failure(regret)) =>
-                      throw new RawlsExceptionWithErrorReport(
-                        errorReport = ErrorReport(
-                          StatusCodes.BadRequest,
-                          "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
-                          ErrorReport(regret)
-                        )
+        traceDBIOWithParent("withSingleEntityRec", parentContext) { _ => withSingleEntityRec(entityType, entityName, workspaceContext, dataAccess) { entities =>
+          traceDBIOWithParent("withNewExpressionEvaluator", parentContext) { _ => ExpressionEvaluator.withNewExpressionEvaluator(dataAccess, Some(entities)) { evaluator =>
+              traceDBIOWithParent("evalFinalAttribute", parentContext) { _ => evaluator.evalFinalAttribute(workspaceContext, expression).asTry map {
+                  // parsing failure
+                  case Failure(regret) =>
+                    throw new RawlsExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, regret))
+                  case Success(valuesByEntity) =>
+                    if (valuesByEntity.size != 1) {
+                      // wrong number of entities?!
+                      throw new RawlsException(
+                        s"Expression parsing should have returned a single entity for ${entityType}/$entityName $expression, but returned ${valuesByEntity.size} entities instead"
                       )
-                  }
+                    } else {
+                      assert(valuesByEntity.head._1 == entityName)
+                      valuesByEntity.head match {
+                        case (_, Success(result)) => result.toSeq
+                        case (_, Failure(regret)) =>
+                          throw new RawlsExceptionWithErrorReport(
+                            errorReport = ErrorReport(
+                              StatusCodes.BadRequest,
+                              "Unable to evaluate expression '${expression}' on ${entityType}/${entityName} in ${workspaceName}",
+                              ErrorReport(regret)
+                            )
+                          )
+                      }
+                    }
                 }
+              }
             }
           }
+        }
         },
       TransactionIsolation.ReadCommitted
     )
@@ -342,10 +347,12 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     }
   }
 
-  override def getEntity(entityType: String, entityName: String): Future[Entity] =
+  override def getEntity(entityType: String, entityName: String, parentContext: RawlsRequestContext): Future[Entity] =
     dataSource.inTransaction(dataAccess =>
-                               withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-                                 DBIO.successful(entity)
+                               traceDBIOWithParent("withEntity", parentContext) { _ =>
+                                 withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+                                   DBIO.successful(entity)
+                                 }
                                },
                              TransactionIsolation.ReadCommitted
     )
@@ -518,14 +525,15 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     }
 
   private def batchUpdateEntitiesImpl(entityUpdates: Seq[EntityUpdateDefinition],
-                                      upsert: Boolean
+                                      upsert: Boolean,
+                                      parentContext: RawlsRequestContext
   ): Future[Traversable[Entity]] = {
     val namesToCheck = for {
       update <- entityUpdates
       operation <- update.operations
     } yield operation.name
 
-    traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", requestArguments.ctx) { localContext =>
+    traceFutureWithParent("LocalEntityProvider.batchUpdateEntitiesImpl", parentContext) { localContext =>
       setTraceSpanAttribute(localContext, AttributeKey.stringKey("workspaceId"), workspaceContext.workspaceId)
       setTraceSpanAttribute(localContext, AttributeKey.booleanKey("upsert"), java.lang.Boolean.valueOf(upsert))
       setTraceSpanAttribute(localContext,
@@ -606,11 +614,11 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     }
   }
 
-  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
-    batchUpdateEntitiesImpl(entityUpdates, upsert = false)
+  override def batchUpdateEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
+    batchUpdateEntitiesImpl(entityUpdates, upsert = false, parentContext)
 
-  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition]): Future[Traversable[Entity]] =
-    batchUpdateEntitiesImpl(entityUpdates, upsert = true)
+  override def batchUpsertEntities(entityUpdates: Seq[EntityUpdateDefinition], parentContext: RawlsRequestContext): Future[Traversable[Entity]] =
+    batchUpdateEntitiesImpl(entityUpdates, upsert = true, parentContext)
 
   override def copyEntities(sourceWorkspaceContext: Workspace,
                             destWorkspaceContext: Workspace,
@@ -633,7 +641,8 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
 
   override def renameAttribute(entityType: EntityName,
                                oldAttributeName: AttributeName,
-                               attributeRenameRequest: AttributeRename
+                               attributeRenameRequest: AttributeRename,
+                               parentContext: RawlsRequestContext
   ): Future[Int] = {
     def validateNewAttributeName(dataAccess: DataAccess,
                                  workspaceContext: Workspace,
@@ -674,30 +683,34 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
     dataSource.inTransaction { dataAccess =>
       val newAttributeName = attributeRenameRequest.newAttributeName
       for {
-        _ <- validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName)
-        rowsUpdated <- dataAccess
-          .entityAttributeShardQuery(workspaceContext)
-          .renameAttribute(workspaceContext, entityType, oldAttributeName, newAttributeName)
+        _ <- traceDBIOWithParent("validateNewAttributeName", parentContext) { _ => validateNewAttributeName(dataAccess, workspaceContext, entityType, newAttributeName) }
+        rowsUpdated <- traceDBIOWithParent("renameAttribute", parentContext) { _ =>
+          dataAccess
+            .entityAttributeShardQuery(workspaceContext)
+            .renameAttribute(workspaceContext, entityType, oldAttributeName, newAttributeName)
+        }
         _ = validateRowsUpdated(rowsUpdated, oldAttributeName)
       } yield rowsUpdated
     }
   }
 
-  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName): Future[Int] =
+  override def renameEntity(entityType: EntityName, entityName: EntityName, newName: EntityName, parentContext: RawlsRequestContext): Future[Int] =
     dataSource.inTransaction { dataAccess =>
-      withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-        dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName) flatMap {
-          case None => dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName)
-          case Some(_) =>
-            throw new RawlsExceptionWithErrorReport(
-              errorReport =
-                ErrorReport(StatusCodes.Conflict, s"Destination ${entity.entityType} ${newName} already exists")
-            )
+      traceDBIOWithParent("withEntity", parentContext) { s =>
+        withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+          traceDBIOWithParent("checkNameConflict getEntity", s) { _ => dataAccess.entityQuery.get(workspaceContext, entity.entityType, newName) } flatMap {
+            case None => traceDBIOWithParent("renameEntity", s) { _ => dataAccess.entityQuery.rename(workspaceContext, entity.entityType, entity.name, newName) }
+            case Some(_) =>
+              throw new RawlsExceptionWithErrorReport(
+                errorReport =
+                  ErrorReport(StatusCodes.Conflict, s"Destination ${entity.entityType} ${newName} already exists")
+              )
+          }
         }
       }
     }
 
-  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename): Future[Int] = {
+  override def renameEntityType(oldName: EntityName, renameInfo: EntityTypeRename, parentContext: RawlsRequestContext): Future[Int] = {
     def validateExistingType(dataAccess: DataAccess,
                              workspaceContext: Workspace,
                              oldName: String
@@ -742,28 +755,31 @@ class LocalEntityProvider(requestArguments: EntityRequestArguments,
 
   override def updateEntity(entityType: EntityName,
                             entityName: EntityName,
-                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation]
+                            operations: Seq[AttributeUpdateOperations.AttributeUpdateOperation],
+                            parentContext: RawlsRequestContext
   ): Future[Entity] =
     dataSource.inTransactionWithAttrTempTable(Set(AttributeTempTableType.Entity)) { dataAccess =>
-      withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
-        val updateAction = Try {
-          val updatedEntity = applyOperationsToEntity(entity, operations)
-          dataAccess.entityQuery.save(workspaceContext, updatedEntity)
-        } match {
-          case Success(result) => result
-          case Failure(e: AttributeUpdateOperationException) =>
-            DBIO.failed(
-              new RawlsExceptionWithErrorReport(
-                errorReport = ErrorReport(
-                  StatusCodes.BadRequest,
-                  s"Unable to update entity ${entityType}/${entityName} in ${workspaceContext.toWorkspaceName}",
-                  ErrorReport(e)
+      traceDBIOWithParent("withEntity", parentContext) { s =>
+        withEntity(workspaceContext, entityType, entityName, dataAccess) { entity =>
+          val updateAction = Try {
+            val updatedEntity = applyOperationsToEntity(entity, operations)
+            traceDBIOWithParent("saveEntity", s) { _ => dataAccess.entityQuery.save(workspaceContext, updatedEntity) }
+          } match {
+            case Success(result) => result
+            case Failure(e: AttributeUpdateOperationException) =>
+              DBIO.failed(
+                new RawlsExceptionWithErrorReport(
+                  errorReport = ErrorReport(
+                    StatusCodes.BadRequest,
+                    s"Unable to update entity ${entityType}/${entityName} in ${workspaceContext.toWorkspaceName}",
+                    ErrorReport(e)
+                  )
                 )
               )
-            )
-          case Failure(regrets) => DBIO.failed(regrets)
+            case Failure(regrets) => DBIO.failed(regrets)
+          }
+          updateAction
         }
-        updateAction
       }
     }
 

--- a/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
+++ b/core/src/main/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitor.scala
@@ -448,12 +448,14 @@ class AvroUpsertMonitorActor(val pollInterval: FiniteDuration,
         logger.info(s"upserting batch #$idx of ${upsertBatch.size} entities for jobId ${jobId.toString} ...")
         for {
           petUserInfo <- getPetServiceAccountUserInfo(workspace.googleProjectId, userEmail)
-          upsertResults <- entityService(RawlsRequestContext(petUserInfo)).batchUpdateEntitiesInternal(
+          requestContext = RawlsRequestContext(petUserInfo)
+          upsertResults <- entityService(requestContext).batchUpdateEntitiesInternal(
             workspace.toWorkspaceName,
             upsertBatch,
             upsert = isUpsert,
             None,
-            None
+            None,
+            requestContext
           )
         } yield upsertResults
       }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/datarepo/DataRepoEntityProviderSpec.scala
@@ -98,7 +98,7 @@ class DataRepoEntityProviderSpec
 
     val provider = createTestProvider()
 
-    provider.entityTypeMetadata() map { metadata: Map[String, EntityTypeMetadata] =>
+    provider.entityTypeMetadata(parentContext = testContext) map { metadata: Map[String, EntityTypeMetadata] =>
       // this is the default expected value, should it move to the support trait?
       val expected = Map(
         ("table1", EntityTypeMetadata(10, "datarepo_row_id", Seq("integer-field", "boolean-field", "timestamp-field"))),
@@ -112,7 +112,7 @@ class DataRepoEntityProviderSpec
   it should "return an empty Map if data repo snapshot has no tables" in {
     val provider = createTestProvider(snapshotModel = createSnapshotModel(List.empty[TableModel]))
 
-    provider.entityTypeMetadata() map { metadata: Map[String, EntityTypeMetadata] =>
+    provider.entityTypeMetadata(parentContext = testContext) map { metadata: Map[String, EntityTypeMetadata] =>
       assert(metadata.isEmpty, "expected response data to be the empty map")
     }
   }
@@ -153,7 +153,7 @@ class DataRepoEntityProviderSpec
     // set up a provider with a mock that returns exactly one BQ row
     val provider =
       createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(createTestTableResult(tableRowCount))))
-    provider.getEntity("table1", "Row0") map { entity: Entity =>
+    provider.getEntity("table1", "Row0", testContext) map { entity: Entity =>
       // this is the default expected value, should it move to the support trait?
       val expected = Entity(
         "Row0",
@@ -173,7 +173,7 @@ class DataRepoEntityProviderSpec
     val provider = createTestProvider(samDAO = new SpecSamDAO(petKeyForUserResponse = Left(new Exception("sam error"))))
 
     val futureEx = recoverToExceptionIf[Exception] {
-      provider.getEntity("table1", "Row0")
+      provider.getEntity("table1", "Row0", testContext)
     }
     futureEx map { ex =>
       assertResult(
@@ -191,7 +191,7 @@ class DataRepoEntityProviderSpec
     val provider = createTestProvider() // default behavior returns three rows
 
     val ex = intercept[EntityTypeNotFoundException] {
-      provider.getEntity("this_table_is_unknown", "Row0")
+      provider.getEntity("this_table_is_unknown", "Row0", testContext)
     }
     assertResult("this_table_is_unknown")(ex.requestedType)
   }
@@ -202,7 +202,7 @@ class DataRepoEntityProviderSpec
     )
 
     val futureEx = recoverToExceptionIf[BigQueryException] {
-      provider.getEntity("table1", "Row0")
+      provider.getEntity("table1", "Row0", testContext)
     }
     futureEx map { ex =>
       assertResult("unit test exception message")(ex.getMessage)
@@ -216,7 +216,7 @@ class DataRepoEntityProviderSpec
     val provider = createTestProvider(bqFactory = MockBigQueryServiceFactory.ioFactory(Right(tableResult)))
 
     val futureEx = recoverToExceptionIf[EntityNotFoundException] {
-      provider.getEntity("table1", "Row0")
+      provider.getEntity("table1", "Row0", testContext)
     }
     futureEx map { ex =>
       assertResult("Entity not found.")(ex.getMessage)
@@ -227,7 +227,7 @@ class DataRepoEntityProviderSpec
     val provider = createTestProvider() // default behavior returns three rows
 
     val futureEx = recoverToExceptionIf[DataEntityException] {
-      provider.getEntity("table1", "Row0")
+      provider.getEntity("table1", "Row0", testContext)
     }
     futureEx map { ex =>
       assertResult("Query succeeded, but returned 3 rows; expected one row.")(ex.getMessage)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/CaseSensitivitySpec.scala
@@ -106,7 +106,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                  "metricsBaseName"
           )
           // get metadata
-          val metadata = provider.entityTypeMetadata(false).futureValue
+          val metadata = provider.entityTypeMetadata(false, testContext).futureValue
           metadata.keySet shouldBe exemplarTypes
         }
 
@@ -179,7 +179,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                    testConf.getDuration("entities.queryTimeout"),
                                                    "metricsBaseName"
             )
-            provider.deleteEntitiesOfType(typeUnderTest).futureValue
+            provider.deleteEntitiesOfType(typeUnderTest, testContext).futureValue
 
             // get actual entity types from the db
             val actualEntityTypes = getAllEntityTypes(testWorkspace.workspace)
@@ -298,7 +298,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           )
           // test gets
           exemplarDataWithCommonNames foreach { entityUnderTest =>
-            val actual = provider.getEntity(entityUnderTest.entityType, entityUnderTest.name).futureValue
+            val actual = provider.getEntity(entityUnderTest.entityType, entityUnderTest.name, testContext).futureValue
             actual shouldBe entityUnderTest
           }
         }
@@ -433,7 +433,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             // delete two entities of target type
             val entRefs =
               Seq(AttributeEntityReference(typeUnderTest, "001"), AttributeEntityReference(typeUnderTest, "002"))
-            provider.deleteEntities(entRefs).futureValue
+            provider.deleteEntities(entRefs, testContext).futureValue
 
             // count actual entities by type
             val actualEntities = getAllEntities(testWorkspace.workspace)
@@ -485,7 +485,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             )
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
-            provider.batchUpsertEntities(Seq(upsert)).futureValue
+            provider.batchUpsertEntities(Seq(upsert), testContext).futureValue
 
             // get database-level entity record for the entity containing the reference
             val entityRecordContainingReference = runAndWait(
@@ -534,7 +534,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
-            provider.batchUpsertEntities(Seq(upsert)).futureValue
+            provider.batchUpsertEntities(Seq(upsert), testContext).futureValue
 
             // get actual entities, after upsert
             val entitiesAfterUpsert = getAllEntities(testWorkspace.workspace)
@@ -578,7 +578,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
             val op = AddUpdateAttribute(fooAttribute, AttributeString("updated"))
             val upsert = EntityUpdateDefinition("001", typeUnderTest, Seq(op))
             // perform upsert
-            provider.batchUpdateEntities(Seq(upsert)).futureValue
+            provider.batchUpdateEntities(Seq(upsert), testContext).futureValue
 
             // get actual entities, after upsert
             val entitiesAfterUpdate = getAllEntities(testWorkspace.workspace)
@@ -621,7 +621,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                "metricsBaseName"
         )
         // get metadata
-        val metadata = provider.entityTypeMetadata(false).futureValue
+        val metadata = provider.entityTypeMetadata(false, testContext).futureValue
         metadata("cat").attributeNames.size shouldEqual exemplarAttributeNames.size
         metadata("cat").attributeNames should contain theSameElementsAs exemplarAttributeNames
       }
@@ -640,7 +640,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
                                                testConf.getDuration("entities.queryTimeout"),
                                                "metricsBaseName"
         )
-        provider.entityTypeMetadata(true).futureValue
+        provider.entityTypeMetadata(true, testContext).futureValue
 
         // cache is now populated
         assert(runAndWait(entityCacheQuery.entityCacheStaleness(testWorkspace.workspace.workspaceIdAsUUID)).isDefined)
@@ -686,7 +686,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         )
 
         // delete our test entity
-        provider.deleteEntities(Seq(AttributeEntityReference("cat", "005"))).futureValue shouldBe 1
+        provider.deleteEntities(Seq(AttributeEntityReference("cat", "005")), testContext).futureValue shouldBe 1
 
         // make sure all attributes are marked as deleted
         import driver.api._
@@ -706,7 +706,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         )
 
         // create our entity
-        provider.createEntity(caseInsensitiveAttributeData.head).futureValue // Entity
+        provider.createEntity(caseInsensitiveAttributeData.head, testContext).futureValue // Entity
 
         // make sure all attributes are created
         import driver.api._
@@ -779,7 +779,7 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
         )
 
         // get our entity
-        val entity = provider.getEntity("cat", "005").futureValue // Entity
+        val entity = provider.getEntity("cat", "005", testContext).futureValue // Entity
 
         // make sure all attributes are created
         exemplarAttributeNames.size should equal(entity.attributes.size)
@@ -824,10 +824,10 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           }.toSeq
           EntityUpdateDefinition(entity.name, entity.entityType, attributeUpdates)
         }
-        provider.batchUpsertEntities(updateDefinition).futureValue
+        provider.batchUpsertEntities(updateDefinition, testContext).futureValue
 
         // get our entity
-        val entity = provider.getEntity("cat", "005").futureValue
+        val entity = provider.getEntity("cat", "005", testContext).futureValue
 
         // make sure all attributes are created
         exemplarAttributeNames.size should equal(entity.attributes.size)
@@ -853,10 +853,10 @@ class CaseSensitivitySpec extends AnyFreeSpec with Matchers with TestDriverCompo
           }.toSeq
           EntityUpdateDefinition(entity.name, entity.entityType, attributeUpdates)
         }
-        provider.batchUpdateEntities(updateDefinition).futureValue
+        provider.batchUpdateEntities(updateDefinition, testContext).futureValue
 
         // get our entity
-        val entity = provider.getEntity("cat", "005").futureValue
+        val entity = provider.getEntity("cat", "005", testContext).futureValue
 
         // make sure all attributes are created
         exemplarAttributeNames.size should equal(entity.attributes.size)

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -347,7 +347,7 @@ class LocalEntityProviderSpec
                                  Seq(AddUpdateAttribute(AttributeName.withDefaultNS("two"), AttributeString("222")))
           )
         )
-        val writes = localEntityProvider.batchUpsertEntities(multiUpsert).futureValue
+        val writes = localEntityProvider.batchUpsertEntities(multiUpsert, testContext).futureValue
 
         writes.size shouldBe 2
 
@@ -415,7 +415,7 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -450,7 +450,7 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -484,7 +484,7 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -517,7 +517,7 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(true, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -579,7 +579,7 @@ class LocalEntityProviderSpec
 
         // verify the attribute name cache is stale on first access, because of the feature flags
         val entityTypeMetadataResultWithFlags =
-          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
         val addedAttrNamesWithFlags = entityTypeMetadataResultWithFlags("participant").attributeNames
         addedAttrNamesWithFlags shouldNot contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
 
@@ -588,7 +588,7 @@ class LocalEntityProviderSpec
           entityTypeMetadataResultWithFlags(typeName).count shouldBe expectedResultWhenUsingCache(typeName).count
         }
         // now call again, this time without the cache, and make sure the values are updated
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false, testContext)))
         val addedAttrNames = entityTypeMetadataResult("participant").attributeNames
         addedAttrNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
 
@@ -640,7 +640,7 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         // metadata response always contains the union of types found by cache and by full queries
         val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
@@ -695,7 +695,7 @@ class LocalEntityProviderSpec
 
         // verify the new attributes are present in uncached metadata
         val entityTypeMetadataResultBeforeFlags =
-          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         val addedAttrNames = entityTypeMetadataResultBeforeFlags(
           "participant"
@@ -734,7 +734,7 @@ class LocalEntityProviderSpec
 
         // with feature flag set, retrieve metadata again. This time it should use the cache, which will NOT return
         // the added attribute names
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true)))
+        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         // metadata response always contains the union of types found by cache and by full queries
         val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
@@ -973,7 +973,7 @@ class LocalEntityProviderSpec
         }
 
         // requesting metadata should update the cache as a side effect
-        localEntityProvider.entityTypeMetadata(true).futureValue
+        localEntityProvider.entityTypeMetadata(true, testContext).futureValue
 
         withClue("cache record should exist after requesting metadata") {
           assert(runAndWait(workspaceFilter.exists.result))
@@ -1003,13 +1003,13 @@ class LocalEntityProviderSpec
 
         // create the first entity with name "myname"
         val entity1 = Entity("myname", "casetest", Map())
-        val created1 = localEntityProvider.createEntity(entity1).futureValue
+        val created1 = localEntityProvider.createEntity(entity1, testContext).futureValue
         created1 shouldBe entity1
 
         // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
         val entity2 = Entity("MyName", "casetest", Map())
         val ex = recoverToExceptionIf[Exception] {
-          localEntityProvider.createEntity(entity2)
+          localEntityProvider.createEntity(entity2, testContext)
         }.futureValue
 
         ex match {
@@ -1039,13 +1039,13 @@ class LocalEntityProviderSpec
 
         // create the first entity with name "myname"
         val upsert1 = Seq(EntityUpdateDefinition("myname", "casetest", Seq()))
-        val created1 = localEntityProvider.batchUpsertEntities(upsert1).futureValue
+        val created1 = localEntityProvider.batchUpsertEntities(upsert1, testContext).futureValue
         created1.size shouldBe 1
 
         // attempt to create the second entity with name "MyName" - differing from entity1's name only in case
         val upsert2 = Seq(EntityUpdateDefinition("MyName", "casetest", Seq()))
         val ex = recoverToExceptionIf[Exception] {
-          localEntityProvider.batchUpsertEntities(upsert2)
+          localEntityProvider.batchUpsertEntities(upsert2, testContext)
         }.futureValue
 
         ex match {

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderSpec.scala
@@ -415,7 +415,8 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
+        val entityTypeMetadataResult =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -450,7 +451,8 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
+        val entityTypeMetadataResult =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -484,7 +486,8 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false, testContext)))
+        val entityTypeMetadataResult =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false, testContext)))
 
         val typeCountCache =
           runAndWait(dataSource.dataAccess.entityTypeStatisticsQuery.getAll(workspaceContext.workspaceIdAsUUID))
@@ -588,7 +591,8 @@ class LocalEntityProviderSpec
           entityTypeMetadataResultWithFlags(typeName).count shouldBe expectedResultWhenUsingCache(typeName).count
         }
         // now call again, this time without the cache, and make sure the values are updated
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false, testContext)))
+        val entityTypeMetadataResult =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = false, testContext)))
         val addedAttrNames = entityTypeMetadataResult("participant").attributeNames
         addedAttrNames should contain theSameElementsAs List("somethingNew", "anotherNew", "yetOneMore")
 
@@ -640,7 +644,8 @@ class LocalEntityProviderSpec
           )
         )
 
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
+        val entityTypeMetadataResult =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         // metadata response always contains the union of types found by cache and by full queries
         val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet
@@ -734,7 +739,8 @@ class LocalEntityProviderSpec
 
         // with feature flag set, retrieve metadata again. This time it should use the cache, which will NOT return
         // the added attribute names
-        val entityTypeMetadataResult = runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
+        val entityTypeMetadataResult =
+          runAndWait(DBIO.from(localEntityProvider.entityTypeMetadata(useCache = true, testContext)))
 
         // metadata response always contains the union of types found by cache and by full queries
         val allTypeNames = expectedResultWhenUsingFullQueries.keySet ++ expectedResultWhenUsingCache.keySet

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
@@ -75,7 +75,8 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
     "enforce on deleteEntities" in withLocalEntityProviderTestDatabase { dataSource =>
       lockedEntitiesTest(dataSource, a[MySQLTimeoutException]) { localEntityProvider =>
         localEntityProvider.deleteEntities(
-          Seq(AttributeEntityReference(entityType = "unitTestType", entityName = "deleteTimeoutTest")), testContext
+          Seq(AttributeEntityReference(entityType = "unitTestType", entityName = "deleteTimeoutTest")),
+          testContext
         )
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/entities/local/LocalEntityProviderTimeoutSpec.scala
@@ -75,14 +75,14 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
     "enforce on deleteEntities" in withLocalEntityProviderTestDatabase { dataSource =>
       lockedEntitiesTest(dataSource, a[MySQLTimeoutException]) { localEntityProvider =>
         localEntityProvider.deleteEntities(
-          Seq(AttributeEntityReference(entityType = "unitTestType", entityName = "deleteTimeoutTest"))
+          Seq(AttributeEntityReference(entityType = "unitTestType", entityName = "deleteTimeoutTest")), testContext
         )
       }
     }
 
     "enforce on deleteEntitiesOfType" in withLocalEntityProviderTestDatabase { dataSource =>
       lockedEntitiesTest(dataSource, a[MySQLTimeoutException]) { localEntityProvider =>
-        localEntityProvider.deleteEntitiesOfType("unitTestType")
+        localEntityProvider.deleteEntitiesOfType("unitTestType", testContext)
       }
     }
 
@@ -91,7 +91,7 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
         val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
         val entityUpdate =
           EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
-        localEntityProvider.batchUpsertEntities(Seq(entityUpdate))
+        localEntityProvider.batchUpsertEntities(Seq(entityUpdate), testContext)
       }
     }
 
@@ -100,7 +100,7 @@ class LocalEntityProviderTimeoutSpec extends AnyWordSpecLike with Matchers with 
         val attrUpdate = AddUpdateAttribute(AttributeName.withDefaultNS("newAttr"), AttributeString("whatever"))
         val entityUpdate =
           EntityUpdateDefinition(name = "deleteTimeoutTest", entityType = "unitTestType", Seq(attrUpdate))
-        localEntityProvider.batchUpdateEntities(Seq(entityUpdate))
+        localEntityProvider.batchUpdateEntities(Seq(entityUpdate), testContext)
       }
     }
 //    "enforce on batchUpdateEntitiesImpl" ignore fail()

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/AvroUpsertMonitorSpec.scala
@@ -198,7 +198,8 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
         any[Seq[EntityUpdateDefinition]],
         any[Boolean],
         any[Option[DataReferenceName]],
-        any[Option[GoogleProjectId]]
+        any[Option[GoogleProjectId]],
+        any[RawlsRequestContext]
       )
     ).thenReturn(Future(Seq.empty[Entity]))
 
@@ -1096,7 +1097,8 @@ class AvroUpsertMonitorSpec(_system: ActorSystem)
           any[Seq[EntityUpdateDefinition]],
           ArgumentMatchers.eq(expectation.isUpsert),
           any[Option[DataReferenceName]],
-          any[Option[GoogleProjectId]]
+          any[Option[GoogleProjectId]],
+          any[RawlsRequestContext]
         )
       }
     }

--- a/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
+++ b/core/src/test/scala/org/broadinstitute/dsde/rawls/monitor/EntityStatisticsCacheMonitorSpec.scala
@@ -166,11 +166,11 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       )
 
       // Load the current cache entries
-      val originalCache = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      val originalCache = Await.result(localEntityProvider.entityTypeMetadata(true, testContext), Duration.Inf)
 
       // Save a new entity to the workspace
       val newEntity = Entity("new-entity-name", "new-entity-tpe", Map.empty)
-      Await.result(localEntityProvider.createEntity(newEntity), Duration.Inf)
+      Await.result(localEntityProvider.createEntity(newEntity, testContext), Duration.Inf)
 
       // Force the monitor to sweep and update the oldest stale cache
       // In this scenario, it's the only workspace so we know it will be picked up
@@ -179,7 +179,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       }
 
       // Load the latest cache
-      val newCache = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      val newCache = Await.result(localEntityProvider.entityTypeMetadata(true, testContext), Duration.Inf)
 
       // Assert that the new cache is different than the old one and contains the new entity type that we added earlier
       originalCache should not be newCache
@@ -220,7 +220,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       )
 
       // Load the current entityMetadata (which should not use the cache)
-      val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      val originalResult = Await.result(localEntityProvider.entityTypeMetadata(true, testContext), Duration.Inf)
 
       // Note that the call to entityTypeMetadata updated the cache as a side effect, since the cache was out of date.
       // Therefore, once again update the entityCacheLastUpdated field to be older than lastModified, so
@@ -247,7 +247,7 @@ class EntityStatisticsCacheMonitorSpec(_system: ActorSystem)
       }
 
       // Load the latest entityMetadata, which should use the cache
-      val latestResult = Await.result(localEntityProvider.entityTypeMetadata(true), Duration.Inf)
+      val latestResult = Await.result(localEntityProvider.entityTypeMetadata(true, testContext), Duration.Inf)
 
       // Assert that the new cache is different than the old one and contains the new entity type that we added earlier
       originalResult shouldBe latestResult


### PR DESCRIPTION
Ticket: [CORE-359](https://broadworkbench.atlassian.net/browse/CORE-359)
* Add tracing to all `EntityService` methods
* Add `RawlsRequestContext` argument to `EntityProvider` methods so we can trace new `CompactEntityProvider` methods and compare performance to the `LocalEntityProvider`
* Add tracing to `LocalEntityProvider` methods that didn't have any


Tested by running locally with sampling probability set to 1 and confirming that tracing for the various entity APIs was working as expected.

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email


[CORE-359]: https://broadworkbench.atlassian.net/browse/CORE-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ