### PR TITLE
[CORE-419] Fix scala steward frequency config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,7 +23,7 @@
 #     the given expression.
 #
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,7 +23,7 @@
 #     the given expression.
 #
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-419

Updated the Scala Steward cron schedule from `0 0 ? * MON` (every Monday at midnight) to `0 0 0 1 * ?` to run at midnight on the 1st of every month, reducing update frequency and aligning with a monthly maintenance cycle.

The cron expression follows the Quartz format, which is what [cron4s](https://github.com/alonsodomin/cron4s) (used by Scala Steward) supports. The updated expression, `0 0 0 1 * ?` means it runs at midnight on the 1st of every month. You can confirm it's valid in the [cron4s user guide](https://www.alonsodomin.me/cron4s/userguide/) or by testing it with any [Quartz cron expression tool](https://www.freeformatter.com/cron-expression-generator-quartz.html).

---

**PR checklist**

- [ ] Include the JIRA issue number in the PR description and title
- [ ] Make sure Swagger is updated if API changes
  - [ ] **...and Orchestration's Swagger too!**
- [ ] If you changed anything in `model/`, then you should publish a new official `rawls-model` and perform the corresponding dependency updates as specified in the [README](https://github.com/broadinstitute/rawls/blob/develop/README.md#publish-rawls-model):
  - [ ] in the automation subdirectory
  - [ ] in workbench-libs
  - [ ] in firecloud-orchestration
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green, including CI tests
- [ ] **Squash commits and merge** to develop (branches are automatically deleted after merging)
- [ ] Inform other teams of any substantial changes via Slack and/or email
